### PR TITLE
Search result view tweaking

### DIFF
--- a/app/src/main/res/layout/project_search_result_view.xml
+++ b/app/src/main/res/layout/project_search_result_view.xml
@@ -18,8 +18,6 @@
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_gravity="bottom"
-    android:gravity="bottom"
     android:layout_marginEnd="@dimen/grid_new_1"
     android:layout_marginStart="@dimen/grid_new_1"
     android:layout_marginLeft="@dimen/grid_new_1"
@@ -40,7 +38,6 @@
     <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_gravity="center_vertical"
       android:orientation="vertical">
 
       <TextView
@@ -51,7 +48,7 @@
         android:maxLines="2"
         android:ellipsize="end"
         android:layout_marginBottom="@dimen/grid_new_2"
-        tools:text="Exploding Kittens"/>
+        tools:text="Somebody Once Told Me"/>
 
       <LinearLayout
         android:layout_width="wrap_content"
@@ -68,7 +65,7 @@
           android:textStyle="bold"
           android:layout_marginRight="@dimen/grid_new_1_half"
           android:layout_marginEnd="@dimen/grid_new_1_half"
-          tools:text="100%"/>
+          tools:text="10,000%"/>
 
         <TextView
           android:id="@+id/search_result_funded_text_view"
@@ -91,6 +88,8 @@
         <TextView
           android:id="@+id/search_result_deadline_unit_text_view"
           style="@style/CaptionSecondary"
+          android:maxLines="1"
+          android:ellipsize="end"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           tools:text="days to go"/>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -113,8 +113,8 @@
   <dimen name="project_card_photo_landscape_height">135dp</dimen>
   <dimen name="project_card_photo_landscape_width">240dp</dimen>
   <dimen name="project_social_photo_height">@dimen/grid_4</dimen>
-  <dimen name="search_result_photo_width">@dimen/grid_14</dimen>
-  <dimen name="search_result_photo_height">63dp</dimen>
+  <dimen name="search_result_photo_width">80dp</dimen>
+  <dimen name="search_result_photo_height">45dp</dimen>
   <dimen name="search_result_featured_photo_height">@dimen/grid_new_33</dimen>
 
   <dimen name="thanks_project_photo_width">208dp</dimen>


### PR DESCRIPTION
## what
Slipped my 👀 that we want our project names to not have bottom gravity, and that our image size should be 80x45dp as per Maggie's mocks

before & after on a 19 moto:
<img src=https://cloud.githubusercontent.com/assets/4934046/25871585/10f912cc-34d6-11e7-8d4b-b9c7afaaf082.png width=300/> <img src=https://cloud.githubusercontent.com/assets/4934046/25871588/13825fa8-34d6-11e7-8a36-0d4edcc29154.png width=300/>

on a 22 nexus 6:
<img src=https://cloud.githubusercontent.com/assets/4934046/25871578/0c9df90e-34d6-11e7-8b47-b54cbece9568.png width=330/>

Takeaways? Make sure to take a few mins to do the visual QA on older devices!!!!! And ~ one day ~ may we will have screenshot tests to catch this for us.