### PR TITLE
Fix logged out users not going to tout in pledge flow

### DIFF
--- a/app/src/main/java/com/kickstarter/services/KSUri.java
+++ b/app/src/main/java/com/kickstarter/services/KSUri.java
@@ -34,7 +34,6 @@ public final class KSUri {
     return DISCOVER_PLACES_PATTERN.matcher(path).matches();
   }
 
-
   public static boolean isHivequeenUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
     return isKickstarterUri(uri, webEndpoint) && Secrets.RegExpPattern.HIVEQUEEN.matcher(uri.getHost()).matches();
   }

--- a/app/src/main/java/com/kickstarter/services/KSUri.java
+++ b/app/src/main/java/com/kickstarter/services/KSUri.java
@@ -34,12 +34,17 @@ public final class KSUri {
     return DISCOVER_PLACES_PATTERN.matcher(path).matches();
   }
 
+
   public static boolean isHivequeenUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
     return isKickstarterUri(uri, webEndpoint) && Secrets.RegExpPattern.HIVEQUEEN.matcher(uri.getHost()).matches();
   }
 
   public static boolean isKickstarterUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
     return uri.getHost().equals(Uri.parse(webEndpoint).getHost());
+  }
+
+  public static boolean isNewGuestCheckoutUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
+    return isKickstarterUri(uri, webEndpoint) && NEW_GUEST_CHECKOUT_PATTERN.matcher(uri.getPath()).matches();
   }
 
   public static boolean isProjectUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
@@ -99,6 +104,11 @@ public final class KSUri {
 
   // /discover/places/param
   private static final Pattern DISCOVER_PLACES_PATTERN = Pattern.compile("\\A\\/discover\\/places\\/[a-zA-Z0-9-_]+\\z");
+
+  // /checkouts/:checkout_id/guest/new
+  private static final Pattern NEW_GUEST_CHECKOUT_PATTERN = Pattern.compile(
+    "\\A\\/checkouts\\/[a-zA-Z0-9-_]+\\/guest\\/new\\z"
+  );
 
   // /projects/:creator_param/:project_param
   private static final Pattern PROJECT_PATTERN = Pattern.compile(

--- a/app/src/main/java/com/kickstarter/ui/activities/CheckoutActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/CheckoutActivity.java
@@ -123,6 +123,7 @@ public final class CheckoutActivity extends BaseActivity<CheckoutViewModel> impl
 
     this.webView.client().registerRequestHandlers(Arrays.asList(
       new RequestHandler(KSUri::isCheckoutThanksUri, this::handleCheckoutThanksUriRequest),
+      new RequestHandler(KSUri::isNewGuestCheckoutUri, this::handleSignupUriRequest),
       new RequestHandler(KSUri::isSignupUri, this::handleSignupUriRequest)
     ));
 

--- a/app/src/test/java/com/kickstarter/services/KSUriTest.java
+++ b/app/src/test/java/com/kickstarter/services/KSUriTest.java
@@ -11,6 +11,7 @@ public final class KSUriTest extends KSRobolectricTestCase {
   private final Uri discoverScopeUri = Uri.parse("https://www.kickstarter.com/discover/ending-soon");
   private final Uri discoverPlacesUri = Uri.parse("https://www.ksr.com/discover/places/newest");
   private final String webEndpoint = "https://www.ksr.com";
+  private final Uri newGuestCheckoutUri = Uri.parse("https://www.ksr.com/checkouts/1/guest/new");
   private final Uri projectUri = Uri.parse("https://www.ksr.com/projects/creator/project");
   private final Uri projectSurveyUri = Uri.parse("https://www.ksr.com/projects/creator/project/surveys/survey-param");
   private final Uri updatesUri = Uri.parse("https://www.ksr.com/projects/creator/project/posts");
@@ -52,7 +53,12 @@ public final class KSUriTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testKSuri_isProjectSurveyUri() {
+  public void testKSUri_isNewGuestCheckoutUri() {
+    assertTrue(KSUri.isNewGuestCheckoutUri(this.newGuestCheckoutUri, this.webEndpoint));
+  }
+
+  @Test
+  public void testKSUri_isProjectSurveyUri() {
     assertTrue(KSUri.isProjectSurveyUri(this.projectSurveyUri, this.webEndpoint));
     assertFalse(KSUri.isProjectSurveyUri(this.userSurveyUri, this.webEndpoint));
   }


### PR DESCRIPTION
Client fix for https://trello.com/c/wAraEE4s/3647-guest-pledging-showing-and-sometimes-404ing-in-android-checkout-webviews

The new guest checkout flow redirected users to a new URL when they tried to pledge while not logged in. We were listening for `/signup`, and the new URI is `/checkouts/:checkout_id/guest/new`. Instead of showing the login tout in the app, we were displaying the web signup/guest checkout form.

Will also have a server side change that fixes things for older clients.