### PR TITLE
Fix survey project request bug

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/SurveyResponseActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/SurveyResponseActivity.java
@@ -1,24 +1,19 @@
 package com.kickstarter.ui.activities;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
-import android.util.Pair;
 import android.view.View;
 import android.webkit.WebView;
 
 import com.kickstarter.R;
 import com.kickstarter.libs.BaseActivity;
-import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
 import com.kickstarter.libs.utils.AnimationUtils;
-import com.kickstarter.models.Project;
 import com.kickstarter.services.KSUri;
 import com.kickstarter.services.KSWebViewClient;
 import com.kickstarter.services.RequestHandler;
-import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.views.KSWebView;
 import com.kickstarter.viewmodels.SurveyResponseViewModel;
 
@@ -63,17 +58,15 @@ public class SurveyResponseActivity extends BaseActivity<SurveyResponseViewModel
     this.viewModel.outputs.showConfirmationDialog()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(__ -> lazyConfirmationDialog().show());
-
-    this.viewModel.outputs.startProjectActivity()
-      .compose(bindToLifecycle())
-      .compose(observeForUI())
-      .subscribe(this::startProjectActivity);
+      .subscribe(__ -> {
+        this.ksWebView.stopLoading(); // this kinda awkwardly stops...stop the next load
+        lazyConfirmationDialog().show();
+      });
   }
 
   private boolean handleProjectUriRequest(final @NonNull Request request, final @NonNull WebView webView) {
     this.viewModel.inputs.projectUriRequest(request);
-    return true;
+    return false;
   }
 
   private boolean handleProjectSurveyUriRequest(final @NonNull Request request, final @NonNull WebView webView) {
@@ -91,13 +84,6 @@ public class SurveyResponseActivity extends BaseActivity<SurveyResponseViewModel
         .create();
     }
     return this.confirmationDialog;
-  }
-
-  private void startProjectActivity(final @NonNull Pair<Project, RefTag> projectAndRefTag) {
-    final Intent intent = new Intent(this, ProjectActivity.class)
-      .putExtra(IntentKey.PROJECT, projectAndRefTag.first)
-      .putExtra(IntentKey.REF_TAG, projectAndRefTag.second);
-    startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }
 
   @Override
@@ -125,7 +111,5 @@ public class SurveyResponseActivity extends BaseActivity<SurveyResponseViewModel
   }
 
   @Override
-  public void webViewPageIntercepted(final @NonNull KSWebViewClient webViewClient, final @NonNull String url) {
-    this.viewModel.inputs.webViewPageIntercepted(url);
-  }
+  public void webViewPageIntercepted(final @NonNull KSWebViewClient webViewClient, final @NonNull String url) {}
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/SurveyResponseActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/SurveyResponseActivity.java
@@ -58,10 +58,7 @@ public class SurveyResponseActivity extends BaseActivity<SurveyResponseViewModel
     this.viewModel.outputs.showConfirmationDialog()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(__ -> {
-        this.ksWebView.stopLoading(); // this kinda awkwardly stops...stop the next load
-        lazyConfirmationDialog().show();
-      });
+      .subscribe(__ -> lazyConfirmationDialog().show());
   }
 
   private boolean handleProjectUriRequest(final @NonNull Request request, final @NonNull WebView webView) {

--- a/app/src/main/java/com/kickstarter/viewmodels/SurveyResponseViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SurveyResponseViewModel.java
@@ -6,7 +6,6 @@ import android.util.Pair;
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.models.SurveyResponse;
-import com.kickstarter.services.ApiClientType;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.activities.SurveyResponseActivity;
 
@@ -20,11 +19,11 @@ import static com.kickstarter.libs.rx.transformers.Transformers.ignoreValues;
 public interface SurveyResponseViewModel {
 
   interface Inputs {
-    /** Call when a project uri request has been made. */
-    void projectUriRequest(Request request);
-
     /** Call when the dialog's OK button has been clicked. */
     void okButtonClicked();
+
+    /** Call when a project uri request has been made. */
+    void projectUriRequest(Request request);
 
     /** Call when a project survey uri request has been made. */
     void projectSurveyUriRequest(Request request);
@@ -42,12 +41,9 @@ public interface SurveyResponseViewModel {
   }
 
   final class ViewModel extends ActivityViewModel<SurveyResponseActivity> implements Inputs, Outputs {
-    private final ApiClientType client;
 
     public ViewModel(final @NonNull Environment environment) {
       super(environment);
-
-      this.client = environment.apiClient();
 
       final Observable<SurveyResponse> surveyResponse = intent()
         .map(i -> i.getParcelableExtra(IntentKey.SURVEY_RESPONSE))
@@ -84,8 +80,8 @@ public interface SurveyResponseViewModel {
         .equals(projectRequestAndSurveyUrl.second);
     }
 
-    private final PublishSubject<Request> projectUriRequest = PublishSubject.create();
     private final PublishSubject<Void> okButtonClicked = PublishSubject.create();
+    private final PublishSubject<Request> projectUriRequest = PublishSubject.create();
     private final PublishSubject<Request> projectSurveyUriRequest = PublishSubject.create();
 
     private final Observable<Void> goBack;
@@ -95,11 +91,11 @@ public interface SurveyResponseViewModel {
     public final Inputs inputs = this;
     public final Outputs outputs = this;
 
-    @Override public void projectUriRequest(final @NonNull Request request) {
-      this.projectUriRequest.onNext(request);
-    }
     @Override public void okButtonClicked() {
       this.okButtonClicked.onNext(null);
+    }
+    @Override public void projectUriRequest(final @NonNull Request request) {
+      this.projectUriRequest.onNext(request);
     }
     @Override public void projectSurveyUriRequest(final @NonNull Request request) {
       this.projectSurveyUriRequest.onNext(request);

--- a/app/src/test/java/com/kickstarter/viewmodels/SurveyResponseViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SurveyResponseViewModelTest.java
@@ -4,28 +4,19 @@ import android.content.Intent;
 import android.support.annotation.NonNull;
 
 import com.kickstarter.KSRobolectricTestCase;
-import com.kickstarter.factories.ProjectFactory;
 import com.kickstarter.factories.SurveyResponseFactory;
 import com.kickstarter.libs.Environment;
-import com.kickstarter.libs.RefTag;
-import com.kickstarter.libs.utils.PairUtils;
-import com.kickstarter.models.Project;
 import com.kickstarter.models.SurveyResponse;
-import com.kickstarter.services.ApiClientType;
-import com.kickstarter.services.MockApiClient;
 import com.kickstarter.ui.IntentKey;
 
 import org.junit.Test;
 
 import okhttp3.Request;
-import rx.Observable;
 import rx.observers.TestSubscriber;
 
 public class SurveyResponseViewModelTest extends KSRobolectricTestCase {
   private SurveyResponseViewModel.ViewModel vm;
   private final TestSubscriber<Void> goBack = new TestSubscriber<>();
-  private final TestSubscriber<Project> project = new TestSubscriber<>();
-  private final TestSubscriber<RefTag> refTag = new TestSubscriber<>();
   private final TestSubscriber<Void> showConfirmationDialog = new TestSubscriber<>();
   private final TestSubscriber<String> webViewUrl = new TestSubscriber<>();
 
@@ -33,8 +24,6 @@ public class SurveyResponseViewModelTest extends KSRobolectricTestCase {
     this.vm = new SurveyResponseViewModel.ViewModel(environment);
     this.vm.outputs.goBack().subscribe(this.goBack);
     this.vm.outputs.showConfirmationDialog().subscribe(this.showConfirmationDialog);
-    this.vm.outputs.startProjectActivity().map(PairUtils::first).subscribe(this.project);
-    this.vm.outputs.startProjectActivity().map(PairUtils::second).subscribe(this.refTag);
     this.vm.outputs.webViewUrl().subscribe(this.webViewUrl);
   }
 
@@ -43,30 +32,6 @@ public class SurveyResponseViewModelTest extends KSRobolectricTestCase {
     setUpEnvironment(environment());
     this.vm.inputs.okButtonClicked();
     this.goBack.assertValueCount(1);
-  }
-
-  @Test
-  public void testStartProjectActivity() {
-    final Project project = ProjectFactory.project().toBuilder().slug("heyo").build();
-
-    final Request projectRequest = new Request.Builder()
-      .url("https://kck.str/projects/param/heyo")
-      .tag(null)
-      .build();
-
-    final ApiClientType apiClient = new MockApiClient() {
-      @Override public @NonNull Observable<Project> fetchProject(final @NonNull String param) {
-        return Observable.just(project);
-      }
-    };
-
-    setUpEnvironment(environment().toBuilder().apiClient(apiClient).build());
-    this.vm.intent(new Intent().putExtra(IntentKey.SURVEY_RESPONSE, SurveyResponseFactory.surveyResponse()));
-
-    this.vm.inputs.projectUriRequest(projectRequest);
-
-    this.project.assertValues(project);
-    this.refTag.assertValues(RefTag.survey());
   }
 
   @Test


### PR DESCRIPTION
## what
Previous `handleProjectUriRequest(...)` logic in the SurveyResponseActivity was duplicating `startProjectActivity` logic and completing the request handling prematurely (i.e. tap project header -> go back -> tap project header again -> nothing happens). 

The [change made here](https://github.com/kickstarter/native-secrets/pull/14) fixes the bug, in conjunction with returning `false` in `handleProjectUriRequest` so that we continue to handle project uris. Other changes include code cleanup.