### PR TITLE
Create `isWebViewUri` helper to allow GraphQL reqs via Webviews

### DIFF
--- a/app/src/main/java/com/kickstarter/services/KSUri.java
+++ b/app/src/main/java/com/kickstarter/services/KSUri.java
@@ -42,6 +42,14 @@ public final class KSUri {
     return uri.getHost().equals(Uri.parse(webEndpoint).getHost());
   }
 
+  public static boolean isKSGraphQLUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
+    return isKickstarterUri(uri, webEndpoint) && uri.getPath().equals("/graph");
+  }
+
+  public static boolean isWebViewUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
+    return isKickstarterUri(uri, webEndpoint) && !isKSGraphQLUri(uri, webEndpoint);
+  }
+
   public static boolean isNewGuestCheckoutUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
     return isKickstarterUri(uri, webEndpoint) && NEW_GUEST_CHECKOUT_PATTERN.matcher(uri.getPath()).matches();
   }

--- a/app/src/test/java/com/kickstarter/services/KSUriTest.java
+++ b/app/src/test/java/com/kickstarter/services/KSUriTest.java
@@ -45,6 +45,29 @@ public final class KSUriTest extends KSRobolectricTestCase {
   }
 
   @Test
+  public void testKSUri_isWebViewUri() {
+    final Uri ksrUri = Uri.parse("https://www.ksr.com/project");
+    final Uri uri = Uri.parse("https://www.hello-world.org/goodbye");
+    final Uri ksrGraphUri = Uri.parse("https://www.ksr.com/graph");
+    final Uri graphUri = Uri.parse("https://www.hello-world.org/graph");
+
+
+    assertTrue(KSUri.isWebViewUri(ksrUri, this.webEndpoint));
+    assertFalse(KSUri.isWebViewUri(uri, this.webEndpoint));
+    assertFalse(KSUri.isWebViewUri(ksrGraphUri, this.webEndpoint));
+    assertFalse(KSUri.isWebViewUri(graphUri, this.webEndpoint));
+  }
+
+  @Test
+  public void testKSUri_isKSGraphQLUri() {
+    final Uri ksrGraphUri = Uri.parse("https://www.ksr.com/graph");
+    final Uri graphUri = Uri.parse("https://www.hello-world.org/graph");
+
+    assertTrue(KSUri.isKSGraphQLUri(ksrGraphUri, this.webEndpoint));
+    assertFalse(KSUri.isKSGraphQLUri(graphUri, this.webEndpoint));
+  }
+
+  @Test
   public void testKSUri_isModalUri() {
     final Uri modalUri = Uri.parse("https://www.ksr.com/project?modal=true");
 


### PR DESCRIPTION
# What + Why 
This PR adds two helper methods, `isWebViewUri` and `isKSGraphQLUri` to determine whether the URI of a HTTP request is for a WebView i.e. a GET request to get the contents of a WebView. Here, we define a WebView URI as one that is a Kickstarter URI, but not to our GraphQL endpoint.