### PR TITLE
Fixing bug with android pay button

### DIFF
--- a/app/src/main/res/layout/checkout_layout.xml
+++ b/app/src/main/res/layout/checkout_layout.xml
@@ -2,7 +2,6 @@
 <RelativeLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-  xmlns:wallet="http://schemas.android.com/apk/res-auto"
   android:orientation="vertical"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
@@ -156,17 +155,9 @@
 
   <FrameLayout
     android:id="@+id/masked_wallet_fragment"
+    android:visibility="gone"
     android:layout_width="0dp"
     android:layout_height="0dp" />
-
-  <fragment
-    android:id="@+id/wallet_fragment"
-    android:visibility="gone"
-    android:name="com.google.android.gms.wallet.fragment.SupportWalletFragment"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    wallet:fragmentMode="buyButton"/>
-
 
   <include
     android:id="@+id/checkout_loading_indicator"


### PR DESCRIPTION
# What ❓
In this huge PR #427, I added TWO (?!?!) `WalletFragment`s.
I got rid of the second one 🙏 

# How Sway?!
I inspected the layout 😭 
<img width="387" alt="Screen Shot 2019-04-02 at 6 21 05 PM" src="https://user-images.githubusercontent.com/1289295/55440046-7b9d8980-5574-11e9-91f1-3bf7ef932752.png">

I initially thought it was in the toolbar but really it was floating on top ༼ ༎ຶ ෴ ༎ຶ༽ We got around this with the first fragment by setting its height and width to `0dp`.

# How to QA? 🤔
Try to pledge to a project! 
The screen should no longer show that ghost button.

# Story 📖
[Trello Story](https://trello.com/c/RLNU1cIC/202-buy-with-android-pay)

# See 👀
(These are Stripe test cards)
<img src="https://user-images.githubusercontent.com/1289295/55440023-5dd02480-5574-11e9-884b-12756eaafc0d.png" width="330"/>
