### PR TITLE
Fix project updates pagination

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectUpdatesActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectUpdatesActivity.java
@@ -73,6 +73,7 @@ public class ProjectUpdatesActivity extends BaseActivity<ProjectUpdatesViewModel
     super.onResume();
 
     this.viewModel.outputs.webViewUrl()
+      .take(1)
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(this.ksWebView::loadUrl);

--- a/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.java
@@ -90,6 +90,7 @@ public class UpdateActivity extends BaseActivity<UpdateViewModel.ViewModel> impl
     super.onResume();
 
     this.viewModel.outputs.webViewUrl()
+      .take(1)
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(this.ksWebView::loadUrl);


### PR DESCRIPTION
scrolling to the second page of project updates is currently broken - we make a request for the second page, but we don't actually end up showing new data.

I'm mostly just following the pattern that we use in the [checkout activity](https://github.com/kickstarter/android-oss/blob/master/app/src/main/java/com/kickstarter/ui/activities/CheckoutActivity.java#L190), but I think what's happening is we get multiple values emitted from [this merge](https://github.com/kickstarter/android-oss/blob/master/app/src/main/java/com/kickstarter/viewmodels/ProjectUpdatesViewModel.java#L70) in our ProjectUpdatesViewModel, so we don't actually load the data that is returned in the first emission.

