### PR TITLE
Refactor all Update activity helpers

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/PushNotifications.java
+++ b/app/src/main/java/com/kickstarter/libs/PushNotifications.java
@@ -31,7 +31,7 @@ import com.kickstarter.ui.activities.ActivityFeedActivity;
 import com.kickstarter.ui.activities.MessagesActivity;
 import com.kickstarter.ui.activities.ProjectActivity;
 import com.kickstarter.ui.activities.SurveyResponseActivity;
-import com.kickstarter.ui.activities.WebViewActivity;
+import com.kickstarter.ui.activities.UpdateActivity;
 import com.squareup.picasso.Picasso;
 import com.squareup.picasso.RequestCreator;
 
@@ -291,8 +291,9 @@ public final class PushNotifications {
     final Intent projectIntent = new Intent(this.context, ProjectActivity.class)
       .putExtra(IntentKey.PROJECT_PARAM, projectParam);
 
-    final Intent updateIntent = new Intent(this.context, WebViewActivity.class)
-      .putExtra(IntentKey.URL, update.urls().web().update())
+    final Intent updateIntent = new Intent(this.context, UpdateActivity.class)
+      .putExtra(IntentKey.PROJECT_PARAM, projectParam)
+      .putExtra(IntentKey.UPDATE, update)
       .putExtra(IntentKey.PUSH_NOTIFICATION_ENVELOPE, envelope);
 
     final TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(this.context)

--- a/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
+++ b/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
@@ -25,7 +25,7 @@ import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.activities.ActivityFeedActivity;
 import com.kickstarter.ui.activities.LoginToutActivity;
 import com.kickstarter.ui.activities.ProjectActivity;
-import com.kickstarter.ui.activities.WebViewActivity;
+import com.kickstarter.ui.activities.UpdateActivity;
 import com.kickstarter.ui.adapters.DiscoveryAdapter;
 import com.kickstarter.ui.data.LoginReason;
 import com.kickstarter.viewmodels.DiscoveryFragmentViewModel;
@@ -83,10 +83,10 @@ public final class DiscoveryFragment extends BaseFragment<DiscoveryFragmentViewM
       .compose(observeForUI())
       .subscribe(__ -> startActivityFeedActivity());
 
-    this.viewModel.outputs.showActivityUpdate()
+    this.viewModel.outputs.startUpdateActivity()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(this::startActivityUpdateActivity);
+      .subscribe(this::startUpdateActivity);
 
     this.viewModel.outputs.showProject()
       .compose(bindToLifecycle())
@@ -118,13 +118,6 @@ public final class DiscoveryFragment extends BaseFragment<DiscoveryFragmentViewM
     return this.recyclerView != null;
   }
 
-  private void startActivityUpdateActivity(final @NonNull Activity activity) {
-    final Intent intent = new Intent(getActivity(), WebViewActivity.class)
-      .putExtra(IntentKey.URL, activity.projectUpdateUrl());
-    startActivity(intent);
-    transition(getActivity(), slideInFromRight());
-  }
-
   private void startActivityFeedActivity() {
     startActivity(new Intent(getActivity(), ActivityFeedActivity.class));
   }
@@ -140,6 +133,14 @@ public final class DiscoveryFragment extends BaseFragment<DiscoveryFragmentViewM
     final Intent intent = new Intent(getActivity(), ProjectActivity.class)
       .putExtra(IntentKey.PROJECT, project)
       .putExtra(IntentKey.REF_TAG, refTag);
+    startActivity(intent);
+    transition(getActivity(), slideInFromRight());
+  }
+
+  private void startUpdateActivity(final @NonNull Activity activity) {
+    final Intent intent = new Intent(getActivity(), UpdateActivity.class)
+      .putExtra(IntentKey.PROJECT, activity.project())
+      .putExtra(IntentKey.UPDATE, activity.update());
     startActivity(intent);
     transition(getActivity(), slideInFromRight());
   }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -90,7 +90,7 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
       .subscribe(this.projectList);
 
     this.showActivityFeed = this.activityClick;
-    this.showActivityUpdate = this.activityUpdateClick;
+    this.startUpdateActivity = this.activityUpdateClick;
     this.showLoginTout = this.discoveryOnboardingLoginToutClick;
 
     Observable.merge(
@@ -140,7 +140,7 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
         );
       });
 
-    this.showActivityUpdate
+    this.startUpdateActivity
       .map(Activity::project)
       .filter(ObjectUtils::isNotNull)
       .compose(bindToLifecycle())
@@ -202,10 +202,10 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
   private final BehaviorSubject<Activity> activity = BehaviorSubject.create();
   private final BehaviorSubject<List<Project>> projectList = BehaviorSubject.create();
   private final Observable<Boolean> showActivityFeed;
-  private final Observable<Activity> showActivityUpdate;
   private final Observable<Boolean> showLoginTout;
   private final PublishSubject<Pair<Project, RefTag>> showProject = PublishSubject.create();
   private final BehaviorSubject<Boolean> shouldShowOnboardingView = BehaviorSubject.create();
+  private final Observable<Activity> startUpdateActivity;
 
   public final DiscoveryFragmentViewModelInputs inputs = this;
   public final DiscoveryFragmentViewModelOutputs outputs = this;
@@ -259,9 +259,6 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
   @Override public @NonNull Observable<Boolean> showActivityFeed() {
     return this.showActivityFeed;
   }
-  @Override public @NonNull Observable<Activity> showActivityUpdate() {
-    return this.showActivityUpdate;
-  }
   @Override public @NonNull Observable<Boolean> showLoginTout() {
     return this.showLoginTout;
   }
@@ -270,5 +267,8 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
   }
   @Override public @NonNull Observable<Boolean> shouldShowOnboardingView() {
     return this.shouldShowOnboardingView;
+  }
+  @Override public @NonNull Observable<Activity> startUpdateActivity() {
+    return this.startUpdateActivity;
   }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.java
@@ -13,6 +13,7 @@ import com.kickstarter.models.Update;
 import com.kickstarter.services.ApiClientType;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.activities.UpdateActivity;
+import com.kickstarter.ui.intentmappers.ProjectIntentMapper;
 
 import okhttp3.Request;
 import rx.Observable;
@@ -72,7 +73,7 @@ public interface UpdateViewModel {
         .take(1);
 
       final Observable<Project> project = intent()
-        .map(i -> i.getParcelableExtra(IntentKey.PROJECT))
+        .map(i -> ProjectIntentMapper.project(i, this.client))
         .ofType(Project.class);
 
       final Observable<String> initialUpdateUrl = initialUpdate

--- a/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.java
@@ -73,8 +73,8 @@ public interface UpdateViewModel {
         .take(1);
 
       final Observable<Project> project = intent()
-        .map(i -> ProjectIntentMapper.project(i, this.client))
-        .ofType(Project.class);
+        .flatMap(i -> ProjectIntentMapper.project(i, this.client))
+        .share();
 
       final Observable<String> initialUpdateUrl = initialUpdate
         .map(u -> u.urls().web().update());

--- a/app/src/main/java/com/kickstarter/viewmodels/outputs/DiscoveryFragmentViewModelOutputs.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/outputs/DiscoveryFragmentViewModelOutputs.java
@@ -22,11 +22,6 @@ public interface DiscoveryFragmentViewModelOutputs {
   Observable<Boolean> showActivityFeed();
 
   /**
-   * Emits an activity when an update should be shown
-   */
-  Observable<Activity> showActivityUpdate();
-
-  /**
    * Emits an activity for the activity sample view
    */
   Observable<Activity> activity();
@@ -45,4 +40,9 @@ public interface DiscoveryFragmentViewModelOutputs {
    * Emits a pair containing a project and a ref tag when a project should be shown
    */
   Observable<Pair<Project, RefTag>> showProject();
+
+  /**
+   * Emits an activity when we should start the {@link com.kickstarter.ui.activities.UpdateActivity}.
+   */
+  Observable<Activity> startUpdateActivity();
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -171,8 +171,8 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     final TestSubscriber<Boolean> showActivityFeed = new TestSubscriber<>();
     vm.outputs.showActivityFeed().subscribe(showActivityFeed);
 
-    final TestSubscriber<Activity> showActivityUpdate = new TestSubscriber<>();
-    vm.outputs.showActivityUpdate().subscribe(showActivityUpdate);
+    final TestSubscriber<Activity> startUpdateActivity = new TestSubscriber<>();
+    vm.outputs.startUpdateActivity().subscribe(startUpdateActivity);
 
     final TestSubscriber<Boolean> showLoginTout = new TestSubscriber<>();
     vm.outputs.showLoginTout().subscribe(showLoginTout);
@@ -190,9 +190,9 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     showActivityFeed.assertValues(true, true, true);
 
     // Clicking activity update on sampler should show activity update.
-    showActivityUpdate.assertNoValues();
+    startUpdateActivity.assertNoValues();
     vm.inputs.activitySampleProjectViewHolderUpdateClicked(null, ActivityFactory.updateActivity());
-    showActivityUpdate.assertValueCount(1);
+    startUpdateActivity.assertValueCount(1);
     koalaTest.assertValues(KoalaEvent.VIEWED_UPDATE);
 
     // Clicking login on onboarding view should show login tout.

--- a/app/src/test/java/com/kickstarter/viewmodels/UpdateViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/UpdateViewModelTest.java
@@ -30,7 +30,7 @@ public final class UpdateViewModelTest extends KSRobolectricTestCase {
   public void testUpdateViewModel_ExternalLinkActivated() {
     final Project project = ProjectFactory.project().toBuilder().slug("meatballs").build();
     final MockApiClient client = new MockApiClient() {
-      @Override public @NonNull Observable<Project> fetchProject(@NonNull String param) {
+      @Override public @NonNull Observable<Project> fetchProject(final @NonNull String param) {
         return Observable.just(project);
       }
     };

--- a/app/src/test/java/com/kickstarter/viewmodels/UpdateViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/UpdateViewModelTest.java
@@ -28,10 +28,24 @@ public final class UpdateViewModelTest extends KSRobolectricTestCase {
 
   @Test
   public void testUpdateViewModel_ExternalLinkActivated() {
-    final UpdateViewModel.ViewModel vm = new UpdateViewModel.ViewModel(environment());
+    final Project project = ProjectFactory.project().toBuilder().slug("meatballs").build();
+    final MockApiClient client = new MockApiClient() {
+      @Override public @NonNull Observable<Project> fetchProject(@NonNull String param) {
+        return Observable.just(project);
+      }
+    };
 
-    // Start the intent with a project and update.
-    vm.intent(this.defaultIntent);
+    final UpdateViewModel.ViewModel vm = new UpdateViewModel.ViewModel(
+      environment().toBuilder().apiClient(client).build()
+    );
+
+    // Start the intent with a project param and update.
+    vm.intent(
+      new Intent()
+        .putExtra(IntentKey.PROJECT_PARAM, "meatballs")
+        .putExtra(IntentKey.UPDATE, UpdateFactory.update())
+    );
+
     vm.inputs.externalLinkActivated();
 
     this.koalaTest.assertValues(KoalaEvent.OPENED_EXTERNAL_LINK);


### PR DESCRIPTION
## what
In #167 we refactored the activity feed to patch its Update logic to use the appropriate `UpdateActivity.class` with `Project` and `Update` extras rather than the legacy `WebViewActivity.class` with a `Url`. 

Well...turns out there were a couple more spots we needed to change: the push notification, and the activity sample from the discovery feed. This PR:
* Refactors PushNotifications and DiscoveryFragment to open the appropriate `UpdateActivity` with proper data
* Refactors `UpdateViewModel` to accept either a Project or its Param 
* Renames an output to align with modern styles

A takeaway from this is to audit more thoroughly when implementing new features that replace "temporary" placeholder features.