### PR TITLE
[🐜] OSS pagination bug

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/RecyclerViewPaginator.java
+++ b/app/src/main/java/com/kickstarter/libs/RecyclerViewPaginator.java
@@ -3,6 +3,8 @@ package com.kickstarter.libs;
 import android.util.Pair;
 
 import com.jakewharton.rxbinding.support.v7.widget.RxRecyclerView;
+import com.kickstarter.libs.utils.BooleanUtils;
+import com.kickstarter.libs.utils.Secrets;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -35,6 +37,7 @@ public final class RecyclerViewPaginator {
     stop();
 
     final Observable<Pair<Integer, Integer>> lastVisibleAndCount = RxRecyclerView.scrollEvents(this.recyclerView)
+      .filter(__ -> BooleanUtils.isFalse(Secrets.IS_OSS))
       .filter(__ -> this.recyclerView.canScrollVertically(DIRECTION_DOWN))
       .map(__ -> this.recyclerView.getLayoutManager())
       .ofType(LinearLayoutManager.class)


### PR DESCRIPTION
# What ❓
Ignoring all `RecyclerView` scroll events when `Secrets.IS_OSS` is `true` because there's no pagination because it doesn't actually hit the server.

# How to QA? 🤔
Build the OSS app without the secrets.
Run it and scroll to the bottom of Discovery.

# Story 📖
Figured it out when this issue was opened #521 
Thanks @sbenitez10!

# See 👀
![device-2019-05-02-153804 2019-05-02 15_39_04](https://user-images.githubusercontent.com/1289295/57101983-6f7e2680-6cf0-11e9-925d-dbe34c0998d8.gif)