### PR TITLE
[⚙️] Docker image update for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 base_job: &base_job
   resource_class: xlarge
   docker:
-    - image: circleci/android:api-27-alpha
+    - image: circleci/android:api-28-alpha
   working_directory: '~/project'
   environment:
     TERM: dumb


### PR DESCRIPTION
# What ❓
We're targeting API 28, our Docker image needs those libraries.

