### PR TITLE
[Bug Fix] - Android 8 + Samsung orientation theme fix

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
 
     <!-- ACTIVITIES -->
 
-    <activity android:name=".ui.activities.AccountActivity" />
+    <activity android:name=".ui.activities.AccountActivity"
+      android:theme="@style/SettingsActivitiesTransitions"/>
     <activity
       android:name=".ui.activities.ActivityFeedActivity"
       android:parentActivityName=".ui.activities.DiscoveryActivity"
@@ -38,8 +39,10 @@
         android:name="android.support.PARENT_ACTIVITY"
         android:value=".ui.activities.DiscoveryActivity" />
     </activity>
-    <activity android:name=".ui.activities.ChangeEmailActivity" />
-    <activity android:name=".ui.activities.ChangePasswordActivity"/>
+    <activity android:name=".ui.activities.ChangeEmailActivity"
+      android:theme="@style/SettingsActivitiesTransitions"/>
+    <activity android:name=".ui.activities.ChangePasswordActivity"
+      android:theme="@style/SettingsActivitiesTransitions"/>
     <activity android:name=".ui.activities.EditProfileActivity"/>
     <activity
       android:name=".ui.activities.CheckoutActivity"
@@ -133,7 +136,8 @@
     <activity
       android:name=".ui.activities.HelpActivity"
       android:theme="@style/HelpActivity" />
-    <activity android:name=".ui.activities.HelpSettingsActivity" />
+    <activity android:name=".ui.activities.HelpSettingsActivity"
+      android:theme="@style/SettingsActivitiesTransitions"/>
     <activity
       android:name=".ui.activities.HelpActivity$CookiePolicy"
       android:theme="@style/HelpActivity" />
@@ -189,9 +193,12 @@
         android:name="android.support.PARENT_ACTIVITY"
         android:value=".ui.activities.ProfileActivity" />
     </activity>
-    <activity android:name=".ui.activities.NewsletterActivity" />
-    <activity android:name=".ui.activities.NotificationsActivity" />
-    <activity android:name=".ui.activities.PrivacyActivity" />
+    <activity android:name=".ui.activities.NewsletterActivity"
+      android:theme="@style/SettingsActivitiesTransitions"/>
+    <activity android:name=".ui.activities.NotificationsActivity"
+      android:theme="@style/SettingsActivitiesTransitions"/>
+    <activity android:name=".ui.activities.PrivacyActivity"
+      android:theme="@style/SettingsActivitiesTransitions"/>
     <activity
       android:name=".ui.activities.ProjectNotificationSettingsActivity"
       android:parentActivityName=".ui.activities.SettingsActivity">

--- a/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.java
@@ -57,7 +57,6 @@ public final class VideoActivity extends BaseActivity<VideoViewModel.ViewModel> 
       .compose(Transformers.takeWhen(lifecycle().filter(ActivityEvent.RESUME::equals)))
       .compose(bindToLifecycle())
       .subscribe(this::preparePlayer);
-
   }
 
   @Override

--- a/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.java
@@ -1,7 +1,6 @@
 package com.kickstarter.ui.activities;
 
 import android.annotation.TargetApi;
-import android.content.pm.ActivityInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
@@ -59,9 +58,6 @@ public final class VideoActivity extends BaseActivity<VideoViewModel.ViewModel> 
       .compose(bindToLifecycle())
       .subscribe(this::preparePlayer);
 
-    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) {
-      setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-    }
   }
 
   @Override

--- a/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.java
@@ -1,6 +1,7 @@
 package com.kickstarter.ui.activities;
 
 import android.annotation.TargetApi;
+import android.content.pm.ActivityInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
@@ -57,6 +58,10 @@ public final class VideoActivity extends BaseActivity<VideoViewModel.ViewModel> 
       .compose(Transformers.takeWhen(lifecycle().filter(ActivityEvent.RESUME::equals)))
       .compose(bindToLifecycle())
       .subscribe(this::preparePlayer);
+
+    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) {
+      setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+    }
   }
 
   @Override

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -16,7 +16,6 @@
     <item name="android:windowNoTitle">true</item>
     <item name="android:windowActionBar">false</item>
     <item name="android:windowAnimationStyle">@null</item>
-    <item name="android:windowIsTranslucent">true</item>
 
     <item name="colorPrimary">@color/primary</item>
     <item name="colorPrimaryDark">@color/primary_dark</item>
@@ -59,6 +58,10 @@
 
   <style name="SearchActivity" parent="KSTheme">
     <item name="android:windowBackground">@color/white</item>
+  </style>
+
+  <style name="SettingsActivitiesTransitions" parent="KSTheme">
+    <item name="android:windowIsTranslucent">true</item>
   </style>
 
   <style name="ThanksActivity" parent="KSTheme">

--- a/fastlane/report.xml
+++ b/fastlane/report.xml
@@ -5,27 +5,27 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: Verifying fastlane version" time="0.027066">
+      <testcase classname="fastlane.lanes" name="0: Verifying fastlane version" time="0.015451">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: default_platform" time="0.002332">
+      <testcase classname="fastlane.lanes" name="1: default_platform" time="0.001874">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="2: build_android_app" time="163.898236">
+      <testcase classname="fastlane.lanes" name="2: build_android_app" time="77.769442">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="3: crashlytics" time="2.683406">
+      <testcase classname="fastlane.lanes" name="3: crashlytics" time="2.59525">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="4: slack" time="0.321022">
+      <testcase classname="fastlane.lanes" name="4: slack" time="0.476255">
         
       </testcase>
     


### PR DESCRIPTION
# What ❓

- So with the adoption of `Android 8` we can't change the orientation for an `Activity` that has a translucent background according to several [stackoverflow](https://stackoverflow.com/a/50832408) posts. The crash was occurring in the `VideoActivity` where the screen changes from `portrait` to `landscape` and since our overall theme had the `<item name="android:windowIsTranslucent">true</item>` it was crashing on Samsung devices and some other devices running `Android 8`. So to fix this issue I removed the `<item name="android:windowIsTranslucent">true</item>` from the main parent theme and created a style for the activities in `Settings` where we're using this attribute to remove the black background during activity transitions. 

- `ChangePassword`,`ChangeEmail`, `Notifications`, `Newsletters`, `Privacy`, `Account`, `Help`

# Story 📖

[Android 8 orientation fix](https://trello.com/c/4LiHQD34/1170-android-8-orientation-crash)

# See 👀
![vid](https://user-images.githubusercontent.com/16387538/51344338-6aa9a580-1a66-11e9-8b76-6d687a897d74.gif)
![jan-17-2019 14-45-19](https://user-images.githubusercontent.com/16387538/51344393-8b71fb00-1a66-11e9-95ab-cbf1b3b7e6bb.gif)






