### PR TITLE
[🐞] Default drawer params bug

### DIFF
--- a/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
+++ b/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
@@ -448,7 +448,7 @@ public abstract class DiscoveryParams implements Parcelable {
   }
 
   public static DiscoveryParams getDefaultParams(final @Nullable User user) {
-    final Builder builder = DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME);
+    final Builder builder = DiscoveryParams.builder();
     if (user != null && isFalse(user.optedOutOfRecommendations())) {
       builder.recommended(true).backed(-1);
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -34,7 +34,6 @@ import com.kickstarter.ui.viewholders.discoverydrawer.TopFilterViewHolder;
 import java.util.List;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
@@ -42,7 +41,6 @@ import rx.subjects.PublishSubject;
 import static com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair;
 import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
 import static com.kickstarter.libs.rx.transformers.Transformers.takeWhen;
-import static com.kickstarter.libs.utils.BooleanUtils.isFalse;
 
 public interface DiscoveryViewModel {
 
@@ -266,13 +264,6 @@ public interface DiscoveryViewModel {
         .filter(IntentMapper::appBannerIsSet)
         .compose(bindToLifecycle())
         .subscribe(__ -> this.koala.trackOpenedAppBanner());
-    }
-
-    private DiscoveryParams getDefaultParams(final @Nullable User user) {
-      if (user != null && isFalse(user.optedOutOfRecommendations())) {
-        return DiscoveryParams.builder().recommended(true).backed(-1).build();
-      }
-      return DiscoveryParams.builder().build();
     }
 
     private final PublishSubject<Void> activityFeedClick = PublishSubject.create();

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -64,7 +64,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
   }
 
   private void setUpInitialHomeAllProjectsParams() {
-    this.vm.inputs.paramsFromActivity(DiscoveryParams.getDefaultParams(null));
+    this.vm.inputs.paramsFromActivity(DiscoveryParams.getDefaultParams(null).toBuilder().sort(DiscoveryParams.Sort.HOME).build());
     this.vm.inputs.rootCategories(CategoryFactory.rootCategories());
   }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -132,7 +132,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.expandSortTabLayout.assertValues(true);
 
     // Toolbar params should be loaded with initial params.
-    this.updateToolbarWithParams.assertValues(DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build());
+    this.updateToolbarWithParams.assertValues(DiscoveryParams.builder().build());
 
     // Select POPULAR sort.
     this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 1);
@@ -141,11 +141,11 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.expandSortTabLayout.assertValues(true, true);
 
     // Unchanged toolbar params should not emit.
-    this.updateToolbarWithParams.assertValues(DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build());
+    this.updateToolbarWithParams.assertValues(DiscoveryParams.builder().build());
 
     // Select ALL PROJECTS filter from drawer.
     this.vm.inputs.topFilterViewHolderRowClick(null,
-      NavigationDrawerData.Section.Row.builder().params(DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build()).build()
+      NavigationDrawerData.Section.Row.builder().params(DiscoveryParams.builder().build()).build()
     );
 
     // Sort tab should be expanded.


### PR DESCRIPTION
# What ❓
Fixing bug with default params not getting selected.
The activity shouldn't determine the sort, the DiscoveryFragment should.
Fixed it by updating `DiscoveryParams.getDefaultParams` to not set the sort.
Updated (more like reverted 😛) the tests.

# How to QA? 🤔
<details><summary>Logged out user sees `All Projects` highlighted in the drawer on app open.</summary>
<p>
<img src="https://user-images.githubusercontent.com/1289295/55825054-2bbe4580-5ad3-11e9-856d-5f53bf357f1d.png" width="330"/>
</p>
</details>
<details><summary>Logged in, opted out of recommendations user sees `All Projects` highlighted in the drawer on app open.</summary>
<p>
<img src="https://user-images.githubusercontent.com/1289295/55825130-5c9e7a80-5ad3-11e9-945c-9b0399112d39.png" width="330"/>
</p>
</details>
<details><summary>Logged in, opted in to recommendations user sees `Recommended for you` highlighted in the drawer on app open.</summary>
<p>
<img src="https://user-images.githubusercontent.com/1289295/55825179-72ac3b00-5ad3-11e9-8a6f-9f58807769ca.png" width="330"/>
</p>
</details>

# Story 📖
[Trello Story](https://trello.com/c/ZJZEaes2/1315-initial-drawer-params-are-not-selected-when-the-app-is-first-opened)

# Note
I found another bug :) Plz see #native-engineering

