### PR TITLE
refresh-user

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/CurrentUser.java
+++ b/app/src/main/java/com/kickstarter/libs/CurrentUser.java
@@ -70,6 +70,7 @@ public class CurrentUser extends CurrentUserType {
 
   @Override
   public void refresh(final @NonNull User freshUser) {
+    Timber.d("refresh user");
     this.user.onNext(freshUser);
   }
 

--- a/app/src/main/java/com/kickstarter/libs/CurrentUser.java
+++ b/app/src/main/java/com/kickstarter/libs/CurrentUser.java
@@ -70,7 +70,6 @@ public class CurrentUser extends CurrentUserType {
 
   @Override
   public void refresh(final @NonNull User freshUser) {
-    Timber.d("refresh user");
     this.user.onNext(freshUser);
   }
 

--- a/app/src/main/java/com/kickstarter/libs/utils/ApplicationLifecycleUtil.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ApplicationLifecycleUtil.java
@@ -62,7 +62,7 @@ public final class ApplicationLifecycleUtil implements Application.ActivityLifec
         .subscribe(c -> this.config.config(c));
 
       // Refresh the user
-      final Observable<User> user = this.currentUser.observable();
+      final Observable<User> user = this.client.fetchCurrentUser();
 
       final String accessToken = this.currentUser.getAccessToken();
 

--- a/app/src/main/java/com/kickstarter/libs/utils/ApplicationLifecycleUtil.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ApplicationLifecycleUtil.java
@@ -7,7 +7,6 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Pair;
 
 import com.facebook.appevents.AppEventsLogger;
 import com.kickstarter.KSApplication;
@@ -16,13 +15,10 @@ import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Koala;
 import com.kickstarter.libs.Logout;
 import com.kickstarter.libs.rx.transformers.Transformers;
-import com.kickstarter.models.User;
 import com.kickstarter.services.ApiClientType;
 import com.kickstarter.services.apiresponses.ErrorEnvelope;
 
 import javax.inject.Inject;
-
-import rx.Observable;
 
 public final class ApplicationLifecycleUtil implements Application.ActivityLifecycleCallbacks, ComponentCallbacks2 {
   protected @Inject Koala koala;
@@ -62,14 +58,12 @@ public final class ApplicationLifecycleUtil implements Application.ActivityLifec
         .subscribe(c -> this.config.config(c));
 
       // Refresh the user
-      final Observable<User> user = this.client.fetchCurrentUser();
-
       final String accessToken = this.currentUser.getAccessToken();
 
-      Observable.just(accessToken)
-        .filter(ObjectUtils::isNotNull)
-        .zipWith(user, Pair::create)
-        .subscribe(tokenUserPair -> this.currentUser.refresh(tokenUserPair.second));
+      if (ObjectUtils.isNotNull(accessToken)) {
+        this.client.fetchCurrentUser()
+          .subscribe(u -> this.currentUser.refresh(u));
+      }
 
       this.isInBackground = false;
     }

--- a/app/src/main/java/com/kickstarter/libs/utils/UserUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/UserUtils.java
@@ -1,6 +1,7 @@
 package com.kickstarter.libs.utils;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.kickstarter.models.Location;
 import com.kickstarter.models.User;
@@ -18,5 +19,14 @@ public final class UserUtils {
     }
 
     return I18nUtils.isCountryGermany(location.country());
+  }
+
+  public static boolean userHasChanged(final @Nullable User u1, final @Nullable User u2) {
+    if (ObjectUtils.isNull(u1) && ObjectUtils.isNull(u2)) {
+      return false;
+    } else if (ObjectUtils.isNotNull(u1) && ObjectUtils.isNotNull(u2)) {
+      return u1.id() != u2.id();
+    }
+    return true;
   }
 }

--- a/app/src/main/java/com/kickstarter/libs/utils/UserUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/UserUtils.java
@@ -21,6 +21,9 @@ public final class UserUtils {
     return I18nUtils.isCountryGermany(location.country());
   }
 
+  /**
+   * Returns whether two users are different where equality is determined by matching IDs.
+   */
   public static boolean userHasChanged(final @Nullable User u1, final @Nullable User u2) {
     if (ObjectUtils.isNull(u1) && ObjectUtils.isNull(u2)) {
       return false;

--- a/app/src/main/java/com/kickstarter/services/apiresponses/ProjectStatsEnvelope.java
+++ b/app/src/main/java/com/kickstarter/services/apiresponses/ProjectStatsEnvelope.java
@@ -2,6 +2,7 @@ package com.kickstarter.services.apiresponses;
 
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.kickstarter.libs.ReferrerType;
 import com.kickstarter.libs.qualifiers.AutoGson;
@@ -20,7 +21,7 @@ public abstract class ProjectStatsEnvelope implements Parcelable {
   public abstract List<FundingDateStats> fundingDistribution();
   public abstract List<ReferrerStats> referralDistribution();
   public abstract List<RewardStats> rewardDistribution();
-  public abstract VideoStats videoStats();
+  public abstract @Nullable VideoStats videoStats();
 
   @AutoParcel.Builder
   public abstract static class Builder {

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -58,7 +58,7 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
     this.currentUser = environment.currentUser();
 
     final Observable<User> changedUser = this.currentUser.observable()
-      .distinctUntilChanged(((u1, u2) -> !UserUtils.userHasChanged(u1, u2)));
+      .distinctUntilChanged((u1, u2) -> !UserUtils.userHasChanged(u1, u2));
 
     final Observable<DiscoveryParams> selectedParams = Observable.combineLatest(
       changedUser,
@@ -117,7 +117,7 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
       .subscribe(this.shouldShowOnboardingView);
 
     this.currentUser.loggedInUser()
-      .distinctUntilChanged(((u1, u2) -> u1 == null ? u2 == null : u1.id() == u2.id()))
+      .distinctUntilChanged((u1, u2) -> !UserUtils.userHasChanged(u1, u2))
       .compose(combineLatestPair(this.paramsFromActivity))
       .flatMap(__ -> this.fetchActivity())
       .filter(this::activityHasNotBeenSeen)

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -15,9 +15,11 @@ import com.kickstarter.libs.utils.DiscoveryUtils;
 import com.kickstarter.libs.utils.ListUtils;
 import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.libs.utils.RefTagUtils;
+import com.kickstarter.libs.utils.UserUtils;
 import com.kickstarter.models.Activity;
 import com.kickstarter.models.Category;
 import com.kickstarter.models.Project;
+import com.kickstarter.models.User;
 import com.kickstarter.services.ApiClientType;
 import com.kickstarter.services.DiscoveryParams;
 import com.kickstarter.services.apiresponses.ActivityEnvelope;
@@ -55,8 +57,11 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
     this.activitySamplePreference = environment.activitySamplePreference();
     this.currentUser = environment.currentUser();
 
+    final Observable<User> changedUser = this.currentUser.observable()
+      .distinctUntilChanged(((u1, u2) -> !UserUtils.userHasChanged(u1, u2)));
+
     final Observable<DiscoveryParams> selectedParams = Observable.combineLatest(
-      this.currentUser.observable(),
+      changedUser,
       this.paramsFromActivity.distinctUntilChanged(),
       (__, params) -> params
     );
@@ -106,12 +111,13 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
       });
 
     this.paramsFromActivity
-      .compose(combineLatestPair(this.currentUser.isLoggedIn()))
+      .compose(combineLatestPair(this.currentUser.isLoggedIn().distinctUntilChanged()))
       .map(pu -> isOnboardingVisible(pu.first, pu.second))
       .compose(bindToLifecycle())
       .subscribe(this.shouldShowOnboardingView);
 
     this.currentUser.loggedInUser()
+      .distinctUntilChanged(((u1, u2) -> u1 == null ? u2 == null : u1.id() == u2.id()))
       .compose(combineLatestPair(this.paramsFromActivity))
       .flatMap(__ -> this.fetchActivity())
       .filter(this::activityHasNotBeenSeen)
@@ -128,14 +134,12 @@ public final class DiscoveryFragmentViewModel extends FragmentViewModel<Discover
     this.paramsFromActivity
       .compose(combineLatestPair(paginator.loadingPage().distinctUntilChanged()))
       .map(paramsAndPage -> paramsAndPage.first.toBuilder().page(paramsAndPage.second).build())
-      .compose(combineLatestPair(this.currentUser.isLoggedIn()))
+      .compose(combineLatestPair(this.currentUser.isLoggedIn().distinctUntilChanged()))
       .compose(bindToLifecycle())
-      .subscribe(paramsAndLoggedIn -> {
-        this.koala.trackDiscovery(
-          paramsAndLoggedIn.first,
-          isOnboardingVisible(paramsAndLoggedIn.first, paramsAndLoggedIn.second)
-        );
-      });
+      .subscribe(paramsAndLoggedIn -> this.koala.trackDiscovery(
+        paramsAndLoggedIn.first,
+        isOnboardingVisible(paramsAndLoggedIn.first, paramsAndLoggedIn.second)
+      ));
 
     this.startUpdateActivity
       .map(Activity::project)

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -122,7 +122,7 @@ public interface DiscoveryViewModel {
       final Observable<User> currentUser = this.currentUser.observable();
 
       final Observable<User> changedUser = currentUser
-        .distinctUntilChanged(((u1, u2) -> !UserUtils.userHasChanged(u1, u2)));
+        .distinctUntilChanged((u1, u2) -> !UserUtils.userHasChanged(u1, u2));
 
       changedUser.subscribe(updatedUser ->
         this.apiClient.config()

--- a/app/src/test/java/com/kickstarter/libs/utils/UserUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/UserUtilsTest.java
@@ -10,8 +10,8 @@ public class UserUtilsTest extends KSRobolectricTestCase {
 
   @Test
   public void testUserHasChanged() {
-    User user15 = UserFactory.user().toBuilder().id(15).build();
-    User user21 = UserFactory.user().toBuilder().id(21).build();
+    final User user15 = UserFactory.user().toBuilder().id(15).build();
+    final User user21 = UserFactory.user().toBuilder().id(21).build();
 
     assertTrue(UserUtils.userHasChanged(null, UserFactory.user()));
     assertTrue(UserUtils.userHasChanged(UserFactory.user(), null));

--- a/app/src/test/java/com/kickstarter/libs/utils/UserUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/UserUtilsTest.java
@@ -1,0 +1,22 @@
+package com.kickstarter.libs.utils;
+
+import com.kickstarter.KSRobolectricTestCase;
+import com.kickstarter.factories.UserFactory;
+import com.kickstarter.models.User;
+
+import org.junit.Test;
+
+public class UserUtilsTest extends KSRobolectricTestCase {
+
+  @Test
+  public void testUserHasChanged() {
+    User user15 = UserFactory.user().toBuilder().id(15).build();
+    User user21 = UserFactory.user().toBuilder().id(21).build();
+
+    assertTrue(UserUtils.userHasChanged(null, UserFactory.user()));
+    assertTrue(UserUtils.userHasChanged(UserFactory.user(), null));
+    assertTrue(UserUtils.userHasChanged(user15, user21));
+    assertFalse(UserUtils.userHasChanged(null, null));
+    assertFalse(UserUtils.userHasChanged(user15, user15));
+  }
+}


### PR DESCRIPTION
# what
Refreshing the user on app resumes.

# why
We are running into a bug where creators won't see the button to the dashboard because their user object is stale. `memberProjectsCount` on the `User` object was previously unused so for all users it's 0 until they are refreshed. Previously, we only refreshed when they logged in or out or they viewed settings, messages or profile. 

# how
This happens in the `onActivityResumed`(when the app is foregrounded) method of `ApplicationLifecycleUtil` where we are currently tracking app opens and refreshing the config. We have the access token (a nullable string) and the user observable. I make the token an observable by calling `.just`. Then, I use `zipWith` to combine them in a pair/tuple (You don’t want to subscribe to the current user observable because it would emit every time the user is refreshed and then you'd kick off never ending network requests to refresh the user ). Then I call refresh using the current user.