### PR TITLE
[Messages] Pagination refactor

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/MessageThreadsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessageThreadsViewModel.java
@@ -24,6 +24,7 @@ import rx.Observable;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 
+import static com.kickstarter.libs.rx.transformers.Transformers.ignoreValues;
 import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
 import static com.kickstarter.libs.rx.transformers.Transformers.takeWhen;
 import static com.kickstarter.libs.utils.IntegerUtils.intValueOrZero;
@@ -77,21 +78,30 @@ public interface MessageThreadsViewModel {
       this.client = environment.apiClient();
       this.currentUser = environment.currentUser();
 
-      final Observable<Void> startOverWith = Observable.merge(this.onResume, this.refresh);
+      final Observable<Void> refreshUser = Observable.merge(this.onResume, this.refresh);
 
       final Observable<User> freshUser = intent()
-        .compose(takeWhen(startOverWith))
+        .compose(takeWhen(refreshUser))
         .switchMap(__ -> this.client.fetchCurrentUser())
         .retry(2)
         .compose(neverError());
 
       freshUser.subscribe(this.currentUser::refresh);
 
+      final Observable<Integer> unreadMessagesCount = this.currentUser.loggedInUser()
+        .map(User::unreadMessagesCount)
+        .distinctUntilChanged();
+
       // Ping refresh on initial load to trigger paginator
       intent()
         .take(1)
         .compose(bindToLifecycle())
         .subscribe(__ -> this.refresh());
+
+      final Observable<Void> startOverWith = Observable.merge(
+        unreadMessagesCount.distinctUntilChanged().compose(ignoreValues()),
+        this.refresh
+      );
 
       final ApiPaginator<MessageThread, MessageThreadsEnvelope, Void> paginator =
         ApiPaginator.<MessageThread, MessageThreadsEnvelope, Void>builder()
@@ -110,10 +120,6 @@ public interface MessageThreadsViewModel {
       paginator.paginatedData()
         .compose(bindToLifecycle())
         .subscribe(this.messageThreads);
-
-      final Observable<Integer> unreadMessagesCount = this.currentUser.loggedInUser()
-        .map(User::unreadMessagesCount)
-        .distinctUntilChanged();
 
       this.hasNoMessages = unreadMessagesCount.map(ObjectUtils::isNull);
       this.hasNoUnreadMessages = unreadMessagesCount.map(IntegerUtils::isZero);

--- a/app/src/main/java/com/kickstarter/viewmodels/MessageThreadsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessageThreadsViewModel.java
@@ -99,7 +99,7 @@ public interface MessageThreadsViewModel {
         .subscribe(__ -> this.refresh());
 
       final Observable<Void> startOverWith = Observable.merge(
-        unreadMessagesCount.distinctUntilChanged().compose(ignoreValues()),
+        unreadMessagesCount.compose(ignoreValues()),
         this.refresh
       );
 

--- a/app/src/test/java/com/kickstarter/viewmodels/MessageThreadsViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/MessageThreadsViewModelTest.java
@@ -65,8 +65,9 @@ public class MessageThreadsViewModelTest extends KSRobolectricTestCase {
     this.vm.intent(new Intent());
     this.messageThreads.assertValueCount(1);
 
+    // Same message threads should not emit again.
     this.vm.inputs.onResume();
-    this.messageThreads.assertValueCount(2);
+    this.messageThreads.assertValueCount(1);
 
     this.koalaTest.assertValues(KoalaEvent.VIEWED_MESSAGE_INBOX);
   }


### PR DESCRIPTION
## what
Fixing a bug that caused the Message Threads RecyclerView to jump around.

## how
I was using 
```java
Observable.merge(this.onResume, this.refresh)
``` 
as the `startOverWith` signal for both refreshing the `currentUser` as well as fetching new message threads. 

Since the message threads are populated in the recycler view we don't want to refresh the threads each time we hit `onResume`, as it causes the threads to re-populate and lose the previous position.

The solution is to use the `merge` above to refresh the current user, then listen to the user's `unreadMessagesCount` and to refresh the RV data only when there are actually new unreads.

[Refresh Trello Card](https://trello.com/c/w0hEVdWN/726-p2-android-messages-pagination-quirk-1)

Bonus: I'm pretty sure this also fixes [this second pagination quirk](https://trello.com/c/N64QRhHt/728-p2-android-messages-pagination-quirk-2)