### PR TITLE
Discovery Toolbar content description

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/toolbars/DiscoveryToolbar.java
+++ b/app/src/main/java/com/kickstarter/ui/toolbars/DiscoveryToolbar.java
@@ -25,7 +25,7 @@ public final class DiscoveryToolbar extends KSToolbar {
   @Bind(R.id.activity_feed_button) ImageButton activityFeedButton;
   @Bind(R.id.creator_dashboard_button) ImageButton creatorDashboardButton;
   @Bind(R.id.filter_text_view) TextView filterTextView;
-  @Bind(R.id.menu_button) TextView menuButton;
+  @Bind(R.id.menu_button) ImageButton menuButton;
   @Bind(R.id.search_button) ImageButton searchButton;
 
   private KSString ksString;

--- a/app/src/main/res/drawable/ic_menu.xml
+++ b/app/src/main/res/drawable/ic_menu.xml
@@ -1,19 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-  android:height="24dp" android:viewportHeight="60.0"
-  android:viewportWidth="60.0" android:width="24dp">
-    <path
-        android:pathData="M0,0h15v2h-15z"
-        android:strokeColor="#00000000"
-        android:fillColor="#9B9E9E"
-        android:strokeWidth="1"/>
-    <path
-        android:pathData="M0,4h15v2h-15z"
-        android:strokeColor="#00000000"
-        android:fillColor="#9B9E9E"
-        android:strokeWidth="1"/>
-    <path
-        android:pathData="M0,8h15v2h-15z"
-        android:strokeColor="#00000000"
-        android:fillColor="#9B9E9E"
-        android:strokeWidth="1"/>
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportHeight="24"
+  android:viewportWidth="24">
+  <path
+    android:fillColor="#282828"
+    android:fillType="nonZero"
+    android:pathData="M4,18L20,18C20.55,18 21,17.55 21,17C21,16.45 20.55,16 20,16L4,16C3.45,16 3,16.45 3,17C3,17.55 3.45,18 4,18Z"
+    android:strokeColor="#00000000"
+    android:strokeWidth="1" />
+  <path
+    android:fillColor="#282828"
+    android:fillType="nonZero"
+    android:pathData="M4,13L20,13C20.55,13 21,12.55 21,12C21,11.45 20.55,11 20,11L4,11C3.45,11 3,11.45 3,12C3,12.55 3.45,13 4,13Z"
+    android:strokeColor="#00000000"
+    android:strokeWidth="1" />
+  <path
+    android:fillColor="#282828"
+    android:fillType="nonZero"
+    android:pathData="M3,7C3,7.55 3.45,8 4,8L20,8C20.55,8 21,7.55 21,7C21,6.45 20.55,6 20,6L4,6C3.45,6 3,6.45 3,7Z"
+    android:strokeColor="#00000000"
+    android:strokeWidth="1" />
 </vector>

--- a/app/src/main/res/layout/discovery_toolbar.xml
+++ b/app/src/main/res/layout/discovery_toolbar.xml
@@ -18,44 +18,63 @@
     android:gravity="center_vertical"
     android:orientation="horizontal">
 
-    <ImageButton
-      android:id="@+id/menu_button"
-      style="@style/ToolbarVectorIcon"
-      android:contentDescription="@string/discovery_accessibility_toolbar_buttons_user_menu"
-      android:src="@drawable/ic_menu" />
-
-    <TextView
-      android:id="@+id/filter_text_view"
-      style="@style/ToolbarTitle"
+    <LinearLayout
       android:layout_width="0dp"
       android:layout_height="match_parent"
-      android:layout_marginStart="0dp"
       android:layout_weight="1"
-      android:background="@drawable/click_indicator_light"
-      android:ellipsize="end"
+      android:clipChildren="false"
+      android:clipToPadding="false"
+      android:focusable="true"
       android:gravity="center_vertical"
-      android:maxLines="1"
-      android:paddingEnd="@dimen/grid_2"
-      android:paddingStart="@dimen/grid_2"
-      tools:text="Staff Picks" />
+      android:orientation="horizontal"
+      tools:ignore="RtlSymmetry">
 
-    <ImageButton
-      android:id="@+id/creator_dashboard_button"
-      style="@style/ToolbarVectorIcon"
-      android:contentDescription="@string/tabbar_dashboard"
-      android:src="@drawable/icon__graph_line" />
+      <ImageButton
+        android:id="@+id/menu_button"
+        style="@style/ToolbarVectorIcon"
+        android:contentDescription="@string/discovery_accessibility_toolbar_buttons_user_menu"
+        android:src="@drawable/ic_menu" />
 
-    <ImageButton
-      android:id="@+id/activity_feed_button"
-      style="@style/ToolbarIcon"
-      android:contentDescription="@string/tabbar_activity"
-      android:src="@drawable/icon__bolt" />
+      <TextView
+        android:id="@+id/filter_text_view"
+        style="@style/ToolbarTitle"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginStart="0dp"
+        android:background="@drawable/click_indicator_light"
+        android:ellipsize="end"
+        android:gravity="center_vertical"
+        android:maxLines="1"
+        android:paddingEnd="@dimen/grid_2"
+        android:paddingStart="@dimen/grid_2"
+        tools:text="Staff Picks" />
 
-    <ImageButton
-      android:id="@+id/search_button"
-      style="@style/ToolbarIcon"
-      android:contentDescription="@string/tabbar_search"
-      android:src="@drawable/icon__search" />
+    </LinearLayout>
+
+    <LinearLayout
+      android:layout_width="wrap_content"
+      android:layout_height="match_parent"
+      android:orientation="horizontal">
+
+      <ImageButton
+        android:id="@+id/creator_dashboard_button"
+        style="@style/ToolbarVectorIcon"
+        android:contentDescription="@string/tabbar_dashboard"
+        android:src="@drawable/icon__graph_line" />
+
+      <ImageButton
+        android:id="@+id/activity_feed_button"
+        style="@style/ToolbarIcon"
+        android:contentDescription="@string/tabbar_activity"
+        android:src="@drawable/icon__bolt" />
+
+      <ImageButton
+        android:id="@+id/search_button"
+        style="@style/ToolbarIcon"
+        android:contentDescription="@string/tabbar_search"
+        android:src="@drawable/icon__search" />
+
+    </LinearLayout>
 
   </LinearLayout>
 

--- a/app/src/main/res/layout/discovery_toolbar.xml
+++ b/app/src/main/res/layout/discovery_toolbar.xml
@@ -5,8 +5,7 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
-  android:layout_height="wrap_content"
-  android:elevation="0.1dp"
+  android:layout_height="?android:attr/actionBarSize"
   app:contentInsetLeft="0dp"
   app:contentInsetStart="0dp"
   tools:ignore="UnusedAttribute"
@@ -14,67 +13,49 @@
 
   <LinearLayout
     android:layout_width="match_parent"
-    android:layout_height="?android:attr/actionBarSize"
+    android:layout_height="match_parent"
     android:baselineAligned="false"
     android:gravity="center_vertical"
     android:orientation="horizontal">
 
-    <LinearLayout
+    <ImageButton
+      android:id="@+id/menu_button"
+      style="@style/ToolbarVectorIcon"
+      android:contentDescription="@string/discovery_accessibility_toolbar_buttons_user_menu"
+      android:src="@drawable/ic_menu" />
+
+    <TextView
+      android:id="@+id/filter_text_view"
+      style="@style/ToolbarTitle"
       android:layout_width="0dp"
       android:layout_height="match_parent"
+      android:layout_marginStart="0dp"
       android:layout_weight="1"
-      android:clipChildren="false"
-      android:clipToPadding="false"
-      android:focusable="true"
+      android:background="@drawable/click_indicator_light"
+      android:ellipsize="end"
       android:gravity="center_vertical"
-      android:orientation="horizontal"
-      tools:ignore="RtlSymmetry">
+      android:maxLines="1"
+      android:paddingEnd="@dimen/grid_2"
+      android:paddingStart="@dimen/grid_2"
+      tools:text="Staff Picks" />
 
-      <com.kickstarter.ui.views.IconButton
-        android:id="@+id/menu_button"
-        style="@style/ToolbarIcon"
-        android:text="@string/menu_icon" />
+    <ImageButton
+      android:id="@+id/creator_dashboard_button"
+      style="@style/ToolbarVectorIcon"
+      android:contentDescription="@string/tabbar_dashboard"
+      android:src="@drawable/icon__graph_line" />
 
-      <TextView
-        android:id="@+id/filter_text_view"
-        style="@style/ToolbarTitle"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginStart="0dp"
-        android:background="@drawable/button_selector"
-        android:ellipsize="end"
-        android:gravity="center_vertical"
-        android:maxLines="1"
-        android:paddingEnd="@dimen/grid_2"
-        android:paddingStart="@dimen/grid_2"
-        tools:text="Staff Picks" />
+    <ImageButton
+      android:id="@+id/activity_feed_button"
+      style="@style/ToolbarIcon"
+      android:contentDescription="@string/tabbar_activity"
+      android:src="@drawable/icon__bolt" />
 
-    </LinearLayout>
-
-    <LinearLayout
-      android:layout_width="wrap_content"
-      android:layout_height="match_parent"
-      android:orientation="horizontal">
-
-      <ImageButton
-        android:id="@+id/creator_dashboard_button"
-        style="@style/ToolbarVectorIcon"
-        android:contentDescription="@string/tabbar_dashboard"
-        android:src="@drawable/icon__graph_line" />
-
-      <ImageButton
-        android:id="@+id/activity_feed_button"
-        style="@style/ToolbarIcon"
-        android:contentDescription="@string/tabbar_activity"
-        android:src="@drawable/icon__bolt" />
-
-      <ImageButton
-        android:id="@+id/search_button"
-        style="@style/ToolbarIcon"
-        android:contentDescription="@string/tabbar_search"
-        android:src="@drawable/icon__search" />
-
-    </LinearLayout>
+    <ImageButton
+      android:id="@+id/search_button"
+      style="@style/ToolbarIcon"
+      android:contentDescription="@string/tabbar_search"
+      android:src="@drawable/icon__search" />
 
   </LinearLayout>
 


### PR DESCRIPTION
# What ❓
- rounded menu icon with content description 
- updated title click indicator to match the buttons 

# How to QA? 🤔
Turn on TalkBack, and select the menu icon, it should say "User menu button -- double tap to activate"

# Story 📖
[Trello](https://trello.com/c/WKp0lN4a/374-add-accessibility-labels-on-nav-bar-icons)

# See 👀
<img width="330" src="https://user-images.githubusercontent.com/1289295/52819757-28c94a80-3078-11e9-9dbb-2caee7bbf20b.png"/>

