### PR TITLE
Settings transitions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
 
     <activity
       android:name=".ui.activities.AccountActivity"
-      android:theme="@style/SettingsActivitiesTransitions" />
+      android:theme="@style/SettingsActivity" />
     <activity
       android:name=".ui.activities.ActivityFeedActivity"
       android:parentActivityName=".ui.activities.DiscoveryActivity"
@@ -42,11 +42,12 @@
     </activity>
     <activity
       android:name=".ui.activities.ChangeEmailActivity"
-      android:theme="@style/SettingsActivitiesTransitions" />
+      android:theme="@style/SettingsActivity" />
     <activity
       android:name=".ui.activities.ChangePasswordActivity"
-      android:theme="@style/SettingsActivitiesTransitions" />
-    <activity android:name=".ui.activities.EditProfileActivity" />
+      android:theme="@style/SettingsActivity" />
+    <activity android:name=".ui.activities.EditProfileActivity"
+      android:theme="@style/SettingsActivity" />
     <activity
       android:name=".ui.activities.CheckoutActivity"
       android:parentActivityName=".ui.activities.ProjectActivity"
@@ -65,7 +66,7 @@
     </activity>
 
     <activity android:name=".ui.activities.CreatePasswordActivity"
-      android:theme="@style/SettingsActivitiesTransitions"/>
+      android:theme="@style/SettingsActivity"/>
     <activity
       android:name=".ui.activities.CreatorDashboardActivity"
       android:parentActivityName=".ui.activities.DiscoveryActivity"
@@ -144,7 +145,7 @@
       android:theme="@style/HelpActivity" />
     <activity
       android:name=".ui.activities.HelpSettingsActivity"
-      android:theme="@style/SettingsActivitiesTransitions" />
+      android:theme="@style/SettingsActivity" />
     <activity
       android:name=".ui.activities.HelpActivity$CookiePolicy"
       android:theme="@style/HelpActivity" />
@@ -202,19 +203,19 @@
     </activity>
     <activity
       android:name=".ui.activities.NewCardActivity"
-      android:theme="@style/SettingsActivitiesTransitions"/>
+      android:theme="@style/SettingsActivity"/>
     <activity
       android:name=".ui.activities.NewsletterActivity"
-      android:theme="@style/SettingsActivitiesTransitions"/>
+      android:theme="@style/SettingsActivity"/>
     <activity
       android:name=".ui.activities.NotificationsActivity"
-      android:theme="@style/SettingsActivitiesTransitions"/>
+      android:theme="@style/SettingsActivity"/>
     <activity
       android:name=".ui.activities.PaymentMethodsSettingsActivity"
-      android:theme="@style/SettingsActivitiesTransitions"/>
+      android:theme="@style/SettingsActivity"/>
     <activity
       android:name=".ui.activities.PrivacyActivity"
-      android:theme="@style/SettingsActivitiesTransitions"/>
+      android:theme="@style/SettingsActivity"/>
     <activity
       android:name=".ui.activities.ProjectNotificationSettingsActivity"
       android:parentActivityName=".ui.activities.SettingsActivity">
@@ -268,6 +269,7 @@
     </activity>
     <activity
       android:name=".ui.activities.SettingsActivity"
+      android:theme="@style/SettingsActivity"
       android:parentActivityName=".ui.activities.DiscoveryActivity">
       <meta-data
         android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -218,6 +218,7 @@
       android:theme="@style/SettingsActivity"/>
     <activity
       android:name=".ui.activities.ProjectNotificationSettingsActivity"
+      android:theme="@style/SettingsActivity"
       android:parentActivityName=".ui.activities.SettingsActivity">
       <meta-data
         android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/java/com/kickstarter/ui/activities/AccountActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/AccountActivity.kt
@@ -2,19 +2,16 @@ package com.kickstarter.ui.activities
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Pair
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import androidx.appcompat.app.AlertDialog
 import com.kickstarter.R
 import com.kickstarter.extensions.showSnackbar
-import com.kickstarter.extensions.startActivityWithSlideUpTransition
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
-import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.viewmodels.AccountViewModel
 import kotlinx.android.synthetic.main.account_toolbar.*
@@ -79,14 +76,12 @@ class AccountActivity : BaseActivity<AccountViewModel.ViewModel>() {
                 .compose(observeForUI())
                 .subscribe { showSnackbar(account_container, R.string.Got_it_your_changes_have_been_saved) }
 
-        create_password_row.setOnClickListener { startActivityWithSlideUpTransition(Intent(this, CreatePasswordActivity::class.java)) }
-        change_email_row.setOnClickListener { startActivityWithSlideUpTransition(Intent(this, ChangeEmailActivity::class.java)) }
-        change_password_row.setOnClickListener { startActivityWithSlideUpTransition(Intent(this, ChangePasswordActivity::class.java)) }
-        payment_methods_row.setOnClickListener { startActivityWithSlideUpTransition(Intent(this, PaymentMethodsSettingsActivity::class.java)) }
-        privacy_row.setOnClickListener { startActivityWithSlideUpTransition(Intent(this, PrivacyActivity::class.java)) }
+        create_password_row.setOnClickListener { startActivity(Intent(this, CreatePasswordActivity::class.java)) }
+        change_email_row.setOnClickListener { startActivity(Intent(this, ChangeEmailActivity::class.java)) }
+        change_password_row.setOnClickListener { startActivity(Intent(this, ChangePasswordActivity::class.java)) }
+        payment_methods_row.setOnClickListener { startActivity(Intent(this, PaymentMethodsSettingsActivity::class.java)) }
+        privacy_row.setOnClickListener { startActivity(Intent(this, PrivacyActivity::class.java)) }
     }
-
-    override fun exitTransition(): Pair<Int, Int> = TransitionUtils.slideUpFromBottom()
 
     private fun getListOfCurrencies(): List<String> {
         val strings = arrayListOf<String>()

--- a/app/src/main/java/com/kickstarter/ui/activities/ChangeEmailActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ChangeEmailActivity.kt
@@ -2,18 +2,16 @@ package com.kickstarter.ui.activities
 
 import android.content.Context
 import android.os.Bundle
-import androidx.core.content.ContextCompat
-import android.util.Pair
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import androidx.core.content.ContextCompat
 import com.kickstarter.R
 import com.kickstarter.extensions.onChange
 import com.kickstarter.extensions.showSnackbar
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
-import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.viewmodels.ChangeEmailViewModel
 import kotlinx.android.synthetic.main.activity_change_email.*
@@ -140,8 +138,6 @@ class ChangeEmailActivity : BaseActivity<ChangeEmailViewModel.ViewModel>() {
         save.isEnabled = this.saveEnabled
         return super.onPrepareOptionsMenu(menu)
     }
-
-    override fun exitTransition(): Pair<Int, Int> = TransitionUtils.slideUpFromBottom()
 
     private fun clearForm() {
         new_email.text = null

--- a/app/src/main/java/com/kickstarter/ui/activities/ChangePasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ChangePasswordActivity.kt
@@ -2,7 +2,6 @@ package com.kickstarter.ui.activities
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Pair
 import android.view.Menu
 import android.view.MenuItem
 import com.kickstarter.R
@@ -13,7 +12,6 @@ import com.kickstarter.libs.Logout
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ApplicationUtils
-import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.data.LoginReason
@@ -92,8 +90,6 @@ class ChangePasswordActivity : BaseActivity<ChangePasswordViewModel.ViewModel>()
         save.isEnabled = saveEnabled
         return super.onPrepareOptionsMenu(menu)
     }
-
-    override fun exitTransition(): Pair<Int, Int> = TransitionUtils.slideUpFromBottom()
 
     private fun logout(email: String) {
         this.logout.execute()

--- a/app/src/main/java/com/kickstarter/ui/activities/CreatePasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CreatePasswordActivity.kt
@@ -2,7 +2,6 @@ package com.kickstarter.ui.activities
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Pair
 import android.view.Menu
 import android.view.MenuItem
 import com.kickstarter.R
@@ -13,7 +12,6 @@ import com.kickstarter.libs.Logout
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.ApplicationUtils
-import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.data.LoginReason
@@ -89,8 +87,6 @@ class CreatePasswordActivity : BaseActivity<CreatePasswordViewModel.ViewModel>()
         save.isEnabled = saveEnabled
         return super.onPrepareOptionsMenu(menu)
     }
-
-    override fun exitTransition(): Pair<Int, Int> = TransitionUtils.slideUpFromBottom()
 
     private fun logout(email: String) {
         this.logout.execute()

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
@@ -216,7 +216,7 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel.Vie
     final Intent intent = new Intent(this, SettingsActivity.class);
     intent.putExtra(IntentKey.LOGIN_REASON, LoginReason.DEFAULT);
     startActivity(intent);
-    overridePendingTransition(R.anim.settings_slide_in_from_bottom, R.anim.fade_out);
+    overridePendingTransition(0, 0);
   }
 
   private void showBuildAlert(final @NonNull InternalBuildEnvelope envelope) {

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
@@ -2,16 +2,6 @@ package com.kickstarter.ui.activities;
 
 import android.content.Intent;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import com.google.android.material.appbar.AppBarLayout;
-import com.google.android.material.tabs.TabLayout;
-import androidx.core.view.GravityCompat;
-import androidx.viewpager.widget.ViewPager;
-import androidx.drawerlayout.widget.DrawerLayout;
-import androidx.appcompat.app.AlertDialog;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import android.widget.ImageButton;
 
 import com.crashlytics.android.Crashlytics;
@@ -19,6 +9,8 @@ import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 import com.google.android.gms.security.ProviderInstaller;
+import com.google.android.material.appbar.AppBarLayout;
+import com.google.android.material.tabs.TabLayout;
 import com.jakewharton.rxbinding.support.v4.widget.RxDrawerLayout;
 import com.kickstarter.R;
 import com.kickstarter.libs.ActivityRequestCodes;
@@ -41,6 +33,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.view.GravityCompat;
+import androidx.drawerlayout.widget.DrawerLayout;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.viewpager.widget.ViewPager;
 import butterknife.Bind;
 import butterknife.BindString;
 import butterknife.ButterKnife;
@@ -216,6 +216,7 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel.Vie
     final Intent intent = new Intent(this, SettingsActivity.class);
     intent.putExtra(IntentKey.LOGIN_REASON, LoginReason.DEFAULT);
     startActivity(intent);
+    overridePendingTransition(R.anim.settings_slide_in_from_bottom, R.anim.fade_out);
   }
 
   private void showBuildAlert(final @NonNull InternalBuildEnvelope envelope) {

--- a/app/src/main/java/com/kickstarter/ui/activities/EditProfileActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/EditProfileActivity.kt
@@ -1,7 +1,6 @@
 package com.kickstarter.ui.activities
 
 import android.os.Bundle
-import android.util.Pair
 import android.widget.TextView
 import com.kickstarter.R
 import com.kickstarter.libs.BaseActivity
@@ -10,7 +9,6 @@ import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.transformations.CircleTransformation
 import com.kickstarter.libs.utils.BooleanUtils
 import com.kickstarter.libs.utils.SwitchCompatUtils
-import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.User
 import com.kickstarter.viewmodels.EditProfileViewModel
@@ -56,8 +54,6 @@ class EditProfileActivity : BaseActivity<EditProfileViewModel.ViewModel>() {
         }
 
     }
-
-    override fun exitTransition(): Pair<Int, Int> = TransitionUtils.slideUpFromBottom()
 
     private fun displayPreferences(user: User) {
         SwitchCompatUtils.setCheckedWithoutAnimation(private_profile_switch, BooleanUtils.isFalse(user.showPublicProfile()))

--- a/app/src/main/java/com/kickstarter/ui/activities/HelpSettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/HelpSettingsActivity.kt
@@ -5,17 +5,14 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.text.TextUtils
-import android.util.Pair
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.content.ContextCompat
 import com.kickstarter.R
-import com.kickstarter.extensions.startActivityWithSlideLeftTransition
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.Build
 import com.kickstarter.libs.CurrentUserType
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.utils.Secrets
-import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.models.User
 import com.kickstarter.models.chrome.ChromeTabsHelperActivity
 import com.kickstarter.ui.activities.HelpActivity.*
@@ -69,8 +66,6 @@ class HelpSettingsActivity : BaseActivity<HelpSettingsViewModel.ViewModel>() {
         }
     }
 
-    override fun exitTransition(): Pair<Int, Int> = TransitionUtils.slideUpFromBottom()
-
     private fun buildHelpUrl(endpoint: String): String {
         val webEndpointBuilder = Uri.parse(this.environment().webEndpoint()).buildUpon()
         webEndpointBuilder.appendEncodedPath(endpoint)
@@ -113,7 +108,7 @@ class HelpSettingsActivity : BaseActivity<HelpSettingsViewModel.ViewModel>() {
 
             override fun openUri(activity: Activity, uri: Uri) {
                 if (helpActivityIntent != null) {
-                    activity.startActivityWithSlideLeftTransition(helpActivityIntent)
+                    activity.startActivity(helpActivityIntent)
                 } else {
                     // We're not handling users without browsers, We'll monitor on Fabric.
                     val intent = Intent(Intent.ACTION_VIEW, uri)

--- a/app/src/main/java/com/kickstarter/ui/activities/NewsletterActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/NewsletterActivity.kt
@@ -2,7 +2,6 @@ package com.kickstarter.ui.activities
 
 import android.os.Bundle
 import androidx.annotation.NonNull
-import android.util.Pair
 import com.kickstarter.R
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.Build
@@ -11,7 +10,6 @@ import com.kickstarter.libs.KSString
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.utils.BooleanUtils.isTrue
 import com.kickstarter.libs.utils.SwitchCompatUtils
-import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.User
 import com.kickstarter.ui.data.Newsletter
@@ -66,8 +64,6 @@ class NewsletterActivity : BaseActivity<NewsletterViewModel.ViewModel>() {
         reads_switch.setOnClickListener { viewModel.inputs.sendReadsNewsletter(reads_switch.isChecked) }
         subscribe_all_switch.setOnClickListener { viewModel.inputs.sendAllNewsletter(subscribe_all_switch.isChecked) }
     }
-
-    override fun exitTransition(): Pair<Int, Int> = TransitionUtils.slideUpFromBottom()
 
     private fun displayPreferences(@NonNull user: User) {
         SwitchCompatUtils.setCheckedWithoutAnimation(alumni_switch, isTrue(user.alumniNewsletter()))

--- a/app/src/main/java/com/kickstarter/ui/activities/NotificationsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/NotificationsActivity.kt
@@ -2,7 +2,6 @@ package com.kickstarter.ui.activities
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Pair
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
@@ -14,7 +13,6 @@ import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.utils.AnimationUtils
 import com.kickstarter.libs.utils.BooleanUtils.isTrue
 import com.kickstarter.libs.utils.IntegerUtils.intValueOrZero
-import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.User
 import com.kickstarter.viewmodels.NotificationsViewModel
@@ -85,8 +83,6 @@ class NotificationsActivity : BaseActivity<NotificationsViewModel.ViewModel>() {
         setUpClickListeners()
 
     }
-
-    override fun exitTransition(): Pair<Int, Int> = TransitionUtils.slideUpFromBottom()
 
     private fun displayPreferences(user: User) {
         project_notifications_count.text = intValueOrZero(user.backedProjectsCount()).toString()

--- a/app/src/main/java/com/kickstarter/ui/activities/NotificationsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/NotificationsActivity.kt
@@ -301,8 +301,7 @@ class NotificationsActivity : BaseActivity<NotificationsViewModel.ViewModel>() {
     }
 
     private fun startProjectNotificationsSettingsActivity() {
-        val intent = Intent(this, ProjectNotificationSettingsActivity::class.java)
-        startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
+        startActivity(Intent(this, ProjectNotificationSettingsActivity::class.java))
     }
 
     private fun toggleImageButtonIconColor(imageButton: ImageButton, enabled: Boolean, typeMobile: Boolean = false) {

--- a/app/src/main/java/com/kickstarter/ui/activities/PaymentMethodsSettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/PaymentMethodsSettingsActivity.kt
@@ -74,24 +74,6 @@ class PaymentMethodsSettingsActivity : BaseActivity<PaymentMethodsViewModel.View
         }
     }
 
-    private fun setCards(cards: MutableList<UserPaymentsQuery.Node>) = this.adapter.populateCards(cards)
-
-    private fun setUpRecyclerView() {
-        this.adapter = PaymentMethodsAdapter(this.viewModel, object: DiffUtil.ItemCallback<Any>() {
-            override fun areItemsTheSame(oldItem: Any, newItem: Any): Boolean {
-                return (oldItem as UserPaymentsQuery.Node).id() == (newItem as UserPaymentsQuery.Node).id()
-            }
-
-            override fun areContentsTheSame(oldItem: Any, newItem: Any): Boolean {
-                return (oldItem as UserPaymentsQuery.Node).id() == (newItem as UserPaymentsQuery.Node).id()
-            }
-
-
-        })
-        recycler_view.adapter = this.adapter
-        recycler_view.layoutManager = LinearLayoutManager(this)
-    }
-
     private fun lazyDeleteCardConfirmationDialog(): AlertDialog {
         if (this.showDeleteCardDialog == null) {
             this.showDeleteCardDialog = AlertDialog.Builder(this, R.style.AlertDialog)
@@ -103,6 +85,22 @@ class PaymentMethodsSettingsActivity : BaseActivity<PaymentMethodsViewModel.View
                     .create()
         }
         return this.showDeleteCardDialog!!
+    }
+
+    private fun setCards(cards: MutableList<UserPaymentsQuery.Node>) = this.adapter.populateCards(cards)
+
+    private fun setUpRecyclerView() {
+        this.adapter = PaymentMethodsAdapter(this.viewModel, object: DiffUtil.ItemCallback<Any>() {
+            override fun areItemsTheSame(oldItem: Any, newItem: Any): Boolean {
+                return (oldItem as UserPaymentsQuery.Node).id() == (newItem as UserPaymentsQuery.Node).id()
+            }
+
+            override fun areContentsTheSame(oldItem: Any, newItem: Any): Boolean {
+                return (oldItem as UserPaymentsQuery.Node).id() == (newItem as UserPaymentsQuery.Node).id()
+            }
+        })
+        recycler_view.adapter = this.adapter
+        recycler_view.layoutManager = LinearLayoutManager(this)
     }
 
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/PrivacyActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/PrivacyActivity.kt
@@ -3,7 +3,6 @@ package com.kickstarter.ui.activities
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.util.Pair
 import androidx.appcompat.app.AlertDialog
 import com.kickstarter.R
 import com.kickstarter.libs.BaseActivity
@@ -12,7 +11,6 @@ import com.kickstarter.libs.utils.BooleanUtils.isFalse
 import com.kickstarter.libs.utils.BooleanUtils.isTrue
 import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.libs.utils.SwitchCompatUtils
-import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.User
 import com.kickstarter.viewmodels.PrivacyViewModel
@@ -67,8 +65,6 @@ class PrivacyActivity : BaseActivity<PrivacyViewModel.ViewModel>() {
         settings_request_data.setOnClickListener { showPrivacyWebpage(Secrets.Privacy.REQUEST_DATA) }
         settings_delete_account.setOnClickListener { showPrivacyWebpage(Secrets.Privacy.DELETE_ACCOUNT) }
     }
-
-    override fun exitTransition(): Pair<Int, Int> = TransitionUtils.slideUpFromBottom()
 
     private fun displayPreferences(user: User) {
         SwitchCompatUtils.setCheckedWithoutAnimation(following_switch, isTrue(user.social()))

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectNotificationSettingsActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectNotificationSettingsActivity.java
@@ -1,7 +1,6 @@
 package com.kickstarter.ui.activities;
 
 import android.os.Bundle;
-import android.util.Pair;
 
 import com.kickstarter.R;
 import com.kickstarter.extensions.ActivityExtKt;
@@ -17,8 +16,6 @@ import butterknife.Bind;
 import butterknife.BindString;
 import butterknife.ButterKnife;
 import rx.android.schedulers.AndroidSchedulers;
-
-import static com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft;
 
 @RequiresActivityViewModel(ProjectNotificationSettingsViewModel.ViewModel.class)
 public final class ProjectNotificationSettingsActivity extends BaseActivity<ProjectNotificationSettingsViewModel.ViewModel> {
@@ -51,10 +48,5 @@ public final class ProjectNotificationSettingsActivity extends BaseActivity<Proj
   protected void onDestroy() {
     super.onDestroy();
     this.recyclerView.setAdapter(null);
-  }
-
-  @Override
-  protected @Nullable Pair<Integer, Integer> exitTransition() {
-    return slideInFromLeft();
   }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
@@ -6,13 +6,12 @@ import android.view.View
 import androidx.appcompat.app.AlertDialog
 import com.kickstarter.BuildConfig
 import com.kickstarter.R
-import com.kickstarter.extensions.startActivityWithSlideUpTransition
 import com.kickstarter.libs.*
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.transformations.CircleTransformation
 import com.kickstarter.libs.utils.ApplicationUtils
-import com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft
+import com.kickstarter.libs.utils.TransitionUtils.slideUpFromBottom
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.viewmodels.SettingsViewModel
 import com.squareup.picasso.Picasso
@@ -70,15 +69,15 @@ class SettingsActivity : BaseActivity<SettingsViewModel.ViewModel>() {
                 .subscribe { name_text_view.text = it }
 
         account_row.setOnClickListener {
-            startActivityWithSlideUpTransition(Intent(this, AccountActivity::class.java))
+            startActivity(Intent(this, AccountActivity::class.java))
         }
 
         edit_profile_row.setOnClickListener {
-            startActivityWithSlideUpTransition(Intent(this, EditProfileActivity::class.java))
+            startActivity(Intent(this, EditProfileActivity::class.java))
         }
 
         help_row.setOnClickListener {
-            startActivityWithSlideUpTransition(Intent(this, HelpSettingsActivity::class.java))
+            startActivity(Intent(this, HelpSettingsActivity::class.java))
         }
 
         log_out_row.setOnClickListener {
@@ -86,11 +85,11 @@ class SettingsActivity : BaseActivity<SettingsViewModel.ViewModel>() {
         }
 
         newsletters_row.setOnClickListener {
-            startActivityWithSlideUpTransition(Intent(this, NewsletterActivity::class.java))
+            startActivity(Intent(this, NewsletterActivity::class.java))
         }
 
         notification_row.setOnClickListener {
-            startActivityWithSlideUpTransition(Intent(this, NotificationsActivity::class.java))
+            startActivity(Intent(this, NotificationsActivity::class.java))
         }
 
         rate_us_row.setOnClickListener { ViewUtils.openStoreRating(this, this.packageName) }
@@ -101,7 +100,7 @@ class SettingsActivity : BaseActivity<SettingsViewModel.ViewModel>() {
         ApplicationUtils.startNewDiscoveryActivity(this)
     }
 
-    override fun exitTransition() = slideInFromLeft()
+    override fun exitTransition() = slideUpFromBottom()
 
     /**
      * Lazily creates a logout confirmation dialog and stores it in an instance variable.

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
@@ -11,7 +11,6 @@ import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.transformations.CircleTransformation
 import com.kickstarter.libs.utils.ApplicationUtils
-import com.kickstarter.libs.utils.TransitionUtils.slideUpFromBottom
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.viewmodels.SettingsViewModel
 import com.squareup.picasso.Picasso
@@ -99,8 +98,6 @@ class SettingsActivity : BaseActivity<SettingsViewModel.ViewModel>() {
         this.logout.execute()
         ApplicationUtils.startNewDiscoveryActivity(this)
     }
-
-    override fun exitTransition() = slideUpFromBottom()
 
     /**
      * Lazily creates a logout confirmation dialog and stores it in an instance variable.

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -62,8 +62,9 @@
     <item name="android:windowBackground">@color/white</item>
   </style>
 
-  <style name="SettingsActivitiesTransitions" parent="KSTheme">
+  <style name="SettingsActivity" parent="KSTheme">
     <item name="android:windowIsTranslucent">true</item>
+    <item name="android:windowAnimationStyle">@style/SettingsActivityTransitions</item>
   </style>
 
   <style name="ThanksActivity" parent="KSTheme">
@@ -83,6 +84,14 @@
 
   <style name="BackingActivity" parent="KSTheme">
     <item name="android:windowBackground">@color/white</item>
+  </style>
+
+  <!-- Activity Transitions-->
+  <style name="SettingsActivityTransitions" parent="android:style/Animation.Activity">
+    <item name="android:activityOpenEnterAnimation">@anim/settings_slide_in_from_bottom</item>
+    <item name="android:activityOpenExitAnimation">@null</item>
+    <item name="android:activityCloseEnterAnimation">@null</item>
+    <item name="android:activityCloseExitAnimation">@anim/settings_slide_out_from_top</item>
   </style>
 
   <!-- Widgets -->


### PR DESCRIPTION
# What ❓
Created standard style `SettingsActivity` for settings transitions  so we don't need to override `exitTransition` everywhere.

Removed Discovery -> Settings transition.

# Story 📖
[Trello](https://trello.com/c/xHWVc2aY/1178-settings-v3-sweep)

# See 👀
**From Discovery** 
![device-2019-02-12-162352 2019-02-12 16_26_19](https://user-images.githubusercontent.com/1289295/52671235-8333a100-2ee8-11e9-9a49-903013669ebc.gif)

**Top Level Settings**
![device-2019-02-12-161633 2019-02-12 16_26_45](https://user-images.githubusercontent.com/1289295/52669002-1073f700-2ee3-11e9-97c8-fcc96d9e2ae2.gif)

**Account & Payment methods**
(change email is omitted from gif on purpose)
![device-2019-02-12-162915 2019-02-12 16_30_22](https://user-images.githubusercontent.com/1289295/52669217-85473100-2ee3-11e9-92e6-0d60ef9f6142.gif)

**Notifications**
![device-2019-02-12-162118 2019-02-12 16_26_03](https://user-images.githubusercontent.com/1289295/52669271-a3149600-2ee3-11e9-80eb-3e2bc191b802.gif)




