### PR TITLE
[Messages] Fix project context banner

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -391,7 +391,7 @@
     </activity>
 
     <activity
-      android:name=".ui.activities.ViewPledgeActivity"
+      android:name=".ui.activities.BackingActivity"
       android:parentActivityName=".ui.activities.ProjectActivity"
       android:theme="@style/ViewPledgeActivity">
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -393,7 +393,7 @@
     <activity
       android:name=".ui.activities.BackingActivity"
       android:parentActivityName=".ui.activities.ProjectActivity"
-      android:theme="@style/ViewPledgeActivity">
+      android:theme="@style/BackingActivity">
 
       <meta-data
         android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/java/com/kickstarter/libs/RefTag.java
+++ b/app/src/main/java/com/kickstarter/libs/RefTag.java
@@ -35,6 +35,10 @@ public abstract class RefTag implements Parcelable {
     return new AutoParcel_RefTag("dashboard");
   }
 
+  public static @NonNull RefTag pledgeInfo() {
+    return new AutoParcel_RefTag("pledge_info");
+  }
+
   public static @NonNull RefTag recommended() {
     return new AutoParcel_RefTag("recommended");
   }

--- a/app/src/main/java/com/kickstarter/ui/activities/BackingActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/BackingActivity.java
@@ -17,6 +17,7 @@ import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.KSString;
 import com.kickstarter.libs.KoalaContext;
+import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
 import com.kickstarter.libs.transformations.CircleTransformation;
 import com.kickstarter.libs.utils.ViewUtils;
@@ -173,6 +174,11 @@ public final class BackingActivity extends BaseActivity<BackingViewModel.ViewMod
       .compose(observeForUI())
       .subscribe(this::startMessagesActivity);
 
+    this.viewModel.outputs.startProjectActivity()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(this::startProjectActivity);
+
     this.viewModel.outputs.viewMessagesButtonIsGone()
       .compose(bindToLifecycle())
       .compose(observeForUI())
@@ -254,6 +260,14 @@ public final class BackingActivity extends BaseActivity<BackingViewModel.ViewMod
       .putExtra(IntentKey.PROJECT, projectAndBacking.first)
       .putExtra(IntentKey.BACKING, projectAndBacking.second)
       .putExtra(IntentKey.KOALA_CONTEXT, KoalaContext.Message.BACKER_MODAL);
+
+    startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
+  }
+
+  private void startProjectActivity(final @NonNull Pair<Project, RefTag> projectAndRefTag) {
+    final Intent intent = new Intent(this, ProjectActivity.class)
+      .putExtra(IntentKey.PROJECT, projectAndRefTag.first)
+      .putExtra(IntentKey.REF_TAG, projectAndRefTag.second);
 
     startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }

--- a/app/src/main/java/com/kickstarter/ui/activities/BackingActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/BackingActivity.java
@@ -24,7 +24,7 @@ import com.kickstarter.models.Backing;
 import com.kickstarter.models.Project;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.adapters.RewardsItemAdapter;
-import com.kickstarter.viewmodels.ViewPledgeViewModel;
+import com.kickstarter.viewmodels.BackingViewModel;
 import com.squareup.picasso.Picasso;
 
 import butterknife.Bind;
@@ -35,26 +35,26 @@ import butterknife.OnClick;
 import static com.kickstarter.libs.rx.transformers.Transformers.observeForUI;
 import static com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft;
 
-@RequiresActivityViewModel(ViewPledgeViewModel.ViewModel.class)
-public final class ViewPledgeActivity extends BaseActivity<ViewPledgeViewModel.ViewModel> {
-  protected @Bind(R.id.view_pledge_avatar_image_view) ImageView avatarImageView;
-  protected @Bind(R.id.view_pledge_backer_name) TextView backerNameTextView;
-  protected @Bind(R.id.view_pledge_backer_number) TextView backerNumberTextView;
-  protected @Bind(R.id.view_pledge_backing_amount_and_date_text_view) TextView backingAmountAndDateTextView;
-  protected @Bind(R.id.view_pledge_backing_status) TextView backingStatusTextView;
-  protected @Bind(R.id.view_pledge_estimated_delivery_section) View pledgeEstimatedDeliverySection;
+@RequiresActivityViewModel(BackingViewModel.ViewModel.class)
+public final class BackingActivity extends BaseActivity<BackingViewModel.ViewModel> {
+  protected @Bind(R.id.backing_avatar_image_view) ImageView avatarImageView;
+  protected @Bind(R.id.backing_backer_name) TextView backerNameTextView;
+  protected @Bind(R.id.backing_backer_number) TextView backerNumberTextView;
+  protected @Bind(R.id.backing_amount_and_date_text_view) TextView backingAmountAndDateTextView;
+  protected @Bind(R.id.backing_status) TextView backingStatusTextView;
+  protected @Bind(R.id.backing_estimated_delivery_section) View pledgeEstimatedDeliverySection;
   protected @Bind(R.id.project_context_creator_name) TextView projectContextCreatorNameTextView;
   protected @Bind(R.id.project_context_image_view) ImageView projectContextPhotoImageView;
   protected @Bind(R.id.project_context_project_name) TextView projectContextProjectNameTextView;
   protected @Bind(R.id.project_context_view) View projectContextView;
-  protected @Bind(R.id.view_pledge_estimated_delivery) TextView pledgeEstimatedDeliveryTextView;
-  protected @Bind(R.id.view_pledge_reward_minimum_and_description) TextView rewardMinimumAndDescriptionTextView;
-  protected @Bind(R.id.view_pledge_rewards_item_recycler_view) RecyclerView rewardsItemRecyclerView;
-  protected @Bind(R.id.view_pledge_rewards_item_section) View rewardsItemSection;
-  protected @Bind(R.id.view_pledge_shipping_amount) TextView shippingAmountTextView;
-  protected @Bind(R.id.view_pledge_shipping_location) TextView shippingLocationTextView;
-  protected @Bind(R.id.view_pledge_shipping_section) View shippingSection;
-  protected @Bind(R.id.view_pledge_view_messages_button) Button viewMessagesButton;
+  protected @Bind(R.id.backing_estimated_delivery) TextView pledgeEstimatedDeliveryTextView;
+  protected @Bind(R.id.backing_reward_minimum_and_description) TextView rewardMinimumAndDescriptionTextView;
+  protected @Bind(R.id.backing_rewards_item_recycler_view) RecyclerView rewardsItemRecyclerView;
+  protected @Bind(R.id.backing_rewards_item_section) View rewardsItemSection;
+  protected @Bind(R.id.backing_shipping_amount) TextView shippingAmountTextView;
+  protected @Bind(R.id.backing_shipping_location) TextView shippingLocationTextView;
+  protected @Bind(R.id.backing_shipping_section) View shippingSection;
+  protected @Bind(R.id.backing_view_messages_button) Button viewMessagesButton;
 
   protected @BindString(R.string.backer_modal_backer_number) String backerNumberString;
   protected @BindString(R.string.backer_modal_status_backing_status) String backingStatusString;
@@ -72,7 +72,7 @@ public final class ViewPledgeActivity extends BaseActivity<ViewPledgeViewModel.V
   @Override
   public void onCreate(final @Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    setContentView(R.layout.view_pledge_layout);
+    setContentView(R.layout.backing_layout);
     ButterKnife.bind(this);
 
     final RewardsItemAdapter rewardsItemAdapter = new RewardsItemAdapter();
@@ -189,7 +189,7 @@ public final class ViewPledgeActivity extends BaseActivity<ViewPledgeViewModel.V
     this.viewModel.inputs.projectClicked();
   }
 
-  @OnClick(R.id.view_pledge_view_messages_button)
+  @OnClick(R.id.backing_view_messages_button)
   protected void viewMessagesButtonClicked() {
     this.viewModel.inputs.viewMessagesButtonClicked();
   }

--- a/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.java
@@ -184,10 +184,10 @@ public final class MessagesActivity extends BaseActivity<MessagesViewModel.ViewM
       .compose(observeForUI())
       .subscribe(error -> ViewUtils.showToast(this, error));
 
-    this.viewModel.outputs.startViewPledgeActivity()
+    this.viewModel.outputs.startBackingActivity()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(this::startViewPledgeActivity);
+      .subscribe(this::startBackingActivity);
 
     this.viewModel.outputs.toolbarIsExpanded()
       .compose(bindToLifecycle())
@@ -262,7 +262,7 @@ public final class MessagesActivity extends BaseActivity<MessagesViewModel.ViewM
     this.messageEditText.setHint(this.ksString.format(this.messageUserNameString, "user_name", name));
   }
 
-  private void startViewPledgeActivity(final @NonNull Project project) {
+  private void startBackingActivity(final @NonNull Project project) {
     final Intent intent = new Intent(this, BackingActivity.class)
       .putExtra(IntentKey.PROJECT, project)
       .putExtra(IntentKey.IS_FROM_MESSAGES_ACTIVITY, true);

--- a/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.java
@@ -263,7 +263,7 @@ public final class MessagesActivity extends BaseActivity<MessagesViewModel.ViewM
   }
 
   private void startViewPledgeActivity(final @NonNull Project project) {
-    final Intent intent = new Intent(this, ViewPledgeActivity.class)
+    final Intent intent = new Intent(this, BackingActivity.class)
       .putExtra(IntentKey.PROJECT, project)
       .putExtra(IntentKey.IS_FROM_MESSAGES_ACTIVITY, true);
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
@@ -121,10 +121,10 @@ public final class ProjectActivity extends BaseActivity<ProjectViewModel.ViewMod
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(this::startManagePledge);
 
-    this.viewModel.outputs.startViewPledgeActivity()
+    this.viewModel.outputs.startBackingActivity()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
-      .subscribe(this::startViewPledgeActivity);
+      .subscribe(this::startBackingActivity);
 
     this.viewModel.outputs.showStarredPrompt()
       .compose(bindToLifecycle())
@@ -241,7 +241,7 @@ public final class ProjectActivity extends BaseActivity<ProjectViewModel.ViewMod
     startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW);
   }
 
-  private void startViewPledgeActivity(final @NonNull Project project) {
+  private void startBackingActivity(final @NonNull Project project) {
     final Intent intent = new Intent(this, BackingActivity.class)
       .putExtra(IntentKey.PROJECT, project);
     startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
@@ -242,7 +242,7 @@ public final class ProjectActivity extends BaseActivity<ProjectViewModel.ViewMod
   }
 
   private void startViewPledgeActivity(final @NonNull Project project) {
-    final Intent intent = new Intent(this, ViewPledgeActivity.class)
+    final Intent intent = new Intent(this, BackingActivity.class)
       .putExtra(IntentKey.PROJECT, project);
     startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardViewHolder.java
@@ -21,7 +21,7 @@ import com.kickstarter.models.Project;
 import com.kickstarter.models.Reward;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.activities.CheckoutActivity;
-import com.kickstarter.ui.activities.ViewPledgeActivity;
+import com.kickstarter.ui.activities.BackingActivity;
 import com.kickstarter.ui.adapters.RewardsItemAdapter;
 import com.kickstarter.viewmodels.RewardViewModel;
 
@@ -234,7 +234,7 @@ public final class RewardViewHolder extends KSViewHolder {
 
   private void goToViewPledge(final @NonNull Project project) {
     final Context context = context();
-    final Intent intent = new Intent(context, ViewPledgeActivity.class)
+    final Intent intent = new Intent(context, BackingActivity.class)
       .putExtra(IntentKey.PROJECT, project);
 
     context.startActivity(intent);

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
@@ -26,7 +26,7 @@ import com.kickstarter.models.RewardsItem;
 import com.kickstarter.models.User;
 import com.kickstarter.services.ApiClientType;
 import com.kickstarter.ui.IntentKey;
-import com.kickstarter.ui.activities.ViewPledgeActivity;
+import com.kickstarter.ui.activities.BackingActivity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +40,7 @@ import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
 import static com.kickstarter.libs.rx.transformers.Transformers.takeWhen;
 import static com.kickstarter.libs.rx.transformers.Transformers.zipPair;
 
-public interface ViewPledgeViewModel {
+public interface BackingViewModel {
 
   interface Inputs {
     /** Call when the project context section is clicked. */
@@ -109,7 +109,7 @@ public interface ViewPledgeViewModel {
     Observable<Boolean> viewMessagesButtonIsGone();
   }
 
-  final class ViewModel extends ActivityViewModel<ViewPledgeActivity> implements Inputs, Outputs {
+  final class ViewModel extends ActivityViewModel<BackingActivity> implements Inputs, Outputs {
     private final ApiClientType client;
     private final CurrentConfigType currentConfig;
     private final CurrentUserType currentUser;

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
@@ -201,10 +201,11 @@ public interface BackingViewModel {
         .map(p -> Pair.create(p, RefTag.pledgeInfo()))
         .subscribe(this.startProjectActivity::onNext);
 
-      this.goBack = isFromMessagesActivity
+      isFromMessagesActivity
         .filter(BooleanUtils::isFalse)
         .compose(takeWhen(this.projectClicked))
-        .compose(ignoreValues());
+        .compose(ignoreValues())
+        .subscribe(this.goBack::onNext);
 
       backer
         .map(User::avatar)
@@ -314,7 +315,7 @@ public interface BackingViewModel {
     private final BehaviorSubject<String> creatorNameTextViewText = BehaviorSubject.create();
     private final BehaviorSubject<Boolean> estimatedDeliverySectionIsGone = BehaviorSubject.create();
     private final BehaviorSubject<String> estimatedDeliverySectionTextViewText = BehaviorSubject.create();
-    private final Observable<Void> goBack;
+    private final PublishSubject<Void> goBack = PublishSubject.create();
     private final BehaviorSubject<String> loadBackerAvatar = BehaviorSubject.create();
     private final BehaviorSubject<String> loadProjectPhoto = BehaviorSubject.create();
     private final BehaviorSubject<String> projectNameTextViewText = BehaviorSubject.create();

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
@@ -9,12 +9,14 @@ import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.FeatureKey;
 import com.kickstarter.libs.KSCurrency;
+import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.rx.transformers.Transformers;
 import com.kickstarter.libs.utils.BackingUtils;
 import com.kickstarter.libs.utils.BooleanUtils;
 import com.kickstarter.libs.utils.DateTimeUtils;
 import com.kickstarter.libs.utils.NumberUtils;
 import com.kickstarter.libs.utils.ObjectUtils;
+import com.kickstarter.libs.utils.PairUtils;
 import com.kickstarter.libs.utils.RewardUtils;
 import com.kickstarter.models.Avatar;
 import com.kickstarter.models.Backing;
@@ -36,6 +38,7 @@ import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 
 import static com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair;
+import static com.kickstarter.libs.rx.transformers.Transformers.ignoreValues;
 import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
 import static com.kickstarter.libs.rx.transformers.Transformers.takeWhen;
 import static com.kickstarter.libs.rx.transformers.Transformers.zipPair;
@@ -104,6 +107,9 @@ public interface BackingViewModel {
 
     /** Emits when we should start the {@link com.kickstarter.ui.activities.MessagesActivity}. */
     Observable<Pair<Project, Backing>> startMessagesActivity();
+
+    /** Emits when we should start the {@link com.kickstarter.ui.activities.ProjectActivity}. */
+    Observable<Pair<Project, RefTag>> startProjectActivity();
 
     /** Emits a boolean to determine when the View Messages button should be gone. */
     Observable<Boolean> viewMessagesButtonIsGone();
@@ -185,7 +191,20 @@ public interface BackingViewModel {
         .compose(bindToLifecycle())
         .subscribe(this.creatorNameTextViewText);
 
-      this.goBack = this.projectClicked;
+      Observable.zip(
+        isFromMessagesActivity.filter(BooleanUtils::isTrue),
+        project,
+        Pair::create
+      )
+        .map(PairUtils::second)
+        .compose(takeWhen(this.projectClicked))
+        .map(p -> Pair.create(p, RefTag.pledgeInfo()))
+        .subscribe(this.startProjectActivity::onNext);
+
+      this.goBack = isFromMessagesActivity
+        .filter(BooleanUtils::isFalse)
+        .compose(takeWhen(this.projectClicked))
+        .compose(ignoreValues());
 
       backer
         .map(User::avatar)
@@ -306,6 +325,7 @@ public interface BackingViewModel {
     private final BehaviorSubject<String> shippingLocationTextViewText = BehaviorSubject.create();
     private final BehaviorSubject<Boolean> shippingSectionIsGone = BehaviorSubject.create();
     private final PublishSubject<Pair<Project, Backing>> startMessagesActivity = PublishSubject.create();
+    private final PublishSubject<Pair<Project, RefTag>> startProjectActivity = PublishSubject.create();
     private final BehaviorSubject<Boolean> viewMessagesButtonIsGone = BehaviorSubject.create();
 
     public final Inputs inputs = this;
@@ -371,6 +391,9 @@ public interface BackingViewModel {
     }
     @Override public @NonNull Observable<Pair<Project, Backing>> startMessagesActivity() {
       return this.startMessagesActivity;
+    }
+    @Override public @NonNull Observable<Pair<Project, RefTag>> startProjectActivity() {
+      return this.startProjectActivity;
     }
     @Override public @NonNull Observable<Boolean> viewMessagesButtonIsGone() {
       return this.viewMessagesButtonIsGone;

--- a/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
@@ -121,7 +121,7 @@ public interface MessagesViewModel {
     Observable<String> showMessageErrorToast();
 
     /** Emits when we should start the {@link BackingActivity}. */
-    Observable<Project> startViewPledgeActivity();
+    Observable<Project> startBackingActivity();
 
     /** Emits when the thread has been marked as read. */
     Observable<Void> successfullyMarkedAsRead();
@@ -326,7 +326,7 @@ public interface MessagesViewModel {
       project
         .compose(takeWhen(this.viewPledgeButtonClicked))
         .compose(bindToLifecycle())
-        .subscribe(this.startViewPledgeActivity::onNext);
+        .subscribe(this.startBackingActivity::onNext);
 
       project
         .take(1)
@@ -390,7 +390,7 @@ public interface MessagesViewModel {
     private final PublishSubject<String> showMessageErrorToast = PublishSubject.create();
     private final Observable<Boolean> sendMessageButtonIsEnabled;
     private final Observable<String> setMessageEditText;
-    private final PublishSubject<Project> startViewPledgeActivity = PublishSubject.create();
+    private final PublishSubject<Project> startBackingActivity = PublishSubject.create();
     private final BehaviorSubject<Void> successfullyMarkedAsRead = BehaviorSubject.create();
     private final Observable<Boolean> toolbarIsExpanded;
     private final BehaviorSubject<Boolean> viewPledgeButtonIsGone = BehaviorSubject.create();
@@ -471,8 +471,8 @@ public interface MessagesViewModel {
     @Override public @NonNull Observable<String> setMessageEditText() {
       return this.setMessageEditText;
     }
-    @Override public @NonNull Observable<Project> startViewPledgeActivity() {
-      return this.startViewPledgeActivity;
+    @Override public @NonNull Observable<Project> startBackingActivity() {
+      return this.startBackingActivity;
     }
     @Override public @NonNull Observable<Void> successfullyMarkedAsRead() {
       return this.successfullyMarkedAsRead;

--- a/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
@@ -23,6 +23,7 @@ import com.kickstarter.services.ApiClientType;
 import com.kickstarter.services.apiresponses.ErrorEnvelope;
 import com.kickstarter.services.apiresponses.MessageThreadEnvelope;
 import com.kickstarter.ui.IntentKey;
+import com.kickstarter.ui.activities.BackingActivity;
 import com.kickstarter.ui.activities.MessagesActivity;
 import com.kickstarter.ui.data.MessageSubject;
 import com.kickstarter.ui.data.MessagesData;
@@ -119,7 +120,7 @@ public interface MessagesViewModel {
     /** Emits a string to display in the message error toast. */
     Observable<String> showMessageErrorToast();
 
-    /** Emits when we should start the {@link com.kickstarter.ui.activities.ViewPledgeActivity}. */
+    /** Emits when we should start the {@link BackingActivity}. */
     Observable<Project> startViewPledgeActivity();
 
     /** Emits when the thread has been marked as read. */

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.java
@@ -103,7 +103,7 @@ public interface ProjectViewModel {
     Observable<Project> startVideoActivity();
 
     /** Emits when we should start the {@link BackingActivity}. */
-    Observable<Project> startViewPledgeActivity();
+    Observable<Project> startBackingActivity();
   }
 
   final class ViewModel extends ActivityViewModel<ProjectActivity> implements ProjectAdapter.Delegate, Inputs, Outputs {
@@ -181,7 +181,7 @@ public interface ProjectViewModel {
       this.startManagePledgeActivity = currentProject.compose(takeWhen(this.managePledgeButtonClicked));
       this.startProjectUpdatesActivity = currentProject.compose(takeWhen(this.updatesTextViewClicked));
       this.startVideoActivity = currentProject.compose(takeWhen(this.playVideoButtonClicked));
-      this.startViewPledgeActivity = currentProject.compose(takeWhen(this.viewPledgeButtonClicked));
+      this.startBackingActivity = currentProject.compose(takeWhen(this.viewPledgeButtonClicked));
 
       this.shareButtonClicked
         .compose(bindToLifecycle())
@@ -276,7 +276,7 @@ public interface ProjectViewModel {
     private final Observable<Project> startManagePledgeActivity;
     private final Observable<Project> startProjectUpdatesActivity;
     private final Observable<Project> startVideoActivity;
-    private final Observable<Project> startViewPledgeActivity;
+    private final Observable<Project> startBackingActivity;
 
     public final Inputs inputs = this;
     public final Outputs outputs = this;
@@ -369,8 +369,8 @@ public interface ProjectViewModel {
     @Override public @NonNull Observable<Project> startManagePledgeActivity() {
       return this.startManagePledgeActivity;
     }
-    @Override public @NonNull Observable<Project> startViewPledgeActivity() {
-      return this.startViewPledgeActivity;
+    @Override public @NonNull Observable<Project> startBackingActivity() {
+      return this.startBackingActivity;
     }
   }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.java
@@ -16,6 +16,7 @@ import com.kickstarter.models.Project;
 import com.kickstarter.models.User;
 import com.kickstarter.services.ApiClientType;
 import com.kickstarter.services.apiresponses.PushNotificationEnvelope;
+import com.kickstarter.ui.activities.BackingActivity;
 import com.kickstarter.ui.activities.ProjectActivity;
 import com.kickstarter.ui.adapters.ProjectAdapter;
 import com.kickstarter.ui.intentmappers.IntentMapper;
@@ -101,7 +102,7 @@ public interface ProjectViewModel {
     /** Emits when we should start the {@link com.kickstarter.ui.activities.VideoActivity}. */
     Observable<Project> startVideoActivity();
 
-    /** Emits when we should start the {@link com.kickstarter.ui.activities.ViewPledgeActivity}. */
+    /** Emits when we should start the {@link BackingActivity}. */
     Observable<Project> startViewPledgeActivity();
   }
 

--- a/app/src/main/res/layout/backing_layout.xml
+++ b/app/src/main/res/layout/backing_layout.xml
@@ -6,7 +6,7 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
-  <include layout="@layout/view_pledge_toolbar"/>
+  <include layout="@layout/backing_toolbar"/>
 
   <ScrollView
     android:layout_width="match_parent"
@@ -33,7 +33,7 @@
           android:layout_height="wrap_content">
 
           <ImageView
-            android:id="@+id/view_pledge_avatar_image_view"
+            android:id="@+id/backing_avatar_image_view"
             android:layout_width="@dimen/grid_new_10"
             android:layout_height="@dimen/grid_new_10"
             android:focusable="false"
@@ -41,7 +41,7 @@
             tools:ignore="ContentDescription" />
 
           <RelativeLayout
-            android:layout_toEndOf="@id/view_pledge_avatar_image_view"
+            android:layout_toEndOf="@id/backing_avatar_image_view"
             android:paddingStart="@dimen/grid_new_3"
             android:paddingEnd="@dimen/grid_new_3"
             android:layout_centerInParent="true"
@@ -49,18 +49,18 @@
             android:layout_height="wrap_content">
 
             <TextView
-              android:id="@+id/view_pledge_backer_name"
+              android:id="@+id/backing_backer_name"
               style="@style/CalloutPrimaryMedium"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               tools:text="Blob Fish"/>
 
             <TextView
-              android:id="@+id/view_pledge_backer_number"
+              android:id="@+id/backing_backer_number"
               style="@style/BodySecondary"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              android:layout_below="@id/view_pledge_backer_name"
+              android:layout_below="@id/backing_backer_name"
               tools:text="Backer #42"/>
 
           </RelativeLayout>
@@ -68,7 +68,7 @@
         </RelativeLayout>
 
         <Button
-          android:id="@+id/view_pledge_view_messages_button"
+          android:id="@+id/backing_view_messages_button"
           android:layout_marginBottom="@dimen/grid_new_3"
           android:visibility="visible"
           style="@style/BorderButton"
@@ -89,14 +89,14 @@
 
         <TextView
           style="@style/BodyPrimary"
-          android:id="@+id/view_pledge_backing_amount_and_date_text_view"
+          android:id="@+id/backing_amount_and_date_text_view"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           tools:text="$1 on Thursday, June 8, 2017"/>
 
         <TextView
           style="@style/BodyPrimary"
-          android:id="@+id/view_pledge_backing_status"
+          android:id="@+id/backing_status"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:paddingBottom="@dimen/grid_new_3"
@@ -120,13 +120,13 @@
 
           <TextView
             style="@style/BodyPrimary"
-            android:id="@+id/view_pledge_reward_minimum_and_description"
+            android:id="@+id/backing_reward_minimum_and_description"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:text="$1 - I will send you some stale bread."/>
 
           <LinearLayout
-            android:id="@+id/view_pledge_rewards_item_section"
+            android:id="@+id/backing_rewards_item_section"
             android:orientation="vertical"
             android:paddingTop="@dimen/grid_new_2"
             android:layout_width="match_parent"
@@ -141,7 +141,7 @@
               android:text="@string/project_view_pledge_includes" />
 
             <android.support.v7.widget.RecyclerView
-              android:id="@+id/view_pledge_rewards_item_recycler_view"
+              android:id="@+id/backing_rewards_item_recycler_view"
               android:layout_width="match_parent"
               android:layout_height="wrap_content" />
 
@@ -150,7 +150,7 @@
         </LinearLayout>
 
         <LinearLayout
-          android:id="@+id/view_pledge_shipping_section"
+          android:id="@+id/backing_shipping_section"
           android:orientation="vertical"
           android:paddingTop="@dimen/grid_new_2"
           android:layout_width="match_parent"
@@ -168,20 +168,20 @@
 
           <TextView
             style="@style/BodyPrimary"
-            android:id="@+id/view_pledge_shipping_location"
+            android:id="@+id/backing_shipping_location"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 
           <TextView
             style="@style/BodyPrimary"
-            android:id="@+id/view_pledge_shipping_amount"
+            android:id="@+id/backing_shipping_amount"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingBottom="@dimen/grid_3"/>
         </LinearLayout>
 
         <LinearLayout
-          android:id="@+id/view_pledge_estimated_delivery_section"
+          android:id="@+id/backing_estimated_delivery_section"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:orientation="vertical">
@@ -198,7 +198,7 @@
 
           <TextView
             style="@style/BodyPrimary"
-            android:id="@+id/view_pledge_estimated_delivery"
+            android:id="@+id/backing_estimated_delivery"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingBottom="@dimen/grid_3"

--- a/app/src/main/res/layout/backing_toolbar.xml
+++ b/app/src/main/res/layout/backing_toolbar.xml
@@ -3,9 +3,9 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
-  tools:showIn="@layout/view_pledge_layout"
+  tools:showIn="@layout/backing_layout"
   style="@style/Toolbar"
-  android:id="@+id/view_pledge_toolbar"
+  android:id="@+id/backing_toolbar"
   app:contentInsetLeft="0dp"
   app:contentInsetStart="0dp">
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -76,7 +76,7 @@
 
   <style name="VideoPlayerActivity" parent="VideoPlayerBase" />
 
-  <style name="ViewPledgeActivity" parent="KSTheme">
+  <style name="BackingActivity" parent="KSTheme">
     <item name="android:windowBackground">@color/white</item>
   </style>
 

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingViewModelTest.java
@@ -15,6 +15,7 @@ import com.kickstarter.libs.FeatureKey;
 import com.kickstarter.libs.KoalaEvent;
 import com.kickstarter.libs.MockCurrentConfig;
 import com.kickstarter.libs.MockCurrentUser;
+import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.utils.DateTimeUtils;
 import com.kickstarter.libs.utils.NumberUtils;
 import com.kickstarter.models.Backing;
@@ -57,6 +58,7 @@ public final class BackingViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<String> shippingLocationTextViewText = new TestSubscriber<>();
   private final TestSubscriber<Boolean> shippingSectionIsGone = new TestSubscriber<>();
   private final TestSubscriber<Pair<Project, Backing>> startMessagesActivity = new TestSubscriber<>();
+  private final TestSubscriber<Pair<Project, RefTag>> startProjectActivity = new TestSubscriber<>();
   private final TestSubscriber<Boolean> viewMessagesButtonIsGone = new TestSubscriber<>();
 
   private void setUpEnvironment(final @NonNull Environment environment) {
@@ -79,6 +81,7 @@ public final class BackingViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.shippingLocationTextViewText().subscribe(this.shippingLocationTextViewText);
     this.vm.outputs.shippingSectionIsGone().subscribe(this.shippingSectionIsGone);
     this.vm.outputs.startMessagesActivity().subscribe(this.startMessagesActivity);
+    this.vm.outputs.startProjectActivity().subscribe(this.startProjectActivity);
     this.vm.outputs.viewMessagesButtonIsGone().subscribe(this.viewMessagesButtonIsGone);
   }
 
@@ -183,6 +186,9 @@ public final class BackingViewModelTest extends KSRobolectricTestCase {
 
     this.vm.inputs.projectClicked();
     this.goBack.assertValueCount(1);
+
+    // Project context click doesn't start project activity if not from Messages.
+    this.startProjectActivity.assertNoValues();
   }
 
   @Test
@@ -292,6 +298,20 @@ public final class BackingViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.viewMessagesButtonClicked();
 
     this.startMessagesActivity.assertValues(Pair.create(backing.project(), backing));
+  }
+
+  @Test
+  public void testStartProjectActivity() {
+    final Backing backing = BackingFactory.backing();
+    setUpEnvironment(envWithBacking(BackingFactory.backing()));
+
+    this.vm.intent(
+      new Intent().putExtra(IntentKey.PROJECT, backing.project()).putExtra(IntentKey.IS_FROM_MESSAGES_ACTIVITY, true)
+    );
+
+    this.vm.inputs.projectClicked();
+    this.startProjectActivity.assertValues(Pair.create(backing.project(), RefTag.pledgeInfo()));
+    this.goBack.assertNoValues();
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingViewModelTest.java
@@ -37,8 +37,8 @@ import rx.observers.TestSubscriber;
 
 import static java.util.Collections.emptyList;
 
-public final class ViewPledgeViewModelTest extends KSRobolectricTestCase {
-  private ViewPledgeViewModel.ViewModel vm;
+public final class BackingViewModelTest extends KSRobolectricTestCase {
+  private BackingViewModel.ViewModel vm;
   private final TestSubscriber<String> backerNameTextViewText = new TestSubscriber<>();
   private final TestSubscriber<String> backerNumberTextViewText = new TestSubscriber<>();
   private final TestSubscriber<String> backingStatusTextViewText = new TestSubscriber<>();
@@ -60,7 +60,7 @@ public final class ViewPledgeViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Boolean> viewMessagesButtonIsGone = new TestSubscriber<>();
 
   private void setUpEnvironment(final @NonNull Environment environment) {
-    this.vm = new ViewPledgeViewModel.ViewModel(environment);
+    this.vm = new BackingViewModel.ViewModel(environment);
     this.vm.outputs.backerNameTextViewText().subscribe(this.backerNameTextViewText);
     this.vm.outputs.backerNumberTextViewText().subscribe(this.backerNumberTextViewText);
     this.vm.outputs.backingStatusTextViewText().subscribe(this.backingStatusTextViewText);

--- a/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
@@ -77,7 +77,7 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.sendMessageButtonIsEnabled().subscribe(this.sendMessageButtonIsEnabled);
     this.vm.outputs.setMessageEditText().subscribe(this.setMessageEditText);
     this.vm.outputs.showMessageErrorToast().subscribe(this.showMessageErrorToast);
-    this.vm.outputs.startViewPledgeActivity().subscribe(this.startViewPledgeActivity);
+    this.vm.outputs.startBackingActivity().subscribe(this.startViewPledgeActivity);
     this.vm.outputs.successfullyMarkedAsRead().subscribe(this.successfullyMarkedAsRead);
     this.vm.outputs.toolbarIsExpanded().subscribe(this.toolbarIsExpanded);
     this.vm.outputs.viewPledgeButtonIsGone().subscribe(this.viewPledgeButtonIsGone);


### PR DESCRIPTION
## what
Project context banner should drill into the project from the backing screen if we're coming from messages. Else we just navigate back (to the project page) if coming from the project. 

Bonus renaming of `ViewPledge__` to `Backing__` to align with our Swift code, .:. making it easier to find / make more sense etc etc

[Trello bug report](https://trello.com/c/H92wWu1u/727-p3-android-messages-project-name-banner-on-pledge-info-screen)