### PR TITLE
Removing pipeErrorsTo

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/rx/transformers/Transformers.java
+++ b/app/src/main/java/com/kickstarter/libs/rx/transformers/Transformers.java
@@ -40,30 +40,6 @@ public final class Transformers {
   }
 
   /**
-   * Prevents an observable from erroring by chaining `onErrorResumeNext`,
-   * and any errors that occur will be piped into the supplied errors publish
-   * subject. `null` values will never be sent to the publish subject.
-   *
-   * @deprecated Use {@link Observable#materialize()} instead.
-   */
-  @Deprecated
-  public static <T> NeverErrorTransformer<T> pipeErrorsTo(final @NonNull PublishSubject<Throwable> errorSubject) {
-    return new NeverErrorTransformer<>(errorSubject::onNext);
-  }
-
-  /**
-   * Prevents an observable from erroring by chaining `onErrorResumeNext`,
-   * and any errors that occur will be piped into the supplied errors action.
-   * `null` values will never be sent to the publish subject.
-   *
-   * @deprecated Use {@link Observable#materialize()} instead.
-   */
-  @Deprecated
-  public static <T> NeverErrorTransformer<T> pipeErrorsTo(final @NonNull Action1<Throwable> errorAction) {
-    return new NeverErrorTransformer<>(errorAction);
-  }
-
-  /**
    * Prevents an observable from erroring on any {@link ApiException} exceptions.
    */
   public static <T> NeverApiErrorTransformer<T> neverApiError() {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectNotificationSettingsActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectNotificationSettingsActivity.java
@@ -6,7 +6,6 @@ import android.util.Pair;
 import com.kickstarter.R;
 import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
-import com.kickstarter.libs.utils.ViewUtils;
 import com.kickstarter.ui.adapters.ProjectNotificationSettingsAdapter;
 import com.kickstarter.viewmodels.ProjectNotificationSettingsViewModel;
 
@@ -18,6 +17,7 @@ import butterknife.BindString;
 import butterknife.ButterKnife;
 import rx.android.schedulers.AndroidSchedulers;
 
+import static com.kickstarter.extensions.ActivityExtKt.showSnackbar;
 import static com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft;
 
 @RequiresActivityViewModel(ProjectNotificationSettingsViewModel.ViewModel.class)
@@ -44,8 +44,7 @@ public final class ProjectNotificationSettingsActivity extends BaseActivity<Proj
     this.viewModel.outputs.unableToFetchProjectNotificationsError()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
-      .map(__ -> this.generalErrorString)
-      .subscribe(ViewUtils.showToast(this));
+      .subscribe(__ -> showSnackbar(this.recyclerView, this.generalErrorString));
   }
 
   @Override

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectNotificationSettingsActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectNotificationSettingsActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.util.Pair;
 
 import com.kickstarter.R;
+import com.kickstarter.extensions.ActivityExtKt;
 import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
 import com.kickstarter.ui.adapters.ProjectNotificationSettingsAdapter;
@@ -17,7 +18,6 @@ import butterknife.BindString;
 import butterknife.ButterKnife;
 import rx.android.schedulers.AndroidSchedulers;
 
-import static com.kickstarter.extensions.ActivityExtKt.showSnackbar;
 import static com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft;
 
 @RequiresActivityViewModel(ProjectNotificationSettingsViewModel.ViewModel.class)
@@ -44,7 +44,7 @@ public final class ProjectNotificationSettingsActivity extends BaseActivity<Proj
     this.viewModel.outputs.unableToFetchProjectNotificationsError()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
-      .subscribe(__ -> showSnackbar(this.recyclerView, this.generalErrorString));
+      .subscribe(__ -> ActivityExtKt.showSnackbar(this.recyclerView, this.generalErrorString));
   }
 
   @Override

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectNotificationSettingsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectNotificationSettingsViewModel.java
@@ -2,7 +2,6 @@ package com.kickstarter.viewmodels;
 
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.Environment;
-import com.kickstarter.libs.rx.transformers.Transformers;
 import com.kickstarter.models.ProjectNotification;
 import com.kickstarter.services.ApiClientType;
 import com.kickstarter.ui.activities.ProjectNotificationSettingsActivity;
@@ -10,8 +9,12 @@ import com.kickstarter.ui.activities.ProjectNotificationSettingsActivity;
 import java.util.List;
 
 import androidx.annotation.NonNull;
+import rx.Notification;
 import rx.Observable;
-import rx.subjects.PublishSubject;
+import rx.subjects.BehaviorSubject;
+
+import static com.kickstarter.libs.rx.transformers.Transformers.errors;
+import static com.kickstarter.libs.rx.transformers.Transformers.values;
 
 public interface ProjectNotificationSettingsViewModel {
 
@@ -23,17 +26,31 @@ public interface ProjectNotificationSettingsViewModel {
 
   final class ViewModel extends ActivityViewModel<ProjectNotificationSettingsActivity> implements Outputs {
 
+    private final ApiClientType client;
+
     public ViewModel(final @NonNull Environment environment) {
       super(environment);
 
-      final ApiClientType client = environment.apiClient();
+      this.client = environment.apiClient();
 
-      this.projectNotifications = client.fetchProjectNotifications()
-        .compose(Transformers.pipeErrorsTo(this.unableToFetchProjectNotificationsError));
+      final Observable<Notification<List<ProjectNotification>>> projectNotificationsNotification =
+        this.client
+          .fetchProjectNotifications()
+          .materialize();
+
+      projectNotificationsNotification
+        .compose(values())
+        .compose(bindToLifecycle())
+        .subscribe(this.projectNotifications::onNext);
+
+      projectNotificationsNotification
+        .compose(errors())
+        .compose(bindToLifecycle())
+        .subscribe(e -> this.unableToFetchProjectNotificationsError.onNext(null));
     }
 
-    private Observable<List<ProjectNotification>> projectNotifications;
-    private final PublishSubject<Throwable> unableToFetchProjectNotificationsError = PublishSubject.create();
+    private final BehaviorSubject<List<ProjectNotification>> projectNotifications = BehaviorSubject.create();
+    private final BehaviorSubject<Void> unableToFetchProjectNotificationsError = BehaviorSubject.create();
 
     public final Outputs outputs = this;
 
@@ -41,8 +58,7 @@ public interface ProjectNotificationSettingsViewModel {
       return this.projectNotifications;
     }
     @Override public @NonNull Observable<Void> unableToFetchProjectNotificationsError() {
-      return this.unableToFetchProjectNotificationsError
-        .map(__ -> null);
+      return this.unableToFetchProjectNotificationsError;
     }
   }
 }

--- a/app/src/test/java/com/kickstarter/libs/rx/transformers/NeverErrorTransformerTest.java
+++ b/app/src/test/java/com/kickstarter/libs/rx/transformers/NeverErrorTransformerTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 
 import rx.Observable;
 import rx.observers.TestSubscriber;
-import rx.subjects.PublishSubject;
 
 public class NeverErrorTransformerTest extends KSRobolectricTestCase {
   @Test
@@ -35,28 +34,5 @@ public class NeverErrorTransformerTest extends KSRobolectricTestCase {
     resultTest.assertValues(1, 2, 3);
     resultTest.assertCompleted();
     resultTest.assertNoErrors();
-  }
-
-  @Test
-  public void testNeverError_pipesErrorsToPublishSubject() {
-
-    final RuntimeException exception = new RuntimeException();
-    final Observable<Integer> errorsOnLast = Observable.just(1, 2, 3, 4)
-      .flatMap(i -> i < 4 ? Observable.just(i) : Observable.error(exception));
-    final PublishSubject<Throwable> error = PublishSubject.create();
-    final Observable<Integer> result = errorsOnLast.compose(Transformers.pipeErrorsTo(error));
-
-    final TestSubscriber<Throwable> errorTest = TestSubscriber.create();
-    error.subscribe(errorTest);
-    final TestSubscriber<Integer> resultTest = TestSubscriber.create();
-    result.subscribe(resultTest);
-
-    resultTest.assertValues(1, 2, 3);
-    resultTest.assertCompleted();
-    resultTest.assertNoErrors();
-
-    errorTest.assertValues(exception);
-    errorTest.assertNotCompleted();
-    errorTest.assertNoErrors();
   }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectNotificationSettingsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectNotificationSettingsViewModelTest.kt
@@ -1,0 +1,49 @@
+package com.kickstarter.viewmodels
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Environment
+import com.kickstarter.mock.factories.ProjectNotificationFactory
+import com.kickstarter.mock.services.MockApiClient
+import com.kickstarter.models.ProjectNotification
+import org.junit.Test
+import rx.Observable
+import rx.observers.TestSubscriber
+import java.util.*
+
+class ProjectNotificationSettingsViewModelTest : KSRobolectricTestCase() {
+
+    private lateinit var vm: ProjectNotificationSettingsViewModel.ViewModel
+
+    private val projectNotifications = TestSubscriber<List<ProjectNotification>>()
+    private val unableToFetchProjectNotificationsError = TestSubscriber<Void>()
+
+    private fun setUpEnvironment(environment: Environment) {
+        this.vm = ProjectNotificationSettingsViewModel.ViewModel(environment)
+
+        this.vm.outputs.projectNotifications().subscribe(this.projectNotifications)
+        this.vm.outputs.unableToFetchProjectNotificationsError().subscribe(this.unableToFetchProjectNotificationsError)
+    }
+
+    @Test
+    fun testProjectNotifications() {
+        val projectNotifications = Collections.singletonList(ProjectNotificationFactory.disabled())
+        setUpEnvironment(environment().toBuilder().apiClient(object : MockApiClient() {
+            override fun fetchProjectNotifications(): Observable<MutableList<ProjectNotification>> {
+                return Observable.just(projectNotifications)
+            }
+        }).build())
+
+        this.projectNotifications.assertValue(projectNotifications)
+    }
+
+    @Test
+    fun testUnableToFetchProjectNotificationsError() {
+        setUpEnvironment(environment().toBuilder().apiClient(object : MockApiClient() {
+            override fun fetchProjectNotifications(): Observable<MutableList<ProjectNotification>> {
+                return Observable.error(Throwable("error"))
+            }
+        }).build())
+
+        this.unableToFetchProjectNotificationsError.assertValueCount(1)
+    }
+}


### PR DESCRIPTION
# What ❓
`pipeErrorsTo` has been deprecated since April 2016 with no helpful explanation why.
This is the final PR to wrap up the official deprecation of `pipeErrorsTo` (#445, #447, #448, #449, #450)     
`ProjectNotificationSettingsViewModel` did not have any tests so I added some 👍 
Showing a `Snackbar` when there is an error instead of a `Toast`.

# Story 📖
[Trello](https://trello.com/c/s2jv9eth/189-removing-deprecated-transformerspipeerrorsto-calls)

# How to QA? 🤔
* [ ]  Project Notification Settings screen retains functionality to display preferences and alert when there's an error.

