### PR TITLE
🎉 Add Either class, in Kotlin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,6 +121,7 @@ android {
         androidTest {
             java.srcDir file('src/androidTest')
         }
+        main.java.srcDirs += 'src/main/kotlin'
     }
 }
 
@@ -147,6 +148,7 @@ dependencies {
     compile 'com.jakewharton:butterknife:7.0.1'
     compile 'com.jakewharton:process-phoenix:1.0.2'
     compile 'com.jakewharton.timber:timber:3.0.1'
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile 'com.stripe:stripe-android:1.0.3'
     debugCompile 'com.squareup.leakcanary:leakcanary-android:1.3.1'
     releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.3.1'
@@ -182,12 +184,15 @@ dependencies {
 }
 
 buildscript {
+    ext.kotlin_version = '1.0.6'
+
     repositories {
         mavenCentral()
     }
 
     dependencies {
         classpath 'me.tatarka:gradle-retrolambda:3.4.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -208,3 +213,4 @@ gradle.taskGraph.beforeTask { Task task ->
 
 apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.google.gms.google-services'
+apply plugin: 'kotlin-android'

--- a/app/src/main/java/com/kickstarter/libs/Either.kt
+++ b/app/src/main/java/com/kickstarter/libs/Either.kt
@@ -1,0 +1,33 @@
+package com.kickstarter.libs
+
+class Either<out A, out B> private constructor (val left: A?, val right: B?) {
+  companion object {
+    fun <A, B> left(left: A): Either<A, B> {
+      return Either(left, null)
+    }
+
+    fun <A, B> right(right: B): Either<A, B> {
+      return Either(null, right)
+    }
+  }
+
+  fun <C> either(ifLeft: (A) -> C, ifRight: (B) -> C): C {
+    if (this.left != null) {
+      return ifLeft(this.left)
+    }
+
+    if (this.right != null) {
+      return ifRight(this.right)
+    }
+
+    throw Exception("Exception: neither left nor right values found")
+  }
+
+  fun isLeft(): Boolean {
+    return this.left != null
+  }
+
+  fun isRight(): Boolean {
+    return this.right != null
+  }
+}

--- a/app/src/main/java/com/kickstarter/libs/Either.kt
+++ b/app/src/main/java/com/kickstarter/libs/Either.kt
@@ -30,4 +30,22 @@ class Either<out A, out B> private constructor (val left: A?, val right: B?) {
   fun isRight(): Boolean {
     return this.right != null
   }
+
+  /**
+   * Maps the right side of an `Either` value.
+   *
+   * @param transform:    A transformation
+   * @return              A new `Either` value.
+   */
+  fun <C> map(transform: (B) -> C): Either<A, C> {
+    if (this.left != null) {
+      return Companion.left(this.left)
+    }
+
+    if (this.right != null) {
+      return Companion.right(transform(this.right))
+    }
+
+    throw Exception()
+  }
 }

--- a/app/src/main/java/com/kickstarter/libs/Either.kt
+++ b/app/src/main/java/com/kickstarter/libs/Either.kt
@@ -15,12 +15,10 @@ class Either<out A, out B> private constructor (val left: A?, val right: B?) {
     if (this.left != null) {
       return ifLeft(this.left)
     }
-
     if (this.right != null) {
       return ifRight(this.right)
     }
-
-    throw Exception("Exception: neither left nor right values found")
+    throw Exception("Exception: Invalid left or right values.")
   }
 
   fun isLeft(): Boolean {
@@ -34,18 +32,32 @@ class Either<out A, out B> private constructor (val left: A?, val right: B?) {
   /**
    * Maps the right side of an `Either` value.
    *
-   * @param transform:    A transformation
-   * @return              A new `Either` value.
+   * @param transform    A transformation
+   * @return             A new `Either` value.
    */
   fun <C> map(transform: (B) -> C): Either<A, C> {
     if (this.left != null) {
       return Companion.left(this.left)
     }
-
     if (this.right != null) {
       return Companion.right(transform(this.right))
     }
+    throw Exception("Exception: Invalid left or right values.")
+  }
 
-    throw Exception()
+  /**
+   * Maps the left side of an `Either` value.
+   *
+   * @param transform    A transformation
+   * @return             A new `Either` value.
+   */
+  fun <C> mapLeft(transform: (A) -> C): Either<C, B> {
+    if (this.left != null) {
+      return Companion.left(transform(this.left))
+    }
+    if (this.right != null) {
+      return Companion.right(this.right)
+    }
+    throw Exception("Exception: Invalid left or right values.")
   }
 }

--- a/app/src/main/java/com/kickstarter/libs/Either.kt
+++ b/app/src/main/java/com/kickstarter/libs/Either.kt
@@ -1,8 +1,8 @@
 package com.kickstarter.libs
 
 sealed class Either<out A, out B> {
-  class Left<out L, out R>(val left: L) : Either<L, R>()
-  class Right<out L, out R>(val right: R) : Either<L, R>()
+  class Left<out L, out R>(internal val left: L) : Either<L, R>()
+  class Right<out L, out R>(internal val right: R) : Either<L, R>()
 
   fun <C> either(ifLeft: (A) -> C, ifRight: (B) -> C): C = when(this) {
     is Left -> ifLeft(this.left)

--- a/app/src/main/java/com/kickstarter/libs/Either.kt
+++ b/app/src/main/java/com/kickstarter/libs/Either.kt
@@ -1,32 +1,40 @@
 package com.kickstarter.libs
 
-class Either<out A, out B> private constructor (val left: A?, val right: B?) {
-  companion object {
-    fun <A, B> left(left: A): Either<A, B> {
-      return Either(left, null)
-    }
+sealed class Either<out A, out B> {
+  class Left<out L, out R>(val left: L) : Either<L, R>()
+  class Right<out L, out R>(val right: R) : Either<L, R>()
 
-    fun <A, B> right(right: B): Either<A, B> {
-      return Either(null, right)
-    }
-  }
-
-  fun <C> either(ifLeft: (A) -> C, ifRight: (B) -> C): C {
-    if (this.left != null) {
-      return ifLeft(this.left)
-    }
-    if (this.right != null) {
-      return ifRight(this.right)
-    }
-    throw Exception("Exception: Invalid left or right values.")
+  fun <C> either(ifLeft: (A) -> C, ifRight: (B) -> C): C = when(this) {
+    is Left -> ifLeft(this.left)
+    is Right -> ifRight(this.right)
   }
 
   fun isLeft(): Boolean {
-    return this.left != null
+    return this is Left
   }
 
   fun isRight(): Boolean {
-    return this.right != null
+    return this is Right
+  }
+
+  /**
+   * Extracts the `left` value from an either.
+   *
+   * @return    A value of type `A` if this is a left either, `null` otherwise.
+   */
+  fun left(): A? = when(this) {
+    is Left -> this.left
+    is Right -> null
+  }
+
+  /**
+   * Extracts the `right` value from an either.
+   *
+   * @return    A value of type `B` if this is a left either, `null` otherwise.
+   */
+  fun right(): B? = when(this) {
+    is Left -> null
+    is Right -> this.right
   }
 
   /**
@@ -35,14 +43,9 @@ class Either<out A, out B> private constructor (val left: A?, val right: B?) {
    * @param transform    A transformation
    * @return             A new `Either` value.
    */
-  fun <C> map(transform: (B) -> C): Either<A, C> {
-    if (this.left != null) {
-      return Companion.left(this.left)
-    }
-    if (this.right != null) {
-      return Companion.right(transform(this.right))
-    }
-    throw Exception("Exception: Invalid left or right values.")
+  fun <C> map(transform: (B) -> C): Either<A, C> = when(this) {
+    is Left -> Left(this.left)
+    is Right -> Right(transform(this.right))
   }
 
   /**
@@ -51,13 +54,8 @@ class Either<out A, out B> private constructor (val left: A?, val right: B?) {
    * @param transform    A transformation
    * @return             A new `Either` value.
    */
-  fun <C> mapLeft(transform: (A) -> C): Either<C, B> {
-    if (this.left != null) {
-      return Companion.left(transform(this.left))
-    }
-    if (this.right != null) {
-      return Companion.right(this.right)
-    }
-    throw Exception("Exception: Invalid left or right values.")
+  fun <C> mapLeft(transform: (A) -> C): Either<C, B> = when(this) {
+    is Left -> Left(transform(this.left))
+    is Right -> Right(this.right)
   }
 }

--- a/app/src/test/java/com/kickstarter/libs/EitherTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/EitherTest.kt
@@ -1,0 +1,38 @@
+package com.kickstarter.libs
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class EitherTest {
+  @Test fun testEither_CaseAnalysis() {
+    val square: (Int) -> Int = { it * it }
+    val length: (String) -> Int = String::length
+
+    assertEquals(4, Either.Companion.left<Int, String>(2).either(ifLeft = square, ifRight = length))
+    assertEquals(5, Either.Companion.right<Int, String>("hello").either(ifLeft = square, ifRight = length))
+  }
+
+  @Test fun testEither_IsLeft() {
+    val intOrString = Either.Companion.left<Int, String>(1)
+    assertTrue(intOrString.isLeft())
+    assertFalse(intOrString.isRight())
+  }
+
+  @Test fun testEither_IsRight() {
+    val intOrString = Either.Companion.right<Int, String>("hello")
+    assertTrue(intOrString.isRight())
+    assertFalse(intOrString.isLeft())
+  }
+
+  @Test fun testEither_Left() {
+    val intOrString = Either.Companion.left<Int, String>(1)
+    assertEquals(1, intOrString.left)
+    assertEquals(null, intOrString.right)
+  }
+
+  @Test fun testEither_Right() {
+    val intOrString = Either.Companion.right<Int, String>("hello")
+    assertEquals("hello", intOrString.right)
+    assertEquals(null, intOrString.left)
+  }
+}

--- a/app/src/test/java/com/kickstarter/libs/EitherTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/EitherTest.kt
@@ -9,7 +9,7 @@ class EitherTest {
     val square: (Int) -> Int = { it * it }
     val length: (String) -> Int = String::length
 
-    assertEquals(4, Either.Companion.left<Int, String>(2).either(ifLeft = square, ifRight = length))
+    assertEquals(9, Either.Companion.left<Int, String>(3).either(ifLeft = square, ifRight = length))
     assertEquals(5, Either.Companion.right<Int, String>("hello").either(ifLeft = square, ifRight = length))
   }
 
@@ -36,6 +36,14 @@ class EitherTest {
     assertEquals(
       Either.Companion.right<Int, String>("hellohello").right,
       Either.Companion.right<Int, String>("hello").map(double).right
+    )
+  }
+
+  @Test fun testEither_MapLeft() {
+    val square: (Int) -> Int = { it * it }
+    assertEquals(
+      Either.Companion.left<Int, String>(9).left,
+      Either.Companion.left<Int, String>(3).mapLeft(square).left
     )
   }
 

--- a/app/src/test/java/com/kickstarter/libs/EitherTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/EitherTest.kt
@@ -27,13 +27,14 @@ class EitherTest {
 
   @Test fun testEither_Left() {
     val intOrString = Either.Left<Int, String>(1)
-    assertEquals(1, intOrString.left)
+    assertEquals(1, intOrString.left())
   }
 
   @Test fun testEither_Map() {
     val double: (String) -> String = { it + it }
+
     assertEquals(
-      Either.Right<Int, String>("hellohello").right,
+      Either.Right<Int, String>("hellohello").right(),
       Either.Right<Int, String>("hello").map(double).right()
     )
   }
@@ -41,13 +42,13 @@ class EitherTest {
   @Test fun testEither_MapLeft() {
     val square: (Int) -> Int = { it * it }
     assertEquals(
-      Either.Left<Int, String>(9).left,
+      Either.Left<Int, String>(9).left(),
       Either.Left<Int, String>(3).mapLeft(square).left()
     )
   }
 
   @Test fun testEither_Right() {
     val intOrString = Either.Right<Int, String>("hello")
-    assertEquals("hello", intOrString.right)
+    assertEquals("hello", intOrString.right())
   }
 }

--- a/app/src/test/java/com/kickstarter/libs/EitherTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/EitherTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.*
 import org.junit.Test
 
 class EitherTest {
+
   @Test fun testEither_CaseAnalysis() {
     val square: (Int) -> Int = { it * it }
     val length: (String) -> Int = String::length
@@ -28,6 +29,14 @@ class EitherTest {
     val intOrString = Either.Companion.left<Int, String>(1)
     assertEquals(1, intOrString.left)
     assertEquals(null, intOrString.right)
+  }
+
+  @Test fun testEither_Map() {
+    val double: (String) -> String = { it + it }
+    assertEquals(
+      Either.Companion.right<Int, String>("hellohello").right,
+      Either.Companion.right<Int, String>("hello").map(double).right
+    )
   }
 
   @Test fun testEither_Right() {

--- a/app/src/test/java/com/kickstarter/libs/EitherTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/EitherTest.kt
@@ -9,47 +9,45 @@ class EitherTest {
     val square: (Int) -> Int = { it * it }
     val length: (String) -> Int = String::length
 
-    assertEquals(9, Either.Companion.left<Int, String>(3).either(ifLeft = square, ifRight = length))
-    assertEquals(5, Either.Companion.right<Int, String>("hello").either(ifLeft = square, ifRight = length))
+    assertEquals(9, Either.Left<Int, String>(3).either(ifLeft = square, ifRight = length))
+    assertEquals(5, Either.Right<Int, String>("hello").either(ifLeft = square, ifRight = length))
   }
 
   @Test fun testEither_IsLeft() {
-    val intOrString = Either.Companion.left<Int, String>(1)
+    val intOrString = Either.Left<Int, String>(1)
     assertTrue(intOrString.isLeft())
     assertFalse(intOrString.isRight())
   }
 
   @Test fun testEither_IsRight() {
-    val intOrString = Either.Companion.right<Int, String>("hello")
+    val intOrString = Either.Right<Int, String>("hello")
     assertTrue(intOrString.isRight())
     assertFalse(intOrString.isLeft())
   }
 
   @Test fun testEither_Left() {
-    val intOrString = Either.Companion.left<Int, String>(1)
+    val intOrString = Either.Left<Int, String>(1)
     assertEquals(1, intOrString.left)
-    assertEquals(null, intOrString.right)
   }
 
   @Test fun testEither_Map() {
     val double: (String) -> String = { it + it }
     assertEquals(
-      Either.Companion.right<Int, String>("hellohello").right,
-      Either.Companion.right<Int, String>("hello").map(double).right
+      Either.Right<Int, String>("hellohello").right,
+      Either.Right<Int, String>("hello").map(double).right()
     )
   }
 
   @Test fun testEither_MapLeft() {
     val square: (Int) -> Int = { it * it }
     assertEquals(
-      Either.Companion.left<Int, String>(9).left,
-      Either.Companion.left<Int, String>(3).mapLeft(square).left
+      Either.Left<Int, String>(9).left,
+      Either.Left<Int, String>(3).mapLeft(square).left()
     )
   }
 
   @Test fun testEither_Right() {
-    val intOrString = Either.Companion.right<Int, String>("hello")
+    val intOrString = Either.Right<Int, String>("hello")
     assertEquals("hello", intOrString.right)
-    assertEquals(null, intOrString.left)
   }
 }


### PR DESCRIPTION
## heck yes!
Say hello to our first Kotlin class. 🤸‍♂️ 

## what
I ran into this 🤔 💭 moment when setting up our code for native comment support on project updates: since we have comments for *either* projects or updates, and Swift in fact handles this with [its own `Either` type](https://github.com/kickstarter/Kickstarter-Prelude/blob/master/Prelude/Either.swift), 💡, add one to android. Maybe even add it in Kotlin.

Things to note:
* [`companion object`](https://kotlinlang.org/docs/reference/object-declarations.html#companion-objects) allows for us to access `left` and `right` as static methods, while keeping our private constructor
    * this ensures that `Either` objects cannot be created with both values, i.e. 
    ```kotlin
    new Either<Int, String>(1, "don't do this!")
    ```
    * **[EDIT]** Using [sealed class](https://kotlinlang.org/docs/reference/classes.html#sealed-classes) instead, thanks for the suggestion @stephencelis  
* `!= null` checks are repeated rather than the defined `isLeft` and `isRight` functions to satisfy compiler optional warnings ¯\_(ツ)_/¯
* I stopped after adding `mapLeft` due to time, but coming soon will be `flatten()`, `flatMap()`, etc. when we have more time to figure out how to define these functions elegantly without enums

s/o to @mbrandonw for helping me explore this, and @christopherwright for the continued moral support