### PR TITLE
[🚀] Defaulting to recommendations for opted in users

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/DiscoveryDrawerUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/DiscoveryDrawerUtils.java
@@ -137,16 +137,17 @@ public final class DiscoveryDrawerUtils {
    */
   private static @NonNull List<NavigationDrawerData.Section> topSections(final @Nullable User user) {
     final List<DiscoveryParams> filters = ListUtils.empty();
+    final boolean userIsLoggedIn = user != null;
+
+    if (userIsLoggedIn && isFalse(user.optedOutOfRecommendations())) {
+      filters.add(DiscoveryParams.builder().recommended(true).backed(-1).build());
+    }
 
     filters.add(DiscoveryParams.builder().build());
     filters.add(DiscoveryParams.builder().staffPicks(true).build());
 
-    if (user != null) {
+    if (userIsLoggedIn) {
       filters.add(DiscoveryParams.builder().starred(1).build());
-
-      if (isFalse(user.optedOutOfRecommendations())) {
-        filters.add(DiscoveryParams.builder().recommended(true).backed(-1).build());
-      }
 
       if (isTrue(user.social())) {
         filters.add(DiscoveryParams.builder().social(1).build());


### PR DESCRIPTION
# what
Defaulting Discovery to recommended projects for users who are logged in and opted in.
Also, moving recommendations to the top of the drawer (it wasn't as tricky as I thought 😛).
Added tests for default params for:
1. logged out users
2. logged in, opted in users
3. logged in, opted out users

# why
iOS ran an experiment to show Recommendations for logged in users by default instead of All Projects and it was a hit. https://github.com/kickstarter/ios-oss/pull/320

# see
![screenshot-2018-10-25_174635](https://user-images.githubusercontent.com/1289295/47532308-f05df080-d87d-11e8-9ba9-a70a7e988d2f.png)

![image](https://user-images.githubusercontent.com/1289295/47532317-f653d180-d87d-11e8-9cd1-2b725f71e244.png)
