### PR TITLE
Remove view from help-layout

### DIFF
--- a/app/src/main/res/layout/help_layout.xml
+++ b/app/src/main/res/layout/help_layout.xml
@@ -19,12 +19,8 @@
     android:id="@+id/loading_indicator_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_below="@id/help_toolbar">
-
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:background="@color/white_alpha_60"/>
+    android:layout_below="@id/help_toolbar"
+    android:background="@color/white_alpha_60">
 
     <ProgressBar
       android:id="@+id/loading_indicator"


### PR DESCRIPTION
This task (#64) remove **<View..>** because it was used just for add a background. Now, this background is set in the enclosing RelativeLayout.