### PR TITLE
[bug] NPE in DiscoveryFragment

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/adapters/DiscoveryPagerAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/DiscoveryPagerAdapter.java
@@ -68,6 +68,7 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
   public void takeCategoriesForPosition(final @NonNull List<Category> categories, final int position) {
     Observable.from(this.fragments)
       .filter(DiscoveryFragment::isInstantiated)
+      .filter(DiscoveryFragment::isAttached)
       .filter(frag -> {
         final int fragmentPosition = frag.getArguments().getInt(ArgumentsKey.DISCOVERY_SORT_POSITION);
         return fragmentPosition == position;
@@ -81,6 +82,7 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
   public void takeParams(final @NonNull DiscoveryParams params) {
     Observable.from(this.fragments)
       .filter(DiscoveryFragment::isInstantiated)
+      .filter(DiscoveryFragment::isAttached)
       .filter(frag -> {
         final int fragmentPosition = frag.getArguments().getInt(ArgumentsKey.DISCOVERY_SORT_POSITION);
         return DiscoveryUtils.positionFromSort(params.sort()) == fragmentPosition;
@@ -94,6 +96,7 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
   public void clearPages(final @NonNull List<Integer> pages) {
     Observable.from(this.fragments)
       .filter(DiscoveryFragment::isInstantiated)
+      .filter(DiscoveryFragment::isAttached)
       .filter(frag -> {
         final int fragmentPosition = frag.getArguments().getInt(ArgumentsKey.DISCOVERY_SORT_POSITION);
         return pages.contains(fragmentPosition);

--- a/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
+++ b/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
@@ -115,7 +115,7 @@ public final class DiscoveryFragment extends BaseFragment<DiscoveryFragmentViewM
   }
 
   public boolean isAttached() {
-    return !isDetached();
+    return this.viewModel != null;
   }
 
   public boolean isInstantiated() {

--- a/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
+++ b/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
@@ -114,6 +114,10 @@ public final class DiscoveryFragment extends BaseFragment<DiscoveryFragmentViewM
     }
   }
 
+  public boolean isAttached() {
+    return !isDetached();
+  }
+
   public boolean isInstantiated() {
     return this.recyclerView != null;
   }


### PR DESCRIPTION
# what
We have a few `NullPointerException`s because we attempt to access the `ViewModel` after the fragment is detached.

# how
Now we check if the `ViewModel` is `null`.

# bug
https://rink.hockeyapp.net/manage/apps/239014/app_versions/51/crash_reasons/215537957?type=overview