### PR TITLE
Use gradle 3.5

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip


### PR DESCRIPTION
First of all, I really like your approach on ViewModel input and output, and I also love Rx. I used it on iOS too 🚀 
I don't know if this happens to other people, but I'm using Android Studio 3 Canary 3, and I get 

```sh
Gradle version 3.3 does not support forTask() method on BuildActionExecuter
```

I hope this will fix it. Thanks 😇 