### PR TITLE
Use SENDTO Intent for sending bug reports

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -168,6 +168,7 @@ dependencies {
     compile 'net.hockeyapp.android:HockeySDK:3.6.1'
     compile 'org.jsoup:jsoup:1.8.2'
     compile "com.mixpanel.android:mixpanel-android:4.6.4"
+    compile 'de.cketti.mailto:email-intent-builder:1.0.0'
 
     // Testing
     testCompile 'junit:junit:4.12'

--- a/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.java
+++ b/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.java
@@ -1,6 +1,5 @@
 package com.kickstarter.ui.activities;
 
-import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -41,6 +40,7 @@ import butterknife.Bind;
 import butterknife.BindDrawable;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import de.cketti.mailto.EmailIntentBuilder;
 
 import static com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft;
 
@@ -124,13 +124,11 @@ public final class InternalToolsActivity extends BaseActivity<InternalToolsViewM
       .append("—————————————\r\n")
       .toString();
 
-    final Intent intent = new Intent(android.content.Intent.ACTION_SEND)
-      .addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET)
-      .setType("message/rfc822")
-      .putExtra(Intent.EXTRA_TEXT, body)
-      .putExtra(Intent.EXTRA_EMAIL, new String[]{email});
-
-    startActivity(Intent.createChooser(intent, getString(R.string.Select_email_application)));
+    EmailIntentBuilder.from(this)
+      .to(email)
+      .subject("Bug report")
+      .body(body)
+      .start();
   }
 
   private void showCustomEndpointDialog() {


### PR DESCRIPTION
This won't prompt the user to select an email app if one was configured as default. If none was configured only email apps will show up in the chooser dialog.
The [EmailIntentBuilder library](https://github.com/cketti/EmailIntentBuilder) is used to construct a properly encoded mailto URI containing the body text.