### PR TITLE
Refactor Project VM

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -91,16 +91,20 @@ public final class Koala {
       properties.put("referrer_credit", cookieRefTag.tag());
     }
 
-    client.track("Project Page", properties);
+    // Deprecated event
+    client.track(KoalaEvent.PROJECT_PAGE, properties);
+
+    client.track(KoalaEvent.VIEWED_PROJECT_PAGE, properties);
   }
 
   // PROJECT STAR
   public void trackProjectStar(final @NonNull Project project) {
-    if (project.isStarred()) {
-      client.track("Project Star");
-    } else {
-      client.track("Project Unstar");
-    }
+    final Map<String, Object> props = KoalaUtils.projectProperties(project);
+
+    // Deprecated events
+    client.track(project.isStarred() ? KoalaEvent.PROJECT_STAR : KoalaEvent.PROJECT_UNSTAR, props);
+
+    client.track(project.isStarred() ? KoalaEvent.STARRED_PROJECT : KoalaEvent.UNSTARRED_PROJECT, props);
   }
 
   // COMMENTS

--- a/app/src/main/java/com/kickstarter/libs/KoalaEvent.java
+++ b/app/src/main/java/com/kickstarter/libs/KoalaEvent.java
@@ -12,7 +12,13 @@ public final class KoalaEvent {
   public static final String PROJECT_COMMENT_CREATE = "Project Comment Create";
   public static final String PROJECT_COMMENT_LOAD_OLDER = "Project Comment Load Older";
   public static final String PROJECT_COMMENT_VIEW = "Project Comment View";
+  public static final String PROJECT_PAGE = "Project Page";
+  public static final String PROJECT_STAR = "Project Star";
+  public static final String PROJECT_UNSTAR = "Project Unstar";
+  public static final String STARRED_PROJECT = "Starred Project";
+  public static final String UNSTARRED_PROJECT = "Unstarred Project";
   public static final String VIEWED_COMMENTS = "Viewed Comments";
+  public static final String VIEWED_PROJECT_PAGE = "Viewed Project Page";
   public static final String VIEWED_UPDATE = "Viewed Update";
   public static final String VIEWED_UPDATES = "Viewed Updates";
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
@@ -111,17 +111,17 @@ public final class ProjectActivity extends BaseActivity<ProjectViewModel.ViewMod
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(this::startVideoPlayerActivity);
 
-    this.viewModel.outputs.startCheckout()
+    this.viewModel.outputs.startCheckoutActivity()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(this::startCheckoutActivity);
 
-    this.viewModel.outputs.startManagePledge()
+    this.viewModel.outputs.startManagePledgeActivity()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(this::startManagePledge);
 
-    this.viewModel.outputs.startViewPledge()
+    this.viewModel.outputs.startViewPledgeActivity()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(this::startViewPledgeActivity);

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
@@ -131,7 +131,7 @@ public final class ProjectActivity extends BaseActivity<ProjectViewModel.ViewMod
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(__ -> this.showStarToast());
 
-    this.viewModel.outputs.showLoginTout()
+    this.viewModel.outputs.startLoginToutActivity()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(__ -> this.startLoginToutActivity());

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.java
@@ -165,17 +165,12 @@ public interface ProjectViewModel {
         starredProjectOnLoginSuccess
       );
 
-      projectOnUserChangeStar.mergeWith(starredProjectOnLoginSuccess)
-        .filter(Project::isStarred)
-        .filter(Project::isLive)
-        .filter(p -> !p.isApproachingDeadline())
-        .compose(bindToLifecycle())
-        .subscribe(__ -> this.showStarredPrompt.onNext(null));
+      this.showStarredPrompt = projectOnUserChangeStar.mergeWith(starredProjectOnLoginSuccess)
+        .filter(p -> p.isStarred() && p.isLive() && !p.isApproachingDeadline())
+        .compose(ignoreValues());
 
-      currentProject
-        .compose(combineLatestPair(this.currentConfig.observable().map(Config::countryCode)))
-        .compose(bindToLifecycle())
-        .subscribe(this.projectAndUserCountry::onNext);
+      this.projectAndUserCountry = currentProject
+        .compose(combineLatestPair(this.currentConfig.observable().map(Config::countryCode)));
 
       this.playVideo = currentProject.compose(takeWhen(this.playVideoButtonClicked));
       this.showShareSheet = currentProject.compose(takeWhen(this.shareButtonClicked));
@@ -271,10 +266,10 @@ public interface ProjectViewModel {
     private final PublishSubject<Void> viewPledgeButtonClicked = PublishSubject.create();
 
     private final Observable<Project> playVideo;
-    private final PublishSubject<Pair<Project, String>> projectAndUserCountry = PublishSubject.create();
+    private final Observable<Pair<Project, String>> projectAndUserCountry;
     private final Observable<Void> startLoginToutActivity;
     private final Observable<Project> showShareSheet;
-    private final PublishSubject<Void> showStarredPrompt = PublishSubject.create();
+    private final Observable<Void> showStarredPrompt;
     private final Observable<Project> startCampaignWebViewActivity;
     private final Observable<Project> startCheckoutActivity;
     private final Observable<Project> startCommentsActivity;

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.java
@@ -72,8 +72,8 @@ public interface ProjectViewModel {
     /** Emits when the success prompt for starring should be displayed. */
     Observable<Void> showStarredPrompt();
 
-    /** Emits when a login prompt should be displayed. */
-    Observable<Void> showLoginTout();
+    /** Emits when we should start {@link com.kickstarter.ui.activities.LoginToutActivity}. */
+    Observable<Void> startLoginToutActivity();
 
     /** Emits when we should show the share sheet. */
     Observable<Project> showShareSheet();
@@ -87,7 +87,7 @@ public interface ProjectViewModel {
     /** Emits when we should start the creator bio {@link com.kickstarter.ui.activities.WebViewActivity}. */
     Observable<Project> startCreatorBioWebViewActivity();
 
-    /** Emits when we should start the `ProjectUpdatesActivity.` */
+    /** Emits when we should start {@link com.kickstarter.ui.activities.ProjectUpdatesActivity}. */
     Observable<Project> startProjectUpdatesActivity();
 
     /** Emits when we should start {@link com.kickstarter.ui.activities.CommentsActivity}. */
@@ -96,7 +96,7 @@ public interface ProjectViewModel {
     /** Emits when we should start the {@link com.kickstarter.ui.activities.CheckoutActivity}. */
     Observable<Project> startCheckoutActivity();
 
-    /** Emits when we should start the {@link com.kickstarter.ui.activities.CheckoutActivity} to manage the plege. */
+    /** Emits when we should start the {@link com.kickstarter.ui.activities.CheckoutActivity} to manage the pledge. */
     Observable<Project> startManagePledgeActivity();
 
     /** Emits when we should start the {@link com.kickstarter.ui.activities.ViewPledgeActivity}. */
@@ -135,11 +135,11 @@ public interface ProjectViewModel {
         .flatMap(ProjectIntentMapper::pushNotificationEnvelope);
 
       final Observable<User> loggedInUserOnStarClick = this.currentUser.observable()
-        .compose(takeWhen(this.starButtonClickedSubject))
+        .compose(takeWhen(this.starButtonClicked))
         .filter(u -> u != null);
 
       final Observable<User> loggedOutUserOnStarClick = this.currentUser.observable()
-        .compose(takeWhen(this.starButtonClickedSubject))
+        .compose(takeWhen(this.starButtonClicked))
         .filter(u -> u == null);
 
       final Observable<Project> projectOnUserChangeStar = initialProject
@@ -147,7 +147,7 @@ public interface ProjectViewModel {
         .switchMap(this::toggleProjectStar)
         .share();
 
-      final Observable<Project> starredProjectOnLoginSuccess = this.showLoginTout
+      final Observable<Project> starredProjectOnLoginSuccess = this.startLoginToutActivity
         .compose(combineLatestPair(this.currentUser.observable()))
         .filter(su -> su.second != null)
         .withLatestFrom(initialProject, (__, p) -> p)
@@ -170,24 +170,25 @@ public interface ProjectViewModel {
 
       loggedOutUserOnStarClick
         .compose(bindToLifecycle())
-        .subscribe(__ -> this.showLoginTout.onNext(null));
+        .subscribe(__ -> this.startLoginToutActivity.onNext(null));
 
       currentProject
         .compose(combineLatestPair(this.currentConfig.observable()))
         .map(pc -> Pair.create(pc.first, pc.second.countryCode()))
+        .compose(bindToLifecycle())
         .subscribe(this.projectAndUserCountry::onNext);
 
-      this.playVideo = currentProject.compose(takeWhen(this.playVideoButtonClickedSubject));
-      this.showShareSheet = currentProject.compose(takeWhen(this.shareButtonClickedSubject));
-      this.startCampaignWebViewActivity = currentProject.compose(takeWhen(this.blurbTextViewClickedSubject));
-      this.startCheckoutActivity = currentProject.compose(takeWhen(this.backProjectButtonClickedSubject));
-      this.startCreatorBioWebViewActivity = currentProject.compose(takeWhen(this.creatorNameTextViewClickedSubject));
-      this.startCommentsActivity = currentProject.compose(takeWhen(this.commentsTextViewClickedSubject));
-      this.startManagePledgeActivity = currentProject.compose(takeWhen(this.managePledgeButtonClickedSubject));
-      this.startProjectUpdatesActivity = currentProject.compose(takeWhen(this.updatesTextViewClickedSubject));
-      this.startViewPledgeActivity = currentProject.compose(takeWhen(this.viewPledgeButtonClickedSubject));
+      this.playVideo = currentProject.compose(takeWhen(this.playVideoButtonClicked));
+      this.showShareSheet = currentProject.compose(takeWhen(this.shareButtonClicked));
+      this.startCampaignWebViewActivity = currentProject.compose(takeWhen(this.blurbTextViewClicked));
+      this.startCheckoutActivity = currentProject.compose(takeWhen(this.backProjectButtonClicked));
+      this.startCreatorBioWebViewActivity = currentProject.compose(takeWhen(this.creatorNameTextViewClicked));
+      this.startCommentsActivity = currentProject.compose(takeWhen(this.commentsTextViewClicked));
+      this.startManagePledgeActivity = currentProject.compose(takeWhen(this.managePledgeButtonClicked));
+      this.startProjectUpdatesActivity = currentProject.compose(takeWhen(this.updatesTextViewClicked));
+      this.startViewPledgeActivity = currentProject.compose(takeWhen(this.viewPledgeButtonClicked));
 
-      this.shareButtonClickedSubject
+      this.shareButtonClicked
         .compose(bindToLifecycle())
         .subscribe(__ -> this.koala.trackShowProjectShareSheet());
 
@@ -259,20 +260,20 @@ public interface ProjectViewModel {
         .compose(neverError());
     }
 
-    private final PublishSubject<Void> backProjectButtonClickedSubject = PublishSubject.create();
-    private final PublishSubject<Void> blurbTextViewClickedSubject = PublishSubject.create();
-    private final PublishSubject<Void> commentsTextViewClickedSubject = PublishSubject.create();
-    private final PublishSubject<Void> creatorNameTextViewClickedSubject = PublishSubject.create();
-    private final PublishSubject<Void> managePledgeButtonClickedSubject = PublishSubject.create();
-    private final PublishSubject<Void> playVideoButtonClickedSubject = PublishSubject.create();
-    private final PublishSubject<Void> shareButtonClickedSubject = PublishSubject.create();
-    private final PublishSubject<Void> starButtonClickedSubject = PublishSubject.create();
-    private final PublishSubject<Void> updatesTextViewClickedSubject = PublishSubject.create();
-    private final PublishSubject<Void> viewPledgeButtonClickedSubject = PublishSubject.create();
+    private final PublishSubject<Void> backProjectButtonClicked = PublishSubject.create();
+    private final PublishSubject<Void> blurbTextViewClicked = PublishSubject.create();
+    private final PublishSubject<Void> commentsTextViewClicked = PublishSubject.create();
+    private final PublishSubject<Void> creatorNameTextViewClicked = PublishSubject.create();
+    private final PublishSubject<Void> managePledgeButtonClicked = PublishSubject.create();
+    private final PublishSubject<Void> playVideoButtonClicked = PublishSubject.create();
+    private final PublishSubject<Void> shareButtonClicked = PublishSubject.create();
+    private final PublishSubject<Void> starButtonClicked = PublishSubject.create();
+    private final PublishSubject<Void> updatesTextViewClicked = PublishSubject.create();
+    private final PublishSubject<Void> viewPledgeButtonClicked = PublishSubject.create();
 
     private final Observable<Project> playVideo;
     private final PublishSubject<Pair<Project, String>> projectAndUserCountry = PublishSubject.create();
-    private final PublishSubject<Void> showLoginTout = PublishSubject.create();
+    private final PublishSubject<Void> startLoginToutActivity = PublishSubject.create();
     private final Observable<Project> showShareSheet;
     private final PublishSubject<Void> showStarredPrompt = PublishSubject.create();
     private final Observable<Project> startCampaignWebViewActivity;
@@ -287,22 +288,22 @@ public interface ProjectViewModel {
     public final Outputs outputs = this;
 
     @Override public void backProjectButtonClicked() {
-      this.backProjectButtonClickedSubject.onNext(null);
+      this.backProjectButtonClicked.onNext(null);
     }
     @Override public void blurbTextViewClicked() {
-      this.blurbTextViewClickedSubject.onNext(null);
+      this.blurbTextViewClicked.onNext(null);
     }
     @Override public void commentsTextViewClicked() {
-      this.commentsTextViewClickedSubject.onNext(null);
+      this.commentsTextViewClicked.onNext(null);
     }
     @Override public void creatorNameTextViewClicked() {
-      this.creatorNameTextViewClickedSubject.onNext(null);
+      this.creatorNameTextViewClicked.onNext(null);
     }
     @Override public void managePledgeButtonClicked() {
-      this.managePledgeButtonClickedSubject.onNext(null);
+      this.managePledgeButtonClicked.onNext(null);
     }
     @Override public void playVideoButtonClicked() {
-      this.playVideoButtonClickedSubject.onNext(null);
+      this.playVideoButtonClicked.onNext(null);
     }
     @Override public void projectViewHolderBackProjectClicked(final @NonNull ProjectViewHolder viewHolder) {
       this.backProjectButtonClicked();
@@ -329,16 +330,16 @@ public interface ProjectViewModel {
       this.updatesTextViewClicked();
     }
     @Override public void shareButtonClicked() {
-      this.shareButtonClickedSubject.onNext(null);
+      this.shareButtonClicked.onNext(null);
     }
     @Override public void starButtonClicked() {
-      this.starButtonClickedSubject.onNext(null);
+      this.starButtonClicked.onNext(null);
     }
     @Override public void updatesTextViewClicked() {
-      this.updatesTextViewClickedSubject.onNext(null);
+      this.updatesTextViewClicked.onNext(null);
     }
     @Override public void viewPledgeButtonClicked() {
-      this.viewPledgeButtonClickedSubject.onNext(null);
+      this.viewPledgeButtonClicked.onNext(null);
     }
 
     @Override public @NonNull Observable<Project> playVideo() {
@@ -356,8 +357,8 @@ public interface ProjectViewModel {
     @Override public @NonNull Observable<Project> startCommentsActivity() {
       return this.startCommentsActivity;
     }
-    @Override public @NonNull Observable<Void> showLoginTout() {
-      return this.showLoginTout;
+    @Override public @NonNull Observable<Void> startLoginToutActivity() {
+      return this.startLoginToutActivity;
     }
     @Override public @NonNull Observable<Project> showShareSheet() {
       return this.showShareSheet;

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.java
@@ -209,8 +209,7 @@ public interface ProjectViewModel {
             data.refTagFromIntent,
             RefTagUtils.storedCookieRefTagForProject(data.project, this.cookieManager, this.sharedPreferences)
           );
-        }
-      );
+        });
 
       pushNotificationEnvelope
         .take(1)

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.java
@@ -8,6 +8,7 @@ import com.kickstarter.factories.ProjectFactory;
 import com.kickstarter.factories.UserFactory;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
+import com.kickstarter.libs.KoalaEvent;
 import com.kickstarter.libs.MockCurrentUser;
 import com.kickstarter.models.Project;
 import com.kickstarter.ui.IntentKey;
@@ -32,7 +33,7 @@ public class ProjectViewModelTest extends KSRobolectricTestCase {
 
     projectTest.assertValues(project, project);
 
-    koalaTest.assertValues("Project Page");
+    koalaTest.assertValues(KoalaEvent.PROJECT_PAGE, KoalaEvent.VIEWED_PROJECT_PAGE);
   }
 
   @Test
@@ -47,7 +48,7 @@ public class ProjectViewModelTest extends KSRobolectricTestCase {
     final ProjectViewModel.ViewModel vm = new ProjectViewModel.ViewModel(environment);
 
     final TestSubscriber<Void> loginToutTest = new TestSubscriber<>();
-    vm.outputs.showLoginTout().subscribe(loginToutTest);
+    vm.outputs.startLoginToutActivity().subscribe(loginToutTest);
 
     final TestSubscriber<Void> showStarredPromptTest = new TestSubscriber<>();
     vm.outputs.showStarredPrompt().subscribe(showStarredPromptTest);
@@ -69,7 +70,7 @@ public class ProjectViewModelTest extends KSRobolectricTestCase {
     loginToutTest.assertValueCount(1);
 
     // A koala event for starring should NOT be tracked
-    koalaTest.assertValues("Project Page");
+    koalaTest.assertValues(KoalaEvent.PROJECT_PAGE, KoalaEvent.VIEWED_PROJECT_PAGE);
 
     // Login
     currentUser.refresh(UserFactory.user());
@@ -79,7 +80,9 @@ public class ProjectViewModelTest extends KSRobolectricTestCase {
     showStarredPromptTest.assertValueCount(1);
 
     // A koala event for starring should be tracked
-    koalaTest.assertValues("Project Page", "Project Star");
+    koalaTest.assertValues(
+      KoalaEvent.PROJECT_PAGE, KoalaEvent.VIEWED_PROJECT_PAGE, KoalaEvent.PROJECT_STAR, KoalaEvent.STARRED_PROJECT
+    );
   }
 
   @Test


### PR DESCRIPTION
## wut
More project view model modernization / cleanup:
* Removed our weird ` private final BehaviorSubject<Project> project = BehaviorSubject.create();` that was neither an input nor an output
* Made all outputs `Observable`s
* Added `currentProject` logic (I think back then we just didn't use `Observable.merge(...)` yet) to distinguish from `initialProject` logic as the project changes on login / starring
* Updated 🐨 events
* Renamed outputs to be more explicit. A lot of noise is from this, sry not sry