### PR TITLE
Mark features as nullable

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Config.java
+++ b/app/src/main/java/com/kickstarter/libs/Config.java
@@ -2,6 +2,7 @@ package com.kickstarter.libs;
 
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.kickstarter.libs.qualifiers.AutoGson;
 
@@ -15,7 +16,7 @@ import auto.parcel.AutoParcel;
 @AutoParcel
 public abstract class Config implements Parcelable {
   public abstract String countryCode();
-  public abstract Map<String, Boolean> features();
+  public abstract @Nullable Map<String, Boolean> features();
   public abstract List<LaunchedCountry> launchedCountries();
 
   @AutoParcel.Builder

--- a/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.java
@@ -5,6 +5,7 @@ import android.util.Pair;
 
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.ApiPaginator;
+import com.kickstarter.libs.Config;
 import com.kickstarter.libs.CurrentConfigType;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
@@ -109,7 +110,9 @@ public interface ActivityFeedViewModel {
         .map(Activity::project);
 
       final Observable<Boolean> surveyFeatureEnabled = this.currentConfig.observable()
-        .map(config -> coalesce(config.features().get(FeatureKey.ANDROID_SURVEYS), false));
+        .map(Config::features)
+        .filter(ObjectUtils::isNotNull)
+        .map(f -> coalesce(f.get(FeatureKey.ANDROID_SURVEYS), false));
 
       Observable.combineLatest(
           resume,

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -6,6 +6,7 @@ import android.util.Pair;
 
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.BuildCheck;
+import com.kickstarter.libs.Config;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.FeatureKey;
@@ -13,6 +14,7 @@ import com.kickstarter.libs.utils.BooleanUtils;
 import com.kickstarter.libs.utils.DiscoveryDrawerUtils;
 import com.kickstarter.libs.utils.DiscoveryUtils;
 import com.kickstarter.libs.utils.IntegerUtils;
+import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.models.Category;
 import com.kickstarter.models.User;
 import com.kickstarter.services.ApiClientType;
@@ -70,7 +72,9 @@ public final class DiscoveryViewModel extends ActivityViewModel<DiscoveryActivit
       .map(u -> u != null && IntegerUtils.isNonZero(u.createdProjectsCount()));
 
     final Observable<Boolean> creatorViewFeatureFlagIsEnabled = environment.currentConfig().observable()
-      .map(config -> coalesce(config.features().get(FeatureKey.ANDROID_CREATOR_VIEW), false));
+      .map(Config::features)
+      .filter(ObjectUtils::isNotNull)
+      .map(f -> coalesce(f.get(FeatureKey.ANDROID_CREATOR_VIEW), false));
 
     this.creatorDashboardButtonIsGone = Observable.combineLatest(
       userIsCreator,

--- a/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.java
@@ -5,12 +5,14 @@ import android.util.Pair;
 
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.ApiPaginator;
+import com.kickstarter.libs.Config;
 import com.kickstarter.libs.CurrentConfigType;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.FeatureKey;
 import com.kickstarter.libs.utils.IntegerUtils;
 import com.kickstarter.libs.utils.NumberUtils;
+import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.models.Project;
 import com.kickstarter.models.User;
 import com.kickstarter.services.ApiClientType;
@@ -151,7 +153,9 @@ public interface ProfileViewModel {
         .map(p -> p.first || p.second);
 
       this.messagesButtonHidden = this.currentConfig.observable()
-        .map(config -> !coalesce(config.features().get(FeatureKey.ANDROID_MESSAGES), false));
+        .map(Config::features)
+        .filter(ObjectUtils::isNotNull)
+        .map(f -> !coalesce(f.get(FeatureKey.ANDROID_MESSAGES), false));
 
       this.projects = paginator.paginatedData();
       this.resumeDiscoveryActivity = this.exploreProjectsButtonClicked;


### PR DESCRIPTION
## what
We have a bunch of crashes since our 1.4.5 release that I thought I had fixed via using:

* `coalesce` to coalesce `config.features().get` with `false` in case a config had not been refreshed properly
* [A default Builder value for features to avoid using Nullable](https://github.com/kickstarter/android-oss/blob/master/app/src/main/java/com/kickstarter/libs/Config.java#L55)

But after some debugging it turns out that the default AutoParcel initialization isn't doing what we expected, i.e. if `features` is null for a non refreshed config we see the crashes in our feature flagged places. This is a hotfix for now so we can move on with making external builds, but for future notice we need to upgrade our AutoParcel to AutoValue.

![bitmoji](https://render.bitstrips.com/v2/cpanel/9886128-115325670_69-s4-v1.png?transparent=1&palette=1&width=246)