### PR TITLE
Fixes DiscoveryViewModelTest.testClearingPages

### DIFF
--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -325,7 +325,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
 
     this.clearPages.assertNoValues();
 
-    this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 4);
+    this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 3);
 
     this.clearPages.assertNoValues();
 
@@ -336,7 +336,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
         .build()
     );
 
-    this.clearPages.assertValues(Arrays.asList(0, 1, 2, 3));
+    this.clearPages.assertValues(Arrays.asList(0, 1, 2));
 
     this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 1);
 
@@ -347,7 +347,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
         .build()
     );
 
-    this.clearPages.assertValues(Arrays.asList(0, 1, 2, 3), Arrays.asList(0, 2, 3));
+    this.clearPages.assertValues(Arrays.asList(0, 1, 2), Arrays.asList(0, 2, 3));
   }
 
   @Test


### PR DESCRIPTION
# how
The `clearPages` output `Emits a list of pages that should be cleared of all their content.` which translates to all of the pages but the current one. Since we got rid of the last sort, our indices went from [0,1,2,3,4] to [0,1,2,3]. Doing `this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 4)` is an illegal condition since position 4 doesn't exist and it will never get "cleared" because it doesn't actually exist.