### PR TITLE
Reward animation

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -20,13 +20,14 @@ import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.FreezeLinearLayoutManager
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
-import com.kickstarter.models.Reward
+import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.ui.ArgumentsKey
 import com.kickstarter.ui.activities.NewCardActivity
 import com.kickstarter.ui.adapters.RewardCardAdapter
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.ScreenLocation
 import com.kickstarter.ui.itemdecorations.RewardCardItemDecoration
+import com.kickstarter.ui.viewholders.HorizontalRewardViewHolder
 import com.kickstarter.ui.viewholders.RewardPledgeCardViewHolder
 import com.kickstarter.viewmodels.PledgeFragmentViewModel
 import kotlinx.android.synthetic.main.fragment_pledge.*
@@ -119,16 +120,17 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.inputs.selectCardButtonClicked(position)
     }
 
-    private fun showPledgeSection(rewardAndLocation: Pair<Reward, ScreenLocation>) {
-        val location = rewardAndLocation.second
-        val reward = rewardAndLocation.first
-        setInitialViewStates(location, reward)
-        startPledgeAnimatorSet(true, location)
+    private fun showPledgeSection(pledgeData: PledgeData) {
+        setInitialViewStates(pledgeData)
+        startPledgeAnimatorSet(true, pledgeData.rewardScreenLocation)
     }
 
-    private fun positionRewardSnapshot(location: ScreenLocation, reward: Reward) {
+    private fun positionRewardSnapshot(pledgeData: PledgeData) {
+        val location = pledgeData.rewardScreenLocation
+        val reward = pledgeData.reward
+        val project = pledgeData.project
         val rewardParams = reward_snapshot.layoutParams as FrameLayout.LayoutParams
-        rewardParams.marginStart = location.x.toInt()
+        rewardParams.leftMargin = location.x.toInt()
         rewardParams.topMargin = location.y.toInt()
         rewardParams.height = location.height.toInt()
         rewardParams.width = location.width.toInt()
@@ -136,13 +138,13 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         reward_snapshot.pivotX = 0f
         reward_snapshot.pivotY = 0f
 
-//        todo: blocked until rewards work is available
-//        val rewardViewHolder = RewardsAdapter.RewardViewHolder(reward_to_copy)
-//        rewardViewHolder.bind(reward)
+        val rewardViewHolder = HorizontalRewardViewHolder(reward_to_copy, null)
+        rewardViewHolder.bindData(Pair(project, reward))
 
         reward_to_copy.post {
             pledge_root.visibility = View.VISIBLE
-//            reward_snapshot.setImageBitmap(ViewUtils.getBitmap(reward_to_copy, location.width, location.width))
+            val bitmap = ViewUtils.getBitmap(reward_to_copy, location.width.toInt(), location.height.toInt())
+            reward_snapshot.setImageBitmap(bitmap)
             reward_to_copy.visibility = View.GONE
         }
     }
@@ -189,7 +191,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         }
 
         val (startMargin, topMargin) = margin.let {
-            getMarginStartAnimator(initMarginX, finalMarginX) to
+            getMarginLeftAnimator(initMarginX, finalMarginX) to
                     getMarginTopAnimator(initMarginY, finalMarginY)
         }
 
@@ -235,12 +237,12 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 }
             }
 
-    private fun getMarginStartAnimator(initialValue: Float, finalValue: Float) =
+    private fun getMarginLeftAnimator(initialValue: Float, finalValue: Float) =
             ValueAnimator.ofFloat(initialValue, finalValue).apply {
                 addUpdateListener {
                     val newParams = reward_snapshot?.layoutParams as FrameLayout.LayoutParams?
                     val newMargin = it.animatedValue as Float
-                    newParams?.marginStart = newMargin.toInt()
+                    newParams?.leftMargin = newMargin.toInt()
                     reward_snapshot?.layoutParams = newParams
                 }
             }
@@ -286,8 +288,8 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         delivery.layoutParams = deliveryParams
     }
 
-    private fun setInitialViewStates(location: ScreenLocation, reward: Reward) {
-        positionRewardSnapshot(location, reward)
+    private fun setInitialViewStates(pledgeData: PledgeData) {
+        positionRewardSnapshot(pledgeData)
         pledge_details.y = pledge_root.height.toFloat()
     }
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/HorizontalRewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/HorizontalRewardViewHolder.kt
@@ -23,7 +23,7 @@ import com.kickstarter.viewmodels.HorizontalRewardViewHolderViewModel
 import kotlinx.android.synthetic.main.item_reward.view.*
 
 
-class HorizontalRewardViewHolder(private val view: View, val delegate: Delegate) : KSViewHolder(view) {
+class HorizontalRewardViewHolder(private val view: View, val delegate: Delegate?) : KSViewHolder(view) {
 
     interface Delegate {
         fun rewardClicked(screenLocation: ScreenLocation, reward: Reward)
@@ -109,7 +109,7 @@ class HorizontalRewardViewHolder(private val view: View, val delegate: Delegate)
         this.viewModel.outputs.showPledgeFragment()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { this.delegate.rewardClicked(getScreenLocationOfReward(), this.reward) }
+                .subscribe { this.delegate?.rewardClicked(getScreenLocationOfReward(), this.reward) }
 
         this.viewModel.outputs.startBackingActivity()
                 .compose(bindToLifecycle())
@@ -137,9 +137,9 @@ class HorizontalRewardViewHolder(private val view: View, val delegate: Delegate)
 
     private fun getScreenLocationOfReward(): ScreenLocation {
         val rewardLocation = IntArray(2)
-        this.itemView.getLocationInWindow(rewardLocation)
-        val x = rewardLocation[0].toFloat()
-        val y = rewardLocation[1].toFloat()
+        this.itemView.horizontal_reward_card.getLocationInWindow(rewardLocation)
+        val x = this.itemView.left.toFloat()
+        val y = this.itemView.top.toFloat()
         val height = this.itemView.height
         val width = this.itemView.width
         return ScreenLocation(x, y, height.toFloat(), width.toFloat())

--- a/app/src/main/java/com/kickstarter/ui/views/BottomCropImageView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/BottomCropImageView.kt
@@ -15,8 +15,7 @@ class BottomCropImageView : AppCompatImageView {
         setup()
     }
 
-    constructor(context: Context, attrs: AttributeSet,
-                defStyle: Int) : super(context, attrs, defStyle) {
+    constructor(context: Context, attrs: AttributeSet, defStyle: Int) : super(context, attrs, defStyle) {
         setup()
     }
 
@@ -31,14 +30,9 @@ class BottomCropImageView : AppCompatImageView {
         val matrix = imageMatrix
 
         val viewWidth = (measuredWidth - paddingLeft - paddingRight).toFloat()
-        val viewHeight = (measuredHeight - paddingTop - paddingBottom).toFloat()
         val drawableWidth = drawable.intrinsicWidth.toFloat()
-        val drawableHeight = drawable.intrinsicHeight.toFloat()
 
-        val scale = when {
-            viewHeight > viewWidth -> viewHeight / drawableHeight
-            else -> viewWidth / drawableWidth
-        }
+        val scale = viewWidth / drawableWidth
 
         matrix.setScale(scale, scale, 0f, 0f)
 

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -5,7 +5,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  android:background="@color/ksr_grey_300"
+  android:background="@color/ksr_grey_400"
   android:fillViewport="true"
   android:scrollbars="none"
   android:visibility="invisible"
@@ -16,10 +16,9 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <View
+    <include
       android:id="@+id/reward_to_copy"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content" />
+      layout="@layout/item_reward" />
 
     <!-- todo: what's the content description? -->
     <com.kickstarter.ui.views.BottomCropImageView
@@ -27,9 +26,9 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_margin="@dimen/activity_horizontal_margin"
-      android:background="@color/white"
       android:contentDescription="@null"
       android:elevation="@dimen/mini_reward_elevation"
+      tools:background="@color/white"
       tools:layout_height="@dimen/mini_reward_height"
       tools:layout_width="@dimen/mini_reward_width" />
 

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -13,10 +13,10 @@ import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.mock.factories.StoredCardFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClient
-import com.kickstarter.models.Reward
 import com.kickstarter.models.StoredCard
 import com.kickstarter.ui.ArgumentsKey
 import com.kickstarter.ui.data.ActivityResult
+import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.ScreenLocation
 import org.junit.Test
 import rx.Observable
@@ -27,7 +27,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var vm: PledgeFragmentViewModel.ViewModel
 
-    private val animateRewardCard = TestSubscriber<Pair<Reward, ScreenLocation>>()
+    private val animateRewardCard = TestSubscriber<PledgeData>()
     private val cards = TestSubscriber<List<StoredCard>>()
     private val estimatedDelivery = TestSubscriber<String>()
     private val pledgeAmount = TestSubscriber<String>()


### PR DESCRIPTION
# What ❓
Showing actual mini reward in `PledgeFragment` with tests.
`BottomCropImageView` now prioritizes scale of the width.

# How to QA? 🤔
With the `Horizontal rewards` (to be renamed) internal flag enabled, select a reward.

# Story 📖
[Trello Story](https://trello.com/c/TP3fSgRb/1344-open-pledgefragment-when-reward-is-clicked)

# See 👀
![device-2019-04-24-123641 2019-04-24 12_37_30](https://user-images.githubusercontent.com/1289295/56677099-bdaa7e80-668d-11e9-93a4-71ef02270a76.gif)


