### PR TITLE
[Messages] Patches 

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/MessageThreadsActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/MessageThreadsActivity.java
@@ -1,10 +1,12 @@
 package com.kickstarter.ui.activities;
 
+import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.CollapsingToolbarLayout;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Pair;
@@ -47,6 +49,7 @@ public class MessageThreadsActivity extends BaseActivity<MessageThreadsViewModel
   protected @BindString(R.string.messages_navigation_inbox) String inboxString;
   protected @BindString(R.string.No_messages) String noMessagesString;
   protected @BindString(R.string.No_unread_messages) String noUnreadMessagesString;
+  protected @BindString(R.string.font_family_sans_serif) String sansSerifString;
   protected @BindString(R.string.unread_count_unread) String unreadCountUnreadString;
 
   @Override
@@ -81,6 +84,16 @@ public class MessageThreadsActivity extends BaseActivity<MessageThreadsViewModel
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(this.adapter::messageThreads);
+
+    this.viewModel.outputs.unreadCountTextViewColorInt()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(colorInt -> this.unreadCountTextView.setTextColor(ContextCompat.getColor(this, colorInt)));
+
+    this.viewModel.outputs.unreadCountTextViewTypefaceInt()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(typeInt -> this.unreadCountTextView.setTypeface(Typeface.create(this.sansSerifString, typeInt)));
 
     this.viewModel.outputs.unreadCountToolbarTextViewIsGone()
       .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.java
@@ -107,6 +107,11 @@ public final class MessagesActivity extends BaseActivity<MessagesViewModel.ViewM
       .compose(observeForUI())
       .subscribe(__ -> back());
 
+    this.viewModel.outputs.messageAndPosition()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(this.adapter::appendNewMessage);
+
     this.viewModel.outputs.messageEditTextHint()
       .compose(bindToLifecycle())
       .compose(observeForUI())

--- a/app/src/main/java/com/kickstarter/ui/adapters/MessagesAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/MessagesAdapter.java
@@ -2,6 +2,7 @@ package com.kickstarter.ui.adapters;
 
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
+import android.util.Pair;
 import android.view.View;
 
 import com.kickstarter.R;
@@ -40,6 +41,14 @@ public final class MessagesAdapter extends KSAdapter {
       });
 
     notifyDataSetChanged();
+  }
+
+  public void appendNewMessage(final @NonNull Pair<Message, Integer> messageAndPosition) {
+    // Add a date view holder and a message body view holder.
+    addSection(Collections.singletonList(messageAndPosition.first.createdAt()));
+    addSection(Collections.singletonList(messageAndPosition.first));
+
+    notifyItemInserted(messageAndPosition.second);
   }
 
   @Override

--- a/app/src/main/java/com/kickstarter/viewmodels/MessageThreadsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessageThreadsViewModel.java
@@ -1,8 +1,10 @@
 package com.kickstarter.viewmodels;
 
+import android.graphics.Typeface;
 import android.support.annotation.NonNull;
 import android.util.Pair;
 
+import com.kickstarter.R;
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.ApiPaginator;
 import com.kickstarter.libs.CurrentUserType;
@@ -22,6 +24,7 @@ import rx.subjects.PublishSubject;
 
 import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
 import static com.kickstarter.libs.rx.transformers.Transformers.takeWhen;
+import static com.kickstarter.libs.utils.IntegerUtils.intValueOrZero;
 
 public interface MessageThreadsViewModel {
 
@@ -48,6 +51,12 @@ public interface MessageThreadsViewModel {
 
     /** Emits a list of message threads to be displayed. */
     Observable<List<MessageThread>> messageThreads();
+
+    /** Emits a color integer to set the unread count text view to. */
+    Observable<Integer> unreadCountTextViewColorInt();
+
+    /** Emits a typeface integer to set the unread count text view to. */
+    Observable<Integer> unreadCountTextViewTypefaceInt();
 
     /** Emits a boolean to determine if the unread count toolbar text view should be gone. */
     Observable<Boolean> unreadCountToolbarTextViewIsGone();
@@ -92,6 +101,13 @@ public interface MessageThreadsViewModel {
 
       this.hasNoMessages = unreadMessagesCount.map(ObjectUtils::isNull);
       this.hasNoUnreadMessages = unreadMessagesCount.map(IntegerUtils::isZero);
+
+      this.unreadCountTextViewColorInt = unreadMessagesCount
+        .map(count -> intValueOrZero(count) > 0 ? R.color.ksr_text_green_700 : R.color.ksr_dark_grey_400);
+
+      this.unreadCountTextViewTypefaceInt = unreadMessagesCount
+        .map(count -> intValueOrZero(count) > 0 ? Typeface.BOLD : Typeface.NORMAL);
+
       this.unreadCountToolbarTextViewIsGone = Observable.zip(
         this.hasNoMessages,
         this.hasNoUnreadMessages,
@@ -112,6 +128,8 @@ public interface MessageThreadsViewModel {
     private final Observable<Boolean> hasNoUnreadMessages;
     private final Observable<Boolean> isFetchingMessageThreads;
     private final Observable<List<MessageThread>> messageThreads;
+    private final Observable<Integer> unreadCountTextViewColorInt;
+    private final Observable<Integer> unreadCountTextViewTypefaceInt;
     private final Observable<Boolean> unreadCountToolbarTextViewIsGone;
     private final Observable<Integer> unreadMessagesCount;
 
@@ -139,6 +157,12 @@ public interface MessageThreadsViewModel {
     }
     @Override public @NonNull Observable<List<MessageThread>> messageThreads() {
       return this.messageThreads;
+    }
+    @Override public @NonNull Observable<Integer> unreadCountTextViewColorInt() {
+      return this.unreadCountTextViewColorInt;
+    }
+    @Override public @NonNull Observable<Integer> unreadCountTextViewTypefaceInt() {
+      return this.unreadCountTextViewTypefaceInt;
     }
     @Override public @NonNull Observable<Boolean> unreadCountToolbarTextViewIsGone() {
       return this.unreadCountToolbarTextViewIsGone;

--- a/app/src/test/java/com/kickstarter/viewmodels/MessageThreadsViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/MessageThreadsViewModelTest.java
@@ -1,9 +1,11 @@
 package com.kickstarter.viewmodels;
 
 import android.content.Intent;
+import android.graphics.Typeface;
 import android.support.annotation.NonNull;
 
 import com.kickstarter.KSRobolectricTestCase;
+import com.kickstarter.R;
 import com.kickstarter.factories.MessageThreadFactory;
 import com.kickstarter.factories.MessageThreadsEnvelopeFactory;
 import com.kickstarter.factories.UserFactory;
@@ -27,6 +29,8 @@ public class MessageThreadsViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Boolean> hasNoMessages = new TestSubscriber<>();
   private final TestSubscriber<Boolean> hasNoUnreadMessages = new TestSubscriber<>();
   private final TestSubscriber<List<MessageThread>> messageThreads = new TestSubscriber<>();
+  private final TestSubscriber<Integer> unreadCountTextViewColorInt = new TestSubscriber<>();
+  private final TestSubscriber<Integer> unreadCountTextViewTypefaceInt = new TestSubscriber<>();
   private final TestSubscriber<Boolean> unreadCountToolbarTextViewIsGone = new TestSubscriber<>();
   private final TestSubscriber<Integer> unreadMessagesCount = new TestSubscriber<>();
 
@@ -35,6 +39,8 @@ public class MessageThreadsViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.hasNoMessages().subscribe(this.hasNoMessages);
     this.vm.outputs.hasNoUnreadMessages().subscribe(this.hasNoUnreadMessages);
     this.vm.outputs.messageThreads().subscribe(this.messageThreads);
+    this.vm.outputs.unreadCountTextViewColorInt().subscribe(this.unreadCountTextViewColorInt);
+    this.vm.outputs.unreadCountTextViewTypefaceInt().subscribe(this.unreadCountTextViewTypefaceInt);
     this.vm.outputs.unreadCountToolbarTextViewIsGone().subscribe(this.unreadCountToolbarTextViewIsGone);
     this.vm.outputs.unreadMessagesCount().subscribe(this.unreadMessagesCount);
   }
@@ -76,6 +82,8 @@ public class MessageThreadsViewModelTest extends KSRobolectricTestCase {
     // Unread count text view is shown.
     this.unreadMessagesCount.assertValues(user.unreadMessagesCount());
     this.hasNoUnreadMessages.assertValues(false);
+    this.unreadCountTextViewColorInt.assertValues(R.color.ksr_text_green_700);
+    this.unreadCountTextViewTypefaceInt.assertValues(Typeface.BOLD);
     this.unreadCountToolbarTextViewIsGone.assertValues(false);
   }
 
@@ -95,6 +103,8 @@ public class MessageThreadsViewModelTest extends KSRobolectricTestCase {
 
     this.hasNoMessages.assertValues(true);
     this.unreadMessagesCount.assertNoValues();
+    this.unreadCountTextViewColorInt.assertValues(R.color.ksr_dark_grey_400);
+    this.unreadCountTextViewTypefaceInt.assertValues(Typeface.NORMAL);
     this.unreadCountToolbarTextViewIsGone.assertValues(true);
   }
 
@@ -114,6 +124,8 @@ public class MessageThreadsViewModelTest extends KSRobolectricTestCase {
 
     this.hasNoUnreadMessages.assertValues(true);
     this.unreadMessagesCount.assertNoValues();
+    this.unreadCountTextViewColorInt.assertValues(R.color.ksr_dark_grey_400);
+    this.unreadCountTextViewTypefaceInt.assertValues(Typeface.NORMAL);
     this.unreadCountToolbarTextViewIsGone.assertValues(true);
   }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
@@ -40,6 +40,7 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Boolean> backingInfoViewIsGone = new TestSubscriber<>();
   private final TestSubscriber<Boolean> closeButtonIsGone = new TestSubscriber<>();
   private final TestSubscriber<Void> goBack = new TestSubscriber<>();
+  private final TestSubscriber<Pair<Message, Integer>> messageAndPosition = new TestSubscriber<>();
   private final TestSubscriber<String> messageEditTextHint = new TestSubscriber<>();
   private final TestSubscriber<List<Message>> messages = new TestSubscriber<>();
   private final TestSubscriber<String> participantNameTextViewText = new TestSubscriber<>();
@@ -59,6 +60,7 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.backingInfoViewIsGone().subscribe(this.backingInfoViewIsGone);
     this.vm.outputs.closeButtonIsGone().subscribe(this.closeButtonIsGone);
     this.vm.outputs.goBack().subscribe(this.goBack);
+    this.vm.outputs.messageAndPosition().subscribe(this.messageAndPosition);
     this.vm.outputs.messageEditTextHint().subscribe(this.messageEditTextHint);
     this.vm.outputs.messages().subscribe(this.messages);
     this.vm.outputs.participantNameTextViewText().subscribe(this.participantNameTextViewText);
@@ -303,9 +305,10 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.messageEditTextChanged("Hello there");
     this.vm.inputs.sendMessageButtonClicked();
 
-    // Error toast is displayed, errored message body remains in edit text.
+    // Error toast is displayed, errored message body remains in edit text, no new message is emitted.
     this.showMessageErrorToast.assertValueCount(1);
     this.setMessageEditText.assertNoValues();
+    this.messageAndPosition.assertNoValues();
 
     // No sent message event tracked.
     this.koalaTest.assertValues(KoalaEvent.VIEWED_MESSAGE_THREAD);
@@ -329,9 +332,17 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
     // Start the view model with a message thread.
     this.vm.intent(messagesContextIntent(MessageThreadFactory.messageThread()));
 
+    // Initial messages emit.
+    this.messages.assertValueCount(1);
+    this.messageAndPosition.assertNoValues();
+
     // Send a message successfully.
     this.vm.inputs.messageEditTextChanged("Salutations friend!");
     this.vm.inputs.sendMessageButtonClicked();
+
+    // Messages list does not emit again, only the new message and its position.
+    this.messages.assertValueCount(1);
+    this.messageAndPosition.assertValueCount(1);
 
     // Reply edit text should be cleared.
     this.setMessageEditText.assertValues("");


### PR DESCRIPTION
## what
1. Fixed a bug in which `backingOrThread.compose(takeWhen(messageSent))` would reload an array of `messages` again in the RecyclerView, rather than just the new message sent
2. Fixed the UI of the `unreadMessageCountTextView` so that the text view is only bold and green when there are new messages