### PR TITLE
[bug] Fixing the drawer getting cut off and reformatting.

### DIFF
--- a/app/src/main/res/layout/discovery_drawer_logged_in_view.xml
+++ b/app/src/main/res/layout/discovery_drawer_logged_in_view.xml
@@ -5,7 +5,6 @@
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:layout_marginBottom="@dimen/grid_1"
-  android:layout_marginTop="@dimen/discovery_drawer_status_bar_height"
   android:orientation="vertical"
   android:theme="@style/ThemeOverlay.AppCompat.Light">
 

--- a/app/src/main/res/layout/discovery_layout.xml
+++ b/app/src/main/res/layout/discovery_layout.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.DrawerLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:id="@+id/discovery_layout"
-  android:layout_height="match_parent"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:fitsSystemWindows="true"
+  android:layout_height="match_parent"
   android:nextFocusDown="@+id/recycler_view"
   tools:context=".ui.activities.DiscoveryActivity">
 
@@ -21,9 +20,9 @@
 
       <android.support.v4.view.ViewPager
         android:id="@+id/discovery_view_pager"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
       <include
         layout="@layout/horizontal_line_1dp_view"
@@ -69,11 +68,11 @@
 
   <android.support.design.widget.NavigationView
     android:id="@+id/discovery_navigation_view"
-    android:layout_height="match_parent"
     android:layout_width="320dp"
+    android:layout_height="match_parent"
     android:layout_gravity="start"
-    android:fitsSystemWindows="true"
-    android:background="@color/white">
+    android:background="@color/white"
+    android:fitsSystemWindows="false">
 
     <android.support.v7.widget.RecyclerView
       android:id="@+id/discovery_drawer_recycler_view"


### PR DESCRIPTION
# what
Finally had time to address https://github.com/kickstarter/android-oss/issues/230 🤓 Now the drawer won't get cut off for devices with cutouts.

# how
It was actually pretty straight-forward (as straight-forward as Android can be 😛)
The default value of `fitsSystemWindows` is `true` so we don't need it in the `DrawerLayout` but for `NavigationView` we do, so it draws below the status bar.

# before and after
<img src=https://user-images.githubusercontent.com/1289295/46544922-e191a880-c892-11e8-841f-5e9df06fdb49.png width=330/> <img src=https://user-images.githubusercontent.com/1289295/46544923-e191a880-c892-11e8-83b5-d9972412c5d6.png width=330/> 

# cool tipz
There's an option in Developer Settings to simulate a cutout. That's how I tested this out!
<img src=https://user-images.githubusercontent.com/1289295/46545339-15b99900-c894-11e8-9671-cde5f08a01d5.png width=330/>

![image](https://user-images.githubusercontent.com/1289295/46545436-63ce9c80-c894-11e8-9de1-e7202e57131b.png)
