### PR TITLE
[🐞] Fixes bug with rewards container getting resized 

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -86,7 +86,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
         this.viewModel.outputs.setInitialRewardsContainerY()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe{ setInitialRewardsContainerY() }
+                .subscribe { setInitialRewardsContainerY() }
 
         this.viewModel.outputs.showRewardsFragment()
                 .compose(bindToLifecycle())
@@ -183,11 +183,11 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
     }
 
     private fun animateRewards(expand: Boolean) {
-        val showTarget = if (!expand) native_back_this_project_button else pledge_container
-        val showRewardsFragment: ObjectAnimator = ObjectAnimator.ofFloat(showTarget, View.ALPHA, 0f, 1f)
+        val targetToShow = if (!expand) native_back_this_project_button else pledge_container
+        val showRewardsFragmentAnimator = ObjectAnimator.ofFloat(targetToShow, View.ALPHA, 0f, 1f)
 
-        val hideTarget = if (!expand) pledge_container else native_back_this_project_button
-        val hideRewardsFragment: ObjectAnimator = ObjectAnimator.ofFloat(hideTarget, View.ALPHA, 1f, 0f)
+        val targetToHide = if (!expand) pledge_container else native_back_this_project_button
+        val hideRewardsFragmentAnimator = ObjectAnimator.ofFloat(targetToHide, View.ALPHA, 1f, 0f)
 
         val guideline = resources.getDimensionPixelSize(R.dimen.reward_fragment_guideline_constraint_end)
         val initialValue = (if (expand) rewards_container.height - guideline else 0).toFloat()
@@ -202,7 +202,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
         }
 
         AnimatorSet().apply {
-            playTogether(showRewardsFragment, hideRewardsFragment, rewardsContainerYAnimator)
+            playTogether(showRewardsFragmentAnimator, hideRewardsFragmentAnimator, rewardsContainerYAnimator)
             duration = animDuration
 
             addListener(object : Animator.AnimatorListener {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -7,11 +7,9 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Pair
 import android.view.View
-import androidx.constraintlayout.widget.ConstraintSet
+import android.view.ViewTreeObserver
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.transition.AutoTransition
-import androidx.transition.TransitionManager
 import com.kickstarter.R
 import com.kickstarter.libs.ActivityRequestCodes
 import com.kickstarter.libs.BaseActivity
@@ -35,8 +33,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
     private lateinit var adapter: ProjectAdapter
     private lateinit var ksString: KSString
 
-    private var grid8Dimen = R.dimen.grid_8
-
     private val projectBackButtonString = R.string.project_back_button
     private val managePledgeString = R.string.project_checkout_manage_navbar_title
     private val projectShareLabelString = R.string.project_accessibility_button_share_label
@@ -46,9 +42,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
     private val creatorString = R.string.project_subpages_menu_buttons_creator
 
     private val animDuration = 200L
-    private val showRewardsFragment: ObjectAnimator = ObjectAnimator.ofFloat(null, View.ALPHA, 0f, 1f)
-    private val hideRewardsFragment: ObjectAnimator = ObjectAnimator.ofFloat(null, View.ALPHA, 1f, 0f)
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -59,6 +52,16 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
         this.adapter = ProjectAdapter(this.viewModel)
         project_recycler_view.adapter = this.adapter
         project_recycler_view.layoutManager = LinearLayoutManager(this)
+
+        val viewTreeObserver = rewards_container.viewTreeObserver
+        if (viewTreeObserver.isAlive) {
+            viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
+                override fun onGlobalLayout() {
+                    this@ProjectActivity.viewModel.inputs.onGlobalLayout()
+                    rewards_container.viewTreeObserver.removeOnGlobalLayoutListener(this)
+                }
+            })
+        }
 
         this.viewModel.outputs.heartDrawableId()
                 .compose(bindToLifecycle())
@@ -79,6 +82,11 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
                         ViewUtils.setGone(view, false)
                     }
                 }
+
+        this.viewModel.outputs.setInitialRewardsContainerY()
+                .compose(bindToLifecycle())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe{ setInitialRewardsContainerY() }
 
         this.viewModel.outputs.showRewardsFragment()
                 .compose(bindToLifecycle())
@@ -175,42 +183,47 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
     }
 
     private fun animateRewards(expand: Boolean) {
-        this.showRewardsFragment.removeAllUpdateListeners()
-        this.showRewardsFragment.addUpdateListener { valueAnim ->
-            val initialRadius = resources.getDimensionPixelSize(R.dimen.fab_radius).toFloat()
-            val radius = initialRadius * if (expand) 1 - valueAnim.animatedFraction else valueAnim.animatedFraction
-            this.rewards_container.radius = radius
+        val showTarget = if (!expand) native_back_this_project_button else pledge_container
+        val showRewardsFragment: ObjectAnimator = ObjectAnimator.ofFloat(showTarget, View.ALPHA, 0f, 1f)
+
+        val hideTarget = if (!expand) pledge_container else native_back_this_project_button
+        val hideRewardsFragment: ObjectAnimator = ObjectAnimator.ofFloat(hideTarget, View.ALPHA, 1f, 0f)
+
+        val guideline = resources.getDimensionPixelSize(R.dimen.reward_fragment_guideline_constraint_end)
+        val initialValue = (if (expand) rewards_container.height - guideline else 0).toFloat()
+        val finalValue = (if (expand) 0 else rewards_container.height - guideline).toFloat()
+        val initialRadius = resources.getDimensionPixelSize(R.dimen.fab_radius).toFloat()
+
+        val rewardsContainerYAnimator = ObjectAnimator.ofFloat(rewards_container, View.Y, initialValue, finalValue).apply {
+            addUpdateListener { valueAnim ->
+                val radius = initialRadius * if (expand) 1 - valueAnim.animatedFraction else valueAnim.animatedFraction
+                rewards_container.radius = radius
+            }
         }
 
-        val durationTransition = AutoTransition()
-        durationTransition.duration = animDuration
-        TransitionManager.beginDelayedTransition(root, durationTransition)
+        AnimatorSet().apply {
+            playTogether(showRewardsFragment, hideRewardsFragment, rewardsContainerYAnimator)
+            duration = animDuration
 
-        val rewardAlphaSet = AnimatorSet()
-        this.showRewardsFragment.target = if (!expand) native_back_this_project_button else pledge_container
-        this.hideRewardsFragment.target = if (!expand) pledge_container else native_back_this_project_button
-        rewardAlphaSet.playTogether(this.showRewardsFragment, this.hideRewardsFragment)
-        rewardAlphaSet.duration = animDuration
+            addListener(object : Animator.AnimatorListener {
+                override fun onAnimationRepeat(animation: Animator?) {}
+                override fun onAnimationCancel(animation: Animator?) {}
 
-        rewardAlphaSet.addListener(object : Animator.AnimatorListener {
-            override fun onAnimationRepeat(animation: Animator?) {}
-            override fun onAnimationCancel(animation: Animator?) {}
-
-            override fun onAnimationEnd(animation: Animator?) {
-                if (expand) {
-                    native_back_this_project_button.visibility = View.GONE
+                override fun onAnimationEnd(animation: Animator?) {
+                    if (expand) {
+                        native_back_this_project_button.visibility = View.GONE
+                    }
                 }
-            }
 
-            override fun onAnimationStart(animation: Animator?) {
-                setRewardConstraints(expand)
-                if (!expand) {
-                    native_back_this_project_button.visibility = View.VISIBLE
+                override fun onAnimationStart(animation: Animator?) {
+                    if (!expand) {
+                        native_back_this_project_button.visibility = View.VISIBLE
+                    }
                 }
-            }
-        })
+            })
 
-        rewardAlphaSet.start()
+            start()
+        }
     }
 
     private fun displayProjectAndRewards(projectCountryAndNativeCheckout: Pair<Pair<Project, String>, Boolean>) {
@@ -230,32 +243,24 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
 
     private fun renderProject(project: Project, configCountry: String, isHorizontalRewardsEnabled: Boolean) {
         this.adapter.takeProject(project, configCountry, isHorizontalRewardsEnabled)
-        this.setRecyclerViewConstraints(isHorizontalRewardsEnabled)
+        setProjectRecyclerViewPadding(isHorizontalRewardsEnabled)
     }
 
-    private fun setRecyclerViewConstraints(isHorizontalRewardsEnabled: Boolean) {
+    private fun setInitialRewardsContainerY() {
+        val guideline = resources.getDimensionPixelSize(R.dimen.reward_fragment_guideline_constraint_end)
+        rewards_container.y = (rewards_container.height - guideline).toFloat()
+    }
+
+    private fun setProjectRecyclerViewPadding(isHorizontalRewardsEnabled: Boolean) {
         if (isHorizontalRewardsEnabled) {
             val paddingBottom = resources.getDimensionPixelSize(R.dimen.reward_fragment_guideline_constraint_end)
             project_recycler_view.setPadding(0, 0, 0, paddingBottom)
         }
     }
 
-    private fun setRewardConstraints(expand: Boolean) {
-        val constraintSet = ConstraintSet()
-        constraintSet.clone(root)
-        if (!expand) {
-            constraintSet.clear(R.id.rewards_container, ConstraintSet.BOTTOM)
-            constraintSet.connect(R.id.rewards_container, ConstraintSet.TOP, R.id.guideline, ConstraintSet.TOP, 0)
-        } else {
-            constraintSet.connect(R.id.rewards_container, ConstraintSet.TOP, R.id.root, ConstraintSet.TOP, 0)
-            constraintSet.connect(R.id.rewards_container, ConstraintSet.BOTTOM, R.id.root, ConstraintSet.BOTTOM, 0)
-        }
-        constraintSet.applyTo(root)
-    }
-
     private fun setupRewardsFragment(project: Project) {
-        val rewardsFragment = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment
-        rewardsFragment.takeProject(project)
+        val rewardsFragment = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment?
+        rewardsFragment?.takeProject(project)
     }
 
     private fun startCampaignWebViewActivity(project: Project) {
@@ -273,7 +278,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
     }
 
     private fun showStarToast() {
-        ViewUtils.showToastFromTop(this, getString(this.projectStarConfirmationString), 0, resources.getDimensionPixelSize(this.grid8Dimen))
+        ViewUtils.showToastFromTop(this, getString(this.projectStarConfirmationString), 0, resources.getDimensionPixelSize(R.dimen.grid_8))
     }
 
     private fun startCheckoutActivity(project: Project) {

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -47,6 +47,9 @@ interface ProjectViewModel {
         /** Call when the native back project button is clicked.  */
         fun nativeCheckoutBackProjectButtonClicked()
 
+        /** Call when the view has been laid out. */
+        fun onGlobalLayout()
+
         /** Call when the play video button is clicked.  */
         fun playVideoButtonClicked()
 
@@ -70,6 +73,9 @@ interface ProjectViewModel {
 
         /** Emits the back, manage, view pledge button, or null. */
         fun setActionButtonId(): Observable<Int>
+
+        /** Emits when we should set the Y position of the rewards container. */
+        fun setInitialRewardsContainerY(): Observable<Void>
 
         /** Emits when rewards fragment should expand. */
         fun showRewardsFragment(): Observable<Boolean>
@@ -123,6 +129,7 @@ interface ProjectViewModel {
         private val hideRewardsFragment = PublishSubject.create<Void>()
         private val managePledgeButtonClicked = PublishSubject.create<Void>()
         private val nativeCheckoutBackProjectButtonClicked = PublishSubject.create<Void>()
+        private val onGlobalLayout = PublishSubject.create<Void>()
         private val playVideoButtonClicked = PublishSubject.create<Void>()
         private val shareButtonClicked = PublishSubject.create<Void>()
         private val updatesTextViewClicked = PublishSubject.create<Void>()
@@ -131,6 +138,7 @@ interface ProjectViewModel {
         private val heartDrawableId = BehaviorSubject.create<Int>()
         private val projectAndUserCountryAndIsFeatureEnabled = BehaviorSubject.create<Pair<Pair<Project, String>, Boolean>>()
         private val setActionButtonId = BehaviorSubject.create<Int>()
+        private val setInitialRewardPosition = BehaviorSubject.create<Void>()
         private val showRewardsFragment = BehaviorSubject.create<Boolean>()
         private val startLoginToutActivity = BehaviorSubject.create<Void>()
         private val showShareSheet = BehaviorSubject.create<Project>()
@@ -244,6 +252,10 @@ interface ProjectViewModel {
                     .compose<Pair<Project, User>>(takeWhen(this.viewPledgeButtonClicked))
                     .subscribe(this.startBackingActivity)
 
+            this.onGlobalLayout
+                    .compose(bindToLifecycle())
+                    .subscribe(this.setInitialRewardPosition)
+
             this.nativeCheckoutBackProjectButtonClicked
                     .map { true }
                     .compose(bindToLifecycle())
@@ -345,6 +357,10 @@ interface ProjectViewModel {
             this.nativeCheckoutBackProjectButtonClicked.onNext(null)
         }
 
+        override fun onGlobalLayout() {
+            this.onGlobalLayout.onNext(null)
+        }
+
         override fun playVideoButtonClicked() {
             this.playVideoButtonClicked.onNext(null)
         }
@@ -405,51 +421,44 @@ interface ProjectViewModel {
             return this.projectAndUserCountryAndIsFeatureEnabled
         }
 
+        @NonNull
         override fun setActionButtonId(): Observable<Int> = this.setActionButtonId
 
-        override fun showSavedPrompt(): Observable<Void> {
-            return this.showSavedPrompt
-        }
+        @NonNull
+        override fun setInitialRewardsContainerY(): Observable<Void> = this.setInitialRewardPosition
 
-        override fun showShareSheet(): Observable<Project> {
-            return this.showShareSheet
-        }
+        @NonNull
+        override fun showSavedPrompt(): Observable<Void> = this.showSavedPrompt
 
-        override fun startBackingActivity(): Observable<Pair<Project, User>> {
-            return this.startBackingActivity
-        }
+        @NonNull
+        override fun showShareSheet(): Observable<Project> = this.showShareSheet
 
-        override fun startCampaignWebViewActivity(): Observable<Project> {
-            return this.startCampaignWebViewActivity
-        }
+        @NonNull
+        override fun startBackingActivity(): Observable<Pair<Project, User>> = this.startBackingActivity
 
-        override fun startCheckoutActivity(): Observable<Project> {
-            return this.startCheckoutActivity
-        }
+        @NonNull
+        override fun startCampaignWebViewActivity(): Observable<Project> = this.startCampaignWebViewActivity
 
-        override fun startCommentsActivity(): Observable<Project> {
-            return this.startCommentsActivity
-        }
+        @NonNull
+        override fun startCheckoutActivity(): Observable<Project> = this.startCheckoutActivity
 
-        override fun startCreatorBioWebViewActivity(): Observable<Project> {
-            return this.startCreatorBioWebViewActivity
-        }
+        @NonNull
+        override fun startCommentsActivity(): Observable<Project> = this.startCommentsActivity
 
-        override fun startLoginToutActivity(): Observable<Void> {
-            return this.startLoginToutActivity
-        }
+        @NonNull
+        override fun startCreatorBioWebViewActivity(): Observable<Project> = this.startCreatorBioWebViewActivity
 
-        override fun startManagePledgeActivity(): Observable<Project> {
-            return this.startManagePledgeActivity
-        }
+        @NonNull
+        override fun startLoginToutActivity(): Observable<Void> = this.startLoginToutActivity
 
-        override fun startProjectUpdatesActivity(): Observable<Project> {
-            return this.startProjectUpdatesActivity
-        }
+        @NonNull
+        override fun startManagePledgeActivity(): Observable<Project> = this.startManagePledgeActivity
 
-        override fun startVideoActivity(): Observable<Project> {
-            return this.startVideoActivity
-        }
+        @NonNull
+        override fun startProjectUpdatesActivity(): Observable<Project> = this.startProjectUpdatesActivity
+
+        @NonNull
+        override fun startVideoActivity(): Observable<Project> = this.startVideoActivity
 
         private fun getActionButtons(project: Project): Int? {
             return if (!project.isBacking && project.isLive) {

--- a/app/src/main/res/layout/project_layout.xml
+++ b/app/src/main/res/layout/project_layout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<RelativeLayout
   android:id="@+id/root"
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -14,14 +14,10 @@
   <androidx.recyclerview.widget.RecyclerView
     android:id="@+id/project_recycler_view"
     android:layout_width="match_parent"
-    android:layout_height="0dp"
+    android:layout_height="match_parent"
     android:clipToPadding="false"
-    android:layout_above="@+id/rewards_container"
-    android:layout_below="@id/project_toolbar"
-    app:layout_constraintBottom_toTopOf="@+id/project_action_buttons"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/project_toolbar" />
+    android:layout_above="@+id/project_action_buttons"
+    android:layout_below="@id/project_toolbar"/>
 
   <RelativeLayout
     android:id="@+id/project_action_buttons"
@@ -29,8 +25,8 @@
     android:layout_height="wrap_content"
     android:focusable="true"
     android:visibility="gone"
-    app:layout_constrainedHeight="false"
-    app:layout_constraintBottom_toBottomOf="parent">
+    tools:visibility="visible"
+    android:layout_alignParentBottom="true">
 
     <Button
       android:id="@+id/back_project_button"
@@ -57,13 +53,11 @@
   <androidx.cardview.widget.CardView
     android:id="@+id/rewards_container"
     android:layout_width="match_parent"
-    android:layout_height="0dp"
+    android:layout_height="match_parent"
     android:visibility="invisible"
     app:cardBackgroundColor="@color/white"
     app:cardCornerRadius="30dp"
-    app:cardElevation="@dimen/grid_2"
-    app:layout_constrainedHeight="false"
-    app:layout_constraintTop_toTopOf="@+id/guideline">
+    app:cardElevation="@dimen/grid_2">
 
     <LinearLayout
       android:id="@+id/pledge_container"
@@ -112,8 +106,7 @@
       android:textAllCaps="false"
       android:layout_marginEnd="@dimen/activity_horizontal_margin"
       android:layout_marginStart="@dimen/activity_horizontal_margin"
-      android:text="@string/project_back_button"
-      app:icon="@null" />
+      android:text="@string/project_back_button" />
 
   </androidx.cardview.widget.CardView>
 
@@ -124,4 +117,4 @@
     android:orientation="horizontal"
     app:layout_constraintGuide_end="@dimen/reward_fragment_guideline_constraint_end" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</RelativeLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -10,13 +10,10 @@ import com.kickstarter.libs.MockCurrentUser
 import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.factories.ConfigFactory
 import com.kickstarter.mock.factories.ProjectFactory
-import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.Project
 import com.kickstarter.models.User
 import com.kickstarter.ui.IntentKey
-import com.kickstarter.ui.data.PledgeData
-import com.kickstarter.ui.data.ScreenLocation
 import org.junit.Test
 import rx.observers.TestSubscriber
 
@@ -29,6 +26,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     private val startLoginToutActivity = TestSubscriber<Void>()
     private val savedTest = TestSubscriber<Boolean>()
     private val setActionButtonId = TestSubscriber<Int>()
+    private val setInitialRewardsContainerY = TestSubscriber<Void>()
     private val showRewardsFragment = TestSubscriber<Boolean>()
     private val startBackingActivity = TestSubscriber<Pair<Project, User>>()
     private val startCampaignWebViewActivity = TestSubscriber<Project>()
@@ -43,6 +41,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.heartDrawableId().subscribe(this.heartDrawableId)
         this.vm.outputs.projectAndUserCountryAndIsFeatureEnabled().map { pc -> pc.first.first }.subscribe(this.projectTest)
         this.vm.outputs.setActionButtonId().subscribe(this.setActionButtonId)
+        this.vm.outputs.setInitialRewardsContainerY().subscribe(this.setInitialRewardsContainerY)
         this.vm.outputs.showShareSheet().subscribe(this.showShareSheet)
         this.vm.outputs.showRewardsFragment().subscribe(this.showRewardsFragment)
         this.vm.outputs.showSavedPrompt().subscribe(this.showSavedPromptTest)
@@ -332,5 +331,12 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment())
         this.vm.inputs.nativeCheckoutBackProjectButtonClicked()
         this.showRewardsFragment.assertValue(true)
+    }
+
+    @Test
+    fun testProjectViewModel_SetInitialRewardsContainerY() {
+        setUpEnvironment(environment())
+        this.vm.inputs.onGlobalLayout()
+        this.setInitialRewardsContainerY.assertValueCount(1)
     }
 }


### PR DESCRIPTION
# What ❓
I noticed an unsightly bug when the keyboard is dismissed while the `RewardsFragment` is up caused by the evil and deceptive `ConstraintLayout`. For example, this can happen when you quick reply to a notification.

# How to QA? 🤔
Confirm the `RewardsFragment` reward cards are always full height.

# Story 📖
issa bug i found

# See 👀
| Before 🐛 | After 🦋 |
| --- | --- |
| ![bug](https://user-images.githubusercontent.com/1289295/56834952-e58e1380-6840-11e9-86c3-7fa1d985d921.gif) | ![fix](https://user-images.githubusercontent.com/1289295/56834953-e58e1380-6840-11e9-8018-e0fa715de8d7.gif) |

