### PR TITLE
Staging toolbar part 2

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/toolbars/KSToolbar.java
+++ b/app/src/main/java/com/kickstarter/ui/toolbars/KSToolbar.java
@@ -20,6 +20,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
 import butterknife.Bind;
+import butterknife.BindDimen;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import rx.Subscription;
@@ -27,12 +28,12 @@ import rx.subscriptions.CompositeSubscription;
 
 public class KSToolbar extends Toolbar {
   protected @Nullable @Bind(R.id.title_text_view) TextView titleTextView;
+  protected @BindDimen(R.dimen.grid_2) float grid_2;
 
   private Paint backgroundPaint;
   private @WebEndpoint String webEndpoint;
 
   private final CompositeSubscription subscriptions = new CompositeSubscription();
-  private int grid_1;
 
   public KSToolbar(final @NonNull Context context) {
     super(context);
@@ -57,7 +58,7 @@ public class KSToolbar extends Toolbar {
     super.onDraw(canvas);
 
     if (!isInEditMode() && !this.webEndpoint.equals(Secrets.WebEndpoint.PRODUCTION)) {
-      canvas.drawRect(0, 0, getWidth(), this.grid_1, this.backgroundPaint);
+      canvas.drawRect(0, 0, this.grid_2, getHeight(), this.backgroundPaint);
     }
   }
 
@@ -112,10 +113,9 @@ public class KSToolbar extends Toolbar {
     if (!isInEditMode()) {
       this.backgroundPaint = new Paint();
       this.backgroundPaint.setStyle(Paint.Style.FILL);
-      this.backgroundPaint.setColor(ContextCompat.getColor(context, R.color.ksr_dark_grey_400));
+      this.backgroundPaint.setColor(ContextCompat.getColor(context, R.color.ksr_cobalt_500));
 
       this.webEndpoint = environment().webEndpoint();
-      this.grid_1 = getContext().getResources().getDimensionPixelSize(R.dimen.grid_1);
     }
   }
 }

--- a/app/src/main/java/com/kickstarter/ui/toolbars/KSToolbar.java
+++ b/app/src/main/java/com/kickstarter/ui/toolbars/KSToolbar.java
@@ -32,6 +32,7 @@ public class KSToolbar extends Toolbar {
   private @WebEndpoint String webEndpoint;
 
   private final CompositeSubscription subscriptions = new CompositeSubscription();
+  private int grid_1;
 
   public KSToolbar(final @NonNull Context context) {
     super(context);
@@ -56,7 +57,7 @@ public class KSToolbar extends Toolbar {
     super.onDraw(canvas);
 
     if (!isInEditMode() && !this.webEndpoint.equals(Secrets.WebEndpoint.PRODUCTION)) {
-      canvas.drawRect(0, 0, getWidth(), getHeight(), this.backgroundPaint);
+      canvas.drawRect(0, 0, getWidth(), this.grid_1, this.backgroundPaint);
     }
   }
 
@@ -114,6 +115,7 @@ public class KSToolbar extends Toolbar {
       this.backgroundPaint.setColor(ContextCompat.getColor(context, R.color.ksr_dark_grey_400));
 
       this.webEndpoint = environment().webEndpoint();
+      this.grid_1 = getContext().getResources().getDimensionPixelSize(R.dimen.grid_1);
     }
   }
 }


### PR DESCRIPTION
# What ❓
In the first pass https://github.com/kickstarter/android-oss/pull/334, I made the toolbar the accent color when we were not hitting prod.
In the second pass https://github.com/kickstarter/android-oss/pull/344, I made the toolbar `ksr_dark_grey_400` because you couldn't see buttons that also were the accent color. 
In this third (and hopefully final) pass, I'm showing a cobalt stripe on toolbar when we're not hitting prod.

# y tho
It's super helpful for us to know when we're not hitting the production server but it's visually distracting to change the whole toolbar's background. This is a good compromise.

# See 👀
<img width="330" src="https://user-images.githubusercontent.com/1289295/52303723-b7461980-295e-11e9-9c63-b0fcc355dc19.png"/>


