### PR TITLE
Remove @Retention from custom Dagger qualifiers

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/qualifiers/AccessTokenPreference.java
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/AccessTokenPreference.java
@@ -1,11 +1,7 @@
 package com.kickstarter.libs.qualifiers;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention(RetentionPolicy.RUNTIME)
 public @interface AccessTokenPreference {
 }

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/ActivitySamplePreference.java
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/ActivitySamplePreference.java
@@ -1,11 +1,7 @@
 package com.kickstarter.libs.qualifiers;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention(RetentionPolicy.RUNTIME)
 public @interface ActivitySamplePreference {
 }

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/ApiEndpointPreference.java
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/ApiEndpointPreference.java
@@ -1,11 +1,7 @@
 package com.kickstarter.libs.qualifiers;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention(RetentionPolicy.RUNTIME)
 public @interface ApiEndpointPreference {
 }

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/ApiRetrofit.java
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/ApiRetrofit.java
@@ -1,12 +1,8 @@
 package com.kickstarter.libs.qualifiers;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention(RetentionPolicy.RUNTIME)
 public @interface ApiRetrofit {
 }
 

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/AppRatingPreference.java
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/AppRatingPreference.java
@@ -1,11 +1,7 @@
 package com.kickstarter.libs.qualifiers;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention(RetentionPolicy.RUNTIME)
 public @interface AppRatingPreference {
 }

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/ApplicationContext.java
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/ApplicationContext.java
@@ -1,12 +1,8 @@
 package com.kickstarter.libs.qualifiers;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention(RetentionPolicy.RUNTIME)
 public @interface ApplicationContext {
 }
 

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/ConfigPreference.java
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/ConfigPreference.java
@@ -1,11 +1,7 @@
 package com.kickstarter.libs.qualifiers;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention(RetentionPolicy.RUNTIME)
 public @interface ConfigPreference {
 }

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/GamesNewsletterPreference.java
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/GamesNewsletterPreference.java
@@ -1,12 +1,8 @@
 package com.kickstarter.libs.qualifiers;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention(RetentionPolicy.RUNTIME)
 public @interface GamesNewsletterPreference {
 }
 

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/PackageNameString.java
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/PackageNameString.java
@@ -1,12 +1,8 @@
 package com.kickstarter.libs.qualifiers;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention(RetentionPolicy.RUNTIME)
 public @interface PackageNameString {
 }
 

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/UserPreference.java
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/UserPreference.java
@@ -1,11 +1,7 @@
 package com.kickstarter.libs.qualifiers;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention(RetentionPolicy.RUNTIME)
 public @interface UserPreference {
 }

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/WebEndpoint.java
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/WebEndpoint.java
@@ -1,11 +1,7 @@
 package com.kickstarter.libs.qualifiers;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention(RetentionPolicy.RUNTIME)
 public @interface WebEndpoint {
 }

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/WebRetrofit.java
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/WebRetrofit.java
@@ -1,12 +1,8 @@
 package com.kickstarter.libs.qualifiers;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 import javax.inject.Qualifier;
 
 @Qualifier
-@Retention(RetentionPolicy.RUNTIME)
 public @interface WebRetrofit {
 }
 


### PR DESCRIPTION
`@Qualifier` itself is annotated with `@Retention(RUNTIME)`.