### PR TITLE
[Messages] Swipe refresh layout

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/MessageThreadsActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/MessageThreadsActivity.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.CollapsingToolbarLayout;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Pair;
@@ -17,6 +18,7 @@ import com.kickstarter.R;
 import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.KSString;
 import com.kickstarter.libs.RecyclerViewPaginator;
+import com.kickstarter.libs.SwipeRefresher;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
 import com.kickstarter.libs.utils.NumberUtils;
 import com.kickstarter.libs.utils.StringUtils;
@@ -37,12 +39,14 @@ public class MessageThreadsActivity extends BaseActivity<MessageThreadsViewModel
   private MessageThreadsAdapter adapter;
   private KSString ksString;
   private RecyclerViewPaginator recyclerViewPaginator;
+  private SwipeRefresher swipeRefresher;
 
   protected @Bind(R.id.message_threads_app_bar_layout) AppBarLayout appBarLayout;
   protected @Bind(R.id.message_threads_collapsed_toolbar_title) View collapsedToolbarTitle;
   protected @Bind(R.id.message_threads_collapsing_toolbar_layout) CollapsingToolbarLayout collapsingToolbarLayout;
   protected @Bind(R.id.mailbox_text_view) TextView mailboxTextView;
   protected @Bind(R.id.message_threads_recycler_view) RecyclerView recyclerView;
+  protected @Bind(R.id.message_threads_swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayout;
   protected @Bind(R.id.unread_count_text_view) TextView unreadCountTextView;
   protected @Bind(R.id.message_threads_toolbar_unread_count_text_view) TextView unreadCountToolbarTextView;
 
@@ -65,6 +69,9 @@ public class MessageThreadsActivity extends BaseActivity<MessageThreadsViewModel
     this.recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
     this.recyclerViewPaginator = new RecyclerViewPaginator(this.recyclerView, this.viewModel.inputs::nextPage);
+    this.swipeRefresher = new SwipeRefresher(
+      this, this.swipeRefreshLayout, this.viewModel.inputs::refresh, this.viewModel.outputs::isFetchingMessageThreads
+    );
 
     this.mailboxTextView.setText(this.inboxString);  // todo: Sent mailbox logic enum
 

--- a/app/src/main/res/layout/message_threads_layout.xml
+++ b/app/src/main/res/layout/message_threads_layout.xml
@@ -62,11 +62,18 @@
 
   </android.support.design.widget.AppBarLayout>
 
-  <android.support.v7.widget.RecyclerView
-    android:id="@+id/message_threads_recycler_view"
-    android:background="@color/white"
+  <android.support.v4.widget.SwipeRefreshLayout
+    android:id="@+id/message_threads_swipe_refresh_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+    android:layout_height="wrap_content"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <android.support.v7.widget.RecyclerView
+      android:id="@+id/message_threads_recycler_view"
+      android:background="@color/white"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"/>
+
+  </android.support.v4.widget.SwipeRefreshLayout>
 
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
## what
Implemented swipe refresh layout for messages. Held off on this for a bit cause there was a bug with threads not loading initially, but after looking at our `ActivityFeedViewModel` and other swipe refresh layout turns out that
1. `paginator` related data with the swipe refresher need to be `BehaviorSubject`s (something to do with `ApiPaginator` using PublishSubjects...)
2. we need to manually ping `this.refresh()` initially to kick off the paginator's `startOverWith`