### PR TITLE
[Enhancement] - Removed privacy feature for creators

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/PrivacyActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/PrivacyActivity.kt
@@ -52,13 +52,13 @@ class PrivacyActivity : BaseActivity<PrivacyViewModel.ViewModel>() {
                 .subscribe({ this.displayPreferences(it) })
 
         this.viewModel.outputs.hidePrivateProfileRow()
-                .compose(bindToLifecycle<Boolean>())
-                .compose(observeForUI<Boolean>())
-                .subscribe { it ->
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe( {
                     ViewUtils.setGone(private_profile_row, it)
                     ViewUtils.setGone(private_profile_text_view, it)
                     ViewUtils.setGone(public_profile_text_view, it)
-                }
+                })
 
         following_switch.setOnClickListener { this.viewModel.inputs.optIntoFollowing(following_switch.isChecked) }
         private_profile_switch.setOnClickListener { this.viewModel.inputs.showPublicProfile(private_profile_switch.isChecked) }

--- a/app/src/main/java/com/kickstarter/ui/activities/PrivacyActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/PrivacyActivity.kt
@@ -7,6 +7,7 @@ import android.support.v7.app.AlertDialog
 import com.kickstarter.R
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
+import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.BooleanUtils.isFalse
 import com.kickstarter.libs.utils.BooleanUtils.isTrue
 import com.kickstarter.libs.utils.Secrets
@@ -50,7 +51,16 @@ class PrivacyActivity : BaseActivity<PrivacyViewModel.ViewModel>() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({ this.displayPreferences(it) })
 
-        following_switch.setOnClickListener{ this.viewModel.inputs.optIntoFollowing(following_switch.isChecked) }
+        this.viewModel.outputs.hidePrivateProfileRow()
+                .compose(bindToLifecycle<Boolean>())
+                .compose(observeForUI<Boolean>())
+                .subscribe { it ->
+                    ViewUtils.setGone(private_profile_row, it)
+                    ViewUtils.setGone(private_profile_text_view, it)
+                    ViewUtils.setGone(public_profile_text_view, it)
+                }
+
+        following_switch.setOnClickListener { this.viewModel.inputs.optIntoFollowing(following_switch.isChecked) }
         private_profile_switch.setOnClickListener { this.viewModel.inputs.showPublicProfile(private_profile_switch.isChecked) }
         recommendations_switch.setOnClickListener { this.viewModel.inputs.optedOutOfRecommendations(recommendations_switch.isChecked) }
         settings_request_data.setOnClickListener { showPrivacyWebpage(Secrets.Privacy.REQUEST_DATA) }
@@ -76,7 +86,7 @@ class PrivacyActivity : BaseActivity<PrivacyViewModel.ViewModel>() {
         return this.followingConfirmationDialog!!
     }
 
-    private fun showPrivacyWebpage(url : String) {
+    private fun showPrivacyWebpage(url: String) {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
         startActivity(intent)
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/PrivacyActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/PrivacyActivity.kt
@@ -7,7 +7,6 @@ import android.support.v7.app.AlertDialog
 import com.kickstarter.R
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
-import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.BooleanUtils.isFalse
 import com.kickstarter.libs.utils.BooleanUtils.isTrue
 import com.kickstarter.libs.utils.Secrets
@@ -53,7 +52,7 @@ class PrivacyActivity : BaseActivity<PrivacyViewModel.ViewModel>() {
 
         this.viewModel.outputs.hidePrivateProfileRow()
                 .compose(bindToLifecycle())
-                .compose(observeForUI())
+                .observeOn(AndroidSchedulers.mainThread())
                 .subscribe( {
                     ViewUtils.setGone(private_profile_row, it)
                     ViewUtils.setGone(private_profile_text_view, it)

--- a/app/src/main/java/com/kickstarter/viewmodels/PrivacyViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PrivacyViewModel.kt
@@ -53,8 +53,9 @@ interface PrivacyViewModel {
         private val optIntoFollowing = PublishSubject.create<Boolean>()
         private val optOutOfFollowing = PublishSubject.create<Boolean>()
         private val userInput = PublishSubject.create<User>()
+
         private val hideConfirmFollowingOptOutPrompt = BehaviorSubject.create<Void>()
-        private var hidePrivateProfileRow: Observable<Boolean>
+        private var hidePrivateProfileRow = BehaviorSubject.create<Boolean>()
         private val showConfirmFollowingOptOutPrompt = BehaviorSubject.create<Void>()
         private val userOutput = BehaviorSubject.create<User>()
         private val updateSuccess = PublishSubject.create<Void>()
@@ -75,15 +76,18 @@ interface PrivacyViewModel {
                     .compose(bindToLifecycle())
                     .subscribe { this.currentUser.refresh(it) }
 
-            this.currentUser.observable()
+            val currentUser = this.currentUser.observable()
+
+            currentUser
                     .take(1)
                     .compose(bindToLifecycle())
                     .subscribe({ this.userOutput.onNext(it) })
 
-            this.hidePrivateProfileRow = this.currentUser.observable()
+            currentUser
                     .compose(bindToLifecycle())
                     .filter(ObjectUtils::isNotNull)
                     .map { user -> IntegerUtils.isNonZero(user.createdProjectsCount()) }
+                    .subscribe(this.hidePrivateProfileRow)
 
             this.userInput
                     .concatMap<User>({ this.updateSettings(it) })
@@ -141,7 +145,7 @@ interface PrivacyViewModel {
 
         override fun hideConfirmFollowingOptOutPrompt(): Observable<Void> = this.hideConfirmFollowingOptOutPrompt
 
-        override fun hidePrivateProfileRow() = this.hidePrivateProfileRow
+        override fun hidePrivateProfileRow(): Observable<Boolean> = this.hidePrivateProfileRow
 
         override fun showConfirmFollowingOptOutPrompt(): Observable<Void> = this.showConfirmFollowingOptOutPrompt
 

--- a/app/src/main/res/layout/activity_privacy.xml
+++ b/app/src/main/res/layout/activity_privacy.xml
@@ -96,6 +96,7 @@
         android:text="@string/We_use_your_activity_internally_to_make_recommendations_for_you" />
 
       <LinearLayout
+        android:id="@+id/private_profile_row"
         style="@style/SettingsLinearRow">
 
         <LinearLayout
@@ -116,12 +117,14 @@
       </LinearLayout>
 
       <TextView
+        android:id="@+id/private_profile_text_view"
         style="@style/NewsLetterTextView"
         android:layout_marginBottom="@dimen/grid_1"
         android:layout_marginTop="@dimen/grid_2"
         android:text="@string/If_your_profile_is_private" />
 
       <TextView
+        android:id="@+id/public_profile_text_view"
         style="@style/NewsLetterTextView"
         android:layout_marginBottom="@dimen/grid_3"
         android:text="@string/If_your_profile_is_public" />

--- a/app/src/test/java/com/kickstarter/viewmodels/PrivacyViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PrivacyViewModelTest.kt
@@ -90,13 +90,8 @@ class PrivacyViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testHidePrivateProfileRow_isFalse() {
         val creator = UserFactory.creator()
-        val currentUser = MockCurrentUser(creator)
+        setUpEnvironment(creator)
 
-        val env = environment().toBuilder()
-                .currentUser(currentUser)
-                .build()
-
-        this.vm = PrivacyViewModel.ViewModel(env)
         this.vm.outputs.hidePrivateProfileRow().subscribe(this.hidePrivateProfile)
         this.hidePrivateProfile.assertValue(true)
     }
@@ -104,13 +99,8 @@ class PrivacyViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testHidePrivateProfileRow_isTrue() {
         val notCreator = UserFactory.user().toBuilder().createdProjectsCount(0).build()
-        val currentUser = MockCurrentUser(notCreator)
+        setUpEnvironment(notCreator)
 
-        val env = environment().toBuilder()
-                .currentUser(currentUser)
-                .build()
-
-        this.vm = PrivacyViewModel.ViewModel(env)
         this.vm.outputs.hidePrivateProfileRow().subscribe(this.hidePrivateProfile)
         this.hidePrivateProfile.assertValue(false)
     }

--- a/app/src/test/java/com/kickstarter/viewmodels/PrivacyViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PrivacyViewModelTest.kt
@@ -98,7 +98,7 @@ class PrivacyViewModelTest : KSRobolectricTestCase() {
 
         this.vm = PrivacyViewModel.ViewModel(env)
         this.vm.outputs.hidePrivateProfileRow().subscribe(this.hidePrivateProfile)
-        this.hidePrivateProfile.assertValue(false)
+        this.hidePrivateProfile.assertValue(true)
     }
 
     @Test
@@ -112,7 +112,7 @@ class PrivacyViewModelTest : KSRobolectricTestCase() {
 
         this.vm = PrivacyViewModel.ViewModel(env)
         this.vm.outputs.hidePrivateProfileRow().subscribe(this.hidePrivateProfile)
-        this.hidePrivateProfile.assertValue(true)
+        this.hidePrivateProfile.assertValue(false)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/PrivacyViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PrivacyViewModelTest.kt
@@ -1,8 +1,8 @@
 package com.kickstarter.viewmodels
 
 import com.kickstarter.KSRobolectricTestCase
-import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.libs.MockCurrentUser
+import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.User
 import org.junit.Test
 import rx.observers.TestSubscriber
@@ -12,6 +12,7 @@ class PrivacyViewModelTest : KSRobolectricTestCase() {
 
     private val currentUserTest = TestSubscriber<User>()
     private val hideConfirmFollowingOptOutPrompt = TestSubscriber<Void>()
+    private val hidePrivateProfile = TestSubscriber<Boolean>()
     private val showConfirmFollowingOptOutPrompt = TestSubscriber<Void>()
 
     private fun setUpEnvironment(user: User) {
@@ -84,6 +85,34 @@ class PrivacyViewModelTest : KSRobolectricTestCase() {
         this.currentUserTest.assertValues(user, user.toBuilder().social(false).build())
 
         this.hideConfirmFollowingOptOutPrompt.assertNoValues()
+    }
+
+    @Test
+    fun testHidePrivateProfileRow_isFalse() {
+        val creator = UserFactory.creator()
+        val currentUser = MockCurrentUser(creator)
+
+        val env = environment().toBuilder()
+                .currentUser(currentUser)
+                .build()
+
+        this.vm = PrivacyViewModel.ViewModel(env)
+        this.vm.outputs.hidePrivateProfileRow().subscribe(this.hidePrivateProfile)
+        this.hidePrivateProfile.assertValue(false)
+    }
+
+    @Test
+    fun testHidePrivateProfileRow_isTrue() {
+        val notCreator = UserFactory.user().toBuilder().createdProjectsCount(0).build()
+        val currentUser = MockCurrentUser(notCreator)
+
+        val env = environment().toBuilder()
+                .currentUser(currentUser)
+                .build()
+
+        this.vm = PrivacyViewModel.ViewModel(env)
+        this.vm.outputs.hidePrivateProfileRow().subscribe(this.hidePrivateProfile)
+        this.hidePrivateProfile.assertValue(true)
     }
 
     @Test


### PR DESCRIPTION
## What
- Added logic to hide privacy rows when the user is a creator.
- Added ViewModelTest functions to test if the privacy row is hidden.

## Why
- Creators can't have private profiles.

## See
![ksl](https://user-images.githubusercontent.com/16387538/45445482-5d377580-b698-11e8-8db9-61926336f752.gif)
![sep-12-2018 14-29-41-rashad](https://user-images.githubusercontent.com/16387538/45445483-5d377580-b698-11e8-8d84-b00819bf07ca.gif)
