### PR TITLE
RC- [Feature] - Privacy Policy Toggle and Info Dialog

### DIFF
--- a/app/src/main/assets/json/server-config.json
+++ b/app/src/main/assets/json/server-config.json
@@ -108,6 +108,7 @@
       "Expands_subcategories": "Expands subcategories.",
       "Explore": "Explore",
       "Facebook_login_disclaimer": "If you login with Facebook, we’ll import your name and profile photo. We'll also access your friend list so you can follow your Facebook friends on Kickstarter. We will never post anything on Facebook without your permission.",
+      "Facebook_login_disclaimer_update": "By logging in with Facebook, we’ll import your name, profile photo and friend list.",
       "Failed_to_retrieve_live_stream_event_details": "Failed to retrieve live stream event details",
       "Failed_to_update_subscription": "Failed to update subscription",
       "Filter_by_all_projects": "Filter by all projects",
@@ -278,6 +279,8 @@
       "Popular_Projects": "Popular Projects",
       "Privacy": "Privacy",
       "Private_profile": "Private profile",
+      "Private_profile_more_info": "Private profile more info",
+      "Private_profile_more_info_content": "Kickstarter profiles are private by default. To make your profile public and visible to the world, turn this off.",
       "Project_Cancelled": "Project Cancelled.",
       "Project_cancelled": "Project cancelled",
       "project_count_projects": {
@@ -2080,6 +2083,7 @@
       "Expands_subcategories": "Erweitert die Anzeige der Unterkategorien.",
       "Explore": "Erkunden",
       "Facebook_login_disclaimer": "Wenn du dich über Facebook anmeldest, importieren wir deinen Namen und dein Profilfoto. Außerdem wird deine Freundesliste importiert, damit du deinen Freunden auf Kickstarter folgen kannst. Wir werden niemals etwas ohne deine Erlaubnis auf Facebook posten.",
+      "Facebook_login_disclaimer_update": "By logging in with Facebook, we’ll import your name, profile photo and friend list.",
       "Failed_to_retrieve_live_stream_event_details": "Details zu Live-Stream-Event konnten nicht geladen werden",
       "Failed_to_update_subscription": "Abo konnte nicht aktualisiert werden",
       "Filter_by_all_projects": "Filter: Alle Projekte",
@@ -2250,6 +2254,8 @@
       "Popular_Projects": "Beliebte Projekte",
       "Privacy": "Datenschutz",
       "Private_profile": "Privates Profil",
+      "Private_profile_more_info": "Privates Profil - Mehr Info",
+      "Private_profile_more_info_content": "Die Standard-Einstellung für Profile sind auf Kickstarter ist privat. Um dein Profil öffentlich zu machen, hebe diese Einstellung bitte auf.",
       "Project_Cancelled": "Projekt abgebrochen.",
       "Project_cancelled": "Projekt abgebrochen",
       "project_count_projects": {
@@ -4052,6 +4058,7 @@
       "Expands_subcategories": "Muestra más subcategorías.",
       "Explore": "Explora",
       "Facebook_login_disclaimer": "Si inicias sesión con Facebook, importaremos tu nombre y foto de perfil. También accederemos a tu lista de amigos para que puedas seguir a tus amigos de Facebook en Kickstarter. Jamás publicaremos nada en Facebook sin tu permiso.",
+      "Facebook_login_disclaimer_update": "By logging in with Facebook, we’ll import your name, profile photo and friend list.",
       "Failed_to_retrieve_live_stream_event_details": "No se pudo cargar la información acerca del evento en vivo",
       "Failed_to_update_subscription": "No se pudo actualizar la suscripción",
       "Filter_by_all_projects": "Filtro: Todos los proyectos",
@@ -4222,6 +4229,8 @@
       "Popular_Projects": "Proyectos populares",
       "Privacy": "Privacidad",
       "Private_profile": "Perfil privado",
+      "Private_profile_more_info": "Más información sobre el perfil privado",
+      "Private_profile_more_info_content": "Los perfiles de Kickstarter son privados por defecto. Para hacer que tu perfil sea público y visible para el mundo, desactiva esta opción.",
       "Project_Cancelled": "Proyecto cancelado.",
       "Project_cancelled": "Proyecto cancelado",
       "project_count_projects": {
@@ -6024,6 +6033,7 @@
       "Expands_subcategories": "Développe les sous-catégories.",
       "Explore": "Explorer",
       "Facebook_login_disclaimer": "Si vous vous connectez avec Facebook, nous importerons votre nom et votre photo de profil. Nous accéderons aussi à votre liste d'amis pour vous permettre de suivre vos connaissances sur Kickstarter. Nous ne publierons jamais sur Facebook sans votre autorisation.",
+      "Facebook_login_disclaimer_update": "By logging in with Facebook, we’ll import your name, profile photo and friend list.",
       "Failed_to_retrieve_live_stream_event_details": "Impossible de récupérer les détails de la diffusion en direct",
       "Failed_to_update_subscription": "Mise à jour de l'abonnement impossible",
       "Filter_by_all_projects": "Filtrer : tous les projets",
@@ -6194,6 +6204,8 @@
       "Popular_Projects": "Les tendances",
       "Privacy": "Vie privée",
       "Private_profile": "Profil privé",
+      "Private_profile_more_info": "Plus d'informations sur le profil privé",
+      "Private_profile_more_info_content": "Par défaut, les profils Kickstarter sont privés. Pour rendre votre profil public et visible par tout le monde, décochez cette case.",
       "Project_Cancelled": "Projet annulé.",
       "Project_cancelled": "Projet annulé",
       "project_count_projects": {
@@ -7996,6 +8008,7 @@
       "Expands_subcategories": "サブカテゴリーを表示",
       "Explore": "さがす",
       "Facebook_login_disclaimer": "Facebook でログインすると、あなたの氏名とプロフィール写真がインポートされます。また、あなたが Kickstarter 上で Facebook 友達をフォローすることができるように、友達リストも Kickstarter によってアクセスされます。あなたの許可なしに Kickstarter が Facebook 上に投稿を行うことは決してありません。  ",
+      "Facebook_login_disclaimer_update": "Facebook を使ってログインすると、お名前とプロフィール写真、友達リストがインポートされます。",
       "Failed_to_retrieve_live_stream_event_details": "ライブ配信の詳細を取得できませんでした",
       "Failed_to_update_subscription": "定期購読の更新に失敗しました",
       "Filter_by_all_projects": "全てのプロジェクトに絞る",
@@ -8166,6 +8179,8 @@
       "Popular_Projects": "人気のプロジェクト",
       "Privacy": "プライバシー",
       "Private_profile": "プライベート設定のプロフィール",
+      "Private_profile_more_info": "プライベート設定のプロフィール詳細",
+      "Private_profile_more_info_content": "Kickstarter でのプロフィールはデフォルト設定ではプライベート (非公開) となっています。プロフィールを公開したい場合はこの設定をオフにしてください。",
       "Project_Cancelled": "プロジェクトが取り消されました。",
       "Project_cancelled": "プロジェクトが取り消されました。",
       "project_count_projects": {
@@ -10054,15 +10069,10 @@
     }
   ],
   "ab_experiments": {
-    "project_build": "control",
     "project_dashboard": "with_dashboard",
-    "react_guest_pledging_run_3": "control",
     "stripe_elements": "experimental",
     "stripe_elements_manage_payments": "experimental",
-    "sticky_global_header_2": "exempt",
-    "react_backer_rewards_public_release": "excluded",
-    "mobile_stripe_elements": "experimental",
-    "native_show_project_card_category": "control"
+    "mobile_stripe_elements": "experimental"
   },
   "stripe": {
     "publishable_key": "pk_live_zjuK52lEUYcvBhIXEUnOEJzk"

--- a/app/src/main/java/com/kickstarter/models/User.java
+++ b/app/src/main/java/com/kickstarter/models/User.java
@@ -38,6 +38,7 @@ public abstract class User implements Parcelable {
   public abstract @Nullable Integer starredProjectsCount();
   public abstract @Nullable Integer unreadMessagesCount();
   public abstract @Nullable Boolean weeklyNewsletter();
+  public abstract @Nullable Boolean showPublicProfile();
 
   @AutoParcel.Builder
   public abstract static class Builder {
@@ -68,6 +69,7 @@ public abstract class User implements Parcelable {
     public abstract Builder starredProjectsCount(Integer __);
     public abstract Builder unreadMessagesCount(Integer __);
     public abstract Builder weeklyNewsletter(Boolean __);
+    public abstract Builder showPublicProfile(Boolean __);
     public abstract User build();
   }
 

--- a/app/src/main/java/com/kickstarter/models/User.java
+++ b/app/src/main/java/com/kickstarter/models/User.java
@@ -34,11 +34,11 @@ public abstract class User implements Parcelable {
   public abstract @Nullable Boolean notifyOfUpdates();
   public abstract @Nullable Boolean optedOutOfRecommendations();
   public abstract @Nullable Boolean promoNewsletter();
+  public abstract @Nullable Boolean showPublicProfile();
   public abstract @Nullable Boolean social();
   public abstract @Nullable Integer starredProjectsCount();
   public abstract @Nullable Integer unreadMessagesCount();
   public abstract @Nullable Boolean weeklyNewsletter();
-  public abstract @Nullable Boolean showPublicProfile();
 
   @AutoParcel.Builder
   public abstract static class Builder {
@@ -65,11 +65,11 @@ public abstract class User implements Parcelable {
     public abstract Builder notifyOfUpdates(Boolean __);
     public abstract Builder optedOutOfRecommendations(Boolean __);
     public abstract Builder promoNewsletter(Boolean __);
+    public abstract Builder showPublicProfile(Boolean __);
     public abstract Builder social(Boolean __);
     public abstract Builder starredProjectsCount(Integer __);
     public abstract Builder unreadMessagesCount(Integer __);
     public abstract Builder weeklyNewsletter(Boolean __);
-    public abstract Builder showPublicProfile(Boolean __);
     public abstract User build();
   }
 

--- a/app/src/main/java/com/kickstarter/services/ApiClient.java
+++ b/app/src/main/java/com/kickstarter/services/ApiClient.java
@@ -488,6 +488,7 @@ public final class ApiClient implements ApiClientType {
           .gamesNewsletter(isTrue(user.gamesNewsletter()) ? 1 : 0)
           .happeningNewsletter(isTrue(user.happeningNewsletter()) ? 1 : 0)
           .promoNewsletter(isTrue(user.promoNewsletter()) ? 1 : 0)
+          .showPublicProfile(isTrue(user.showPublicProfile()) ? 1 : 0)
           .social(isTrue(user.social()) ? 1 : 0)
           .weeklyNewsletter(isTrue(user.weeklyNewsletter()) ? 1 : 0)
           .build())

--- a/app/src/main/java/com/kickstarter/services/apirequests/SettingsBody.java
+++ b/app/src/main/java/com/kickstarter/services/apirequests/SettingsBody.java
@@ -16,12 +16,12 @@ public abstract class SettingsBody {
   public abstract boolean notifyOfFriendActivity();
   public abstract boolean notifyOfMessages();
   public abstract boolean notifyOfUpdates();
+  public abstract int showPublicProfile();
   public abstract int social();
   public abstract int gamesNewsletter();
   public abstract int happeningNewsletter();
   public abstract int promoNewsletter();
   public abstract int weeklyNewsletter();
-  public abstract int showPublicProfile();
 
   @AutoParcel.Builder
   public abstract static class Builder {
@@ -34,12 +34,12 @@ public abstract class SettingsBody {
     public abstract Builder notifyOfFriendActivity(boolean __);
     public abstract Builder notifyOfMessages(boolean __);
     public abstract Builder notifyOfUpdates(boolean __);
+    public abstract Builder showPublicProfile(int __);
     public abstract Builder social(int __);
     public abstract Builder gamesNewsletter(int __);
     public abstract Builder happeningNewsletter(int __);
     public abstract Builder promoNewsletter(int __);
     public abstract Builder weeklyNewsletter(int __);
-    public abstract Builder showPublicProfile(int __);
     public abstract SettingsBody build();
   }
 

--- a/app/src/main/java/com/kickstarter/services/apirequests/SettingsBody.java
+++ b/app/src/main/java/com/kickstarter/services/apirequests/SettingsBody.java
@@ -21,6 +21,7 @@ public abstract class SettingsBody {
   public abstract int happeningNewsletter();
   public abstract int promoNewsletter();
   public abstract int weeklyNewsletter();
+  public abstract int showPublicProfile();
 
   @AutoParcel.Builder
   public abstract static class Builder {
@@ -38,6 +39,7 @@ public abstract class SettingsBody {
     public abstract Builder happeningNewsletter(int __);
     public abstract Builder promoNewsletter(int __);
     public abstract Builder weeklyNewsletter(int __);
+    public abstract Builder showPublicProfile(int __);
     public abstract SettingsBody build();
   }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.java
@@ -385,7 +385,7 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
     SwitchCompatUtils.setCheckedWithoutAnimation(this.happeningNewsletterSwitch, isTrue(user.happeningNewsletter()));
     SwitchCompatUtils.setCheckedWithoutAnimation(this.promoNewsletterSwitch, isTrue(user.promoNewsletter()));
     SwitchCompatUtils.setCheckedWithoutAnimation(this.weeklyNewsletterSwitch, isTrue(user.weeklyNewsletter()));
-    SwitchCompatUtils.setCheckedWithoutAnimation(this.privateProfileSwitch, isTrue(user.showPublicProfile()));
+    SwitchCompatUtils.setCheckedWithoutAnimation(this.privateProfileSwitch, isFalse(user.showPublicProfile()));
   }
 
   private @NonNull AlertDialog lazyFollowingInfoDialog() {

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.java
@@ -90,6 +90,8 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
   protected @BindString(R.string.Recommendations) String recommendationsString;
   protected @BindString(R.string.We_use_your_activity_internally_to_make_recommendations_for_you) String recommendationsInfo;
   protected @BindString(R.string.Yes_turn_off) String yesTurnOffString;
+  protected @BindString(R.string.Private_profile) String privateProfileString;
+  protected @BindString(R.string.Private_profile_more_info_content) String privateProfileInfoString;
 
   private CurrentUserType currentUser;
   private Build build;
@@ -201,6 +203,11 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(__ -> lazyRecommendationsInfoDialog().show());
+
+    this.viewModel.outputs.showPrivateProfileInfo()
+      .compose(bindToLifecycle())
+      .observeOn(AndroidSchedulers.mainThread())
+      .subscribe(__ -> lazyPrivateProfileInfoDialog().show());
   }
 
   @OnClick(R.id.contact)
@@ -253,6 +260,11 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
   @OnClick(R.id.recommendations_info)
   public void recommendationsInfoClick() {
     this.viewModel.inputs.recommendationsInfoClicked();
+  }
+
+  @OnClick(R.id.private_profile_info)
+  public void privateProfileInfoClick() {
+    this.viewModel.inputs.privateProfileInfoClicked();
   }
 
   public void startHelpActivity(final @NonNull Class<? extends HelpActivity> helpClass) {
@@ -373,6 +385,7 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
     SwitchCompatUtils.setCheckedWithoutAnimation(this.happeningNewsletterSwitch, isTrue(user.happeningNewsletter()));
     SwitchCompatUtils.setCheckedWithoutAnimation(this.promoNewsletterSwitch, isTrue(user.promoNewsletter()));
     SwitchCompatUtils.setCheckedWithoutAnimation(this.weeklyNewsletterSwitch, isTrue(user.weeklyNewsletter()));
+    SwitchCompatUtils.setCheckedWithoutAnimation(this.privateProfileSwitch, isTrue(user.showPublicProfile()));
   }
 
   private @NonNull AlertDialog lazyFollowingInfoDialog() {
@@ -430,18 +443,17 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
     return this.recommendationsInfoDialog;
   }
 
-  //TODO - Finish AlertDialog
   private @NonNull AlertDialog lazyPrivateProfileInfoDialog() {
     if (this.privateProfileInfoDialog == null) {
       final String capitalizedGotIt = this.gotItString.toUpperCase(Locale.getDefault());
       this.privateProfileInfoDialog = new AlertDialog.Builder(this)
-        .setTitle(this.recommendationsString)
-        .setMessage(this.recommendationsInfo)
-        .setPositiveButton(capitalizedGotIt, (__, ___) -> this.recommendationsInfoDialog.dismiss())
+        .setTitle(this.privateProfileString)
+        .setMessage(this.privateProfileInfoString)
+        .setPositiveButton(capitalizedGotIt, (__, ___) -> this.privateProfileInfoDialog.dismiss())
         .setCancelable(true)
         .create();
     }
-    return this.recommendationsInfoDialog;
+    return this.privateProfileInfoDialog;
   }
 
   private void logout() {

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.java
@@ -60,6 +60,7 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
   protected @Bind(R.id.project_updates_phone_icon) IconTextView projectUpdatesPhoneIconTextView;
   protected @Bind(R.id.kickstarter_news_and_events_switch) SwitchCompat promoNewsletterSwitch;
   protected @Bind(R.id.recommendations_switch) SwitchCompat recommendationsSwitch;
+  protected @Bind(R.id.private_profile_switch) SwitchCompat privateProfileSwitch;
   protected @Bind(R.id.projects_we_love_switch) SwitchCompat weeklyNewsletterSwitch;
   protected @Bind(R.id.version_name) TextView versionName;
 
@@ -107,6 +108,7 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
   private AlertDialog followingInfoDialog;
   private AlertDialog logoutConfirmationDialog;
   private AlertDialog recommendationsInfoDialog;
+  private AlertDialog privateProfileInfoDialog;
 
   @Override
   protected void onCreate(final @Nullable Bundle savedInstanceState) {
@@ -174,6 +176,10 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
     RxView.clicks(this.weeklyNewsletterSwitch)
       .compose(bindToLifecycle())
       .subscribe(__ -> this.viewModel.inputs.sendWeeklyNewsletter(this.weeklyNewsletterSwitch.isChecked()));
+
+    RxView.clicks(this.privateProfileSwitch)
+      .compose(bindToLifecycle())
+      .subscribe(__ -> this.viewModel.inputs.showPublicProfile(this.privateProfileSwitch.isChecked()));
 
     this.viewModel.outputs.showConfirmLogoutPrompt()
       .compose(bindToLifecycle())
@@ -415,6 +421,20 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
     if (this.recommendationsInfoDialog == null) {
       final String capitalizedGotIt = this.gotItString.toUpperCase(Locale.getDefault());
       this.recommendationsInfoDialog = new AlertDialog.Builder(this)
+        .setTitle(this.recommendationsString)
+        .setMessage(this.recommendationsInfo)
+        .setPositiveButton(capitalizedGotIt, (__, ___) -> this.recommendationsInfoDialog.dismiss())
+        .setCancelable(true)
+        .create();
+    }
+    return this.recommendationsInfoDialog;
+  }
+
+  //TODO - Finish AlertDialog
+  private @NonNull AlertDialog lazyPrivateProfileInfoDialog() {
+    if (this.privateProfileInfoDialog == null) {
+      final String capitalizedGotIt = this.gotItString.toUpperCase(Locale.getDefault());
+      this.privateProfileInfoDialog = new AlertDialog.Builder(this)
         .setTitle(this.recommendationsString)
         .setMessage(this.recommendationsInfo)
         .setPositiveButton(capitalizedGotIt, (__, ___) -> this.recommendationsInfoDialog.dismiss())

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.java
@@ -55,12 +55,12 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
   protected @Bind(R.id.messages_phone_icon) IconTextView messagesPhoneIconTextView;
   protected @Bind(R.id.new_followers_mail_icon) ImageButton newFollowersMailImageButton;
   protected @Bind(R.id.new_followers_phone_icon) IconTextView newFollowersPhoneIconTextView;
+  protected @Bind(R.id.private_profile_switch) SwitchCompat privateProfileSwitch;
   protected @Bind(R.id.project_notifications_count) TextView projectNotificationsCountTextView;
   protected @Bind(R.id.project_updates_mail_icon) ImageButton projectUpdatesMailImageButton;
   protected @Bind(R.id.project_updates_phone_icon) IconTextView projectUpdatesPhoneIconTextView;
   protected @Bind(R.id.kickstarter_news_and_events_switch) SwitchCompat promoNewsletterSwitch;
   protected @Bind(R.id.recommendations_switch) SwitchCompat recommendationsSwitch;
-  protected @Bind(R.id.private_profile_switch) SwitchCompat privateProfileSwitch;
   protected @Bind(R.id.projects_we_love_switch) SwitchCompat weeklyNewsletterSwitch;
   protected @Bind(R.id.version_name) TextView versionName;
 
@@ -75,10 +75,13 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
   protected @BindString(R.string.profile_settings_newsletter_happening) String happeningNewsletterString;
   protected @BindString(R.string.mailto) String mailtoString;
   protected @BindString(R.string.Logged_Out) String loggedOutString;
-  protected @BindString(R.string.profile_settings_newsletter_weekly) String weeklyNewsletterString;
-  protected @BindString(R.string.profile_settings_newsletter_promo) String promoNewsletterString;
   protected @BindString(R.string.profile_settings_newsletter_opt_in_message) String optInMessageString;
   protected @BindString(R.string.profile_settings_newsletter_opt_in_title) String optInTitleString;
+  protected @BindString(R.string.Private_profile) String privateProfileString;
+  protected @BindString(R.string.Private_profile_more_info_content) String privateProfileInfoString;
+  protected @BindString(R.string.profile_settings_newsletter_promo) String promoNewsletterString;
+  protected @BindString(R.string.Recommendations) String recommendationsString;
+  protected @BindString(R.string.We_use_your_activity_internally_to_make_recommendations_for_you) String recommendationsInfo;
   protected @BindString(R.string.profile_settings_accessibility_subscribe_mobile_notifications) String subscribeMobileString;
   protected @BindString(R.string.profile_settings_accessibility_subscribe_notifications) String subscribeString;
   protected @BindString(R.string.support_email_body) String supportEmailBodyString;
@@ -87,11 +90,9 @@ public final class SettingsActivity extends BaseActivity<SettingsViewModel.ViewM
   protected @BindString(R.string.profile_settings_error) String unableToSaveString;
   protected @BindString(R.string.profile_settings_accessibility_unsubscribe_mobile_notifications) String unsubscribeMobileString;
   protected @BindString(R.string.profile_settings_accessibility_unsubscribe_notifications) String unsubscribeString;
-  protected @BindString(R.string.Recommendations) String recommendationsString;
-  protected @BindString(R.string.We_use_your_activity_internally_to_make_recommendations_for_you) String recommendationsInfo;
+  protected @BindString(R.string.profile_settings_newsletter_weekly) String weeklyNewsletterString;
   protected @BindString(R.string.Yes_turn_off) String yesTurnOffString;
-  protected @BindString(R.string.Private_profile) String privateProfileString;
-  protected @BindString(R.string.Private_profile_more_info_content) String privateProfileInfoString;
+
 
   private CurrentUserType currentUser;
   private Build build;

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
@@ -349,7 +349,7 @@ public interface SettingsViewModel {
       return this.showRecommendationsInfo;
     }
     @Override public @NonNull Observable<Void> showPrivateProfileInfo() {
-      return  this.showPrivateProfileInfo; }
+      return this.showPrivateProfileInfo; }
     @Override public @NonNull Observable<User> user() {
       return this.userOutput;
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
@@ -348,7 +348,8 @@ public interface SettingsViewModel {
     @Override public @NonNull Observable<Void> showRecommendationsInfo() {
       return this.showRecommendationsInfo;
     }
-    @Override public @NonNull Observable<Void> showPrivateProfileInfo() { return  this.showPrivateProfileInfo; }
+    @Override public @NonNull Observable<Void> showPrivateProfileInfo() {
+      return  this.showPrivateProfileInfo;}
     @Override public @NonNull Observable<User> user() {
       return this.userOutput;
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
@@ -324,7 +324,7 @@ public interface SettingsViewModel {
       this.newsletterInput.onNext(new Pair<>(checked, Newsletter.WEEKLY));
     }
     @Override public void showPublicProfile(final boolean checked) {
-      this.userInput.onNext(this.userOutput.getValue().toBuilder().showPublicProfile(checked).build());
+      this.userInput.onNext(this.userOutput.getValue().toBuilder().showPublicProfile(!checked).build());
     }
 
     @Override public @NonNull Observable<Void> logout() {

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
@@ -86,6 +86,9 @@ public interface SettingsViewModel {
 
     /** Call when the user toggles the Projects We Love newsletter switch. */
     void sendWeeklyNewsletter(boolean checked);
+
+    /** Call when user toggles the private profile switch. */
+    void showPublicProfile(boolean checked);
   }
 
   interface Outputs {
@@ -308,6 +311,9 @@ public interface SettingsViewModel {
     @Override public void sendWeeklyNewsletter(final boolean checked) {
       this.userInput.onNext(this.userOutput.getValue().toBuilder().weeklyNewsletter(checked).build());
       this.newsletterInput.onNext(new Pair<>(checked, Newsletter.WEEKLY));
+    }
+    @Override public void showPublicProfile(final boolean checked) {
+      this.userInput.onNext(this.userOutput.getValue().toBuilder().showPublicProfile(checked).build());
     }
 
     @Override public @NonNull Observable<Void> logout() {

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
@@ -113,11 +113,11 @@ public interface SettingsViewModel {
     /** Show a dialog to inform the user that their newsletter subscription must be confirmed via email. */
     Observable<Newsletter> showOptInPrompt();
 
-    /** Emits when user should be shown the Recommendations info dialog. */
-    Observable<Void> showRecommendationsInfo();
-
     /** Emits when user should be shown the Private Profile info dialog */
     Observable<Void> showPrivateProfileInfo();
+
+    /** Emits when user should be shown the Recommendations info dialog. */
+    Observable<Void> showRecommendationsInfo();
 
     /** Emits user containing settings state. */
     Observable<User> user();
@@ -270,8 +270,7 @@ public interface SettingsViewModel {
     @Override public void recommendationsInfoClicked() {
       this.showRecommendationsInfo.onNext(null);
     }
-    @Override
-    public void privateProfileInfoClicked() {
+    @Override public void privateProfileInfoClicked() {
       this.showPrivateProfileInfo.onNext(null);
     }
     @Override public void logoutClicked() {

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
@@ -75,7 +75,7 @@ public interface SettingsViewModel {
     /** Call when the user clicks the Recommendations info icon. */
     void recommendationsInfoClicked();
 
-    /** Call when the user clicks the Recommendations info icon. */
+    /** Call when the user clicks the Private Profile info icon. */
     void privateProfileInfoClicked();
 
     /** Call when the user toggles the Kickstarter Loves Games newsletter switch. */

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
@@ -349,7 +349,7 @@ public interface SettingsViewModel {
       return this.showRecommendationsInfo;
     }
     @Override public @NonNull Observable<Void> showPrivateProfileInfo() {
-      return  this.showPrivateProfileInfo;}
+      return  this.showPrivateProfileInfo; }
     @Override public @NonNull Observable<User> user() {
       return this.userOutput;
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
@@ -75,6 +75,9 @@ public interface SettingsViewModel {
     /** Call when the user clicks the Recommendations info icon. */
     void recommendationsInfoClicked();
 
+    /** Call when the user clicks the Recommendations info icon. */
+    void privateProfileInfoClicked();
+
     /** Call when the user toggles the Kickstarter Loves Games newsletter switch. */
     void sendGamesNewsletter(boolean checked);
 
@@ -112,6 +115,9 @@ public interface SettingsViewModel {
 
     /** Emits when user should be shown the Recommendations info dialog. */
     Observable<Void> showRecommendationsInfo();
+
+    /** Emits when user should be shown the Private Profile info dialog */
+    Observable<Void> showPrivateProfileInfo();
 
     /** Emits user containing settings state. */
     Observable<User> user();
@@ -234,6 +240,7 @@ public interface SettingsViewModel {
     private final BehaviorSubject<Void> showFollowingInfo = BehaviorSubject.create();
     private final PublishSubject<Newsletter> showOptInPrompt = PublishSubject.create();
     private final PublishSubject<Void> showRecommendationsInfo = PublishSubject.create();
+    private final PublishSubject<Void> showPrivateProfileInfo = PublishSubject.create();
     private final PublishSubject<Void> updateSuccess = PublishSubject.create();
     private final BehaviorSubject<User> userOutput = BehaviorSubject.create();
 
@@ -262,6 +269,10 @@ public interface SettingsViewModel {
     }
     @Override public void recommendationsInfoClicked() {
       this.showRecommendationsInfo.onNext(null);
+    }
+    @Override
+    public void privateProfileInfoClicked() {
+      this.showPrivateProfileInfo.onNext(null);
     }
     @Override public void logoutClicked() {
       this.showConfirmLogoutPrompt.onNext(true);
@@ -337,6 +348,7 @@ public interface SettingsViewModel {
     @Override public @NonNull Observable<Void> showRecommendationsInfo() {
       return this.showRecommendationsInfo;
     }
+    @Override public @NonNull Observable<Void> showPrivateProfileInfo() { return  this.showPrivateProfileInfo; }
     @Override public @NonNull Observable<User> user() {
       return this.userOutput;
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.java
@@ -349,7 +349,8 @@ public interface SettingsViewModel {
       return this.showRecommendationsInfo;
     }
     @Override public @NonNull Observable<Void> showPrivateProfileInfo() {
-      return this.showPrivateProfileInfo; }
+      return this.showPrivateProfileInfo;
+    }
     @Override public @NonNull Observable<User> user() {
       return this.userOutput;
     }

--- a/app/src/main/res/layout/settings_layout.xml
+++ b/app/src/main/res/layout/settings_layout.xml
@@ -368,6 +368,66 @@
         android:text="@string/Privacy" />
 
       <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/grid_10"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+          style="@style/SettingsSectionLabel"
+          android:text="@string/Following" />
+
+        <ImageButton
+          android:id="@+id/following_info"
+          style="@style/SettingsInfoIcon"
+          android:contentDescription="@string/Following_More_Info" />
+
+        <android.support.v7.widget.SwitchCompat
+          android:id="@+id/following_switch"
+          style="@style/EndSettingsWidget" />
+      </LinearLayout>
+
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/grid_10"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+          style="@style/SettingsSectionLabel"
+          android:text="@string/Recommendations" />
+
+        <ImageButton
+          android:id="@+id/recommendations_info"
+          style="@style/SettingsInfoIcon"
+          android:contentDescription="@string/Recommendations_More_Info" />
+
+        <android.support.v7.widget.SwitchCompat
+          android:id="@+id/recommendations_switch"
+          style="@style/EndSettingsWidget" />
+      </LinearLayout>
+
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/grid_10"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+          style="@style/SettingsSectionLabel"
+          android:text="@string/Private_profile" />
+
+        <ImageButton
+          android:id="@+id/private_profile_info"
+          style="@style/SettingsInfoIcon"
+          android:contentDescription="@string/Private_profile" />
+
+        <android.support.v7.widget.SwitchCompat
+          android:id="@+id/private_profile_switch"
+          style="@style/EndSettingsWidget" />
+      </LinearLayout>
+
+      <LinearLayout
         android:id="@+id/settings_delete_account"
         style="@style/SettingsClickableSection">
 
@@ -393,46 +453,6 @@
           style="@style/EndSettingsWidget"
           android:text="@string/chevron_right_icon"
           android:textColor="@color/ksr_soft_black" />
-      </LinearLayout>
-
-      <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/grid_10"
-        android:gravity="center_vertical"
-        android:orientation="horizontal">
-
-        <TextView
-          style="@style/SettingsSectionLabel"
-          android:text="@string/Recommendations" />
-
-        <ImageButton
-          android:id="@+id/recommendations_info"
-          android:contentDescription="@string/Recommendations_More_Info"
-          style="@style/SettingsInfoIcon" />
-
-        <android.support.v7.widget.SwitchCompat
-          android:id="@+id/recommendations_switch"
-          style="@style/EndSettingsWidget" />
-      </LinearLayout>
-
-      <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/grid_10"
-        android:gravity="center_vertical"
-        android:orientation="horizontal">
-
-        <TextView
-          style="@style/SettingsSectionLabel"
-          android:text="@string/Following" />
-
-        <ImageButton
-          android:id="@+id/following_info"
-          android:contentDescription="@string/Following_More_Info"
-          style="@style/SettingsInfoIcon" />
-
-        <android.support.v7.widget.SwitchCompat
-          android:id="@+id/following_switch"
-          style="@style/EndSettingsWidget" />
       </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/layout/settings_layout.xml
+++ b/app/src/main/res/layout/settings_layout.xml
@@ -420,7 +420,7 @@
         <ImageButton
           android:id="@+id/private_profile_info"
           style="@style/SettingsInfoIcon"
-          android:contentDescription="@string/Private_profile" />
+          android:contentDescription="@string/Private_profile_more_info" />
 
         <android.support.v7.widget.SwitchCompat
           android:id="@+id/private_profile_switch"

--- a/app/src/main/res/values-de/strings_i18n.xml
+++ b/app/src/main/res/values-de/strings_i18n.xml
@@ -94,6 +94,7 @@ Unterstützer</string>
   <string name="Explore_creative_projects" formatted="false">Erkunde kreative Projekte</string>
   <string name="Explore_projects" formatted="false">Projekte erkunden</string>
   <string name="Facebook_login_disclaimer" formatted="false">Wenn du dich über Facebook anmeldest, importieren wir deinen Namen und dein Profilfoto. Außerdem wird deine Freundesliste importiert, damit du deinen Freunden auf Kickstarter folgen kannst. Wir werden niemals etwas ohne deine Erlaubnis auf Facebook posten.</string>
+  <string name="Facebook_login_disclaimer_update" formatted="false">By logging in with Facebook, we’ll import your name, profile photo and friend list.</string>
   <string name="Failed_to_retrieve_live_stream_event_details" formatted="false">Details zu Live-Stream-Event konnten nicht geladen werden</string>
   <string name="Failed_to_update_subscription" formatted="false">Abo konnte nicht aktualisiert werden</string>
   <string name="Filter_by_all_projects" formatted="false">Filter: Alle Projekte</string>
@@ -241,6 +242,8 @@ Unterstützer</string>
   <string name="Popular_Projects" formatted="false">Beliebte Projekte</string>
   <string name="Privacy" formatted="false">Datenschutz</string>
   <string name="Private_profile" formatted="false">Privates Profil</string>
+  <string name="Private_profile_more_info" formatted="false">Privates Profil - Mehr Info</string>
+  <string name="Private_profile_more_info_content" formatted="false">Die Standard-Einstellung für Profile sind auf Kickstarter ist privat. Um dein Profil öffentlich zu machen, hebe diese Einstellung bitte auf.</string>
   <string name="Project_Cancelled" formatted="false">Projekt abgebrochen.</string>
   <string name="Project_Suspended" formatted="false">Projekt ausgesetzt.</string>
   <string name="Project_cancelled" formatted="false">Projekt abgebrochen</string>

--- a/app/src/main/res/values-es/strings_i18n.xml
+++ b/app/src/main/res/values-es/strings_i18n.xml
@@ -94,6 +94,7 @@ patrocinadores</string>
   <string name="Explore_creative_projects" formatted="false">Explora proyectos creativos</string>
   <string name="Explore_projects" formatted="false">Explora proyectos</string>
   <string name="Facebook_login_disclaimer" formatted="false">Si inicias sesión con Facebook, importaremos tu nombre y foto de perfil. También accederemos a tu lista de amigos para que puedas seguir a tus amigos de Facebook en Kickstarter. Jamás publicaremos nada en Facebook sin tu permiso.</string>
+  <string name="Facebook_login_disclaimer_update" formatted="false">By logging in with Facebook, we’ll import your name, profile photo and friend list.</string>
   <string name="Failed_to_retrieve_live_stream_event_details" formatted="false">No se pudo cargar la información acerca del evento en vivo</string>
   <string name="Failed_to_update_subscription" formatted="false">No se pudo actualizar la suscripción</string>
   <string name="Filter_by_all_projects" formatted="false">Filtro: Todos los proyectos</string>
@@ -241,6 +242,8 @@ patrocinadores</string>
   <string name="Popular_Projects" formatted="false">Proyectos populares</string>
   <string name="Privacy" formatted="false">Privacidad</string>
   <string name="Private_profile" formatted="false">Perfil privado</string>
+  <string name="Private_profile_more_info" formatted="false">Más información sobre el perfil privado</string>
+  <string name="Private_profile_more_info_content" formatted="false">Los perfiles de Kickstarter son privados por defecto. Para hacer que tu perfil sea público y visible para el mundo, desactiva esta opción.</string>
   <string name="Project_Cancelled" formatted="false">Proyecto cancelado.</string>
   <string name="Project_Suspended" formatted="false">Proyecto suspendido.</string>
   <string name="Project_cancelled" formatted="false">Proyecto cancelado</string>

--- a/app/src/main/res/values-fr/strings_i18n.xml
+++ b/app/src/main/res/values-fr/strings_i18n.xml
@@ -94,6 +94,7 @@ contributeurs</string>
   <string name="Explore_creative_projects" formatted="false">Découvrez des projets créatifs</string>
   <string name="Explore_projects" formatted="false">Découvrir des projets</string>
   <string name="Facebook_login_disclaimer" formatted="false">Si vous vous connectez avec Facebook, nous importerons votre nom et votre photo de profil. Nous accéderons aussi à votre liste d\'amis pour vous permettre de suivre vos connaissances sur Kickstarter. Nous ne publierons jamais sur Facebook sans votre autorisation.</string>
+  <string name="Facebook_login_disclaimer_update" formatted="false">By logging in with Facebook, we’ll import your name, profile photo and friend list.</string>
   <string name="Failed_to_retrieve_live_stream_event_details" formatted="false">Impossible de récupérer les détails de la diffusion en direct</string>
   <string name="Failed_to_update_subscription" formatted="false">Mise à jour de l\'abonnement impossible</string>
   <string name="Filter_by_all_projects" formatted="false">Filtrer : tous les projets</string>
@@ -242,6 +243,8 @@ n\'ont rien soutenu.</string>
   <string name="Popular_Projects" formatted="false">Les tendances</string>
   <string name="Privacy" formatted="false">Vie privée</string>
   <string name="Private_profile" formatted="false">Profil privé</string>
+  <string name="Private_profile_more_info" formatted="false">Plus d\'informations sur le profil privé</string>
+  <string name="Private_profile_more_info_content" formatted="false">Par défaut, les profils Kickstarter sont privés. Pour rendre votre profil public et visible par tout le monde, décochez cette case.</string>
   <string name="Project_Cancelled" formatted="false">Projet annulé.</string>
   <string name="Project_Suspended" formatted="false">Projet suspendu.</string>
   <string name="Project_cancelled" formatted="false">Projet annulé</string>

--- a/app/src/main/res/values-ja/strings_i18n.xml
+++ b/app/src/main/res/values-ja/strings_i18n.xml
@@ -93,6 +93,7 @@
   <string name="Explore_creative_projects" formatted="false">クリエイティブなプロジェクトをさがす</string>
   <string name="Explore_projects" formatted="false">プロジェクトをさがす</string>
   <string name="Facebook_login_disclaimer" formatted="false">Facebook でログインすると、あなたの氏名とプロフィール写真がインポートされます。また、あなたが Kickstarter 上で Facebook 友達をフォローすることができるように、友達リストも Kickstarter によってアクセスされます。あなたの許可なしに Kickstarter が Facebook 上に投稿を行うことは決してありません。  </string>
+  <string name="Facebook_login_disclaimer_update" formatted="false">Facebook を使ってログインすると、お名前とプロフィール写真、友達リストがインポートされます。</string>
   <string name="Failed_to_retrieve_live_stream_event_details" formatted="false">ライブ配信の詳細を取得できませんでした</string>
   <string name="Failed_to_update_subscription" formatted="false">定期購読の更新に失敗しました</string>
   <string name="Filter_by_all_projects" formatted="false">全てのプロジェクトに絞る</string>
@@ -240,6 +241,8 @@
   <string name="Popular_Projects" formatted="false">人気のプロジェクト</string>
   <string name="Privacy" formatted="false">プライバシー</string>
   <string name="Private_profile" formatted="false">プライベート設定のプロフィール</string>
+  <string name="Private_profile_more_info" formatted="false">プライベート設定のプロフィール詳細</string>
+  <string name="Private_profile_more_info_content" formatted="false">Kickstarter でのプロフィールはデフォルト設定ではプライベート (非公開) となっています。プロフィールを公開したい場合はこの設定をオフにしてください。</string>
   <string name="Project_Cancelled" formatted="false">プロジェクトが取り消されました。</string>
   <string name="Project_Suspended" formatted="false">中止プロジェクト</string>
   <string name="Project_cancelled" formatted="false">プロジェクトが取り消されました。</string>

--- a/app/src/main/res/values/strings_i18n.xml
+++ b/app/src/main/res/values/strings_i18n.xml
@@ -94,6 +94,7 @@ backers</string>
   <string name="Explore_creative_projects" formatted="false">Explore creative projects</string>
   <string name="Explore_projects" formatted="false">Explore projects</string>
   <string name="Facebook_login_disclaimer" formatted="false">If you login with Facebook, we’ll import your name and profile photo. We\'ll also access your friend list so you can follow your Facebook friends on Kickstarter. We will never post anything on Facebook without your permission.</string>
+  <string name="Facebook_login_disclaimer_update" formatted="false">By logging in with Facebook, we’ll import your name, profile photo and friend list.</string>
   <string name="Failed_to_retrieve_live_stream_event_details" formatted="false">Failed to retrieve live stream event details</string>
   <string name="Failed_to_update_subscription" formatted="false">Failed to update subscription</string>
   <string name="Filter_by_all_projects" formatted="false">Filter by all projects</string>
@@ -243,6 +244,8 @@ from friends yet.</string>
   <string name="Popular_Projects" formatted="false">Popular Projects</string>
   <string name="Privacy" formatted="false">Privacy</string>
   <string name="Private_profile" formatted="false">Private profile</string>
+  <string name="Private_profile_more_info" formatted="false">Private profile more info</string>
+  <string name="Private_profile_more_info_content" formatted="false">Kickstarter profiles are private by default. To make your profile public and visible to the world, turn this off.</string>
   <string name="Project_Cancelled" formatted="false">Project Cancelled.</string>
   <string name="Project_Suspended" formatted="false">Project Suspended.</string>
   <string name="Project_cancelled" formatted="false">Project cancelled</string>

--- a/app/src/test/java/com/kickstarter/viewmodels/SettingsViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SettingsViewModelTest.java
@@ -20,8 +20,8 @@ public final class SettingsViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Void> hideConfirmFollowingOptOutPrompt = new TestSubscriber<>();
   private final TestSubscriber<Void> showConfirmFollowingOptOutPrompt = new TestSubscriber<>();
   private final TestSubscriber<Newsletter> showOptInPromptTest = new TestSubscriber<>();
-  private final TestSubscriber<Void> showRecommendationsInfo = new TestSubscriber<>();
   private final TestSubscriber<Void> showPrivateProfileInfo = new TestSubscriber<>();
+  private final TestSubscriber<Void> showRecommendationsInfo = new TestSubscriber<>();
 
 
   private void setUpEnvironment(final @NonNull User user) {

--- a/app/src/test/java/com/kickstarter/viewmodels/SettingsViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SettingsViewModelTest.java
@@ -21,6 +21,7 @@ public final class SettingsViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Void> showConfirmFollowingOptOutPrompt = new TestSubscriber<>();
   private final TestSubscriber<Newsletter> showOptInPromptTest = new TestSubscriber<>();
   private final TestSubscriber<Void> showRecommendationsInfo = new TestSubscriber<>();
+  private final TestSubscriber<Void> showPrivateProfileInfo = new TestSubscriber<>();
 
 
   private void setUpEnvironment(final @NonNull User user) {
@@ -35,6 +36,7 @@ public final class SettingsViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.hideConfirmFollowingOptOutPrompt().subscribe(this.hideConfirmFollowingOptOutPrompt);
     this.vm.outputs.showConfirmFollowingOptOutPrompt().subscribe(this.showConfirmFollowingOptOutPrompt);
     this.vm.outputs.showRecommendationsInfo().subscribe(this.showRecommendationsInfo);
+    this.vm.outputs.showPrivateProfileInfo().subscribe(this.showPrivateProfileInfo);
     this.vm.outputs.showOptInPrompt().subscribe(this.showOptInPromptTest);
   }
 
@@ -124,6 +126,22 @@ public final class SettingsViewModelTest extends KSRobolectricTestCase {
 
     this.vm.inputs.recommendationsInfoClicked();
     this.showRecommendationsInfo.assertValueCount(1);
+
+    this.showOptInPromptTest.assertNoValues();
+    this.koalaTest.assertValues("Settings View");
+  }
+
+  @Test
+  public void testSettingsViewModel_showPrivateProfileInfo() {
+    final User user = UserFactory.user();
+
+    setUpEnvironment(user);
+
+    this.currentUserTest.assertValues(user);
+    this.showPrivateProfileInfo.assertValueCount(0);
+
+    this.vm.inputs.privateProfileInfoClicked();
+    this.showPrivateProfileInfo.assertValueCount(1);
 
     this.showOptInPromptTest.assertNoValues();
     this.koalaTest.assertValues("Settings View");


### PR DESCRIPTION
## Why
- Due to GDPR we needed to add the ability for users to make their profile private from the mobile app.

## What
- Refactored the `settings_layout.xml` to bring parody to the iOS settings screen.
- Added methods to `SettingsActivity`, `SettingsViewModel`, `User`, `ApiClient`, and `SettingsBody`.

## Screenshots
<img src=https://user-images.githubusercontent.com/16387538/41668504-7f3e350e-747d-11e8-90c0-23f054c84830.png width=330/> <img src=https://user-images.githubusercontent.com/16387538/41668506-7f4a3e08-747d-11e8-9632-1de364c8ee99.png width=330/>
<img src=https://user-images.githubusercontent.com/16387538/41668507-7f6097d4-747d-11e8-8552-b8700210dd86.png width=330/>
