### PR TITLE
Consolidate toolbar offsetlisteners

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.java
@@ -22,7 +22,6 @@ import com.kickstarter.libs.KSCurrency;
 import com.kickstarter.libs.KSString;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
 import com.kickstarter.libs.utils.DateTimeUtils;
-import com.kickstarter.libs.utils.ToolbarUtils;
 import com.kickstarter.libs.utils.TransitionUtils;
 import com.kickstarter.libs.utils.ViewUtils;
 import com.kickstarter.models.Backing;
@@ -85,17 +84,12 @@ public final class MessagesActivity extends BaseActivity<MessagesViewModel.ViewM
 
     this.viewPledgeButton.setText(this.viewPledgeString);
 
-    ToolbarUtils.INSTANCE.fadeToolbarTitleOnExpand(this.appBarLayout, this.projectNameToolbarTextView);
+    setAppBarOffsetChangedListener(this.appBarLayout);
 
     RxView.focusChanges(this.messageEditText)
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(this.viewModel.inputs::messageEditTextIsFocused);
-
-    this.appBarLayout.addOnOffsetChangedListener((layout, offset) -> {
-      this.viewModel.inputs.appBarTotalScrollRange(layout.getTotalScrollRange());
-      this.viewModel.inputs.appBarOffset(offset);
-    });
 
     this.viewModel.outputs.backButtonIsGone()
       .compose(bindToLifecycle())
@@ -234,6 +228,20 @@ public final class MessagesActivity extends BaseActivity<MessagesViewModel.ViewM
   private void requestFocusAndOpenKeyboard() {
     this.messageEditText.requestFocus();
     this.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+  }
+
+  /**
+   * Sets an OffsetChangedListener for the view's AppBarLayout to:
+   * 1. determine the toolbar's alpha based on scroll range
+   * 2. adjust the view's bottom padding via inputs
+   */
+  private void setAppBarOffsetChangedListener(final @NonNull AppBarLayout appBarLayout) {
+    appBarLayout.addOnOffsetChangedListener((layout, offset) -> {
+      this.projectNameToolbarTextView.setAlpha(Math.abs(offset) / layout.getTotalScrollRange());
+
+      this.viewModel.inputs.appBarTotalScrollRange(layout.getTotalScrollRange());
+      this.viewModel.inputs.appBarOffset(offset);
+    });
   }
 
   private void setBackingInfoView(final @NonNull Pair<Backing, Project> backingAndProject) {


### PR DESCRIPTION
## what
Got [this crash in HockeyApp](https://rink.hockeyapp.net/manage/apps/239008/app_versions/81/crash_reasons/178790844?type=crashes) and while I'm not able to re-pro the bug, my hunch is that setting 2 offset listeners on the same `AppBarLayout` in `MessagesActivity` is causing a rendering race condition.

For this instance, in which we do want the toolbar fade effect that `ToolbarUtils` provides us, but also additional logic from listening to the offset changes, let's consolidate the listeners for peace of mind.