### PR TITLE
Ensure that only supported locales are downloaded from the config

### DIFF
--- a/lib/milkrun/i18n_string_resources.rb
+++ b/lib/milkrun/i18n_string_resources.rb
@@ -2,6 +2,8 @@ require "cgi"
 
 module Milkrun
   class I18nStringResources
+    SUPPORTED_LOCALES = %w(de en es fr ja)
+
     def create
       locales.each do |country_code, translations|
         File.open(resource_path(country_code), 'w') do |f|
@@ -50,7 +52,7 @@ module Milkrun
     end
 
     def locales
-      @locales ||= config["locales"]
+      @locales ||= config["locales"].select { |locale, _| SUPPORTED_LOCALES.include?(locale) }
     end
 
     def resource_path(country_code)


### PR DESCRIPTION
# What ❓

Like the title - we only want to download localizations for the locales that we currently support in the app.

# Story 📖

When new languages are supported on the web these locales are automatically returned in the config. We don't yet want to have these strings downloaded locally until we know we're supporting them in the app so this just allows us to filter based on what we know we support.

Thanks @pcreux for the Ruby tips.

# See 👀

https://trello.com/c/WqK6zXfF/655-filter-for-supported-languages