### PR TITLE
[Fix] - added Maven url for exoplayer failure in circleCi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ allprojects {
         maven {
             url 'https://oss.sonatype.org/content/repositories/snapshots/'
         }
+        maven { url 'https://dl.bintray.com/google/exoplayer' }
     }
 }
 


### PR DESCRIPTION
## What
- There's an issue with retrieving Exoplayer from Maven so this fixes the build issues we're currently having.