### PR TITLE
creator-tools-collab-bug

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/CreatorDashboardHeaderHolderViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/CreatorDashboardHeaderHolderViewModel.java
@@ -83,7 +83,7 @@ public interface CreatorDashboardHeaderHolderViewModel {
       final Observable<User> user = this.currentUser.observable();
 
       this.otherProjectsButtonIsGone = user
-        .map(User::createdProjectsCount)
+        .map(User::memberProjectsCount)
         .filter(ObjectUtils::isNotNull)
         .map(count -> count <= 1)
         .compose(bindToLifecycle());

--- a/app/src/test/java/com/kickstarter/factories/UserFactory.java
+++ b/app/src/test/java/com/kickstarter/factories/UserFactory.java
@@ -18,6 +18,14 @@ public final class UserFactory {
     return user().toBuilder().social(true).build();
   }
 
+  public static User collaborator() {
+    return user()
+      .toBuilder()
+      .createdProjectsCount(0)
+      .memberProjectsCount(10)
+      .build();
+  }
+
   public static User creator() {
     return user()
       .toBuilder()

--- a/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardHeaderHolderViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardHeaderHolderViewModelTest.java
@@ -55,7 +55,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
   @Test
   public void testMessagesButtonIsGone() {
     final User creator = UserFactory.creator();
-    final CurrentUserType currentUser = new MockCurrentUser(UserFactory.user());
+    final CurrentUserType currentUser = new MockCurrentUser(UserFactory.collaborator());
 
     final Project project = ProjectFactory.project().toBuilder().creator(creator).build();
     final ProjectStatsEnvelope projectStatsEnvelope = ProjectStatsEnvelopeFactory.projectStatsEnvelope();
@@ -68,21 +68,21 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
   }
 
   @Test
-  public void testOtherProjectsButtonIsGone_WhenCreatorHas1Project() {
-    final User creatorWith1Project = UserFactory.creator().toBuilder().createdProjectsCount(1).build();
-    final CurrentUserType creator = new MockCurrentUser(creatorWith1Project);
+  public void testOtherProjectsButtonIsGone_WhenCollaboratorHas1Project() {
+    final User collaboratorWith1Project = UserFactory.collaborator().toBuilder().memberProjectsCount(1).build();
+    final CurrentUserType collaborator = new MockCurrentUser(collaboratorWith1Project);
 
-    setUpEnvironment(environment().toBuilder().currentUser(creator).build());
+    setUpEnvironment(environment().toBuilder().currentUser(collaborator).build());
     this.vm.inputs.projectAndStats(Pair.create(ProjectFactory.project(), ProjectStatsEnvelopeFactory.projectStatsEnvelope()));
 
     this.otherProjectsButtonIsGone.assertValues(true);
   }
 
   @Test
-  public void testOtherProjectsButtonIsGone_WhenCreatorHasManyProjects() {
-    final CurrentUserType creator = new MockCurrentUser(UserFactory.creator());
+  public void testOtherProjectsButtonIsGone_WhenCollaboratorHasManyProjects() {
+    final CurrentUserType collaborator = new MockCurrentUser(UserFactory.collaborator());
 
-    setUpEnvironment(environment().toBuilder().currentUser(creator).build());
+    setUpEnvironment(environment().toBuilder().currentUser(collaborator).build());
     this.vm.inputs.projectAndStats(Pair.create(ProjectFactory.project(), ProjectStatsEnvelopeFactory.projectStatsEnvelope()));
 
     this.otherProjectsButtonIsGone.assertValues(false);
@@ -190,7 +190,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
 
     // Messages button is shown to project creator, messages activity starts.
     this.messagesButtonIsGone.assertValues(false);
-    this.startMessageThreadsActivity.assertValues(Pair.create(project, RefTag.dashboard()));
+    this.startMessageThreadsActivity.assertValue(Pair.create(project, RefTag.dashboard()));
   }
 
   @Test
@@ -201,7 +201,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStats(Pair.create(project, projectStatsEnvelope));
     this.vm.inputs.projectButtonClicked();
-    this.startProjectActivity.assertValues(Pair.create(project, RefTag.dashboard()));
+    this.startProjectActivity.assertValue(Pair.create(project, RefTag.dashboard()));
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardHeaderHolderViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/CreatorDashboardHeaderHolderViewModelTest.java
@@ -64,28 +64,28 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
     this.vm.inputs.projectAndStats(Pair.create(project, projectStatsEnvelope));
 
     // Messages button is gone if current user is not the project creator (e.g. a collaborator).
-    this.messagesButtonIsGone.assertValues(true);
+    this.messagesButtonIsGone.assertValue(true);
   }
 
   @Test
-  public void testOtherProjectsButtonIsGone_WhenCollaboratorHas1Project() {
+  public void testOtherProjectsButtonIsGone_isTrue_WhenCollaboratorHas1Project() {
     final User collaboratorWith1Project = UserFactory.collaborator().toBuilder().memberProjectsCount(1).build();
     final CurrentUserType collaborator = new MockCurrentUser(collaboratorWith1Project);
 
     setUpEnvironment(environment().toBuilder().currentUser(collaborator).build());
     this.vm.inputs.projectAndStats(Pair.create(ProjectFactory.project(), ProjectStatsEnvelopeFactory.projectStatsEnvelope()));
 
-    this.otherProjectsButtonIsGone.assertValues(true);
+    this.otherProjectsButtonIsGone.assertValue(true);
   }
 
   @Test
-  public void testOtherProjectsButtonIsGone_WhenCollaboratorHasManyProjects() {
+  public void testOtherProjectsButtonIsGone_isFalse_WhenCollaboratorHasManyProjects() {
     final CurrentUserType collaborator = new MockCurrentUser(UserFactory.collaborator());
 
     setUpEnvironment(environment().toBuilder().currentUser(collaborator).build());
     this.vm.inputs.projectAndStats(Pair.create(ProjectFactory.project(), ProjectStatsEnvelopeFactory.projectStatsEnvelope()));
 
-    this.otherProjectsButtonIsGone.assertValues(false);
+    this.otherProjectsButtonIsGone.assertValue(false);
   }
 
   @Test
@@ -95,7 +95,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStats(Pair.create(project, projectStatsEnvelope));
-    this.projectBackersCountText.assertValues("10");
+    this.projectBackersCountText.assertValue("10");
   }
 
   @Test
@@ -105,7 +105,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
 
     setUpEnvironment(environment());
     this.vm.inputs.projectAndStats(Pair.create(project, projectStatsEnvelope));
-    this.projectNameTextViewText.assertValues("somebody once told me");
+    this.projectNameTextViewText.assertValue("somebody once told me");
   }
 
   @Test
@@ -118,7 +118,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
     final String percentageFundedOutput = NumberUtils.flooredPercentage(project.percentageFunded());
     this.percentageFunded.assertValues(percentageFundedOutput);
     final int percentageFundedProgressOutput = ProgressBarUtils.progress(project.percentageFunded());
-    this.percentageFundedProgress.assertValues(percentageFundedProgressOutput);
+    this.percentageFundedProgress.assertValue(percentageFundedProgressOutput);
   }
 
   @Test
@@ -126,7 +126,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
     setUpEnvironment(environment());
 
     this.vm.inputs.projectAndStats(getProjectAndStats(Project.STATE_LIVE));
-    this.progressBarBackground.assertValues(R.drawable.progress_bar_green_horizontal);
+    this.progressBarBackground.assertValue(R.drawable.progress_bar_green_horizontal);
   }
 
   @Test
@@ -134,7 +134,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
     setUpEnvironment(environment());
 
     this.vm.inputs.projectAndStats(getProjectAndStats(Project.STATE_SUBMITTED));
-    this.progressBarBackground.assertValues(R.drawable.progress_bar_green_horizontal);
+    this.progressBarBackground.assertValue(R.drawable.progress_bar_green_horizontal);
   }
 
   @Test
@@ -142,7 +142,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
     setUpEnvironment(environment());
 
     this.vm.inputs.projectAndStats(getProjectAndStats(Project.STATE_STARTED));
-    this.progressBarBackground.assertValues(R.drawable.progress_bar_green_horizontal);
+    this.progressBarBackground.assertValue(R.drawable.progress_bar_green_horizontal);
   }
 
   @Test
@@ -150,7 +150,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
     setUpEnvironment(environment());
 
     this.vm.inputs.projectAndStats(getProjectAndStats(Project.STATE_SUCCESSFUL));
-    this.progressBarBackground.assertValues(R.drawable.progress_bar_green_horizontal);
+    this.progressBarBackground.assertValue(R.drawable.progress_bar_green_horizontal);
   }
 
   @Test
@@ -158,7 +158,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
     setUpEnvironment(environment());
 
     this.vm.inputs.projectAndStats(getProjectAndStats(Project.STATE_FAILED));
-    this.progressBarBackground.assertValues(R.drawable.progress_bar_grey_horizontal);
+    this.progressBarBackground.assertValue(R.drawable.progress_bar_grey_horizontal);
   }
 
   @Test
@@ -166,7 +166,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
     setUpEnvironment(environment());
 
     this.vm.inputs.projectAndStats(getProjectAndStats(Project.STATE_CANCELED));
-    this.progressBarBackground.assertValues(R.drawable.progress_bar_grey_horizontal);
+    this.progressBarBackground.assertValue(R.drawable.progress_bar_grey_horizontal);
   }
 
   @Test
@@ -174,7 +174,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
     setUpEnvironment(environment());
 
     this.vm.inputs.projectAndStats(getProjectAndStats(Project.STATE_SUSPENDED));
-    this.progressBarBackground.assertValues(R.drawable.progress_bar_grey_horizontal);
+    this.progressBarBackground.assertValue(R.drawable.progress_bar_grey_horizontal);
   }
 
   @Test
@@ -212,7 +212,7 @@ public class CreatorDashboardHeaderHolderViewModelTest extends KSRobolectricTest
     final int deadlineVal = ProjectUtils.deadlineCountdownValue(project);
 
     this.vm.inputs.projectAndStats(Pair.create(project, projectStatsEnvelope));
-    this.timeRemainingText.assertValues(NumberUtils.format(deadlineVal));
+    this.timeRemainingText.assertValue(NumberUtils.format(deadlineVal));
   }
 
   private Pair<Project, ProjectStatsEnvelope> getProjectAndStats(final String state) {

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -75,9 +75,23 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testCreatorDashboardButtonIsGone__isCreatorOrCollaborator() {
+  public void testCreatorDashboardButtonIsGone__isCreator() {
     final User creator = UserFactory.creator();
     final MockCurrentUser currentUser = new MockCurrentUser(creator);
+
+    final Environment env = environment().toBuilder()
+      .currentUser(currentUser)
+      .build();
+
+    this.vm = new DiscoveryViewModel.ViewModel(env);
+    this.vm.outputs.creatorDashboardButtonIsGone().subscribe(this.creatorDashboardButtonIsGone);
+    this.creatorDashboardButtonIsGone.assertValues(false);
+  }
+
+  @Test
+  public void testCreatorDashboardButtonIsGone__isCollaborator() {
+    final User collaborator = UserFactory.collaborator();
+    final MockCurrentUser currentUser = new MockCurrentUser(collaborator);
 
     final Environment env = environment().toBuilder()
       .currentUser(currentUser)

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -61,7 +61,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testCreatorDashboardButtonIsGone__notCreatorOrCollaborator() {
+  public void testCreatorDashboardButtonIsGone_isTrue_WhenCreatorOrCollaborator() {
     final User notCreator = UserFactory.user().toBuilder().memberProjectsCount(0).build();
     final MockCurrentUser currentUser = new MockCurrentUser(notCreator);
 
@@ -71,11 +71,11 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
 
     this.vm = new DiscoveryViewModel.ViewModel(env);
     this.vm.outputs.creatorDashboardButtonIsGone().subscribe(this.creatorDashboardButtonIsGone);
-    this.creatorDashboardButtonIsGone.assertValues(true);
+    this.creatorDashboardButtonIsGone.assertValue(true);
   }
 
   @Test
-  public void testCreatorDashboardButtonIsGone__isCreator() {
+  public void testCreatorDashboardButtonIsGone_isFalse_WhenCreator() {
     final User creator = UserFactory.creator();
     final MockCurrentUser currentUser = new MockCurrentUser(creator);
 
@@ -85,11 +85,11 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
 
     this.vm = new DiscoveryViewModel.ViewModel(env);
     this.vm.outputs.creatorDashboardButtonIsGone().subscribe(this.creatorDashboardButtonIsGone);
-    this.creatorDashboardButtonIsGone.assertValues(false);
+    this.creatorDashboardButtonIsGone.assertValue(false);
   }
 
   @Test
-  public void testCreatorDashboardButtonIsGone__isCollaborator() {
+  public void testCreatorDashboardButtonIsGone_isFalse_WhenCollaborator() {
     final User collaborator = UserFactory.collaborator();
     final MockCurrentUser currentUser = new MockCurrentUser(collaborator);
 
@@ -99,7 +99,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
 
     this.vm = new DiscoveryViewModel.ViewModel(env);
     this.vm.outputs.creatorDashboardButtonIsGone().subscribe(this.creatorDashboardButtonIsGone);
-    this.creatorDashboardButtonIsGone.assertValues(false);
+    this.creatorDashboardButtonIsGone.assertValue(false);
   }
 
   @Test


### PR DESCRIPTION
# what
Collaborators were not seeing the "Select another project" button because we were checking `created_projects_count` and not `member_projects_count`.
Did an audit of where `User.creator` is used so we don't miss any collaborators.
Added a helper User that is a collaborator and not a creator.

# see
As a collaborator of 2 projects and no created projects, I see the "Select another project" button.
<img src=https://user-images.githubusercontent.com/1289295/37538730-ed444878-2927-11e8-8ed3-ed551296a95d.png width=330/>
