### PR TITLE
[UI-Fix] - Settings Currency UI slightly off from designs

### DIFF
--- a/app/src/main/res/layout/activity_account.xml
+++ b/app/src/main/res/layout/activity_account.xml
@@ -110,9 +110,9 @@
             style="@style/Base.Widget.AppCompat.Spinner.Underlined"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/grid_1"
             android:layout_marginEnd="@dimen/activity_horizontal_margin"
-            android:layout_marginStart="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/grid_1">
+            android:layout_marginStart="@dimen/activity_horizontal_margin">
 
           </Spinner>
 


### PR DESCRIPTION
## What ❓
- Fixed the Spinner layout dimens to final specs with @dannyalright. 
- Removed `marginTop` from the spinner and gave it `marginBottom`.

## Story 📖
[Settings Currency UI slightly off from designs](https://trello.com/c/YzUczdZy/1107-settings-currency-ui-slightly-off-from-designs)

## See  👀
<img src=https://user-images.githubusercontent.com/16387538/49594584-28a82280-f944-11e8-88a6-37603b0c9bc2.jpg width=330 />
