### PR TITLE
Add feature flags to config, implement for messages

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Config.java
+++ b/app/src/main/java/com/kickstarter/libs/Config.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import com.kickstarter.libs.qualifiers.AutoGson;
 
 import java.util.List;
+import java.util.Map;
 
 import auto.parcel.AutoParcel;
 
@@ -13,11 +14,13 @@ import auto.parcel.AutoParcel;
 @AutoParcel
 public abstract class Config implements Parcelable {
   public abstract String countryCode();
+  public abstract Map<String, Boolean> features();
   public abstract List<LaunchedCountry> launchedCountries();
 
   @AutoParcel.Builder
   public abstract static class Builder {
     public abstract Builder countryCode(String __);
+    public abstract Builder features(Map<String, Boolean> __);
     public abstract Builder launchedCountries(List<LaunchedCountry> __);
     public abstract Config build();
   }

--- a/app/src/main/java/com/kickstarter/libs/CurrentUser.java
+++ b/app/src/main/java/com/kickstarter/libs/CurrentUser.java
@@ -73,7 +73,7 @@ public class CurrentUser extends CurrentUserType {
   }
 
   @Override
-  public Observable<User> observable() {
+  public @NonNull Observable<User> observable() {
     return user;
   }
 }

--- a/app/src/main/java/com/kickstarter/libs/FeatureKey.java
+++ b/app/src/main/java/com/kickstarter/libs/FeatureKey.java
@@ -1,0 +1,7 @@
+package com.kickstarter.libs;
+
+public final class FeatureKey {
+  private FeatureKey() {}
+
+  public static final String ANDROID_MESSAGES = "android_messages";
+}

--- a/app/src/main/java/com/kickstarter/ui/activities/ProfileActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProfileActivity.java
@@ -23,6 +23,7 @@ import com.kickstarter.libs.utils.ViewUtils;
 import com.kickstarter.models.Project;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.adapters.ProfileAdapter;
+import com.kickstarter.ui.views.IconButton;
 import com.kickstarter.viewmodels.ProfileViewModel;
 import com.squareup.picasso.Picasso;
 
@@ -45,6 +46,7 @@ public final class ProfileActivity extends BaseActivity<ProfileViewModel.ViewMod
   protected @Bind(R.id.created_text_view) TextView createdTextView;
   protected @Bind(R.id.backed_text_view) TextView backedTextView;
   protected @Bind(R.id.divider_view) View dividerView;
+  protected @Bind(R.id.messages_button) IconButton messagesButton;
   protected @Bind(R.id.recycler_view) RecyclerView recyclerView;
 
   @Override
@@ -99,6 +101,11 @@ public final class ProfileActivity extends BaseActivity<ProfileViewModel.ViewMod
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(ViewUtils.setGone(this.dividerView));
+
+    this.viewModel.outputs.messagesButtonHidden()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(ViewUtils.setGone(this.messagesButton));
 
     viewModel.outputs.projects()
       .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/activities/ProfileActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProfileActivity.java
@@ -34,20 +34,22 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 import rx.android.schedulers.AndroidSchedulers;
 
+import static com.kickstarter.libs.rx.transformers.Transformers.observeForUI;
+
 @RequiresActivityViewModel(ProfileViewModel.ViewModel.class)
 public final class ProfileActivity extends BaseActivity<ProfileViewModel.ViewModel> {
   private ProfileAdapter adapter;
   private RecyclerViewPaginator paginator;
 
   protected @Bind(R.id.avatar_image_view) ImageView avatarImageView;
-  protected @Bind(R.id.user_name_text_view) TextView userNameTextView;
-  protected @Bind(R.id.created_count_text_view) TextView createdCountTextView;
   protected @Bind(R.id.backed_count_text_view) TextView backedCountTextView;
-  protected @Bind(R.id.created_text_view) TextView createdTextView;
   protected @Bind(R.id.backed_text_view) TextView backedTextView;
+  protected @Bind(R.id.created_count_text_view) TextView createdCountTextView;
+  protected @Bind(R.id.created_text_view) TextView createdTextView;
   protected @Bind(R.id.divider_view) View dividerView;
   protected @Bind(R.id.messages_button) IconButton messagesButton;
   protected @Bind(R.id.recycler_view) RecyclerView recyclerView;
+  protected @Bind(R.id.user_name_text_view) TextView userNameTextView;
 
   @Override
   protected void onCreate(final @Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProfileActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProfileActivity.java
@@ -32,7 +32,6 @@ import java.util.List;
 import butterknife.Bind;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import rx.android.schedulers.AndroidSchedulers;
 
 import static com.kickstarter.libs.rx.transformers.Transformers.observeForUI;
 
@@ -66,42 +65,42 @@ public final class ProfileActivity extends BaseActivity<ProfileViewModel.ViewMod
 
     this.viewModel.outputs.avatarImageViewUrl()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(url -> Picasso.with(this).load(url).transform(new CircleTransformation()).into(this.avatarImageView));
 
     this.viewModel.outputs.backedCountTextViewHidden()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(ViewUtils.setGone(this.backedCountTextView));
 
     this.viewModel.outputs.backedCountTextViewText()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(this.backedCountTextView::setText);
 
     this.viewModel.outputs.backedTextViewHidden()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(ViewUtils.setGone(this.backedTextView));
 
     this.viewModel.outputs.createdCountTextViewHidden()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(ViewUtils.setGone(this.createdCountTextView));
 
     this.viewModel.outputs.createdCountTextViewText()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(this.createdCountTextView::setText);
 
     this.viewModel.outputs.createdTextViewHidden()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(ViewUtils.setGone(this.createdTextView));
 
     this.viewModel.outputs.dividerViewHidden()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(ViewUtils.setGone(this.dividerView));
 
     this.viewModel.outputs.messagesButtonHidden()
@@ -111,27 +110,27 @@ public final class ProfileActivity extends BaseActivity<ProfileViewModel.ViewMod
 
     this.viewModel.outputs.projects()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(this::loadProjects);
 
     this.viewModel.outputs.resumeDiscoveryActivity()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(__ -> resumeDiscoveryActivity());
 
     this.viewModel.outputs.startMessageThreadsActivity()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(__ -> this.startMessageThreadsActivity());
 
     this.viewModel.outputs.startProjectActivity()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(this::startProjectActivity);
 
     this.viewModel.outputs.userNameTextViewText()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(this.userNameTextView::setText);
   }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ProfileActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProfileActivity.java
@@ -57,49 +57,49 @@ public final class ProfileActivity extends BaseActivity<ProfileViewModel.ViewMod
     setContentView(R.layout.profile_layout);
     ButterKnife.bind(this);
 
-    adapter = new ProfileAdapter(viewModel);
+    this.adapter = new ProfileAdapter(viewModel);
     final int spanCount = ViewUtils.isLandscape(this) ? 3 : 2;
-    recyclerView.setLayoutManager(new GridLayoutManager(this, spanCount));
-    recyclerView.setAdapter(adapter);
+    this.recyclerView.setLayoutManager(new GridLayoutManager(this, spanCount));
+    this.recyclerView.setAdapter(this.adapter);
 
-    paginator = new RecyclerViewPaginator(recyclerView, viewModel.inputs::nextPage);
+    this.paginator = new RecyclerViewPaginator(this.recyclerView, this.viewModel.inputs::nextPage);
 
-    viewModel.outputs.avatarImageViewUrl()
+    this.viewModel.outputs.avatarImageViewUrl()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
-      .subscribe(url -> Picasso.with(this).load(url).transform(new CircleTransformation()).into(avatarImageView));
+      .subscribe(url -> Picasso.with(this).load(url).transform(new CircleTransformation()).into(this.avatarImageView));
 
-    viewModel.outputs.backedCountTextViewHidden()
+    this.viewModel.outputs.backedCountTextViewHidden()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(ViewUtils.setGone(this.backedCountTextView));
 
-    viewModel.outputs.backedCountTextViewText()
+    this.viewModel.outputs.backedCountTextViewText()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(this.backedCountTextView::setText);
 
-    viewModel.outputs.backedTextViewHidden()
+    this.viewModel.outputs.backedTextViewHidden()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(ViewUtils.setGone(this.backedTextView));
 
-    viewModel.outputs.createdCountTextViewHidden()
+    this.viewModel.outputs.createdCountTextViewHidden()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(ViewUtils.setGone(this.createdCountTextView));
 
-    viewModel.outputs.createdCountTextViewText()
+    this.viewModel.outputs.createdCountTextViewText()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(this.createdCountTextView::setText);
 
-    viewModel.outputs.createdTextViewHidden()
+    this.viewModel.outputs.createdTextViewHidden()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(ViewUtils.setGone(this.createdTextView));
 
-    viewModel.outputs.dividerViewHidden()
+    this.viewModel.outputs.dividerViewHidden()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(ViewUtils.setGone(this.dividerView));
@@ -109,27 +109,27 @@ public final class ProfileActivity extends BaseActivity<ProfileViewModel.ViewMod
       .compose(observeForUI())
       .subscribe(ViewUtils.setGone(this.messagesButton));
 
-    viewModel.outputs.projects()
+    this.viewModel.outputs.projects()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(this::loadProjects);
 
-    viewModel.outputs.resumeDiscoveryActivity()
+    this.viewModel.outputs.resumeDiscoveryActivity()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(__ -> resumeDiscoveryActivity());
 
-    viewModel.outputs.startMessageThreadsActivity()
+    this.viewModel.outputs.startMessageThreadsActivity()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(__ -> this.startMessageThreadsActivity());
 
-    viewModel.outputs.startProjectActivity()
+    this.viewModel.outputs.startProjectActivity()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(this::startProjectActivity);
 
-    viewModel.outputs.userNameTextViewText()
+    this.viewModel.outputs.userNameTextViewText()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(this.userNameTextView::setText);
@@ -138,31 +138,34 @@ public final class ProfileActivity extends BaseActivity<ProfileViewModel.ViewMod
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    paginator.stop();
-    recyclerView.setAdapter(null);
+    this.paginator.stop();
+    this.recyclerView.setAdapter(null);
   }
 
   @OnClick(R.id.messages_button)
   public void messagesButtonClicked() {
-    viewModel.inputs.messsagesButtonClicked();
+    this.viewModel.inputs.messsagesButtonClicked();
   }
 
   private void loadProjects(final @NonNull List<Project> projects) {
     if (projects.size() == 0) {
-      recyclerView.setLayoutManager(new LinearLayoutManager(this));
-      recyclerView.setPadding(0, recyclerView.getPaddingTop(), recyclerView.getPaddingRight(), recyclerView.getPaddingBottom());
+      this.recyclerView.setLayoutManager(new LinearLayoutManager(this));
+      this.recyclerView.setPadding(
+        0, this.recyclerView.getPaddingTop(), this.recyclerView.getPaddingRight(), this.recyclerView.getPaddingBottom()
+      );
+
       if (ViewUtils.isPortrait(this)) {
         disableNestedScrolling();
       }
     }
 
-    adapter.takeProjects(projects);
+    this.adapter.takeProjects(projects);
   }
 
   @TargetApi(21)
   private void disableNestedScrolling() {
     if (ApiCapabilities.canSetNestingScrollingEnabled()) {
-      recyclerView.setNestedScrollingEnabled(false);
+      this.recyclerView.setNestedScrollingEnabled(false);
     }
   }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.java
@@ -8,7 +8,6 @@ import com.kickstarter.libs.ApiPaginator;
 import com.kickstarter.libs.CurrentConfigType;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
-import com.kickstarter.libs.rx.transformers.Transformers;
 import com.kickstarter.libs.utils.IntegerUtils;
 import com.kickstarter.libs.utils.NumberUtils;
 import com.kickstarter.models.Project;
@@ -25,6 +24,8 @@ import java.util.List;
 
 import rx.Observable;
 import rx.subjects.PublishSubject;
+
+import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
 
 public interface ProfileViewModel {
 
@@ -100,7 +101,7 @@ public interface ProfileViewModel {
 
       final Observable<User> freshUser = this.client.fetchCurrentUser()
         .retry(2)
-        .compose(Transformers.neverError());
+        .compose(neverError());
       freshUser.subscribe(this.currentUser::refresh);
 
       final DiscoveryParams params = DiscoveryParams.builder()

--- a/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.java
@@ -151,7 +151,7 @@ public interface ProfileViewModel {
         .map(p -> p.first || p.second);
 
       this.messagesButtonHidden = this.currentConfig.observable()
-        .map(config -> !coalesce(config.features().get(FeatureKey.ANDROID_MESSAGES) , true));
+        .map(config -> !coalesce(config.features().get(FeatureKey.ANDROID_MESSAGES), true));
 
       this.projects = paginator.paginatedData();
       this.resumeDiscoveryActivity = this.exploreProjectsButtonClicked;

--- a/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.java
@@ -5,6 +5,7 @@ import android.util.Pair;
 
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.ApiPaginator;
+import com.kickstarter.libs.CurrentConfigType;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.rx.transformers.Transformers;
@@ -66,8 +67,14 @@ public interface ProfileViewModel {
     /** Emits when the divider view should be hidden. */
     Observable<Boolean> dividerViewHidden();
 
+    /** Emits when the messages button should be hidden. */
+    Observable<Boolean> messagesButtonHidden();
+
     /** Emits a list of projects to display in the profile. */
     Observable<List<Project>> projects();
+
+    /** Emits when we should resume the {@link com.kickstarter.ui.activities.DiscoveryActivity}. */
+    Observable<Void> resumeDiscoveryActivity();
 
     /** Emits when we should start the {@link com.kickstarter.ui.activities.MessageThreadsActivity}. */
     Observable<Void> startMessageThreadsActivity();
@@ -75,21 +82,20 @@ public interface ProfileViewModel {
     /** Emits when we should start the {@link com.kickstarter.ui.activities.ProjectActivity}. */
     Observable<Project> startProjectActivity();
 
-    /** Emits when we should resume the {@link com.kickstarter.ui.activities.DiscoveryActivity}. */
-    Observable<Void> resumeDiscoveryActivity();
-
     /** Emits the user name to be displayed. */
     Observable<String> userNameTextViewText();
   }
 
   final class ViewModel extends ActivityViewModel<ProfileActivity> implements ProfileAdapter.Delegate, Inputs, Outputs {
     private final ApiClientType client;
+    private final CurrentConfigType currentConfig;
     private final CurrentUserType currentUser;
 
     public ViewModel(final @NonNull Environment environment) {
       super(environment);
 
       this.client = environment.apiClient();
+      this.currentConfig = environment.currentConfig();
       this.currentUser = environment.currentUser();
 
       final Observable<User> freshUser = this.client.fetchCurrentUser()
@@ -141,6 +147,9 @@ public interface ProfileViewModel {
       )
         .map(p -> p.first || p.second);
 
+      this.messagesButtonHidden = this.currentConfig.observable()
+        .map(config -> !config.features().getOrDefault("android_messages", false));
+
       this.projects = paginator.paginatedData();
       this.resumeDiscoveryActivity = this.exploreProjectsButtonClicked;
       this.startProjectActivity = this.projectCardClicked;
@@ -163,6 +172,7 @@ public interface ProfileViewModel {
     private final Observable<String> createdCountTextViewText;
     private final Observable<Boolean> createdTextViewHidden;
     private final Observable<Boolean> dividerViewHidden;
+    private final Observable<Boolean> messagesButtonHidden;
     private final Observable<List<Project>> projects;
     private final Observable<Void> resumeDiscoveryActivity;
     private final Observable<Project> startProjectActivity;
@@ -214,6 +224,9 @@ public interface ProfileViewModel {
     }
     @Override public @NonNull Observable<Boolean> dividerViewHidden() {
       return this.dividerViewHidden;
+    }
+    @Override public @NonNull Observable<Boolean> messagesButtonHidden() {
+      return this.messagesButtonHidden;
     }
     @Override public @NonNull Observable<List<Project>> projects() {
       return this.projects;

--- a/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.java
@@ -8,6 +8,7 @@ import com.kickstarter.libs.ApiPaginator;
 import com.kickstarter.libs.CurrentConfigType;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
+import com.kickstarter.libs.FeatureKey;
 import com.kickstarter.libs.utils.IntegerUtils;
 import com.kickstarter.libs.utils.NumberUtils;
 import com.kickstarter.models.Project;
@@ -26,6 +27,7 @@ import rx.Observable;
 import rx.subjects.PublishSubject;
 
 import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
+import static com.kickstarter.libs.utils.ObjectUtils.coalesce;
 
 public interface ProfileViewModel {
 
@@ -149,7 +151,7 @@ public interface ProfileViewModel {
         .map(p -> p.first || p.second);
 
       this.messagesButtonHidden = this.currentConfig.observable()
-        .map(config -> !config.features().getOrDefault("android_messages", false));
+        .map(config -> !coalesce(config.features().get(FeatureKey.ANDROID_MESSAGES) , true));
 
       this.projects = paginator.paginatedData();
       this.resumeDiscoveryActivity = this.exploreProjectsButtonClicked;

--- a/app/src/main/res/layout/profile_toolbar.xml
+++ b/app/src/main/res/layout/profile_toolbar.xml
@@ -26,7 +26,7 @@
       android:contentDescription="@string/general_navigation_accessibility_button_navigate_back_label"
       android:text="@string/arrow_back_icon" />
 
-    <com.kickstarter.ui.views.IconTextView
+    <com.kickstarter.ui.views.IconButton
       app:iconType="ss_kickstarter"
       style="@style/ToolbarIcon"
       android:id="@+id/messages_button"

--- a/app/src/test/java/com/kickstarter/factories/ConfigFactory.java
+++ b/app/src/test/java/com/kickstarter/factories/ConfigFactory.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import com.kickstarter.libs.Config;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 public final class ConfigFactory {
   private ConfigFactory() {}
@@ -33,6 +34,7 @@ public final class ConfigFactory {
 
     return Config.builder()
       .countryCode("US")
+      .features(Collections.emptyMap())
       .launchedCountries(Arrays.asList(US, GB, CA))
       .build();
   }

--- a/app/src/test/java/com/kickstarter/viewmodels/ProfileViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProfileViewModelTest.java
@@ -9,6 +9,7 @@ import com.kickstarter.factories.ProjectFactory;
 import com.kickstarter.factories.UserFactory;
 import com.kickstarter.libs.Config;
 import com.kickstarter.libs.Environment;
+import com.kickstarter.libs.FeatureKey;
 import com.kickstarter.libs.KoalaEvent;
 import com.kickstarter.libs.MockCurrentConfig;
 import com.kickstarter.libs.utils.NumberUtils;
@@ -185,10 +186,10 @@ public class ProfileViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testProfileViewModel_MessagesButtonHidden() {
+  public void testProfileViewModel_MessagesButton_EnabledFeature() {
     final Config config = ConfigFactory.config()
       .toBuilder()
-      .features(Collections.singletonMap("android_messages", false))
+      .features(Collections.singletonMap(FeatureKey.ANDROID_MESSAGES, false))
       .build();
 
     final MockCurrentConfig currentConfig = new MockCurrentConfig();
@@ -198,6 +199,38 @@ public class ProfileViewModelTest extends KSRobolectricTestCase {
 
     // Messages button hidden for config with disabled feature flag.
     this.messagesButtonHidden.assertValues(true);
+  }
+
+  @Test
+  public void testProfileViewModel_MessagesButton_DisabledFeature() {
+    final Config config = ConfigFactory.config()
+      .toBuilder()
+      .features(Collections.singletonMap(FeatureKey.ANDROID_MESSAGES, true))
+      .build();
+
+    final MockCurrentConfig currentConfig = new MockCurrentConfig();
+    currentConfig.config(config);
+
+    setUpEnvironment(environment().toBuilder().currentConfig(currentConfig).build());
+
+    // Messages button shown for config with enabled feature flag.
+    this.messagesButtonHidden.assertValues(false);
+  }
+
+  @Test
+  public void testProfileViewModel_MessagesButton_NullFeature() {
+    final Config config = ConfigFactory.config()
+      .toBuilder()
+      .features(Collections.emptyMap())
+      .build();
+
+    final MockCurrentConfig currentConfig = new MockCurrentConfig();
+    currentConfig.config(config);
+
+    setUpEnvironment(environment().toBuilder().currentConfig(currentConfig).build());
+
+    // Messages button shown for config with missing feature flag.
+    this.messagesButtonHidden.assertValues(false);
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProfileViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProfileViewModelTest.java
@@ -3,11 +3,14 @@ package com.kickstarter.viewmodels;
 import android.support.annotation.NonNull;
 
 import com.kickstarter.KSRobolectricTestCase;
+import com.kickstarter.factories.ConfigFactory;
 import com.kickstarter.factories.DiscoverEnvelopeFactory;
 import com.kickstarter.factories.ProjectFactory;
 import com.kickstarter.factories.UserFactory;
+import com.kickstarter.libs.Config;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.KoalaEvent;
+import com.kickstarter.libs.MockCurrentConfig;
 import com.kickstarter.libs.utils.NumberUtils;
 import com.kickstarter.models.Project;
 import com.kickstarter.models.User;
@@ -25,6 +28,41 @@ import rx.Observable;
 import rx.observers.TestSubscriber;
 
 public class ProfileViewModelTest extends KSRobolectricTestCase {
+  private ProfileViewModel.ViewModel vm;
+
+  private final TestSubscriber<String> avatarImageViewUrl = new TestSubscriber<>();
+  private final TestSubscriber<Boolean> backedCountTextViewHidden = new TestSubscriber<>();
+  private final TestSubscriber<String> backedCountTextViewText = new TestSubscriber<>();
+  private final TestSubscriber<Boolean> backedTextViewHidden = new TestSubscriber<>();
+  private final TestSubscriber<Boolean> createdCountTextViewHidden = new TestSubscriber<>();
+  private final TestSubscriber<String> createdCountTextViewText = new TestSubscriber<>();
+  private final TestSubscriber<Boolean> createdTextViewHidden = new TestSubscriber<>();
+  private final TestSubscriber<Boolean> dividerViewHidden = new TestSubscriber<>();
+  private final TestSubscriber<Boolean> messagesButtonHidden= new TestSubscriber<>();
+  private final TestSubscriber<List<Project>> projects = new TestSubscriber<>();
+  private final TestSubscriber<Void> resumeDiscoveryActivity = new TestSubscriber<>();
+  private final TestSubscriber<Void> startMessageThreadsActivity = new TestSubscriber<>();
+  private final TestSubscriber<Project> startProjectActivity = new TestSubscriber<>();
+  private final TestSubscriber<String> userNameTextViewText = new TestSubscriber<>();
+
+  private void setUpEnvironment(final @NonNull Environment environment) {
+    this.vm = new ProfileViewModel.ViewModel(environment);
+
+    this.vm.outputs.avatarImageViewUrl().subscribe(this.avatarImageViewUrl);
+    this.vm.outputs.backedCountTextViewHidden().subscribe(this.backedCountTextViewHidden);
+    this.vm.outputs.backedCountTextViewText().subscribe(this.backedCountTextViewText);
+    this.vm.outputs.backedTextViewHidden().subscribe(this.backedTextViewHidden);
+    this.vm.outputs.createdCountTextViewHidden().subscribe(this.createdCountTextViewHidden);
+    this.vm.outputs.createdCountTextViewText().subscribe(this.createdCountTextViewText);
+    this.vm.outputs.createdTextViewHidden().subscribe(this.createdTextViewHidden);
+    this.vm.outputs.dividerViewHidden().subscribe(this.dividerViewHidden);
+    this.vm.outputs.messagesButtonHidden().subscribe(this.messagesButtonHidden);
+    this.vm.outputs.projects().subscribe(this.projects);
+    this.vm.outputs.resumeDiscoveryActivity().subscribe(this.resumeDiscoveryActivity);
+    this.vm.outputs.startMessageThreadsActivity().subscribe(this.startMessageThreadsActivity);
+    this.vm.outputs.startProjectActivity().subscribe(this.startProjectActivity);
+    this.vm.outputs.userNameTextViewText().subscribe(this.userNameTextViewText);
+  }
 
   @Test
   public void testProfileViewModel_EmitsBackedAndCreatedProjectsData() {
@@ -39,42 +77,20 @@ public class ProfileViewModelTest extends KSRobolectricTestCase {
       }
     };
 
-    final Environment env = environment().toBuilder().apiClient(apiClient).build();
-    final ProfileViewModel.ViewModel vm = new ProfileViewModel.ViewModel(env);
-
-    final TestSubscriber<Boolean> backedCountTextViewHidden = new TestSubscriber<>();
-    vm.outputs.backedCountTextViewHidden().subscribe(backedCountTextViewHidden);
-
-    final TestSubscriber<String> backedCountTextViewText = new TestSubscriber<>();
-    vm.outputs.backedCountTextViewText().subscribe(backedCountTextViewText);
-
-    final TestSubscriber<Boolean> backedTextViewHidden = new TestSubscriber<>();
-    vm.outputs.backedTextViewHidden().subscribe(backedTextViewHidden);
-
-    final TestSubscriber<Boolean> createdCountTextViewHidden = new TestSubscriber<>();
-    vm.outputs.createdCountTextViewHidden().subscribe(createdCountTextViewHidden);
-
-    final TestSubscriber<String> createdCountTextViewText = new TestSubscriber<>();
-    vm.outputs.createdCountTextViewText().subscribe(createdCountTextViewText);
-
-    final TestSubscriber<Boolean> createdTextViewHidden = new TestSubscriber<>();
-    vm.outputs.createdTextViewHidden().subscribe(createdTextViewHidden);
-
-    final TestSubscriber<Boolean> dividerViewHidden = new TestSubscriber<>();
-    vm.outputs.dividerViewHidden().subscribe(dividerViewHidden);
+    setUpEnvironment(environment().toBuilder().apiClient(apiClient).build());
 
     // Backed text views are displayed.
-    backedCountTextViewHidden.assertValues(false);
-    backedCountTextViewText.assertValues(NumberUtils.format(user.backedProjectsCount()));
-    backedTextViewHidden.assertValues(false);
+    this.backedCountTextViewHidden.assertValues(false);
+    this.backedCountTextViewText.assertValues(NumberUtils.format(user.backedProjectsCount()));
+    this.backedTextViewHidden.assertValues(false);
 
     // Created text views are displayed.
-    createdCountTextViewHidden.assertValues(false);
-    createdCountTextViewText.assertValues(NumberUtils.format(user.createdProjectsCount()));
-    createdTextViewHidden.assertValues(false);
+    this.createdCountTextViewHidden.assertValues(false);
+    this.createdCountTextViewText.assertValues(NumberUtils.format(user.createdProjectsCount()));
+    this.createdTextViewHidden.assertValues(false);
 
     // Divider view is displayed.
-    dividerViewHidden.assertValues(false);
+    this.dividerViewHidden.assertValues(false);
   }
 
   @Test
@@ -90,42 +106,20 @@ public class ProfileViewModelTest extends KSRobolectricTestCase {
       }
     };
 
-    final Environment env = environment().toBuilder().apiClient(apiClient).build();
-    final ProfileViewModel.ViewModel vm = new ProfileViewModel.ViewModel(env);
-
-    final TestSubscriber<Boolean> backedCountTextViewHidden = new TestSubscriber<>();
-    vm.outputs.backedCountTextViewHidden().subscribe(backedCountTextViewHidden);
-
-    final TestSubscriber<String> backedCountTextViewText = new TestSubscriber<>();
-    vm.outputs.backedCountTextViewText().subscribe(backedCountTextViewText);
-
-    final TestSubscriber<Boolean> backedTextViewHidden = new TestSubscriber<>();
-    vm.outputs.backedTextViewHidden().subscribe(backedTextViewHidden);
-
-    final TestSubscriber<Boolean> createdCountTextViewHidden = new TestSubscriber<>();
-    vm.outputs.createdCountTextViewHidden().subscribe(createdCountTextViewHidden);
-
-    final TestSubscriber<String> createdCountTextViewText = new TestSubscriber<>();
-    vm.outputs.createdCountTextViewText().subscribe(createdCountTextViewText);
-
-    final TestSubscriber<Boolean> createdTextViewHidden = new TestSubscriber<>();
-    vm.outputs.createdTextViewHidden().subscribe(createdTextViewHidden);
-
-    final TestSubscriber<Boolean> dividerViewHidden = new TestSubscriber<>();
-    vm.outputs.dividerViewHidden().subscribe(dividerViewHidden);
+    setUpEnvironment(environment().toBuilder().apiClient(apiClient).build());
 
     // Backed text views are displayed.
-    backedCountTextViewHidden.assertValues(false);
-    backedCountTextViewText.assertValues(NumberUtils.format(user.backedProjectsCount()));
-    backedTextViewHidden.assertValues(false);
+    this.backedCountTextViewHidden.assertValues(false);
+    this.backedCountTextViewText.assertValues(NumberUtils.format(user.backedProjectsCount()));
+    this.backedTextViewHidden.assertValues(false);
 
     // Created text views are hidden.
-    createdCountTextViewHidden.assertValues(true);
-    createdCountTextViewText.assertNoValues();
-    createdTextViewHidden.assertValues(true);
+    this.createdCountTextViewHidden.assertValues(true);
+    this.createdCountTextViewText.assertNoValues();
+    this.createdTextViewHidden.assertValues(true);
 
     // Divider view is hidden.
-    dividerViewHidden.assertValues(true);
+    this.dividerViewHidden.assertValues(true);
   }
 
   @Test
@@ -141,42 +135,20 @@ public class ProfileViewModelTest extends KSRobolectricTestCase {
       }
     };
 
-    final Environment env = environment().toBuilder().apiClient(apiClient).build();
-    final ProfileViewModel.ViewModel vm = new ProfileViewModel.ViewModel(env);
-
-    final TestSubscriber<Boolean> backedCountTextViewHidden = new TestSubscriber<>();
-    vm.outputs.backedCountTextViewHidden().subscribe(backedCountTextViewHidden);
-
-    final TestSubscriber<String> backedCountTextViewText = new TestSubscriber<>();
-    vm.outputs.backedCountTextViewText().subscribe(backedCountTextViewText);
-
-    final TestSubscriber<Boolean> backedTextViewHidden = new TestSubscriber<>();
-    vm.outputs.backedTextViewHidden().subscribe(backedTextViewHidden);
-
-    final TestSubscriber<Boolean> createdCountTextViewHidden = new TestSubscriber<>();
-    vm.outputs.createdCountTextViewHidden().subscribe(createdCountTextViewHidden);
-
-    final TestSubscriber<String> createdCountTextViewText = new TestSubscriber<>();
-    vm.outputs.createdCountTextViewText().subscribe(createdCountTextViewText);
-
-    final TestSubscriber<Boolean> createdTextViewHidden = new TestSubscriber<>();
-    vm.outputs.createdTextViewHidden().subscribe(createdTextViewHidden);
-
-    final TestSubscriber<Boolean> dividerViewHidden = new TestSubscriber<>();
-    vm.outputs.dividerViewHidden().subscribe(dividerViewHidden);
+    setUpEnvironment(environment().toBuilder().apiClient(apiClient).build());
 
     // Backed text views are hidden.
-    backedCountTextViewHidden.assertValues(true);
-    backedCountTextViewText.assertNoValues();
-    backedTextViewHidden.assertValues(true);
+    this.backedCountTextViewHidden.assertValues(true);
+    this.backedCountTextViewText.assertNoValues();
+    this.backedTextViewHidden.assertValues(true);
 
     // Created text views are displayed.
-    createdCountTextViewHidden.assertValues(false);
-    createdCountTextViewText.assertValues(NumberUtils.format(user.createdProjectsCount()));
-    createdTextViewHidden.assertValues(false);
+    this.createdCountTextViewHidden.assertValues(false);
+    this.createdCountTextViewText.assertValues(NumberUtils.format(user.createdProjectsCount()));
+    this.createdTextViewHidden.assertValues(false);
 
     // Divider view is hidden.
-    dividerViewHidden.assertValues(true);
+    this.dividerViewHidden.assertValues(true);
   }
 
   @Test
@@ -190,14 +162,10 @@ public class ProfileViewModelTest extends KSRobolectricTestCase {
       }
     };
 
-    final Environment env = environment().toBuilder().apiClient(apiClient).build();
-    final ProfileViewModel.ViewModel vm = new ProfileViewModel.ViewModel(env);
+    setUpEnvironment(environment().toBuilder().apiClient(apiClient).build());
 
-    final TestSubscriber<List<Project>> projects = new TestSubscriber<>();
-    vm.outputs.projects().subscribe(projects);
-
-    koalaTest.assertValues(KoalaEvent.PROFILE_VIEW_MY, KoalaEvent.VIEWED_PROFILE);
-    projects.assertValueCount(1);
+    this.koalaTest.assertValues(KoalaEvent.PROFILE_VIEW_MY, KoalaEvent.VIEWED_PROFILE);
+    this.projects.assertValueCount(1);
   }
 
   @Test
@@ -210,38 +178,49 @@ public class ProfileViewModelTest extends KSRobolectricTestCase {
       }
     };
 
-    final Environment env = environment().toBuilder().apiClient(apiClient).build();
-    final ProfileViewModel.ViewModel vm = new ProfileViewModel.ViewModel(env);
+    setUpEnvironment(environment().toBuilder().apiClient(apiClient).build());
 
-    final TestSubscriber<String> avatarImageViewUrl = new TestSubscriber<>();
-    vm.outputs.avatarImageViewUrl().subscribe(avatarImageViewUrl);
+    this.avatarImageViewUrl.assertValues(user.avatar().medium());
+    this.userNameTextViewText.assertValues(user.name());
+  }
 
-    final TestSubscriber<String> userNameTextViewText = new TestSubscriber<>();
-    vm.outputs.userNameTextViewText().subscribe(userNameTextViewText);
+  @Test
+  public void testProfileViewModel_MessagesButtonHidden() {
+    final Config config = ConfigFactory.config()
+      .toBuilder()
+      .features(Collections.singletonMap("android_messages", false))
+      .build();
 
-    avatarImageViewUrl.assertValues(user.avatar().medium());
-    userNameTextViewText.assertValues(user.name());
+    final MockCurrentConfig currentConfig = new MockCurrentConfig();
+    currentConfig.config(config);
+
+    setUpEnvironment(environment().toBuilder().currentConfig(currentConfig).build());
+
+    // Messages button hidden for config with disabled feature flag.
+    this.messagesButtonHidden.assertValues(true);
   }
 
   @Test
   public void testProfileViewModel_ResumeDiscoveryActivity() {
-    final ProfileViewModel.ViewModel vm = new ProfileViewModel.ViewModel(environment());
+    setUpEnvironment(environment());
 
-    final TestSubscriber<Void> resumeDiscoveryActivity = new TestSubscriber<>();
-    vm.outputs.resumeDiscoveryActivity().subscribe(resumeDiscoveryActivity);
-
-    vm.inputs.exploreProjectsButtonClicked();
-    resumeDiscoveryActivity.assertValueCount(1);
+    this.vm.inputs.exploreProjectsButtonClicked();
+    this.resumeDiscoveryActivity.assertValueCount(1);
   }
 
   @Test
   public void testProfileViewModel_StartMessageThreadsActivity() {
-    final ProfileViewModel.ViewModel vm = new ProfileViewModel.ViewModel(environment());
+    setUpEnvironment(environment());
 
-    final TestSubscriber<Void> startMessageThreadsActivity = new TestSubscriber<>();
-    vm.outputs.startMessageThreadsActivity().subscribe(startMessageThreadsActivity);
+    this.vm.inputs.messsagesButtonClicked();
+    this.startMessageThreadsActivity.assertValueCount(1);
+  }
 
-    vm.inputs.messsagesButtonClicked();
-    startMessageThreadsActivity.assertValueCount(1);
+  @Test
+  public void testProfileViewModel_StartProjectActivity() {
+    setUpEnvironment(environment());
+
+    this.vm.inputs.projectCardClicked(ProjectFactory.project());
+    this.startProjectActivity.assertValueCount(1);
   }
 }


### PR DESCRIPTION
## what
1. Added `features` to our config model so we can start tapping into our feature flags to use them! Config is already a part of our `environment` so this was a breeze.

2. Implemented flag for messages in our `ProfileViewModel`.

3. Modernized `ProfileViewModelTest` and added additional tests. 