### PR TITLE
Fixing broken `Crashlytics` and `Fabric` imports

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,12 +4,7 @@ buildscript {
     }
 
     dependencies {
-        // These docs use an open ended version so that our plugin
-        // can be updated quickly in response to Android tooling updates
-
-        // We recommend changing it to the latest version from our changelog:
-        // https://docs.fabric.io/android/changelog.html#fabric-gradle-plugin
-        classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'io.fabric.tools:gradle:1.25.4'
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,18 @@
+buildscript {
+    repositories {
+        maven { url 'https://maven.fabric.io/public' }
+    }
+
+    dependencies {
+        // These docs use an open ended version so that our plugin
+        // can be updated quickly in response to Android tooling updates
+
+        // We recommend changing it to the latest version from our changelog:
+        // https://docs.fabric.io/android/changelog.html#fabric-gradle-plugin
+        classpath 'io.fabric.tools:gradle:1.+'
+    }
+}
+
 apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
 apply plugin: 'kotlin-android'

--- a/build.gradle
+++ b/build.gradle
@@ -4,14 +4,12 @@ buildscript {
     repositories {
         jcenter()
         google()
-        maven { url 'https://maven.fabric.io/public' }
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.google.gms:google-services:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'io.fabric.tools:gradle:1.+'
     }
 }
 
@@ -20,8 +18,6 @@ allprojects {
         google()
         jcenter()
         mavenCentral()
-        maven { url 'https://maven.fabric.io/public' }
-
         maven {
             url 'https://oss.sonatype.org/content/repositories/snapshots/'
         }


### PR DESCRIPTION
# what
I couldn't run my tests because the imports didn't resolve. So I moved the Fabric imports to `app/build.gradle`.

# why
The `Fabric` and `Crashlytic` imports weren't resolving.

# how
[Per the docs](https://fabric.io/kits/android/crashlytics/install)
They also recommend using the latest version number and not `+` so I changed that too.