### PR TITLE
[UI-Fix] - Settings bottom padding missing

### DIFF
--- a/app/src/main/res/layout/settings_layout.xml
+++ b/app/src/main/res/layout/settings_layout.xml
@@ -139,7 +139,7 @@
       <LinearLayout
         android:id="@+id/rate_us_row"
         style="@style/SettingsLinearRow"
-        android:layout_marginBottom="@dimen/grid_3">
+        android:layout_marginBottom="@dimen/grid_12">
 
         <LinearLayout
           style="@style/SettingsSingleRow"


### PR DESCRIPTION
## What ❓
- Fixed the `Rate us` container dimens to final specs with @dannyalright. 
- gave it `grid_12` `marginBottom`.

## Story 📖
[Settings bottom padding missing](https://trello.com/c/BpDfHKNH/1110-settings-bottom-padding-missing)

## See  👀
<img src=https://user-images.githubusercontent.com/16387538/49610599-0bd41500-f96d-11e8-9cf6-7334588dc875.jpg width=330 />

<img src=https://user-images.githubusercontent.com/16387538/49611479-a7668500-f96f-11e8-9088-1ba4f405775b.png width=330 />
