### PR TITLE
[Bug Fix] - fixed bug in discovery layout Toolbar

### DIFF
--- a/app/src/main/res/layout/discovery_layout.xml
+++ b/app/src/main/res/layout/discovery_layout.xml
@@ -34,21 +34,27 @@
           android:layout_height="wrap_content"
           app:layout_scrollFlags="scroll|enterAlways">
 
-          <include
-            layout="@layout/discovery_toolbar"
+          <LinearLayout
+            android:orientation="vertical"
             android:layout_width="match_parent"
-            android:layout_height="?android:attr/actionBarSize" />
+            android:layout_height="wrap_content">
 
-          <com.kickstarter.ui.views.SortTabLayout
-            android:id="@+id/discovery_tab_layout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="?android:attr/actionBarSize"
-            app:tabBackground="@drawable/click_indicator_light"
-            app:tabMode="fixed"
-            app:tabSelectedTextColor="@color/text_primary"
-            app:tabTextAppearance="@style/TabTextAppearance"
-            app:tabTextColor="@color/black_alpha_30" />
+            <include
+              layout="@layout/discovery_toolbar"
+              android:layout_width="match_parent"
+              android:layout_height="?android:attr/actionBarSize" />
+
+            <com.kickstarter.ui.views.SortTabLayout
+              android:id="@+id/discovery_tab_layout"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              app:tabBackground="@drawable/click_indicator_light"
+              app:tabMode="fixed"
+              app:tabSelectedTextColor="@color/text_primary"
+              app:tabTextAppearance="@style/TabTextAppearance"
+              app:tabTextColor="@color/black_alpha_30" />
+
+          </LinearLayout>
 
         </android.support.design.widget.CollapsingToolbarLayout>
 


### PR DESCRIPTION
## What
- fixed bug in discovery layout by wrapping the toolbar and tabs in a linear layout

## Issue
- The toolbar wasn't responding to clicks due to the `CollapsingToolbarLayout` not having one direct child.

## Tested On
- Galaxy S7 (Aaliyah 7.0)
- Galaxy S3 (Enya 4.4.2)
- HTC One (Cher 4.4.2)