### PR TITLE
[👩🏾‍💻👨🏿‍💻] Hiding change password and change email

### DIFF
--- a/app/src/main/graphql/userprivacy.graphql
+++ b/app/src/main/graphql/userprivacy.graphql
@@ -2,6 +2,7 @@ query UserPrivacy {
   me {
     name
     email
+    hasPassword
     isCreator
     isDeliverable
     isEmailVerified

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -32,7 +32,7 @@ open class MockApolloClient : ApolloClientType {
 
     override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
         return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "Some Name",
-                "some@email.com", true, true, true, "USD")))
+                "some@email.com", true, true, true, true, "USD")))
     }
 }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/AccountActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/AccountActivity.kt
@@ -54,6 +54,11 @@ class AccountActivity : BaseActivity<AccountViewModel.ViewModel>() {
                 .compose(observeForUI())
                 .subscribe { ViewUtils.setGone(progress_bar, !it) }
 
+        this.viewModel.outputs.showChangePassword()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { ViewUtils.setGone(change_password_row, it) }
+
         this.viewModel.outputs.showEmailErrorIcon()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())

--- a/app/src/main/java/com/kickstarter/ui/activities/AccountActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/AccountActivity.kt
@@ -40,9 +40,7 @@ class AccountActivity : BaseActivity<AccountViewModel.ViewModel>() {
         this.viewModel.outputs.chosenCurrency()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe {
-                    setSpinnerSelection(it)
-                }
+                .subscribe { setSpinnerSelection(it)  }
 
         this.viewModel.outputs.error()
                 .compose(bindToLifecycle())
@@ -54,10 +52,10 @@ class AccountActivity : BaseActivity<AccountViewModel.ViewModel>() {
                 .compose(observeForUI())
                 .subscribe { ViewUtils.setGone(progress_bar, !it) }
 
-        this.viewModel.outputs.showChangePassword()
+        this.viewModel.outputs.passwordRequiredContainerIsVisible()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { ViewUtils.setGone(change_password_row, it) }
+                .subscribe { ViewUtils.setGone(password_required_container, !it) }
 
         this.viewModel.outputs.showEmailErrorIcon()
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/AccountViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/AccountViewModel.kt
@@ -30,11 +30,11 @@ interface AccountViewModel {
         /** Emits whenever there is an error updating the user's currency.  */
         fun error(): Observable<String>
 
+        /** Emits when the password required container should be visible. */
+        fun passwordRequiredContainerIsVisible(): Observable<Boolean>
+
         /** Emits when the progress bar should be visible. */
         fun progressBarIsVisible(): Observable<Boolean>
-
-        /** Emits true when the user has a password. (Facebook users don't have passwords). */
-        fun showChangePassword(): Observable<Boolean>
 
         /** Emits a boolean determining when we should show the email error icon. */
         fun showEmailErrorIcon(): Observable<Boolean>
@@ -51,8 +51,8 @@ interface AccountViewModel {
         private val onSelectedCurrency = PublishSubject.create<CurrencyCode>()
 
         private val chosenCurrency = BehaviorSubject.create<String>()
+        private val passwordRequiredContainerIsVisible = BehaviorSubject.create<Boolean>()
         private val progressBarIsVisible = BehaviorSubject.create<Boolean>()
-        private val showChangePassword = BehaviorSubject.create<Boolean>()
         private val showEmailErrorIcon = BehaviorSubject.create<Boolean>()
         private val success = BehaviorSubject.create<String>()
 
@@ -72,8 +72,8 @@ interface AccountViewModel {
                     .subscribe { this.chosenCurrency.onNext(it) }
 
             userPrivacy
-                    .map { showChangePassword(it) }
-                    .subscribe { this.showChangePassword.onNext(it) }
+                    .map { it?.me()?.hasPassword() ?: false }
+                    .subscribe { this.passwordRequiredContainerIsVisible.onNext(it) }
 
             userPrivacy
                     .map { showEmailErrorImage(it) }
@@ -111,22 +111,13 @@ interface AccountViewModel {
 
         override fun error(): Observable<String> = this.error
 
-        override fun progressBarIsVisible(): Observable<Boolean> {
-            return this.progressBarIsVisible
-        }
+        override fun passwordRequiredContainerIsVisible(): Observable<Boolean> = this.passwordRequiredContainerIsVisible
 
-        override fun showChangePassword(): Observable<Boolean> = this.showChangePassword
+        override fun progressBarIsVisible(): Observable<Boolean> = this.progressBarIsVisible
 
         override fun showEmailErrorIcon(): Observable<Boolean> = this.showEmailErrorIcon
 
-        override fun success(): BehaviorSubject<String> {
-            return this.success
-        }
-
-        private fun showChangePassword(userPrivacy: UserPrivacyQuery.Data?) : Boolean?{
-            val hasPassword = userPrivacy?.me()?.hasPassword() ?: false
-            return !hasPassword
-        }
+        override fun success(): BehaviorSubject<String> = this.success
 
         private fun showEmailErrorImage(userPrivacy: UserPrivacyQuery.Data?): Boolean? {
             val creator = userPrivacy?.me()?.isCreator ?: false

--- a/app/src/main/java/com/kickstarter/viewmodels/AccountViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/AccountViewModel.kt
@@ -33,6 +33,9 @@ interface AccountViewModel {
         /** Emits when the progress bar should be visible. */
         fun progressBarIsVisible(): Observable<Boolean>
 
+        /** Emits true when the user has a password. (Facebook users don't have passwords). */
+        fun showChangePassword(): Observable<Boolean>
+
         /** Emits a boolean determining when we should show the email error icon. */
         fun showEmailErrorIcon(): Observable<Boolean>
 
@@ -49,6 +52,7 @@ interface AccountViewModel {
 
         private val chosenCurrency = BehaviorSubject.create<String>()
         private val progressBarIsVisible = BehaviorSubject.create<Boolean>()
+        private val showChangePassword = BehaviorSubject.create<Boolean>()
         private val showEmailErrorIcon = BehaviorSubject.create<Boolean>()
         private val success = BehaviorSubject.create<String>()
 
@@ -66,6 +70,10 @@ interface AccountViewModel {
                     .map { ObjectUtils.coalesce(it, CurrencyCode.USD.rawValue()) }
                     .compose(bindToLifecycle())
                     .subscribe { this.chosenCurrency.onNext(it) }
+
+            userPrivacy
+                    .map { showChangePassword(it) }
+                    .subscribe { this.showChangePassword.onNext(it) }
 
             userPrivacy
                     .map { showEmailErrorImage(it) }
@@ -107,10 +115,17 @@ interface AccountViewModel {
             return this.progressBarIsVisible
         }
 
+        override fun showChangePassword(): Observable<Boolean> = this.showChangePassword
+
         override fun showEmailErrorIcon(): Observable<Boolean> = this.showEmailErrorIcon
 
         override fun success(): BehaviorSubject<String> {
             return this.success
+        }
+
+        private fun showChangePassword(userPrivacy: UserPrivacyQuery.Data?) : Boolean?{
+            val hasPassword = userPrivacy?.me()?.hasPassword() ?: false
+            return !hasPassword
         }
 
         private fun showEmailErrorImage(userPrivacy: UserPrivacyQuery.Data?): Boolean? {

--- a/app/src/main/res/layout/activity_account.xml
+++ b/app/src/main/res/layout/activity_account.xml
@@ -55,7 +55,9 @@
               android:layout_gravity="center_vertical"
               android:layout_marginEnd="@dimen/activity_horizontal_margin"
               android:contentDescription="@null"
-              android:src="@drawable/ic_email_error" />
+              android:src="@drawable/ic_email_error"
+              android:visibility="gone"
+              tools:visibility="visible" />
           </LinearLayout>
 
           <TextView

--- a/app/src/main/res/layout/activity_account.xml
+++ b/app/src/main/res/layout/activity_account.xml
@@ -32,8 +32,8 @@
         android:orientation="vertical">
 
         <LinearLayout
+          android:id="@+id/password_required_container"
           style="@style/SettingsLinearRow"
-          android:layout_marginBottom="@dimen/grid_3"
           android:layout_marginTop="@dimen/grid_3">
 
           <LinearLayout
@@ -53,10 +53,8 @@
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_gravity="center_vertical"
-              android:visibility="gone"
               android:layout_marginEnd="@dimen/activity_horizontal_margin"
               android:contentDescription="@null"
-              android:scaleType="centerCrop"
               android:src="@drawable/ic_email_error" />
           </LinearLayout>
 
@@ -68,7 +66,8 @@
         </LinearLayout>
 
         <LinearLayout
-          style="@style/SettingsLinearRow">
+          style="@style/SettingsLinearRow"
+          android:layout_marginTop="@dimen/grid_3">
 
           <TextView
             android:id="@+id/privacy_row"

--- a/app/src/test/java/com/kickstarter/viewmodels/AccountViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AccountViewModelTest.kt
@@ -16,6 +16,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
 
     private val chosenCurrency = TestSubscriber<String>()
     private val error = TestSubscriber<String>()
+    private val showChangePassword = TestSubscriber<Boolean>()
     private val showEmailErrorIcon = TestSubscriber<Boolean>()
     private val success = TestSubscriber<String>()
 
@@ -24,6 +25,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
 
         this.vm.outputs.chosenCurrency().subscribe(this.chosenCurrency)
         this.vm.outputs.error().subscribe(this.error)
+        this.vm.outputs.showChangePassword().subscribe(this.showChangePassword)
         this.vm.outputs.showEmailErrorIcon().subscribe(this.showEmailErrorIcon)
         this.vm.outputs.success().subscribe(this.success)
     }
@@ -33,7 +35,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
             override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                 return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "",
-                        "",  true, true, true, "MXN")))
+                        "",  true, true, true, true, "MXN")))
             }
         }).build())
 
@@ -62,13 +64,14 @@ class AccountViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowEmailErrorIcon() {
+        val hasPassword = true
         val isCreator = true
         val isDeliverable = false
         val isEmailVerified = true
         setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
             override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                 return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "",
-                        "",  isCreator, isDeliverable, isEmailVerified, "MXN")))
+                        "", hasPassword, isCreator, isDeliverable, isEmailVerified, "MXN")))
             }
         }).build())
 
@@ -77,13 +80,14 @@ class AccountViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowEmailErrorIconForBackerUndeliverable() {
+        val hasPassword = true
         val isCreator = false
         val isDeliverable = false
         val isEmailVerified = false
         setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
             override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                 return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "",
-                        "",  isCreator, isDeliverable, isEmailVerified, "MXN")))
+                        "",  hasPassword, isCreator, isDeliverable, isEmailVerified, "MXN")))
             }
         }).build())
 
@@ -92,13 +96,14 @@ class AccountViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowEmailErrorIconGoneForBackerUnverified() {
+        val hasPassword = true
         val isCreator = false
         val isDeliverable = true
         val isEmailVerified = true
         setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
             override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                 return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "",
-                        "",  isCreator, isDeliverable, isEmailVerified, "MXN")))
+                        "", hasPassword, isCreator, isDeliverable, isEmailVerified, "MXN")))
             }
         }).build())
 
@@ -106,14 +111,47 @@ class AccountViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShowEmailErrorIconGoneForBackerDeliverable() {
+    fun testShowChangePassword() {
+        val hasPassword = true
         val isCreator = false
         val isDeliverable = true
         val isEmailVerified = false
         setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
             override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                 return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "",
-                        "",  isCreator, isDeliverable, isEmailVerified, "MXN")))
+                        "", hasPassword, isCreator, isDeliverable, isEmailVerified, "MXN")))
+            }
+        }).build())
+
+        this.showEmailErrorIcon.assertValue(false)
+    }
+
+    @Test
+    fun testShowChangePasswordHidden() {
+        val hasPassword = false
+        val isCreator = false
+        val isDeliverable = true
+        val isEmailVerified = false
+        setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
+            override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
+                return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "",
+                        "", hasPassword, isCreator, isDeliverable, isEmailVerified, "MXN")))
+            }
+        }).build())
+
+        this.showChangePassword.assertValue(true)
+    }
+
+    @Test
+    fun testShowEmailErrorIconGoneForBackerDeliverable() {
+        val hasPassword = true
+        val isCreator = false
+        val isDeliverable = true
+        val isEmailVerified = false
+        setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
+            override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
+                return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "",
+                        "", hasPassword, isCreator, isDeliverable, isEmailVerified, "MXN")))
             }
         }).build())
 
@@ -122,13 +160,14 @@ class AccountViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowEmailErrorIconForCreatorUnverified() {
+        val hasPassword = true
         val isCreator = true
         val isDeliverable = false
         val isEmailVerified = false
         setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
             override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                 return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "",
-                        "",  isCreator, isDeliverable, isEmailVerified, "MXN")))
+                        "",  hasPassword, isCreator, isDeliverable, isEmailVerified, "MXN")))
             }
         }).build())
 

--- a/app/src/test/java/com/kickstarter/viewmodels/AccountViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AccountViewModelTest.kt
@@ -16,7 +16,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
 
     private val chosenCurrency = TestSubscriber<String>()
     private val error = TestSubscriber<String>()
-    private val showChangePassword = TestSubscriber<Boolean>()
+    private val passwordRequiredContainerIsVisible = TestSubscriber<Boolean>()
     private val showEmailErrorIcon = TestSubscriber<Boolean>()
     private val success = TestSubscriber<String>()
 
@@ -25,7 +25,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
 
         this.vm.outputs.chosenCurrency().subscribe(this.chosenCurrency)
         this.vm.outputs.error().subscribe(this.error)
-        this.vm.outputs.showChangePassword().subscribe(this.showChangePassword)
+        this.vm.outputs.passwordRequiredContainerIsVisible().subscribe(this.passwordRequiredContainerIsVisible)
         this.vm.outputs.showEmailErrorIcon().subscribe(this.showEmailErrorIcon)
         this.vm.outputs.success().subscribe(this.success)
     }
@@ -111,7 +111,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShowChangePassword() {
+    fun testPasswordRequiredContainerIsVisible_hasPassword() {
         val hasPassword = true
         val isCreator = false
         val isDeliverable = true
@@ -123,11 +123,11 @@ class AccountViewModelTest : KSRobolectricTestCase() {
             }
         }).build())
 
-        this.showEmailErrorIcon.assertValue(false)
+        this.passwordRequiredContainerIsVisible.assertValue(true)
     }
 
     @Test
-    fun testShowChangePasswordHidden() {
+    fun testPasswordRequiredContainerIsVisible_noPassword() {
         val hasPassword = false
         val isCreator = false
         val isDeliverable = true
@@ -139,7 +139,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
             }
         }).build())
 
-        this.showChangePassword.assertValue(true)
+        this.passwordRequiredContainerIsVisible.assertValue(false)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ChangeEmailViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ChangeEmailViewModelTest.kt
@@ -46,7 +46,7 @@ class ChangeEmailViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
             override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                 return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "",
-                        "rashad@test.com", true, true, true, ""
+                        "rashad@test.com", true,true, true, true, ""
                 )))
             }
         }).build())
@@ -86,7 +86,7 @@ class ChangeEmailViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
             override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                 return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "",
-                        "rashad@test.com", true, true, false, ""
+                        "rashad@test.com", true,true, true, false, ""
                 )))
             }
         }).build())
@@ -103,7 +103,7 @@ class ChangeEmailViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
             override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                 return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "",
-                        "rashad@test.com", true, false, false, ""
+                        "rashad@test.com", true,true, false, false, ""
                 )))
             }
         }).build())
@@ -120,7 +120,7 @@ class ChangeEmailViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
             override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                 return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "",
-                        "rashad@test.com", false, true, true, ""
+                        "rashad@test.com", true,false, true, true, ""
                 )))
             }
         }).build())
@@ -138,7 +138,7 @@ class ChangeEmailViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment().toBuilder().apolloClient(object : MockApolloClient() {
             override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                 return Observable.just(UserPrivacyQuery.Data(UserPrivacyQuery.Me("", "",
-                        "rashad@test.com", true, true, true, ""
+                        "rashad@test.com", true,true, true, true, ""
                 )))
             }
         }).build())


### PR DESCRIPTION
This is another fire collabo between @Rcureton and I.

# what
Users who have logged in with Facebook™ don't have a password. The change email and change password features require a current password. This PR hides those rows from users who don't have a password.

# how
When `user.hasPassword` is false, hide the change email and change password rows.

# see password vs no password
<img src=https://user-images.githubusercontent.com/1289295/49248864-ba65dc00-f3e8-11e8-836a-207ab01b7277.png width=330/> <img src=https://user-images.githubusercontent.com/1289295/49248865-ba65dc00-f3e8-11e8-96fb-b2085ed6ce71.png width=330/>
