### PR TITLE
Pass categories from DiscoveryActivity to Fragment

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
@@ -106,7 +106,7 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel> {
     viewModel.outputs.updateParamsForPage()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(pp -> pagerAdapter.takeParams(pp.first, pp.second));
+      .subscribe(cp -> pagerAdapter.takeParams(cp.first, cp.second));
 
     viewModel.outputs.clearPages()
       .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
@@ -106,12 +106,17 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel> {
     viewModel.outputs.updateParamsForPage()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(cp -> pagerAdapter.takeParams(cp.first, cp.second));
+      .subscribe(pagerAdapter::takeParams);
 
     viewModel.outputs.clearPages()
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(pagerAdapter::clearPages);
+
+    viewModel.outputs.rootCategoriesAndPosition()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(cp -> pagerAdapter.takeCategoriesForPosition(cp.first, cp.second));
 
     viewModel.outputs.showBuildCheckAlert()
       .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/adapters/DiscoveryPagerAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/DiscoveryPagerAdapter.java
@@ -5,6 +5,8 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
 
+import com.kickstarter.libs.utils.DiscoveryUtils;
+import com.kickstarter.models.Category;
 import com.kickstarter.services.DiscoveryParams;
 import com.kickstarter.ui.ArgumentsKey;
 import com.kickstarter.ui.fragments.DiscoveryFragment;
@@ -50,14 +52,14 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
   /**
    * Take current params from activity and pass to the appropriate fragment.
    */
-  public void takeParams(final @NonNull DiscoveryParams params, final int currentPosition) {
+  public void takeParams(final @NonNull List<Category> categories, final @NonNull DiscoveryParams params) {
     Observable.from(fragmentManager.getFragments())
       .ofType(DiscoveryFragment.class)
       .filter(frag -> {
         final int fragmentPosition = frag.getArguments().getInt(ArgumentsKey.DISCOVERY_SORT_POSITION);
-        return currentPosition == fragmentPosition;
+        return DiscoveryUtils.positionFromSort(params.sort()) == fragmentPosition;
       })
-      .subscribe(frag -> frag.updateParams(params));
+      .subscribe(frag -> frag.updateParams(params));  // todo: add categories next
   }
 
   /**

--- a/app/src/main/java/com/kickstarter/ui/adapters/DiscoveryPagerAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/DiscoveryPagerAdapter.java
@@ -50,16 +50,29 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
   }
 
   /**
+   * Passes along root categories to its fragment position to help fetch appropriate projects.
+   */
+  public void takeCategoriesForPosition(final @NonNull List<Category> categories, final int position) {
+    Observable.from(fragmentManager.getFragments())
+      .ofType(DiscoveryFragment.class)
+      .filter(frag -> {
+        final int fragmentPosition = frag.getArguments().getInt(ArgumentsKey.DISCOVERY_SORT_POSITION);
+        return fragmentPosition == position;
+      })
+      .subscribe(frag -> frag.takeCategories(categories));
+  }
+
+  /**
    * Take current params from activity and pass to the appropriate fragment.
    */
-  public void takeParams(final @NonNull List<Category> categories, final @NonNull DiscoveryParams params) {
+  public void takeParams(final @NonNull DiscoveryParams params) {
     Observable.from(fragmentManager.getFragments())
       .ofType(DiscoveryFragment.class)
       .filter(frag -> {
         final int fragmentPosition = frag.getArguments().getInt(ArgumentsKey.DISCOVERY_SORT_POSITION);
         return DiscoveryUtils.positionFromSort(params.sort()) == fragmentPosition;
       })
-      .subscribe(frag -> frag.updateParams(params));  // todo: add categories next
+      .subscribe(frag -> frag.updateParams(params));
   }
 
   /**

--- a/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
+++ b/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
@@ -18,6 +18,7 @@ import com.kickstarter.libs.RecyclerViewPaginator;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel;
 import com.kickstarter.models.Activity;
+import com.kickstarter.models.Category;
 import com.kickstarter.models.Project;
 import com.kickstarter.services.DiscoveryParams;
 import com.kickstarter.ui.ArgumentsKey;
@@ -29,6 +30,8 @@ import com.kickstarter.ui.activities.WebViewActivity;
 import com.kickstarter.ui.adapters.DiscoveryAdapter;
 import com.kickstarter.ui.data.LoginReason;
 import com.kickstarter.viewmodels.DiscoveryFragmentViewModel;
+
+import java.util.List;
 
 import static com.kickstarter.libs.rx.transformers.Transformers.observeForUI;
 import static com.kickstarter.libs.utils.TransitionUtils.slideInFromRight;
@@ -137,6 +140,10 @@ public final class DiscoveryFragment extends BaseFragment<DiscoveryFragmentViewM
       .putExtra(IntentKey.REF_TAG, refTag);
     startActivity(intent);
     transition(getActivity(), slideInFromRight());
+  }
+
+  public void takeCategories(final @NonNull List<Category> categories) {
+    viewModel.inputs.rootCategories(categories);
   }
 
   public void updateParams(final @NonNull DiscoveryParams params) {

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -239,29 +239,29 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
   @Override public void paramsFromActivity(final @NonNull DiscoveryParams params) {
     paramsFromActivity.onNext(params);
   }
-  @Override public void projectCardViewHolderClick(final @NonNull ProjectCardViewHolder viewHolder, final Project project) {
+  @Override public void projectCardViewHolderClick(final @NonNull ProjectCardViewHolder viewHolder, final @NonNull Project project) {
     clickProject.onNext(project);
   }
 
-  @Override public Observable<Activity> activity() {
+  @Override public @NonNull Observable<Activity> activity() {
     return activity;
   }
-  @Override public Observable<List<Project>> projects() {
+  @Override public @NonNull Observable<List<Project>> projects() {
     return projects;
   }
-  @Override public Observable<Boolean> showActivityFeed() {
+  @Override public @NonNull Observable<Boolean> showActivityFeed() {
     return showActivityFeed;
   }
-  @Override public Observable<Activity> showActivityUpdate() {
+  @Override public @NonNull Observable<Activity> showActivityUpdate() {
     return showActivityUpdate;
   }
-  @Override public Observable<Boolean> showLoginTout() {
+  @Override public @NonNull Observable<Boolean> showLoginTout() {
     return showLoginTout;
   }
-  @Override public Observable<Pair<Project, RefTag>> showProject() {
+  @Override public @NonNull Observable<Pair<Project, RefTag>> showProject() {
     return showProject;
   }
-  @Override public Observable<Boolean> shouldShowOnboardingView() {
+  @Override public @NonNull Observable<Boolean> shouldShowOnboardingView() {
     return shouldShowOnboardingView;
   }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -225,7 +225,7 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
     activityUpdateClick.onNext(activity);
   }
   @Override public void rootCategories(final @NonNull List<Category> rootCategories) {
-    rootCategories.onNext(rootCategories);
+    this.rootCategories.onNext(rootCategories);
   }
   @Override public void clearPage() {
     clearPage.onNext(null);

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -227,21 +227,41 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
   @Override public void rootCategories(final @NonNull List<Category> rootCategories) {
     this.rootCategories.onNext(rootCategories);
   }
-  @Override public void clearPage() { clearPage.onNext(null); }
+  @Override public void clearPage() {
+    clearPage.onNext(null);
+  }
   @Override public void discoveryOnboardingViewHolderLoginToutClick(final @NonNull DiscoveryOnboardingViewHolder viewHolder) {
     discoveryOnboardingLoginToutClick.onNext(true);
   }
-  @Override public void nextPage() { nextPage.onNext(null); }
-  @Override public void paramsFromActivity(final @NonNull DiscoveryParams params) { paramsFromActivity.onNext(params); }
-  @Override public void projectCardViewHolderClick(final @NonNull ProjectCardViewHolder viewHolder, final @NonNull Project project) {
+  @Override public void nextPage() {
+    nextPage.onNext(null);
+  }
+  @Override public void paramsFromActivity(final @NonNull DiscoveryParams params) {
+    paramsFromActivity.onNext(params);
+  }
+  @Override public void projectCardViewHolderClick(final @NonNull ProjectCardViewHolder viewHolder, final Project project) {
     clickProject.onNext(project);
   }
 
-  @Override public @NonNull Observable<Activity> activity() { return activity; }
-  @Override public @NonNull Observable<List<Project>> projects() { return projects; }
-  @Override public @NonNull Observable<Boolean> showActivityFeed() { return showActivityFeed; }
-  @Override public @NonNull Observable<Activity> showActivityUpdate() { return showActivityUpdate; }
-  @Override public @NonNull Observable<Boolean> showLoginTout() { return showLoginTout; }
-  @Override public @NonNull Observable<Pair<Project, RefTag>> showProject() { return showProject; }
-  @Override public @NonNull Observable<Boolean> shouldShowOnboardingView() { return shouldShowOnboardingView; }
+  @Override public Observable<Activity> activity() {
+    return activity;
+  }
+  @Override public Observable<List<Project>> projects() {
+    return projects;
+  }
+  @Override public Observable<Boolean> showActivityFeed() {
+    return showActivityFeed;
+  }
+  @Override public Observable<Activity> showActivityUpdate() {
+    return showActivityUpdate;
+  }
+  @Override public Observable<Boolean> showLoginTout() {
+    return showLoginTout;
+  }
+  @Override public Observable<Pair<Project, RefTag>> showProject() {
+    return showProject;
+  }
+  @Override public Observable<Boolean> shouldShowOnboardingView() {
+    return shouldShowOnboardingView;
+  }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -227,41 +227,21 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
   @Override public void rootCategories(final @NonNull List<Category> rootCategories) {
     this.rootCategories.onNext(rootCategories);
   }
-  @Override public void clearPage() {
-    clearPage.onNext(null);
-  }
+  @Override public void clearPage() { clearPage.onNext(null); }
   @Override public void discoveryOnboardingViewHolderLoginToutClick(final @NonNull DiscoveryOnboardingViewHolder viewHolder) {
     discoveryOnboardingLoginToutClick.onNext(true);
   }
-  @Override public void nextPage() {
-    nextPage.onNext(null);
-  }
-  @Override public void paramsFromActivity(final @NonNull DiscoveryParams params) {
-    paramsFromActivity.onNext(params);
-  }
-  @Override public void projectCardViewHolderClick(final @NonNull ProjectCardViewHolder viewHolder, final Project project) {
+  @Override public void nextPage() { nextPage.onNext(null); }
+  @Override public void paramsFromActivity(final @NonNull DiscoveryParams params) { paramsFromActivity.onNext(params); }
+  @Override public void projectCardViewHolderClick(final @NonNull ProjectCardViewHolder viewHolder, final @NonNull Project project) {
     clickProject.onNext(project);
   }
 
-  @Override public Observable<Activity> activity() {
-    return activity;
-  }
-  @Override public Observable<List<Project>> projects() {
-    return projects;
-  }
-  @Override public Observable<Boolean> showActivityFeed() {
-    return showActivityFeed;
-  }
-  @Override public Observable<Activity> showActivityUpdate() {
-    return showActivityUpdate;
-  }
-  @Override public Observable<Boolean> showLoginTout() {
-    return showLoginTout;
-  }
-  @Override public Observable<Pair<Project, RefTag>> showProject() {
-    return showProject;
-  }
-  @Override public Observable<Boolean> shouldShowOnboardingView() {
-    return shouldShowOnboardingView;
-  }
+  @Override public @NonNull Observable<Activity> activity() { return activity; }
+  @Override public @NonNull Observable<List<Project>> projects() { return projects; }
+  @Override public @NonNull Observable<Boolean> showActivityFeed() { return showActivityFeed; }
+  @Override public @NonNull Observable<Activity> showActivityUpdate() { return showActivityUpdate; }
+  @Override public @NonNull Observable<Boolean> showLoginTout() { return showLoginTout; }
+  @Override public @NonNull Observable<Pair<Project, RefTag>> showProject() { return showProject; }
+  @Override public @NonNull Observable<Boolean> shouldShowOnboardingView() { return shouldShowOnboardingView; }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -48,119 +48,6 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
   private final CurrentUserType currentUser;
   private final IntPreferenceType activitySamplePreference;
 
-  // INPUTS
-  private PublishSubject<DiscoveryParams> paramsFromActivity = PublishSubject.create();
-  @Override
-  public void paramsFromActivity(final @NonNull DiscoveryParams params) {
-    paramsFromActivity.onNext(params);
-  }
-
-  private PublishSubject<Void> clearPage = PublishSubject.create();
-  @Override
-  public void clearPage() {
-    clearPage.onNext(null);
-  }
-
-  private PublishSubject<Void> nextPage = PublishSubject.create();
-  @Override
-  public void nextPage() {
-    nextPage.onNext(null);
-  }
-
-  // PROJECT VIEW HOLDER DELEGATE INPUTS
-  private PublishSubject<Project> clickProject = PublishSubject.create();
-  @Override
-  public void projectCardViewHolderClick(final @NonNull ProjectCardViewHolder viewHolder, final Project project) {
-    clickProject.onNext(project);
-  }
-
-  // ONBOARDING DELEGATE INPUTS
-  private PublishSubject<Boolean> discoveryOnboardingLoginToutClick = PublishSubject.create();
-  @Override
-  public void discoveryOnboardingViewHolderLoginToutClick(final @NonNull DiscoveryOnboardingViewHolder viewHolder) {
-    discoveryOnboardingLoginToutClick.onNext(true);
-  }
-
-  // ACTIVITY SAMPLE DELEGATE INPUTS
-  private PublishSubject<Activity> activityUpdateClick = PublishSubject.create();
-  @Override
-  public void activitySampleProjectViewHolderUpdateClicked(final @NonNull ActivitySampleProjectViewHolder viewHolder,
-    final @NonNull Activity activity) {
-    activityUpdateClick.onNext(activity);
-  }
-
-  private PublishSubject<Project> activitySampleProjectClick = PublishSubject.create();
-  @Override
-  public void activitySampleProjectViewHolderProjectClicked(final @NonNull ActivitySampleProjectViewHolder viewHolder,
-    final @NonNull Project project) {
-    activitySampleProjectClick.onNext(project);
-  }
-  @Override
-  public void activitySampleFriendBackingViewHolderProjectClicked(final @NonNull ActivitySampleFriendBackingViewHolder viewHolder,
-    final @NonNull Project project) {
-    activitySampleProjectClick.onNext(project);
-  }
-
-  private PublishSubject<Boolean> activityClick = PublishSubject.create();
-  @Override
-  public void activitySampleFriendBackingViewHolderSeeActivityClicked(final @NonNull ActivitySampleFriendBackingViewHolder viewHolder) {
-    activityClick.onNext(true);
-  }
-  @Override
-  public void activitySampleFriendFollowViewHolderSeeActivityClicked(final @NonNull ActivitySampleFriendFollowViewHolder viewHolder) {
-    activityClick.onNext(true);
-  }
-  @Override
-  public void activitySampleProjectViewHolderSeeActivityClicked(final @NonNull ActivitySampleProjectViewHolder viewHolder) {
-    activityClick.onNext(true);
-  }
-
-  // OUTPUTS
-  private final BehaviorSubject<Activity> activity = BehaviorSubject.create();
-  @Override
-  public Observable<Activity> activity() {
-    return activity;
-  }
-
-  final BehaviorSubject<List<Project>> projects = BehaviorSubject.create();
-  @Override
-  public Observable<List<Project>> projects() {
-    return projects;
-  }
-
-  private final Observable<Boolean> showActivityFeed;
-  @Override
-  public Observable<Boolean> showActivityFeed() {
-    return showActivityFeed;
-  }
-
-  private final Observable<Activity> showActivityUpdate;
-  @Override
-  public Observable<Activity> showActivityUpdate() {
-    return showActivityUpdate;
-  }
-
-  private final Observable<Boolean> showLoginTout;
-  @Override
-  public Observable<Boolean> showLoginTout() {
-    return showLoginTout;
-  }
-
-  private final BehaviorSubject<Boolean> shouldShowOnboardingView = BehaviorSubject.create();
-  @Override
-  public Observable<Boolean> shouldShowOnboardingView() {
-    return shouldShowOnboardingView;
-  }
-
-  private final PublishSubject<Pair<Project, RefTag>> showProject = PublishSubject.create();
-  @Override
-  public Observable<Pair<Project, RefTag>> showProject() {
-    return showProject;
-  }
-
-  public final DiscoveryFragmentViewModelInputs inputs = this;
-  public final DiscoveryFragmentViewModelOutputs outputs = this;
-
   public DiscoveryFragmentViewModel(final @NonNull Environment environment) {
     super(environment);
 
@@ -300,5 +187,84 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
     if (activity != null) {
       activitySamplePreference.set((int) activity.id());
     }
+  }
+
+  private final PublishSubject<Boolean> activityClick = PublishSubject.create();
+  private final PublishSubject<Project> activitySampleProjectClick = PublishSubject.create();
+  private final PublishSubject<Activity> activityUpdateClick = PublishSubject.create();
+  private final PublishSubject<Void> clearPage = PublishSubject.create();
+  private final PublishSubject<Project> clickProject = PublishSubject.create();
+  private final PublishSubject<Boolean> discoveryOnboardingLoginToutClick = PublishSubject.create();
+  private final PublishSubject<Void> nextPage = PublishSubject.create();
+  private final PublishSubject<DiscoveryParams> paramsFromActivity = PublishSubject.create();
+
+  private final BehaviorSubject<Activity> activity = BehaviorSubject.create();
+  private final BehaviorSubject<List<Project>> projects = BehaviorSubject.create();
+  private final Observable<Boolean> showActivityFeed;
+  private final Observable<Activity> showActivityUpdate;
+  private final Observable<Boolean> showLoginTout;
+  private final PublishSubject<Pair<Project, RefTag>> showProject = PublishSubject.create();
+  private final BehaviorSubject<Boolean> shouldShowOnboardingView = BehaviorSubject.create();
+
+  public final DiscoveryFragmentViewModelInputs inputs = this;
+  public final DiscoveryFragmentViewModelOutputs outputs = this;
+
+  @Override public void activitySampleFriendBackingViewHolderProjectClicked(final @NonNull ActivitySampleFriendBackingViewHolder viewHolder,
+    final @NonNull Project project) {
+    activitySampleProjectClick.onNext(project);
+  }
+  @Override public void activitySampleFriendBackingViewHolderSeeActivityClicked(final @NonNull ActivitySampleFriendBackingViewHolder viewHolder) {
+    activityClick.onNext(true);
+  }
+  @Override public void activitySampleFriendFollowViewHolderSeeActivityClicked(final @NonNull ActivitySampleFriendFollowViewHolder viewHolder) {
+    activityClick.onNext(true);
+  }
+  @Override public void activitySampleProjectViewHolderProjectClicked(final @NonNull ActivitySampleProjectViewHolder viewHolder,
+    final @NonNull Project project) {
+    activitySampleProjectClick.onNext(project);
+  }
+  @Override public void activitySampleProjectViewHolderSeeActivityClicked(final @NonNull ActivitySampleProjectViewHolder viewHolder) {
+    activityClick.onNext(true);
+  }
+  @Override public void activitySampleProjectViewHolderUpdateClicked(final @NonNull ActivitySampleProjectViewHolder viewHolder,
+    final @NonNull Activity activity) {
+    activityUpdateClick.onNext(activity);
+  }
+  @Override public void clearPage() {
+    clearPage.onNext(null);
+  }
+  @Override public void discoveryOnboardingViewHolderLoginToutClick(final @NonNull DiscoveryOnboardingViewHolder viewHolder) {
+    discoveryOnboardingLoginToutClick.onNext(true);
+  }
+  @Override public void nextPage() {
+    nextPage.onNext(null);
+  }
+  @Override public void paramsFromActivity(final @NonNull DiscoveryParams params) {
+    paramsFromActivity.onNext(params);
+  }
+  @Override public void projectCardViewHolderClick(final @NonNull ProjectCardViewHolder viewHolder, final Project project) {
+    clickProject.onNext(project);
+  }
+
+  @Override public Observable<Activity> activity() {
+    return activity;
+  }
+  @Override public Observable<List<Project>> projects() {
+    return projects;
+  }
+  @Override public Observable<Boolean> showActivityFeed() {
+    return showActivityFeed;
+  }
+  @Override public Observable<Activity> showActivityUpdate() {
+    return showActivityUpdate;
+  }
+  @Override public Observable<Boolean> showLoginTout() {
+    return showLoginTout;
+  }
+  @Override public Observable<Pair<Project, RefTag>> showProject() {
+    return showProject;
+  }
+  @Override public Observable<Boolean> shouldShowOnboardingView() {
+    return shouldShowOnboardingView;
   }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -4,7 +4,6 @@ import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.util.Pair;
 
-import com.kickstarter.libs.ActivityRequestCodes;
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.BuildCheck;
 import com.kickstarter.libs.CurrentUserType;
@@ -21,7 +20,6 @@ import com.kickstarter.services.apiresponses.InternalBuildEnvelope;
 import com.kickstarter.ui.activities.DiscoveryActivity;
 import com.kickstarter.ui.adapters.DiscoveryPagerAdapter;
 import com.kickstarter.ui.adapters.data.NavigationDrawerData;
-import com.kickstarter.ui.data.ActivityResult;
 import com.kickstarter.ui.intentmappers.DiscoveryIntentMapper;
 import com.kickstarter.ui.viewholders.discoverydrawer.ChildFilterViewHolder;
 import com.kickstarter.ui.viewholders.discoverydrawer.LoggedInViewHolder;
@@ -49,149 +47,6 @@ public final class DiscoveryViewModel extends ActivityViewModel<DiscoveryActivit
   private final WebClientType webClient;
   private final BuildCheck buildCheck;
   private final CurrentUserType currentUser;
-
-  // INPUTS
-  private final PublishSubject<Boolean> openDrawer = PublishSubject.create();
-  @Override
-  public void openDrawer(final boolean open) {
-    openDrawer.onNext(open);
-  }
-
-  private final PublishSubject<Integer> pageChanged = PublishSubject.create();
-  @Override
-  public void pageChanged(final int position) {
-    pageChanged.onNext(position);
-  }
-
-  // DiscoveryPagerAdapter.Delegate inputs
-  private final PublishSubject<Integer> pagerCreatedPage = PublishSubject.create();
-  @Override
-  public void discoveryPagerAdapterCreatedPage(final DiscoveryPagerAdapter adapter, final int position) {
-    pagerCreatedPage.onNext(position);
-  }
-
-  // NAVIGATION DRAWER DELEGATE INPUTS
-  private PublishSubject<NavigationDrawerData.Section.Row> childFilterRowClick = PublishSubject.create();
-  @Override
-  public void childFilterViewHolderRowClick(final @NonNull ChildFilterViewHolder viewHolder, final @NonNull NavigationDrawerData.Section.Row row) {
-    childFilterRowClick.onNext(row);
-  }
-
-  private PublishSubject<Void> loggedOutLoginToutClick = PublishSubject.create();
-  @Override
-  public void loggedOutViewHolderLoginToutClick(final @NonNull LoggedOutViewHolder viewHolder) {
-    loggedOutLoginToutClick.onNext(null);
-  }
-
-  private PublishSubject<NavigationDrawerData.Section.Row> parentFilterRowClick = PublishSubject.create();
-  @Override
-  public void parentFilterViewHolderRowClick(final @NonNull ParentFilterViewHolder viewHolder, final @NonNull NavigationDrawerData.Section.Row row) {
-    parentFilterRowClick.onNext(row);
-  }
-
-  private PublishSubject<InternalBuildEnvelope> newerBuildIsAvailable = PublishSubject.create();
-  @Override
-  public void newerBuildIsAvailable(final @NonNull InternalBuildEnvelope envelope) {
-    newerBuildIsAvailable.onNext(envelope);
-  }
-
-  private PublishSubject<Void> internalToolsClick = PublishSubject.create();
-  @Override
-  public void loggedInViewHolderInternalToolsClick(final @NonNull LoggedInViewHolder viewHolder) {
-    internalToolsClick.onNext(null);
-  }
-
-  @Override
-  public void loggedOutViewHolderInternalToolsClick(final @NonNull LoggedOutViewHolder viewHolder) {
-    internalToolsClick.onNext(null);
-  }
-
-  private PublishSubject<Void> profileClick = PublishSubject.create();
-  @Override
-  public void loggedInViewHolderProfileClick(final @NonNull LoggedInViewHolder viewHolder, final @NonNull User user) {
-    profileClick.onNext(null);
-  }
-
-  private PublishSubject<Void> settingsClick = PublishSubject.create();
-  @Override
-  public void loggedInViewHolderSettingsClick(final @NonNull LoggedInViewHolder viewHolder, final @NonNull User user) {
-    settingsClick.onNext(null);
-  }
-
-  private PublishSubject<NavigationDrawerData.Section.Row> topFilterRowClick = PublishSubject.create();
-  @Override
-  public void topFilterViewHolderRowClick(final @NonNull TopFilterViewHolder viewHolder, final @NonNull NavigationDrawerData.Section.Row row) {
-    topFilterRowClick.onNext(row);
-  }
-
-  // OUTPUTS
-  private final Observable<InternalBuildEnvelope> showBuildCheckAlert;
-  @Override
-  public Observable<InternalBuildEnvelope> showBuildCheckAlert() {
-    return showBuildCheckAlert;
-  }
-
-  private final Observable<Void> showInternalTools;
-  @Override
-  public Observable<Void> showInternalTools() {
-    return showInternalTools;
-  }
-
-  private final Observable<Void> showProfile;
-  @Override
-  public Observable<Void> showProfile() {
-    return showProfile;
-  }
-
-  private final Observable<Void> showLoginTout;
-  @Override
-  public Observable<Void> showLoginTout() {
-    return showLoginTout;
-  }
-
-  private final Observable<Void> showSettings;
-  @Override
-  public Observable<Void> showSettings() {
-    return showSettings;
-  }
-
-  private BehaviorSubject<NavigationDrawerData> navigationDrawerData = BehaviorSubject.create();
-  @Override
-  public Observable<NavigationDrawerData> navigationDrawerData() {
-    return navigationDrawerData;
-  }
-
-  private BehaviorSubject<Boolean> drawerIsOpen = BehaviorSubject.create();
-  @Override
-  public Observable<Boolean> drawerIsOpen() {
-    return drawerIsOpen;
-  }
-
-  final BehaviorSubject<DiscoveryParams> updateToolbarWithParams = BehaviorSubject.create();
-  @Override
-  public Observable<DiscoveryParams> updateToolbarWithParams() {
-    return updateToolbarWithParams;
-  }
-
-  final PublishSubject<Pair<DiscoveryParams, Integer>> updateParamsForPage = PublishSubject.create();
-  @Override
-  public Observable<Pair<DiscoveryParams, Integer>> updateParamsForPage() {
-    return updateParamsForPage;
-  }
-
-  final PublishSubject<List<Integer>> clearPages = PublishSubject.create();
-  public Observable<List<Integer>> clearPages() {
-    return clearPages;
-  }
-
-  final BehaviorSubject<Boolean> expandSortTabLayout = BehaviorSubject.create();
-  @Override
-  public Observable<Boolean> expandSortTabLayout() {
-    return expandSortTabLayout;
-  }
-
-  public final DiscoveryViewModelInputs inputs = this;
-  public final DiscoveryViewModelOutputs outputs = this;
 
   public DiscoveryViewModel(final @NonNull Environment environment) {
     super(environment);
@@ -334,7 +189,101 @@ public final class DiscoveryViewModel extends ActivityViewModel<DiscoveryActivit
       .subscribe(__ -> koala.trackDiscoveryFilters());
   }
 
-  private static boolean isSuccessfulLogin(final @NonNull ActivityResult activityResult) {
-    return activityResult.isOk() && activityResult.isRequestCode(ActivityRequestCodes.LOGIN_FLOW);
+  private final PublishSubject<NavigationDrawerData.Section.Row> childFilterRowClick = PublishSubject.create();
+  private final PublishSubject<Void> internalToolsClick = PublishSubject.create();
+  private final PublishSubject<Void> loggedOutLoginToutClick = PublishSubject.create();
+  private final PublishSubject<InternalBuildEnvelope> newerBuildIsAvailable = PublishSubject.create();
+  private final PublishSubject<Boolean> openDrawer = PublishSubject.create();
+  private final PublishSubject<Integer> pageChanged = PublishSubject.create();
+  private final PublishSubject<Integer> pagerCreatedPage = PublishSubject.create();
+  private final PublishSubject<NavigationDrawerData.Section.Row> parentFilterRowClick = PublishSubject.create();
+  private final PublishSubject<Void> profileClick = PublishSubject.create();
+  private final PublishSubject<Void> settingsClick = PublishSubject.create();
+  private final PublishSubject<NavigationDrawerData.Section.Row> topFilterRowClick = PublishSubject.create();
+
+  private final PublishSubject<List<Integer>> clearPages = PublishSubject.create();
+  private final BehaviorSubject<Boolean> drawerIsOpen = BehaviorSubject.create();
+  private final BehaviorSubject<Boolean> expandSortTabLayout = BehaviorSubject.create();
+  private final BehaviorSubject<NavigationDrawerData> navigationDrawerData = BehaviorSubject.create();
+  private final Observable<InternalBuildEnvelope> showBuildCheckAlert;
+  private final Observable<Void> showInternalTools;
+  private final Observable<Void> showLoginTout;
+  private final Observable<Void> showProfile;
+  private final Observable<Void> showSettings;
+  private final PublishSubject<Pair<DiscoveryParams, Integer>> updateParamsForPage = PublishSubject.create();
+  private final BehaviorSubject<DiscoveryParams> updateToolbarWithParams = BehaviorSubject.create();
+
+  public final DiscoveryViewModelInputs inputs = this;
+  public final DiscoveryViewModelOutputs outputs = this;
+
+  @Override public void childFilterViewHolderRowClick(final @NonNull ChildFilterViewHolder viewHolder, final @NonNull NavigationDrawerData.Section.Row row) {
+    childFilterRowClick.onNext(row);
+  }
+  @Override public void discoveryPagerAdapterCreatedPage(final DiscoveryPagerAdapter adapter, final int position) {
+    pagerCreatedPage.onNext(position);
+  }
+  @Override public void loggedInViewHolderInternalToolsClick(final @NonNull LoggedInViewHolder viewHolder) {
+    internalToolsClick.onNext(null);
+  }
+  @Override public void loggedInViewHolderProfileClick(final @NonNull LoggedInViewHolder viewHolder, final @NonNull User user) {
+    profileClick.onNext(null);
+  }
+  @Override public void loggedInViewHolderSettingsClick(final @NonNull LoggedInViewHolder viewHolder, final @NonNull User user) {
+    settingsClick.onNext(null);
+  }
+  @Override public void loggedOutViewHolderInternalToolsClick(final @NonNull LoggedOutViewHolder viewHolder) {
+    internalToolsClick.onNext(null);
+  }
+  @Override public void loggedOutViewHolderLoginToutClick(final @NonNull LoggedOutViewHolder viewHolder) {
+    loggedOutLoginToutClick.onNext(null);
+  }
+  @Override public void newerBuildIsAvailable(final @NonNull InternalBuildEnvelope envelope) {
+    newerBuildIsAvailable.onNext(envelope);
+  }
+  @Override public void openDrawer(final boolean open) {
+    openDrawer.onNext(open);
+  }
+  @Override public void pageChanged(final int position) {
+    pageChanged.onNext(position);
+  }
+  @Override public void parentFilterViewHolderRowClick(final @NonNull ParentFilterViewHolder viewHolder, final @NonNull NavigationDrawerData.Section.Row row) {
+    parentFilterRowClick.onNext(row);
+  }
+  @Override public void topFilterViewHolderRowClick(final @NonNull TopFilterViewHolder viewHolder, final @NonNull NavigationDrawerData.Section.Row row) {
+    topFilterRowClick.onNext(row);
+  }
+
+  @Override public Observable<List<Integer>> clearPages() {
+    return clearPages;
+  }
+  @Override public Observable<Boolean> drawerIsOpen() {
+    return drawerIsOpen;
+  }
+  @Override public Observable<Boolean> expandSortTabLayout() {
+    return expandSortTabLayout;
+  }
+  @Override public Observable<NavigationDrawerData> navigationDrawerData() {
+    return navigationDrawerData;
+  }
+  @Override public Observable<InternalBuildEnvelope> showBuildCheckAlert() {
+    return showBuildCheckAlert;
+  }
+  @Override public Observable<Void> showInternalTools() {
+    return showInternalTools;
+  }
+  @Override public Observable<Void> showLoginTout() {
+    return showLoginTout;
+  }
+  @Override public Observable<Void> showProfile() {
+    return showProfile;
+  }
+  @Override public Observable<Void> showSettings() {
+    return showSettings;
+  }
+  @Override public Observable<Pair<DiscoveryParams, Integer>> updateParamsForPage() {
+    return updateParamsForPage;
+  }
+  @Override public Observable<DiscoveryParams> updateToolbarWithParams() {
+    return updateToolbarWithParams;
   }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -227,7 +227,7 @@ public final class DiscoveryViewModel extends ActivityViewModel<DiscoveryActivit
   @Override public void childFilterViewHolderRowClick(final @NonNull ChildFilterViewHolder viewHolder, final @NonNull NavigationDrawerData.Section.Row row) {
     childFilterRowClick.onNext(row);
   }
-  @Override public void discoveryPagerAdapterCreatedPage(final @NonNull DiscoveryPagerAdapter adapter, final int position) {
+  @Override public void discoveryPagerAdapterCreatedPage(final DiscoveryPagerAdapter adapter, final int position) {
     pagerCreatedPage.onNext(position);
   }
   @Override public void loggedInViewHolderInternalToolsClick(final @NonNull LoggedInViewHolder viewHolder) {
@@ -248,8 +248,12 @@ public final class DiscoveryViewModel extends ActivityViewModel<DiscoveryActivit
   @Override public void newerBuildIsAvailable(final @NonNull InternalBuildEnvelope envelope) {
     newerBuildIsAvailable.onNext(envelope);
   }
-  @Override public void openDrawer(final boolean open) { openDrawer.onNext(open); }
-  @Override public void pageChanged(final int position) { pageChanged.onNext(position); }
+  @Override public void openDrawer(final boolean open) {
+    openDrawer.onNext(open);
+  }
+  @Override public void pageChanged(final int position) {
+    pageChanged.onNext(position);
+  }
   @Override public void parentFilterViewHolderRowClick(final @NonNull ParentFilterViewHolder viewHolder, final @NonNull NavigationDrawerData.Section.Row row) {
     parentFilterRowClick.onNext(row);
   }
@@ -257,18 +261,40 @@ public final class DiscoveryViewModel extends ActivityViewModel<DiscoveryActivit
     topFilterRowClick.onNext(row);
   }
 
-  @Override public @NonNull Observable<List<Integer>> clearPages() { return clearPages; }
-  @Override public @NonNull Observable<Boolean> drawerIsOpen() { return drawerIsOpen; }
-  @Override public @NonNull Observable<Boolean> expandSortTabLayout() { return expandSortTabLayout; }
-  @Override public @NonNull Observable<NavigationDrawerData> navigationDrawerData() { return navigationDrawerData; }
-  @Override public @NonNull Observable<Pair<List<Category>, Integer>> rootCategoriesAndPosition() {
+  @Override public Observable<List<Integer>> clearPages() {
+    return clearPages;
+  }
+  @Override public Observable<Boolean> drawerIsOpen() {
+    return drawerIsOpen;
+  }
+  @Override public Observable<Boolean> expandSortTabLayout() {
+    return expandSortTabLayout;
+  }
+  @Override public Observable<NavigationDrawerData> navigationDrawerData() {
+    return navigationDrawerData;
+  }
+  @Override public Observable<Pair<List<Category>, Integer>> rootCategoriesAndPosition() {
     return rootCategoriesAndPosition;
   }
-  @Override public @NonNull Observable<InternalBuildEnvelope> showBuildCheckAlert() { return showBuildCheckAlert; }
-  @Override public @NonNull Observable<Void> showInternalTools() { return showInternalTools; }
-  @Override public @NonNull Observable<Void> showLoginTout() { return showLoginTout; }
-  @Override public @NonNull Observable<Void> showProfile() { return showProfile; }
-  @Override public @NonNull Observable<Void> showSettings() { return showSettings; }
-  @Override public @NonNull Observable<DiscoveryParams> updateParamsForPage() { return updateParamsForPage; }
-  @Override public @NonNull Observable<DiscoveryParams> updateToolbarWithParams() { return updateToolbarWithParams; }
+  @Override public Observable<InternalBuildEnvelope> showBuildCheckAlert() {
+    return showBuildCheckAlert;
+  }
+  @Override public Observable<Void> showInternalTools() {
+    return showInternalTools;
+  }
+  @Override public Observable<Void> showLoginTout() {
+    return showLoginTout;
+  }
+  @Override public Observable<Void> showProfile() {
+    return showProfile;
+  }
+  @Override public Observable<Void> showSettings() {
+    return showSettings;
+  }
+  @Override public Observable<DiscoveryParams> updateParamsForPage() {
+    return updateParamsForPage;
+  }
+  @Override public Observable<DiscoveryParams> updateToolbarWithParams() {
+    return updateToolbarWithParams;
+  }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -227,7 +227,7 @@ public final class DiscoveryViewModel extends ActivityViewModel<DiscoveryActivit
   @Override public void childFilterViewHolderRowClick(final @NonNull ChildFilterViewHolder viewHolder, final @NonNull NavigationDrawerData.Section.Row row) {
     childFilterRowClick.onNext(row);
   }
-  @Override public void discoveryPagerAdapterCreatedPage(final DiscoveryPagerAdapter adapter, final int position) {
+  @Override public void discoveryPagerAdapterCreatedPage(final @NonNull DiscoveryPagerAdapter adapter, final int position) {
     pagerCreatedPage.onNext(position);
   }
   @Override public void loggedInViewHolderInternalToolsClick(final @NonNull LoggedInViewHolder viewHolder) {
@@ -248,12 +248,8 @@ public final class DiscoveryViewModel extends ActivityViewModel<DiscoveryActivit
   @Override public void newerBuildIsAvailable(final @NonNull InternalBuildEnvelope envelope) {
     newerBuildIsAvailable.onNext(envelope);
   }
-  @Override public void openDrawer(final boolean open) {
-    openDrawer.onNext(open);
-  }
-  @Override public void pageChanged(final int position) {
-    pageChanged.onNext(position);
-  }
+  @Override public void openDrawer(final boolean open) { openDrawer.onNext(open); }
+  @Override public void pageChanged(final int position) { pageChanged.onNext(position); }
   @Override public void parentFilterViewHolderRowClick(final @NonNull ParentFilterViewHolder viewHolder, final @NonNull NavigationDrawerData.Section.Row row) {
     parentFilterRowClick.onNext(row);
   }
@@ -261,40 +257,18 @@ public final class DiscoveryViewModel extends ActivityViewModel<DiscoveryActivit
     topFilterRowClick.onNext(row);
   }
 
-  @Override public Observable<List<Integer>> clearPages() {
-    return clearPages;
-  }
-  @Override public Observable<Boolean> drawerIsOpen() {
-    return drawerIsOpen;
-  }
-  @Override public Observable<Boolean> expandSortTabLayout() {
-    return expandSortTabLayout;
-  }
-  @Override public Observable<NavigationDrawerData> navigationDrawerData() {
-    return navigationDrawerData;
-  }
-  @Override public Observable<Pair<List<Category>, Integer>> rootCategoriesAndPosition() {
+  @Override public @NonNull Observable<List<Integer>> clearPages() { return clearPages; }
+  @Override public @NonNull Observable<Boolean> drawerIsOpen() { return drawerIsOpen; }
+  @Override public @NonNull Observable<Boolean> expandSortTabLayout() { return expandSortTabLayout; }
+  @Override public @NonNull Observable<NavigationDrawerData> navigationDrawerData() { return navigationDrawerData; }
+  @Override public @NonNull Observable<Pair<List<Category>, Integer>> rootCategoriesAndPosition() {
     return rootCategoriesAndPosition;
   }
-  @Override public Observable<InternalBuildEnvelope> showBuildCheckAlert() {
-    return showBuildCheckAlert;
-  }
-  @Override public Observable<Void> showInternalTools() {
-    return showInternalTools;
-  }
-  @Override public Observable<Void> showLoginTout() {
-    return showLoginTout;
-  }
-  @Override public Observable<Void> showProfile() {
-    return showProfile;
-  }
-  @Override public Observable<Void> showSettings() {
-    return showSettings;
-  }
-  @Override public Observable<DiscoveryParams> updateParamsForPage() {
-    return updateParamsForPage;
-  }
-  @Override public Observable<DiscoveryParams> updateToolbarWithParams() {
-    return updateToolbarWithParams;
-  }
+  @Override public @NonNull Observable<InternalBuildEnvelope> showBuildCheckAlert() { return showBuildCheckAlert; }
+  @Override public @NonNull Observable<Void> showInternalTools() { return showInternalTools; }
+  @Override public @NonNull Observable<Void> showLoginTout() { return showLoginTout; }
+  @Override public @NonNull Observable<Void> showProfile() { return showProfile; }
+  @Override public @NonNull Observable<Void> showSettings() { return showSettings; }
+  @Override public @NonNull Observable<DiscoveryParams> updateParamsForPage() { return updateParamsForPage; }
+  @Override public @NonNull Observable<DiscoveryParams> updateToolbarWithParams() { return updateToolbarWithParams; }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -227,7 +227,7 @@ public final class DiscoveryViewModel extends ActivityViewModel<DiscoveryActivit
   @Override public void childFilterViewHolderRowClick(final @NonNull ChildFilterViewHolder viewHolder, final @NonNull NavigationDrawerData.Section.Row row) {
     childFilterRowClick.onNext(row);
   }
-  @Override public void discoveryPagerAdapterCreatedPage(final DiscoveryPagerAdapter adapter, final int position) {
+  @Override public void discoveryPagerAdapterCreatedPage(final @NonNull DiscoveryPagerAdapter adapter, final int position) {
     pagerCreatedPage.onNext(position);
   }
   @Override public void loggedInViewHolderInternalToolsClick(final @NonNull LoggedInViewHolder viewHolder) {
@@ -261,40 +261,40 @@ public final class DiscoveryViewModel extends ActivityViewModel<DiscoveryActivit
     topFilterRowClick.onNext(row);
   }
 
-  @Override public Observable<List<Integer>> clearPages() {
+  @Override public @NonNull Observable<List<Integer>> clearPages() {
     return clearPages;
   }
-  @Override public Observable<Boolean> drawerIsOpen() {
+  @Override public @NonNull Observable<Boolean> drawerIsOpen() {
     return drawerIsOpen;
   }
-  @Override public Observable<Boolean> expandSortTabLayout() {
+  @Override public @NonNull Observable<Boolean> expandSortTabLayout() {
     return expandSortTabLayout;
   }
-  @Override public Observable<NavigationDrawerData> navigationDrawerData() {
+  @Override public @NonNull Observable<NavigationDrawerData> navigationDrawerData() {
     return navigationDrawerData;
   }
-  @Override public Observable<Pair<List<Category>, Integer>> rootCategoriesAndPosition() {
+  @Override public @NonNull Observable<Pair<List<Category>, Integer>> rootCategoriesAndPosition() {
     return rootCategoriesAndPosition;
   }
-  @Override public Observable<InternalBuildEnvelope> showBuildCheckAlert() {
+  @Override public @NonNull Observable<InternalBuildEnvelope> showBuildCheckAlert() {
     return showBuildCheckAlert;
   }
-  @Override public Observable<Void> showInternalTools() {
+  @Override public @NonNull Observable<Void> showInternalTools() {
     return showInternalTools;
   }
-  @Override public Observable<Void> showLoginTout() {
+  @Override public @NonNull Observable<Void> showLoginTout() {
     return showLoginTout;
   }
-  @Override public Observable<Void> showProfile() {
+  @Override public @NonNull Observable<Void> showProfile() {
     return showProfile;
   }
-  @Override public Observable<Void> showSettings() {
+  @Override public @NonNull Observable<Void> showSettings() {
     return showSettings;
   }
-  @Override public Observable<DiscoveryParams> updateParamsForPage() {
+  @Override public @NonNull Observable<DiscoveryParams> updateParamsForPage() {
     return updateParamsForPage;
   }
-  @Override public Observable<DiscoveryParams> updateToolbarWithParams() {
+  @Override public @NonNull Observable<DiscoveryParams> updateToolbarWithParams() {
     return updateToolbarWithParams;
   }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/outputs/DiscoveryFragmentViewModelInputs.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/outputs/DiscoveryFragmentViewModelInputs.java
@@ -1,7 +1,10 @@
 package com.kickstarter.viewmodels.outputs;
 
+import com.kickstarter.models.Category;
 import com.kickstarter.services.DiscoveryParams;
 import com.kickstarter.ui.adapters.DiscoveryAdapter;
+
+import java.util.List;
 
 public interface DiscoveryFragmentViewModelInputs extends DiscoveryAdapter.Delegate {
   /**
@@ -18,4 +21,9 @@ public interface DiscoveryFragmentViewModelInputs extends DiscoveryAdapter.Deleg
    * Call for project pagination.
    */
   void nextPage();
+
+  /**
+   * Call when we should load the root categories.
+   */
+  void rootCategories(final List<Category> rootCategories);
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/outputs/DiscoveryViewModelOutputs.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/outputs/DiscoveryViewModelOutputs.java
@@ -31,9 +31,15 @@ public interface DiscoveryViewModelOutputs {
    * Emits when the params of a particular page should be updated. The page will be responsible for
    * taking those params and creating paginating projects from it.
    */
-  Observable<Pair<List<Category>, DiscoveryParams>> updateParamsForPage();
+  Observable<DiscoveryParams> updateParamsForPage();
 
   Observable<NavigationDrawerData> navigationDrawerData();
+
+  /**
+   * Emits the root categories and position. Position is used to determine the appropriate fragment
+   * to pass the categories to.
+   */
+  Observable<Pair<List<Category>, Integer>> rootCategoriesAndPosition();
 
   /**
    * Emits a list of pages that should be cleared of all their content.

--- a/app/src/main/java/com/kickstarter/viewmodels/outputs/DiscoveryViewModelOutputs.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/outputs/DiscoveryViewModelOutputs.java
@@ -2,6 +2,7 @@ package com.kickstarter.viewmodels.outputs;
 
 import android.util.Pair;
 
+import com.kickstarter.models.Category;
 import com.kickstarter.services.DiscoveryParams;
 import com.kickstarter.services.apiresponses.InternalBuildEnvelope;
 import com.kickstarter.ui.adapters.data.NavigationDrawerData;
@@ -30,7 +31,7 @@ public interface DiscoveryViewModelOutputs {
    * Emits when the params of a particular page should be updated. The page will be responsible for
    * taking those params and creating paginating projects from it.
    */
-  Observable<Pair<DiscoveryParams, Integer>> updateParamsForPage();
+  Observable<Pair<List<Category>, DiscoveryParams>> updateParamsForPage();
 
   Observable<NavigationDrawerData> navigationDrawerData();
 

--- a/app/src/test/java/com/kickstarter/factories/CategoryFactory.java
+++ b/app/src/test/java/com/kickstarter/factories/CategoryFactory.java
@@ -4,6 +4,9 @@ import android.support.annotation.NonNull;
 
 import com.kickstarter.models.Category;
 
+import java.util.Arrays;
+import java.util.List;
+
 public final class CategoryFactory {
   private CategoryFactory() {}
 
@@ -79,6 +82,10 @@ public final class CategoryFactory {
       .projectsCount(160)
       .slug("photography")
       .build();
+  }
+
+  public static @NonNull List<Category> rootCategories() {
+    return Arrays.asList(artCategory(), gamesCategory(), musicCategory(), photographyCategory());
   }
 
   public static @NonNull Category tabletopGamesCategory() {

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -39,11 +39,12 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     final TestSubscriber<Boolean> hasProjects = new TestSubscriber<>();
     vm.outputs.projects().map(ListUtils::nonEmpty).subscribe(hasProjects);
 
-    // Load initial params from activity.
+    // Load initial params and root categories from activity.
     vm.inputs.paramsFromActivity(DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build());
+    vm.inputs.rootCategories(CategoryFactory.rootCategories());
 
     // Should emit current fragment's projects.
-    hasProjects.assertValues(false, true);
+    hasProjects.assertValues(true);
     koalaTest.assertValues("Discover List View");
 
     // Select a new category.
@@ -53,11 +54,13 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
         .sort(DiscoveryParams.Sort.HOME)
         .build()
     );
-    hasProjects.assertValues(false, true, false, true);
+
+    // Projects are cleared, new projects load.
+    hasProjects.assertValues(true, false, true);
     koalaTest.assertValues("Discover List View", "Discover List View");
 
     vm.inputs.clearPage();
-    hasProjects.assertValues(false, true, false, true, false);
+    hasProjects.assertValues(true, false, true, false);
   }
 
   @Test
@@ -69,6 +72,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
 
     // Initial load.
     vm.inputs.paramsFromActivity(DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build());
+    vm.inputs.rootCategories(CategoryFactory.rootCategories());
 
     projects.assertValueCount(1);
     koalaTest.assertValues("Discover List View");
@@ -93,6 +97,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     vm.outputs.projects().filter(ListUtils::nonEmpty).subscribe(projects);
 
     // Initial load.
+    vm.inputs.rootCategories(CategoryFactory.rootCategories());
     vm.inputs.paramsFromActivity(DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build());
 
     // Projects should emit.
@@ -135,6 +140,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
 
     // Initial home all projects params.
     vm.inputs.paramsFromActivity(DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build());
+    vm.inputs.rootCategories(CategoryFactory.rootCategories());
 
     // Should show onboarding view.
     shouldShowOnboardingViewTest.assertValues(true);

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -9,6 +9,7 @@ import com.kickstarter.factories.UserFactory;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.MockCurrentUser;
 import com.kickstarter.libs.rx.transformers.Transformers;
+import com.kickstarter.libs.utils.DiscoveryUtils;
 import com.kickstarter.services.DiscoveryParams;
 import com.kickstarter.services.apiresponses.InternalBuildEnvelope;
 import com.kickstarter.ui.adapters.data.NavigationDrawerData;
@@ -195,9 +196,9 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     final DiscoveryViewModel vm = new DiscoveryViewModel(environment());
 
     final TestSubscriber<DiscoveryParams> updateParams= new TestSubscriber<>();
-    vm.outputs.updateParamsForPage().map(pair -> pair.first).subscribe(updateParams);
+    vm.outputs.updateParamsForPage().map(cp -> cp.second).subscribe(updateParams);
     final TestSubscriber<Integer> updatePage = new TestSubscriber<>();
-    vm.outputs.updateParamsForPage().map(pair -> pair.second).subscribe(updatePage);
+    vm.outputs.updateParamsForPage().map(cp -> DiscoveryUtils.positionFromSort(cp.second.sort())).subscribe(updatePage);
 
     // Start initial activity.
     final Intent intent = new Intent(Intent.ACTION_MAIN);
@@ -253,9 +254,9 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
 
     // Simulate rotating the device and hitting initial inputs again.
     final TestSubscriber<DiscoveryParams> rotatedUpdateParams= new TestSubscriber<>();
-    vm.outputs.updateParamsForPage().map(pair -> pair.first).subscribe(rotatedUpdateParams);
+    vm.outputs.updateParamsForPage().map(cp -> cp.second).subscribe(rotatedUpdateParams);
     final TestSubscriber<Integer> rotatedUpdatePage = new TestSubscriber<>();
-    vm.outputs.updateParamsForPage().map(pair -> pair.second).subscribe(rotatedUpdatePage);
+    vm.outputs.updateParamsForPage().map(cp -> DiscoveryUtils.positionFromSort(cp.second.sort())).subscribe(rotatedUpdatePage);
 
     vm.inputs.discoveryPagerAdapterCreatedPage(null, 0);
     vm.inputs.discoveryPagerAdapterCreatedPage(null, 1);


### PR DESCRIPTION
## what
This is some much needed infrastructural cleanup in our `DiscoveryViewModel` and `DiscoveryFragmentViewModel`. It paves a clearer route for tackling our blank sorts Discovery bug, trust me.

## changes
The main change is passing `rootCategories` as an `output` from `DiscoveryActivity` to the `DiscoveryFragment` via an `input`, rather than calling `fetchCategories` again in the fragment.

We need the categories in the fragment for our `DiscoveryUtils.fillRootCategoryForFeaturedProjects` function:
```java
  /**
   * Given a list of projects and root categories this will determine if the first project is featured
   * and is in need of its root category. If that is the case we will find its root and fill in that
   * data and return a new list of projects.
   */
```

Before: 4 fetch categories requests on app startup
![image](https://cloud.githubusercontent.com/assets/4934046/21732847/910db714-d429-11e6-86fc-6cb90ba7646d.png)

After: 1 fetch categories request on app startup
![image](https://cloud.githubusercontent.com/assets/4934046/21732850/9665d192-d429-11e6-9c64-e77b7d538db7.png)

Why didn't we do this earlier? Good question. An oversight in a large (sorts) project, my responsibility.

* Another major win is disentangling our `params` logic. I will explain below.
* A lot of noise is from modernizing the two Discovery VMs, i.e. moving inputs and outputs to the bottom of the file.