### PR TITLE
ENHANCE ✨Smooth scrolling to the top of the disco fragment when reselecting a tab.

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.AppBarLayout;
+import android.support.design.widget.TabLayout;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v4.widget.DrawerLayout;
@@ -95,6 +96,7 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel.Vie
 
     this.sortViewPager.setAdapter(this.pagerAdapter);
     this.sortTabLayout.setupWithViewPager(this.sortViewPager);
+    addTabSelectedListenerToTabLayout();
 
     this.viewModel.outputs.creatorDashboardButtonIsGone()
       .compose(bindToLifecycle())
@@ -180,6 +182,23 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel.Vie
 
   public @NonNull DrawerLayout discoveryLayout() {
     return this.discoveryLayout;
+  }
+
+  private void addTabSelectedListenerToTabLayout() {
+    this.sortTabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
+      @Override
+      public void onTabSelected(final TabLayout.Tab tab) {
+
+      }
+      @Override
+      public void onTabUnselected(final TabLayout.Tab tab) {
+
+      }
+      @Override
+      public void onTabReselected(final TabLayout.Tab tab) {
+        DiscoveryActivity.this.pagerAdapter.scrollToTop(tab.getPosition());
+      }
+    });
   }
 
   private void startLoginToutActivity() {

--- a/app/src/main/java/com/kickstarter/ui/adapters/DiscoveryPagerAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/DiscoveryPagerAdapter.java
@@ -103,4 +103,15 @@ public final class DiscoveryPagerAdapter extends FragmentPagerAdapter {
       })
       .subscribe(DiscoveryFragment::clearPage);
   }
+
+  public void scrollToTop(final int position) {
+    Observable.from(this.fragments)
+      .filter(DiscoveryFragment::isInstantiated)
+      .filter(DiscoveryFragment::isAttached)
+      .filter(frag -> {
+        final int fragmentPosition = frag.getArguments().getInt(ArgumentsKey.DISCOVERY_SORT_POSITION);
+        return position == fragmentPosition;
+      })
+      .subscribe(DiscoveryFragment::scrollToTop);
+  }
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
+++ b/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
@@ -203,4 +203,8 @@ public final class DiscoveryFragment extends BaseFragment<DiscoveryFragmentViewM
   public void clearPage() {
     this.viewModel.inputs.clearPage();
   }
+
+  public void scrollToTop() {
+    this.recyclerView.smoothScrollToPosition(0);
+  }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -249,7 +249,6 @@ public interface DiscoveryFragmentViewModel {
     private final PublishSubject<DiscoveryParams> paramsFromActivity = PublishSubject.create();
     private final PublishSubject<Project> projectCardClicked = PublishSubject.create();
     private final PublishSubject<List<Category>> rootCategories = PublishSubject.create();
-    private final PublishSubject<Void> startHeartAnimation = PublishSubject.create();
 
     private final BehaviorSubject<Activity> activity = BehaviorSubject.create();
     private final BehaviorSubject<Void> heartContainerClicked = BehaviorSubject.create();
@@ -260,6 +259,7 @@ public interface DiscoveryFragmentViewModel {
     private final BehaviorSubject<Boolean> shouldShowOnboardingView = BehaviorSubject.create();
     private final Observable<Pair<Project, RefTag>> startProjectActivity;
     private final Observable<Activity> startUpdateActivity;
+    private final BehaviorSubject<Void> startHeartAnimation = BehaviorSubject.create();
 
     public final Inputs inputs = this;
     public final Outputs outputs = this;


### PR DESCRIPTION
# what
Smooth scrolling to the top of the Disco fragment when a tab is reselected.

# how
Added a `TabSelectedListener` to the `TabLayout` and  `onTabReselected`, letting the `DiscoveryPagerAdapter` know the current fragment needs to scroll to the top.

# see
![2018-09-13 18_12_55](https://user-images.githubusercontent.com/1289295/45518785-ac58d580-b780-11e8-9317-8a6cb7c19d41.gif)
