### PR TITLE
toolbar refresh

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/toolbars/AlphaBehavior.java
+++ b/app/src/main/java/com/kickstarter/ui/toolbars/AlphaBehavior.java
@@ -23,10 +23,10 @@ public class AlphaBehavior<V extends View> extends CoordinatorLayout.Behavior<V>
 
   @Override
   public boolean onDependentViewChanged(final CoordinatorLayout parent, final View child, final View dependency) {
-    AppBarLayout appBarLayout = (AppBarLayout) dependency;
+    final AppBarLayout appBarLayout = (AppBarLayout) dependency;
 
-    float translationY = dependency.getY();
-    float percentComplete = -translationY / appBarLayout.getTotalScrollRange();
+    final float translationY = dependency.getY();
+    final float percentComplete = -translationY / appBarLayout.getTotalScrollRange();
 
     child.setY(dependency.getBottom());
     child.setAlpha(percentComplete);

--- a/app/src/main/java/com/kickstarter/ui/toolbars/AlphaBehavior.java
+++ b/app/src/main/java/com/kickstarter/ui/toolbars/AlphaBehavior.java
@@ -1,0 +1,41 @@
+package com.kickstarter.ui.toolbars;
+
+import android.content.Context;
+import android.support.design.widget.AppBarLayout;
+import android.support.design.widget.CoordinatorLayout;
+import android.util.AttributeSet;
+import android.view.View;
+
+
+public class AlphaBehavior<V extends View> extends CoordinatorLayout.Behavior<V> {
+
+  public AlphaBehavior() {
+  }
+  public AlphaBehavior(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+  @Override
+  public boolean layoutDependsOn(CoordinatorLayout parent, View child, View dependency) {
+    return dependency instanceof AppBarLayout;
+  }
+
+  @Override
+  public boolean onDependentViewChanged(CoordinatorLayout parent, View child, View dependency) {
+    AppBarLayout appBarLayout = (AppBarLayout) dependency;
+
+    float translationY = dependency.getY();
+    float percentComplete = -translationY / appBarLayout.getTotalScrollRange();
+
+    child.setY(dependency.getBottom());
+    child.setAlpha(percentComplete);
+    return false;
+  }
+
+  @Override
+  public void onNestedScroll(CoordinatorLayout coordinatorLayout, V child, View target, int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed) {
+    super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed);
+
+    /* check if position 0 is visible, check its top compared to the view pagers top? also need top of parent !_!
+      * distance btween pager top and paremt top vs position 0 */
+  }
+}

--- a/app/src/main/java/com/kickstarter/ui/toolbars/AlphaBehavior.java
+++ b/app/src/main/java/com/kickstarter/ui/toolbars/AlphaBehavior.java
@@ -1,6 +1,7 @@
 package com.kickstarter.ui.toolbars;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.CoordinatorLayout;
 import android.util.AttributeSet;
@@ -12,7 +13,7 @@ public class AlphaBehavior<V extends View> extends CoordinatorLayout.Behavior<V>
   public AlphaBehavior() {
   }
 
-  public AlphaBehavior(final Context context, final AttributeSet attrs) {
+  public AlphaBehavior(final @NonNull Context context, final @NonNull AttributeSet attrs) {
     super(context, attrs);
   }
 

--- a/app/src/main/java/com/kickstarter/ui/toolbars/AlphaBehavior.java
+++ b/app/src/main/java/com/kickstarter/ui/toolbars/AlphaBehavior.java
@@ -11,9 +11,11 @@ public class AlphaBehavior<V extends View> extends CoordinatorLayout.Behavior<V>
 
   public AlphaBehavior() {
   }
+
   public AlphaBehavior(Context context, AttributeSet attrs) {
     super(context, attrs);
   }
+
   @Override
   public boolean layoutDependsOn(CoordinatorLayout parent, View child, View dependency) {
     return dependency instanceof AppBarLayout;
@@ -29,13 +31,5 @@ public class AlphaBehavior<V extends View> extends CoordinatorLayout.Behavior<V>
     child.setY(dependency.getBottom());
     child.setAlpha(percentComplete);
     return false;
-  }
-
-  @Override
-  public void onNestedScroll(CoordinatorLayout coordinatorLayout, V child, View target, int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed) {
-    super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed);
-
-    /* check if position 0 is visible, check its top compared to the view pagers top? also need top of parent !_!
-      * distance btween pager top and paremt top vs position 0 */
   }
 }

--- a/app/src/main/java/com/kickstarter/ui/toolbars/AlphaBehavior.java
+++ b/app/src/main/java/com/kickstarter/ui/toolbars/AlphaBehavior.java
@@ -12,17 +12,17 @@ public class AlphaBehavior<V extends View> extends CoordinatorLayout.Behavior<V>
   public AlphaBehavior() {
   }
 
-  public AlphaBehavior(Context context, AttributeSet attrs) {
+  public AlphaBehavior(final Context context, final AttributeSet attrs) {
     super(context, attrs);
   }
 
   @Override
-  public boolean layoutDependsOn(CoordinatorLayout parent, View child, View dependency) {
+  public boolean layoutDependsOn(final CoordinatorLayout parent, final View child, final View dependency) {
     return dependency instanceof AppBarLayout;
   }
 
   @Override
-  public boolean onDependentViewChanged(CoordinatorLayout parent, View child, View dependency) {
+  public boolean onDependentViewChanged(final CoordinatorLayout parent, final View child, final View dependency) {
     AppBarLayout appBarLayout = (AppBarLayout) dependency;
 
     float translationY = dependency.getY();

--- a/app/src/main/res/drawable/click_indicator_light.xml
+++ b/app/src/main/res/drawable/click_indicator_light.xml
@@ -2,6 +2,5 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:drawable="@color/dark_gray_click" android:state_focused="true" />
   <item android:drawable="@color/dark_gray_click" android:state_pressed="true" />
-  <item android:drawable="@color/dark_gray_click" android:state_selected="true" />
   <item android:drawable="@color/transparent" />
 </selector>

--- a/app/src/main/res/layout/discovery_layout.xml
+++ b/app/src/main/res/layout/discovery_layout.xml
@@ -22,22 +22,35 @@
 
       <android.support.design.widget.AppBarLayout
         android:id="@+id/discovery_sort_app_bar_layout"
-        app:elevation="@dimen/card_no_elevation"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:elevation="@dimen/card_no_elevation">
 
-          <include layout="@layout/discovery_toolbar"/>
+        <android.support.design.widget.CollapsingToolbarLayout
+          android:layout_width="match_parent"
+          android:layout_height="96dp"
+          app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+          <include
+            layout="@layout/discovery_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:layout_gravity="top" />
 
           <com.kickstarter.ui.views.SortTabLayout
             android:id="@+id/discovery_tab_layout"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:layout_gravity="bottom"
+            app:layout_collapseMode="pin"
+            app:tabBackground="@drawable/click_indicator_light"
             app:tabMode="scrollable"
+            app:tabSelectedTextColor="@color/text_primary"
             app:tabTextAppearance="@style/TabTextAppearance"
             app:tabTextColor="@color/black_alpha_30"
-            app:tabSelectedTextColor="@color/text_primary"
-            app:tabBackground="@drawable/click_indicator_light"
-            app:layout_collapseMode="pin"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            />
+
+        </android.support.design.widget.CollapsingToolbarLayout>
 
       </android.support.design.widget.AppBarLayout>
 
@@ -48,10 +61,10 @@
         android:layout_height="match_parent"/>
 
       <include
-      layout="@layout/horizontal_line_1dp_view"
-      android:layout_height="wrap_content"
-      android:layout_width="match_parent"
-        app:layout_behavior="com.kickstarter.ui.toolbars.AlphaBehavior"/>
+        layout="@layout/horizontal_line_1dp_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_behavior="com.kickstarter.ui.toolbars.AlphaBehavior" />
 
     </android.support.design.widget.CoordinatorLayout>
 

--- a/app/src/main/res/layout/discovery_layout.xml
+++ b/app/src/main/res/layout/discovery_layout.xml
@@ -16,7 +16,6 @@
     android:fitsSystemWindows="true">
 
     <android.support.design.widget.CoordinatorLayout
-      android:elevation="4dp"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       tools:ignore="UnusedAttribute">
@@ -40,13 +39,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 
-        <include
-          layout="@layout/horizontal_line_1dp_view"
-          android:layout_height="wrap_content"
-          android:layout_width="match_parent"
-          android:layout_marginTop="@dimen/sort_tab_divider_margin_top_negative"
-          app:layout_scrollFlags="scroll"/>
-
       </android.support.design.widget.AppBarLayout>
 
       <android.support.v4.view.ViewPager
@@ -54,6 +46,12 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
+
+      <include
+      layout="@layout/horizontal_line_1dp_view"
+      android:layout_height="wrap_content"
+      android:layout_width="match_parent"
+        app:layout_behavior="com.kickstarter.ui.toolbars.AlphaBehavior"/>
 
     </android.support.design.widget.CoordinatorLayout>
 

--- a/app/src/main/res/layout/discovery_layout.xml
+++ b/app/src/main/res/layout/discovery_layout.xml
@@ -11,40 +11,23 @@
   tools:context=".ui.activities.DiscoveryActivity">
 
   <RelativeLayout
-    android:layout_marginTop="@dimen/discovery_drawer_status_bar_height_negative"
-    android:paddingTop="@dimen/discovery_drawer_status_bar_height"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
 
-    <android.support.design.widget.AppBarLayout
-      android:id="@+id/parent_app_bar"
-      android:fitsSystemWindows="true"
-      android:elevation="0dp"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      tools:ignore="UnusedAttribute">
-
-      <include layout="@layout/discovery_toolbar"/>
-
-    </android.support.design.widget.AppBarLayout>
-
     <android.support.design.widget.CoordinatorLayout
       android:elevation="4dp"
-      android:layout_below="@id/parent_app_bar"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       tools:ignore="UnusedAttribute">
 
       <android.support.design.widget.AppBarLayout
         android:id="@+id/discovery_sort_app_bar_layout"
+        app:elevation="@dimen/card_no_elevation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <android.support.design.widget.CollapsingToolbarLayout
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          app:layout_scrollFlags="scroll|enterAlways">
+          <include layout="@layout/discovery_toolbar"/>
 
           <com.kickstarter.ui.views.SortTabLayout
             android:id="@+id/discovery_tab_layout"
@@ -53,17 +36,16 @@
             app:tabTextColor="@color/black_alpha_30"
             app:tabSelectedTextColor="@color/text_primary"
             app:tabBackground="@drawable/click_indicator_light"
+            app:layout_collapseMode="pin"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 
-        </android.support.design.widget.CollapsingToolbarLayout>
-
         <include
-          layout="@layout/horizontal_line_0_5dp_view"
+          layout="@layout/horizontal_line_1dp_view"
           android:layout_height="wrap_content"
           android:layout_width="match_parent"
           android:layout_marginTop="@dimen/sort_tab_divider_margin_top_negative"
-          app:layout_scrollFlags="scroll|enterAlways" />
+          app:layout_scrollFlags="scroll"/>
 
       </android.support.design.widget.AppBarLayout>
 

--- a/app/src/main/res/layout/discovery_toolbar.xml
+++ b/app/src/main/res/layout/discovery_toolbar.xml
@@ -9,7 +9,7 @@
   android:elevation="0dp"
   app:contentInsetLeft="0dp"
   app:contentInsetStart="0dp"
-  app:layout_scrollFlags="scroll|enterAlways"
+  app:layout_collapseMode="parallax"
   tools:ignore="UnusedAttribute"
   tools:showIn="@layout/discovery_layout">
 

--- a/app/src/main/res/layout/discovery_toolbar.xml
+++ b/app/src/main/res/layout/discovery_toolbar.xml
@@ -9,14 +9,13 @@
   android:elevation="0dp"
   app:contentInsetLeft="0dp"
   app:contentInsetStart="0dp"
-  app:layout_scrollFlags="scroll|exitUntilCollapsed"
+  app:layout_scrollFlags="scroll|enterAlways"
   tools:ignore="UnusedAttribute"
   tools:showIn="@layout/discovery_layout">
 
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
-    android:layout_marginTop="@dimen/discovery_drawer_status_bar_height"
     android:baselineAligned="false"
     android:gravity="center_vertical"
     android:orientation="horizontal">


### PR DESCRIPTION
## what
Started with discovery as a first pass since it's most visible. `AppBarLayout` no longer has elevation, now has a divider whose alpha is based on how much the user has scrolled. The toolbar is only expanded when at the top of the list.

For fun, I got rid of the awkward selected state in the toolbar on pre 21 devices.

### who is she
![2017-11-28 17_52_05](https://user-images.githubusercontent.com/1289295/33349141-ec79a548-d466-11e7-9597-57e50aa1ba5c.gif)

