### PR TITLE
BUG 🕷fixing crash when switching endpoints

### DIFF
--- a/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.java
+++ b/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.java
@@ -203,10 +203,15 @@ public final class InternalToolsActivity extends BaseActivity<InternalToolsViewM
   private void setEndpointAndRelaunch(final @NonNull ApiEndpoint apiEndpoint) {
     this.apiEndpointPreference.set(apiEndpoint.url());
     this.logout.execute();
+    try {
+      Thread.sleep(500L);
+    } catch (InterruptedException ignored) {
+
+    }
     ProcessPhoenix.triggerRebirth(this);
   }
 
-  protected @Nullable Pair<Integer, Integer> exitTransition() {
+  protected @NonNull Pair<Integer, Integer> exitTransition() {
     return slideInFromLeft();
   }
 }

--- a/app/src/main/java/com/kickstarter/KSApplication.java
+++ b/app/src/main/java/com/kickstarter/KSApplication.java
@@ -9,10 +9,10 @@ import android.text.TextUtils;
 
 import com.crashlytics.android.Crashlytics;
 import com.facebook.FacebookSdk;
+import com.google.firebase.FirebaseApp;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.kickstarter.libs.ApiCapabilities;
 import com.kickstarter.libs.ApiEndpoint;
-import com.kickstarter.libs.Build;
 import com.kickstarter.libs.PushNotifications;
 import com.kickstarter.libs.utils.ApplicationLifecycleUtil;
 import com.kickstarter.libs.utils.Secrets;
@@ -20,7 +20,6 @@ import com.squareup.leakcanary.LeakCanary;
 import com.squareup.leakcanary.RefWatcher;
 
 import net.danlew.android.joda.JodaTimeAndroid;
-
 
 import org.joda.time.DateTime;
 
@@ -46,11 +45,6 @@ public class KSApplication extends MultiDexApplication {
   public void onCreate() {
     super.onCreate();
 
-    // Send crash reports in release builds
-    if (!BuildConfig.DEBUG && !isInUnitTests()) {
-      checkForCrashes();
-    }
-
     MultiDex.install(this);
 
     // Only log for internal builds
@@ -69,6 +63,8 @@ public class KSApplication extends MultiDexApplication {
       .applicationModule(new ApplicationModule(this))
       .build();
     component().inject(this);
+
+    FirebaseApp.initializeApp(this);
 
     if (!isInUnitTests()) {
       setVisitorCookie();
@@ -95,14 +91,6 @@ public class KSApplication extends MultiDexApplication {
   public boolean isInUnitTests() {
     return false;
   }
-
-  private void checkForCrashes() {
-    final String appId = Build.isExternal()
-      ? Secrets.HockeyAppId.EXTERNAL
-      : Secrets.HockeyAppId.INTERNAL;
-
-  }
-
 
   private void setVisitorCookie() {
     final String deviceId = FirebaseInstanceId.getInstance().getId();


### PR DESCRIPTION
# what
The app would crash when switching endpoints because Firebase wasn't initialized or sometimes just not switch at all.

# how
Initialized Firebase in `onCreate` on the application.
Added a delay before we trigger a rebirth.
Removed unused method.