### PR TITLE
Bump Kotlin version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -188,7 +188,7 @@ dependencies {
 }
 
 buildscript {
-    ext.kotlin_version = '1.0.6'
+    ext.kotlin_version = '1.1.2'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
Hooray let's get on the latest (stable) Kotlin! Kotlin files are still slim, so no breaking changes.

https://blog.jetbrains.com/kotlin/2017/04/kotlin-1-1-2-is-out/

If Android Studio isn't or hasn't been prompting you already to upgrade your plugin, go to `Tools > Kotlin > Configure Kotlin Plugin Updates` and check for updates. 