### PR TITLE
[bug?] Filtering null currencies because it causes a crash on Account screen.

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/AccountViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/AccountViewModel.kt
@@ -90,6 +90,7 @@ interface AccountViewModel {
             updateCurrencyNotification
                     .compose(values())
                     .map { it.updateUserProfile()?.user()?.chosenCurrency() }
+                    .filter { ObjectUtils.isNotNull(it) }
                     .subscribe {
                         this.chosenCurrency.onNext(it)
                         this.success.onNext(it)


### PR DESCRIPTION
# what
I was testing this [PR](https://github.com/kickstarter/kickstarter/pull/13556#pullrequestreview-182861708) and got my user in a weird state where the chosen currency was returned as null. This causes a crash.

# how
Filtering the result of `UpdateUserCurrency` mutation because the value it returns is optional.