### PR TITLE
Reward bottom gradient

### DIFF
--- a/app/src/main/res/drawable/white_gradient_background.xml
+++ b/app/src/main/res/drawable/white_gradient_background.xml
@@ -9,7 +9,7 @@
         android:endColor="@color/transparent"
         android:type="linear" />
       <corners
-        android:radius="@dimen/grid_1" >
+        android:radius="@dimen/grid_2" >
       </corners>
     </shape>
   </item>

--- a/app/src/main/res/drawable/white_gradient_background.xml
+++ b/app/src/main/res/drawable/white_gradient_background.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item>
-    <shape>
+    <shape
+      android:shape="rectangle">
       <gradient
         android:angle="90"
         android:startColor="@color/white"
         android:endColor="@color/transparent"
         android:type="linear" />
+      <corners
+        android:radius="@dimen/grid_1" >
+      </corners>
     </shape>
-
-    <corners
-      android:radius="11dp"   >
-    </corners>
   </item>
 </selector>

--- a/app/src/main/res/drawable/white_gradient_background.xml
+++ b/app/src/main/res/drawable/white_gradient_background.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item>
+    <shape>
+      <gradient
+        android:angle="90"
+        android:startColor="@color/white"
+        android:endColor="@color/transparent"
+        android:type="linear" />
+    </shape>
+
+    <corners
+      android:radius="11dp"   >
+    </corners>
+  </item>
+</selector>

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -113,12 +113,12 @@
 
         </LinearLayout>
 
-        <com.google.android.material.button.MaterialButton
-          android:id="@+id/placeholder"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:visibility="invisible"
-          tools:text="Pledge $10 or more" />
+          <com.google.android.material.button.MaterialButton
+            android:id="@+id/placeholder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="invisible"
+            tools:text="Pledge $10 or more" />
 
       </LinearLayout>
 
@@ -126,11 +126,25 @@
 
   </androidx.core.widget.NestedScrollView>
 
-  <com.google.android.material.button.MaterialButton
-    style="@style/PledgeButton"
-    android:id="@+id/horizontal_reward_pledge_button"
-    android:layout_width="match_parent"
+  <FrameLayout
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    tools:text="Pledge $10 or more" />
+    android:layout_gravity="bottom">
+
+    <View
+      android:id="@+id/total_amount_loading_view"
+      android:layout_width="match_parent"
+      android:layout_height="@dimen/grid_20"
+      android:background="@drawable/white_gradient_background" />
+
+    <com.google.android.material.button.MaterialButton
+      style="@style/PledgeButton"
+      android:id="@+id/horizontal_reward_pledge_button"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      tools:text="Pledge $10 or more" />
+
+  </FrameLayout>
+
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
# What ❓
- Added a fade effect on the bottom of long Reward Cards.

# How to QA? 🤔
- [ ] With the native checkout feature flag on, open the rewards screen.
- [ ] Rewards on which the content fits on the screen (non-scrollable) shouldn't have any changes
- [ ] Scrollable rewards should have a fade-out effect on the bottom indicating that there's more content to be seen.

# Story 📖
https://trello.com/c/Z1jiiSsK/1355-add-fade-out-effect-to-the-bottom-scrollable-reward-items

# See 👀
| Before | After |
| --- | --- | 
| <img src="https://user-images.githubusercontent.com/3709676/57088758-f6230b80-6cd0-11e9-95f1-fe9736bf1a8a.png" > | <img src="https://user-images.githubusercontent.com/3709676/57088792-03d89100-6cd1-11e9-8762-17759a31a24f.png"> |



