### PR TITLE
Expand icon

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -251,13 +251,15 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         val detailsY = getYAnimator(initY, finalY)
 
         if (reveal) {
-            reward_snapshot.setOnClickListener {
+            val shrinkClickListener = View.OnClickListener { v ->
                 if (!width.isRunning) {
-                    it.setOnClickListener(null)
-                    this.animDuration = this.defaultAnimationDuration
+                    v?.setOnClickListener(null)
+                    this@PledgeFragment.animDuration = this@PledgeFragment.defaultAnimationDuration
                     startPledgeAnimatorSet(false, location)
                 }
             }
+            reward_snapshot.setOnClickListener(shrinkClickListener)
+            expand_icon_container.setOnClickListener(shrinkClickListener)
         } else {
             width.addUpdateListener {
                 if (it.animatedFraction == 1f) {
@@ -318,7 +320,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                     val newWidth = it.animatedValue as Float
                     newParams?.width = newWidth.toInt()
                     reward_snapshot?.layoutParams = newParams
-                    expand_icon?.alpha = if (finalValue < initialValue) animatedFraction else 1 - animatedFraction
+                    expand_icon_container?.alpha = if (finalValue < initialValue) animatedFraction else 1 - animatedFraction
                 }
             }
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -10,8 +10,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
-import android.widget.FrameLayout
 import android.widget.LinearLayout
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.kickstarter.R
@@ -177,7 +177,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         val location = pledgeData.rewardScreenLocation
         val reward = pledgeData.reward
         val project = pledgeData.project
-        val rewardParams = reward_snapshot.layoutParams as FrameLayout.LayoutParams
+        val rewardParams = reward_snapshot.layoutParams as CoordinatorLayout.LayoutParams
         rewardParams.leftMargin = location.x.toInt()
         rewardParams.topMargin = location.y.toInt()
         rewardParams.height = location.height.toInt()
@@ -278,7 +278,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     private fun getHeightAnimator(initialValue: Float, finalValue: Float) =
             ValueAnimator.ofFloat(initialValue, finalValue).apply {
                 addUpdateListener {
-                    val newParams = reward_snapshot?.layoutParams as FrameLayout.LayoutParams?
+                    val newParams = reward_snapshot?.layoutParams as CoordinatorLayout.LayoutParams?
                     val newHeight = it.animatedValue as Float
                     newParams?.height = newHeight.toInt()
                     reward_snapshot?.layoutParams = newParams
@@ -288,7 +288,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     private fun getMarginLeftAnimator(initialValue: Float, finalValue: Float) =
             ValueAnimator.ofFloat(initialValue, finalValue).apply {
                 addUpdateListener {
-                    val newParams = reward_snapshot?.layoutParams as FrameLayout.LayoutParams?
+                    val newParams = reward_snapshot?.layoutParams as CoordinatorLayout.LayoutParams?
                     val newMargin = it.animatedValue as Float
                     newParams?.leftMargin = newMargin.toInt()
                     reward_snapshot?.layoutParams = newParams
@@ -298,7 +298,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     private fun getMarginTopAnimator(initialValue: Float, finalValue: Float): ValueAnimator =
             ValueAnimator.ofFloat(initialValue, finalValue).apply {
                 addUpdateListener {
-                    val newParams = reward_snapshot?.layoutParams as FrameLayout.LayoutParams?
+                    val newParams = reward_snapshot?.layoutParams as CoordinatorLayout.LayoutParams?
                     val newMargin = it.animatedValue as Float
                     newParams?.topMargin = newMargin.toInt()
                     reward_snapshot?.layoutParams = newParams
@@ -314,10 +314,11 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     private fun getWidthAnimator(initialValue: Float, finalValue: Float) =
             ValueAnimator.ofFloat(initialValue, finalValue).apply {
                 addUpdateListener {
-                    val newParams = reward_snapshot?.layoutParams as FrameLayout.LayoutParams?
+                    val newParams = reward_snapshot?.layoutParams as CoordinatorLayout.LayoutParams?
                     val newWidth = it.animatedValue as Float
                     newParams?.width = newWidth.toInt()
                     reward_snapshot?.layoutParams = newParams
+                    expand_icon?.alpha = if (finalValue < initialValue) animatedFraction else 1 - animatedFraction
                 }
             }
 

--- a/app/src/main/res/drawable/ic_expand.xml
+++ b/app/src/main/res/drawable/ic_expand.xml
@@ -1,18 +1,18 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportHeight="24"
+  android:viewportWidth="24">
   <path
-      android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"
-      android:strokeWidth="1"
-      android:fillColor="#DCDEDD"
-      android:fillType="nonZero"
-      android:strokeColor="#00000000"/>
+    android:fillColor="#DCDEDD"
+    android:fillType="nonZero"
+    android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"
+    android:strokeColor="#00000000"
+    android:strokeWidth="1" />
   <path
-      android:pathData="M16.6062,7.2L13.3942,7.2C13.2214,7.2 13.135,7.4084 13.257,7.5308L14.439,8.7124L12.1758,10.9756L13.0242,11.8244L15.2874,9.5608L16.4694,10.7428C16.5914,10.8648 16.7998,10.7784 16.7998,10.606L16.7998,7.3936C16.7998,7.2868 16.7134,7.2 16.6062,7.2L16.6062,7.2ZM11.8242,13.0244L9.561,15.2876L10.743,16.4696C10.8646,16.5916 10.7786,16.8 10.6058,16.8L7.3938,16.8C7.2866,16.8 7.1998,16.7132 7.1998,16.6064L7.1998,13.394C7.1998,13.2216 7.4086,13.1352 7.5306,13.2572L8.7126,14.4392L10.9758,12.1756L11.8242,13.0244Z"
-      android:strokeWidth="1"
-      android:fillColor="#000000"
-      android:fillType="evenOdd"
-      android:strokeColor="#00000000"/>
+    android:fillColor="#000000"
+    android:fillType="evenOdd"
+    android:pathData="M16.6062,7.2L13.3942,7.2C13.2214,7.2 13.135,7.4084 13.257,7.5308L14.439,8.7124L12.1758,10.9756L13.0242,11.8244L15.2874,9.5608L16.4694,10.7428C16.5914,10.8648 16.7998,10.7784 16.7998,10.606L16.7998,7.3936C16.7998,7.2868 16.7134,7.2 16.6062,7.2L16.6062,7.2ZM11.8242,13.0244L9.561,15.2876L10.743,16.4696C10.8646,16.5916 10.7786,16.8 10.6058,16.8L7.3938,16.8C7.2866,16.8 7.1998,16.7132 7.1998,16.6064L7.1998,13.394C7.1998,13.2216 7.4086,13.1352 7.5306,13.2572L8.7126,14.4392L10.9758,12.1756L11.8242,13.0244Z"
+    android:strokeColor="#00000000"
+    android:strokeWidth="1" />
 </vector>

--- a/app/src/main/res/drawable/ic_expand.xml
+++ b/app/src/main/res/drawable/ic_expand.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"
+      android:strokeWidth="1"
+      android:fillColor="#DCDEDD"
+      android:fillType="nonZero"
+      android:strokeColor="#00000000"/>
+  <path
+      android:pathData="M16.6062,7.2L13.3942,7.2C13.2214,7.2 13.135,7.4084 13.257,7.5308L14.439,8.7124L12.1758,10.9756L13.0242,11.8244L15.2874,9.5608L16.4694,10.7428C16.5914,10.8648 16.7998,10.7784 16.7998,10.606L16.7998,7.3936C16.7998,7.2868 16.7134,7.2 16.6062,7.2L16.6062,7.2ZM11.8242,13.0244L9.561,15.2876L10.743,16.4696C10.8646,16.5916 10.7786,16.8 10.6058,16.8L7.3938,16.8C7.2866,16.8 7.1998,16.7132 7.1998,16.6064L7.1998,13.394C7.1998,13.2216 7.4086,13.1352 7.5306,13.2572L8.7126,14.4392L10.9758,12.1756L11.8242,13.0244Z"
+      android:strokeWidth="1"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"
+      android:strokeColor="#00000000"/>
+</vector>

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -42,7 +42,7 @@
       android:alpha="0"
       android:contentDescription="@null"
       android:elevation="@dimen/mini_reward_elevation"
-      android:src="@drawable/circle_black_alpha"
+      android:src="@drawable/ic_expand"
       app:layout_anchor="@id/reward_snapshot"
       app:layout_anchorGravity="end"
       tools:alpha="1" />

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -37,8 +37,8 @@
 
     <ImageView
       android:id="@+id/expand_icon"
-      android:layout_width="@dimen/grid_4"
-      android:layout_height="@dimen/grid_4"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
       android:alpha="0"
       android:contentDescription="@null"
       android:elevation="@dimen/mini_reward_elevation"

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -2,6 +2,7 @@
 <ScrollView
   android:id="@+id/pledge_root"
   xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
@@ -13,7 +14,7 @@
   android:visibility="invisible"
   tools:visibility="visible">
 
-  <FrameLayout
+  <androidx.coordinatorlayout.widget.CoordinatorLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -33,6 +34,18 @@
       tools:background="@color/white"
       tools:layout_height="@dimen/mini_reward_height"
       tools:layout_width="@dimen/mini_reward_width" />
+
+    <ImageView
+      android:id="@+id/expand_icon"
+      android:layout_width="@dimen/grid_4"
+      android:layout_height="@dimen/grid_4"
+      android:alpha="0"
+      android:contentDescription="@null"
+      android:elevation="@dimen/mini_reward_elevation"
+      android:src="@drawable/circle_black_alpha"
+      app:layout_anchor="@id/reward_snapshot"
+      app:layout_anchorGravity="end"
+      tools:alpha="1" />
 
     <LinearLayout
       android:id="@+id/pledge_details"
@@ -273,5 +286,5 @@
 
     </LinearLayout>
 
-  </FrameLayout>
+  </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -35,17 +35,27 @@
       tools:layout_height="@dimen/mini_reward_height"
       tools:layout_width="@dimen/mini_reward_width" />
 
-    <ImageView
-      android:id="@+id/expand_icon"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
+    <!-- todo: what's the content description? -->
+    <FrameLayout
+      android:id="@+id/expand_icon_container"
+      android:layout_width="@dimen/grid_8"
+      android:layout_height="@dimen/grid_8"
       android:alpha="0"
-      android:contentDescription="@null"
       android:elevation="@dimen/mini_reward_elevation"
-      android:src="@drawable/ic_expand"
       app:layout_anchor="@id/reward_snapshot"
       app:layout_anchorGravity="end"
-      tools:alpha="1" />
+      tools:alpha="1">
+
+      <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/grid_1"
+        android:layout_marginTop="@dimen/grid_2"
+        android:contentDescription="@null"
+        android:src="@drawable/ic_expand"
+        />
+    </FrameLayout>
+
 
     <LinearLayout
       android:id="@+id/pledge_details"


### PR DESCRIPTION
# What ❓
Showing the little expand icon on the top right of the mini reward.
Added a click listener at the request of @nnekab and @Rcureton. The icon is 24 x 24, which is too small for a tappable container so I put it in a `FrameLayout` that's the proper size.

# Story 📖
[Trello Story](https://trello.com/c/kpcmzWpD/1364-add-expand-icon-to-min-reward-after-transition-animation)

# See 👀

<img src=https://user-images.githubusercontent.com/1289295/58711046-a9902600-838b-11e9-8ed7-125b0f1bb43c.gif width=330/> <img src=https://user-images.githubusercontent.com/1289295/58711057-adbc4380-838b-11e9-8d62-6f90a10fe3ab.png width=330/>



