### PR TITLE
Not all signup errors are created equal.

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/SignupActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/SignupActivity.java
@@ -41,7 +41,6 @@ public final class SignupActivity extends BaseActivity<SignupViewModel> {
   @Bind(R.id.disclaimer) TextView disclaimerTextView;
 
   @BindString(R.string.signup_button) String signUpString;
-  @BindString(R.string.signup_error_title) String errorTitleString;
 
   @Override
   protected void onCreate(final @Nullable Bundle savedInstanceState) {
@@ -74,7 +73,7 @@ public final class SignupActivity extends BaseActivity<SignupViewModel> {
     viewModel.errors.signupError()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
-      .subscribe(e -> ViewUtils.showDialog(this, errorTitleString, e));
+      .subscribe(e -> ViewUtils.showDialog(this, null, e));
 
     RxView.clicks(newsletterSwitch)
       .skip(1)

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,10 @@
 buildscript {
-    ext.kotlin_version = '1.0.7'
     repositories {
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.google.gms:google-services:3.0.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,12 @@
 buildscript {
+    ext.kotlin_version = '1.0.7'
     repositories {
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.google.gms:google-services:3.0.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 


### PR DESCRIPTION
Some signup errors aren't really errors (tho their http status code is 4xx), such as when we ask the user to verify their email. This will come up more often with guest checkout stuff.

So, let's just not show the "Sign up error" title in the dialog, and just show the message that the server provided us.