### PR TITLE
Remove flag from backing screen

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/FeatureKey.java
+++ b/app/src/main/java/com/kickstarter/libs/FeatureKey.java
@@ -4,6 +4,5 @@ public final class FeatureKey {
   private FeatureKey() {}
 
   public static final String ANDROID_CREATOR_VIEW = "android_creator_view";
-  public static final String ANDROID_MESSAGES = "android_messages";
   public static final String ANDROID_SURVEYS = "android_surveys";
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingViewModelTest.java
@@ -6,14 +6,10 @@ import android.util.Pair;
 
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.factories.BackingFactory;
-import com.kickstarter.factories.ConfigFactory;
 import com.kickstarter.factories.LocationFactory;
 import com.kickstarter.factories.RewardFactory;
-import com.kickstarter.libs.Config;
 import com.kickstarter.libs.Environment;
-import com.kickstarter.libs.FeatureKey;
 import com.kickstarter.libs.KoalaEvent;
-import com.kickstarter.libs.MockCurrentConfig;
 import com.kickstarter.libs.MockCurrentUser;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.utils.DateTimeUtils;
@@ -30,7 +26,6 @@ import com.kickstarter.ui.IntentKey;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 
 import rx.Observable;
@@ -315,34 +310,9 @@ public final class BackingViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testViewMessagesButtonIsGone_FlagDisabled() {
+  public void testViewMessagesButtonIsGone_FromMessages() {
     final Backing backing = BackingFactory.backing();
-    final Config config = ConfigFactory.config()
-      .toBuilder()
-      .features(Collections.emptyMap())
-      .build();
-
-    final MockCurrentConfig currentConfig = new MockCurrentConfig();
-    currentConfig.config(config);
-
-    setUpEnvironment(envWithBacking(backing).toBuilder().currentConfig(currentConfig).build());
-    this.vm.intent(new Intent().putExtra(IntentKey.PROJECT, backing.project()));
-
-    this.viewMessagesButtonIsGone.assertValues(true);
-  }
-
-  @Test
-  public void testViewMessagesButtonIsGone_FlagEnabled_FromMessages() {
-    final Backing backing = BackingFactory.backing();
-    final Config config = ConfigFactory.config()
-      .toBuilder()
-      .features(Collections.singletonMap(FeatureKey.ANDROID_MESSAGES, true))
-      .build();
-
-    final MockCurrentConfig currentConfig = new MockCurrentConfig();
-    currentConfig.config(config);
-
-    setUpEnvironment(envWithBacking(backing).toBuilder().currentConfig(currentConfig).build());
+    setUpEnvironment(envWithBacking(backing));
 
     this.vm.intent(
       new Intent().putExtra(IntentKey.PROJECT, backing.project()).putExtra(IntentKey.IS_FROM_MESSAGES_ACTIVITY, true)
@@ -352,17 +322,10 @@ public final class BackingViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testViewMessagesButtonIsVisible_FlagEnabled() {
+  public void testViewMessagesButtonIsVisible() {
     final Backing backing = BackingFactory.backing();
-    final Config config = ConfigFactory.config()
-      .toBuilder()
-      .features(Collections.singletonMap(FeatureKey.ANDROID_MESSAGES, true))
-      .build();
+    setUpEnvironment(envWithBacking(backing));
 
-    final MockCurrentConfig currentConfig = new MockCurrentConfig();
-    currentConfig.config(config);
-
-    setUpEnvironment(envWithBacking(backing).toBuilder().currentConfig(currentConfig).build());
     this.vm.intent(new Intent().putExtra(IntentKey.PROJECT, backing.project()));
 
     this.viewMessagesButtonIsGone.assertValues(false);


### PR DESCRIPTION
Finishing what I started in #140, since we also show a `Message creator` button in our Backing info view, which would be nice to release since it's ya know already there

Refresher: we still do need to hide the button if we're navigating to the view from Messages, to avoid a weird loop of Backing -> Messages -> Backing -> Messages