### PR TITLE
Allow static imports of assert functions.

### DIFF
--- a/app/src/test/java/com/kickstarter/libs/utils/DiscoveryParamsUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/DiscoveryParamsUtilsTest.java
@@ -5,49 +5,51 @@ import com.kickstarter.factories.LocationFactory;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.services.DiscoveryParams;
 
-import org.junit.Assert;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class DiscoveryParamsUtilsTest {
 
   @Test
   public void testRefTag() {
-    Assert.assertEquals(
+    assertEquals(
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().category(CategoryFactory.artCategory()).build()),
       RefTag.category()
     );
 
-    Assert.assertEquals(
+    assertEquals(
       RefTag.category(DiscoveryParams.Sort.POPULAR),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().category(CategoryFactory.artCategory()).sort(DiscoveryParams.Sort.POPULAR).build())
     );
 
-    Assert.assertEquals(
+    assertEquals(
       RefTag.city(),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().location(LocationFactory.germany()).build())
     );
 
-    Assert.assertEquals(
+    assertEquals(
       RefTag.recommended(),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().staffPicks(true).build())
     );
 
-    Assert.assertEquals(
+    assertEquals(
       RefTag.recommended(DiscoveryParams.Sort.POPULAR),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().staffPicks(true).sort(DiscoveryParams.Sort.POPULAR).build())
     );
 
-    Assert.assertEquals(
+    assertEquals(
       RefTag.social(),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().social(1).build())
     );
 
-    Assert.assertEquals(
+    assertEquals(
       RefTag.search(),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().term("art").build())
     );
 
-    Assert.assertEquals(
+    assertEquals(
       RefTag.discovery(),
       DiscoveryParamsUtils.refTag(DiscoveryParams.builder().build())
     );
@@ -55,9 +57,9 @@ public class DiscoveryParamsUtilsTest {
 
   @Test
   public void testShouldIncludePotd() {
-    Assert.assertFalse(DiscoveryParams.builder().term("cat").build().shouldIncludePotd());
-    Assert.assertTrue(DiscoveryParams.builder().build().shouldIncludePotd());
-    Assert.assertFalse(DiscoveryParams.builder().page(2).build().shouldIncludePotd());
-    Assert.assertFalse(DiscoveryParams.builder().sort(DiscoveryParams.Sort.ENDING_SOON).build().shouldIncludePotd());
+    assertFalse(DiscoveryParams.builder().term("cat").build().shouldIncludePotd());
+    assertTrue(DiscoveryParams.builder().build().shouldIncludePotd());
+    assertFalse(DiscoveryParams.builder().page(2).build().shouldIncludePotd());
+    assertFalse(DiscoveryParams.builder().sort(DiscoveryParams.Sort.ENDING_SOON).build().shouldIncludePotd());
   }
 }

--- a/script/style/checkstyle.xml
+++ b/script/style/checkstyle.xml
@@ -67,6 +67,7 @@
       <property name="excludes" value="java.util.Collections.emptyList" />
       <property name="excludes" value="org.mockito.Mockito.*" />
       <property name="excludes" value="rx.android.schedulers.AndroidSchedulers.*" />
+      <property name="excludes" value="org.junit.Assert.*" />
     </module>
     <module name="IllegalImport" />
     <module name="RedundantImport" />


### PR DESCRIPTION
### What

Our checkstyle rules currently disallows static import of functions unless their package is specifically allowed. We only wanna statically import things that enhance the expressiveness of Java, such as being able to do `observable.filter(isEmpty)` instead of `observable.filter(StringUtils::isEmpty)`.

I propose to add the assert helpers `org.junit.Assert.*` to this list so that we can write tests like:

```java
assertEquals(thingA, thingB);
```

instead of 

```java
Assert.assertEquals(thingA, thingB);
```

Note that we haven't run into this in the vast majority of our tests because we have historically inherited from `TestCase`, which has static assert methods and we can use them without saying `TestCase.assert` cause we are in a subclass. However, current JUnit best practices dictate that you do not inherit from `TestCase` and instead annotate your tests with `@Test`. They want you to do it this way cause it gives you access to other features of JUnit via annotations, but we also don't use any of that stuff :/

### Alternatives

Instead of doing this we could eschew the JUnit "best" practice and just require inheriting from `TestCase`. I'm down with either!


