### PR TITLE
Toggling following in settings

### DIFF
--- a/app/src/main/java/com/kickstarter/services/ApiClient.java
+++ b/app/src/main/java/com/kickstarter/services/ApiClient.java
@@ -488,6 +488,7 @@ public final class ApiClient implements ApiClientType {
           .gamesNewsletter(isTrue(user.gamesNewsletter()) ? 1 : 0)
           .happeningNewsletter(isTrue(user.happeningNewsletter()) ? 1 : 0)
           .promoNewsletter(isTrue(user.promoNewsletter()) ? 1 : 0)
+          .social(isTrue(user.social()) ? 1 : 0)
           .weeklyNewsletter(isTrue(user.weeklyNewsletter()) ? 1 : 0)
           .build())
       .lift(apiErrorOperator())

--- a/app/src/main/java/com/kickstarter/services/apirequests/SettingsBody.java
+++ b/app/src/main/java/com/kickstarter/services/apirequests/SettingsBody.java
@@ -16,6 +16,7 @@ public abstract class SettingsBody {
   public abstract boolean notifyOfFriendActivity();
   public abstract boolean notifyOfMessages();
   public abstract boolean notifyOfUpdates();
+  public abstract int social();
   public abstract int gamesNewsletter();
   public abstract int happeningNewsletter();
   public abstract int promoNewsletter();
@@ -32,6 +33,7 @@ public abstract class SettingsBody {
     public abstract Builder notifyOfFriendActivity(boolean __);
     public abstract Builder notifyOfMessages(boolean __);
     public abstract Builder notifyOfUpdates(boolean __);
+    public abstract Builder social(int __);
     public abstract Builder gamesNewsletter(int __);
     public abstract Builder happeningNewsletter(int __);
     public abstract Builder promoNewsletter(int __);

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.java
@@ -389,8 +389,8 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
         .setCancelable(false)
         .setTitle(getString(R.string.Are_you_sure))
         .setMessage(getString(R.string.If_you_turn_following_off))
-        .setNegativeButton(cancelString, (__, ___) -> this.viewModel.inputs.optOutOfFollowing(false))
-        .setPositiveButton(yesTurnOffString, (__, ___) -> this.viewModel.inputs.optOutOfFollowing(true))
+        .setNegativeButton(this.cancelString, (__, ___) -> this.viewModel.inputs.optOutOfFollowing(false))
+        .setPositiveButton(this.yesTurnOffString, (__, ___) -> this.viewModel.inputs.optOutOfFollowing(true))
         .create();
     }
     return this.followingConfirmationDialog;

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
@@ -33,6 +33,9 @@ public interface SettingsViewModel {
     /** Call when the user clicks on contact email. */
     void contactEmailClicked();
 
+    /** Call when the user clicks the Follwing info icon. */
+    void followingInfoClicked();
+
     /** Call when the user taps the logout button. */
     void logoutClicked();
 
@@ -60,6 +63,9 @@ public interface SettingsViewModel {
     /** Call when the notify of project updates toggle changes. */
     void notifyOfUpdates(boolean checked);
 
+    /** Call when the user toggles the Following switch. */
+    void optIntoFollowing();
+
     /** Call when the user toggles the Recommendations switch. */
     void optedOutOfRecommendations(boolean checked);
 
@@ -77,6 +83,8 @@ public interface SettingsViewModel {
 
     /** Call when the user toggles the Projects We Love newsletter switch. */
     void sendWeeklyNewsletter(boolean checked);
+
+    void tentativelyOptOutOfFollowing();
   }
 
   interface Outputs {
@@ -85,6 +93,12 @@ public interface SettingsViewModel {
 
     /** Emits a boolean that determines if the logout confirmation should be displayed. */
     Observable<Boolean> showConfirmLogoutPrompt();
+
+    /** Emits a boolean that determines if the logout confirmation should be displayed. */
+    Observable<Void> showConfirmFollowingOptOutPrompt();
+
+    /** Emits when user should be shown the Following info dialog. */
+    Observable<Void> showFollowingInfo();
 
     /** Show a dialog to inform the user that their newsletter subscription must be confirmed via email. */
     Observable<Newsletter> showOptInPrompt();
@@ -185,7 +199,9 @@ public interface SettingsViewModel {
     private final PublishSubject<User> userInput = PublishSubject.create();
 
     private final BehaviorSubject<Void> logout = BehaviorSubject.create();
+    private final BehaviorSubject<Void> showConfirmFollowingOptOutPrompt = BehaviorSubject.create();
     private final BehaviorSubject<Boolean> showConfirmLogoutPrompt = BehaviorSubject.create();
+    private final BehaviorSubject<Void> showFollowingInfo = BehaviorSubject.create();
     private final PublishSubject<Newsletter> showOptInPrompt = PublishSubject.create();
     private final PublishSubject<Void> showRecommendationsInfo = PublishSubject.create();
     private final PublishSubject<Void> updateSuccess = PublishSubject.create();
@@ -205,6 +221,9 @@ public interface SettingsViewModel {
     }
     @Override public void contactEmailClicked() {
       this.contactEmailClicked.onNext(null);
+    }
+    @Override public void followingInfoClicked() {
+      this.showFollowingInfo.onNext(null);
     }
     @Override
     public void optedOutOfRecommendations(final boolean checked) {
@@ -241,6 +260,9 @@ public interface SettingsViewModel {
     @Override public void notifyOfUpdates(final boolean b) {
       this.userInput.onNext(this.userOutput.getValue().toBuilder().notifyOfUpdates(b).build());
     }
+    @Override public void optIntoFollowing() {
+      this.userInput.onNext(this.userOutput.getValue().toBuilder().social(true).build());
+    }
     @Override public void sendGamesNewsletter(final boolean checked) {
       this.userInput.onNext(this.userOutput.getValue().toBuilder().gamesNewsletter(checked).build());
       this.newsletterInput.onNext(new Pair<>(checked, Newsletter.GAMES));
@@ -257,12 +279,22 @@ public interface SettingsViewModel {
       this.userInput.onNext(this.userOutput.getValue().toBuilder().weeklyNewsletter(checked).build());
       this.newsletterInput.onNext(new Pair<>(checked, Newsletter.WEEKLY));
     }
+    @Override
+    public void tentativelyOptOutOfFollowing() {
+      this.showConfirmFollowingOptOutPrompt.onNext(null);
+    }
 
     @Override public @NonNull Observable<Void> logout() {
       return this.logout;
     }
     @Override public @NonNull Observable<Boolean> showConfirmLogoutPrompt() {
       return this.showConfirmLogoutPrompt;
+    }
+    @Override public @NonNull Observable<Void> showConfirmFollowingOptOutPrompt() {
+      return this.showConfirmFollowingOptOutPrompt;
+    }
+    @Override public @NonNull Observable<Void> showFollowingInfo() {
+      return this.showFollowingInfo;
     }
     @Override public @NonNull Observable<Newsletter> showOptInPrompt() {
       return this.showOptInPrompt;

--- a/app/src/main/res/layout/settings_layout.xml
+++ b/app/src/main/res/layout/settings_layout.xml
@@ -415,6 +415,26 @@
           style="@style/EndSettingsWidget" />
       </LinearLayout>
 
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/grid_10"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+          style="@style/SettingsSectionLabel"
+          android:text="@string/Following" />
+
+        <ImageButton
+          android:id="@+id/following_info"
+          android:contentDescription="@string/Following_More_Info"
+          style="@style/SettingsInfoIcon" />
+
+        <android.support.v7.widget.SwitchCompat
+          android:id="@+id/following_switch"
+          style="@style/EndSettingsWidget" />
+      </LinearLayout>
+
     </LinearLayout>
 
   </ScrollView>


### PR DESCRIPTION
# what
Users should be able to toggle whether or not they can be following or `social` via settings. This change also updates whether the `Backed by people you follow` section is visible in the drawer.
This is a destructive change so we need to confirm they definitely want to do this.

# why
G
D
P
R

# how 🤔 
The `optIntoFollowing` input determines whether user has checked the switch on or off. The `optOutOfFollowing` input determines whether user has confirmed turning Following off.

When `optIntoFollowing` is `true`, we just turn Following on.
When `optIntoFollowing` is `false`, we show the confirmation dialog. This dialog is not cancelable, I ~~expect~~ demand, they make a choice!

When `optOutOfFollowing` is `true`, that's a confirmation, we turn Following off.
When `optOutOfFollowing` is `false`, we change the switch back to on!

# see 👀 
First, I'm `social` and my drawer shows  `Backed by people you follow`. I attempt to turn it off, cancel. I attempt to turn it off again, and confirm. My drawer no longer shows  `Backed by people you follow`.
![2018-06-07 13_37_43](https://user-images.githubusercontent.com/1289295/41116328-fd55bb0e-6a57-11e8-80ab-462400356152.gif)
