### PR TITLE
Upgrade AS to 2.3.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -213,7 +213,7 @@ def commitTime() {
 }
 
 buildscript {
-    ext.kotlin_version = '1.1.2'
+    ext.kotlin_version = '1.1.2-3'
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.google.gms:google-services:3.0.0'
     }
 }


### PR DESCRIPTION
## what
Bumping Android Studio to 2.3.3. Release notes here:
https://developer.android.com/studio/releases/index.html

Subsequently upgrading our Kotlin plugin to match our AS version. 