### PR TITLE
BUG 🐛Qualifying WebEndpoint in Environment provider

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -120,7 +120,7 @@ public final class ApplicationModule {
     final @NonNull Scheduler scheduler,
     final @NonNull SharedPreferences sharedPreferences,
     final @NonNull WebClientType webClient,
-    final @NonNull String webEndpoint) {
+    final @NonNull @WebEndpoint String webEndpoint) {
 
     return Environment.builder()
       .activitySamplePreference(activitySamplePreference)

--- a/app/src/main/java/com/kickstarter/ui/activities/HelpActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/HelpActivity.java
@@ -12,7 +12,6 @@ import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
 import com.kickstarter.libs.qualifiers.WebEndpoint;
 import com.kickstarter.libs.utils.AnimationUtils;
-import com.kickstarter.libs.utils.Secrets;
 import com.kickstarter.services.KSWebViewClient;
 import com.kickstarter.ui.views.KSWebView;
 import com.kickstarter.viewmodels.HelpViewModel;
@@ -68,7 +67,7 @@ public class HelpActivity extends BaseActivity<HelpViewModel> implements KSWebVi
     super.onCreate(savedInstanceState);
     setContentView(R.layout.help_layout);
     ButterKnife.bind(this);
-    this.webEndpoint = Secrets.WebEndpoint.PRODUCTION;
+    this.webEndpoint = environment().webEndpoint();
 
     final String url = getUrlForHelpType(this.helpType);
     this.kickstarterWebView.loadUrl(url);


### PR DESCRIPTION
# what
`environment.webEndpoint` was providing the wrong value (it was returning the client ID) because we didn't qualify it. When 2 providers are ambiguous (they both are returning a `String` and take in `ApiEndpoint`) , Dagger just picks the first one alphabetically 🙃 
So now, I can revert the change I made in January #200 because I was confused about why the URLs were wrong. 

# how
Qualifying `webEndpoint` with `@WebEndpoint`