### PR TITLE
[✨] Payment methods divider

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/PaymentMethodsSettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/PaymentMethodsSettingsActivity.kt
@@ -37,6 +37,11 @@ class PaymentMethodsSettingsActivity : BaseActivity<PaymentMethodsViewModel.View
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { setCards(it) }
 
+        this.viewModel.outputs.dividerIsVisible()
+                .compose(bindToLifecycle())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe { ViewUtils.setGone(payments_divider, !it) }
+
         this.viewModel.outputs.error()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/kickstarter/viewmodels/PaymentMethodsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PaymentMethodsViewModel.kt
@@ -30,6 +30,9 @@ interface PaymentMethodsViewModel {
         /** Emits a list of stored cards for a user. */
         fun cards(): Observable<MutableList<UserPaymentsQuery.Node>>
 
+        /** Emits when the divider should be visible (if there are cards). */
+        fun dividerIsVisible(): Observable<Boolean>
+
         /** Emits whenever there is an error deleting a stored card.  */
         fun error(): Observable<String>
 
@@ -50,6 +53,7 @@ interface PaymentMethodsViewModel {
         private val refreshCards = PublishSubject.create<Void>()
 
         private val cards = BehaviorSubject.create<MutableList<UserPaymentsQuery.Node>>()
+        private val dividerIsVisible = BehaviorSubject.create<Boolean>()
         private val error = BehaviorSubject.create<String>()
         private val progressBarIsVisible = BehaviorSubject.create<Boolean>()
         private val showDeleteCardDialog = BehaviorSubject.create<Void>()
@@ -65,7 +69,12 @@ interface PaymentMethodsViewModel {
             getListOfStoredCards()
                     .subscribe { this.cards.onNext(it) }
 
-            this.deleteCardClicked.subscribe { this.showDeleteCardDialog.onNext(null) }
+            this.cards
+                    .map { it.isNotEmpty()  }
+                    .subscribe { this.dividerIsVisible.onNext(it)}
+
+            this.deleteCardClicked
+                    .subscribe { this.showDeleteCardDialog.onNext(null) }
 
             val deleteCardNotification = this.deleteCardClicked
                     .compose<String>(takeWhen(this.confirmDeleteCardClicked))
@@ -101,6 +110,8 @@ interface PaymentMethodsViewModel {
         override fun refreshCards() = this.refreshCards.onNext(null)
 
         override fun cards(): Observable<MutableList<UserPaymentsQuery.Node>> = this.cards
+
+        override fun dividerIsVisible(): Observable<Boolean> = this.dividerIsVisible
 
         override fun error(): Observable<String> = this.error
 

--- a/app/src/main/res/layout/activity_settings_payment_methods.xml
+++ b/app/src/main/res/layout/activity_settings_payment_methods.xml
@@ -39,21 +39,27 @@
           android:id="@+id/recycler_view"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          tools:listitem="@layout/item_payment_method" />
+          tools:listitem="@layout/item_payment_method"
+          tools:visibility="gone" />
 
         <LinearLayout
           android:id="@+id/add_new_card"
-          style="@style/SettingsLinearRow"
-          android:layout_marginTop="@dimen/grid_1">
+          style="@style/SettingsLinearRow">
+
+          <View
+            android:id="@+id/payments_divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginEnd="@dimen/grid_12"
+            android:background="@color/ksr_grey_300"
+            android:visibility="gone" />
 
           <TextView
             style="@style/CalloutPrimaryMedium"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/grid_2"
-            android:layout_marginEnd="@dimen/activity_horizontal_margin"
-            android:layout_marginStart="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/grid_2"
+            android:layout_margin="@dimen/activity_vertical_margin"
+            android:gravity="center_vertical"
             android:text="@string/Add_new_card"
             android:textAllCaps="true"
             android:textColor="@color/ksr_green_500" />

--- a/app/src/test/java/com/kickstarter/viewmodels/PaymentMethodsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PaymentMethodsViewModelTest.kt
@@ -18,6 +18,7 @@ class PaymentMethodsViewModelTest : KSRobolectricTestCase() {
     private lateinit var vm: PaymentMethodsViewModel.ViewModel
 
     private val cards = TestSubscriber<MutableList<UserPaymentsQuery.Node>>()
+    private val dividerIsVisible = TestSubscriber<Boolean>()
     private val error = TestSubscriber<String>()
     private val progressBarIsVisible = TestSubscriber<Boolean>()
     private val showDeleteCardDialog = TestSubscriber<Void>()
@@ -28,6 +29,7 @@ class PaymentMethodsViewModelTest : KSRobolectricTestCase() {
 
         this.vm.outputs.error().subscribe(this.error)
         this.vm.outputs.cards().subscribe(this.cards)
+        this.vm.outputs.dividerIsVisible().subscribe(this.dividerIsVisible)
         this.vm.outputs.progressBarIsVisible().subscribe(this.progressBarIsVisible)
         this.vm.outputs.showDeleteCardDialog().subscribe(this.showDeleteCardDialog)
         this.vm.outputs.success().subscribe(this.success)
@@ -41,12 +43,30 @@ class PaymentMethodsViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
             override fun getStoredCards(): Observable<UserPaymentsQuery.Data> {
                 return Observable.just(UserPaymentsQuery.Data(UserPaymentsQuery.Me("",
-                        UserPaymentsQuery.StoredCards("", List(1
-                        ) { _ -> node }))))
+                        UserPaymentsQuery.StoredCards("", List(1) { _ -> node }))))
             }
         }).build())
 
         this.cards.assertValue(Collections.singletonList(node))
+    }
+
+    @Test
+    fun testDividerIsVisible_hasCards() {
+        setUpEnvironment(environment())
+
+        this.dividerIsVisible.assertValues(true)
+    }
+
+    @Test
+    fun testDividerIsVisible_noCards() {
+        setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
+            override fun getStoredCards(): Observable<UserPaymentsQuery.Data> {
+                return Observable.just(UserPaymentsQuery.Data(UserPaymentsQuery.Me("",
+                        UserPaymentsQuery.StoredCards("", Collections.emptyList()))))
+            }
+        }).build())
+
+        this.dividerIsVisible.assertValues(false)
     }
 
     @Test


### PR DESCRIPTION
# What
I noticed in @dannyalright's [designs](https://app.goabstract.com/projects/ff85f7f0-23b6-11e8-9c12-3d345000cd85/branches/master/commits/efe3a35bdf1ea1c406cd89069504b6686da04da5/files/DD4807BD-4D34-43F3-853E-4765774306D1/layers/0EBFCADE-A8F6-4C2C-8910-2FEDDB76810B?mode=build&selected=4278085803-8C454A8A-61FB-4846-A935-201E6DA09C78) there's a really cute divider on the payment methods screen.
Also fixed the height of the button.
With tests 👾 

# no cards vs cards
<img src=https://user-images.githubusercontent.com/1289295/49118504-79e45200-f272-11e8-8868-fc8bebb4ac40.png width=330/> <img src=https://user-images.githubusercontent.com/1289295/49118505-79e45200-f272-11e8-8d49-ee2069aa5464.png width=330/>

