### PR TITLE
Suppress secrets error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ submodules:
 	git submodule foreach git checkout $(sha1)
 
 secrets:
-	-rm -rf vendor/native-secrets
-	-git clone https://github.com/kickstarter/native-secrets vendor/native-secrets
-
 	# Copy java secrets over. Fallback to example secrets if they don't exist.
+	-@rm -rf vendor/native-secrets
+	-@git clone https://github.com/kickstarter/native-secrets vendor/native-secrets 2>/dev/null || echo '(Skipping secrets.)'
+
 	cp vendor/native-secrets/android/Secrets.java app/src/main/java/com/kickstarter/libs/utils/Secrets.java \
 		|| cp app/src/main/java/com/kickstarter/libs/utils/Secrets.java.example app/src/main/java/com/kickstarter/libs/utils/Secrets.java
 


### PR DESCRIPTION
This should suppress the error emitted when attempting to clone the private, non-OSS repo, hopefully reducing the number of false positives reported.