### PR TITLE
[🚮] Removing deprecated calls to pipeErrorsTo in Reset Password

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
@@ -3,107 +3,125 @@ package com.kickstarter.viewmodels
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.rx.transformers.Transformers
+import com.kickstarter.libs.rx.transformers.Transformers.errors
+import com.kickstarter.libs.rx.transformers.Transformers.values
+import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.StringUtils
 import com.kickstarter.models.User
 import com.kickstarter.services.ApiClientType
 import com.kickstarter.services.apiresponses.ErrorEnvelope
 import com.kickstarter.ui.activities.ResetPasswordActivity
+import rx.Notification
 import rx.Observable
 import rx.subjects.PublishSubject
 
 interface ResetPasswordViewModel {
 
-  interface Inputs {
-    /** Call when the email field changes. */
-    fun email(emailInput: String)
+    interface Inputs {
+        /** Call when the email field changes. */
+        fun email(emailInput: String)
 
-    /** Call when the reset password button is clicked. */
-    fun resetPasswordClick()
-  }
-
-  interface Outputs {
-    /** Emits a boolean that determines if the form is in the progress of being submitted. */
-    fun isFormSubmitting(): Observable<Boolean>
-
-    /** Emits a boolean that determines if the form validation is passing. */
-    fun isFormValid(): Observable<Boolean>
-
-    /** Emits when password reset is completed successfully. */
-    fun resetSuccess(): Observable<Void>
-
-    /** Emits when password reset fails. */
-    fun resetError(): Observable<String>
-  }
-
-  class ViewModel(val environment: Environment) : ActivityViewModel<ResetPasswordActivity>(environment), Inputs, Outputs {
-    private val client: ApiClientType = environment.apiClient()
-
-    private val email = PublishSubject.create<String>()
-    private val resetPasswordClick = PublishSubject.create<Void>()
-
-    private val isFormSubmitting = PublishSubject.create<Boolean>()
-    private val isFormValid = PublishSubject.create<Boolean>()
-    private val resetSuccess = PublishSubject.create<Void>()
-    private val resetError = PublishSubject.create<ErrorEnvelope>()
-
-    val inputs: Inputs = this
-    val outputs: Outputs = this
-
-    init {
-      this.email
-        .map(StringUtils::isEmail)
-        .compose(bindToLifecycle())
-        .subscribe(this.isFormValid)
-
-      this.email
-        .compose<String>(Transformers.takeWhen(this.resetPasswordClick))
-        .switchMap(this::submitEmail)
-        .compose(bindToLifecycle())
-        .subscribe { success() }
-
-      this.resetError
-        .compose(bindToLifecycle())
-        .subscribe { this.koala.trackResetPasswordError() }
-
-      this.resetSuccess
-        .compose(bindToLifecycle())
-        .subscribe { this.koala.trackResetPasswordSuccess() }
-
-      this.koala.trackResetPasswordFormView()
+        /** Call when the reset password button is clicked. */
+        fun resetPasswordClick()
     }
 
-    private fun success() {
-      this.resetSuccess.onNext(null)
+    interface Outputs {
+        /** Emits a boolean that determines if the form is in the progress of being submitted. */
+        fun isFormSubmitting(): Observable<Boolean>
+
+        /** Emits a boolean that determines if the form validation is passing. */
+        fun isFormValid(): Observable<Boolean>
+
+        /** Emits when password reset is completed successfully. */
+        fun resetSuccess(): Observable<Void>
+
+        /** Emits when password reset fails. */
+        fun resetError(): Observable<String>
     }
 
-    private fun submitEmail(email: String) : Observable<User> {
-      return this.client.resetPassword(email)
-        .compose(Transformers.pipeApiErrorsTo(this.resetError))
-        .compose(Transformers.neverError())
-        .doOnSubscribe { this.isFormSubmitting.onNext(true) }
-        .doAfterTerminate { this.isFormSubmitting.onNext(false) }
-    }
+    class ViewModel(val environment: Environment) : ActivityViewModel<ResetPasswordActivity>(environment), Inputs, Outputs {
+        private val client: ApiClientType = environment.apiClient()
 
-    override fun email(emailInput: String) {
-      this.email.onNext(emailInput)
-    }
-    override fun resetPasswordClick() {
-      this.resetPasswordClick.onNext(null)
-    }
+        private val email = PublishSubject.create<String>()
+        private val resetPasswordClick = PublishSubject.create<Void>()
 
-    override fun isFormSubmitting(): Observable<Boolean> {
-      return this.isFormSubmitting
+        private val isFormSubmitting = PublishSubject.create<Boolean>()
+        private val isFormValid = PublishSubject.create<Boolean>()
+        private val resetSuccess = PublishSubject.create<Void>()
+        private val resetError = PublishSubject.create<ErrorEnvelope>()
+
+        val inputs: Inputs = this
+        val outputs: Outputs = this
+
+        init {
+            this.email
+                    .map(StringUtils::isEmail)
+                    .compose(bindToLifecycle())
+                    .subscribe(this.isFormValid)
+
+            val resetPasswordNotification = this.email
+                    .compose<String>(Transformers.takeWhen(this.resetPasswordClick))
+                    .switchMap(this::submitEmail)
+
+            resetPasswordNotification
+                    .compose(values())
+                    .compose(bindToLifecycle())
+                    .subscribe { success() }
+
+            resetPasswordNotification
+                    .compose(errors())
+                    .map { ErrorEnvelope.fromThrowable(it) }
+                    .filter { ObjectUtils.isNotNull(it) }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.resetError)
+
+            this.resetError
+                    .compose(bindToLifecycle())
+                    .subscribe { this.koala.trackResetPasswordError() }
+
+            this.resetSuccess
+                    .compose(bindToLifecycle())
+                    .subscribe { this.koala.trackResetPasswordSuccess() }
+
+            this.koala.trackResetPasswordFormView()
+        }
+
+        private fun success() {
+            this.resetSuccess.onNext(null)
+        }
+
+        private fun submitEmail(email: String): Observable<Notification<User>> {
+            return this.client.resetPassword(email)
+                    .doOnSubscribe { this.isFormSubmitting.onNext(true) }
+                    .doAfterTerminate { this.isFormSubmitting.onNext(false) }
+                    .materialize()
+                    .share()
+        }
+
+        override fun email(emailInput: String) {
+            this.email.onNext(emailInput)
+        }
+
+        override fun resetPasswordClick() {
+            this.resetPasswordClick.onNext(null)
+        }
+
+        override fun isFormSubmitting(): Observable<Boolean> {
+            return this.isFormSubmitting
+        }
+
+        override fun isFormValid(): Observable<Boolean> {
+            return this.isFormValid
+        }
+
+        override fun resetSuccess(): Observable<Void> {
+            return this.resetSuccess
+        }
+
+        override fun resetError(): Observable<String> {
+            return this.resetError
+                    .takeUntil(this.resetSuccess)
+                    .map { it.errorMessage() }
+        }
     }
-    override fun isFormValid(): Observable<Boolean> {
-      return this.isFormValid
-    }
-    override fun resetSuccess(): Observable<Void> {
-      return this.resetSuccess
-    }
-    override fun resetError(): Observable<String> {
-      return this.resetError
-        .takeUntil(this.resetSuccess)
-        .map { it.errorMessage() }
-    }
-  }
 }


### PR DESCRIPTION
# What ❓
`Transformers.pipeErrorsTo` is deprecated. Instead, we should use `Observable.materialize` and handle the error state and the values state.
Removed deprecated call and changed file spacing for 2 to 4.

# how to test ⁉️ 
Reset password screen successfully:

- [ ] resets password
- [ ] handles a reset attempt made when a user is offline

![image](https://user-images.githubusercontent.com/1289295/51773977-a8d64300-20be-11e9-8897-d258841bd3b9.png)


