### PR TITLE
[🐛] Koala timestamps

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/KoalaTrackingClient.java
+++ b/app/src/main/java/com/kickstarter/libs/KoalaTrackingClient.java
@@ -153,7 +153,7 @@ public final class KoalaTrackingClient extends TrackingClientType {
 
   @Override
   protected Long time() {
-    return System.currentTimeMillis();
+    return System.currentTimeMillis() / 1000;
   }
 
   @Override

--- a/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
+++ b/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
@@ -21,13 +21,12 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.multidex.ShadowMultiDex;
 
 import androidx.annotation.NonNull;
 import rx.observers.TestSubscriber;
 
 @RunWith(KSRobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, shadows = ShadowMultiDex.class, sdk = KSRobolectricGradleTestRunner.DEFAULT_SDK)
+@Config(constants = BuildConfig.class, shadows = ShadowAndroidXMultiDex.class, sdk = KSRobolectricGradleTestRunner.DEFAULT_SDK)
 public abstract class KSRobolectricTestCase extends TestCase {
   private TestKSApplication application;
   public TestSubscriber<String> koalaTest;

--- a/app/src/test/java/com/kickstarter/ShadowAndroidXMultiDex.kt
+++ b/app/src/test/java/com/kickstarter/ShadowAndroidXMultiDex.kt
@@ -1,0 +1,14 @@
+package com.kickstarter
+
+import android.content.Context
+import androidx.multidex.MultiDex
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+
+@Implements(MultiDex::class)
+object ShadowAndroidXMultiDex{
+
+    @JvmStatic
+    @Implementation
+    fun install(context: Context) {}
+}

--- a/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
@@ -243,7 +243,7 @@ class KoalaTest : KSRobolectricTestCase() {
         assertEquals("android", expectedProperties["mp_lib"])
         assertEquals("Android", expectedProperties["os"])
         assertEquals("9", expectedProperties["os_version"])
-        assertEquals(DateTime.parse("2018-11-02T18:42:05Z").millis, expectedProperties["time"])
+        assertEquals(DateTime.parse("2018-11-02T18:42:05Z").millis / 1000, expectedProperties["time"])
         assertEquals(user != null, expectedProperties["user_logged_in"])
     }
 

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -12,7 +12,7 @@ import rx.Observable;
 import rx.subjects.PublishSubject;
 
 public final class MockTrackingClient extends TrackingClientType {
-  private static final long DEFAULT_TIME = DateTime.parse("2018-11-02T18:42:05Z").getMillis();
+  private static final long DEFAULT_TIME = DateTime.parse("2018-11-02T18:42:05Z").getMillis() / 1000;
   @Nullable private User loggedInUser;
 
 


### PR DESCRIPTION
# What ❓
Sending koala timestamp in seconds vs millis. Updated tests. Changed Roboloectric MultiDex shadows to support AndroidX.

# Story 📖
The Android app is currently in the future and we need to bring it back to the present. Our timestamps are expected in seconds vs millis.

# See 👀
Nothing to see here!

# shout-out
Thank you @abelsonlive for helping me out and knowing where to look 💡 