### PR TITLE
Remove back logic from Update activities

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectUpdatesActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectUpdatesActivity.java
@@ -69,15 +69,6 @@ public class ProjectUpdatesActivity extends BaseActivity<ProjectUpdatesViewModel
   }
 
   @Override
-  public void back() {
-    if (ksWebView.canGoBack()) {
-      ksWebView.goBack();
-    } else {
-      super.back();
-    }
-  }
-
-  @Override
   protected void onResume() {
     super.onResume();
 

--- a/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.java
@@ -86,15 +86,6 @@ public class UpdateActivity extends BaseActivity<UpdateViewModel.ViewModel> impl
   }
 
   @Override
-  public void back() {
-    if (ksWebView.canGoBack()) {
-      ksWebView.goBack();
-    } else {
-      super.back();
-    }
-  }
-
-  @Override
   protected void onResume() {
     super.onResume();
 

--- a/app/src/main/java/com/kickstarter/ui/activities/WebViewActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/WebViewActivity.java
@@ -48,6 +48,8 @@ public final class WebViewActivity extends BaseActivity<WebViewViewModel> implem
 
   @Override
   public void back() {
+    // This logic is sound only for web view activities without RequestHandlers.
+    // TODO: Refactor the client to update web history properly for activities with RequestHandlers.
     if (webView.canGoBack()) {
       webView.goBack();
     } else {


### PR DESCRIPTION
### sad quick PR for posterity
Found a bug in the latest internal build where tapping on `Updates -> Update -> Nav back -> Nav back` (or `Updates -> Comments -> Nav back -> Nav back`) results in a navigation loop. 

This is because any of our WebView activities with `RequestHandler`s handle the requests, but still store said requests in the webview's history. 

This is a gnarlier bug that I'm going to leave out of this next build, meaning that our webviews for updates will continue to function as they do now on production (jank) (sryverysry)