### PR TITLE
Change password warning copy

### DIFF
--- a/app/src/main/assets/json/server-config.json
+++ b/app/src/main/assets/json/server-config.json
@@ -316,6 +316,8 @@
       "Other_payment_methods": "Other payment methods",
       "Other_projects_you_might_like": "Other projects you might like.",
       "percentage_funded": "%{percentage} funded",
+      "Password_min_length_message": "Your password must be at least 6 characters long.",
+      "Passwords_matching_message": "New passwords must match.",
       "Password_visibility": "Password visibility",
       "Past_live_stream": "Past live stream",
       "Payment_methods": "Payment methods",
@@ -2379,6 +2381,8 @@
       "Other_payment_methods": "Weitere Zahlungsmethoden",
       "Other_projects_you_might_like": "Ähnliche Projekte:",
       "percentage_funded": "%{percentage} finanziert",
+      "Password_min_length_message": "Your password must be at least 6 characters long.",
+      "Passwords_matching_message": "New passwords must match.",
       "Password_visibility": "Passwort-Anzeige",
       "Past_live_stream": "Früherer Live-Stream",
       "Payment_methods": "Zahlungsmethoden",
@@ -4260,7 +4264,7 @@
       "Either_the_pledge_or_the_project_was_canceled": "Se canceló la contribución o el proyecto antes de que el plazo terminara.",
       "Email": "Correo electrónico",
       "Email_frequency": "Frecuencia de aviso por correo electrónico",
-      "Email_must_be_a_valid_email_address": "Email must be a valid email address.",
+      "Email_must_be_a_valid_email_address": "El correo electrónico debe tener una dirección de correo electrónico válida.",
       "Email_notifications": "Notificaciones por correo electrónico",
       "Email_unverified": "Esta dirección de correo electrónico no está verificada.",
       "Ending_soon": "Finaliza pronto",
@@ -4442,6 +4446,8 @@
       "Other_payment_methods": "Otros métodos de pago",
       "Other_projects_you_might_like": "Otros proyectos que te pueden gustar.",
       "percentage_funded": "%{percentage} financiado",
+      "Password_min_length_message": "Tu contraseña debe tener al menos 6 caracteres.",
+      "Passwords_matching_message": "Las nuevas contraseñas deben coincidir.",
       "Password_visibility": "Visibilidad de la contraseña",
       "Past_live_stream": "Live Stream pasado",
       "Payment_methods": "Métodos de pago",
@@ -6505,6 +6511,8 @@
       "Other_payment_methods": "Autres moyens de paiement",
       "Other_projects_you_might_like": "Autre projets qui pourraient vous intéresser",
       "percentage_funded": "Financé à %{percentage}",
+      "Password_min_length_message": "Your password must be at least 6 characters long.",
+      "Passwords_matching_message": "New passwords must match.",
       "Password_visibility": "Visibilité du mot de passe",
       "Past_live_stream": "Diffusion en direct passée",
       "Payment_methods": "Moyens de paiement ",
@@ -8568,6 +8576,8 @@
       "Other_payment_methods": "その他の支払方法",
       "Other_projects_you_might_like": "おすすめをさらに見る",
       "percentage_funded": "%{percentage} 達成",
+      "Password_min_length_message": "Your password must be at least 6 characters long.",
+      "Passwords_matching_message": "New passwords must match.",
       "Password_visibility": "パスワードの表示/非表示",
       "Past_live_stream": "過去のプロジェクト",
       "Payment_methods": "お支払い方法",
@@ -10326,6 +10336,7 @@
     "ios_live_stream_discovery": true,
     "ios_live_stream_chat": true,
     "ios_backer_dashboard": true,
+    "new_project_build_reward_scheduling": true,
     "message_spam": true,
     "drip_iterate": true,
     "creator_search": true
@@ -10511,7 +10522,7 @@
   "ab_experiments": {
     "project_dashboard": "with_dashboard",
     "new_project_header": "experimental",
-    "stripe_elements_sepa": "control"
+    "stripe_elements_sepa": "experimental"
   },
   "stripe": {
     "publishable_key": "pk_live_zjuK52lEUYcvBhIXEUnOEJzk"

--- a/app/src/main/java/com/kickstarter/ui/activities/ChangePasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ChangePasswordActivity.kt
@@ -38,22 +38,12 @@ class ChangePasswordActivity : BaseActivity<ChangePasswordViewModel.ViewModel>()
                 .compose(Transformers.observeForUI())
                 .subscribe { ViewUtils.setGone(progress_bar, !it) }
 
-        this.viewModel.outputs.passwordConfirmationWarningIsVisible()
+        this.viewModel.outputs.passwordWarning()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .subscribe {
                     warning.text = when {
-                        it -> getString(R.string.Confirm_password)
-                        else -> null
-                    }
-                }
-
-        this.viewModel.outputs.passwordLengthWarningIsVisible()
-                .compose(bindToLifecycle())
-                .compose(Transformers.observeForUI())
-                .subscribe {
-                    warning.text = when {
-                        it -> getString(R.string.signup_input_fields_password_min_characters)
+                        it != null -> getString(it)
                         else -> null
                     }
                 }

--- a/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
@@ -151,7 +151,6 @@ interface ChangePasswordViewModel {
                         && this.confirmPassword == this.newPassword
             }
 
-            private fun isNotEmptyAndAtLeast6Chars(password: String) = !password.isEmpty() && password.length >= MINIMUM_PASSWORD_LENGTH
             fun warning(): Int? {
                 return if (newPassword.isNotEmpty() && newPassword.length in 1 until MINIMUM_PASSWORD_LENGTH)
                     R.string.Password_min_length_message
@@ -159,6 +158,8 @@ interface ChangePasswordViewModel {
                     R.string.Passwords_matching_message
                 else null
             }
+
+            private fun isNotEmptyAndAtLeast6Chars(password: String) = !password.isEmpty() && password.length >= MINIMUM_PASSWORD_LENGTH
         }
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
@@ -34,7 +34,7 @@ interface ChangePasswordViewModel {
         /** Emits when the password update was unsuccessful. */
         fun error(): Observable<String>
 
-        /** Emits when the user types a new password less than 6 characters. */
+        /** Emits a string resource to display when the user's new password entries are invalid. */
         fun passwordWarning(): Observable<Int>
 
         /** Emits when the progress bar should be visible. */

--- a/app/src/main/res/drawable/icon__check_gray.xml
+++ b/app/src/main/res/drawable/icon__check_gray.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportHeight="60.0"
+  android:viewportWidth="60.0">
+  <path
+    android:fillColor="#DCDEDD"
+    android:pathData="M23.14,49.11L6.34,34.41C5.93,34.05 5.88,33.42 6.25,33L8.88,29.99C9.25,29.58 9.88,29.54 10.29,29.9L23.21,41.21L48.61,10.36C48.97,9.94 49.6,9.88 50.02,10.23L53.11,12.77C53.53,13.12 53.6,13.75 53.24,14.18L24.57,49C24.21,49.43 23.56,49.49 23.14,49.11Z" />
+</vector>

--- a/app/src/main/res/drawable/save.xml
+++ b/app/src/main/res/drawable/save.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:drawable="@drawable/icon__check" android:state_enabled="false" />
+  <item android:drawable="@drawable/icon__check_gray" android:state_enabled="false" />
   <item android:drawable="@drawable/icon__check_green" />
 </selector>

--- a/app/src/main/res/values-de/strings_i18n.xml
+++ b/app/src/main/res/values-de/strings_i18n.xml
@@ -281,7 +281,9 @@ Unterstützer</string>
   <string name="Or_select_a_different_reward_below_colon" formatted="false">Oder eine andere Belohnung wählen:</string>
   <string name="Other_payment_methods" formatted="false">Weitere Zahlungsmethoden</string>
   <string name="Other_projects_you_might_like" formatted="false">Ähnliche Projekte:</string>
+  <string name="Password_min_length_message" formatted="false">Your password must be at least 6 characters long.</string>
   <string name="Password_visibility" formatted="false">Passwort-Anzeige</string>
+  <string name="Passwords_matching_message" formatted="false">New passwords must match.</string>
   <string name="Past_live_stream" formatted="false">Früherer Live-Stream</string>
   <string name="Payment_method_was_successfully_charged" formatted="false">Zahlungsmethode wurde erfolgreich belastet.</string>
   <string name="Payment_methods" formatted="false">Zahlungsmethoden</string>

--- a/app/src/main/res/values-es/strings_i18n.xml
+++ b/app/src/main/res/values-es/strings_i18n.xml
@@ -121,7 +121,7 @@ patrocinadores</string>
   <string name="Either_the_pledge_or_the_project_was_canceled" formatted="false">Se canceló la contribución o el proyecto antes de que el plazo terminara.</string>
   <string name="Email" formatted="false">Correo electrónico</string>
   <string name="Email_frequency" formatted="false">Frecuencia de aviso por correo electrónico</string>
-  <string name="Email_must_be_a_valid_email_address" formatted="false">Email must be a valid email address.</string>
+  <string name="Email_must_be_a_valid_email_address" formatted="false">El correo electrónico debe tener una dirección de correo electrónico válida.</string>
   <string name="Email_notifications" formatted="false">Notificaciones por correo electrónico</string>
   <string name="Email_unverified" formatted="false">Esta dirección de correo electrónico no está verificada.</string>
   <string name="Ending_soon" formatted="false">Finaliza pronto</string>
@@ -282,7 +282,9 @@ patrocinadores</string>
   <string name="Or_select_a_different_reward_below_colon" formatted="false">También puedes seleccionar una de las siguientes recompensas:</string>
   <string name="Other_payment_methods" formatted="false">Otros métodos de pago</string>
   <string name="Other_projects_you_might_like" formatted="false">Otros proyectos que te pueden gustar.</string>
+  <string name="Password_min_length_message" formatted="false">Tu contraseña debe tener al menos 6 caracteres.</string>
   <string name="Password_visibility" formatted="false">Visibilidad de la contraseña</string>
+  <string name="Passwords_matching_message" formatted="false">Las nuevas contraseñas deben coincidir.</string>
   <string name="Past_live_stream" formatted="false">Live Stream pasado</string>
   <string name="Payment_method_was_successfully_charged" formatted="false">Cargo efectuado a método de pago indicado.</string>
   <string name="Payment_methods" formatted="false">Métodos de pago</string>

--- a/app/src/main/res/values-fr/strings_i18n.xml
+++ b/app/src/main/res/values-fr/strings_i18n.xml
@@ -282,7 +282,9 @@ n\'ont rien soutenu.</string>
   <string name="Or_select_a_different_reward_below_colon" formatted="false">Ou sélectionner une autre récompense ci-dessous :</string>
   <string name="Other_payment_methods" formatted="false">Autres moyens de paiement</string>
   <string name="Other_projects_you_might_like" formatted="false">Autre projets qui pourraient vous intéresser</string>
+  <string name="Password_min_length_message" formatted="false">Your password must be at least 6 characters long.</string>
   <string name="Password_visibility" formatted="false">Visibilité du mot de passe</string>
+  <string name="Passwords_matching_message" formatted="false">New passwords must match.</string>
   <string name="Past_live_stream" formatted="false">Diffusion en direct passée</string>
   <string name="Payment_method_was_successfully_charged" formatted="false">Le moyen de paiement a bien été débité.</string>
   <string name="Payment_methods" formatted="false">Moyens de paiement </string>

--- a/app/src/main/res/values-ja/strings_i18n.xml
+++ b/app/src/main/res/values-ja/strings_i18n.xml
@@ -280,7 +280,9 @@
   <string name="Or_select_a_different_reward_below_colon" formatted="false">別のリワードをみる：</string>
   <string name="Other_payment_methods" formatted="false">その他の支払方法</string>
   <string name="Other_projects_you_might_like" formatted="false">おすすめをさらに見る</string>
+  <string name="Password_min_length_message" formatted="false">Your password must be at least 6 characters long.</string>
   <string name="Password_visibility" formatted="false">パスワードの表示/非表示</string>
+  <string name="Passwords_matching_message" formatted="false">New passwords must match.</string>
   <string name="Past_live_stream" formatted="false">過去のプロジェクト</string>
   <string name="Payment_method_was_successfully_charged" formatted="false">支払い方法が登録されました。</string>
   <string name="Payment_methods" formatted="false">お支払い方法</string>

--- a/app/src/main/res/values/strings_i18n.xml
+++ b/app/src/main/res/values/strings_i18n.xml
@@ -283,7 +283,9 @@ from friends yet.</string>
   <string name="Or_select_a_different_reward_below_colon" formatted="false">Or select a different reward below:</string>
   <string name="Other_payment_methods" formatted="false">Other payment methods</string>
   <string name="Other_projects_you_might_like" formatted="false">Other projects you might like.</string>
+  <string name="Password_min_length_message" formatted="false">Your password must be at least 6 characters long.</string>
   <string name="Password_visibility" formatted="false">Password visibility</string>
+  <string name="Passwords_matching_message" formatted="false">New passwords must match.</string>
   <string name="Past_live_stream" formatted="false">Past live stream</string>
   <string name="Payment_method_was_successfully_charged" formatted="false">Payment method was successfully charged.</string>
   <string name="Payment_methods" formatted="false">Payment methods</string>

--- a/app/src/test/java/com/kickstarter/viewmodels/ChangePasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ChangePasswordViewModelTest.kt
@@ -2,6 +2,7 @@ package com.kickstarter.viewmodels
 
 import UpdateUserPasswordMutation
 import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.R
 import com.kickstarter.libs.Environment
 import com.kickstarter.mock.services.MockApolloClient
 import org.junit.Test
@@ -12,8 +13,7 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
     private lateinit var vm: ChangePasswordViewModel.ViewModel
 
     private val error = TestSubscriber<String>()
-    private val passwordConfirmationWarningIsVisible = TestSubscriber<Boolean>()
-    private val passwordLengthWarningIsVisible = TestSubscriber<Boolean>()
+    private val passwordWarning = TestSubscriber<Int>()
     private val progressBarIsVisible = TestSubscriber<Boolean>()
     private val saveButtonIsEnabled = TestSubscriber<Boolean>()
     private val success = TestSubscriber<String>()
@@ -22,8 +22,7 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
         this.vm = ChangePasswordViewModel.ViewModel(environment)
 
         this.vm.outputs.error().subscribe(this.error)
-        this.vm.outputs.passwordConfirmationWarningIsVisible().subscribe(this.passwordConfirmationWarningIsVisible)
-        this.vm.outputs.passwordLengthWarningIsVisible().subscribe(this.passwordLengthWarningIsVisible)
+        this.vm.outputs.passwordWarning().subscribe(this.passwordWarning)
         this.vm.outputs.progressBarIsVisible().subscribe(this.progressBarIsVisible)
         this.vm.outputs.saveButtonIsEnabled().subscribe(this.saveButtonIsEnabled)
         this.vm.outputs.success().subscribe(this.success)
@@ -45,29 +44,21 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPasswordConfirmationWarningIsVisible() {
+    fun testPasswordWarning() {
         setUpEnvironment(environment())
 
         this.vm.inputs.newPassword("password")
-
-        this.passwordConfirmationWarningIsVisible.assertNoValues()
-        this.vm.inputs.confirmPassword("p")
-        this.passwordConfirmationWarningIsVisible.assertValues(true)
-        this.vm.inputs.confirmPassword("password")
-        this.passwordConfirmationWarningIsVisible.assertValues(true, false)
-    }
-
-    @Test
-    fun testPasswordLengthWarningIsVisible() {
-        setUpEnvironment(environment())
-
-        this.passwordLengthWarningIsVisible.assertNoValues()
+        this.passwordWarning.assertValue(null)
         this.vm.inputs.newPassword("p")
-        this.passwordLengthWarningIsVisible.assertValues(true)
-        this.vm.inputs.newPassword("passw")
-        this.passwordLengthWarningIsVisible.assertValues(true)
+        this.passwordWarning.assertValues(null, R.string.Password_min_length_message)
         this.vm.inputs.newPassword("password")
-        this.passwordLengthWarningIsVisible.assertValues(true, false)
+        this.passwordWarning.assertValues(null, R.string.Password_min_length_message, null)
+        this.vm.inputs.confirmPassword("p")
+        this.passwordWarning.assertValues(null, R.string.Password_min_length_message, null, R.string.Passwords_matching_message)
+        this.vm.inputs.confirmPassword("passw")
+        this.passwordWarning.assertValues(null, R.string.Password_min_length_message, null, R.string.Passwords_matching_message)
+        this.vm.inputs.confirmPassword("password")
+        this.passwordWarning.assertValues(null, R.string.Password_min_length_message, null, R.string.Passwords_matching_message, null)
     }
 
     @Test
@@ -88,11 +79,11 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.currentPassword("password")
         this.vm.inputs.newPassword("password")
         this.vm.inputs.confirmPassword("password")
-        this.saveButtonIsEnabled.assertValue(true)
+        this.saveButtonIsEnabled.assertValues(false, true)
         this.vm.inputs.confirmPassword("pass")
-        this.saveButtonIsEnabled.assertValues(true, false)
+        this.saveButtonIsEnabled.assertValues(false, true, false)
         this.vm.inputs.confirmPassword("passwerd")
-        this.saveButtonIsEnabled.assertValues(true, false)
+        this.saveButtonIsEnabled.assertValues(false,true, false)
     }
 
     @Test


### PR DESCRIPTION
# what
Updated strings for change password warning copy.
Fixed bug where confirm and new password were swapped.
Fixed save disabled icon color.
Changed logic for showing warning.
Updated tests.

# see
![device-2018-10-19-120458 2018-10-19 12_05_45](https://user-images.githubusercontent.com/1289295/47230138-61416c00-d397-11e8-9b4a-fb44e874d852.gif)
