### PR TITLE
ENHANCE 🗣 fixing overlap in disco toolbar

### DIFF
--- a/app/src/main/res/layout/discovery_layout.xml
+++ b/app/src/main/res/layout/discovery_layout.xml
@@ -17,42 +17,7 @@
 
     <android.support.design.widget.CoordinatorLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      tools:ignore="UnusedAttribute">
-
-      <android.support.design.widget.AppBarLayout
-        android:id="@+id/discovery_sort_app_bar_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:elevation="@dimen/card_no_elevation">
-
-        <android.support.design.widget.CollapsingToolbarLayout
-          android:layout_width="match_parent"
-          android:layout_height="96dp"
-          app:layout_scrollFlags="scroll|exitUntilCollapsed">
-
-          <include
-            layout="@layout/discovery_toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:layout_gravity="top" />
-
-          <com.kickstarter.ui.views.SortTabLayout
-            android:id="@+id/discovery_tab_layout"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:layout_gravity="bottom"
-            app:layout_collapseMode="pin"
-            app:tabBackground="@drawable/click_indicator_light"
-            app:tabMode="scrollable"
-            app:tabSelectedTextColor="@color/text_primary"
-            app:tabTextAppearance="@style/TabTextAppearance"
-            app:tabTextColor="@color/black_alpha_30"
-            />
-
-        </android.support.design.widget.CollapsingToolbarLayout>
-
-      </android.support.design.widget.AppBarLayout>
+      android:layout_height="match_parent">
 
       <android.support.v4.view.ViewPager
         android:id="@+id/discovery_view_pager"
@@ -65,6 +30,38 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_behavior="com.kickstarter.ui.toolbars.AlphaBehavior" />
+
+      <android.support.design.widget.AppBarLayout
+        android:id="@+id/discovery_sort_app_bar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:elevation="@dimen/card_no_elevation">
+
+        <android.support.design.widget.CollapsingToolbarLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          app:layout_scrollFlags="scroll">
+
+          <include
+            layout="@layout/discovery_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?android:attr/actionBarSize"
+            android:layout_gravity="top" />
+
+        </android.support.design.widget.CollapsingToolbarLayout>
+
+        <com.kickstarter.ui.views.SortTabLayout
+          android:id="@+id/discovery_tab_layout"
+          android:layout_width="match_parent"
+          android:layout_height="?android:attr/actionBarSize"
+          android:layout_gravity="bottom"
+          app:tabBackground="@drawable/click_indicator_light"
+          app:tabMode="scrollable"
+          app:tabSelectedTextColor="@color/text_primary"
+          app:tabTextAppearance="@style/TabTextAppearance"
+          app:tabTextColor="@color/black_alpha_30" />
+
+      </android.support.design.widget.AppBarLayout>
 
     </android.support.design.widget.CoordinatorLayout>
 

--- a/app/src/main/res/layout/discovery_toolbar.xml
+++ b/app/src/main/res/layout/discovery_toolbar.xml
@@ -15,7 +15,7 @@
 
   <LinearLayout
     android:layout_width="match_parent"
-    android:layout_height="?attr/actionBarSize"
+    android:layout_height="?android:attr/actionBarSize"
     android:baselineAligned="false"
     android:gravity="center_vertical"
     android:orientation="horizontal">


### PR DESCRIPTION
# what
My second pass of collapsing the Discovery toolbar.
Using `?android:attr/actionBarSize` because `?attr/actionBarSize` throws an error.

# why
Previously, the toolbar and the tablayout overlapped and it looked janky. Currently, I actually have time to read documentation and do it properly 😛 

# before and after (showing layout bounds)
<img src=https://user-images.githubusercontent.com/1289295/45516794-4701e600-b77a-11e8-9082-2b522781577f.png width=330/> <img src=https://user-images.githubusercontent.com/1289295/45516795-4701e600-b77a-11e8-84d2-0c5c33808bc2.png width=330/>