### PR TITLE
[Bug] fixed the delay in the pledge activity digest spinner

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/NotificationsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/NotificationsActivity.kt
@@ -51,7 +51,6 @@ class NotificationsActivity : BaseActivity<NotificationsViewModel.ViewModel>() {
     private var notifyOfFollower: Boolean = false
     private var notifyOfFriendActivity: Boolean = false
     private var notifyOfMessages: Boolean = false
-    private var notifyOfPostLikes: Boolean = false
     private var notifyOfUpdates: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/kickstarter/viewmodels/NotificationsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/NotificationsViewModel.kt
@@ -118,7 +118,7 @@ interface NotificationsViewModel {
                     .compose(bindToLifecycle())
                     .subscribe { this.userOutput.onNext(it) }
 
-            this.creatorDigestFrequencyIsGone = currentUser
+            this.creatorDigestFrequencyIsGone = Observable.merge(currentUser, this.userInput)
                     .compose(bindToLifecycle())
                     .map { it.notifyOfBackings() != true  }
                     .distinctUntilChanged()


### PR DESCRIPTION
# What ❓
- Paired with @eoji on fixing the delay in the `NotificationsActivity` it was due the emissions of the `userInput` and `userOutput` being in separate observables. 

# How to QA? 🤔
> Upon deselecting 'Project activity' if I have 'Daily summary' as my chosen value, the spinner will first change from 'Daily summary' to 'Twice a day summary', then close. If I re-enable 'Project activity', it will start from 'Twice a day summary'.

- It should now just collapse the spinner without changing the values.

# See 👀
![pledge-fix](https://user-images.githubusercontent.com/16387538/52427789-a1576680-2ace-11e9-9343-c0d0c41afaca.gif)


