### PR TITLE
Local endpoint for updating strings.

### DIFF
--- a/lib/milkrun/server_config_refresher.rb
+++ b/lib/milkrun/server_config_refresher.rb
@@ -37,7 +37,7 @@ module Milkrun
     end
 
     def host
-      local ? "http://api.ksr.dev/" : "https://#{Secrets::Api::Endpoint::PRODUCTION}"
+      local ? "http://api.ksr.test/" : "https://#{Secrets::Api::Endpoint::PRODUCTION}"
     end
 
     def oauth_token


### PR DESCRIPTION
# what
Per the wiki, we can update strings locally by running `bin/milkrun update-strings --local`.
But we haven't updated the endpoint since it changed.

