### PR TITLE
Discovery user refresh bug 🐜

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -139,7 +139,7 @@ public interface DiscoveryViewModel {
         .take(1)
         .map(Intent::getAction)
         .filter(Intent.ACTION_MAIN::equals)
-        .compose(combineLatestPair(currentUser))
+        .compose(combineLatestPair(changedUser))
         .map(intentAndUser -> getDefaultParams(intentAndUser.second))
         .share();
 


### PR DESCRIPTION
# What ❓
I was going to open another PR but then I noticed, if you're logged in, looking at a category in Discovery and you leave that screen, Discovery shows the default params (recommended if you’re opted in or all projects). This PR fixes the bug that causes Discovery to show default params every time `currentUser` emits. We really only care if the user changes (shoutout to my friend `changedUser` https://github.com/kickstarter/android-oss/pull/224). 

# How to QA? 🤔
In Discovery, view a category or top filter that's not your default. Trigger a user refresh; you can open up settings or open up a different app. When you return, you should see the category/top filter you previously chose.

# currently in prod 
![device-2019-02-12-160236 2019-02-12 16_05_47](https://user-images.githubusercontent.com/1289295/52667884-16b4a400-2ee0-11e9-9039-b0f1eb4994b9.gif)

# the fix
![device-2019-02-12-160354 2019-02-12 16_05_42](https://user-images.githubusercontent.com/1289295/52667897-1caa8500-2ee0-11e9-8768-8ef7d7c78225.gif)
