### PR TITLE
Naive fix for timing in test

### DIFF
--- a/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardViewModelTest.java
@@ -10,6 +10,8 @@ import com.kickstarter.factories.ProjectsEnvelopeFactory;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.utils.ListUtils;
+import com.kickstarter.libs.utils.NumberUtils;
+import com.kickstarter.libs.utils.ProjectUtils;
 import com.kickstarter.models.Project;
 import com.kickstarter.services.MockApiClient;
 import com.kickstarter.services.apiresponses.ProjectsEnvelope;
@@ -120,6 +122,8 @@ public class CreatorDashboardViewModelTest extends KSRobolectricTestCase {
     };
 
     setUpEnvironment(environment().toBuilder().apiClient(apiClient).build());
-    this.timeRemaining.assertValues("9");
+    final Project project = ListUtils.first(projects);
+    final int deadlineVal = ProjectUtils.deadlineCountdownValue(project);
+    this.timeRemaining.assertValues(NumberUtils.format(deadlineVal));
   }
 }


### PR DESCRIPTION
build is failing on circle on a test that [compares times](https://github.com/kickstarter/android-oss/blob/master/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardViewModelTest.java#L110).  I'm hoping this will fix it by not hardcoding the value that we expect to come back from the view model.


![bitmoji](https://render.bitstrips.com/v2/cpanel/9945706-166112684_3-s1-v1.png?transparent=1&palette=1&width=246)