### PR TITLE
fixing broken videos and images on 19 and below

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,4 @@ secrets:
 	mkdir -p app/src/main/assets/www/
 	cp vendor/native-secrets/android/WebViewJavascript.html app/src/main/assets/www/WebViewJavascript.html || true
 
-	# Copy TLS helpers over.
-	cp -rf vendor/native-secrets/android/SocketUtils.java app/src/main/java/com/kickstarter/libs/utils/SocketUtils.java \
-		|| cp -rf config/SocketUtils.java app/src/main/java/com/kickstarter/libs/utils/SocketUtils.java
-	cp -rf vendor/native-secrets/android/TLSSocketFactory.java app/src/main/java/com/kickstarter/libs/TLSSocketFactory.java || true
-
 .PHONY: bootstrap bootstrap-circle dependencies secrets

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,6 +144,7 @@ dependencies {
     compile 'com.facebook.android:facebook-android-sdk:4.7.0'
     compile 'com.github.frankiesardo:auto-parcel:0.3.1'
     annotationProcessor 'com.github.frankiesardo:auto-parcel-processor:0.3.1'
+    compile 'com.google.android.gms:play-services-auth:10.0.1'
     compile 'com.google.android.gms:play-services-gcm:10.0.1'
     compile 'com.google.android.gms:play-services-wallet:10.0.1'
     compile 'com.google.android.exoplayer:exoplayer:2.7.0'

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -53,7 +53,6 @@ import com.kickstarter.libs.qualifiers.WebEndpoint;
 import com.kickstarter.libs.qualifiers.WebRetrofit;
 import com.kickstarter.libs.utils.PlayServicesCapability;
 import com.kickstarter.libs.utils.Secrets;
-import com.kickstarter.libs.utils.SocketUtils;
 import com.kickstarter.services.ApiClient;
 import com.kickstarter.services.ApiClientType;
 import com.kickstarter.services.ApiService;
@@ -253,7 +252,7 @@ public final class ApplicationModule {
 
   private static @NonNull Retrofit createRetrofit(final @NonNull String baseUrl, final @NonNull Gson gson, final @NonNull OkHttpClient okHttpClient) {
     return new Retrofit.Builder()
-      .client(SocketUtils.enableTLS1_2OnPreLollipop(okHttpClient))
+      .client(okHttpClient)
       .baseUrl(baseUrl)
       .addConverterFactory(GsonConverterFactory.create(gson))
       .addCallAdapterFactory(RxJavaCallAdapterFactory.create())


### PR DESCRIPTION
# what, why, how
TLS 1.0 and 1.1 is no longer supported on our image host starting 5/18/18.  https://blog.imgix.com/2018/05/18/tls-deprecation.html

Android versions 19 and below don't have TLS 1.2 enabled by default :neutral_face: So videos and images are currently broken for all users on 19 and below 😢 

This change uses Google Play Services to patch Android's security provider, it's lit 👏 
Shout out to this StackOverflow answer: https://stackoverflow.com/questions/29916962/javax-net-ssl-sslhandshakeexception-javax-net-ssl-sslprotocolexception-ssl-han/36892715#36892715

I'm removing the work Lisa did to enable TLS on 19 > devices because it was only on Retrofit, we have external dependencies that make network calls including Picasso (I think uses Okhttp) and ExoPlayer. This needs to be a global change.

# before & after
<img src=https://user-images.githubusercontent.com/1289295/41118826-1cae71c4-6a5f-11e8-810d-a99418d4a915.png width=330/> <img src=https://user-images.githubusercontent.com/1289295/41118829-1e3f4c3e-6a5f-11e8-9e4a-963d20da3e31.png width=330/>

