### PR TITLE
ReferrerType update

### DIFF
--- a/app/src/main/java/com/kickstarter/services/apiresponses/ProjectStatsEnvelope.java
+++ b/app/src/main/java/com/kickstarter/services/apiresponses/ProjectStatsEnvelope.java
@@ -114,12 +114,8 @@ public abstract class ProjectStatsEnvelope implements Parcelable {
     // enum type.
     public ReferrerType referrerTypeEnumType() {
       switch (referrerType().toLowerCase(Locale.getDefault())) {
-        case "campaign":
-          return ReferrerType.CAMPAIGN;
         case "custom":
           return ReferrerType.CUSTOM;
-        case "domain":
-          return ReferrerType.DOMAIN;
         case "external":
           return ReferrerType.EXTERNAL;
         case "kickstarter":


### PR DESCRIPTION
# what
The server will now only be returning `["kickstarter", "custom", "external"]` as referral types so we don't need to check for campaign and domain. Check out this PR https://github.com/kickstarter/kickstarter/pull/9962 for reference. 

@Scollaco @cdolm92 it's not necessary for iOS to make this change but it affected my chart work in the #221 PR (basically I have no corresponding colors for `["campaign", "domain"]` so I removed them).