### PR TITLE
attach new fragment when project switcher is clicked in dashboard

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/CreatorDashboardActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/CreatorDashboardActivity.java
@@ -6,9 +6,9 @@ import android.support.annotation.Nullable;
 import android.support.design.widget.BottomSheetBehavior;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
-import android.util.Pair;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Pair;
 
 import com.kickstarter.R;
 import com.kickstarter.libs.BaseActivity;
@@ -41,7 +41,7 @@ public final class CreatorDashboardActivity extends BaseActivity<CreatorDashboar
     ButterKnife.bind(this);
 
     // Set up the bottom sheet recycler view.
-    this.bottomSheetAdapter = new CreatorDashboardBottomSheetAdapter();
+    this.bottomSheetAdapter = new CreatorDashboardBottomSheetAdapter(this.viewModel.inputs);
     this.bottomSheetRecyclerView.setAdapter(this.bottomSheetAdapter);
     this.bottomSheetRecyclerView.setLayoutManager(new LinearLayoutManager(this)); // todo: reuse LayoutManager?
     this.bottomSheetBehavior = BottomSheetBehavior.from(this.bottomSheetRecyclerView);
@@ -49,23 +49,33 @@ public final class CreatorDashboardActivity extends BaseActivity<CreatorDashboar
     this.viewModel.outputs.projectAndStats()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(this::createProjectDashboardFragments);
+      .subscribe(this::createProjectDashboardFragment);
 
     this.viewModel.outputs.projectsForBottomSheet()
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(this::setProjectsForDropdown);
+
+    this.viewModel.outputs.projectSwitcherProjectClickOutput()
+       .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(this::newProjectClicked);
   }
 
   private void setProjectsForDropdown(final @NonNull List<Project> projects) {
     this.bottomSheetAdapter.takeProjects(projects);
   }
 
-  private void createProjectDashboardFragments(final @NonNull Pair<Project, ProjectStatsEnvelope> projectAndStats) {
+  private void newProjectClicked(final @NonNull Project project) {
+    this.viewModel.refreshProject(project);
+    this.bottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+  }
+
+  private void createProjectDashboardFragment(final @NonNull Pair<Project, ProjectStatsEnvelope> projectAndStats) {
     final FragmentManager fragmentManager = getSupportFragmentManager();
     final FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
     final CreatorDashboardFragment fragment = CreatorDashboardFragment.newInstance(projectAndStats);
-    fragmentTransaction.add(R.id.creator_dashboard_coordinator_view, fragment);
+    fragmentTransaction.replace(R.id.creator_dashboard_coordinator_view, fragment);
     fragmentTransaction.commit();
   }
 

--- a/app/src/main/java/com/kickstarter/ui/adapters/CreatorDashboardBottomSheetAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/CreatorDashboardBottomSheetAdapter.java
@@ -2,6 +2,7 @@ package com.kickstarter.ui.adapters;
 
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.View;
 
 import com.kickstarter.R;
@@ -13,6 +14,14 @@ import java.util.List;
 
 public final class CreatorDashboardBottomSheetAdapter extends KSAdapter {
 
+  private Delegate delegate;
+
+  public interface Delegate extends CreatorDashboardBottomSheetViewHolder.Delegate {}
+
+  public CreatorDashboardBottomSheetAdapter(final @Nullable Delegate delegate) {
+    this.delegate = delegate;
+  }
+
   @Override
   protected int layout(final @NonNull SectionRow sectionRow) {
     return R.layout.creator_dashboard_project_switcher_view;
@@ -20,7 +29,7 @@ public final class CreatorDashboardBottomSheetAdapter extends KSAdapter {
 
   @Override
   protected @NonNull KSViewHolder viewHolder(final @LayoutRes int layout, final @NonNull View view) {
-    return new CreatorDashboardBottomSheetViewHolder(view);
+    return new CreatorDashboardBottomSheetViewHolder(view, this.delegate);
   }
 
   public void takeProjects(final @NonNull List<Project> projects) {

--- a/app/src/main/java/com/kickstarter/ui/fragments/CreatorDashboardFragment.java
+++ b/app/src/main/java/com/kickstarter/ui/fragments/CreatorDashboardFragment.java
@@ -70,8 +70,11 @@ public final class CreatorDashboardFragment extends BaseFragment<CreatorDashboar
   }
 
   @Override
-  public void onDestroy() {
-    super.onDestroy();
-    this.creatorDashboardRecyclerView.setAdapter(null);
+  public void onDetach() {
+    super.onDetach();
+
+    if (this.creatorDashboardRecyclerView != null) {
+      this.creatorDashboardRecyclerView.setAdapter(null);
+    }
   }
 }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardBottomSheetViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardBottomSheetViewHolder.java
@@ -11,6 +11,7 @@ import com.kickstarter.viewmodels.CreatorDashboardBottomSheetHolderViewModel;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
+import butterknife.OnClick;
 
 import static com.kickstarter.libs.rx.transformers.Transformers.observeForUI;
 import static com.kickstarter.libs.utils.ObjectUtils.requireNonNull;
@@ -20,15 +21,32 @@ public final class CreatorDashboardBottomSheetViewHolder extends KSViewHolder {
 
   protected @Bind(R.id.creator_dashboard_project_switcher_text_view) TextView projectNameTextView;
 
-  public CreatorDashboardBottomSheetViewHolder(final @NonNull View view) {
+  private final @Nullable Delegate delegate;
+
+  public interface Delegate {
+    void projectSwitcherProjectClickInput(Project project);
+  }
+
+  public CreatorDashboardBottomSheetViewHolder(final @NonNull View view, final @Nullable Delegate delegate) {
     super(view);
     this.viewModel = new CreatorDashboardBottomSheetHolderViewModel.ViewModel(environment());
+    this.delegate = delegate;
     ButterKnife.bind(this, view);
 
     this.viewModel.outputs.projectNameText()
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(this.projectNameTextView::setText);
+
+    this.viewModel.outputs.projectSwitcherProject()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(this.delegate::projectSwitcherProjectClickInput);
+  }
+
+  @OnClick(R.id.creator_dashboard_bottom_sheet_project_view)
+  public void projectSwitcherProjectClicked() {
+    this.viewModel.inputs.projectSwitcherProjectClicked();
   }
 
   @Override

--- a/app/src/main/java/com/kickstarter/viewmodels/CreatorDashboardBottomSheetHolderViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/CreatorDashboardBottomSheetHolderViewModel.java
@@ -57,6 +57,8 @@ public interface CreatorDashboardBottomSheetHolderViewModel {
       return this.projectNameText;
     }
     @Override
-    public @NonNull Observable<Project> projectSwitcherProject() { return this.projectSwitcherProject; }
+    public @NonNull Observable<Project> projectSwitcherProject() {
+      return this.projectSwitcherProject;
+    }
   }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/CreatorDashboardBottomSheetHolderViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/CreatorDashboardBottomSheetHolderViewModel.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.Environment;
+import com.kickstarter.libs.rx.transformers.Transformers;
 import com.kickstarter.models.Project;
 import com.kickstarter.ui.viewholders.CreatorDashboardBottomSheetViewHolder;
 
@@ -14,9 +15,11 @@ public interface CreatorDashboardBottomSheetHolderViewModel {
 
   interface Inputs {
     void projectInput(Project project);
+    void projectSwitcherProjectClicked();
   }
   interface Outputs {
     Observable<String> projectNameText();
+    Observable<Project> projectSwitcherProject();
   }
 
   final class ViewModel extends ActivityViewModel<CreatorDashboardBottomSheetViewHolder> implements Inputs, Outputs {
@@ -25,14 +28,19 @@ public interface CreatorDashboardBottomSheetHolderViewModel {
       super(environment);
 
       this.projectNameText = this.currentProject.map(Project::name);
+
+      this.projectSwitcherProject = this.currentProject
+        .compose(Transformers.takeWhen(this.projectSwitcherClicked));
     }
 
     public final Inputs inputs = this;
     public final Outputs outputs = this;
 
     private final PublishSubject<Project> currentProject = PublishSubject.create();
+    private final PublishSubject<Void> projectSwitcherClicked = PublishSubject.create();
 
     private final Observable<String> projectNameText;
+    private final Observable<Project> projectSwitcherProject;
 
     @Override
     public void projectInput(final @NonNull Project project) {
@@ -40,8 +48,15 @@ public interface CreatorDashboardBottomSheetHolderViewModel {
     }
 
     @Override
+    public void projectSwitcherProjectClicked() {
+      this.projectSwitcherClicked.onNext(null);
+    }
+
+    @Override
     public @NonNull Observable<String> projectNameText() {
       return this.projectNameText;
     }
+    @Override
+    public @NonNull Observable<Project> projectSwitcherProject() { return this.projectSwitcherProject; }
   }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/CreatorDashboardViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/CreatorDashboardViewModel.java
@@ -63,7 +63,9 @@ public interface CreatorDashboardViewModel {
       final Observable<List<Project>> projects = projectsEnvelope
         .map(ProjectsEnvelope::projects);
 
-      final Observable<Notification<ProjectStatsEnvelope>> projectStatsEnvelopeNotification = currentProject
+      projects.map(ListUtils::first).subscribe(this.projectSelected::onNext);
+
+      final Observable<Notification<ProjectStatsEnvelope>> projectStatsEnvelopeNotification = this.projectSelected
         .switchMap(this.client::fetchProjectStats)
         .share()
         .materialize();
@@ -73,21 +75,19 @@ public interface CreatorDashboardViewModel {
 
       this.projectsForBottomSheet = projects;
 
-      projects.map(ListUtils::first).subscribe(this.currentProject::onNext);
-
-      this.projectAndStats = currentProject
+      this.projectAndStats = this.projectSelected
         .compose(combineLatestPair(projectStatsEnvelope));
 
       this.projectSwitcherProjectClickOutput = this.projectSwitcherClicked;
 
-      this.startProjectActivity = currentProject
+      this.startProjectActivity = this.projectSelected
         .compose(takeWhen(this.projectViewClicked))
         .map(p -> Pair.create(p, RefTag.dashboard()));
     }
 
     private final PublishSubject<Void> projectViewClicked = PublishSubject.create();
     private final PublishSubject<Project> projectSwitcherClicked = PublishSubject.create();
-    private final BehaviorSubject<Project> currentProject = BehaviorSubject.create();
+    private final BehaviorSubject<Project> projectSelected = BehaviorSubject.create();
 
     private final Observable<Pair<Project, ProjectStatsEnvelope>> projectAndStats;
     private final Observable<List<Project>> projectsForBottomSheet;
@@ -109,7 +109,7 @@ public interface CreatorDashboardViewModel {
 
     @Override
     public void refreshProject(final @NonNull Project project) {
-      this.currentProject.onNext(project);
+      this.projectSelected.onNext(project);
     }
 
     @Override public @NonNull Observable<Pair<Project, ProjectStatsEnvelope>> projectAndStats() {
@@ -118,7 +118,9 @@ public interface CreatorDashboardViewModel {
     @Override public @NonNull Observable<List<Project>> projectsForBottomSheet() {
       return this.projectsForBottomSheet;
     }
-    @Override public @NonNull Observable<Project> projectSwitcherProjectClickOutput() { return this.projectSwitcherProjectClickOutput; }
+    @Override public @NonNull Observable<Project> projectSwitcherProjectClickOutput() {
+      return this.projectSwitcherProjectClickOutput;
+    }
     @Override public @NonNull Observable<Pair<Project, RefTag>> startProjectActivity() {
       return this.startProjectActivity;
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/CreatorDashboardViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/CreatorDashboardViewModel.java
@@ -65,9 +65,6 @@ public interface CreatorDashboardViewModel {
       final Observable<List<Project>> projects = projectsEnvelope
         .map(ProjectsEnvelope::projects);
 
-//      final Observable<Project> latestProject = projects
-//        .map(ListUtils::first);
-
       projects.map(ListUtils::first).subscribe(this.currentProject::onNext);
 
       final Observable<Notification<ProjectStatsEnvelope>> projectStatsEnvelopeNotification = currentProject

--- a/app/src/main/res/layout/creator_dashboard_project_switcher_view.xml
+++ b/app/src/main/res/layout/creator_dashboard_project_switcher_view.xml
@@ -2,6 +2,7 @@
 <LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/creator_dashboard_bottom_sheet_project_view"
   android:orientation="vertical"
   android:layout_width="match_parent"
   android:layout_height="wrap_content">

--- a/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardViewModelTest.java
@@ -27,7 +27,6 @@ import rx.observers.TestSubscriber;
 public class CreatorDashboardViewModelTest extends KSRobolectricTestCase {
   private CreatorDashboardViewModel.ViewModel vm;
 
-  private final TestSubscriber<Project> latestProject = new TestSubscriber<>();
   private final TestSubscriber<Pair<Project, ProjectStatsEnvelope>> projectAndStats = new TestSubscriber<>();
   private final TestSubscriber<Pair<Project, RefTag>> startProjectActivity = new TestSubscriber<>();
   private final TestSubscriber<List<Project>> projectsForBottomSheet = new TestSubscriber<>();
@@ -35,7 +34,6 @@ public class CreatorDashboardViewModelTest extends KSRobolectricTestCase {
 
   protected void setUpEnvironment(final @NonNull Environment environment) {
     this.vm = new CreatorDashboardViewModel.ViewModel(environment);
-    this.vm.outputs.latestProject().subscribe(this.latestProject);
     this.vm.outputs.startProjectActivity().subscribe(this.startProjectActivity);
     this.vm.outputs.projectAndStats().subscribe(this.projectAndStats);
     this.vm.outputs.projectsForBottomSheet().subscribe(this.projectsForBottomSheet);
@@ -60,7 +58,7 @@ public class CreatorDashboardViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testLatestProjectAndStats() {
+  public void testProjectAndStats() {
     final List<Project> projects = Arrays.asList(
       ProjectFactory.project()
     );
@@ -77,7 +75,6 @@ public class CreatorDashboardViewModelTest extends KSRobolectricTestCase {
     };
 
     setUpEnvironment(environment().toBuilder().apiClient(apiClient).build());
-    this.latestProject.assertValues(ListUtils.first(projects));
     final Pair<Project, ProjectStatsEnvelope> outputPair = Pair.create(ListUtils.first(projects), ProjectStatsEnvelope);
     this.projectAndStats.assertValues(outputPair);
   }

--- a/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardViewModelTest.java
@@ -31,6 +31,7 @@ public class CreatorDashboardViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Pair<Project, ProjectStatsEnvelope>> projectAndStats = new TestSubscriber<>();
   private final TestSubscriber<Pair<Project, RefTag>> startProjectActivity = new TestSubscriber<>();
   private final TestSubscriber<List<Project>> projectsForBottomSheet = new TestSubscriber<>();
+  private final TestSubscriber<Project> projectSwitcherProjectClickOutput = new TestSubscriber<>();
 
   protected void setUpEnvironment(final @NonNull Environment environment) {
     this.vm = new CreatorDashboardViewModel.ViewModel(environment);
@@ -38,6 +39,7 @@ public class CreatorDashboardViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.startProjectActivity().subscribe(this.startProjectActivity);
     this.vm.outputs.projectAndStats().subscribe(this.projectAndStats);
     this.vm.outputs.projectsForBottomSheet().subscribe(this.projectsForBottomSheet);
+    this.vm.outputs.projectSwitcherProjectClickOutput().subscribe(this.projectSwitcherProjectClickOutput);
   }
 
   @Test
@@ -93,6 +95,23 @@ public class CreatorDashboardViewModelTest extends KSRobolectricTestCase {
     };
     setUpEnvironment(environment().toBuilder().apiClient(apiClient).build());
     this.projectsForBottomSheet.assertValues(projects);
+  }
 
+  @Test
+  public void testProjectSwitcherProjectClickOutput() {
+    final Project project = ProjectFactory.project();
+    final List<Project> projects = Arrays.asList(
+      ProjectFactory.project()
+    );
+    final MockApiClient apiClient = new MockApiClient() {
+      @Override public @NonNull
+      Observable<ProjectsEnvelope> fetchProjects(final boolean member) {
+        return Observable.just(ProjectsEnvelopeFactory.projectsEnvelope(projects));
+      }
+    };
+    setUpEnvironment(environment().toBuilder().apiClient(apiClient).build());
+
+    this.vm.inputs.projectSwitcherProjectClickInput(project);
+    this.projectSwitcherProjectClickOutput.assertValue(project);
   }
 }


### PR DESCRIPTION
hello, attaching an onclick and updating the fragment when the project switcher is clicked.  here's a look:

![project_switcher](https://user-images.githubusercontent.com/1313981/30075004-8eb682e4-9241-11e7-8029-c28fec220c6e.gif)
