### PR TITLE
[Enhance] Quick return Discovery CollapsingToolbarLayout

### DIFF
--- a/app/src/main/res/layout/discovery_layout.xml
+++ b/app/src/main/res/layout/discovery_layout.xml
@@ -34,31 +34,34 @@
         android:id="@+id/discovery_sort_app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:elevation="@dimen/card_no_elevation">
+        app:elevation="0dp">
 
         <android.support.design.widget.CollapsingToolbarLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          app:layout_scrollFlags="scroll">
+          android:minHeight="?android:attr/actionBarSize"
+          app:layout_scrollFlags="scroll|exitUntilCollapsed|enterAlways">
 
           <include
             layout="@layout/discovery_toolbar"
             android:layout_width="match_parent"
+            android:background="@color/white"
             android:layout_height="?android:attr/actionBarSize"
-            android:layout_gravity="top" />
+            app:layout_collapseMode="pin" />
+
+          <com.kickstarter.ui.views.SortTabLayout
+            android:id="@+id/discovery_tab_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="?android:attr/actionBarSize"
+            app:layout_collapseMode="none"
+            app:tabBackground="@drawable/click_indicator_light"
+            app:tabMode="fixed"
+            app:tabSelectedTextColor="@color/text_primary"
+            app:tabTextAppearance="@style/TabTextAppearance"
+            app:tabTextColor="@color/black_alpha_30" />
 
         </android.support.design.widget.CollapsingToolbarLayout>
-
-        <com.kickstarter.ui.views.SortTabLayout
-          android:id="@+id/discovery_tab_layout"
-          android:layout_width="match_parent"
-          android:layout_height="?android:attr/actionBarSize"
-          android:layout_gravity="bottom"
-          app:tabBackground="@drawable/click_indicator_light"
-          app:tabMode="fixed"
-          app:tabSelectedTextColor="@color/text_primary"
-          app:tabTextAppearance="@style/TabTextAppearance"
-          app:tabTextColor="@color/black_alpha_30" />
 
       </android.support.design.widget.AppBarLayout>
 

--- a/app/src/main/res/layout/discovery_layout.xml
+++ b/app/src/main/res/layout/discovery_layout.xml
@@ -24,13 +24,6 @@
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-      <include
-        layout="@layout/horizontal_line_1dp_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:layout_behavior="com.kickstarter.ui.toolbars.AlphaBehavior" />
-
       <android.support.design.widget.AppBarLayout
         android:id="@+id/discovery_sort_app_bar_layout"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/discovery_layout.xml
+++ b/app/src/main/res/layout/discovery_layout.xml
@@ -28,33 +28,29 @@
         layout="@layout/horizontal_line_1dp_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:visibility="gone"
         app:layout_behavior="com.kickstarter.ui.toolbars.AlphaBehavior" />
 
       <android.support.design.widget.AppBarLayout
         android:id="@+id/discovery_sort_app_bar_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:elevation="0dp">
+        android:layout_height="wrap_content">
 
         <android.support.design.widget.CollapsingToolbarLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:minHeight="?android:attr/actionBarSize"
-          app:layout_scrollFlags="scroll|exitUntilCollapsed|enterAlways">
+          app:layout_scrollFlags="scroll|enterAlways">
 
           <include
             layout="@layout/discovery_toolbar"
             android:layout_width="match_parent"
-            android:background="@color/white"
-            android:layout_height="?android:attr/actionBarSize"
-            app:layout_collapseMode="pin" />
+            android:layout_height="?android:attr/actionBarSize" />
 
           <com.kickstarter.ui.views.SortTabLayout
             android:id="@+id/discovery_tab_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="?android:attr/actionBarSize"
-            app:layout_collapseMode="none"
             app:tabBackground="@drawable/click_indicator_light"
             app:tabMode="fixed"
             app:tabSelectedTextColor="@color/text_primary"

--- a/app/src/main/res/layout/discovery_toolbar.xml
+++ b/app/src/main/res/layout/discovery_toolbar.xml
@@ -6,7 +6,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_height="wrap_content"
-  android:elevation="0dp"
+  android:elevation="0.1dp"
   app:contentInsetLeft="0dp"
   app:contentInsetStart="0dp"
   app:layout_collapseMode="parallax"

--- a/app/src/main/res/layout/discovery_toolbar.xml
+++ b/app/src/main/res/layout/discovery_toolbar.xml
@@ -9,7 +9,6 @@
   android:elevation="0.1dp"
   app:contentInsetLeft="0dp"
   app:contentInsetStart="0dp"
-  app:layout_collapseMode="parallax"
   tools:ignore="UnusedAttribute"
   tools:showIn="@layout/discovery_layout">
 


### PR DESCRIPTION
### THE CHAMP IS HERE

# what
Quick returning the entire Discovery CollapsingToolbarLayout on scroll and stubbornly bringing back the elevation.
Removing the divider line with AlphaBehavior because it's no longer visually relevant when the Appbar is collapsed.

# see
![device-2018-10-26-165952 2018-10-29 15_29_37](https://user-images.githubusercontent.com/1289295/47675120-784e3e00-db8f-11e8-8cc8-0936948b5912.gif)


![image](https://user-images.githubusercontent.com/1289295/47674981-0544c780-db8f-11e8-8016-c5450306de58.png)
