### PR TITLE
[Messages] Render unread state correctly on refresh

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/adapters/MessageThreadsAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/MessageThreadsAdapter.java
@@ -19,7 +19,8 @@ public final class MessageThreadsAdapter extends KSAdapter {
   }
 
   public void messageThreads(final @NonNull List<MessageThread> messageThreads) {
-    setSection(0, messageThreads);
+    clearSections();
+    addSection(messageThreads);
     notifyDataSetChanged();
   }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/MessageThreadHolderViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessageThreadHolderViewModel.java
@@ -76,7 +76,6 @@ public interface MessageThreadHolderViewModel {
 
       // Store the correct initial hasUnreadMessages value.
       this.messageThread
-        .take(1)
         .compose(observeForUI())
         .subscribe(thread -> setHasUnreadMessagesPreference(thread, this.sharedPreferences));
 

--- a/app/src/main/java/com/kickstarter/viewmodels/MessageThreadsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessageThreadsViewModel.java
@@ -77,8 +77,10 @@ public interface MessageThreadsViewModel {
       this.client = environment.apiClient();
       this.currentUser = environment.currentUser();
 
+      final Observable<Void> startOverWith = Observable.merge(this.onResume, this.refresh);
+
       final Observable<User> freshUser = intent()
-        .compose(takeWhen(Observable.merge(this.onResume, this.refresh)))
+        .compose(takeWhen(startOverWith))
         .switchMap(__ -> this.client.fetchCurrentUser())
         .retry(2)
         .compose(neverError());
@@ -94,7 +96,7 @@ public interface MessageThreadsViewModel {
       final ApiPaginator<MessageThread, MessageThreadsEnvelope, Void> paginator =
         ApiPaginator.<MessageThread, MessageThreadsEnvelope, Void>builder()
           .nextPage(this.nextPage)
-          .startOverWith(this.refresh)
+          .startOverWith(startOverWith)
           .envelopeToListOfData(MessageThreadsEnvelope::messageThreads)
           .envelopeToMoreUrl(env -> env.urls().api().moreMessageThreads())
           .loadWithParams(__ -> this.client.fetchMessageThreads(Mailbox.INBOX))

--- a/app/src/main/res/layout/messages_layout.xml
+++ b/app/src/main/res/layout/messages_layout.xml
@@ -12,7 +12,6 @@
     android:id="@+id/messages_app_bar_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:expanded="true"
     app:elevation="0dp">
 
     <android.support.design.widget.CollapsingToolbarLayout

--- a/app/src/test/java/com/kickstarter/viewmodels/MessageThreadsViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/MessageThreadsViewModelTest.java
@@ -61,10 +61,13 @@ public class MessageThreadsViewModelTest extends KSRobolectricTestCase {
     };
 
     setUpEnvironment(environment().toBuilder().apiClient(apiClient).build());
-    this.vm.intent(new Intent());
-    this.vm.inputs.onResume();
 
+    this.vm.intent(new Intent());
     this.messageThreads.assertValueCount(1);
+
+    this.vm.inputs.onResume();
+    this.messageThreads.assertValueCount(2);
+
     this.koalaTest.assertValues(KoalaEvent.VIEWED_MESSAGE_INBOX);
   }
 


### PR DESCRIPTION
## what
There was a lil bug with rendering the correct `unread` state for messages on resume.

## how
Turns out since we weren't passing down the correctly refreshed `List<MessageThread>` data from the parent `MessageThreadsViewModel` to its `MessageThreadHolderViewModel`s, so despite caching, the previous value would be fed through again on rotation and recycling (i.e. `onResume`). Wahoo!