### PR TITLE
Android automatic alpha builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,45 @@ jobs:
           paths:
             - ~/.gradle
             - ~/.android
+      - run: ./gradlew assembleExternalPre21Release
+      - store_artifacts:
+          path: app/build/reports
+          destination: reports
+
+  test:
+    resource_class: xlarge
+    docker:
+      - image: kickstarter/android-ci:65a9b01
+        auth:
+          username: ksrci
+          password: $DOCKERHUB_PASSWORD
+    environment:
+      ADB_INSTALL_TIMEOUT: 8
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError"'
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-android-{{ .Branch }}
+            - v1-android-
+
+      - run: $ANDROID_HOME/tools/android list target
+      - run: make bootstrap-circle
+      - run: echo y | android update sdk --no-ui --all --filter android-27
+      - run: echo y | android update sdk --no-ui --all --filter build-tools-27.0.3
+      - run: echo y | android update sdk --no-ui --all --filter platform-tools
+      - run: echo y | android update sdk --no-ui --all --filter extra-android-m2repository
+      - run: echo y | android update sdk --no-ui --all --filter extra-google-m2repository
+      - run: echo y | android update sdk --no-ui --all --filter extra-android-support
+      - run: ./gradlew dependencies
+      - save_cache:
+          key: v1-android-{{ .Branch }}
+          paths:
+            - ~/.gradle
+            - ~/.android
       - run: ./gradlew checkstyle
       - run: ./gradlew lintExternalPre21Release
-      - run: ./gradlew assembleExternalPre21Release testExternalPre21Release -PdisablePreDex
+      - run: ./gradlew testExternalPre21Release -PdisablePreDex
       - store_artifacts:
           path: app/build/reports
           destination: reports
@@ -43,44 +79,40 @@ jobs:
 
 
   deploy_crashlytics:
+    resource_class: xlarge
     docker:
-          - image: kickstarter/android-ci:65a9b01
-            auth:
-              username: ksrci  # can specify string literal values
-              password: $DOCKERHUB_PASSWORD
+      - image: circleci/android:api-27-alpha
+        auth:
+          username: ksrci
+          password: $DOCKERHUB_PASSWORD
     environment:
+      TERM: dumb
       ADB_INSTALL_TIMEOUT: 8
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError"'
     steps:
-      - restore_cache:
-          keys:
-          - v1-android-{{ .Branch }}
-          - v1-android-
-
-      - run:
-          name: Make bootstrap
-          command: make bootstrap
-
-      - restore_cache:
-          keys:
-            - v1-gems-{{ checksum "Gemfile.lock" }}
+      - checkout
+      # how can i cache this?
+      - run: make bootstrap-circle
+      - run: ./gradlew dependencies
 
       - run:
           name: Bundle install
-          command: bundle check || bundle install
+          command: bundle check || bundle install --path vendor/bundle
 
       - run:
           name: Deploy to Crashlytics Alpha
           command: bundle exec fastlane alpha
 
-
-# Workflows
 workflows:
   version: 2
   build_and_test:
     jobs:
       - build
+      - test
       - deploy_crashlytics:
+          requires:
+            - build
+            - test
           filters:
             branches:
               only: alpha
@@ -90,3 +122,4 @@ experimental:
     branches:
       only:
         - master
+        - alpha

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,9 @@ workflows:
   build_and_test:
     jobs:
       - build
-      - test
+      - test:
+          requires:
+            -build
       - deploy_crashlytics:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ workflows:
       - build
       - test:
           requires:
-            -build
+            - build
       - deploy_crashlytics:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           path: app/build/outputs
 
 
-  deploy_crashlytics:
+  alpha:
     resource_class: xlarge
     docker:
       - image: circleci/android:api-27-alpha
@@ -103,6 +103,28 @@ jobs:
           name: Deploy to Crashlytics Alpha
           command: bundle exec fastlane alpha
 
+  create_alpha:
+     resource_class: xlarge
+        docker:
+          - image: circleci/android:api-27-alpha
+            auth:
+              username: ksrci
+              password: $DOCKERHUB_PASSWORD
+        environment:
+          TERM: dumb
+          ADB_INSTALL_TIMEOUT: 8
+          GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError"'
+        steps:
+          - checkout
+          # how can i cache this?
+          - run: make bootstrap-circle
+          - run: ./gradlew dependencies
+
+
+          - run:
+              name: push to alpha branch
+              command: make alpha
+
 workflows:
   version: 2
   build_and_test:
@@ -111,13 +133,20 @@ workflows:
       - test:
           requires:
             - build
-      - deploy_crashlytics:
+      - alpha:
           requires:
             - build
             - test
           filters:
             branches:
               only: alpha
+      - create_alpha:
+          requires:
+            - build
+            - test
+          filters:
+            branches:
+              only: master
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,26 +104,25 @@ jobs:
           command: bundle exec fastlane alpha
 
   create_alpha:
-     resource_class: xlarge
-        docker:
-          - image: circleci/android:api-27-alpha
-            auth:
-              username: ksrci
-              password: $DOCKERHUB_PASSWORD
-        environment:
-          TERM: dumb
-          ADB_INSTALL_TIMEOUT: 8
-          GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError"'
-        steps:
-          - checkout
-          # how can i cache this?
-          - run: make bootstrap-circle
-          - run: ./gradlew dependencies
+    resource_class: xlarge
+    docker:
+      - image: circleci/android:api-27-alpha
+        auth:
+          username: ksrci
+          password: $DOCKERHUB_PASSWORD
+    environment:
+      TERM: dumb
+      ADB_INSTALL_TIMEOUT: 8
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError"'
+    steps:
+      - checkout
+      # how can i cache this?
+      - run: make bootstrap-circle
+      - run: ./gradlew dependencies
 
-
-          - run:
-              name: push to alpha branch
-              command: make alpha
+      - run:
+          name: push to alpha branch
+          command: make alpha
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -47,17 +47,17 @@ secrets:
 .PHONY: bootstrap bootstrap-circle dependencies secrets
 
 sync_oss_to_private:
-  @echo "Syncing oss to private..."
-  @git checkout oss $(BRANCH)
-  @git pull oss $(BRANCH)
-  @git push private $(BRANCH)
+	@echo "Syncing oss to private..."
+	@git checkout oss $(BRANCH)
+	@git pull oss $(BRANCH)
+	@git push private $(BRANCH)
 
-  @echo "private and oss remotes are now synced!"
+	@echo "private and oss remotes are now synced!"
 
 sync_private_to_oss:
-  @echo "Syncing private to oss..."
-  @git checkout private $(BRANCH)
-  @git pull private $(BRANCH)
-  @git push oss $(BRANCH)
+	@echo "Syncing private to oss..."
+	@git checkout private $(BRANCH)
+	@git pull private $(BRANCH)
+	@git push oss $(BRANCH)
 
-  @echo "private and oss remotes are now synced!"
+	@echo "private and oss remotes are now synced!"

--- a/Makefile
+++ b/Makefile
@@ -47,17 +47,17 @@ secrets:
 .PHONY: bootstrap bootstrap-circle dependencies secrets
 
 sync_oss_to_private:
-	@echo "Syncing oss to private..."
- 	@git checkout oss $(BRANCH)
-	@git pull oss $(BRANCH)
-	@git push private $(BRANCH)
+  @echo "Syncing oss to private..."
+  @git checkout oss $(BRANCH)
+  @git pull oss $(BRANCH)
+  @git push private $(BRANCH)
 
-	@echo "private and oss remotes are now synced!"
+  @echo "private and oss remotes are now synced!"
 
 sync_private_to_oss:
-	@echo "Syncing private to oss..."
- 	@git checkout private $(BRANCH)
-	@git pull private $(BRANCH)
-	@git push oss $(BRANCH)
+  @echo "Syncing private to oss..."
+  @git checkout private $(BRANCH)
+  @git pull private $(BRANCH)
+  @git push oss $(BRANCH)
 
-	@echo "private and oss remotes are now synced!"
+  @echo "private and oss remotes are now synced!"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BRANCH ?= master
+COMMIT ?= $(CIRCLE_SHA1)
 
 bootstrap: dependencies secrets
 	./script/bootstrap
@@ -61,3 +62,17 @@ sync_private_to_oss:
 	@git push oss $(BRANCH)
 
 	@echo "private and oss remotes are now synced!"
+
+
+alpha:
+	@echo "Adding remotes..."
+	@git remote add oss https://github.com/kickstarter/android-oss
+	@git remote add private https://github.com/kickstarter/android-private
+
+	@echo "Deploying private/alpha-$(COMMIT)..."
+
+	@git branch -f alpha-$(COMMIT)
+	@git push -f private alpha-$(COMMIT)
+	@git branch -d alpha-$(COMMIT)
+
+	@echo "Deploy has been kicked off to CircleCI!"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+BRANCH ?= master
+
 bootstrap: dependencies secrets
 	./script/bootstrap
 
@@ -43,3 +45,19 @@ secrets:
 	cp vendor/native-secrets/android/WebViewJavascript.html app/src/main/assets/www/WebViewJavascript.html || true
 
 .PHONY: bootstrap bootstrap-circle dependencies secrets
+
+sync_oss_to_private:
+	@echo "Syncing oss to private..."
+ 	@git checkout oss $(BRANCH)
+	@git pull oss $(BRANCH)
+	@git push private $(BRANCH)
+
+	@echo "private and oss remotes are now synced!"
+
+sync_private_to_oss:
+	@echo "Syncing private to oss..."
+ 	@git checkout private $(BRANCH)
+	@git pull private $(BRANCH)
+	@git push oss $(BRANCH)
+
+	@echo "private and oss remotes are now synced!"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,9 +15,15 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 apply from: 'quality.gradle'
 
-def externalPrivateVersion = new File(project.rootDir.path + "/app/external_version_code.txt").text.trim().toInteger()
+def getVersionCodeTimestamp() {
+    def date = new Date()
+    def formattedDate = date.format('yyMMddHHmm')
+    def code = formattedDate.toInteger()
+    println sprintf("VersionCode: %d", code)
+    return code
+}
+
 def externalPublicVersion = new File(project.rootDir.path + "/app/external_version_name.txt").text.trim()
-def internalPrivateVersion = new File(project.rootDir.path + "/app/internal_version_code.txt").text.trim().toInteger()
 def internalPublicVersion = new File(project.rootDir.path + "/app/internal_version_name.txt").text.trim()
 def isCircle = "true" == System.getenv("CIRCLECI")
 
@@ -106,13 +112,13 @@ android {
         internal {
             dimension "AUDIENCE"
             applicationId "com.kickstarter.kickstarter.internal"
-            versionCode internalPrivateVersion
+            versionCode getVersionCodeTimestamp()
             versionName internalPublicVersion
         }
         external {
             dimension "AUDIENCE"
             applicationId "com.kickstarter.kickstarter"
-            versionCode externalPrivateVersion
+            versionCode getVersionCodeTimestamp()
             versionName externalPublicVersion
         }
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,9 +21,10 @@ lane :update_strings do
   Milkrun::ServerConfigRefresher.new(local: false).refresh
   Milkrun::I18nStringResources.new.create
 
+  current_branch = git_branch
+
   push_to_git_remote(
-    current_branch = git_branch
-    remote: "oss",         # optional, default: "origin"
+    remote-branch: "oss",         # optional, default: "origin"
     local_branch: current_branch,  # optional, aliased by "branch", default: "master"
     force: true,    # optional, default: false
     tags: false     # optional, default: true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,68 +17,58 @@ default_platform :android
 # don't worry, fastlane will prompt you for required
 # info which you can add here later
 
-  lane :update_strings do
-    Milkrun::ServerConfigRefresher.new(local: false).refresh
-    Milkrun::I18nStringResources.new.create
-  end
+lane :update_strings do
+  Milkrun::ServerConfigRefresher.new(local: false).refresh
+  Milkrun::I18nStringResources.new.create
 
-  private_lane :increment_internal_version_code do
-    Milkrun::VersionCode.new(audience: "internal").bump
-  end
+  push_to_git_remote(
+    current_branch = git_branch
+    remote: "oss",         # optional, default: "origin"
+    local_branch: current_branch,  # optional, aliased by "branch", default: "master"
+    force: true,    # optional, default: false
+    tags: false     # optional, default: true
+  )
+end
 
-  private_lane :increment_external_version_code do
-    Milkrun::VersionCode.new(audience: "external").bump
-  end
-
- lane :alpha do
-   update_strings
-   increment_internal_version_code
-   gradle(task: "assembleInternalPre21Debug")
-   slack(
-     slack_url: ENV["slack_webhook"],
-     message: "Internal debug build successfully delivered!"
-    )
-
-    # upload to Beta by Crashlytics
-    crashlytics(
-      api_token: ENV["apiKey"],
-      build_secret: ENV["apiSecret"],
-      notifications: true
-    )
- end
-
- lane :production do
-   update_strings
-   increment_external_version_code
-   build_android_app(task: "assembleExternalPre21Release")
-   slack(
+lane :alpha do
+  gradle(task: "assembleInternalPre21Debug")
+  slack(
     slack_url: ENV["slack_webhook"],
-    message: "External debug build successfully delivered!"
-   )
-
-    # upload to Beta by Crashlytics
-    crashlytics(
-      api_token: ENV["apiKey"],
-      build_secret: ENV["apiSecret"],
-      notifications: true
+    message: "Internal debug build successfully delivered!"
     )
- end
 
-lane :internal do
-  update_strings
-  increment_internal_version_code
-
-  # build the release variant
-  build_android_app(task: "assembleInternalPre21Release")
-
-  # upload to Beta by Crashlytics
   crashlytics(
     api_token: ENV["apiKey"],
     build_secret: ENV["apiSecret"],
     notifications: true
-  )
+    )
+end
+
+lane :external do
+  build_android_app(task: "assembleExternalPre21Release")
   slack(
-   slack_url: ENV["slack_webhook"],
-   message: "Internal release build successfully delivered!"
-  )
- end
+    slack_url: ENV["slack_webhook"],
+    message: "External debug build successfully delivered!"
+    )
+
+  crashlytics(
+    api_token: ENV["apiKey"],
+    build_secret: ENV["apiSecret"],
+    notifications: true
+    )
+end
+
+lane :internal do
+  build_android_app(task: "assembleInternalPre21Release")
+
+  crashlytics(
+    api_token: ENV["apiKey"],
+    build_secret: ENV["apiSecret"],
+    notifications: true
+    )
+
+  slack(
+    slack_url: ENV["slack_webhook"],
+    message: "Internal release build successfully delivered!"
+    )
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,7 +24,7 @@ lane :update_strings do
   current_branch = git_branch
 
   push_to_git_remote(
-    remote-branch: "oss",         # optional, default: "origin"
+    remote: "oss",         # optional, default: "origin"
     local_branch: current_branch,  # optional, aliased by "branch", default: "master"
     force: true,    # optional, default: false
     tags: false     # optional, default: true


### PR DESCRIPTION
@Rcureton and I did a fire collabo on this!

# Small stuff
I added some helper methods in our Makefile: `sync_oss_to_private` and `sync_private_to_oss` to keep the heads up to date.

The `update_strings` lane in the Fastfile, pulls down the latest config and strings and pushes to the current branch.

The version codes are now automatically incremented in `build.gradle`.

# Big stuff
**Android CI process:**
We now have a workflow called `build_and_test` that includes 4 jobs: `build`, `test`, `create_alpha` and `alpha`.

`build`- makes sure the app can still build. Its main task is running `assembleExternalPre21Release`.

`test`- runs lint, checkstyle and unit tests. It's main tasks are: `checkstyle`, `lintExternalPre21Release` and `testExternalPre21Release`. Its dependent on the `build` job passing.

`create_alpha`- runs when any commits are pushed to the `master` branch. It pushes your latest changes to the `alpha` branch on the `private` repo. It's dependent on the `build` and `test` jobs passing.

`alpha`- runs when any commits are pushed to the `alpha` branch. Its main task is to run `bundle exec fastlane alpha` which creates and deploys a debug build to crashlytics (`assembleInternalPre21Debug`). It's dependent on the `build` and `test` jobs passing.

Automatic alpha TA-DA!