### PR TITLE
[Maintenance] - Kotlin let feature

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ChangeEmailActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ChangeEmailActivity.kt
@@ -95,12 +95,11 @@ class ChangeEmailActivity : BaseActivity<ChangeEmailViewModel.ViewModel>() {
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe {
-                    if (it != null) {
+                    it?.let {
                         email_warning_text_view.text = getString(it)
-                        email_warning_text_view.visibility = View.VISIBLE
-                    } else {
-                        ViewUtils.setGone(email_warning_text_view, true)
-                    }
+                        email_warning_text_view.visibility = View.VISIBLE }
+
+                    ViewUtils.setGone(email_warning_text_view, true)
                 }
 
         this.viewModel.outputs.warningTextColor()

--- a/app/src/main/java/com/kickstarter/ui/activities/HelpSettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/HelpSettingsActivity.kt
@@ -107,13 +107,10 @@ class HelpSettingsActivity : BaseActivity<HelpSettingsViewModel.ViewModel>() {
                 ChromeTabsHelperActivity.CustomTabFallback {
 
             override fun openUri(activity: Activity, uri: Uri) {
-                if (helpActivityIntent != null) {
-                    activity.startActivity(helpActivityIntent)
-                } else {
-                    // We're not handling users without browsers, We'll monitor on Fabric.
-                    val intent = Intent(Intent.ACTION_VIEW, uri)
-                    activity.startActivity(intent)
-                }
+                helpActivityIntent?.let { activity.startActivity(helpActivityIntent) }
+                // We're not handling users without browsers, We'll monitor on Fabric.
+                val intent = Intent(Intent.ACTION_VIEW, uri)
+                activity.startActivity(intent)
             }
         })
     }


### PR DESCRIPTION
# What ❓
- Decided to use a cool Kotlin trick to clean up some small things. So before we were previously checking if a value `!=null` and then executing what we want. With `let` we can clean up our code a little bit but with the same expected function and result. So instead of 

[Kotlin let run also apply with](https://www.journaldev.com/19467/kotlin-let-run-also-apply-with)

```
if (it != null) {
// something we want to do
}
```
We can now use this
```
item.?let {
// Something we want to do
}
```


# How to QA? 🤔
- For `ChangeEmailActivity` and `HelpSettingsActivity` they should both function the same way. So just type and check if the validation text shows and disappears. For the Help screen the chrome tabs should launch as expected.


