### PR TITLE
[Messages] QA round dos

### DIFF
--- a/app/src/main/res/layout/message_reply_layout.xml
+++ b/app/src/main/res/layout/message_reply_layout.xml
@@ -6,7 +6,7 @@
   android:layout_gravity="bottom"
   android:background="@color/white"
   android:layout_width="match_parent"
-  android:layout_height="@dimen/message_reply_layout_height">
+  android:layout_height="wrap_content">
 
   <View
     android:id="@+id/divider_view"
@@ -18,7 +18,7 @@
     android:layout_below="@id/divider_view"
     android:layout_marginStart="@dimen/grid_new_4"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <EditText
       android:id="@+id/message_edit_text"
@@ -29,8 +29,8 @@
       android:background="@color/transparent"
       android:layout_toStartOf="@+id/send_message_button"
       android:layout_width="match_parent"
-      android:layout_height="@dimen/grid_new_10"
-      android:maxLines="1"
+      android:layout_height="wrap_content"
+      android:minHeight="@dimen/message_reply_layout_height"
       android:ellipsize="end"
       tools:hint="Message Blob..."
       tools:ignore="LabelFor"/>
@@ -46,7 +46,7 @@
       android:clickable="true"
       android:layout_centerVertical="true"
       android:layout_width="wrap_content"
-      android:layout_height="match_parent"
+      android:layout_height="wrap_content"
       android:textColor="@color/navy_600_enabled_dark_grey_400_disabled_color"
       android:text="@string/social_buttons_send"/>
 

--- a/app/src/main/res/layout/message_view.xml
+++ b/app/src/main/res/layout/message_view.xml
@@ -14,15 +14,6 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
 
-    <ImageView
-      android:id="@+id/message_sender_avatar_image_view"
-      android:layout_width="@dimen/grid_new_4"
-      android:layout_height="@dimen/grid_new_4"
-      android:layout_marginStart="@dimen/grid_new_3"
-      android:elevation="2dp"
-      android:background="@drawable/message_avatar_circle_background"
-      tools:ignore="ContentDescription,UnusedAttribute"/>
-
     <android.support.v7.widget.CardView
       android:id="@+id/message_body_recipient_card_view"
       android:layout_width="wrap_content"
@@ -48,6 +39,15 @@
         tools:text="Hey there!"/>
 
     </android.support.v7.widget.CardView>
+
+    <ImageView
+      android:id="@+id/message_sender_avatar_image_view"
+      android:layout_width="@dimen/grid_new_4"
+      android:layout_height="@dimen/grid_new_4"
+      android:layout_marginStart="@dimen/grid_new_3"
+      android:elevation="2dp"
+      android:background="@drawable/message_avatar_circle_background"
+      tools:ignore="ContentDescription,UnusedAttribute"/>
 
   </RelativeLayout>
 

--- a/app/src/main/res/layout/messages_backing_info_view.xml
+++ b/app/src/main/res/layout/messages_backing_info_view.xml
@@ -3,13 +3,13 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/backing_info_view"
   android:orientation="vertical"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   tools:showIn="@layout/messages_layout">
 
   <RelativeLayout
-    android:id="@+id/backing_info_view"
     android:background="@color/white"
     android:paddingStart="@dimen/grid_new_3"
     android:paddingEnd="0dp"

--- a/app/src/main/res/layout/messages_layout.xml
+++ b/app/src/main/res/layout/messages_layout.xml
@@ -17,8 +17,8 @@
     <android.support.design.widget.CollapsingToolbarLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:elevation="@dimen/toolbar_elevation"
       android:background="@color/white"
+      android:elevation="@dimen/toolbar_elevation"
       app:contentScrim="@color/white"
       app:layout_scrollFlags="scroll|exitUntilCollapsed"
       tools:ignore="UnusedAttribute">
@@ -57,6 +57,11 @@
       <include layout="@layout/messages_toolbar"/>
 
     </android.support.design.widget.CollapsingToolbarLayout>
+
+    <View
+      android:background="@color/white"
+      android:layout_width="match_parent"
+      android:layout_height="@dimen/grid_new_1"/>
 
     <include layout="@layout/messages_backing_info_view"/>
 

--- a/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
@@ -146,12 +146,19 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
 
   @Test
   public void testBackingInfo_NoBacking() {
-    final MessageThread messageThread = MessageThreadFactory.messageThread().toBuilder().backing(null).build();
+    final Project project = ProjectFactory.project().toBuilder()
+      .isBacking(false)
+      .build();
+
+    final MessageThread messageThread = MessageThreadFactory.messageThread().toBuilder()
+      .project(project)
+      .backing(null)
+      .build();
 
     final MockApiClient apiClient = new MockApiClient() {
       @Override
       public @NonNull Observable<Backing> fetchProjectBacking(final @NonNull Project project, final @NonNull User user) {
-        return Observable.just(null);
+        return Observable.error(ApiExceptionFactory.badRequestException());
       }
     };
 
@@ -162,7 +169,7 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
     // Start the view model with a message thread.
     this.vm.intent(messagesContextIntent(messageThread));
 
-    this.backingAndProject.assertValues(Pair.create(null, messageThread.project()));
+    this.backingAndProject.assertNoValues();
     this.backingInfoViewIsGone.assertValues(true);
   }
 


### PR DESCRIPTION
## What
Feedback from our QA session, fixed
1. Hide backing info banner if no backing [card](https://trello.com/c/oYTOEtzX/738-p2-view-pledge-cta-shows-in-thread-view-even-if-you-arent-a-backer)
2. Rend sent message to a new message thread [card](https://trello.com/c/G1jTflJY/737-p2-if-you-send-a-new-message-to-a-thread-from-your-backing-info-message-content-doesnt-show-in-the-screen-youre-on)
3. Let reply expand to >1 line [card](https://trello.com/c/5PWLTfJY/736-when-message-goes-onto-2nd-line-see-last-line-of-text-and-only-bottom-of-characters-on-line-above)