### PR TITLE
No reward -> PledgeFragment

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/ViewUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ViewUtils.java
@@ -18,6 +18,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.kickstarter.R;
+import com.kickstarter.ui.data.ScreenLocation;
 import com.kickstarter.ui.views.AppRatingDialog;
 import com.kickstarter.ui.views.ConfirmDialog;
 
@@ -37,6 +38,10 @@ public final class ViewUtils {
 
   public static float getScreenDensity(final @NonNull Context context) {
     return context.getResources().getDisplayMetrics().density;
+  }
+
+  public static ScreenLocation getScreenLocation(final  @NonNull View view) {
+    return new ScreenLocation(view.getLeft(), view.getTop(), view.getHeight(), view.getWidth());
   }
 
   public static int getScreenHeightDp(final @NonNull Context context) {

--- a/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.java
@@ -88,6 +88,7 @@ public final class RewardFactory {
   public static @NonNull Reward noReward() {
     return Reward.builder()
       .id(0)
+      .estimatedDeliveryOn(null)
       .description("No reward")
       .minimum(1.0f)
       .build();

--- a/app/src/main/java/com/kickstarter/ui/adapters/HorizontalRewardsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/HorizontalRewardsAdapter.kt
@@ -13,7 +13,7 @@ import rx.Observable
 
 class HorizontalRewardsAdapter(private val delegate: Delegate) : KSAdapter() {
 
-    interface Delegate: HorizontalRewardViewHolder.Delegate
+    interface Delegate: HorizontalRewardViewHolder.Delegate, HorizontalNoRewardViewHolder.Delegate
 
     override fun layout(sectionRow: SectionRow): Int {
         return when (sectionRow.section()) {
@@ -24,7 +24,7 @@ class HorizontalRewardsAdapter(private val delegate: Delegate) : KSAdapter() {
 
     override fun viewHolder(layout: Int, view: View): KSViewHolder {
         return when(layout) {
-            R.layout.item_no_reward -> HorizontalNoRewardViewHolder(view)
+            R.layout.item_no_reward -> HorizontalNoRewardViewHolder(view, this.delegate)
             R.layout.item_reward -> HorizontalRewardViewHolder(view, this.delegate)
             else -> EmptyViewHolder(view)
         }

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -20,6 +20,7 @@ import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.FreezeLinearLayoutManager
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
+import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.ui.ArgumentsKey
 import com.kickstarter.ui.activities.LoginToutActivity
@@ -28,6 +29,7 @@ import com.kickstarter.ui.adapters.RewardCardAdapter
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.ScreenLocation
 import com.kickstarter.ui.itemdecorations.RewardCardItemDecoration
+import com.kickstarter.ui.viewholders.HorizontalNoRewardViewHolder
 import com.kickstarter.ui.viewholders.HorizontalRewardViewHolder
 import com.kickstarter.ui.viewholders.RewardPledgeCardViewHolder
 import com.kickstarter.viewmodels.PledgeFragmentViewModel
@@ -75,6 +77,11 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
                 .subscribe { pledge_estimated_delivery.text = it }
+
+        this.viewModel.outputs.estimatedDeliveryInfoIsGone()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { ViewUtils.setGone(pledge_estimated_delivery_container, it) }
 
         this.viewModel.outputs.continueButtonIsGone()
                 .compose(bindToLifecycle())
@@ -186,7 +193,12 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         reward_snapshot.pivotX = 0f
         reward_snapshot.pivotY = 0f
 
-        val rewardViewHolder = HorizontalRewardViewHolder(reward_to_copy, null)
+        val rewardViewHolder = when {
+            RewardUtils.isNoReward(reward) -> HorizontalNoRewardViewHolder(no_reward_layout, null)
+            else -> HorizontalRewardViewHolder(reward_layout, null)
+        }
+
+        rewardViewHolder.itemView.visibility = View.VISIBLE
         rewardViewHolder.bindData(Pair(project, reward))
 
         reward_to_copy.post {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/HorizontalNoRewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/HorizontalNoRewardViewHolder.kt
@@ -22,7 +22,7 @@ class HorizontalNoRewardViewHolder(val view: View, val delegate: HorizontalNoRew
         fun rewardClicked(screenLocation: ScreenLocation, reward: Reward)
     }
 
-    private var viewModel = HorizontalNoRewardViewHolderViewModel.ViewModel(environment())
+    private val viewModel = HorizontalNoRewardViewHolderViewModel.ViewModel(environment())
 
     init {
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/HorizontalNoRewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/HorizontalNoRewardViewHolder.kt
@@ -4,23 +4,25 @@ import android.content.Intent
 import android.util.Pair
 import android.view.View
 import androidx.annotation.NonNull
-import com.kickstarter.R
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.TransitionUtils
+import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.BackingActivity
-import com.kickstarter.ui.activities.CheckoutActivity
+import com.kickstarter.ui.data.ScreenLocation
 import com.kickstarter.viewmodels.HorizontalNoRewardViewHolderViewModel
 import kotlinx.android.synthetic.main.item_no_reward.view.*
 
-class HorizontalNoRewardViewHolder(val view: View): KSViewHolder(view) {
+class HorizontalNoRewardViewHolder(val view: View, val delegate: HorizontalNoRewardViewHolder.Delegate?): KSViewHolder(view) {
+
+    interface Delegate {
+        fun rewardClicked(screenLocation: ScreenLocation, reward: Reward)
+    }
 
     private var viewModel = HorizontalNoRewardViewHolderViewModel.ViewModel(environment())
-
-    private val projectBackButtonString = context().getString(R.string.project_back_button)
 
     init {
 
@@ -29,10 +31,10 @@ class HorizontalNoRewardViewHolder(val view: View): KSViewHolder(view) {
                 .compose(Transformers.observeForUI())
                 .subscribe { startBackingActivity(it) }
 
-        this.viewModel.outputs.startCheckoutActivity()
+        this.viewModel.outputs.showPledgeFragment()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
-                .subscribe { pr -> startCheckoutActivity(pr.first, pr.second) }
+                .subscribe { this.delegate?.rewardClicked(ViewUtils.getScreenLocation(this.itemView), it.second) }
 
         view.horizontal_no_reward_pledge_button.setOnClickListener {
             this.viewModel.inputs.rewardClicked()
@@ -51,17 +53,6 @@ class HorizontalNoRewardViewHolder(val view: View): KSViewHolder(view) {
         val context = context()
         val intent = Intent(context, BackingActivity::class.java)
                 .putExtra(IntentKey.PROJECT, project)
-
-        context.startActivity(intent)
-        TransitionUtils.transition(context, TransitionUtils.slideInFromRight())
-    }
-
-    private fun startCheckoutActivity(@NonNull project: Project, @NonNull reward: Reward) {
-        val context = context()
-        val intent = Intent(context, CheckoutActivity::class.java)
-                .putExtra(IntentKey.PROJECT, project)
-                .putExtra(IntentKey.TOOLBAR_TITLE, this.projectBackButtonString)
-                .putExtra(IntentKey.URL, project.rewardSelectedUrl(reward))
 
         context.startActivity(intent)
         TransitionUtils.transition(context, TransitionUtils.slideInFromRight())

--- a/app/src/main/java/com/kickstarter/ui/viewholders/HorizontalRewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/HorizontalRewardViewHolder.kt
@@ -109,7 +109,7 @@ class HorizontalRewardViewHolder(private val view: View, val delegate: Delegate?
         this.viewModel.outputs.showPledgeFragment()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { this.delegate?.rewardClicked(getScreenLocationOfReward(), this.reward) }
+                .subscribe { this.delegate?.rewardClicked(ViewUtils.getScreenLocation(this.itemView), this.reward) }
 
         this.viewModel.outputs.startBackingActivity()
                 .compose(bindToLifecycle())
@@ -136,8 +136,6 @@ class HorizontalRewardViewHolder(private val view: View, val delegate: Delegate?
     }
 
     private fun getScreenLocationOfReward(): ScreenLocation {
-        val rewardLocation = IntArray(2)
-        this.itemView.horizontal_reward_card.getLocationInWindow(rewardLocation)
         val x = this.itemView.left.toFloat()
         val y = this.itemView.top.toFloat()
         val height = this.itemView.height

--- a/app/src/main/java/com/kickstarter/viewmodels/HorizontalRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/HorizontalRewardViewHolderViewModel.kt
@@ -12,7 +12,6 @@ import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.RewardsItem
 import com.kickstarter.ui.viewholders.HorizontalRewardViewHolder
-import com.kickstarter.ui.viewholders.KSViewHolder
 import rx.Observable
 import rx.subjects.PublishSubject
 import java.math.RoundingMode

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -18,9 +18,21 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <include
+    <FrameLayout
       android:id="@+id/reward_to_copy"
-      layout="@layout/item_reward" />
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content">
+
+      <include
+        android:id="@+id/reward_layout"
+        android:visibility="invisible"
+        layout="@layout/item_reward" />
+
+      <include
+        android:id="@+id/no_reward_layout"
+        android:visibility="invisible"
+        layout="@layout/item_no_reward" />
+    </FrameLayout>
 
     <!-- todo: what's the content description? -->
     <com.kickstarter.ui.views.BottomCropImageView
@@ -46,24 +58,32 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/grid_4"
         android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:minHeight="@dimen/mini_reward_height"
         android:orientation="vertical"
         android:paddingEnd="@dimen/activity_horizontal_margin"
         android:paddingStart="@dimen/grid_4">
 
-        <TextView
-          style="@style/CalloutSecondary"
+        <LinearLayout
+          android:id="@+id/pledge_estimated_delivery_container"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:text="@string/Estimated_delivery" />
+          android:orientation="vertical">
 
-        <TextView
-          android:id="@+id/pledge_estimated_delivery"
-          style="@style/CalloutPrimaryMedium"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_1"
-          tools:text="December 2019" />
+          <TextView
+            style="@style/CalloutSecondary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/Estimated_delivery" />
 
+          <TextView
+            android:id="@+id/pledge_estimated_delivery"
+            style="@style/CalloutPrimaryMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/grid_1"
+            tools:text="December 2019" />
+
+        </LinearLayout>
         <LinearLayout
           android:id="@+id/accountability"
           android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_no_reward.xml
+++ b/app/src/main/res/layout/item_no_reward.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout
-  android:id="@+id/reward_container"
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="@dimen/item_reward_layout_width"
   android:layout_height="wrap_content"
   android:orientation="vertical">
@@ -29,7 +27,6 @@
         android:padding="@dimen/grid_3">
 
         <TextView
-          android:id="@+id/horizontal_reward_title_text_view"
           style="@style/Headline"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
@@ -38,7 +35,6 @@
           android:text="@string/Make_a_pledge_without_a_reward" />
 
         <TextView
-          android:id="@+id/horizontal_reward_description_text_view"
           style="@style/BodyPrimary"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
@@ -47,7 +43,6 @@
           android:text="@string/Pledge_any_amount_to_help_bring_this_project_to_life"/>
 
         <com.google.android.material.button.MaterialButton
-          android:id="@+id/placeholder"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:visibility="invisible"

--- a/app/src/main/res/layout/item_no_reward.xml
+++ b/app/src/main/res/layout/item_no_reward.xml
@@ -44,7 +44,7 @@
         <com.google.android.material.button.MaterialButton
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:visibility="invisible"reward_contents
+          android:visibility="invisible"
           android:text="@string/Pledge_without_a_reward"/>
 
       </LinearLayout>

--- a/app/src/main/res/layout/item_no_reward.xml
+++ b/app/src/main/res/layout/item_no_reward.xml
@@ -20,7 +20,6 @@
       app:cardElevation="0dp">
 
       <LinearLayout
-        android:id="@+id/reward_contents"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
@@ -45,7 +44,7 @@
         <com.google.android.material.button.MaterialButton
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:visibility="invisible"
+          android:visibility="invisible"reward_contents
           android:text="@string/Pledge_without_a_reward"/>
 
       </LinearLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/HorizontalNoRewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/HorizontalNoRewardViewHolderViewModelTest.kt
@@ -14,30 +14,30 @@ import rx.observers.TestSubscriber
 class HorizontalNoRewardViewHolderViewModelTest: KSRobolectricTestCase() {
 
     private lateinit var vm: HorizontalNoRewardViewHolderViewModel.ViewModel
+    private val showPledgeFragment = TestSubscriber<Pair<Project, Reward>>()
     private val startBackingActivity = TestSubscriber<Project>()
-    private val startCheckoutActivity = TestSubscriber<Pair<Project, Reward>>()
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = HorizontalNoRewardViewHolderViewModel.ViewModel(environment)
+        this.vm.outputs.showPledgeFragment().subscribe(this.showPledgeFragment)
         this.vm.outputs.startBackingActivity().subscribe(this.startBackingActivity)
-        this.vm.outputs.startCheckoutActivity().subscribe(this.startCheckoutActivity)
     }
 
     @Test
-    fun testGoToCheckoutWhenProjectIsSuccessful() {
+    fun testShowPledgeFragmentWhenProjectIsSuccessful() {
         val project = ProjectFactory.successfulProject()
         val reward = RewardFactory.reward()
         setUpEnvironment(environment())
 
         this.vm.inputs.projectAndReward(project, reward)
-        this.startCheckoutActivity.assertNoValues()
+        this.showPledgeFragment.assertNoValues()
 
         this.vm.inputs.rewardClicked()
-        this.startCheckoutActivity.assertNoValues()
+        this.showPledgeFragment.assertNoValues()
     }
 
     @Test
-    fun testGoToCheckoutWhenProjectIsSuccessfulAndHasBeenBacked() {
+    fun testShowPledgeFragmentWhenProjectIsSuccessfulAndHasBeenBacked() {
         val project = ProjectFactory.backedProject().toBuilder()
                 .state(Project.STATE_SUCCESSFUL)
                 .build()
@@ -45,24 +45,24 @@ class HorizontalNoRewardViewHolderViewModelTest: KSRobolectricTestCase() {
         setUpEnvironment(environment())
 
         this.vm.inputs.projectAndReward(project, reward!!)
-        this.startCheckoutActivity.assertNoValues()
+        this.showPledgeFragment.assertNoValues()
 
         this.vm.inputs.rewardClicked()
-        this.startCheckoutActivity.assertNoValues()
+        this.showPledgeFragment.assertNoValues()
     }
 
     @Test
-    fun testGoToCheckoutWhenProjectIsLive() {
+    fun testShowPledgeFragmentWhenProjectIsLive() {
         val reward = RewardFactory.reward()
         val liveProject = ProjectFactory.project()
         setUpEnvironment(environment())
 
         this.vm.inputs.projectAndReward(liveProject, reward)
-        this.startCheckoutActivity.assertNoValues()
+        this.showPledgeFragment.assertNoValues()
 
         // When a reward from a live project is clicked, start checkout.
         this.vm.inputs.rewardClicked()
-        this.startCheckoutActivity.assertValue(Pair.create(liveProject, reward))
+        this.showPledgeFragment.assertValue(Pair.create(liveProject, reward))
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -36,6 +36,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val continueButtonIsGone = TestSubscriber<Boolean>()
     private val decreasePledgeButtonIsEnabled = TestSubscriber<Boolean>()
     private val estimatedDelivery = TestSubscriber<String>()
+    private val estimatedDeliveryInfoIsGone = TestSubscriber<Boolean>()
     private val increasePledgeButtonIsEnabled = TestSubscriber<Boolean>()
     private val paymentContainerIsGone = TestSubscriber<Boolean>()
     private val pledgeAmount = TestSubscriber<String>()
@@ -53,6 +54,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.continueButtonIsGone().subscribe(this.continueButtonIsGone)
         this.vm.outputs.decreasePledgeButtonIsEnabled().subscribe(this.decreasePledgeButtonIsEnabled)
         this.vm.outputs.estimatedDelivery().subscribe(this.estimatedDelivery)
+        this.vm.outputs.estimatedDeliveryInfoIsGone().subscribe(this.estimatedDeliveryInfoIsGone)
         this.vm.outputs.increasePledgeButtonIsEnabled().subscribe(this.increasePledgeButtonIsEnabled)
         this.vm.outputs.paymentContainerIsGone().subscribe(this.paymentContainerIsGone)
         this.vm.outputs.pledgeAmount().subscribe(this.pledgeAmount)
@@ -137,6 +139,15 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment())
 
         this.estimatedDelivery.assertValue("March 2019")
+        this.estimatedDeliveryInfoIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testDelivery_whenNoReward() {
+        setUpEnvironment(environment(), RewardFactory.noReward())
+
+        this.estimatedDelivery.assertNoValues()
+        this.estimatedDeliveryInfoIsGone.assertValue(true)
     }
 
     @Test


### PR DESCRIPTION
# What ❓
Selecting a no reward reward takes user to `PledgeFragment`.
Delivery info is hidden.
Tests.

# How to QA? 🤔
Back a project with no reward and verify the Pledge screen is shown and the estimated delivery is gone.

# Story 📖
We discussed but where's the card? I don't know 👀 

# See 👀
![device-2019-05-30-113213 2019-05-30 11_32_39](https://user-images.githubusercontent.com/1289295/58644339-0e397b00-82cf-11e9-9bc4-753c1a038f1d.gif)

