### PR TITLE
messaging links

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,7 +105,7 @@ android {
 
     // Fixes build error hitting GC overhead limit
     dexOptions {
-        javaMaxHeapSize "2560M"
+        javaMaxHeapSize "3072M"
     }
 
     lintOptions {

--- a/app/src/main/res/layout/message_view.xml
+++ b/app/src/main/res/layout/message_view.xml
@@ -36,6 +36,7 @@
         android:background="@color/ksr_grey_400"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:autoLink="web"
         tools:text="Hey there!"/>
 
     </android.support.v7.widget.CardView>
@@ -71,6 +72,7 @@
       android:background="@color/ksr_soft_black"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:autoLink="web"
       tools:text="What's up?"/>
 
   </android.support.v7.widget.CardView>


### PR DESCRIPTION
## what
Enabling web links in messages. I went with `web` but the other options are `all, email, phone, map`.

## why
Links in messages should be clickable ヽ(。_°)ノ 

![2017-09-28 18_27_01](https://user-images.githubusercontent.com/1289295/30993162-90b47d02-a47b-11e7-99f7-589962f27c17.gif)

