### PR TITLE
[POC] Mutations? ✅ Custom scalar support? ✅

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -175,6 +175,10 @@ buildscript {
     }
 }
 
+apollo {
+    customTypeMapping['Email'] = "java.lang.String"
+}
+
 afterEvaluate {
     buildFabricPropertiesIfNeeded()
 }

--- a/app/src/main/graphql/userprivacy.graphql
+++ b/app/src/main/graphql/userprivacy.graphql
@@ -4,3 +4,12 @@ query UserPrivacy {
     email
   }
 }
+
+mutation UpdateUserEmail($email: Email!, $current_password: String!) {
+  updateUserAccount(input: {email: $email, current_password: $current_password}) {
+    user {
+      name
+      email
+    }
+  }
+}

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -35,6 +35,7 @@ import com.kickstarter.libs.Koala;
 import com.kickstarter.libs.KoalaTrackingClient;
 import com.kickstarter.libs.Logout;
 import com.kickstarter.libs.PushNotifications;
+import com.kickstarter.libs.graphql.EmailAdapter;
 import com.kickstarter.libs.preferences.BooleanPreference;
 import com.kickstarter.libs.preferences.BooleanPreferenceType;
 import com.kickstarter.libs.preferences.IntPreference;
@@ -88,6 +89,7 @@ import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
 import rx.Scheduler;
 import rx.schedulers.Schedulers;
+import type.CustomType;
 
 @Module
 public final class ApplicationModule {
@@ -173,6 +175,7 @@ public final class ApplicationModule {
 
     return ApolloClient.builder()
       .serverUrl("https://www.kickstarter.com/graph")
+      .addCustomTypeAdapter(CustomType.EMAIL, new EmailAdapter())
       .okHttpClient(okHttpClient)
       .build();
   }

--- a/app/src/main/java/com/kickstarter/libs/graphql/EmailAdapter.kt
+++ b/app/src/main/java/com/kickstarter/libs/graphql/EmailAdapter.kt
@@ -1,0 +1,14 @@
+package com.kickstarter.libs.graphql
+
+import com.apollographql.apollo.response.CustomTypeAdapter
+import com.apollographql.apollo.response.CustomTypeValue
+
+class EmailAdapter : CustomTypeAdapter<String> {
+    override fun encode(value: String): CustomTypeValue<*> {
+        return CustomTypeValue.GraphQLString(value)
+    }
+
+    override fun decode(value: CustomTypeValue<*>): String {
+        return value.toString()
+    }
+}

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -1,10 +1,15 @@
 package com.kickstarter.mock.services
 
+import UpdateUserEmailMutation
 import UserPrivacyQuery
 import com.kickstarter.services.ApolloClientType
 import rx.Observable
 
 open class MockApolloClient : ApolloClientType {
+    override fun updateUserEmail(email: String, currentPassword: String): Observable<UpdateUserEmailMutation.Data> {
+        return Observable.empty()
+    }
+
     override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
         return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "Some Name", "some@email.com")))
     }

--- a/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
+++ b/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
@@ -1,8 +1,11 @@
 package com.kickstarter.services
 
+import UpdateUserEmailMutation
 import UserPrivacyQuery
 import rx.Observable
 
 interface ApolloClientType {
+    fun updateUserEmail(email: String, currentPassword: String): Observable<UpdateUserEmailMutation.Data>
+
     fun userPrivacy(): Observable<UserPrivacyQuery.Data>
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/TestApolloActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/TestApolloActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.widget.Toast
 import com.kickstarter.R
+import com.kickstarter.extensions.text
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.utils.ViewUtils
@@ -27,6 +28,12 @@ class TestApolloActivity : BaseActivity<TestApolloViewModel.ViewModel>() {
         make_graphql_call_with_errors.text = "Make GraphQL call with errors"
         make_graphql_call_with_errors.setOnClickListener {
             this.viewModel.inputs.makeNetworkCallWithErrorsClicked()
+            clearNameAndEmail()
+        }
+
+        update_email.text = "Update email"
+        update_email.setOnClickListener {
+            this.viewModel.inputs.updateEmailClicked(new_email.text(), current_password.text())
             clearNameAndEmail()
         }
 

--- a/app/src/main/res/layout/activity_test_apollo.xml
+++ b/app/src/main/res/layout/activity_test_apollo.xml
@@ -67,6 +67,52 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content" />
 
+    <android.support.design.widget.TextInputLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="@dimen/grid_3">
+
+      <android.support.design.widget.TextInputEditText
+        android:id="@+id/new_email"
+        style="@style/CalloutPrimary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:hint="@string/login_placeholder_email"
+        android:inputType="textEmailAddress"
+        android:maxLines="1" />
+    </android.support.design.widget.TextInputLayout>
+
+    <android.support.design.widget.TextInputLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="@dimen/grid_2"
+      android:layout_marginTop="@dimen/grid_2"
+      app:hintTextAppearance="@style/BodySecondary"
+      app:passwordToggleEnabled="true"
+      app:passwordToggleTint="@color/password_toggle">
+
+      <android.support.design.widget.TextInputEditText
+        android:id="@+id/current_password"
+        style="@style/CalloutPrimary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="@dimen/grid_1"
+        android:hint="@string/Current_password"
+        android:inputType="textPassword" />
+    </android.support.design.widget.TextInputLayout>
+
+    <Button
+      android:id="@+id/update_email"
+      style="@style/PrimaryButton"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_horizontal"
+      android:layout_marginBottom="@dimen/grid_1" />
+
     <ProgressBar
       android:id="@+id/progress_bar"
       android:visibility="gone"


### PR DESCRIPTION
# what
Added a POC for custom scalars.
Added adapter for Email custom scalar.
In the `TestApolloActivity`, logged in users can now update their email addresses.

# how sway
Added `Email`, defined as a `java.lang.String` to `customTypeMapping` in `build.gradle`.
Added adapter for encoding and decoding `Email` in `EmailAdapter`. Should we do some validation here? It happens server side.
Added mutation for `UpdateUserEmail` that takes in `email` and `current_password`.
Updated `TestApolloActivity` to actually make this call.

![image](https://user-images.githubusercontent.com/1289295/45575215-b510e080-b840-11e8-91cc-00c2f03c5b52.png)

Shouts to @orionmcc for support!