### PR TITLE
Showing categories on thanks page

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/ProjectUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ProjectUtils.java
@@ -3,6 +3,7 @@ package com.kickstarter.libs.utils;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Pair;
 import android.view.View;
 import android.widget.Button;
 
@@ -10,12 +11,24 @@ import com.kickstarter.R;
 import com.kickstarter.libs.KSString;
 import com.kickstarter.models.Project;
 import com.kickstarter.models.User;
+import com.kickstarter.services.DiscoveryParams;
 
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public final class ProjectUtils {
   private ProjectUtils() {}
+
+  public static List<Pair<Project, DiscoveryParams>> combineProjectsAndParams(final @NonNull List<Project> projects, final @NonNull DiscoveryParams params) {
+    final ArrayList<Pair<Project, DiscoveryParams>> projectAndParams = new ArrayList<>(projects.size());
+    for (int i = 0; i < projects.size(); i++) {
+      projectAndParams.add(Pair.create(projects.get(i), params));
+    }
+    return projectAndParams;
+  }
 
   /**
    * Returns time until project reaches deadline along with the unit,

--- a/app/src/main/java/com/kickstarter/ui/adapters/ThanksAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/ThanksAdapter.java
@@ -5,6 +5,8 @@ import android.support.annotation.NonNull;
 import android.view.View;
 
 import com.kickstarter.R;
+import com.kickstarter.libs.utils.ProjectUtils;
+import com.kickstarter.services.DiscoveryParams;
 import com.kickstarter.ui.adapters.data.ThanksData;
 import com.kickstarter.ui.viewholders.EmptyViewHolder;
 import com.kickstarter.ui.viewholders.KSViewHolder;
@@ -55,7 +57,7 @@ public final class ThanksAdapter extends KSAdapter {
 
   public void takeData(final @NonNull ThanksData data) {
     setSection(SECTION_SHARE_VIEW, Collections.singletonList(data.getBackedProject()));
-    setSection(SECTION_RECOMMENDED_PROJECTS_VIEW, data.getRecommendedProjects());
+    setSection(SECTION_RECOMMENDED_PROJECTS_VIEW, ProjectUtils.combineProjectsAndParams(data.getRecommendedProjects(), DiscoveryParams.builder().build()));
     setSection(SECTION_CATEGORY_VIEW, Collections.singletonList(data.getCategory()));
     notifyDataSetChanged();
   }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -15,6 +15,7 @@ import com.kickstarter.libs.utils.BooleanUtils;
 import com.kickstarter.libs.utils.DiscoveryUtils;
 import com.kickstarter.libs.utils.ListUtils;
 import com.kickstarter.libs.utils.ObjectUtils;
+import com.kickstarter.libs.utils.ProjectUtils;
 import com.kickstarter.libs.utils.RefTagUtils;
 import com.kickstarter.libs.utils.UserUtils;
 import com.kickstarter.models.Activity;
@@ -143,7 +144,7 @@ public interface DiscoveryFragmentViewModel {
 
       Observable.combineLatest(projects,
         selectedParams.distinctUntilChanged(),
-        this::combineProjectsAndParams)
+        ProjectUtils::combineProjectsAndParams)
         .compose(bindToLifecycle())
         .subscribe(this.projectList);
 

--- a/app/src/test/java/com/kickstarter/libs/utils/ProjectUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/ProjectUtilsTest.java
@@ -1,14 +1,28 @@
 package com.kickstarter.libs.utils;
 
+import android.util.Pair;
+
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.mock.factories.ProjectFactory;
 import com.kickstarter.mock.factories.UserFactory;
 import com.kickstarter.models.Project;
+import com.kickstarter.services.DiscoveryParams;
 
 import org.joda.time.DateTime;
 import org.junit.Test;
 
+import java.util.Collections;
+
 public final class ProjectUtilsTest extends KSRobolectricTestCase {
+
+  @Test
+  public void testCombineProjectsAndParams() {
+    final Project project = ProjectFactory.project();
+    final DiscoveryParams discoveryParams = DiscoveryParams.builder().build();
+    assertEquals(ProjectUtils.combineProjectsAndParams(Collections.singletonList(project), discoveryParams),
+      Collections.singletonList(Pair.create(project, discoveryParams)));
+  }
+
   @Test
   public void testIsCompleted() {
     assertTrue(ProjectUtils.isCompleted(ProjectFactory.successfulProject()));


### PR DESCRIPTION
# What ❓
Showing categories on thanks page.
Moved `combineProjectsAndParams` to `ProjectUtils` because it is now used in 2 places: Discovery and Thanks.
Added a test.

# Story 📖
Very Popular™ non-fatal that I missed because I usually look at crashes here: https://fabric.io/kickstarter2/android/apps/com.kickstarter.kickstarter/issues/5c00af84f8b88c2963f42498?time=last-seven-days

# See 👀
<img src=https://user-images.githubusercontent.com/1289295/50175265-538e6100-02ca-11e9-8a4e-15626a84e402.png width=330/>

