### PR TITLE
creator-tools-clipped-text

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardReferrerBreakdownViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardReferrerBreakdownViewHolder.java
@@ -148,7 +148,8 @@ public class CreatorDashboardReferrerBreakdownViewHolder extends KSViewHolder {
 
   private void flipIndicatorIfStatsOffScreen(final View indicator, final View stats) {
     stats.post(() -> {
-      if (stats.getLeft() < this.referrerBreakdownLayout.getLeft()) {
+      final int leftVisibleEdgeOfBreakdownView = this.referrerBreakdownLayout.getLeft() + this.referrerBreakdownLayout.getPaddingLeft();
+      if (stats.getLeft() < leftVisibleEdgeOfBreakdownView) {
         indicator.setScaleX(-1);
         final ConstraintLayout.LayoutParams indicatorLayoutParams = (ConstraintLayout.LayoutParams) indicator.getLayoutParams();
         indicatorLayoutParams.setMarginStart(this.grid3Pixels);


### PR DESCRIPTION
# what
Checking if external stats are to the left of the breakdown view,  :sparkles: including padding :sparkles: so it doesn't get clipped

# before & after
<img src=https://user-images.githubusercontent.com/1289295/37539024-e3bee230-2928-11e8-8313-c9bef9ad4d37.png width=330/><img src=https://user-images.githubusercontent.com/1289295/37539019-e0eacc72-2928-11e8-9bc6-69bf38f04dd1.png width=330/>
