### PR TITLE
Don't put the POTD at the top of search pages

### DIFF
--- a/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
+++ b/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
@@ -415,7 +415,11 @@ public abstract class DiscoveryParams implements Parcelable {
    * POTD comes back.
    */
   public boolean shouldIncludePotd() {
-    return isAllProjects() && page() != null && page() == 1 && (sort() == null && (term() == null || term().isEmpty()) || sort() == Sort.HOME);
+    return isAllProjects()
+      && page() != null
+      && page() == 1
+      && (sort() == null || sort() == Sort.HOME)
+      && (term() == null || term().isEmpty());
   }
 
   /**

--- a/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
+++ b/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
@@ -415,7 +415,7 @@ public abstract class DiscoveryParams implements Parcelable {
    * POTD comes back.
    */
   public boolean shouldIncludePotd() {
-    return isAllProjects() && page() != null && page() == 1 && (sort() == null || sort() == Sort.HOME);
+    return isAllProjects() && page() != null && page() == 1 && (sort() == null && (term() == null || term().isEmpty()) || sort() == Sort.HOME);
   }
 
   /**

--- a/app/src/test/java/com/kickstarter/libs/utils/DiscoveryParamsUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/DiscoveryParamsUtilsTest.java
@@ -5,10 +5,15 @@ import com.kickstarter.factories.LocationFactory;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.services.DiscoveryParams;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class DiscoveryParamsUtilsTest extends TestCase {
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
 
+public class DiscoveryParamsUtilsTest {
+
+  @Test
   public void testRefTag() {
     assertEquals(
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().category(CategoryFactory.artCategory()).build()),
@@ -49,5 +54,13 @@ public class DiscoveryParamsUtilsTest extends TestCase {
       RefTag.discovery(),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().build())
     );
+  }
+
+  @Test
+  public void testShouldIncludePotd() {
+    assertFalse(DiscoveryParams.builder().term("cat").build().shouldIncludePotd());
+    assertTrue(DiscoveryParams.builder().build().shouldIncludePotd());
+    assertFalse(DiscoveryParams.builder().page(2).build().shouldIncludePotd());
+    assertFalse(DiscoveryParams.builder().sort(DiscoveryParams.Sort.ENDING_SOON).build().shouldIncludePotd());
   }
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/DiscoveryParamsUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/DiscoveryParamsUtilsTest.java
@@ -5,52 +5,49 @@ import com.kickstarter.factories.LocationFactory;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.services.DiscoveryParams;
 
+import org.junit.Assert;
 import org.junit.Test;
-
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
 
 public class DiscoveryParamsUtilsTest {
 
   @Test
   public void testRefTag() {
-    assertEquals(
+    Assert.assertEquals(
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().category(CategoryFactory.artCategory()).build()),
       RefTag.category()
     );
 
-    assertEquals(
+    Assert.assertEquals(
       RefTag.category(DiscoveryParams.Sort.POPULAR),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().category(CategoryFactory.artCategory()).sort(DiscoveryParams.Sort.POPULAR).build())
     );
 
-    assertEquals(
+    Assert.assertEquals(
       RefTag.city(),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().location(LocationFactory.germany()).build())
     );
 
-    assertEquals(
+    Assert.assertEquals(
       RefTag.recommended(),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().staffPicks(true).build())
     );
 
-    assertEquals(
+    Assert.assertEquals(
       RefTag.recommended(DiscoveryParams.Sort.POPULAR),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().staffPicks(true).sort(DiscoveryParams.Sort.POPULAR).build())
     );
 
-    assertEquals(
+    Assert.assertEquals(
       RefTag.social(),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().social(1).build())
     );
 
-    assertEquals(
+    Assert.assertEquals(
       RefTag.search(),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().term("art").build())
     );
 
-    assertEquals(
+    Assert.assertEquals(
       RefTag.discovery(),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().build())
     );
@@ -58,9 +55,9 @@ public class DiscoveryParamsUtilsTest {
 
   @Test
   public void testShouldIncludePotd() {
-    assertFalse(DiscoveryParams.builder().term("cat").build().shouldIncludePotd());
-    assertTrue(DiscoveryParams.builder().build().shouldIncludePotd());
-    assertFalse(DiscoveryParams.builder().page(2).build().shouldIncludePotd());
-    assertFalse(DiscoveryParams.builder().sort(DiscoveryParams.Sort.ENDING_SOON).build().shouldIncludePotd());
+    Assert.assertFalse(DiscoveryParams.builder().term("cat").build().shouldIncludePotd());
+    Assert.assertTrue(DiscoveryParams.builder().build().shouldIncludePotd());
+    Assert.assertFalse(DiscoveryParams.builder().page(2).build().shouldIncludePotd());
+    Assert.assertFalse(DiscoveryParams.builder().sort(DiscoveryParams.Sort.ENDING_SOON).build().shouldIncludePotd());
   }
 }


### PR DESCRIPTION
## What
When performing searches it seemed weird that the top project had nothing to do with the search term

## How
Change the criteria for showing the POTD to not include search