### PR TITLE
Round reward conversion label up

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/KSCurrency.java
+++ b/app/src/main/java/com/kickstarter/libs/KSCurrency.java
@@ -61,7 +61,7 @@ public final class KSCurrency {
     final NumberOptions numberOptions = NumberOptions.builder()
       .currencyCode(showCurrencyCode ? currencyOptions.currencyCode() : "")
       .currencySymbol(currencyOptions.currencySymbol())
-      .roundingMode(RoundingMode.UP)
+      .roundingMode(RoundingMode.DOWN)
       .build();
 
     return NumberUtils.format(currencyOptions.value(), numberOptions);

--- a/app/src/main/java/com/kickstarter/libs/KSCurrency.java
+++ b/app/src/main/java/com/kickstarter/libs/KSCurrency.java
@@ -24,7 +24,7 @@ public final class KSCurrency {
    * @param project      The project to use to look up currency information.
    */
   public @NonNull String format(final float initialValue, final @NonNull Project project) {
-    return format(initialValue, project, false, false);
+    return format(initialValue, project, false, false, RoundingMode.DOWN);
   }
 
   /**
@@ -38,7 +38,7 @@ public final class KSCurrency {
   public @NonNull String format(final float initialValue, final @NonNull Project project,
     final boolean excludeCurrencyCode) {
 
-    return format(initialValue, project, excludeCurrencyCode, false);
+    return format(initialValue, project, excludeCurrencyCode, false, RoundingMode.DOWN);
   }
 
   /**
@@ -52,7 +52,7 @@ public final class KSCurrency {
    *                            the US.
    */
   public @NonNull String format(final float initialValue, final @NonNull Project project,
-    final boolean excludeCurrencyCode, final boolean preferUSD) {
+    final boolean excludeCurrencyCode, final boolean preferUSD, final @NonNull RoundingMode roundingMode) {
 
     final CurrencyOptions currencyOptions = currencyOptions(initialValue, project, preferUSD);
 
@@ -61,7 +61,7 @@ public final class KSCurrency {
     final NumberOptions numberOptions = NumberOptions.builder()
       .currencyCode(showCurrencyCode ? currencyOptions.currencyCode() : "")
       .currencySymbol(currencyOptions.currencySymbol())
-      .roundingMode(RoundingMode.DOWN)
+      .roundingMode(roundingMode)
       .build();
 
     return NumberUtils.format(currencyOptions.value(), numberOptions);

--- a/app/src/main/java/com/kickstarter/libs/KSCurrency.java
+++ b/app/src/main/java/com/kickstarter/libs/KSCurrency.java
@@ -61,7 +61,7 @@ public final class KSCurrency {
     final NumberOptions numberOptions = NumberOptions.builder()
       .currencyCode(showCurrencyCode ? currencyOptions.currencyCode() : "")
       .currencySymbol(currencyOptions.currencySymbol())
-      .roundingMode(RoundingMode.DOWN)
+      .roundingMode(RoundingMode.UP)
       .build();
 
     return NumberUtils.format(currencyOptions.value(), numberOptions);

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.java
@@ -39,6 +39,8 @@ import com.squareup.picasso.Picasso;
 
 import org.joda.time.DateTime;
 
+import java.math.RoundingMode;
+
 import javax.inject.Inject;
 
 import butterknife.Bind;
@@ -302,10 +304,10 @@ public final class ProjectViewHolder extends KSViewHolder {
   }
 
   public void setPledgedOfGoalView() {
-    pledgedTextView.setText(ksCurrency.format(project.pledged(), project, false, true));
+    pledgedTextView.setText(ksCurrency.format(project.pledged(), project, false, true, RoundingMode.DOWN));
 
     /* a11y */
-    final String goalString = ksCurrency.format(project.goal(), project, false, true);
+    final String goalString = ksCurrency.format(project.goal(), project, false, true, RoundingMode.DOWN);
     final String goalText = ViewUtils.isFontScaleLarge(context) ?
       ksString.format(ofGoalString, "goal", goalString) : ksString.format(pledgedOfGoalString, "goal", goalString);
     goalTextView.setText(goalText);

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewModel.java
@@ -210,7 +210,7 @@ public final class RewardViewModel extends ActivityViewModel<RewardViewHolder> i
       .subscribe(usdConversionTextViewIsHidden);
 
     projectAndReward
-      .map(pr -> ksCurrency.format(pr.second.minimum(), pr.first, true, true))
+      .map(pr -> ksCurrency.format((float) Math.ceil(pr.second.minimum()), pr.first, true, true))
       .compose(takeWhen(
         shouldDisplayUsdConversion
           .filter(BooleanUtils::isTrue)

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewModel.java
@@ -24,6 +24,7 @@ import com.kickstarter.viewmodels.outputs.RewardViewModelOutputs;
 
 import org.joda.time.DateTime;
 
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -210,7 +211,7 @@ public final class RewardViewModel extends ActivityViewModel<RewardViewHolder> i
       .subscribe(usdConversionTextViewIsHidden);
 
     projectAndReward
-      .map(pr -> ksCurrency.format((float) Math.ceil(pr.second.minimum()), pr.first, true, true))
+      .map(pr -> ksCurrency.format(pr.second.minimum(), pr.first, true, true, RoundingMode.UP))
       .compose(takeWhen(
         shouldDisplayUsdConversion
           .filter(BooleanUtils::isTrue)

--- a/app/src/test/java/com/kickstarter/KSCurrencyTest.java
+++ b/app/src/test/java/com/kickstarter/KSCurrencyTest.java
@@ -10,6 +10,8 @@ import com.kickstarter.models.Project;
 
 import junit.framework.TestCase;
 
+import java.math.RoundingMode;
+
 public class KSCurrencyTest extends TestCase {
   public void testFormatCurrency_withUserInUS() {
     final KSCurrency currency = createKSCurrency("US");
@@ -46,12 +48,12 @@ public class KSCurrencyTest extends TestCase {
 
   public void testFormatCurrency_withUserInUSAndUSDPreferred() {
     final KSCurrency currency = createKSCurrency("US");
-    assertEquals("$150", currency.format(100.0f, ProjectFactory.ukProject(), false, true));
+    assertEquals("$150", currency.format(100.0f, ProjectFactory.ukProject(), false, true, RoundingMode.DOWN));
   }
 
   public void testFormatCurrency_withUserInUKAndUSDPreferred() {
     final KSCurrency currency = createKSCurrency("UK");
-    assertEquals("£100", currency.format(100.0f, ProjectFactory.ukProject(), false, true));
+    assertEquals("£100", currency.format(100.0f, ProjectFactory.ukProject(), false, true, RoundingMode.DOWN));
   }
 
   public void testFormatCurrency_roundsDown() {

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewModelTest.java
@@ -497,6 +497,28 @@ public final class RewardViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
+  public void testUsdConversionTextRoundsUp() {
+    // Set user's country to US.
+    final Config config = ConfigFactory.configForUSUser();
+    final Environment environment = environment();
+    environment.currentConfig().config(config);
+    final RewardViewModel vm = new RewardViewModel(environment);
+
+    // Set project's country to CA and reward minimum to $0.40.
+    final Project project = ProjectFactory.project().toBuilder().country("CA").build();
+    final Reward reward = RewardFactory.reward().toBuilder().minimum(0.3f).build();
+
+    final TestSubscriber<String> usdConversionTextViewText = TestSubscriber.create();
+    vm.outputs.usdConversionTextViewText().subscribe(usdConversionTextViewText);
+    final TestSubscriber<Boolean> usdConversionSectionIsHidden = TestSubscriber.create();
+    vm.outputs.usdConversionTextViewIsHidden().subscribe(usdConversionSectionIsHidden);
+
+    // USD conversion should be rounded up.
+    vm.inputs.projectAndReward(project, reward);
+    usdConversionTextViewText.assertValue("$1");
+  }
+
+  @Test
   public void testWhiteOverlayIsHidden() {
     final RewardViewModel vm = new RewardViewModel(environment());
     final Project project = ProjectFactory.project();

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewModelTest.java
@@ -444,7 +444,7 @@ public final class RewardViewModelTest extends KSRobolectricTestCase {
     final RewardViewModel vm = new RewardViewModel(environment);
 
     // Set project's country to CA.
-    final Project project = ProjectFactory.project().toBuilder().country("CA").build();
+    final Project project = ProjectFactory.caProject();
     final Reward reward = RewardFactory.reward();
 
     final TestSubscriber<String> usdConversionTextViewText = TestSubscriber.create();
@@ -504,8 +504,8 @@ public final class RewardViewModelTest extends KSRobolectricTestCase {
     environment.currentConfig().config(config);
     final RewardViewModel vm = new RewardViewModel(environment);
 
-    // Set project's country to CA and reward minimum to $0.40.
-    final Project project = ProjectFactory.project().toBuilder().country("CA").build();
+    // Set project's country to CA and reward minimum to $0.30.
+    final Project project = ProjectFactory.caProject();
     final Reward reward = RewardFactory.reward().toBuilder().minimum(0.3f).build();
 
     final TestSubscriber<String> usdConversionTextViewText = TestSubscriber.create();

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewModelTest.java
@@ -510,8 +510,6 @@ public final class RewardViewModelTest extends KSRobolectricTestCase {
 
     final TestSubscriber<String> usdConversionTextViewText = TestSubscriber.create();
     vm.outputs.usdConversionTextViewText().subscribe(usdConversionTextViewText);
-    final TestSubscriber<Boolean> usdConversionSectionIsHidden = TestSubscriber.create();
-    vm.outputs.usdConversionTextViewIsHidden().subscribe(usdConversionSectionIsHidden);
 
     // USD conversion should be rounded up.
     vm.inputs.projectAndReward(project, reward);


### PR DESCRIPTION
## what
Rounded our USD conversion text up so we avoid showing `$0` amounts in rewards.

<img src=https://cloud.githubusercontent.com/assets/4934046/21550666/b60dc0e2-cdc9-11e6-9665-2d071be18060.png width=300/> → <img src=https://cloud.githubusercontent.com/assets/4934046/21549857/463cdd4e-cdc3-11e6-9a0c-f86f0fb4f95f.png width=300/>

We want to be sure to only round `UP` for currency in the reward conversion, since generally in other use cases we want the currency to be rounded down.