### PR TITLE
creator tools collaborator access

### DIFF
--- a/app/src/main/java/com/kickstarter/models/User.java
+++ b/app/src/main/java/com/kickstarter/models/User.java
@@ -18,6 +18,7 @@ public abstract class User implements Parcelable {
   public abstract @Nullable Boolean happeningNewsletter();
   public abstract long id();
   public abstract @Nullable Location location();
+  public abstract @Nullable Integer memberProjectsCount();
   public abstract String name();
   public abstract @Nullable Boolean notifyMobileOfBackings();
   public abstract @Nullable Boolean notifyMobileOfComments();
@@ -44,6 +45,7 @@ public abstract class User implements Parcelable {
     public abstract Builder happeningNewsletter(Boolean __);
     public abstract Builder id(long __);
     public abstract Builder location(Location __);
+    public abstract Builder memberProjectsCount(Integer __);
     public abstract Builder name(String __);
     public abstract Builder notifyMobileOfBackings(Boolean __);
     public abstract Builder notifyMobileOfComments(Boolean __);

--- a/app/src/main/java/com/kickstarter/services/gcm/RegisterService.java
+++ b/app/src/main/java/com/kickstarter/services/gcm/RegisterService.java
@@ -67,7 +67,7 @@ public class RegisterService extends IntentService {
       .subscribe(__ ->
         this.apiClient.registerPushToken(token)
           .compose(Transformers.neverError())
-          .first().toBlocking().single()
+          .toList().toBlocking().single()
       );
   }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -119,7 +119,7 @@ public interface DiscoveryViewModel {
       this.showSettings = this.settingsClick;
 
       final Observable<Boolean> userIsCreator = this.currentUser.observable()
-        .map(u -> u != null && IntegerUtils.isNonZero(u.createdProjectsCount()));
+        .map(u -> u != null && IntegerUtils.isNonZero(u.memberProjectsCount()));
 
       final Observable<Boolean> creatorViewFeatureFlagIsEnabled = environment.currentConfig().observable()
         .map(Config::features)

--- a/app/src/test/java/com/kickstarter/factories/UserFactory.java
+++ b/app/src/test/java/com/kickstarter/factories/UserFactory.java
@@ -22,6 +22,7 @@ public final class UserFactory {
     return user()
       .toBuilder()
       .createdProjectsCount(5)
+      .memberProjectsCount(10)
       .build();
   }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -108,8 +108,52 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
+  public void testCreatorDashboardButtonIsGone__notCollaboratorFeatureEnabled() {
+    final User notCreator = UserFactory.user().toBuilder().memberProjectsCount(0).build();
+    final MockCurrentUser currentUser = new MockCurrentUser(notCreator);
+
+    final Config config = ConfigFactory.config()
+      .toBuilder()
+      .features(Collections.singletonMap(FeatureKey.ANDROID_CREATOR_VIEW, true))
+      .build();
+
+    final MockCurrentConfig currentConfig = new MockCurrentConfig();
+    currentConfig.config(config);
+
+    final Environment env = environment().toBuilder()
+      .currentUser(currentUser)
+      .currentConfig(currentConfig).build();
+
+    this.vm = new DiscoveryViewModel.ViewModel(env);
+    this.vm.outputs.creatorDashboardButtonIsGone().subscribe(this.creatorDashboardButtonIsGone);
+    this.creatorDashboardButtonIsGone.assertValues(true);
+  }
+
+  @Test
   public void testCreatorDashboardButtonIsGone__isCreatorFeatureEnabled() {
     final User creator = UserFactory.creator();
+    final MockCurrentUser currentUser = new MockCurrentUser(creator);
+
+    final Config config = ConfigFactory.config()
+      .toBuilder()
+      .features(Collections.singletonMap(FeatureKey.ANDROID_CREATOR_VIEW, true))
+      .build();
+
+    final MockCurrentConfig currentConfig = new MockCurrentConfig();
+    currentConfig.config(config);
+
+    final Environment env = environment().toBuilder()
+      .currentUser(currentUser)
+      .currentConfig(currentConfig).build();
+
+    this.vm = new DiscoveryViewModel.ViewModel(env);
+    this.vm.outputs.creatorDashboardButtonIsGone().subscribe(this.creatorDashboardButtonIsGone);
+    this.creatorDashboardButtonIsGone.assertValues(false);
+  }
+
+  @Test
+  public void testCreatorDashboardButtonIsGone__isCollaboratorFeatureEnabled() {
+    final User creator = UserFactory.user().toBuilder().memberProjectsCount(2).build();
     final MockCurrentUser currentUser = new MockCurrentUser(creator);
 
     final Config config = ConfigFactory.config()


### PR DESCRIPTION
# what 
Adds `memberProjectsCount` to the `User` object so we show creator dashboard icon for collaborators, not just creators.
Fixes error when registering push token (can't call first() on an `Empty`).
Tests!