### PR TITLE
Settings a11y

### DIFF
--- a/app/src/internal/res/layout/internal_tools_button_view.xml
+++ b/app/src/internal/res/layout/internal_tools_button_view.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   android:orientation="vertical"
-  android:layout_width="@dimen/grid_6"
-  android:layout_height="@dimen/grid_6">
+  android:layout_width="@dimen/grid_8"
+  android:layout_height="@dimen/grid_8">
 
   <com.kickstarter.ui.views.IconButton
     android:background="@drawable/click_indicator_light"

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
@@ -40,7 +40,8 @@ class SettingsActivity : BaseActivity<SettingsViewModel.ViewModel>() {
         this.ksString = environment().ksString()
         this.logout = environment().logout()
 
-        version_name_text_view.text = this.build.versionName()
+        version_name_text_view.text = ksString.format(getString(R.string.profile_settings_version_number),
+                "version_number", this.build.versionName())
 
         this.viewModel.outputs.avatarImageViewUrl()
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectNotificationViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectNotificationViewHolder.java
@@ -19,6 +19,7 @@ import butterknife.BindString;
 import butterknife.ButterKnife;
 import rx.android.schedulers.AndroidSchedulers;
 
+import static com.kickstarter.libs.rx.transformers.Transformers.observeForUI;
 import static com.kickstarter.libs.utils.ObjectUtils.requireNonNull;
 
 @RequiresActivityViewModel(ProjectNotificationViewModel.ViewModel.class)
@@ -49,7 +50,7 @@ public final class ProjectNotificationViewHolder extends KSViewHolder {
 
     this.viewModel.outputs.enabledSwitch()
       .compose(bindToLifecycle())
-      .observeOn(AndroidSchedulers.mainThread())
+      .compose(observeForUI())
       .subscribe(SwitchCompatUtils.setCheckedWithoutAnimation(this.enabledSwitch));
 
     this.viewModel.outputs.showUnableToSaveProjectNotificationError()

--- a/app/src/main/res/layout/activity_account.xml
+++ b/app/src/main/res/layout/activity_account.xml
@@ -54,7 +54,7 @@
               android:id="@+id/email_error_icon"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              android:contentDescription="@null"
+              android:contentDescription="@string/Email_unverified"
               android:scaleType="centerCrop"
               android:src="@drawable/ic_email_error"
               android:visibility="gone"

--- a/app/src/main/res/layout/activity_newsletter.xml
+++ b/app/src/main/res/layout/activity_newsletter.xml
@@ -35,7 +35,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 
@@ -57,7 +57,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 
@@ -82,7 +82,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 

--- a/app/src/main/res/layout/activity_newsletter.xml
+++ b/app/src/main/res/layout/activity_newsletter.xml
@@ -106,7 +106,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 
@@ -130,7 +130,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 
@@ -154,7 +154,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 
@@ -178,7 +178,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 
@@ -203,7 +203,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 
@@ -227,7 +227,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 
@@ -251,7 +251,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 
@@ -275,7 +275,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 

--- a/app/src/main/res/layout/activity_privacy.xml
+++ b/app/src/main/res/layout/activity_privacy.xml
@@ -52,7 +52,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 
@@ -76,7 +76,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 
@@ -101,7 +101,7 @@
 
         <LinearLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_10"
+          android:layout_height="wrap_content"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 

--- a/app/src/main/res/layout/project_notification_settings_layout.xml
+++ b/app/src/main/res/layout/project_notification_settings_layout.xml
@@ -1,17 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="vertical"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-  <include layout="@layout/project_notification_settings_toolbar"/>
+  <android.support.design.widget.AppBarLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <include layout="@layout/project_notification_settings_toolbar" />
+
+  </android.support.design.widget.AppBarLayout>
 
   <android.support.v7.widget.RecyclerView
     android:id="@+id/project_notification_settings_recycler_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginStart="@dimen/form_margin_x"
-    android:layout_marginEnd="@dimen/form_margin_x"/>
+    tools:listitem="@layout/project_notification_view" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/project_notification_view.xml
+++ b/app/src/main/res/layout/project_notification_view.xml
@@ -1,32 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="vertical"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="wrap_content">
+  android:layout_height="wrap_content"
+  android:gravity="center_vertical"
+  android:orientation="horizontal"
+  android:padding="@dimen/activity_vertical_margin">
 
-  <RelativeLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+  <TextView
+    android:id="@+id/project_name"
+    style="@style/TextPrimary"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="@dimen/activity_vertical_margin"
+    android:layout_weight="1"
+    tools:text="A Project With A Really Long Title: You Should Back It" />
 
-    <TextView
-      android:id="@+id/project_name"
-      style="@style/BodyPrimary"
-      android:ellipsize="end"
-      android:layout_toStartOf="@+id/enabled_switch"
-      android:layout_marginEnd="@dimen/grid_2"
-      android:maxLines="1"
-      android:paddingTop="@dimen/feed_padding_y"
-      android:paddingBottom="@dimen/feed_padding_y"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content" />
-
-    <android.support.v7.widget.SwitchCompat
-      android:id="@+id/enabled_switch"
-      style="@style/EndSettingsWidget"/>
-
-  </RelativeLayout>
-
-  <include layout="@layout/horizontal_line_1dp_view"/>
+  <android.support.v7.widget.SwitchCompat
+    android:id="@+id/enabled_switch"
+    style="@style/EndSettingsWidget"
+    android:layout_height="wrap_content" />
 
 </LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -211,7 +211,7 @@
   <style name="EndSettingsWidgetBase">
     <item name="android:layout_centerVertical">true</item>
     <item name="android:textSize">@dimen/settings_icon</item>
-    <item name="android:layout_height">wrap_content</item>
+    <item name="android:layout_height">match_parent</item>
     <item name="android:layout_width">wrap_content</item>
     <item name="android:gravity">center</item>
     <item name="android:layout_alignParentRight">true</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -211,7 +211,7 @@
   <style name="EndSettingsWidgetBase">
     <item name="android:layout_centerVertical">true</item>
     <item name="android:textSize">@dimen/settings_icon</item>
-    <item name="android:layout_height">match_parent</item>
+    <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_width">wrap_content</item>
     <item name="android:gravity">center</item>
     <item name="android:layout_alignParentRight">true</item>


### PR DESCRIPTION
# what
### A naive accessibility sweep of settings
**Touch target size:**
-Drawer buttons

**Fixed large text cut off:**
-Privacy rows
-Newsletters rows

**Voice over:**
-Added accessibility label for the undeliverable warning icon
-Added copy for version

**UX:**
Project notifications - (Went off the rails because Danny is busy 😅)removed divider, allowed multiline text and fixed bug with delayed switches.

Before vs After
<img src=https://user-images.githubusercontent.com/1289295/49661613-7f326100-fa17-11e8-8a78-4b89b04d3d7a.png width=330/> <img src=https://user-images.githubusercontent.com/1289295/49661612-7f326100-fa17-11e8-8e65-38e7f71ee08f.png width=330/>

# why
|￣￣￣￣￣￣ |
|&nbsp;   &nbsp;   say NO to&nbsp;   &nbsp;  |
|&nbsp;&nbsp;  hardcoded&nbsp;&nbsp;  |
|&nbsp;   &nbsp;  &nbsp;   heights&nbsp;   &nbsp;  &nbsp;   |
| ＿＿＿＿＿__|
(\ __/) ||
(•ㅅ•) ||
/ 　 づ

Hardcoding a height causes text to be cut off