### PR TITLE
Dont show featured projects in subcategories

### DIFF
--- a/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
+++ b/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
@@ -427,7 +427,7 @@ public abstract class DiscoveryParams implements Parcelable {
    * featured project for the category comes back.
    */
   public boolean shouldIncludeFeatured() {
-    return category() != null && page() != null && page() == 1 && (sort() == null || sort() == Sort.HOME);
+    return category() != null && category().parent() == null && page() != null && page() == 1 && (sort() == null || sort() == Sort.HOME);
   }
 
   @Override

--- a/app/src/test/java/com/kickstarter/services/DiscoveryParamsTest.java
+++ b/app/src/test/java/com/kickstarter/services/DiscoveryParamsTest.java
@@ -3,6 +3,8 @@ package com.kickstarter.services;
 import android.net.Uri;
 
 import com.kickstarter.KSRobolectricTestCase;
+import com.kickstarter.factories.CategoryFactory;
+import com.kickstarter.models.Category;
 
 import org.junit.Test;
 
@@ -132,5 +134,16 @@ public final class DiscoveryParamsTest extends KSRobolectricTestCase {
 
     final Uri searchUri = Uri.parse("https://www.kickstarter.com/projects/search?term=skull+graphic+tee");
     assertEquals(params, DiscoveryParams.fromUri(searchUri));
+  }
+
+  @Test
+  public void testShouldIncludeFeatured() {
+    final Category nonRootCategory = CategoryFactory.bluesCategory();
+    final DiscoveryParams nonRootParams = DiscoveryParams.builder().category(nonRootCategory).build();
+    assertEquals(false, nonRootParams.shouldIncludeFeatured());
+
+    final Category rootCategory = CategoryFactory.gamesCategory();
+    final DiscoveryParams rootParams = DiscoveryParams.builder().category(rootCategory).build();
+    assertEquals(true, rootParams.shouldIncludeFeatured());
   }
 }


### PR DESCRIPTION
we are currently showing the featured project for a parent category as the first project in all of it's child, more narrow categories.  This has been determined to be a bad discovery experience!  sad!

small little fix to check if the category has no parent so we don't grab the featured project from api.  should there be a test for this? maybe! I'll try to figure that out.

cc @ktman 👋 