### PR TITLE
Patch activity feed update comments

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
@@ -86,10 +86,10 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
       .compose(observeForUI())
       .subscribe(this::startProjectActivity);
 
-    this.viewModel.outputs.goToProjectUpdate()
+    this.viewModel.outputs.startUpdateActivity()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(this::startProjectUpdateActivity);
+      .subscribe(this::startUpdateActivity);
 
     this.viewModel.outputs.loggedOutEmptyStateIsVisible()
       .compose(bindToLifecycle())
@@ -145,9 +145,10 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
     startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }
 
-  private void startProjectUpdateActivity(final @NonNull Activity activity) {
-    final Intent intent = new Intent(this, WebViewActivity.class)
-      .putExtra(IntentKey.URL, activity.projectUpdateUrl());
+  private void startUpdateActivity(final @NonNull Activity activity) {
+    final Intent intent = new Intent(this, UpdateActivity.class)
+      .putExtra(IntentKey.PROJECT, activity.project())
+      .putExtra(IntentKey.UPDATE, activity.update());
     startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ActivityFeedViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ActivityFeedViewModelTest.java
@@ -31,10 +31,10 @@ public class ActivityFeedViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Void> goToDiscovery = new TestSubscriber<>();
   private final TestSubscriber<Void> goToLogin = new TestSubscriber<>();
   private final TestSubscriber<Project> goToProject = new TestSubscriber<>();
-  private final TestSubscriber<Activity> goToProjectUpdate = new TestSubscriber<>();
   private final TestSubscriber<SurveyResponse> goToSurvey = new TestSubscriber<>();
   private final TestSubscriber<Boolean> loggedOutEmptyStateIsVisible = new TestSubscriber<>();
   private final TestSubscriber<Boolean> loggedInEmptyStateIsVisible = new TestSubscriber<>();
+  private final TestSubscriber<Activity> startUpdateActivity = new TestSubscriber<>();
   private final TestSubscriber<List<SurveyResponse>> surveys = new TestSubscriber<>();
 
   private void setUpEnvironment(final @NonNull Environment environment) {
@@ -43,10 +43,10 @@ public class ActivityFeedViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.goToDiscovery().subscribe(this.goToDiscovery);
     this.vm.outputs.goToLogin().subscribe(this.goToLogin);
     this.vm.outputs.goToProject().subscribe(this.goToProject);
-    this.vm.outputs.goToProjectUpdate().subscribe(this.goToProjectUpdate);
     this.vm.outputs.goToSurvey().subscribe(this.goToSurvey);
     this.vm.outputs.loggedOutEmptyStateIsVisible().subscribe(this.loggedOutEmptyStateIsVisible);
     this.vm.outputs.loggedInEmptyStateIsVisible().subscribe(this.loggedInEmptyStateIsVisible);
+    this.vm.outputs.startUpdateActivity().subscribe(this.startUpdateActivity);
     this.vm.outputs.surveys().subscribe(this.surveys);
   }
 
@@ -74,7 +74,7 @@ public class ActivityFeedViewModelTest extends KSRobolectricTestCase {
     this.goToDiscovery.assertNoValues();
     this.goToLogin.assertNoValues();
     this.goToProject.assertNoValues();
-    this.goToProjectUpdate.assertNoValues();
+    this.startUpdateActivity.assertNoValues();
     this.koalaTest.assertValues(KoalaEvent.ACTIVITY_VIEW);
 
     // Empty activity feed clicks do not trigger events yet.
@@ -97,7 +97,7 @@ public class ActivityFeedViewModelTest extends KSRobolectricTestCase {
 
     this.vm.inputs.projectUpdateClicked(null, ActivityFactory.activity());
 
-    this.goToProjectUpdate.assertValueCount(1);
+    this.startUpdateActivity.assertValueCount(1);
     this.koalaTest.assertValues(
       KoalaEvent.ACTIVITY_VIEW, KoalaEvent.ACTIVITY_VIEW_ITEM, KoalaEvent.ACTIVITY_VIEW_ITEM, KoalaEvent.ACTIVITY_VIEW_ITEM,
       KoalaEvent.ACTIVITY_VIEW_ITEM, KoalaEvent.VIEWED_UPDATE
@@ -156,6 +156,15 @@ public class ActivityFeedViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.resume();
 
     this.surveys.assertNoValues();
+  }
+
+  @Test
+  public void testStartUpdateActivity() {
+    final Activity activity = ActivityFactory.updateActivity();
+    setUpEnvironment(environment());
+
+    this.vm.inputs.projectUpdateClicked(null, activity);
+    this.startUpdateActivity.assertValues(activity);
   }
 
   @Test


### PR DESCRIPTION
## what
Fixing [this bug](https://trello.com/c/LTdz1Af6/186-zd-android-error-when-accessing-comments-on-an-update) of web comments loading rather than native app comments when accessing updates from the activity feed.

## how
When implementing `UpdatesActivity` for native updates, I forgot to refactor the `ActivityFeedActivity`--we were still launching a `WebViewActivity` with an updates url rather than the proper `UpdateActivity` with a project and update.