### PR TITLE
[Enhancement] - Pledge Activity Digest

### DIFF
--- a/app/src/main/assets/json/server-config.json
+++ b/app/src/main/assets/json/server-config.json
@@ -118,6 +118,7 @@
       "Current_email": "Current email",
       "Current_password": "Current password",
       "CVC": "CVC",
+      "Daily_summary": "Daily summary",
       "Daily_digest": "Daily digest",
       "Data_will_appear_here_once": "Data will appear here once somebody backs your project.",
       "days": {
@@ -507,6 +508,7 @@
       "Top_ten_pledge_sources": "Top 10 pledge sources",
       "Top_ten_rewards": "Top 10 rewards",
       "Total_pledged": "Total pledged",
+      "Twice_a_day_summary": "Twice a day summary",
       "updates_count_updates": {
         "zero": "%{updates_count} updates",
         "one": "%{updates_count} update",
@@ -517,6 +519,7 @@
       "Unable_to_request": "Unable to request data.",
       "Unsaved": "Unsaved",
       "Unsaves_project": "Unsaves project.",
+      "Unsupported_card_type": "We don't accept this card type. Please try again with another one.",
       "Unfollow_friend_name": "Unfollow %{friend_name}",
       "Unfollows_friend_name": "Unfollows %{friend_name}.",
       "unread_count_unread": "%{unread_count} unread",
@@ -2208,6 +2211,7 @@
       "Current_email": "Derzeitige E-Mail",
       "Current_password": "Derzeitiges Passwort",
       "CVC": "CVC",
+      "Daily_summary": "Daily summary",
       "Daily_digest": "Tägliche Zusammenfassung",
       "Data_will_appear_here_once": "Info wird hier angezeigt, sobald jemand dein Projekt unterstützt.",
       "days": {
@@ -2597,6 +2601,7 @@
       "Top_ten_pledge_sources": "Top 10 Quellen deiner Beiträge",
       "Top_ten_rewards": "Top 10-Belohnungen",
       "Total_pledged": "Anzahl der Beiträge insgesamt",
+      "Twice_a_day_summary": "Twice a day summary",
       "updates_count_updates": {
         "zero": "%{updates_count} Updates",
         "one": "%{updates_count} Update",
@@ -2607,6 +2612,7 @@
       "Unable_to_request": "Daten konnten nicht angefordert werden.",
       "Unsaved": "Speichern wurde rückgängig gemacht",
       "Unsaves_project": "Macht Speichern dieses Projektes rückgängig.",
+      "Unsupported_card_type": "Dieser Kartentyp wird nicht von uns anerkannt. Bitte versuche es mit einer anderen Karte erneut.",
       "Unfollow_friend_name": "%{friend_name} nicht mehr folgen",
       "Unfollows_friend_name": "%{friend_name} nicht mehr folgen.",
       "unread_count_unread": "%{unread_count} ungelesen",
@@ -4298,6 +4304,7 @@
       "Current_email": "Correo electrónico actual",
       "Current_password": "Contraseña actual",
       "CVC": "CVC",
+      "Daily_summary": "Daily summary",
       "Daily_digest": "Resumen diario",
       "Data_will_appear_here_once": "Los datos aparecerán aquí una vez que alguien patrocine tu proyecto.",
       "days": {
@@ -4687,6 +4694,7 @@
       "Top_ten_pledge_sources": "Las 10 principales fuentes de contribución",
       "Top_ten_rewards": "Las 10 mejores recompensas",
       "Total_pledged": "Contribuciones en total",
+      "Twice_a_day_summary": "Twice a day summary",
       "updates_count_updates": {
         "zero": "%{updates_count} actualizaciones",
         "one": "%{updates_count} actualización",
@@ -4697,6 +4705,7 @@
       "Unable_to_request": "No se pueden solicitar datos.",
       "Unsaved": "Sin guardar",
       "Unsaves_project": "Deshacer \"guardar proyecto\".",
+      "Unsupported_card_type": "No aceptamos este tipo de tarjeta. Intenta de nuevo con otra.",
       "Unfollow_friend_name": "Dejar de seguir a %{friend_name}",
       "Unfollows_friend_name": "Dejar de seguir a %{friend_name}.",
       "unread_count_unread": "%{unread_count} sin leer",
@@ -6388,6 +6397,7 @@
       "Current_email": "Adresse e-mail actuelle",
       "Current_password": "Mot de passe actuel",
       "CVC": "Cryptogramme",
+      "Daily_summary": "Daily summary",
       "Daily_digest": "Résumé quotidien",
       "Data_will_appear_here_once": "Ces données seront visibles dès que vous aurez reçu votre première contribution.",
       "days": {
@@ -6777,6 +6787,7 @@
       "Top_ten_pledge_sources": "Vos 10 principales sources de contributions",
       "Top_ten_rewards": "Les 10 récompenses qui ont le plus de succès",
       "Total_pledged": "Total engagé",
+      "Twice_a_day_summary": "Twice a day summary",
       "updates_count_updates": {
         "zero": "%{updates_count} actus",
         "one": "%{updates_count} actu",
@@ -6787,6 +6798,7 @@
       "Unable_to_request": "Demande de données impossible.",
       "Unsaved": "Non enregistré",
       "Unsaves_project": "Annule l'enregistrement du projet.",
+      "Unsupported_card_type": "Ce type n'est pas accepté. Veuillez réessayer avec une autre carte.",
       "Unfollow_friend_name": "Ne plus suivre %{friend_name}",
       "Unfollows_friend_name": "Désabonnement des actus de %{friend_name}.",
       "unread_count_unread": "%{unread_count} messages non lus",
@@ -8478,6 +8490,7 @@
       "Current_email": "Current email",
       "Current_password": "Current password",
       "CVC": "CVC",
+      "Daily_summary": "Daily summary",
       "Daily_digest": "Daily digest",
       "Data_will_appear_here_once": "Data will appear here once somebody backs your project.",
       "days": {
@@ -8867,6 +8880,7 @@
       "Top_ten_pledge_sources": "Top 10 pledge sources",
       "Top_ten_rewards": "Top 10 rewards",
       "Total_pledged": "Total pledged",
+      "Twice_a_day_summary": "Twice a day summary",
       "updates_count_updates": {
         "zero": "%{updates_count} updates",
         "one": "%{updates_count} update",
@@ -8877,6 +8891,7 @@
       "Unable_to_request": "Unable to request data.",
       "Unsaved": "Unsaved",
       "Unsaves_project": "Unsaves project.",
+      "Unsupported_card_type": "We don't accept this card type. Please try again with another one.",
       "Unfollow_friend_name": "Unfollow %{friend_name}",
       "Unfollows_friend_name": "Unfollows %{friend_name}.",
       "unread_count_unread": "%{unread_count} unread",
@@ -10568,6 +10583,7 @@
       "Current_email": "現在のメールアドレス",
       "Current_password": "現在のパスワード",
       "CVC": "CVC",
+      "Daily_summary": "Daily summary",
       "Daily_digest": "デイリーダイジェスト",
       "Data_will_appear_here_once": "誰かがプロジェクトをバック（支援）すると、ここにデータが表示されます。",
       "days": {
@@ -10957,6 +10973,7 @@
       "Top_ten_pledge_sources": "プレッジソースのトップ10",
       "Top_ten_rewards": "リワードのトップ10",
       "Total_pledged": "プレッジ総計",
+      "Twice_a_day_summary": "Twice a day summary",
       "updates_count_updates": {
         "zero": "%{updates_count} 件のアップデート",
         "one": "%{updates_count} 件のアップデート",
@@ -10967,6 +10984,7 @@
       "Unable_to_request": "データをリクエストできません。",
       "Unsaved": "未保存",
       "Unsaves_project": "保存されていないプロジェクト。",
+      "Unsupported_card_type": "残念ながらこのタイプのカードには対応しておりません。別のカードにてもう一度お試しください。",
       "Unfollow_friend_name": "%{friend_name} のフォロー解除",
       "Unfollows_friend_name": "%{friend_name} のフォロー解除",
       "unread_count_unread": "%{unread_count} 件の未読メッセージ",
@@ -12658,6 +12676,7 @@
       "Current_email": "Current email",
       "Current_password": "Current password",
       "CVC": "CVC",
+      "Daily_summary": "Daily summary",
       "Daily_digest": "Daily digest",
       "Data_will_appear_here_once": "Data will appear here once somebody backs your project.",
       "days": {
@@ -13047,6 +13066,7 @@
       "Top_ten_pledge_sources": "Top 10 pledge sources",
       "Top_ten_rewards": "Top 10 rewards",
       "Total_pledged": "Total pledged",
+      "Twice_a_day_summary": "Twice a day summary",
       "updates_count_updates": {
         "zero": "%{updates_count} updates",
         "one": "%{updates_count} update",
@@ -13057,6 +13077,7 @@
       "Unable_to_request": "Unable to request data.",
       "Unsaved": "Unsaved",
       "Unsaves_project": "Unsaves project.",
+      "Unsupported_card_type": "We don't accept this card type. Please try again with another one.",
       "Unfollow_friend_name": "Unfollow %{friend_name}",
       "Unfollows_friend_name": "Unfollows %{friend_name}.",
       "unread_count_unread": "%{unread_count} unread",
@@ -14644,10 +14665,10 @@
     "new_project_build_reward_scheduling": true,
     "message_spam": true,
     "drip_iterate": true,
-    "project_post_interface": true,
     "creator_search": true,
     "jumio_v4": true,
-    "rich_editor_hosted_media_uploads": true
+    "rich_editor_hosted_media_uploads": true,
+    "project_build_people_tab": true
   },
   "launched_countries": [
     {

--- a/app/src/main/java/com/kickstarter/models/User.java
+++ b/app/src/main/java/com/kickstarter/models/User.java
@@ -44,7 +44,6 @@ public abstract class User implements Parcelable {
   public abstract @Nullable Boolean notifyOfFollower();
   public abstract @Nullable Boolean notifyOfFriendActivity();
   public abstract @Nullable Boolean notifyOfMessages();
-  public abstract @Nullable Boolean notifyOfPostLikes();
   public abstract @Nullable Boolean notifyOfUpdates();
   public abstract @Nullable Boolean optedOutOfRecommendations();
   public abstract @Nullable Boolean promoNewsletter();
@@ -86,7 +85,6 @@ public abstract class User implements Parcelable {
     public abstract Builder notifyOfFollower(Boolean __);
     public abstract Builder notifyOfFriendActivity(Boolean __);
     public abstract Builder notifyOfMessages(Boolean __);
-    public abstract Builder notifyOfPostLikes(Boolean __);
     public abstract Builder notifyOfUpdates(Boolean __);
     public abstract Builder optedOutOfRecommendations(Boolean __);
     public abstract Builder promoNewsletter(Boolean __);
@@ -110,8 +108,8 @@ public abstract class User implements Parcelable {
   public abstract Builder toBuilder();
 
   public enum EmailFrequency {
-    INDIVIDUAL(R.string.Individual_Emails),
-    DIGEST(R.string.Daily_digest);
+    TWICE_A_DAY_SUMMARY(R.string.Twice_a_day_summary),
+    DAILY_SUMMARY(R.string.Daily_summary);
 
     private int stringResId;
 

--- a/app/src/main/java/com/kickstarter/services/ApiClient.java
+++ b/app/src/main/java/com/kickstarter/services/ApiClient.java
@@ -491,7 +491,6 @@ public final class ApiClient implements ApiClientType {
           .notifyOfFollower(isTrue(user.notifyOfFollower()))
           .notifyOfFriendActivity(isTrue(user.notifyOfFriendActivity()))
           .notifyOfMessages(isTrue(user.notifyOfMessages()))
-          .notifyOfPostLikes(isTrue(user.notifyOfPostLikes()))
           .notifyOfUpdates(isTrue(user.notifyOfUpdates()))
           .alumniNewsletter(isTrue(user.alumniNewsletter()) ? 1 : 0)
           .artsCultureNewsletter(isTrue(user.artsCultureNewsletter()) ? 1 : 0)

--- a/app/src/main/java/com/kickstarter/services/apirequests/SettingsBody.java
+++ b/app/src/main/java/com/kickstarter/services/apirequests/SettingsBody.java
@@ -23,7 +23,6 @@ public abstract class SettingsBody {
   public abstract boolean notifyOfFollower();
   public abstract boolean notifyOfFriendActivity();
   public abstract boolean notifyOfMessages();
-  public abstract boolean notifyOfPostLikes();
   public abstract boolean notifyOfUpdates();
   public abstract int showPublicProfile();
   public abstract int social();
@@ -56,7 +55,6 @@ public abstract class SettingsBody {
     public abstract Builder notifyOfFollower(boolean __);
     public abstract Builder notifyOfFriendActivity(boolean __);
     public abstract Builder notifyOfMessages(boolean __);
-    public abstract Builder notifyOfPostLikes(boolean __);
     public abstract Builder notifyOfUpdates(boolean __);
     public abstract Builder showPublicProfile(int __);
     public abstract Builder social(int __);

--- a/app/src/main/java/com/kickstarter/ui/activities/NotificationsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/NotificationsActivity.kt
@@ -108,8 +108,8 @@ class NotificationsActivity : BaseActivity<NotificationsViewModel.ViewModel>() {
         this.notifyOfCreatorDigest = isTrue(user.notifyOfCreatorDigest())
 
         val frequencyIndex = when {
-            notifyOfCreatorDigest -> User.EmailFrequency.DIGEST.ordinal
-            else -> User.EmailFrequency.INDIVIDUAL.ordinal
+            notifyOfCreatorDigest -> User.EmailFrequency.DAILY_SUMMARY.ordinal
+            else -> User.EmailFrequency.TWICE_A_DAY_SUMMARY.ordinal
         }
 
         toggleImageButtonIconColor(backings_phone_icon, this.notifyMobileOfBackings, true)
@@ -126,7 +126,7 @@ class NotificationsActivity : BaseActivity<NotificationsViewModel.ViewModel>() {
 
             override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
                 if (frequencyIndex != position) {
-                    viewModel.inputs.notifyOfCreatorDigest(position == User.EmailFrequency.DIGEST.ordinal)
+                    viewModel.inputs.notifyOfCreatorDigest(position == User.EmailFrequency.DAILY_SUMMARY.ordinal)
                 }
             }
         }
@@ -174,10 +174,8 @@ class NotificationsActivity : BaseActivity<NotificationsViewModel.ViewModel>() {
 
     private fun displayPostLikesNotificationSettings(user: User) {
         this.notifyMobileOfPostLikes = isTrue(user.notifyMobileOfPostLikes())
-        this.notifyOfPostLikes = isTrue(user.notifyOfPostLikes())
 
         toggleImageButtonIconColor(post_likes_phone_icon, this.notifyMobileOfPostLikes, true)
-        toggleImageButtonIconColor(post_likes_mail_icon, this.notifyOfPostLikes)
     }
 
     private fun displayUpdatesNotificationSettings(user: User) {
@@ -290,16 +288,8 @@ class NotificationsActivity : BaseActivity<NotificationsViewModel.ViewModel>() {
             AnimationUtils.notificationBounceAnimation(new_followers_phone_icon, new_followers_mail_icon)
         }
 
-        post_likes_mail_icon.setOnClickListener {
-            this.viewModel.inputs.notifyOfPostLikes(!this.notifyOfPostLikes)
-        }
-
         post_likes_phone_icon.setOnClickListener {
             this.viewModel.inputs.notifyMobileOfPostLikes(!this.notifyMobileOfPostLikes)
-        }
-
-        post_likes_row.setOnClickListener {
-            AnimationUtils.notificationBounceAnimation(post_likes_phone_icon, post_likes_mail_icon)
         }
 
         project_updates_mail_icon.setOnClickListener {

--- a/app/src/main/java/com/kickstarter/viewmodels/NotificationsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/NotificationsViewModel.kt
@@ -65,9 +65,6 @@ interface NotificationsViewModel {
         /** Call when the notify of messages toggle changes.  */
         fun notifyOfMessages(checked: Boolean)
 
-        /** Call when the notify of post likes toggle changes.  */
-        fun notifyOfPostLikes(checked: Boolean)
-
         /** Call when the notify of project updates toggle changes.  */
         fun notifyOfUpdates(checked: Boolean)
     }
@@ -221,10 +218,6 @@ interface NotificationsViewModel {
 
         override fun notifyOfMessages(checked: Boolean) {
             this.userInput.onNext(this.userOutput.value.toBuilder().notifyOfMessages(checked).build())
-        }
-
-        override fun notifyOfPostLikes(checked: Boolean) {
-            this.userInput.onNext(this.userOutput.value.toBuilder().notifyOfPostLikes(checked).build())
         }
 
         override fun notifyOfUpdates(checked: Boolean) {

--- a/app/src/main/res/layout/activity_notifications.xml
+++ b/app/src/main/res/layout/activity_notifications.xml
@@ -129,7 +129,7 @@
 
           <TextView
             style="@style/SettingsSectionLabel"
-            android:text="@string/Pledge_activity" />
+            android:text="@string/Project_activity" />
 
           <ImageButton
             android:id="@+id/backings_mail_icon"
@@ -200,11 +200,6 @@
           <TextView
             style="@style/SettingsSectionLabel"
             android:text="@string/profile_settings_creator_likes" />
-
-          <ImageButton
-            android:id="@+id/post_likes_mail_icon"
-            style="@style/KSSettingsMailIcon"
-            android:contentDescription="@null" />
 
           <Space
             android:layout_width="@dimen/grid_2"

--- a/app/src/main/res/values-de/strings_i18n.xml
+++ b/app/src/main/res/values-de/strings_i18n.xml
@@ -114,6 +114,7 @@ Unterstützer</string>
   <string name="Current_email" formatted="false">Derzeitige E-Mail</string>
   <string name="Current_password" formatted="false">Derzeitiges Passwort</string>
   <string name="Daily_digest" formatted="false">Tägliche Zusammenfassung</string>
+  <string name="Daily_summary" formatted="false">Daily summary</string>
   <string name="Data_will_appear_here_once" formatted="false">Info wird hier angezeigt, sobald jemand dein Projekt unterstützt.</string>
   <string name="Delete_my_Kickstarter_Account" formatted="false">Mein Kickstarter-Konto löschen</string>
   <string name="Delivered" formatted="false">Verschickt</string>
@@ -442,6 +443,7 @@ Unterstützer</string>
   <string name="Top_ten_pledge_sources" formatted="false">Top 10 Quellen deiner Beiträge</string>
   <string name="Top_ten_rewards" formatted="false">Top 10-Belohnungen</string>
   <string name="Total_pledged" formatted="false">Anzahl der Beiträge insgesamt</string>
+  <string name="Twice_a_day_summary" formatted="false">Twice a day summary</string>
   <string name="Unable_to_request" formatted="false">Daten konnten nicht angefordert werden.</string>
   <string name="Unfollow_friend_name" formatted="false">%{friend_name} nicht mehr folgen</string>
   <string name="Unfollows_friend_name" formatted="false">%{friend_name} nicht mehr folgen.</string>
@@ -450,6 +452,7 @@ Unterstützer</string>
   <string name="Unsubscribe" formatted="false">Abo abbestellen</string>
   <string name="Unsubscribes_from_upcoming_lives_streams" formatted="false">Abo für zukünftige Live-Streams abbestellen.</string>
   <string name="Unsuccessfully_Funded" formatted="false">Finanzierung fehlgeschlagen.</string>
+  <string name="Unsupported_card_type" formatted="false">Dieser Kartentyp wird nicht von uns anerkannt. Bitte versuche es mit einer anderen Karte erneut.</string>
   <string name="Upcoming_live_stream" formatted="false">Nächster Live-Stream</string>
   <string name="Upcoming_live_streams" formatted="false">Zukünftige Live-Streams</string>
   <string name="Upcoming_with_creator_name" formatted="false">Demnächst: Video von &lt;br/>&lt;b>%{creator_name}&lt;/b></string>

--- a/app/src/main/res/values-es/strings_i18n.xml
+++ b/app/src/main/res/values-es/strings_i18n.xml
@@ -114,6 +114,7 @@ patrocinadores</string>
   <string name="Current_email" formatted="false">Correo electrónico actual</string>
   <string name="Current_password" formatted="false">Contraseña actual</string>
   <string name="Daily_digest" formatted="false">Resumen diario</string>
+  <string name="Daily_summary" formatted="false">Daily summary</string>
   <string name="Data_will_appear_here_once" formatted="false">Los datos aparecerán aquí una vez que alguien patrocine tu proyecto.</string>
   <string name="Delete_my_Kickstarter_Account" formatted="false">Eliminar mi cuenta de Kickstarter</string>
   <string name="Delivered" formatted="false">Entregado</string>
@@ -443,6 +444,7 @@ patrocinadores</string>
   <string name="Top_ten_pledge_sources" formatted="false">Las 10 principales fuentes de contribución</string>
   <string name="Top_ten_rewards" formatted="false">Las 10 mejores recompensas</string>
   <string name="Total_pledged" formatted="false">Contribuciones en total</string>
+  <string name="Twice_a_day_summary" formatted="false">Twice a day summary</string>
   <string name="Unable_to_request" formatted="false">No se pueden solicitar datos.</string>
   <string name="Unfollow_friend_name" formatted="false">Dejar de seguir a %{friend_name}</string>
   <string name="Unfollows_friend_name" formatted="false">Dejar de seguir a %{friend_name}.</string>
@@ -451,6 +453,7 @@ patrocinadores</string>
   <string name="Unsubscribe" formatted="false">Anular suscripción</string>
   <string name="Unsubscribes_from_upcoming_lives_streams" formatted="false">Desactiva subscripción a futuros Live-Streams.</string>
   <string name="Unsuccessfully_Funded" formatted="false">Financiación falló.</string>
+  <string name="Unsupported_card_type" formatted="false">No aceptamos este tipo de tarjeta. Intenta de nuevo con otra.</string>
   <string name="Upcoming_live_stream" formatted="false">Futuro Live-Stream</string>
   <string name="Upcoming_live_streams" formatted="false">Live streams futuros</string>
   <string name="Upcoming_with_creator_name" formatted="false">Próximamente: Video de &lt;br/>&lt;b>%{creator_name}&lt;/b></string>

--- a/app/src/main/res/values-fr/strings_i18n.xml
+++ b/app/src/main/res/values-fr/strings_i18n.xml
@@ -114,6 +114,7 @@ contributeurs</string>
   <string name="Current_email" formatted="false">Adresse e-mail actuelle</string>
   <string name="Current_password" formatted="false">Mot de passe actuel</string>
   <string name="Daily_digest" formatted="false">Résumé quotidien</string>
+  <string name="Daily_summary" formatted="false">Daily summary</string>
   <string name="Data_will_appear_here_once" formatted="false">Ces données seront visibles dès que vous aurez reçu votre première contribution.</string>
   <string name="Delete_my_Kickstarter_Account" formatted="false">Supprimer mon compte Kickstarter</string>
   <string name="Delivered" formatted="false">Distribué</string>
@@ -443,6 +444,7 @@ n\'ont rien soutenu.</string>
   <string name="Top_ten_pledge_sources" formatted="false">Vos 10 principales sources de contributions</string>
   <string name="Top_ten_rewards" formatted="false">Les 10 récompenses qui ont le plus de succès</string>
   <string name="Total_pledged" formatted="false">Total engagé</string>
+  <string name="Twice_a_day_summary" formatted="false">Twice a day summary</string>
   <string name="Unable_to_request" formatted="false">Demande de données impossible.</string>
   <string name="Unfollow_friend_name" formatted="false">Ne plus suivre %{friend_name}</string>
   <string name="Unfollows_friend_name" formatted="false">Désabonnement des actus de %{friend_name}.</string>
@@ -451,6 +453,7 @@ n\'ont rien soutenu.</string>
   <string name="Unsubscribe" formatted="false">Se désabonner</string>
   <string name="Unsubscribes_from_upcoming_lives_streams" formatted="false">Désabonnement des diffusions en direct à venir.</string>
   <string name="Unsuccessfully_Funded" formatted="false">Non financé.</string>
+  <string name="Unsupported_card_type" formatted="false">Ce type n\'est pas accepté. Veuillez réessayer avec une autre carte.</string>
   <string name="Upcoming_live_stream" formatted="false">Diffusion en direct à venir</string>
   <string name="Upcoming_live_streams" formatted="false">Diffusions en direct à venir</string>
   <string name="Upcoming_with_creator_name" formatted="false">&lt;br/>&lt;b>%{creator_name}&lt;/b> bientôt en direct</string>

--- a/app/src/main/res/values-ja/strings_i18n.xml
+++ b/app/src/main/res/values-ja/strings_i18n.xml
@@ -113,6 +113,7 @@
   <string name="Current_email" formatted="false">現在のメールアドレス</string>
   <string name="Current_password" formatted="false">現在のパスワード</string>
   <string name="Daily_digest" formatted="false">デイリーダイジェスト</string>
+  <string name="Daily_summary" formatted="false">Daily summary</string>
   <string name="Data_will_appear_here_once" formatted="false">誰かがプロジェクトをバック（支援）すると、ここにデータが表示されます。</string>
   <string name="Delete_my_Kickstarter_Account" formatted="false">Kickstarter アカウントを削除</string>
   <string name="Delivered" formatted="false">発送済</string>
@@ -442,6 +443,7 @@
   <string name="Top_ten_pledge_sources" formatted="false">プレッジソースのトップ10</string>
   <string name="Top_ten_rewards" formatted="false">リワードのトップ10</string>
   <string name="Total_pledged" formatted="false">プレッジ総計</string>
+  <string name="Twice_a_day_summary" formatted="false">Twice a day summary</string>
   <string name="Unable_to_request" formatted="false">データをリクエストできません。</string>
   <string name="Unfollow_friend_name" formatted="false">%{friend_name} のフォロー解除</string>
   <string name="Unfollows_friend_name" formatted="false">%{friend_name} のフォロー解除</string>
@@ -450,6 +452,7 @@
   <string name="Unsubscribe" formatted="false">購読キャンセル済み</string>
   <string name="Unsubscribes_from_upcoming_lives_streams" formatted="false">ライブ配信の購読を停止</string>
   <string name="Unsuccessfully_Funded" formatted="false">資金調達失敗</string>
+  <string name="Unsupported_card_type" formatted="false">残念ながらこのタイプのカードには対応しておりません。別のカードにてもう一度お試しください。</string>
   <string name="Upcoming_live_stream" formatted="false">ライブ配信が開始します</string>
   <string name="Upcoming_live_streams" formatted="false">ライブ配信が開始します</string>
   <string name="Upcoming_with_creator_name" formatted="false">&lt;br/>&lt;b>%{creator_name}&lt;/b>が近日配信</string>

--- a/app/src/main/res/values/strings_i18n.xml
+++ b/app/src/main/res/values/strings_i18n.xml
@@ -114,6 +114,7 @@ backers</string>
   <string name="Current_email" formatted="false">Current email</string>
   <string name="Current_password" formatted="false">Current password</string>
   <string name="Daily_digest" formatted="false">Daily digest</string>
+  <string name="Daily_summary" formatted="false">Daily summary</string>
   <string name="Data_will_appear_here_once" formatted="false">Data will appear here once somebody backs your project.</string>
   <string name="Delete_my_Kickstarter_Account" formatted="false">Delete my Kickstarter account</string>
   <string name="Delivered" formatted="false">Delivered</string>
@@ -446,6 +447,7 @@ catch your eye?</string>
   <string name="Top_ten_pledge_sources" formatted="false">Top 10 pledge sources</string>
   <string name="Top_ten_rewards" formatted="false">Top 10 rewards</string>
   <string name="Total_pledged" formatted="false">Total pledged</string>
+  <string name="Twice_a_day_summary" formatted="false">Twice a day summary</string>
   <string name="Unable_to_request" formatted="false">Unable to request data.</string>
   <string name="Unfollow_friend_name" formatted="false">Unfollow %{friend_name}</string>
   <string name="Unfollows_friend_name" formatted="false">Unfollows %{friend_name}.</string>
@@ -454,6 +456,7 @@ catch your eye?</string>
   <string name="Unsubscribe" formatted="false">Unsubscribe</string>
   <string name="Unsubscribes_from_upcoming_lives_streams" formatted="false">Unsubscribes from upcoming live streams.</string>
   <string name="Unsuccessfully_Funded" formatted="false">Unsuccessfully Funded.</string>
+  <string name="Unsupported_card_type" formatted="false">We don\'t accept this card type. Please try again with another one.</string>
   <string name="Upcoming_live_stream" formatted="false">Upcoming live stream</string>
   <string name="Upcoming_live_streams" formatted="false">Upcoming live streams</string>
   <string name="Upcoming_with_creator_name" formatted="false">Upcoming with&lt;br/>&lt;b>%{creator_name}&lt;/b></string>

--- a/app/src/test/java/com/kickstarter/viewmodels/NotificationsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/NotificationsViewModelTest.kt
@@ -240,16 +240,6 @@ class NotificationsViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testNotifyOfPostLikes() {
-        val user = UserFactory.user().toBuilder().notifyOfPostLikes(false).build()
-
-        setUpEnvironment(user)
-
-        this.vm.inputs.notifyOfPostLikes(true)
-        this.currentUserTest.assertValues(user, user.toBuilder().notifyOfPostLikes(true).build())
-    }
-
-    @Test
     fun testNotifyOfUpdates() {
         val user = UserFactory.user().toBuilder().notifyOfUpdates(false).build()
 


### PR DESCRIPTION
# What ❓

- Updated the `NotificationsActivity` to use the new strings for the creators digest.
- Removed the `mail_icon` and `notifyOfPostLikes` email from the `SettingsBody` and `User` models
- Updated strings from `milkrun`

# Story 📖

[Pledge Activity Digest](https://trello.com/c/L2keALkt/1166-pledge-activity-digest)

# See 👀

![jan-31-2019 14-46-43](https://user-images.githubusercontent.com/16387538/52080997-1d99f900-2567-11e9-983f-e43c6ce2464e.gif)


<img src =https://user-images.githubusercontent.com/16387538/51858202-2211a800-2302-11e9-951e-cbf7d42a8eff.jpg width=200 />

<img src =https://user-images.githubusercontent.com/16387538/51858204-276ef280-2302-11e9-9edb-fdc13cb26db9.jpg width=200 />

