### PR TITLE
[UI Fix] - Ripple of profile section in logged in drawer layout goes outside of the bounds of the view.

### DIFF
--- a/app/src/main/res/layout/discovery_drawer_logged_in_view.xml
+++ b/app/src/main/res/layout/discovery_drawer_logged_in_view.xml
@@ -13,10 +13,6 @@
     android:id="@+id/user_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="@dimen/activity_vertical_margin"
-    android:layout_marginEnd="@dimen/grid_5_half"
-    android:layout_marginStart="@dimen/grid_5_half"
-    android:layout_marginTop="@dimen/activity_vertical_margin"
     android:foreground="@drawable/click_indicator_light"
     android:gravity="center_vertical"
     android:orientation="vertical">
@@ -26,6 +22,9 @@
       android:layout_width="@dimen/grid_8"
       android:layout_height="@dimen/grid_8"
       android:layout_marginBottom="@dimen/grid_3"
+      android:layout_marginEnd="@dimen/grid_5_half"
+      android:layout_marginStart="@dimen/grid_5_half"
+      android:layout_marginTop="@dimen/activity_vertical_margin"
       android:adjustViewBounds="true"
       android:contentDescription="@null"
       tools:src="@drawable/ic_face" />
@@ -35,6 +34,9 @@
       style="@style/Title2Medium"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:layout_marginBottom="@dimen/activity_vertical_margin"
+      android:layout_marginEnd="@dimen/grid_5_half"
+      android:layout_marginStart="@dimen/grid_5_half"
       android:textColor="@color/ksr_soft_black"
       tools:text="Lisa Luo" />
 

--- a/app/src/main/res/layout/discovery_drawer_logged_in_view.xml
+++ b/app/src/main/res/layout/discovery_drawer_logged_in_view.xml
@@ -17,7 +17,7 @@
     android:layout_marginEnd="@dimen/grid_5_half"
     android:layout_marginStart="@dimen/grid_5_half"
     android:layout_marginTop="@dimen/activity_vertical_margin"
-    android:background="@drawable/click_indicator_light"
+    android:foreground="@drawable/click_indicator_light"
     android:gravity="center_vertical"
     android:orientation="vertical">
 


### PR DESCRIPTION
# What ❓
- changed the container attribute from background to foreground so the ripple stays within the view.

# How to QA? 🤔
- Log into the app `->` open the drawer `->` long press the profile row.

# Story 📖

[Ripple of profile section in logged in drawer layout goes outside of the bounds of the view.](https://trello.com/c/yYvRnJsn/1256-ripple-of-profile-section-in-logged-in-drawer-layout-goes-outside-of-the-bounds-of-the-view)

# See 👀
![ripple](https://user-images.githubusercontent.com/16387538/53739562-0f8a1180-3e60-11e9-99d8-136893cac42c.gif)


