### PR TITLE
Use setCurrentMillisFixed for timing test????

### DIFF
--- a/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
+++ b/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
@@ -13,6 +13,9 @@ import com.kickstarter.services.MockWebClient;
 
 import junit.framework.TestCase;
 
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
@@ -36,6 +39,7 @@ public abstract class KSRobolectricTestCase extends TestCase {
     final MockTrackingClient testTrackingClient = new MockTrackingClient();
     koalaTest = new TestSubscriber<>();
     testTrackingClient.eventNames.subscribe(koalaTest);
+    DateTimeUtils.setCurrentMillisFixed(new DateTime().getMillis());
 
     environment = application().component().environment().toBuilder()
       .apiClient(new MockApiClient())
@@ -52,6 +56,13 @@ public abstract class KSRobolectricTestCase extends TestCase {
 
     application = (TestKSApplication) RuntimeEnvironment.application;
     return application;
+  }
+
+  @Override
+  @After
+  public void tearDown() throws Exception {
+    super.tearDown();
+    DateTimeUtils.setCurrentMillisSystem();
   }
 
   protected @NonNull Context context() {

--- a/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardHeaderHolderViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardHeaderHolderViewModelTest.java
@@ -14,9 +14,7 @@ import com.kickstarter.models.Project;
 import com.kickstarter.services.apiresponses.ProjectStatsEnvelope;
 
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeUtils;
 import org.junit.Test;
-
 import rx.observers.TestSubscriber;
 
 public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTestCase {
@@ -82,13 +80,11 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
   @Test
   public void testTimeRemainingText() {
     setUpEnvironment(environment());
-    DateTimeUtils.setCurrentMillisFixed(new DateTime().getMillis());
     final Project project = ProjectFactory.project().toBuilder().deadline(new DateTime().plusDays(10)).build();
     final ProjectStatsEnvelope projectStatsEnvelope = ProjectStatsEnvelopeFactory.ProjectStatsEnvelope();
     final int deadlineVal = ProjectUtils.deadlineCountdownValue(project);
 
     this.vm.inputs.projectAndStats(Pair.create(project, projectStatsEnvelope));
     this.timeRemainingText.assertValues(NumberUtils.format(deadlineVal));
-    DateTimeUtils.setCurrentMillisSystem();
   }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardHeaderHolderViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardHeaderHolderViewModelTest.java
@@ -14,7 +14,9 @@ import com.kickstarter.models.Project;
 import com.kickstarter.services.apiresponses.ProjectStatsEnvelope;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
 import org.junit.Test;
+
 import rx.observers.TestSubscriber;
 
 public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTestCase {
@@ -80,11 +82,13 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
   @Test
   public void testTimeRemainingText() {
     setUpEnvironment(environment());
+    DateTimeUtils.setCurrentMillisFixed(new DateTime().getMillis());
     final Project project = ProjectFactory.project().toBuilder().deadline(new DateTime().plusDays(10)).build();
     final ProjectStatsEnvelope projectStatsEnvelope = ProjectStatsEnvelopeFactory.ProjectStatsEnvelope();
     final int deadlineVal = ProjectUtils.deadlineCountdownValue(project);
 
     this.vm.inputs.projectAndStats(Pair.create(project, projectStatsEnvelope));
     this.timeRemainingText.assertValues(NumberUtils.format(deadlineVal));
+    DateTimeUtils.setCurrentMillisSystem();
   }
 }


### PR DESCRIPTION
joda time has [a method to freeze time in it's current state](http://www.joda.org/joda-time/apidocs/org/joda/time/DateTimeUtils.html#setCurrentMillisFixed-long-).  Maybe this will solve our flaky timing test? Maybe there is a better place to do this like in setup/teardown blocks, but we only need it for one test right now.

anyway, here's a dance about millys

![giphy](https://user-images.githubusercontent.com/1313981/28596362-2253cbc6-7166-11e7-81e3-ed426e8ba946.gif)
