### PR TITLE
No longer consuming project preview links

### DIFF
--- a/app/src/main/java/com/kickstarter/services/KSUri.java
+++ b/app/src/main/java/com/kickstarter/services/KSUri.java
@@ -3,6 +3,7 @@ package com.kickstarter.services;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
+import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.libs.utils.Secrets;
 
 import java.util.regex.Matcher;
@@ -60,6 +61,10 @@ public final class KSUri {
 
   public static boolean isProjectUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
     return isKickstarterUri(uri, webEndpoint) && PROJECT_PATTERN.matcher(uri.getPath()).matches();
+  }
+
+  public static boolean isProjectPreviewUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
+    return isProjectUri(uri, webEndpoint) && ObjectUtils.isNotNull(uri.getQueryParameter("token"));
   }
 
   public static boolean isSignupUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {

--- a/app/src/test/java/com/kickstarter/services/KSUriTest.java
+++ b/app/src/test/java/com/kickstarter/services/KSUriTest.java
@@ -10,13 +10,14 @@ public final class KSUriTest extends KSRobolectricTestCase {
   private final Uri discoverCategoriesUri = Uri.parse("https://www.ksr.com/discover/categories/art");
   private final Uri discoverScopeUri = Uri.parse("https://www.kickstarter.com/discover/ending-soon");
   private final Uri discoverPlacesUri = Uri.parse("https://www.ksr.com/discover/places/newest");
-  private final String webEndpoint = "https://www.ksr.com";
   private final Uri newGuestCheckoutUri = Uri.parse("https://www.ksr.com/checkouts/1/guest/new");
   private final Uri projectUri = Uri.parse("https://www.ksr.com/projects/creator/project");
+  private final Uri projectPreviewUri = Uri.parse("https://www.ksr.com/projects/creator/project?token=token");
   private final Uri projectSurveyUri = Uri.parse("https://www.ksr.com/projects/creator/project/surveys/survey-param");
   private final Uri updatesUri = Uri.parse("https://www.ksr.com/projects/creator/project/posts");
   private final Uri updateUri = Uri.parse("https://www.ksr.com/projects/creator/project/posts/id");
   private final Uri userSurveyUri = Uri.parse("https://www.ksr.com/users/user-param/surveys/survey-id");
+  private final String webEndpoint = "https://www.ksr.com";
 
   @Test
   public void testKSUri_isDiscoverCategoriesPath() {
@@ -119,7 +120,14 @@ public final class KSUriTest extends KSRobolectricTestCase {
   @Test
   public void testKSUri_isProjectUri() {
     assertTrue(KSUri.isProjectUri(this.projectUri, this.webEndpoint));
+    assertTrue(KSUri.isProjectUri(this.projectPreviewUri, this.webEndpoint));
     assertFalse(KSUri.isProjectUri(this.updateUri, this.webEndpoint));
+  }
+
+  @Test
+  public void testKSUri_isProjectPreviewUri() {
+    assertTrue(KSUri.isProjectPreviewUri(this.projectPreviewUri, this.webEndpoint));
+    assertFalse(KSUri.isProjectPreviewUri(this.projectUri, this.webEndpoint));
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.java
@@ -43,6 +43,21 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
+  public void testProjectPreviewLink_startsBrowser() {
+    setUpEnvironment();
+
+    final String url = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap?token=beepboop";
+    this.vm.intent(intentWithData(url));
+    this.vm.packageManager(application().getPackageManager());
+
+    this.requestPackageManager.assertValueCount(1);
+    this.startBrowser.assertValueCount(1);
+    this.startDiscoveryActivity.assertNoValues();
+    this.startProjectActivity.assertNoValues();
+    this.koalaTest.assertNoValues();
+  }
+
+  @Test
   public void testProjectDeepLink_startsProjectActivity() {
     setUpEnvironment();
 


### PR DESCRIPTION
# what
No longer showing a blank project page when a user navigates to a project preview. Instead, taking the user to their external browser.

# how
Checking if the URL looks like a project but contains the param `token` 🦆 
WITH TESTS

# seeing is believing
![2018-08-03 18_42_02](https://user-images.githubusercontent.com/1289295/43668815-efd2b974-974c-11e8-8c68-a2a235adf150.gif)

cc @roblum @willmanduffy thanks for your help!