### PR TITLE
ENHANCE 📈Updating search query length to 60 chars per front end.

### DIFF
--- a/app/src/main/res/layout/search_toolbar.xml
+++ b/app/src/main/res/layout/search_toolbar.xml
@@ -18,13 +18,16 @@
       android:id="@+id/back_button"/>
 
     <EditText
-      style="@style/ToolbarTitle"
       android:id="@+id/search_edit_text"
+      style="@style/ToolbarTitle"
+      android:layout_width="match_parent"
+      android:layout_toStartOf="@+id/clear_button"
       android:background="@color/transparent"
-      android:maxLength="25"
-      android:inputType="textNoSuggestions"
-      android:maxLines="1"
       android:hint="@string/tabbar_search"
+      android:inputType="textNoSuggestions"
+      android:maxLength="60"
+      android:maxLines="1"
+      android:minHeight="@dimen/grid_8"
       android:textCursorDrawable="@null" />
 
     <com.kickstarter.ui.views.IconButton


### PR DESCRIPTION
# what 
Updating search query length to 60 chars per front end.
Made the search EditText height conform to minimum accessible touch target size of `48dp`.
Made the search EditText take up the width between back button and clear icon.

# why
@mcstew pointed out the 25 char limit. it's downright restrictive!

# see
![2018-09-14 18_30_49](https://user-images.githubusercontent.com/1289295/45577890-52254680-b84c-11e8-90e0-a75f0e86c420.gif)

# before & after
<img src=https://user-images.githubusercontent.com/1289295/45577917-6cf7bb00-b84c-11e8-98c5-0f303a8c0308.png width=330/> <img src=https://user-images.githubusercontent.com/1289295/45577916-6cf7bb00-b84c-11e8-9c71-1e7e32a6395d.png width=330/> 
