### PR TITLE
Add one second to fix rounding error

### DIFF
--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectCardholderViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectCardholderViewModelTest.java
@@ -139,12 +139,12 @@ public class ProjectCardholderViewModelTest extends KSRobolectricTestCase {
   @Test
   public void testEmitsDeadlineCountdownText() {
     final Project project = ProjectFactory.project().toBuilder()
-      .deadline(new DateTime().plusHours(25))
+      .deadline(new DateTime().plusSeconds(60 * 60 * 24 + 1))
       .build();
     setUpEnvironment(environment());
 
     this.vm.inputs.configureWith(project);
-    this.deadlineCountdownText.assertValues(NumberUtils.format(ProjectUtils.deadlineCountdownValue(project)));
+    this.deadlineCountdownText.assertValues("24");
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectCardholderViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectCardholderViewModelTest.java
@@ -10,7 +10,6 @@ import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.utils.NumberUtils;
 import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.libs.utils.ProgressBarUtils;
-import com.kickstarter.libs.utils.ProjectUtils;
 import com.kickstarter.models.Category;
 import com.kickstarter.models.Project;
 import com.kickstarter.models.User;


### PR DESCRIPTION
We have a date rounding error right now that is quite similar to some stuff we saw in iOS until we took control of the co-effect of using dates. This is a fix for now, and we'll look into a proper way of adding date constructors to the environment v soon!