### PR TITLE
creator tools breakdown empty view

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/ReferrerType.kt
+++ b/app/src/main/java/com/kickstarter/libs/ReferrerType.kt
@@ -8,6 +8,6 @@ import com.kickstarter.R
 enum class ReferrerType(val referrerType: String, val referrerColorId : Int) {
   CUSTOM("custom", R.color.ksr_highlighter_green),
   EXTERNAL("external", R.color.ksr_green_500),
-  INTERNAL("kickstarter", R.color.ksr_green_800)
+  KICKSTARTER("kickstarter", R.color.ksr_green_800)
 }
 

--- a/app/src/main/java/com/kickstarter/services/apiresponses/ProjectStatsEnvelope.java
+++ b/app/src/main/java/com/kickstarter/services/apiresponses/ProjectStatsEnvelope.java
@@ -120,9 +120,9 @@ public abstract class ProjectStatsEnvelope implements Parcelable {
         case "external":
           return ReferrerType.EXTERNAL;
         case "kickstarter":
-          return ReferrerType.INTERNAL;
+          return ReferrerType.KICKSTARTER;
         default:
-          return ReferrerType.INTERNAL;
+          return ReferrerType.KICKSTARTER;
       }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardReferrerBreakdownViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardReferrerBreakdownViewHolder.java
@@ -26,12 +26,13 @@ import static com.kickstarter.libs.utils.ObjectUtils.requireNonNull;
 public class CreatorDashboardReferrerBreakdownViewHolder extends KSViewHolder {
   private final CreatorDashboardReferrerBreakdownHolderViewModel.ViewModel viewModel;
 
-  protected @Bind(R.id.amount_pledged_via_kickstarter_text_view) TextView amountPledgedViaInternalTextView;
-  protected @Bind(R.id.amount_pledged_via_external_text_view) TextView amountPledgedViaExternalTextView;
   protected @Bind(R.id.amount_pledged_via_custom_text_view) TextView amountPledgedViaCustomTextView;
+  protected @Bind(R.id.amount_pledged_via_external_text_view) TextView amountPledgedViaExternalTextView;
+  protected @Bind(R.id.amount_pledged_via_kickstarter_text_view) TextView amountPledgedViaKickstarterTextView;
+  protected @Bind(R.id.dashboard_referrer_breakdown_empty_text_view) TextView emptyCopyTextView;
   protected @Bind(R.id.percent_via_custom_text_view) TextView percentCustomTextView;
   protected @Bind(R.id.percent_via_external_text_view) TextView percentExternalTextView;
-  protected @Bind(R.id.percent_via_kickstarter_text_view) TextView percentInternalTextView;
+  protected @Bind(R.id.percent_via_kickstarter_text_view) TextView percentKickstarterTextView;
   protected @Bind(R.id.pledged_via_custom) View pledgedViaCustomLayout;
   protected @Bind(R.id.pledged_via_custom_bar) View pledgedViaCustomBar;
   protected @Bind(R.id.pledged_via_custom_indicator) View pledgedViaCustomIndicator;
@@ -54,6 +55,11 @@ public class CreatorDashboardReferrerBreakdownViewHolder extends KSViewHolder {
     this.ksCurrency = this.environment().ksCurrency();
 
     this.viewModel = new CreatorDashboardReferrerBreakdownHolderViewModel.ViewModel(environment());
+
+    this.viewModel.outputs.breakdownViewIsGone()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(this::toggleChartAndEmptyVisibility);
 
     this.viewModel.outputs.customReferrerPercent()
       .compose(bindToLifecycle())
@@ -80,15 +86,15 @@ public class CreatorDashboardReferrerBreakdownViewHolder extends KSViewHolder {
       .compose(observeForUI())
       .subscribe(this.percentExternalTextView::setText);
 
-    this.viewModel.outputs.internalReferrerPercent()
+    this.viewModel.outputs.kickstarterReferrerPercent()
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(percent -> setReferrerWidth(percent, this.pledgedViaKickstarterBar, this.pledgedViaKickstarterIndicator));
 
-    this.viewModel.outputs.internalReferrerPercentText()
+    this.viewModel.outputs.kickstarterReferrerPercentText()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(this.percentInternalTextView::setText);
+      .subscribe(this.percentKickstarterTextView::setText);
 
     this.viewModel.outputs.pledgedViaCustomLayoutIsGone()
       .compose(bindToLifecycle())
@@ -100,7 +106,7 @@ public class CreatorDashboardReferrerBreakdownViewHolder extends KSViewHolder {
       .compose(observeForUI())
       .subscribe(gone -> this.hideReferrer(gone, this.pledgedViaExternalLayout, this.pledgedViaExternalBar, this.pledgedViaExternalIndicator));
 
-    this.viewModel.outputs.pledgedViaInternalLayoutIsGone()
+    this.viewModel.outputs.pledgedViaKickstarterLayoutIsGone()
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(gone -> this.hideReferrer(gone, this.pledgedViaKickstarterLayout, this.pledgedViaKickstarterBar, this.pledgedViaKickstarterIndicator));
@@ -115,10 +121,10 @@ public class CreatorDashboardReferrerBreakdownViewHolder extends KSViewHolder {
       .compose(observeForUI())
       .subscribe(pa -> this.setAmountPledgedTextViewText(pa, this.amountPledgedViaExternalTextView));
 
-    this.viewModel.outputs.projectAndInternalReferrerPledgedAmount()
+    this.viewModel.outputs.projectAndKickstarterReferrerPledgedAmount()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(pa -> this.setAmountPledgedTextViewText(pa, this.amountPledgedViaInternalTextView));
+      .subscribe(pa -> this.setAmountPledgedTextViewText(pa, this.amountPledgedViaKickstarterTextView));
   }
 
   private void setReferrerWidth(final Float percent, final View bar, final View indicator) {
@@ -161,6 +167,11 @@ public class CreatorDashboardReferrerBreakdownViewHolder extends KSViewHolder {
     ViewUtils.setGone(layout, gone);
     ViewUtils.setGone(bar, gone);
     ViewUtils.setGone(indicator, gone);
+  }
+
+  private void toggleChartAndEmptyVisibility(final boolean gone) {
+    ViewUtils.setGone(this.referrerBreakdownLayout, gone);
+    ViewUtils.setGone(this.emptyCopyTextView, !gone);
   }
 
   @Override

--- a/app/src/main/res/layout/creator_dashboard_layout.xml
+++ b/app/src/main/res/layout/creator_dashboard_layout.xml
@@ -10,6 +10,11 @@
 
     <include layout="@layout/creator_dashboard_toolbar" />
 
+    <ProgressBar
+      android:layout_gravity="center"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content" />
+
     <FrameLayout
       android:id="@+id/creator_dashboard_coordinator_view"
       android:layout_width="match_parent"

--- a/app/src/main/res/layout/creator_dashboard_recycler_layout.xml
+++ b/app/src/main/res/layout/creator_dashboard_recycler_layout.xml
@@ -5,4 +5,5 @@
   android:id="@+id/creator_dashboard_recycler_view"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
+  android:background="@color/white"
   app:layout_behavior="@string/appbar_scrolling_view_behavior"/>

--- a/app/src/main/res/layout/dashboard_referrer_breakdown_layout.xml
+++ b/app/src/main/res/layout/dashboard_referrer_breakdown_layout.xml
@@ -13,8 +13,8 @@
     style="@style/Title2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginTop="@dimen/grid_7"
     android:layout_marginBottom="@dimen/grid_6"
+    android:layout_marginTop="@dimen/grid_7"
     android:paddingEnd="@dimen/grid_2"
     android:paddingStart="@dimen/grid_2"
     android:text="@string/How_backers_found_your_project" />
@@ -248,4 +248,15 @@
       app:layout_constraintTop_toTopOf="@+id/pledged_via_custom_bar" />
 
   </android.support.constraint.ConstraintLayout>
+
+  <TextView
+    android:id="@+id/dashboard_referrer_breakdown_empty_text_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:paddingBottom="@dimen/grid_10"
+    android:paddingEnd="@dimen/grid_12"
+    android:paddingStart="@dimen/grid_12"
+    android:paddingTop="@dimen/grid_10"
+    android:text="@string/Data_will_appear_here_once" />
 </LinearLayout>

--- a/app/src/main/res/layout/dashboard_referrer_stats_view.xml
+++ b/app/src/main/res/layout/dashboard_referrer_stats_view.xml
@@ -79,6 +79,8 @@
     android:layout_height="wrap_content"
     android:gravity="center"
     android:paddingBottom="@dimen/grid_10"
+    android:paddingEnd="@dimen/grid_12"
+    android:paddingStart="@dimen/grid_12"
     android:paddingTop="@dimen/grid_10"
     android:text="@string/Data_will_appear_here_once" />
 

--- a/app/src/main/res/layout/dashboard_reward_stats_view.xml
+++ b/app/src/main/res/layout/dashboard_reward_stats_view.xml
@@ -79,8 +79,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
-        android:paddingBottom="@dimen/grid_10"
-        android:paddingTop="@dimen/grid_10"
+        android:padding="@dimen/grid_10"
         android:text="@string/Data_will_appear_here_once" />
 
       <TextView

--- a/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardReferrerBreakdownHolderViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardReferrerBreakdownHolderViewModelTest.java
@@ -8,6 +8,7 @@ import com.kickstarter.factories.ProjectFactory;
 import com.kickstarter.factories.ProjectStatsEnvelopeFactory;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.ReferrerType;
+import com.kickstarter.libs.utils.ListUtils;
 import com.kickstarter.libs.utils.NumberUtils;
 import com.kickstarter.models.Project;
 import com.kickstarter.services.apiresponses.ProjectStatsEnvelope;
@@ -23,46 +24,83 @@ import rx.observers.TestSubscriber;
 public class CreatorDashboardReferrerBreakdownHolderViewModelTest extends KSRobolectricTestCase {
   private CreatorDashboardReferrerBreakdownHolderViewModel.ViewModel vm;
 
+  private final TestSubscriber<Boolean> breakdownViewIsGone = new TestSubscriber<>();
   private final TestSubscriber<Float> customReferrerPercent = new TestSubscriber<>();
   private final TestSubscriber<Float> externalReferrerPercent = new TestSubscriber<>();
-  private final TestSubscriber<Float> internalReferrerPercent = new TestSubscriber<>();
+  private final TestSubscriber<Float> kickstarterReferrerPercent = new TestSubscriber<>();
   private final TestSubscriber<String> customReferrerPercentText = new TestSubscriber<>();
   private final TestSubscriber<String> externalReferrerPercentText = new TestSubscriber<>();
-  private final TestSubscriber<String> internalReferrerPercentText = new TestSubscriber<>();
+  private final TestSubscriber<String> kickstarterReferrerPercentText = new TestSubscriber<>();
   private final TestSubscriber<Boolean> pledgedViaCustomLayoutIsGone = new TestSubscriber<>();
   private final TestSubscriber<Boolean> pledgedViaExternalLayoutIsGone = new TestSubscriber<>();
-  private final TestSubscriber<Boolean> pledgedViaInternalLayoutIsGone = new TestSubscriber<>();
+  private final TestSubscriber<Boolean> pledgedViaKickstarterLayoutIsGone = new TestSubscriber<>();
   private final TestSubscriber<Pair<Project, Integer>> projectAndAveragePledge = new TestSubscriber<>();
   private final TestSubscriber<Pair<Project, Float>> projectAndCustomReferrerPledgedAmount = new TestSubscriber<>();
   private final TestSubscriber<Pair<Project, Float>> projectAndExternalReferrerPledgedAmount = new TestSubscriber<>();
-  private final TestSubscriber<Pair<Project, Float>> projectAndInternalReferrerPledgedAmount = new TestSubscriber<>();
+  private final TestSubscriber<Pair<Project, Float>> projectAndKickstarterReferrerPledgedAmount = new TestSubscriber<>();
 
   protected void setUpEnvironment(final @NonNull Environment environment) {
     this.vm = new CreatorDashboardReferrerBreakdownHolderViewModel.ViewModel(environment);
+    this.vm.outputs.breakdownViewIsGone().subscribe(this.breakdownViewIsGone);
     this.vm.outputs.customReferrerPercent().subscribe(this.customReferrerPercent);
     this.vm.outputs.customReferrerPercentText().subscribe(this.customReferrerPercentText);
     this.vm.outputs.externalReferrerPercent().subscribe(this.externalReferrerPercent);
     this.vm.outputs.externalReferrerPercentText().subscribe(this.externalReferrerPercentText);
-    this.vm.outputs.internalReferrerPercent().subscribe(this.internalReferrerPercent);
-    this.vm.outputs.internalReferrerPercentText().subscribe(this.internalReferrerPercentText);
+    this.vm.outputs.kickstarterReferrerPercent().subscribe(this.kickstarterReferrerPercent);
+    this.vm.outputs.kickstarterReferrerPercentText().subscribe(this.kickstarterReferrerPercentText);
     this.vm.outputs.pledgedViaCustomLayoutIsGone().subscribe(this.pledgedViaCustomLayoutIsGone);
     this.vm.outputs.pledgedViaExternalLayoutIsGone().subscribe(this.pledgedViaExternalLayoutIsGone);
-    this.vm.outputs.pledgedViaInternalLayoutIsGone().subscribe(this.pledgedViaInternalLayoutIsGone);
+    this.vm.outputs.pledgedViaKickstarterLayoutIsGone().subscribe(this.pledgedViaKickstarterLayoutIsGone);
     this.vm.outputs.projectAndAveragePledge().subscribe(this.projectAndAveragePledge);
     this.vm.outputs.projectAndCustomReferrerPledgedAmount().subscribe(this.projectAndCustomReferrerPledgedAmount);
     this.vm.outputs.projectAndExternalReferrerPledgedAmount().subscribe(this.projectAndExternalReferrerPledgedAmount);
-    this.vm.outputs.projectAndInternalReferrerPledgedAmount().subscribe(this.projectAndInternalReferrerPledgedAmount);
+    this.vm.outputs.projectAndKickstarterReferrerPledgedAmount()
+      .subscribe(this.projectAndKickstarterReferrerPledgedAmount);
+  }
+
+  @Test
+  public void testBreakdownViewIsGone_whenStatsEmpty() {
+    final Project project = ProjectFactory.project();
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(ListUtils.empty())
+      .build();
+
+    setUpEnvironment(environment());
+    this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
+    this.breakdownViewIsGone.assertValues(true);
+  }
+
+  @Test
+  public void testBreakdownViewIsGone_whenStatsNotEmpty() {
+    final Project project = ProjectFactory.project();
+    final ProjectStatsEnvelope.ReferrerStats referrerStat = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats();
+    final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Collections.singletonList(referrerStat);
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
+
+    setUpEnvironment(environment());
+    this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
+    this.breakdownViewIsGone.assertValues(false);
   }
 
   @Test
   public void testCustomReferrerPercent() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.ReferrerStats fiftyFivePercentCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats fiftyFivePercentCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .percentageOfDollars(55f)
       .referrerType(ReferrerType.CUSTOM.getReferrerType())
       .build();
     final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Collections.singletonList(fiftyFivePercentCustomReferrer);
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().referralDistribution(referrerList).build();
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
@@ -72,12 +110,17 @@ public class CreatorDashboardReferrerBreakdownHolderViewModelTest extends KSRobo
   @Test
   public void testCustomReferrerPercentText() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.ReferrerStats fiftyFivePercentCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats fiftyFivePercentCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .percentageOfDollars(.55f)
       .referrerType(ReferrerType.CUSTOM.getReferrerType())
       .build();
     final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Collections.singletonList(fiftyFivePercentCustomReferrer);
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().referralDistribution(referrerList).build();
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
@@ -87,12 +130,17 @@ public class CreatorDashboardReferrerBreakdownHolderViewModelTest extends KSRobo
   @Test
   public void testExternalReferrerPercent() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.ReferrerStats fifteenPercentExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats fifteenPercentExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .percentageOfDollars(15f)
       .referrerType(ReferrerType.EXTERNAL.getReferrerType())
       .build();
     final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Collections.singletonList(fifteenPercentExternalReferrer);
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().referralDistribution(referrerList).build();
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
@@ -102,12 +150,17 @@ public class CreatorDashboardReferrerBreakdownHolderViewModelTest extends KSRobo
   @Test
   public void testExternalReferrerPercentText() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.ReferrerStats fifteenPercentExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats fifteenPercentExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .percentageOfDollars(15f)
       .referrerType(ReferrerType.EXTERNAL.getReferrerType())
       .build();
     final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Collections.singletonList(fifteenPercentExternalReferrer);
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().referralDistribution(referrerList).build();
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
@@ -115,44 +168,59 @@ public class CreatorDashboardReferrerBreakdownHolderViewModelTest extends KSRobo
   }
 
   @Test
-  public void testInternalReferrerPercent() {
+  public void testKickstarterReferrerPercent() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.ReferrerStats thirtyPercentInternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats thirtyPercentKickstarterReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .percentageOfDollars(30f)
-      .referrerType(ReferrerType.INTERNAL.getReferrerType())
+      .referrerType(ReferrerType.KICKSTARTER.getReferrerType())
       .build();
-    final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Collections.singletonList(thirtyPercentInternalReferrer);
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().referralDistribution(referrerList).build();
+    final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Collections.singletonList(thirtyPercentKickstarterReferrer);
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
-    this.internalReferrerPercent.assertValues(30f);
+    this.kickstarterReferrerPercent.assertValues(30f);
   }
 
   @Test
-  public void testInternalReferrerPercentText() {
+  public void testKickstarterReferrerPercentText() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.ReferrerStats thirtyPercentInternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats thirtyPercentKickstarterReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .percentageOfDollars(30f)
-      .referrerType(ReferrerType.INTERNAL.getReferrerType())
+      .referrerType(ReferrerType.KICKSTARTER.getReferrerType())
       .build();
-    final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Collections.singletonList(thirtyPercentInternalReferrer);
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().referralDistribution(referrerList).build();
+    final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Collections.singletonList(thirtyPercentKickstarterReferrer);
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
-    this.internalReferrerPercentText.assertValues(NumberUtils.flooredPercentage(30f * 100f));
+    this.kickstarterReferrerPercentText.assertValues(NumberUtils.flooredPercentage(30f * 100f));
   }
 
   @Test
   public void testPledgedViaCustomLayoutIsGone() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.ReferrerStats zeroPledgedCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats zeroPledgedCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .pledged(0f)
       .referrerType(ReferrerType.CUSTOM.getReferrerType())
       .build();
     final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Collections.singletonList(zeroPledgedCustomReferrer);
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().referralDistribution(referrerList).build();
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
@@ -162,12 +230,17 @@ public class CreatorDashboardReferrerBreakdownHolderViewModelTest extends KSRobo
   @Test
   public void testPledgedViaExternalLayoutIsGone() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.ReferrerStats zeroPledgedExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats zeroPledgedExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .pledged(0f)
       .referrerType(ReferrerType.EXTERNAL.getReferrerType())
       .build();
     final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Collections.singletonList(zeroPledgedExternalReferrer);
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().referralDistribution(referrerList).build();
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
@@ -175,28 +248,37 @@ public class CreatorDashboardReferrerBreakdownHolderViewModelTest extends KSRobo
   }
 
   @Test
-  public void testPledgedViaInternalLayoutIsGone() {
+  public void testPledgedViaKickstarterLayoutIsGone() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.ReferrerStats zeroPledgedInternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats zeroPledgedKickstarterReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .pledged(0f)
-      .referrerType(ReferrerType.INTERNAL.getReferrerType())
+      .referrerType(ReferrerType.KICKSTARTER.getReferrerType())
       .build();
-    final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Collections.singletonList(zeroPledgedInternalReferrer);
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().referralDistribution(referrerList).build();
+    final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Collections.singletonList(zeroPledgedKickstarterReferrer);
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
-    this.pledgedViaInternalLayoutIsGone.assertValues(true);
+    this.pledgedViaKickstarterLayoutIsGone.assertValues(true);
   }
 
   @Test
   public void testProjectAndAveragePledge() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.CumulativeStats cumulativeStats = ProjectStatsEnvelopeFactory.CumulativeStatsFactory.cumulativeStats().toBuilder()
+    final ProjectStatsEnvelope.CumulativeStats cumulativeStats = ProjectStatsEnvelopeFactory.CumulativeStatsFactory.cumulativeStats()
+      .toBuilder()
       .averagePledge(10f)
       .build();
 
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().cumulative(cumulativeStats).build();
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .cumulative(cumulativeStats)
+      .build();
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
     this.projectAndAveragePledge.assertValue(Pair.create(project, 10));
@@ -205,21 +287,30 @@ public class CreatorDashboardReferrerBreakdownHolderViewModelTest extends KSRobo
   @Test
   public void testProjectAndCustomReferrerPledgedAmount() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.ReferrerStats onePledgedCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats onePledgedCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .pledged(1f)
       .referrerType(ReferrerType.CUSTOM.getReferrerType())
       .build();
-    final ProjectStatsEnvelope.ReferrerStats twoPledgedCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats twoPledgedCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .pledged(2f)
       .referrerType(ReferrerType.CUSTOM.getReferrerType())
       .build();
-    final ProjectStatsEnvelope.ReferrerStats threePledgedExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats threePledgedExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .pledged(3f)
       .referrerType(ReferrerType.EXTERNAL.getReferrerType())
       .build();
     final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Arrays.asList(
       onePledgedCustomReferrer, twoPledgedCustomReferrer, threePledgedExternalReferrer);
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().referralDistribution(referrerList).build();
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
@@ -229,21 +320,30 @@ public class CreatorDashboardReferrerBreakdownHolderViewModelTest extends KSRobo
   @Test
   public void testProjectAndExternalReferrerPledgedAmount() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.ReferrerStats onePledgedCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats onePledgedCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .pledged(1f)
       .referrerType(ReferrerType.CUSTOM.getReferrerType())
       .build();
-    final ProjectStatsEnvelope.ReferrerStats twoPledgedCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats twoPledgedCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .pledged(2f)
       .referrerType(ReferrerType.CUSTOM.getReferrerType())
       .build();
-    final ProjectStatsEnvelope.ReferrerStats threePledgedExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats threePledgedExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .pledged(3f)
       .referrerType(ReferrerType.EXTERNAL.getReferrerType())
       .build();
     final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Arrays.asList(
       onePledgedCustomReferrer, twoPledgedCustomReferrer, threePledgedExternalReferrer);
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().referralDistribution(referrerList).build();
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
@@ -251,58 +351,78 @@ public class CreatorDashboardReferrerBreakdownHolderViewModelTest extends KSRobo
   }
 
   @Test
-  public void testProjectAndInternalReferrerPledgedAmount() {
+  public void testProjectAndKickstarterReferrerPledgedAmount() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.ReferrerStats onePledgedCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats onePledgedCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .pledged(1f)
       .referrerType(ReferrerType.CUSTOM.getReferrerType())
       .build();
-    final ProjectStatsEnvelope.ReferrerStats twoPledgedInternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats twoPledgedKickstarterReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .pledged(2f)
-      .referrerType(ReferrerType.INTERNAL.getReferrerType())
+      .referrerType(ReferrerType.KICKSTARTER.getReferrerType())
       .build();
-    final ProjectStatsEnvelope.ReferrerStats threePledgedExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats threePledgedExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .pledged(3f)
       .referrerType(ReferrerType.EXTERNAL.getReferrerType())
       .build();
     final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Arrays.asList(
-      onePledgedCustomReferrer, twoPledgedInternalReferrer, threePledgedExternalReferrer);
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().referralDistribution(referrerList).build();
+      onePledgedCustomReferrer, twoPledgedKickstarterReferrer, threePledgedExternalReferrer);
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
-    this.projectAndInternalReferrerPledgedAmount.assertValue(Pair.create(project, 2f));
+    this.projectAndKickstarterReferrerPledgedAmount.assertValue(Pair.create(project, 2f));
   }
 
   @Test
   public void testReferrerPercents() {
     final Project project = ProjectFactory.project();
-    final ProjectStatsEnvelope.ReferrerStats fiftyFivePercentCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats fiftyFivePercentCustomReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .percentageOfDollars(55f)
       .referrerType(ReferrerType.CUSTOM.getReferrerType())
       .build();
-    final ProjectStatsEnvelope.ReferrerStats fifteenPercentExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats fifteenPercentExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .percentageOfDollars(15f)
       .referrerType(ReferrerType.EXTERNAL.getReferrerType())
       .build();
-    final ProjectStatsEnvelope.ReferrerStats tenPercentExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats tenPercentExternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .percentageOfDollars(10f)
       .referrerType(ReferrerType.EXTERNAL.getReferrerType())
       .build();
-    final ProjectStatsEnvelope.ReferrerStats thirtyPercentInternalReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory.referrerStats().toBuilder()
+    final ProjectStatsEnvelope.ReferrerStats thirtyPercentKickstarterReferrer = ProjectStatsEnvelopeFactory.ReferrerStatsFactory
+      .referrerStats()
+      .toBuilder()
       .percentageOfDollars(30f)
-      .referrerType(ReferrerType.INTERNAL.getReferrerType())
+      .referrerType(ReferrerType.KICKSTARTER.getReferrerType())
       .build();
     final List<ProjectStatsEnvelope.ReferrerStats> referrerList = Arrays.asList(
       fifteenPercentExternalReferrer,
       tenPercentExternalReferrer,
-      thirtyPercentInternalReferrer,
+      thirtyPercentKickstarterReferrer,
       fiftyFivePercentCustomReferrer);
     setUpEnvironment(environment());
-    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope().toBuilder().referralDistribution(referrerList).build();
+    final ProjectStatsEnvelope statsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope()
+      .toBuilder()
+      .referralDistribution(referrerList)
+      .build();
     this.vm.inputs.projectAndStatsInput(Pair.create(project, statsEnvelope));
     this.customReferrerPercent.assertValues(55.0f);
     this.externalReferrerPercent.assertValues(25.0f);
-    this.internalReferrerPercent.assertValues(30.0f);
+    this.kickstarterReferrerPercent.assertValues(30.0f);
   }
 }


### PR DESCRIPTION
# what
Changing internal to kickstarter for consistency.
Adding empty state for breakdown with tests.
Adding a progress bar for the dashboard because on a bad connection, you're just looking at a white screen with a back arrow.

# see
![2018-03-09 16_27_07](https://user-images.githubusercontent.com/1289295/37231209-557d8852-23b8-11e8-9dac-b731ba543178.gif)

![GIF](https://media.giphy.com/media/yr7n0u3qzO9nG/giphy.gif)