### PR TITLE
Payment methods padding

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/PaymentMethodsViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/PaymentMethodsViewHolder.kt
@@ -47,8 +47,8 @@ class PaymentMethodsViewHolder(@NonNull view: View, @NonNull val delegate: Deleg
     }
 
     override fun bindData(data: Any?) {
-        val cards = requireNotNull(data as UserPaymentsQuery.Node)
-        this.vm.inputs.card(cards)
+        val card = requireNotNull(data as UserPaymentsQuery.Node)
+        this.vm.inputs.card(card)
     }
 
     private fun setExpirationDateTextView(date: String) {

--- a/app/src/main/res/layout/activity_account.xml
+++ b/app/src/main/res/layout/activity_account.xml
@@ -82,9 +82,7 @@
         <LinearLayout
           android:id="@+id/payment_methods_row"
           style="@style/SettingsLinearRow"
-          android:layout_marginTop="@dimen/grid_3"
-          android:visibility="gone"
-          tools:visibility="visible">
+          android:layout_marginTop="@dimen/grid_3">
 
           <TextView
             style="@style/SettingsSingleRow"

--- a/app/src/main/res/layout/item_payment_method.xml
+++ b/app/src/main/res/layout/item_payment_method.xml
@@ -6,7 +6,10 @@
   android:layout_height="wrap_content"
   android:background="@color/white"
   android:orientation="horizontal"
-  android:padding="@dimen/activity_vertical_margin">
+  android:paddingBottom="@dimen/activity_vertical_margin"
+  android:paddingStart="@dimen/activity_horizontal_margin"
+  android:paddingTop="@dimen/activity_vertical_margin"
+  tools:ignore="RtlSymmetry">
 
   <ImageView
     android:id="@+id/credit_card_logo"


### PR DESCRIPTION
# What ❓
Making payment methods visible, typo fix and pushing delete icon in card row to the end of the layout.

# How to QA? 🤔
Visually confirm the same start and end padding for card rows.

# Story 📖

[Trello](https://trello.com/c/xHWVc2aY/1178-settings-v3-sweep)
- [ ] Payment methods: trash can icon on right should have same _visual_ padding to edge as left-side.

# See 👀
<img src="https://user-images.githubusercontent.com/1289295/52379743-54758080-2a39-11e9-84c2-457cf0f74b04.png" width="330"/> <img src="https://user-images.githubusercontent.com/1289295/52379838-a28a8400-2a39-11e9-9c78-a065e7be5170.png" width="330"/>
