### PR TITLE
Remove getFragments() usage

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
@@ -30,6 +30,7 @@ import com.kickstarter.ui.toolbars.DiscoveryToolbar;
 import com.kickstarter.ui.views.SortTabLayout;
 import com.kickstarter.viewmodels.DiscoveryViewModel;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -81,18 +82,14 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel> {
     drawerAdapter = new DiscoveryDrawerAdapter(viewModel.inputs);
     drawerRecyclerView.setAdapter(drawerAdapter);
 
-    final List<String> viewPagerTitles = Arrays.asList(homeString, popularString, newestString, endingSoonString,
-      mostFundedString);
-
-    final List<DiscoveryFragment> fragments = Arrays.asList(
-      DiscoveryFragment.newInstance(0),
-      DiscoveryFragment.newInstance(1),
-      DiscoveryFragment.newInstance(2),
-      DiscoveryFragment.newInstance(3),
-      DiscoveryFragment.newInstance(4)
+    final List<String> viewPagerTitles = Arrays.asList(
+      homeString, popularString, newestString, endingSoonString, mostFundedString
     );
 
-    pagerAdapter = new DiscoveryPagerAdapter(getSupportFragmentManager(), fragments, viewPagerTitles, viewModel.inputs);
+    pagerAdapter = new DiscoveryPagerAdapter(
+      getSupportFragmentManager(), createFragments(viewPagerTitles.size()), viewPagerTitles, viewModel.inputs
+    );
+
     sortViewPager.setAdapter(pagerAdapter);
     sortTabLayout.setupWithViewPager(sortViewPager);
 
@@ -161,6 +158,14 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel> {
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(viewModel.inputs::openDrawer);
+  }
+
+  private static @NonNull List<DiscoveryFragment> createFragments(final int pages) {
+    List<DiscoveryFragment> fragments = new ArrayList<>(pages);
+    for (int position = 0; position <= pages; position++) {
+      fragments.add(DiscoveryFragment.newInstance(position ));
+    }
+    return fragments;
   }
 
   public @NonNull DrawerLayout discoveryLayout() {

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
@@ -25,6 +25,7 @@ import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.adapters.DiscoveryDrawerAdapter;
 import com.kickstarter.ui.adapters.DiscoveryPagerAdapter;
 import com.kickstarter.ui.data.LoginReason;
+import com.kickstarter.ui.fragments.DiscoveryFragment;
 import com.kickstarter.ui.toolbars.DiscoveryToolbar;
 import com.kickstarter.ui.views.SortTabLayout;
 import com.kickstarter.viewmodels.DiscoveryViewModel;
@@ -82,7 +83,16 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel> {
 
     final List<String> viewPagerTitles = Arrays.asList(homeString, popularString, newestString, endingSoonString,
       mostFundedString);
-    pagerAdapter = new DiscoveryPagerAdapter(getSupportFragmentManager(), viewPagerTitles, viewModel.inputs);
+
+    final List<DiscoveryFragment> fragments = Arrays.asList(
+      DiscoveryFragment.newInstance(0),
+      DiscoveryFragment.newInstance(1),
+      DiscoveryFragment.newInstance(2),
+      DiscoveryFragment.newInstance(3),
+      DiscoveryFragment.newInstance(4)
+    );
+
+    pagerAdapter = new DiscoveryPagerAdapter(getSupportFragmentManager(), fragments, viewPagerTitles, viewModel.inputs);
     sortViewPager.setAdapter(pagerAdapter);
     sortTabLayout.setupWithViewPager(sortViewPager);
 

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
@@ -161,9 +161,9 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel> {
   }
 
   private static @NonNull List<DiscoveryFragment> createFragments(final int pages) {
-    List<DiscoveryFragment> fragments = new ArrayList<>(pages);
+    final List<DiscoveryFragment> fragments = new ArrayList<>(pages);
     for (int position = 0; position <= pages; position++) {
-      fragments.add(DiscoveryFragment.newInstance(position ));
+      fragments.add(DiscoveryFragment.newInstance(position));
     }
     return fragments;
   }

--- a/app/src/main/java/com/kickstarter/ui/adapters/DiscoveryPagerAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/DiscoveryPagerAdapter.java
@@ -18,30 +18,40 @@ import rx.Observable;
 
 public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
   private final Delegate delegate;
-  private final FragmentManager fragmentManager;
+//  private final FragmentManager fragmentManager;
   private List<String> pageTitles;
+  private List<DiscoveryFragment> fragments;
 
   public interface Delegate {
     void discoveryPagerAdapterSetPrimaryPage(DiscoveryPagerAdapter adapter, int position);
   }
 
-  public DiscoveryPagerAdapter(final @NonNull FragmentManager fragmentManager, final @NonNull List<String> pageTitles,
-    final Delegate delegate) {
+  public DiscoveryPagerAdapter(final @NonNull FragmentManager fragmentManager, final @NonNull List<DiscoveryFragment> fragments,
+    final @NonNull List<String> pageTitles, final Delegate delegate) {
     super(fragmentManager);
     this.delegate = delegate;
-    this.fragmentManager = fragmentManager;
+//    this.fragmentManager = fragmentManager;
+    this.fragments = fragments;
     this.pageTitles = pageTitles;
   }
 
   @Override
   public void setPrimaryItem(final @NonNull ViewGroup container, final int position, final @NonNull Object object) {
     super.setPrimaryItem(container, position, object);
+
     delegate.discoveryPagerAdapterSetPrimaryPage(this, position);
   }
 
   @Override
+  public @NonNull Object instantiateItem(final @NonNull ViewGroup container, final int position) {
+    final DiscoveryFragment fragment = (DiscoveryFragment) super.instantiateItem(container, position);
+    this.fragments.set(position, fragment);
+    return fragment;
+  }
+
+  @Override
   public @NonNull Fragment getItem(final int position) {
-    return DiscoveryFragment.newInstance(position);
+    return this.fragments.get(position);
   }
 
   @Override
@@ -58,8 +68,8 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
    * Passes along root categories to its fragment position to help fetch appropriate projects.
    */
   public void takeCategoriesForPosition(final @NonNull List<Category> categories, final int position) {
-    Observable.from(fragmentManager.getFragments())
-      .ofType(DiscoveryFragment.class)
+    Observable.from(this.fragments)
+      .filter(DiscoveryFragment::isAdded)
       .filter(frag -> {
         final int fragmentPosition = frag.getArguments().getInt(ArgumentsKey.DISCOVERY_SORT_POSITION);
         return fragmentPosition == position;
@@ -71,8 +81,8 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
    * Take current params from activity and pass to the appropriate fragment.
    */
   public void takeParams(final @NonNull DiscoveryParams params) {
-    Observable.from(fragmentManager.getFragments())
-      .ofType(DiscoveryFragment.class)
+    Observable.from(this.fragments)
+      .filter(DiscoveryFragment::isAdded) // this filters out fragments on rotation for some reason
       .filter(frag -> {
         final int fragmentPosition = frag.getArguments().getInt(ArgumentsKey.DISCOVERY_SORT_POSITION);
         return DiscoveryUtils.positionFromSort(params.sort()) == fragmentPosition;
@@ -84,8 +94,8 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
    * Call when the view model tells us to clear specific pages.
    */
   public void clearPages(final @NonNull List<Integer> pages) {
-    Observable.from(fragmentManager.getFragments())
-      .ofType(DiscoveryFragment.class)
+    Observable.from(this.fragments)
+      .filter(DiscoveryFragment::isAdded)
       .filter(frag -> {
         final int fragmentPosition = frag.getArguments().getInt(ArgumentsKey.DISCOVERY_SORT_POSITION);
         return pages.contains(fragmentPosition);

--- a/app/src/main/java/com/kickstarter/ui/adapters/DiscoveryPagerAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/DiscoveryPagerAdapter.java
@@ -18,9 +18,8 @@ import rx.Observable;
 
 public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
   private final Delegate delegate;
-//  private final FragmentManager fragmentManager;
-  private List<String> pageTitles;
   private List<DiscoveryFragment> fragments;
+  private List<String> pageTitles;
 
   public interface Delegate {
     void discoveryPagerAdapterSetPrimaryPage(DiscoveryPagerAdapter adapter, int position);
@@ -29,8 +28,8 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
   public DiscoveryPagerAdapter(final @NonNull FragmentManager fragmentManager, final @NonNull List<DiscoveryFragment> fragments,
     final @NonNull List<String> pageTitles, final Delegate delegate) {
     super(fragmentManager);
+
     this.delegate = delegate;
-//    this.fragmentManager = fragmentManager;
     this.fragments = fragments;
     this.pageTitles = pageTitles;
   }
@@ -38,8 +37,7 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
   @Override
   public void setPrimaryItem(final @NonNull ViewGroup container, final int position, final @NonNull Object object) {
     super.setPrimaryItem(container, position, object);
-
-    delegate.discoveryPagerAdapterSetPrimaryPage(this, position);
+    this.delegate.discoveryPagerAdapterSetPrimaryPage(this, position);
   }
 
   @Override
@@ -61,7 +59,7 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
 
   @Override
   public CharSequence getPageTitle(final int position) {
-    return pageTitles.get(position);
+    return this.pageTitles.get(position);
   }
 
   /**
@@ -69,7 +67,7 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
    */
   public void takeCategoriesForPosition(final @NonNull List<Category> categories, final int position) {
     Observable.from(this.fragments)
-      .filter(DiscoveryFragment::isAdded)
+      .filter(DiscoveryFragment::isInstantiated)
       .filter(frag -> {
         final int fragmentPosition = frag.getArguments().getInt(ArgumentsKey.DISCOVERY_SORT_POSITION);
         return fragmentPosition == position;
@@ -82,7 +80,7 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
    */
   public void takeParams(final @NonNull DiscoveryParams params) {
     Observable.from(this.fragments)
-      .filter(DiscoveryFragment::isAdded) // this filters out fragments on rotation for some reason
+      .filter(DiscoveryFragment::isInstantiated)
       .filter(frag -> {
         final int fragmentPosition = frag.getArguments().getInt(ArgumentsKey.DISCOVERY_SORT_POSITION);
         return DiscoveryUtils.positionFromSort(params.sort()) == fragmentPosition;
@@ -95,7 +93,7 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
    */
   public void clearPages(final @NonNull List<Integer> pages) {
     Observable.from(this.fragments)
-      .filter(DiscoveryFragment::isAdded)
+      .filter(DiscoveryFragment::isInstantiated)
       .filter(frag -> {
         final int fragmentPosition = frag.getArguments().getInt(ArgumentsKey.DISCOVERY_SORT_POSITION);
         return pages.contains(fragmentPosition);

--- a/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
+++ b/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
@@ -4,7 +4,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -44,7 +43,7 @@ public final class DiscoveryFragment extends BaseFragment<DiscoveryFragmentViewM
 
   public DiscoveryFragment() {}
 
-  public static @NonNull Fragment newInstance(final int position) {
+  public static @NonNull DiscoveryFragment newInstance(final int position) {
     final DiscoveryFragment fragment = new DiscoveryFragment();
     final Bundle bundle = new Bundle();
     bundle.putInt(ArgumentsKey.DISCOVERY_SORT_POSITION, position);

--- a/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
+++ b/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
@@ -115,6 +115,10 @@ public final class DiscoveryFragment extends BaseFragment<DiscoveryFragmentViewM
     }
   }
 
+  public boolean isInstantiated() {
+    return this.recyclerView != null;
+  }
+
   private void startActivityUpdateActivity(final @NonNull Activity activity) {
     final Intent intent = new Intent(getActivity(), WebViewActivity.class)
       .putExtra(IntentKey.URL, activity.projectUpdateUrl());


### PR DESCRIPTION
## what
It all began in #79 when @coryroy discovered that the upgraded linter no longer allowed us to use `getFragments()` from `FragmentManager`. This fix removes our usage of `getFragments()` from our `DiscoveryPagerAdapter`, a method we relied on to get references to our fragments safely for our sort pages.

The plan is to merge this in first, then we can go ahead with merging in #79 to get us onto the latest greatest Android Studio and gradle. 

## why
Turns out that `FragmentManager` always had an annotation to restrict its `getFragments()` usage, but since the method was still public our linter previously allowed it:
```java
@RestrictTo(LIBRARY_GROUP)
public abstract List<Fragment> getFragments();
```

## how
We know the `FragmentPagerAdapter` is finicky with keeping its references to instantiated fragments on rotation, so the biggest challenge was, is, and will always be to keep reliable references to non-null fragment views. Let's use our existing infrastructure to help us:

1. Create the `DiscoveryFragment`s in the Activity and pass them to the adapter. This way we know for sure that the lifecycle of the fragments is tied with the lifecycle of our parent activity.
2. Use the pager adapter's [`instantiateItem`](https://developer.android.com/reference/android/support/v4/app/FragmentPagerAdapter.html#instantiateItem) method to update our fragments when they get re-instantiated.
3. Add an `isInstantiated` helper in the `DiscoveryFragment` to filter for fragments that are actually ready to take data.