### PR TITLE
[🚮] Removing deprecated calls to pipeErrorsTo in Privacy

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/PrivacyActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/PrivacyActivity.kt
@@ -50,16 +50,16 @@ class PrivacyActivity : BaseActivity<PrivacyViewModel.ViewModel>() {
         this.viewModel.outputs.user()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({ this.displayPreferences(it) })
+                .subscribe { this.displayPreferences(it) }
 
         this.viewModel.outputs.hidePrivateProfileRow()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe( {
+                .subscribe {
                     ViewUtils.setGone(private_profile_row, it)
                     ViewUtils.setGone(private_profile_text_view, it)
                     ViewUtils.setGone(public_profile_text_view, it)
-                })
+                }
 
         following_switch.setOnClickListener { this.viewModel.inputs.optIntoFollowing(following_switch.isChecked) }
         private_profile_switch.setOnClickListener { this.viewModel.inputs.showPublicProfile(private_profile_switch.isChecked) }
@@ -83,7 +83,7 @@ class PrivacyActivity : BaseActivity<PrivacyViewModel.ViewModel>() {
                     .setTitle(getString(R.string.Are_you_sure))
                     .setMessage(getString(R.string.If_you_turn_following_off))
                     .setNegativeButton(this.cancelString) { _, _ -> this.viewModel.inputs.optOutOfFollowing(false) }
-                    .setPositiveButton(this.yesTurnOffString, { _, _ -> this.viewModel.inputs.optOutOfFollowing(true) })
+                    .setPositiveButton(this.yesTurnOffString) { _, _ -> this.viewModel.inputs.optOutOfFollowing(true) }
                     .create()
         }
         return this.followingConfirmationDialog!!


### PR DESCRIPTION
# What ❓
`Transformers.pipeErrorsTo` is deprecated. Instead, we should use `Observable.materialize` and handle the error state and the values state.
Removing `pipeErrorsTo` from `PrivacyViewModel`. Also displaying when there's an error (added a test).

# how to test ⁉️ 
Privacy screen successfully:

- [ ] updates user privacy preferences
- [ ] displays an error toast when a user is offline

![image](https://user-images.githubusercontent.com/1289295/51775985-85fb5d00-20c5-11e9-9858-44cfce7efb0b.png)

