### PR TITLE
[Messages] More bugfixes

### DIFF
--- a/app/src/main/java/com/kickstarter/services/ApiClient.java
+++ b/app/src/main/java/com/kickstarter/services/ApiClient.java
@@ -388,14 +388,16 @@ public final class ApiClient implements ApiClientType {
 
   @Override
   public @NonNull Observable<Message> sendMessage(final @NonNull MessageSubject messageSubject, final @NonNull String body) {
+    final MessageBody messageBody = MessageBody.builder().body(body).build();
+
     return messageSubject
       .value(
         backing -> this.service
-          .sendMessageToBacking(backing.projectId(), backing.backerId(), MessageBody.builder().body(body).build()),
+          .sendMessageToBacking(backing.projectId(), backing.backerId(), messageBody),
         messageThread -> this.service
-          .sendMessageToThread(messageThread.id(), MessageBody.builder().body(body).build()),
+          .sendMessageToThread(messageThread.id(), messageBody),
         project -> this.service
-          .sendMessageToProject(project.id(), MessageBody.builder().body(body).build())
+          .sendMessageToProject(project.id(), messageBody)
       )
       .lift(apiErrorOperator())
       .subscribeOn(Schedulers.io());

--- a/app/src/main/java/com/kickstarter/services/ApiClient.java
+++ b/app/src/main/java/com/kickstarter/services/ApiClient.java
@@ -40,6 +40,7 @@ import com.kickstarter.services.apiresponses.MessageThreadEnvelope;
 import com.kickstarter.services.apiresponses.MessageThreadsEnvelope;
 import com.kickstarter.services.apiresponses.ProjectsEnvelope;
 import com.kickstarter.services.apiresponses.StarEnvelope;
+import com.kickstarter.ui.data.MessageSubject;
 
 import java.util.Arrays;
 import java.util.List;
@@ -386,17 +387,16 @@ public final class ApiClient implements ApiClientType {
   }
 
   @Override
-  public @NonNull Observable<Message> sendMessageToBacking(final @NonNull Backing backing, final @NonNull String body) {
-    return service
-      .sendMessageToBacking(backing.projectId(), backing.backerId(), MessageBody.builder().body(body).build())
-      .lift(apiErrorOperator())
-      .subscribeOn(Schedulers.io());
-  }
-
-  @Override
-  public @NonNull Observable<Message> sendMessageToThread(final @NonNull MessageThread messageThread, final @NonNull String body) {
-    return service
-      .sendMessageToThread(messageThread.id(), MessageBody.builder().body(body).build())
+  public @NonNull Observable<Message> sendMessage(final @NonNull MessageSubject messageSubject, final @NonNull String body) {
+    return messageSubject
+      .value(
+        backing -> this.service
+          .sendMessageToBacking(backing.projectId(), backing.backerId(), MessageBody.builder().body(body).build()),
+        messageThread -> this.service
+          .sendMessageToThread(messageThread.id(), MessageBody.builder().body(body).build()),
+        project -> this.service
+          .sendMessageToProject(project.id(), MessageBody.builder().body(body).build())
+      )
       .lift(apiErrorOperator())
       .subscribeOn(Schedulers.io());
   }

--- a/app/src/main/java/com/kickstarter/services/ApiClientType.java
+++ b/app/src/main/java/com/kickstarter/services/ApiClientType.java
@@ -23,6 +23,7 @@ import com.kickstarter.services.apiresponses.DiscoverEnvelope;
 import com.kickstarter.services.apiresponses.MessageThreadEnvelope;
 import com.kickstarter.services.apiresponses.MessageThreadsEnvelope;
 import com.kickstarter.services.apiresponses.ProjectsEnvelope;
+import com.kickstarter.ui.data.MessageSubject;
 
 import java.util.List;
 
@@ -103,9 +104,7 @@ public interface ApiClientType {
 
   @NonNull Observable<User> resetPassword(final @NonNull String email);
 
-  @NonNull Observable<Message> sendMessageToBacking(final @NonNull Backing backing, final @NonNull String body);
-
-  @NonNull Observable<Message> sendMessageToThread(final @NonNull MessageThread messageThread, final @NonNull String body);
+  @NonNull Observable<Message> sendMessage(final @NonNull MessageSubject messageSubject, final @NonNull String body);
 
   @NonNull Observable<AccessTokenEnvelope> signup(final @NonNull String name, final @NonNull String email, final @NonNull String password,
     final @NonNull String passwordConfirmation, final boolean sendNewsletters);

--- a/app/src/main/java/com/kickstarter/services/apiresponses/MessageThreadEnvelope.java
+++ b/app/src/main/java/com/kickstarter/services/apiresponses/MessageThreadEnvelope.java
@@ -1,6 +1,7 @@
 package com.kickstarter.services.apiresponses;
 
 import android.os.Parcelable;
+import android.support.annotation.Nullable;
 
 import com.kickstarter.libs.qualifiers.AutoGson;
 import com.kickstarter.models.Message;
@@ -14,7 +15,7 @@ import auto.parcel.AutoParcel;
 @AutoGson
 @AutoParcel
 public abstract class MessageThreadEnvelope implements Parcelable {
-  public abstract List<Message> messages();
+  public abstract @Nullable List<Message> messages();
   public abstract MessageThread messageThread();
   public abstract List<User> participants();
 

--- a/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.java
@@ -117,6 +117,11 @@ public final class MessagesActivity extends BaseActivity<MessagesViewModel.ViewM
       .compose(observeForUI())
       .subscribe(this::setMessageEditTextHint);
 
+    this.viewModel.outputs.messageEditTextShouldRequestFocus()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(__ -> this.messageEditText.requestFocus());
+
     this.viewModel.outputs.messages()
       .compose(bindToLifecycle())
       .compose(observeForUI())

--- a/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.java
@@ -10,6 +10,7 @@ import android.support.v7.widget.RecyclerView;
 import android.text.Html;
 import android.util.Pair;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -120,7 +121,7 @@ public final class MessagesActivity extends BaseActivity<MessagesViewModel.ViewM
     this.viewModel.outputs.messageEditTextShouldRequestFocus()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(__ -> this.messageEditText.requestFocus());
+      .subscribe(__ -> this.requestFocusAndOpenKeyboard());
 
     this.viewModel.outputs.messages()
       .compose(bindToLifecycle())
@@ -202,6 +203,11 @@ public final class MessagesActivity extends BaseActivity<MessagesViewModel.ViewM
   @OnTextChanged(R.id.message_edit_text)
   public void onMessageEditTextChanged(final @NonNull CharSequence message) {
     this.viewModel.inputs.messageEditTextChanged(message.toString());
+  }
+
+  private void requestFocusAndOpenKeyboard() {
+    this.messageEditText.requestFocus();
+    this.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
   }
 
   private void setBackingInfoView(final @NonNull Pair<Backing, Project> backingAndProject) {

--- a/app/src/main/java/com/kickstarter/ui/data/LoginReason.java
+++ b/app/src/main/java/com/kickstarter/ui/data/LoginReason.java
@@ -33,5 +33,4 @@ public enum LoginReason {
         return "generic";
     }
   }
-};
-
+}

--- a/app/src/main/java/com/kickstarter/ui/data/MessageSubject.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/MessageSubject.kt
@@ -1,0 +1,17 @@
+package com.kickstarter.ui.data
+
+sealed class MessageSubject {
+  class Backing(val backing: com.kickstarter.models.Backing) : MessageSubject()
+  class Project(val project: com.kickstarter.models.Project) : MessageSubject()
+  class MessageThread(val messageThread: com.kickstarter.models.MessageThread) : MessageSubject()
+
+  fun <A> value(
+    ifBacking: (com.kickstarter.models.Backing) -> A,
+    ifMessageThread: (com.kickstarter.models.MessageThread) -> A,
+    ifProject: (com.kickstarter.models.Project) -> A) : A = when(this) {
+
+    is Backing -> ifBacking(this.backing)
+    is MessageThread -> ifMessageThread(this.messageThread)
+    is Project -> ifProject(this.project)
+  }
+}

--- a/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
@@ -77,8 +77,8 @@ public interface MessagesViewModel {
     /** Emits a string to display as the message edit text hint. */
     Observable<String> messageEditTextHint();
 
-    /** Emits a boolean to determine when the edit text should request focus. */
-    Observable<Boolean> messageEditTextShouldRequestFocus();
+    /** Emits when the edit text should request focus. */
+    Observable<Void> messageEditTextShouldRequestFocus();
 
     /** Emits a list of messages to be displayed. */
     Observable<List<Message>> messages();
@@ -248,9 +248,11 @@ public interface MessagesViewModel {
         .compose(bindToLifecycle())
         .subscribe(this.participantNameTextViewText::onNext);
 
-      this.messages
-        .map(m -> m.size() == 0)
+      initialMessageThreadEnvelope
+        .map(MessageThreadEnvelope::messages)
+        .filter(ObjectUtils::isNull)
         .take(1)
+        .compose(ignoreValues())
         .compose(bindToLifecycle())
         .subscribe(this.messageEditTextShouldRequestFocus::onNext);
 
@@ -334,7 +336,7 @@ public interface MessagesViewModel {
     private final Observable<Void> goBack;
     private final BehaviorSubject<Pair<Message, Integer>> messageAndPosition = BehaviorSubject.create();
     private final Observable<String> messageEditTextHint;
-    private final PublishSubject<Boolean> messageEditTextShouldRequestFocus = PublishSubject.create();
+    private final PublishSubject<Void> messageEditTextShouldRequestFocus = PublishSubject.create();
     private final BehaviorSubject<List<Message>> messages = BehaviorSubject.create();
     private final BehaviorSubject<String> participantNameTextViewText = BehaviorSubject.create();
     private final BehaviorSubject<String> projectNameTextViewText = BehaviorSubject.create();
@@ -383,7 +385,7 @@ public interface MessagesViewModel {
     @Override public @NonNull Observable<String> messageEditTextHint() {
       return this.messageEditTextHint;
     }
-    @Override public @NonNull Observable<Boolean> messageEditTextShouldRequestFocus() {
+    @Override public @NonNull Observable<Void> messageEditTextShouldRequestFocus() {
       return messageEditTextShouldRequestFocus;
     }
     @Override public @NonNull Observable<List<Message>> messages() {

--- a/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
@@ -76,6 +76,9 @@ public interface MessagesViewModel {
     /** Emits a string to display as the message edit text hint. */
     Observable<String> messageEditTextHint();
 
+    /** Emits a boolean to determine when the edit text should request focus. */
+    Observable<Boolean> messageEditTextShouldRequestFocus();
+
     /** Emits a list of messages to be displayed. */
     Observable<List<Message>> messages();
 
@@ -226,6 +229,12 @@ public interface MessagesViewModel {
         .compose(bindToLifecycle())
         .subscribe(this.participantNameTextViewText::onNext);
 
+      this.messages
+        .map(m -> m.size() == 0)
+        .take(1)
+        .compose(bindToLifecycle())
+        .subscribe(this.messageEditTextShouldRequestFocus::onNext);
+
       this.messageEditTextHint = this.participantNameTextViewText;
 
       Observable.combineLatest(
@@ -312,6 +321,7 @@ public interface MessagesViewModel {
     private final Observable<Void> goBack;
     private final BehaviorSubject<Pair<Message, Integer>> messageAndPosition = BehaviorSubject.create();
     private final Observable<String> messageEditTextHint;
+    private final PublishSubject<Boolean> messageEditTextShouldRequestFocus = PublishSubject.create();
     private final BehaviorSubject<List<Message>> messages = BehaviorSubject.create();
     private final BehaviorSubject<String> participantNameTextViewText = BehaviorSubject.create();
     private final BehaviorSubject<String> projectNameTextViewText = BehaviorSubject.create();
@@ -359,6 +369,9 @@ public interface MessagesViewModel {
     }
     @Override public @NonNull Observable<String> messageEditTextHint() {
       return this.messageEditTextHint;
+    }
+    @Override public @NonNull Observable<Boolean> messageEditTextShouldRequestFocus() {
+      return messageEditTextShouldRequestFocus;
     }
     @Override public @NonNull Observable<List<Message>> messages() {
       return this.messages;

--- a/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
@@ -183,7 +183,7 @@ public interface MessagesViewModel {
           data.getBackingOrThread().either(
             // Message subject is the project if the current user is the backer,
             // otherwise the current user is the creator and will send a message to the backing.
-            backing -> backing.backer() == data.getCurrentUser()
+            backing -> backing.backerId() == data.getCurrentUser().id()
               ? new MessageSubject.Project(data.getProject())
               : new MessageSubject.Backing(backing),
             // If instantiated with a message thread the thread is the subject.

--- a/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
@@ -22,6 +22,7 @@ import com.kickstarter.services.apiresponses.ErrorEnvelope;
 import com.kickstarter.services.apiresponses.MessageThreadEnvelope;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.activities.MessagesActivity;
+import com.kickstarter.ui.data.MessageSubject;
 import com.kickstarter.ui.data.MessagesData;
 
 import java.util.List;
@@ -155,8 +156,8 @@ public interface MessagesViewModel {
         .compose(takeWhen(this.sendMessageButtonClicked))
         .switchMap(backingOrThreadAndBody ->
           backingOrThreadAndBody.first.either(
-            backing -> this.client.sendMessageToBacking(backing, backingOrThreadAndBody.second),
-            thread -> this.client.sendMessageToThread(thread, backingOrThreadAndBody.second)
+            backing -> this.client.sendMessage(new MessageSubject.Backing(backing), backingOrThreadAndBody.second),
+            thread -> this.client.sendMessage(new MessageSubject.MessageThread(thread), backingOrThreadAndBody.second)
           )
           .doOnSubscribe(() -> messageIsSending.onNext(true))
         )

--- a/app/src/main/res/layout/message_threads_layout.xml
+++ b/app/src/main/res/layout/message_threads_layout.xml
@@ -3,6 +3,7 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/message_threads_coordinator_layout"
   android:focusable="true"
   android:layout_width="match_parent"
   android:layout_height="match_parent"

--- a/app/src/main/res/layout/messages_layout.xml
+++ b/app/src/main/res/layout/messages_layout.xml
@@ -3,6 +3,7 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/messages_coordinator_layout"
   android:fitsSystemWindows="true"
   android:layout_width="match_parent"
   android:layout_height="match_parent">

--- a/app/src/test/java/com/kickstarter/services/MockApiClient.java
+++ b/app/src/test/java/com/kickstarter/services/MockApiClient.java
@@ -11,7 +11,6 @@ import com.kickstarter.factories.CategoryFactory;
 import com.kickstarter.factories.CommentFactory;
 import com.kickstarter.factories.CommentsEnvelopeFactory;
 import com.kickstarter.factories.LocationFactory;
-import com.kickstarter.factories.MessageFactory;
 import com.kickstarter.factories.MessageThreadEnvelopeFactory;
 import com.kickstarter.factories.MessageThreadsEnvelopeFactory;
 import com.kickstarter.factories.ProjectFactory;
@@ -38,6 +37,7 @@ import com.kickstarter.services.apiresponses.DiscoverEnvelope;
 import com.kickstarter.services.apiresponses.MessageThreadEnvelope;
 import com.kickstarter.services.apiresponses.MessageThreadsEnvelope;
 import com.kickstarter.services.apiresponses.ProjectsEnvelope;
+import com.kickstarter.ui.data.MessageSubject;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -323,13 +323,8 @@ public class MockApiClient implements ApiClientType {
   }
 
   @Override
-  public @NonNull Observable<Message> sendMessageToBacking(final @NonNull Backing backing, final @NonNull String body) {
+  public @NonNull Observable<Message> sendMessage(final @NonNull MessageSubject messageSubject, final @NonNull String body) {
     return Observable.empty();
-  }
-
-  @Override
-  public @NonNull Observable<Message> sendMessageToThread(final @NonNull MessageThread thread, final @NonNull String body) {
-    return Observable.just(MessageFactory.message());
   }
 
   @Override

--- a/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
@@ -24,6 +24,7 @@ import com.kickstarter.models.User;
 import com.kickstarter.services.MockApiClient;
 import com.kickstarter.services.apiresponses.MessageThreadEnvelope;
 import com.kickstarter.ui.IntentKey;
+import com.kickstarter.ui.data.MessageSubject;
 
 import org.junit.Test;
 
@@ -292,7 +293,7 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
   public void testSendMessage_Error() {
     final MockApiClient apiClient = new MockApiClient() {
       @Override
-      public @NonNull Observable<Message> sendMessageToThread(final @NonNull MessageThread thread, final @NonNull String body) {
+      public @NonNull Observable<Message> sendMessage(final @NonNull MessageSubject messageSubject, final @NonNull String body) {
         return Observable.error(ApiExceptionFactory.badRequestException());
       }
     };
@@ -323,7 +324,7 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
 
     final MockApiClient apiClient = new MockApiClient() {
       @Override
-      public @NonNull Observable<Message> sendMessageToThread(final @NonNull MessageThread thread, final @NonNull String body) {
+      public @NonNull Observable<Message> sendMessage(final @NonNull MessageSubject messageSubject, final @NonNull String body) {
         return Observable.just(sentMessage);
       }
     };
@@ -387,7 +388,6 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
     // Start the view model with a message thread.
     this.vm.intent(messagesContextIntent(MessageThreadFactory.messageThread()));
 
-    this.messages.assertNoValues();
     this.messageEditTextShouldRequestFocus.assertValues(true);
   }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
@@ -43,7 +43,7 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Void> goBack = new TestSubscriber<>();
   private final TestSubscriber<Pair<Message, Integer>> messageAndPosition = new TestSubscriber<>();
   private final TestSubscriber<String> messageEditTextHint = new TestSubscriber<>();
-  private final TestSubscriber<Boolean> messageEditTextShouldRequestFocus = new TestSubscriber<>();
+  private final TestSubscriber<Void> messageEditTextShouldRequestFocus = new TestSubscriber<>();
   private final TestSubscriber<List<Message>> messages = new TestSubscriber<>();
   private final TestSubscriber<String> participantNameTextViewText = new TestSubscriber<>();
   private final TestSubscriber<String> projectNameTextViewText = new TestSubscriber<>();
@@ -261,7 +261,7 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
 
     // Messages emit, keyboard not shown.
     this.messages.assertValueCount(1);
-    this.messageEditTextShouldRequestFocus.assertValues(false);
+    this.messageEditTextShouldRequestFocus.assertNoValues();
   }
 
   @Test
@@ -370,13 +370,15 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
 
   @Test
   public void testShouldRequestFocus() {
+    final Backing backing = BackingFactory.backing();
+
     final MessageThreadEnvelope envelope = MessageThreadEnvelopeFactory.messageThreadEnvelope()
       .toBuilder()
-      .messages(Collections.emptyList())
+      .messages(null)
       .build();
 
     final MockApiClient apiClient = new MockApiClient() {
-      @Override public @NonNull Observable<MessageThreadEnvelope> fetchMessagesForThread(final @NonNull MessageThread messageThread) {
+      @Override public @NonNull Observable<MessageThreadEnvelope> fetchMessagesForBacking(final @NonNull Backing backing) {
         return Observable.just(envelope);
       }
     };
@@ -385,10 +387,10 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
       environment().toBuilder().apiClient(apiClient).currentUser(new MockCurrentUser(UserFactory.user())).build()
     );
 
-    // Start the view model with a message thread.
-    this.vm.intent(messagesContextIntent(MessageThreadFactory.messageThread()));
+    // Start the view model with a backing and project.
+    this.vm.intent(backerModalContextIntent(backing, ProjectFactory.project()));
 
-    this.messageEditTextShouldRequestFocus.assertValues(true);
+    this.messageEditTextShouldRequestFocus.assertValueCount(1);
   }
 
   @Test


### PR DESCRIPTION
## what
* Preserve toolbar expanded state on rotation, done by setting the id of its CoordinatorLayout
* Open keyboard when there are no messages in a thread
* Add `MessageSubject` & refactor MessagesVM to use it! (this VM is where most of the surgery is done)
  * Previously, I was sending messages to a Backing thread as a backer and thus received 422s, since backers should be sending to a Project thread. The overall flow of our messages via message subjects is
  ```
  MessageSubject.Backing : creator -> backer
  MessageSubject.Project : backer / user -> creator
  MessageSubject.MessageThread : user to a message thread, navigated from Inbox
  ```

I missed this logic the first time through because in Swift, we have a `MessagesViewModel` as well as a `MessageDialogViewModel` since our editor for writing messages is its own view controller.

## todo
It's been a journey and what's left now is ironing out the expanded toolbar UX for MessageThreads, then more rounds of bugfixes if necessary 😎 