### PR TITLE
Use POSIX syntax in bootstrap script

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,11 +1,11 @@
 #!/usr/bin/env sh
 
-function say {
+say () {
   str=$1
   ruby -e "print \"\033[0;32m$1\033[0m\n\""
 }
 
-function loudspeaker {
+loudspeaker () {
   str=$1
   ruby -e "print \"\n\033[0;31m📢  📢  📢  $1\033[0m\n\n\""
 }


### PR DESCRIPTION
This change addresses #7 #28 #30. I believe many Windows users are using [Bash on Ubuntu for Windows](https://msdn.microsoft.com/en-gb/commandline/wsl/about) or a POSIX-compliant shell to run the bootstrap script. The `function` keyword is not defined on POSIX. This change improves portability and should not break the bash shell on OSX. I am able to build and run the Kickstarter app successfully on Windows.

http://unix.stackexchange.com/questions/73750/difference-between-function-foo-and-foo
