### PR TITLE
Fix to use doAfterTerminate instead of finallyDo.

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/ApiPaginator.java
+++ b/app/src/main/java/com/kickstarter/libs/ApiPaginator.java
@@ -234,7 +234,7 @@ public final class ApiPaginator<Data, Envelope, Params> {
       .map(envelopeToListOfData)
       .map(pageTransformation)
       .doOnSubscribe(() -> _isFetching.onNext(true))
-      .finallyDo(() -> _isFetching.onNext(false));
+      .doAfterTerminate(() -> _isFetching.onNext(false));
   }
 
   private void keepMorePath(final @NonNull Envelope envelope) {

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentFeedViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentFeedViewModel.java
@@ -262,6 +262,6 @@ public final class CommentFeedViewModel extends ActivityViewModel<CommentFeedAct
       .compose(Transformers.pipeApiErrorsTo(postCommentError))
       .compose(Transformers.neverError())
       .doOnSubscribe(() -> commentIsPosting.onNext(true))
-      .finallyDo(() -> commentIsPosting.onNext(false));
+      .doAfterTerminate(() -> commentIsPosting.onNext(false));
   }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.java
@@ -94,7 +94,7 @@ public final class ResetPasswordViewModel extends ActivityViewModel<ResetPasswor
       .compose(Transformers.pipeApiErrorsTo(resetError))
       .compose(Transformers.neverError())
       .doOnSubscribe(() -> isFormSubmitting.onNext(true))
-      .finallyDo(() -> isFormSubmitting.onNext(false));
+      .doAfterTerminate(() -> isFormSubmitting.onNext(false));
   }
 
   private void success() {

--- a/app/src/main/java/com/kickstarter/viewmodels/SignupViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SignupViewModel.java
@@ -154,7 +154,7 @@ public final class SignupViewModel extends ActivityViewModel<SignupActivity> imp
       .compose(Transformers.pipeApiErrorsTo(signupError))
       .compose(Transformers.neverError())
       .doOnSubscribe(() -> formSubmitting.onNext(true))
-      .finallyDo(() -> formSubmitting.onNext(false));
+      .doAfterTerminate(() -> formSubmitting.onNext(false));
   }
 
   private void success(final @NonNull AccessTokenEnvelope envelope) {

--- a/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.java
@@ -170,7 +170,7 @@ public final class TwoFactorViewModel extends ActivityViewModel<TwoFactorActivit
       .compose(Transformers.pipeApiErrorsTo(tfaError))
       .compose(Transformers.neverError())
       .doOnSubscribe(() -> formSubmitting.onNext(true))
-      .finallyDo(() -> formSubmitting.onNext(false));
+      .doAfterTerminate(() -> formSubmitting.onNext(false));
   }
 
   public Observable<AccessTokenEnvelope> loginWithFacebook(final @NonNull String code, final @NonNull String fbAccessToken) {
@@ -178,7 +178,7 @@ public final class TwoFactorViewModel extends ActivityViewModel<TwoFactorActivit
       .compose(Transformers.pipeApiErrorsTo(tfaError))
       .compose(Transformers.neverError())
       .doOnSubscribe(() -> formSubmitting.onNext(true))
-      .finallyDo(() -> formSubmitting.onNext(false));
+      .doAfterTerminate(() -> formSubmitting.onNext(false));
   }
 
   private Observable<AccessTokenEnvelope> resendCode(final @NonNull String email, final @NonNull String password) {


### PR DESCRIPTION
### Overview

- Just Fix to use `doAfterTerminate` instead of `finallyDo` since `finallyDo` is deprecated already.