### PR TITLE
[UI] Snackbar style update

### DIFF
--- a/app/src/main/java/com/kickstarter/extensions/SnackbarExt.kt
+++ b/app/src/main/java/com/kickstarter/extensions/SnackbarExt.kt
@@ -44,8 +44,8 @@ fun Snackbar.setTextColor(colorId: Int): Snackbar {
     return this
 }
 
-fun Snackbar.style(gravity: Int, textColorId: Int, backgroundId: Int) {
+fun Snackbar.style(gravity: Int, textColorId: Int, backgroundColorId: Int) {
     setTextGravity(gravity)
     setTextColor(textColorId)
-    setBackgroundColor(backgroundId)
+    setBackgroundColor(backgroundColorId)
 }

--- a/app/src/main/java/com/kickstarter/extensions/SnackbarExt.kt
+++ b/app/src/main/java/com/kickstarter/extensions/SnackbarExt.kt
@@ -1,46 +1,37 @@
 package com.kickstarter.extensions
 
 import android.view.Gravity
-import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import com.google.android.material.snackbar.Snackbar
 import com.kickstarter.R
 
 fun Snackbar.confirmation(): Snackbar {
-    style(true, Gravity.CENTER, R.color.white, R.drawable.bg_snackbar_confirmation)
+    style(Gravity.CENTER, R.color.white, R.color.ksr_cobalt_500)
     return this
 }
 
 fun Snackbar.error(): Snackbar {
-    style(true, Gravity.CENTER, R.color.ksr_soft_black, R.drawable.bg_snackbar_error)
+    style( Gravity.CENTER, R.color.ksr_soft_black, R.color.ksr_apricot_500)
     return this
 }
 
 fun Snackbar.headsUp(): Snackbar {
-    style(true, Gravity.CENTER, R.color.ksr_teal_500, R.drawable.bg_snackbar_heads_up)
+    style(Gravity.CENTER, R.color.ksr_teal_500, R.color.ksr_soft_black)
     return this
 }
 
 fun Snackbar.networkError(): Snackbar {
-    style(true, Gravity.CENTER, R.color.ksr_soft_black, R.drawable.bg_snackbar_network_error)
+    style(Gravity.CENTER, R.color.ksr_soft_black, R.color.ksr_teal_500)
     return this
-}
-
-fun Snackbar.adjustMargins() {
-    val params = this.view.layoutParams as ViewGroup.MarginLayoutParams
-    val grid1 = context.resources.getDimensionPixelSize(R.dimen.grid_1)
-    val grid2 = context.resources.getDimensionPixelSize(R.dimen.grid_2)
-    params.setMargins(grid1, 0, grid1, grid2)
-    this.view.layoutParams = params
 }
 
 private fun Snackbar.getTextView(): TextView {
     return view.findViewById(com.google.android.material.R.id.snackbar_text) as TextView
 }
 
-private fun Snackbar.setBackground(backgroundId: Int) {
-    this.view.background = ContextCompat.getDrawable(context, backgroundId)
+private fun Snackbar.setBackgroundColor(backgroundColor: Int) {
+    this.view.setBackgroundColor(ContextCompat.getColor(context, backgroundColor))
 }
 
 fun Snackbar.setTextGravity(gravity: Int): Snackbar {
@@ -53,11 +44,8 @@ fun Snackbar.setTextColor(colorId: Int): Snackbar {
     return this
 }
 
-fun Snackbar.style(adjustMargins: Boolean, gravity: Int, textColorId: Int, backgroundId: Int) {
-    when {
-        adjustMargins -> adjustMargins()
-    }
+fun Snackbar.style(gravity: Int, textColorId: Int, backgroundId: Int) {
     setTextGravity(gravity)
     setTextColor(textColorId)
-    setBackground(backgroundId)
+    setBackgroundColor(backgroundId)
 }

--- a/app/src/main/res/drawable/bg_snackbar_confirmation.xml
+++ b/app/src/main/res/drawable/bg_snackbar_confirmation.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-  android:shape="rectangle">
-  <solid android:color="@color/ksr_cobalt_500" />
-  <corners android:radius="@dimen/grid_1" />
-</shape>

--- a/app/src/main/res/drawable/bg_snackbar_error.xml
+++ b/app/src/main/res/drawable/bg_snackbar_error.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-  android:shape="rectangle">
-  <solid android:color="@color/ksr_apricot_500" />
-  <corners android:radius="@dimen/grid_1" />
-</shape>

--- a/app/src/main/res/drawable/bg_snackbar_heads_up.xml
+++ b/app/src/main/res/drawable/bg_snackbar_heads_up.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-  android:shape="rectangle">
-  <solid android:color="@color/ksr_soft_black" />
-  <corners android:radius="@dimen/grid_1" />
-</shape>

--- a/app/src/main/res/drawable/bg_snackbar_network_error.xml
+++ b/app/src/main/res/drawable/bg_snackbar_network_error.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-  android:shape="rectangle">
-  <solid android:color="@color/ksr_teal_500" />
-  <corners android:radius="@dimen/grid_1" />
-</shape>


### PR DESCRIPTION
# What ❓
Removing rounded corners and margin from Snackbars because they were all forced to the bottom in API 28.

# Story 📖
[Update Snackbar Styles](https://trello.com/c/ZgWvg0ok/1151-update-snackbar-styles)

# B4 & After 👀

<img src=https://user-images.githubusercontent.com/1289295/50842373-89a48b00-1334-11e9-910d-88fab4c01537.png width=330/> <img src=https://user-images.githubusercontent.com/1289295/50842384-91642f80-1334-11e9-9ae1-d62df6a21b8e.png width=330/>
