### PR TITLE
project share intent

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
@@ -50,7 +50,8 @@ public final class ProjectActivity extends BaseActivity<ProjectViewModel.ViewMod
 
   protected @BindString(R.string.project_back_button) String projectBackButtonString;
   protected @BindString(R.string.project_checkout_manage_navbar_title) String managePledgeString;
-  protected @BindString(R.string.project_share_twitter_message) String projectShareString;
+  protected @BindString(R.string.project_accessibility_button_share_label) String projectShareLabelString;
+  protected @BindString(R.string.project_share_twitter_message) String projectShareCopyString;
   protected @BindString(R.string.project_star_confirmation) String projectStarConfirmationString;
   protected @BindString(R.string.project_subpages_menu_buttons_campaign) String campaignString;
   protected @BindString(R.string.project_subpages_menu_buttons_creator) String creatorString;
@@ -216,12 +217,12 @@ public final class ProjectActivity extends BaseActivity<ProjectViewModel.ViewMod
 
   // todo: limit the apps you can share to
   private void startShareIntent(final @NonNull Project project) {
-    final String shareMessage = this.ksString.format(this.projectShareString, "project_title", project.name());
+    final String shareMessage = this.ksString.format(this.projectShareCopyString, "project_title", project.name());
 
     final Intent intent = new Intent(Intent.ACTION_SEND)
       .setType("text/plain")
       .putExtra(Intent.EXTRA_TEXT, shareMessage + " " + project.webProjectUrl());
-    startActivity(Intent.createChooser(intent, getResources().getText(R.string.project_accessibility_button_share_label)));
+    startActivity(Intent.createChooser(intent, projectShareLabelString));
   }
 
   private void startWebViewActivity(final @NonNull String toolbarTitle, final @NonNull String url) {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
@@ -222,7 +222,7 @@ public final class ProjectActivity extends BaseActivity<ProjectViewModel.ViewMod
     final Intent intent = new Intent(Intent.ACTION_SEND)
       .setType("text/plain")
       .putExtra(Intent.EXTRA_TEXT, shareMessage + " " + project.webProjectUrl());
-    startActivity(Intent.createChooser(intent, projectShareLabelString));
+    startActivity(Intent.createChooser(intent, this.projectShareLabelString));
   }
 
   private void startWebViewActivity(final @NonNull String toolbarTitle, final @NonNull String url) {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.java
@@ -221,7 +221,7 @@ public final class ProjectActivity extends BaseActivity<ProjectViewModel.ViewMod
     final Intent intent = new Intent(Intent.ACTION_SEND)
       .setType("text/plain")
       .putExtra(Intent.EXTRA_TEXT, shareMessage + " " + project.webProjectUrl());
-    startActivity(intent);
+    startActivity(Intent.createChooser(intent, getResources().getText(R.string.project_accessibility_button_share_label)));
   }
 
   private void startWebViewActivity(final @NonNull String toolbarTitle, final @NonNull String url) {


### PR DESCRIPTION
# what
Updating how we share projects because Samsung ruins everything.

# why
We've gotten some Android feedback about users not being able to choose a different app to share projects. On Samsung devices, once you share a project via say Facebook, you get defaulted to sharing via Facebook and you have to reset app defaults to reset it. We should be using this way to share anyway, not sure why the project screen was different. 

# how
Here are the docs on it: https://developer.android.com/training/sharing/send.html

# before and after
<img src=https://user-images.githubusercontent.com/1289295/36602270-99c792e8-1885-11e8-811a-55144bd88605.png width=330/> <img src=https://user-images.githubusercontent.com/1289295/36602269-99b5e520-1885-11e8-9853-7818b39c2e69.png width=330/>
