### PR TITLE
Add launching of webview on click of survey.

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
@@ -33,6 +33,7 @@ import javax.inject.Inject;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
+import timber.log.Timber;
 
 import static com.kickstarter.libs.rx.transformers.Transformers.observeForUI;
 
@@ -93,10 +94,10 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
       .compose(observeForUI())
       .subscribe(this::startProjectUpdateActivity);
 
-    /*viewModel.outputs.goToSurvey()
+    viewModel.outputs.goToSurvey()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(this::startSurveyWebView);*/
+      .subscribe(this::startSurveyWebView);
 
     viewModel.outputs.loggedOutEmptyStateIsVisible()
       .compose(bindToLifecycle())
@@ -158,15 +159,15 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
     startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }
 
-//  private void startSurveyWebView(final @NonNull SurveyResponse surveyResponse) {
-//    try {
-//      final Intent intent = new Intent(this, WebViewActivity.class)
-//        .putExtra(IntentKey.URL, surveyResponse.urls().web().survey());
-//      startActivityWithTransition(intent, R.anim.slide_in_bottom, R.anim.com_mixpanel_android_slide_down);
-//    } catch (final NullPointerException npe) {
-//      npe.printStackTrace();
-//      Timber.e("Missing url for survey!");
-//      // missing a url to go to for the survey
-//    }
-//  }
+  private void startSurveyWebView(final @NonNull SurveyResponse surveyResponse) {
+    try {
+      final Intent intent = new Intent(this, WebViewActivity.class)
+        .putExtra(IntentKey.URL, surveyResponse.urls().web().survey());
+      startActivityWithTransition(intent, R.anim.slide_in_bottom, R.anim.com_mixpanel_android_slide_down);
+    } catch (final NullPointerException npe) {
+      npe.printStackTrace();
+      Timber.e("Missing url for survey!");
+      // missing a url to go to for the survey
+    }
+  }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
@@ -32,6 +32,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import butterknife.Bind;
+import butterknife.BindString;
 import butterknife.ButterKnife;
 import timber.log.Timber;
 
@@ -46,6 +47,7 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
   @Inject CurrentUserType currentUser;
 
   private RecyclerViewPaginator recyclerViewPaginator;
+  protected @BindString(R.string.discovery_survey_reward_survey) String rewardSurveyString;
   private SwipeRefresher swipeRefresher;
 
   @Override
@@ -162,7 +164,8 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
   private void startSurveyWebView(final @NonNull SurveyResponse surveyResponse) {
     try {
       final Intent intent = new Intent(this, WebViewActivity.class)
-        .putExtra(IntentKey.URL, surveyResponse.urls().web().survey());
+        .putExtra(IntentKey.URL, surveyResponse.urls().web().survey())
+        .putExtra(IntentKey.TOOLBAR_TITLE, rewardSurveyString);
       startActivityWithTransition(intent, R.anim.slide_in_bottom, R.anim.com_mixpanel_android_slide_down);
     } catch (final NullPointerException npe) {
       npe.printStackTrace();

--- a/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.java
@@ -3,6 +3,7 @@ package com.kickstarter.viewmodels;
 import android.support.annotation.NonNull;
 import android.util.Pair;
 
+import com.kickstarter.BuildConfig;
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.ApiPaginator;
 import com.kickstarter.libs.CurrentConfigType;
@@ -109,7 +110,7 @@ public interface ActivityFeedViewModel {
         .map(Activity::project);
 
       final Observable<Boolean> surveyFeatureEnabled = this.currentConfig.observable()
-        .map(config -> coalesce(config.features().get(FeatureKey.ANDROID_SURVEYS), false));
+        .map(config -> coalesce(config.features().get(FeatureKey.ANDROID_SURVEYS), false) || BuildConfig.DEBUG);
 
       Observable.combineLatest(
           resume,


### PR DESCRIPTION
# What

Surveys are currently shown under a feature flag, but do not allow you to take them.

# Why

Allowing backers to take surveys is the next step in the android app. Currently you have to use the web app and that breaks the work flow.

# How

A webview will be used.

# TODO ⏰

- [X] Capture clicks
- [X] Launch webview
- [ ] Handling all cases and polish 
