### PR TITLE
Filter backings from recommended projects

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/DiscoveryDrawerUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/DiscoveryDrawerUtils.java
@@ -142,7 +142,7 @@ public final class DiscoveryDrawerUtils {
 
     if (user != null) {
       filters.add(DiscoveryParams.builder().starred(1).build());
-      filters.add(DiscoveryParams.builder().recommended(true).build());
+      filters.add(DiscoveryParams.builder().recommended(true).backed(-1).build());
 
       if (isTrue(user.social())) {
         filters.add(DiscoveryParams.builder().social(1).build());


### PR DESCRIPTION
hey hi what up

## what is this

This adds `backed(-1)` to the recommendations discovery params.

## why would you do that

We filter user's backed projects from recommendations on web, and we also filter them in the native Thanks activity. Filtering them here will homogenize the backer experience across our platforms and stop people from asking jeff what's up with that rec engine.

The Thanks activity also filters backings from staff picks, so that's a possibility here.
