### PR TITLE
[🔢] Currency refactor 2

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/KSCurrency.java
+++ b/app/src/main/java/com/kickstarter/libs/KSCurrency.java
@@ -1,14 +1,11 @@
 package com.kickstarter.libs;
 
 import android.os.Parcelable;
-import android.text.SpannableString;
-import android.text.Spanned;
-import android.text.style.RelativeSizeSpan;
 
 import com.kickstarter.libs.models.Country;
 import com.kickstarter.libs.utils.NumberUtils;
+import com.kickstarter.libs.utils.StringUtils;
 import com.kickstarter.models.Project;
-import com.kickstarter.ui.views.CenterSpan;
 
 import java.math.RoundingMode;
 
@@ -29,7 +26,7 @@ public final class KSCurrency {
    * @param project      The project to use to look up currency information.
    */
   public @NonNull String format(final double initialValue, final @NonNull Project project, final @NonNull RoundingMode roundingMode) {
-    return format(initialValue, project, true, roundingMode, 0);
+    return format(initialValue, project, true, roundingMode);
   }
 
   /**
@@ -41,7 +38,17 @@ public final class KSCurrency {
    */
   public @NonNull String format(final double initialValue, final @NonNull Project project,
     final boolean excludeCurrencyCode) {
-    return format(initialValue, project, excludeCurrencyCode, RoundingMode.DOWN, 0);
+    return format(initialValue, project, excludeCurrencyCode, RoundingMode.DOWN);
+  }
+
+  /**
+   * Returns a currency string appropriate to the user's locale and location relative to a project.
+   *
+   * @param initialValue        Value to display, local to the project's currency.
+   * @param project             The project to use to look up currency information.
+   */
+  public @NonNull String format(final double initialValue, final @NonNull Project project) {
+    return format(initialValue, project, true, RoundingMode.DOWN);
   }
 
   /**
@@ -52,7 +59,7 @@ public final class KSCurrency {
    * @param excludeCurrencyCode If true, hide the US currency code for US users only.
    */
   public @NonNull String format(final double initialValue, final @NonNull Project project,
-    final boolean excludeCurrencyCode, final @NonNull RoundingMode roundingMode, final int precision) {
+    final boolean excludeCurrencyCode, final @NonNull RoundingMode roundingMode) {
 
     final Country country = Country.findByCurrencyCode(project.currency());
     if (country == null) {
@@ -66,21 +73,9 @@ public final class KSCurrency {
       .currencyCode(currencyOptions.currencyCode())
       .currencySymbol(currencyOptions.currencySymbol())
       .roundingMode(roundingMode)
-      .precision(precision > 0 ? 2 : 0)
       .build();
 
-    return trim(NumberUtils.format(currencyOptions.value(), numberOptions));
-  }
-
-  public @NonNull SpannableString formatSpanned(final double initialValue, final @NonNull Project project) {
-    final Country country = Country.findByCurrencyCode(project.currency());
-    if (country == null) {
-      return SpannableString.valueOf("");
-    }
-
-    final String currencySymbol = trim(getSymbolForCurrency(country, true, this.currentConfig.getConfig()));
-    final String formattedCurrency = format(initialValue, project, true, RoundingMode.HALF_UP, 2);
-    return getSpannedString(currencySymbol, formattedCurrency);
+    return StringUtils.trim(NumberUtils.format(currencyOptions.value(), numberOptions));
   }
 
   /**
@@ -88,11 +83,9 @@ public final class KSCurrency {
    *
    * @param initialValue Value to convert, local to the project's currency.
    * @param project The project to use to look up currency information.
-   * @param roundingMode This determines whether we should round the values down or up.
    */
-  public @NonNull String formatWithUserPreference(final double initialValue, final @NonNull Project project,
-    final @NonNull RoundingMode roundingMode) {
-    return formatWithUserPreference(initialValue, project, roundingMode, 0);
+  public @NonNull String formatWithUserPreference(final double initialValue, final @NonNull Project project) {
+    return formatWithUserPreference(initialValue, project, RoundingMode.DOWN, 0);
   }
 
   /**
@@ -121,7 +114,27 @@ public final class KSCurrency {
       .precision(precision > 0 ? 2 : 0)
       .build();
 
-    return trim(NumberUtils.format(currencyOptions.value(), numberOptions));
+    return StringUtils.trim(NumberUtils.format(currencyOptions.value(), numberOptions));
+  }
+
+  /**
+   * Returns a boolean determining if a country's currency is ambiguous.
+   * Special case: US people looking at US currency just get the currency symbol.
+   *
+   * @param country The country to check if a code is necessary.
+   * @param excludeCurrencyCode If true, hide the US currency code for US users only.
+   */
+  public boolean currencyNeedsCode(final @NonNull Country country, final boolean excludeCurrencyCode) {
+    final boolean countryIsUS = country == Country.US;
+    final Config config = this.currentConfig.getConfig();
+    final boolean currencyNeedsCode = config.currencyNeedsCode(country.getCurrencySymbol());
+    final boolean userInUS = config.countryCode().equals(Country.US.getCountryCode());
+
+    if (userInUS && excludeCurrencyCode && countryIsUS) {
+      return false;
+    } else {
+      return currencyNeedsCode;
+    }
   }
 
   /**
@@ -131,43 +144,34 @@ public final class KSCurrency {
     return CurrencyOptions.builder()
       .country(country.getCountryCode())
       .currencyCode("")
-      .currencySymbol(getSymbolForCurrency(country, excludeCurrencyCode, this.currentConfig.getConfig()))
+      .currencySymbol(getCurrencySymbol(country, excludeCurrencyCode))
       .value(value)
       .build();
   }
 
-  private float getRoundedValue(final double initialValue, final @NonNull RoundingMode roundingMode) {
-    return roundingMode == RoundingMode.DOWN ? (float) Math.floor(initialValue) : (float) Math.round(initialValue);
-  }
-
-  private SpannableString getSpannedString(String currencySymbol, String currency) {
-    final SpannableString string = new SpannableString(currency);
-
-    final int startOfSymbol = currency.indexOf(currencySymbol);
-    final int endOfSymbol = startOfSymbol + currencySymbol.length();
-    string.setSpan(new RelativeSizeSpan(.5f), startOfSymbol, endOfSymbol, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
-    string.setSpan(new CenterSpan(), startOfSymbol, endOfSymbol, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
-
-    final int precision = 2;
-    final int length = string.length();
-    final int startOfPrecision = length - precision - 1;
-    string.setSpan(new RelativeSizeSpan(.5f), startOfPrecision, length, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
-    string.setSpan(new CenterSpan(), startOfPrecision, length, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
-
-    return string;
-  }
-
-  private String getSymbolForCurrency(final @NonNull Country country, final boolean excludeCurrencyCode, final @NonNull Config config) {
-    final boolean countryIsUS = country == Country.US;
-    final boolean userInUS = config.countryCode().equals(Country.US.getCountryCode());
-
-    if (!config.currencyNeedsCode(country.getCurrencySymbol())) {
-      return country.getCurrencySymbol();
+  /**
+   * Returns a number rounded to the specification.
+   *
+   * @param initialValue Value to convert, local to the project's currency.
+   * @param roundingMode When this is DOWN, we get the floor of the initialValue.
+   */
+  private static float getRoundedValue(final double initialValue, final @NonNull RoundingMode roundingMode) {
+    if (roundingMode == RoundingMode.DOWN) {
+      return (float) Math.floor(initialValue);
+    } else {
+      return (float) initialValue;
     }
+  }
 
-    if (userInUS && excludeCurrencyCode && countryIsUS) {
-      // US people looking at US projects just get the currency symbol
-      return Country.US.getCurrencySymbol();
+  /**
+   * Returns the currency symbol for a country.
+   *
+   * @param country The country the currency will be displayed in.
+   * @param excludeCurrencyCode If true, hide the US currency code for US users only.
+   */
+  public String getCurrencySymbol(final @NonNull Country country, final boolean excludeCurrencyCode) {
+    if (!currencyNeedsCode(country, excludeCurrencyCode)) {
+      return country.getCurrencySymbol();
     } else if (country == Country.SG) {
       // Singapore projects get a special currency prefix
       return "\u00A0" + "S" + country.getCurrencySymbol() + "\u00A0";
@@ -177,10 +181,6 @@ public final class KSCurrency {
     } else {
       return "\u00A0" + country.getCountryCode() + country.getCurrencySymbol() + "\u00A0";
     }
-  }
-
-  private String trim(final @NonNull String formattedString) {
-    return formattedString.replace('\u00A0', ' ').trim();
   }
 
   @AutoParcel

--- a/app/src/main/java/com/kickstarter/libs/utils/StringUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/StringUtils.java
@@ -39,6 +39,13 @@ public final class StringUtils {
   }
 
   /**
+   * Returns a string with no leading or trailing whitespace.
+   */
+  public static String trim(final @NonNull String str) {
+    return str.replace('\u00A0', ' ').trim();
+  }
+
+  /**
    * Returns a string wrapped in parentheses.
    */
   public static @NonNull String wrapInParentheses(final @NonNull String str) {

--- a/app/src/main/java/com/kickstarter/mock/factories/ShippingRuleFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/ShippingRuleFactory.kt
@@ -1,13 +1,12 @@
 package com.kickstarter.mock.factories
 
-import com.kickstarter.models.Location
 import com.kickstarter.models.ShippingRule
 
 class ShippingRuleFactory private constructor() {
     companion object {
         fun usShippingRule(): ShippingRule {
             return ShippingRule.builder()
-                    .id(10)
+                    .id(1L)
                     .cost(30.0)
                     .location(LocationFactory.unitedStates())
                     .build()
@@ -15,8 +14,8 @@ class ShippingRuleFactory private constructor() {
 
         fun germanyShippingRule(): ShippingRule {
             return ShippingRule.builder()
-                    .id(10)
-                    .cost(30.0)
+                    .id(2L)
+                    .cost(40.0)
                     .location(LocationFactory.germany())
                     .build()
         }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardHeaderViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardHeaderViewHolder.java
@@ -145,10 +145,10 @@ public final class CreatorDashboardHeaderViewHolder extends KSViewHolder {
   }
 
   private void setPledgedOfGoalString(final @NonNull Project currentProject) {
-    final String pledgedString = this.ksCurrency.format(currentProject.pledged(), currentProject, true);
+    final String pledgedString = this.ksCurrency.format(currentProject.pledged(), currentProject);
     this.amountRaisedTextView.setText(pledgedString);
 
-    final String goalString = this.ksCurrency.format(currentProject.goal(), currentProject, true);
+    final String goalString = this.ksCurrency.format(currentProject.goal(), currentProject);
     final String goalText = this.ksString.format(this.pledgedOfGoalString, "goal", goalString);
     this.fundingTextTextView.setText(goalText);
   }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardReferrerBreakdownViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardReferrerBreakdownViewHolder.java
@@ -180,7 +180,7 @@ public class CreatorDashboardReferrerBreakdownViewHolder extends KSViewHolder {
   }
 
   private void setAmountPledgedTextViewText(final @NonNull Pair<Project, Float> projectAndAmount, final TextView textview) {
-    final String amountString = this.ksCurrency.format(projectAndAmount.second, projectAndAmount.first, true);
+    final String amountString = this.ksCurrency.format(projectAndAmount.second, projectAndAmount.first);
     textview.setText(amountString);
   }
 }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardReferrerStatsRowViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardReferrerStatsRowViewHolder.java
@@ -66,7 +66,7 @@ public final class CreatorDashboardReferrerStatsRowViewHolder extends KSViewHold
   }
 
   private void setPledgedColumnValue(final @NonNull Pair<Project, Float> projectAndPledgedForReferrer) {
-    final String goalString = this.ksCurrency.format(projectAndPledgedForReferrer.second, projectAndPledgedForReferrer.first, true);
+    final String goalString = this.ksCurrency.format(projectAndPledgedForReferrer.second, projectAndPledgedForReferrer.first);
     this.amountPledgedForReferrerTextView.setText(goalString);
   }
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardRewardStatsRowViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CreatorDashboardRewardStatsRowViewHolder.java
@@ -11,8 +11,6 @@ import com.kickstarter.models.Project;
 import com.kickstarter.services.apiresponses.ProjectStatsEnvelope;
 import com.kickstarter.viewmodels.DashboardRewardStatsRowHolderViewModel;
 
-import java.math.RoundingMode;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import butterknife.Bind;
@@ -68,14 +66,13 @@ public class CreatorDashboardRewardStatsRowViewHolder extends KSViewHolder {
   }
 
   private void setPledgedColumnValue(final @NonNull Pair<Project, Float> projectAndPledgedForReward) {
-    final String goalString = this.ksCurrency
-      .format(projectAndPledgedForReward.second, projectAndPledgedForReward.first, true);
+    final String goalString = this.ksCurrency.format(projectAndPledgedForReward.second, projectAndPledgedForReward.first);
     this.amountForRewardPledgedTextView.setText(goalString);
   }
 
   private void setRewardMinimumText(final @NonNull Pair<Project, Integer> projectAndMinimumForReward) {
     final String minimumString = IntegerUtils.isZero(projectAndMinimumForReward.second) ?
-      this.noRewardString : this.ksCurrency.format(projectAndMinimumForReward.second, projectAndMinimumForReward.first, RoundingMode.HALF_UP);
+      this.noRewardString : this.ksCurrency.format(projectAndMinimumForReward.second, projectAndMinimumForReward.first);
     this.rewardMinimumTextView.setText(minimumString);
   }
 }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectStateChangedPositiveViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectStateChangedPositiveViewHolder.java
@@ -84,7 +84,7 @@ public final class ProjectStateChangedPositiveViewHolder extends ActivityListVie
       case Activity.CATEGORY_LAUNCH:
         final DateTime launchedAt = coalesce(project.launchedAt(), new DateTime());
         this.cardView.setCardBackgroundColor(this.blueDarken10Color);
-        this.leftStatFirstTextView.setText(this.ksCurrency.format(project.goal(), project, true));
+        this.leftStatFirstTextView.setText(this.ksCurrency.format(project.goal(), project));
         this.leftStatSecondTextView.setText(this.goalString);
         this.rightStatFirstTextView.setText(this.launchedString);
         this.rightStatSecondTextView.setText(DateTimeUtils.mediumDate(launchedAt));
@@ -98,11 +98,11 @@ public final class ProjectStateChangedPositiveViewHolder extends ActivityListVie
         break;
       case Activity.CATEGORY_SUCCESS:
         this.cardView.setCardBackgroundColor(this.greenDarken10Color);
-        this.leftStatFirstTextView.setText(this.ksCurrency.format(project.pledged(), project, true));
+        this.leftStatFirstTextView.setText(this.ksCurrency.format(project.pledged(), project));
         this.leftStatSecondTextView.setText(this.ksString.format(
           this.pledgedOfGoalString,
           "goal",
-          this.ksCurrency.format(project.goal(), project, true)
+          this.ksCurrency.format(project.goal(), project)
         ));
         this.rightStatFirstTextView.setText(this.fundedString);
         this.rightStatSecondTextView.setText(DateTimeUtils.mediumDate(activity().createdAt()));

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
@@ -261,7 +261,7 @@ public interface BackingViewModel {
 
       project
         .compose(zipPair(shippableBacking))
-        .map(pb -> this.ksCurrency.format(pb.second.shippingAmount(), pb.first, true))
+        .map(pb -> this.ksCurrency.format(pb.second.shippingAmount(), pb.first))
         .compose(bindToLifecycle())
         .subscribe(this.shippingAmountTextViewText);
 

--- a/app/src/main/java/com/kickstarter/viewmodels/HorizontalRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/HorizontalRewardViewHolderViewModel.kt
@@ -112,7 +112,7 @@ interface HorizontalRewardViewHolderViewModel {
 
             val formattedMinimum = this.projectAndReward
                     .filter { RewardUtils.isReward(it.second) }
-                    .map { pr -> this.ksCurrency.format(pr.second.minimum(), pr.first, true) }
+                    .map { pr -> this.ksCurrency.format(pr.second.minimum(), pr.first) }
 
             val isSelectable = this.projectAndReward
                     .map { pr -> isSelectable(pr.first, pr.second) }

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -198,7 +198,7 @@ interface PledgeFragmentViewModel {
 
             rewardAmount
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map<SpannableString> { this.ksCurrency.formatWithProjectCurrency(it.first, it.second, RoundingMode.HALF_UP, 0) }
+                    .map<SpannableString> { this.ksCurrency.formatSpanned(it.first, it.second) }
                     .compose(bindToLifecycle())
                     .subscribe { this.pledgeAmount.onNext(it) }
 
@@ -298,7 +298,7 @@ interface PledgeFragmentViewModel {
 
             shippingAmount
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map<SpannableString> { this.ksCurrency.formatWithProjectCurrency(it.first, it.second, RoundingMode.UP, 2) }
+                    .map<SpannableString> { this.ksCurrency.formatSpanned(it.first, it.second) }
                     .compose(bindToLifecycle())
                     .subscribe(this.shippingAmount)
 
@@ -316,14 +316,14 @@ interface PledgeFragmentViewModel {
             val initialTotalAmount = rulesAndRewardAndAdditional
                     .map { it.second }
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map<SpannableString> { this.ksCurrency.formatWithProjectCurrency(it.first, it.second, RoundingMode.UP, 2) }
+                    .map<SpannableString> { this.ksCurrency.formatSpanned(it.first, it.second) }
                     .compose(bindToLifecycle())
 
             val totalWithShippingRule = rewardAmountPlusAdditional
                     .compose<Pair<Double, Double>>(combineLatestPair(shippingAmount))
                     .map { it.first + it.second }
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map<SpannableString> { this.ksCurrency.formatWithProjectCurrency(it.first, it.second, RoundingMode.UP, 2) }
+                    .map<SpannableString> { this.ksCurrency.formatSpanned(it.first, it.second) }
                     .compose(bindToLifecycle())
 
             Observable.merge(initialTotalAmount, totalWithShippingRule)

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -69,10 +69,10 @@ interface PledgeFragmentViewModel {
         /**  Emits a boolean determining if the continue button should be hidden. */
         fun continueButtonIsGone(): Observable<Boolean>
 
-        /** Set the USD conversion.  */
+        /** Emits a string representing the total pledge amount in the user's preferred currency.  */
         fun conversionText(): Observable<String>
 
-        /** Returns `true` if the USD conversion section should be hidden, `false` otherwise.  */
+        /** Returns `true` if the conversion should be hidden, `false` otherwise.  */
         fun conversionTextViewIsGone(): Observable<Boolean>
 
         /**  Emits a boolean determining if the decrease pledge button should be enabled. */
@@ -198,7 +198,7 @@ interface PledgeFragmentViewModel {
 
             rewardAmount
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map<SpannableString> { this.ksCurrency.formatSpanned(it.first, it.second) }
+                    .map<SpannableString> { ViewUtils.styleCurrency(it.first, it.second, this.ksCurrency) }
                     .compose(bindToLifecycle())
                     .subscribe { this.pledgeAmount.onNext(it) }
 
@@ -298,7 +298,7 @@ interface PledgeFragmentViewModel {
 
             shippingAmount
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map<SpannableString> { this.ksCurrency.formatSpanned(it.first, it.second) }
+                    .map<SpannableString> { ViewUtils.styleCurrency(it.first, it.second, this.ksCurrency) }
                     .compose(bindToLifecycle())
                     .subscribe(this.shippingAmount)
 
@@ -316,14 +316,14 @@ interface PledgeFragmentViewModel {
             val initialTotalAmount = rulesAndRewardAndAdditional
                     .map { it.second }
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map<SpannableString> { this.ksCurrency.formatSpanned(it.first, it.second) }
+                    .map<SpannableString> { ViewUtils.styleCurrency(it.first, it.second, this.ksCurrency) }
                     .compose(bindToLifecycle())
 
             val totalWithShippingRule = rewardAmountPlusAdditional
                     .compose<Pair<Double, Double>>(combineLatestPair(shippingAmount))
                     .map { it.first + it.second }
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map<SpannableString> { this.ksCurrency.formatSpanned(it.first, it.second) }
+                    .map<SpannableString> { ViewUtils.styleCurrency(it.first, it.second, this.ksCurrency) }
                     .compose(bindToLifecycle())
 
             Observable.merge(initialTotalAmount, totalWithShippingRule)
@@ -333,14 +333,14 @@ interface PledgeFragmentViewModel {
             val initialTotalConversionAmount = rulesAndRewardAndAdditional
                     .map { it.second }
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map { this.ksCurrency.formatWithUserPreference(it.first, it.second, RoundingMode.UP, 2) }
+                    .map { this.ksCurrency.formatWithUserPreference(it.first, it.second, RoundingMode.HALF_UP, 2) }
                     .compose(bindToLifecycle())
 
             val totalConversionAmount = rewardAmountPlusAdditional
                     .compose<Pair<Double, Double>>(combineLatestPair(shippingAmount))
                     .map { it.first + it.second }
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map { this.ksCurrency.formatWithUserPreference(it.first, it.second, RoundingMode.UP, 2) }
+                    .map { this.ksCurrency.formatWithUserPreference(it.first, it.second, RoundingMode.HALF_UP, 2) }
 
             Observable.merge(initialTotalConversionAmount, totalConversionAmount)
                     .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectHolderViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectHolderViewModel.java
@@ -224,7 +224,7 @@ public interface ProjectHolderViewModel {
         .map(Category::name);
 
       this.goalStringForTextView = project
-        .map(p -> this.ksCurrency.formatWithUserPreference(p.goal(), p, RoundingMode.DOWN, 0));
+        .map(p -> this.ksCurrency.formatWithUserPreference(p.goal(), p, RoundingMode.DOWN));
 
       this.locationTextViewText = project
         .map(Project::location)
@@ -239,7 +239,7 @@ public interface ProjectHolderViewModel {
       this.playButtonIsGone = project.map(Project::hasVideo).map(BooleanUtils::negate);
 
       this.pledgedTextViewText = project
-        .map(p -> this.ksCurrency.formatWithUserPreference(p.pledged(), p, RoundingMode.DOWN, 0));
+        .map(p -> this.ksCurrency.formatWithUserPreference(p.pledged(), p, RoundingMode.DOWN));
 
       this.projectDisclaimerGoalReachedDateTime = project
         .filter(Project::isFunded)

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectHolderViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectHolderViewModel.java
@@ -22,7 +22,6 @@ import com.kickstarter.ui.viewholders.ProjectViewHolder;
 
 import org.joda.time.DateTime;
 
-import java.math.RoundingMode;
 import java.util.List;
 
 import androidx.annotation.NonNull;
@@ -202,8 +201,8 @@ public interface ProjectHolderViewModel {
 
       this.conversionPledgedAndGoalText = project
         .map(p -> {
-          final String pledged = this.ksCurrency.format(p.pledged(), p, true);
-          final String goal = this.ksCurrency.format(p.goal(), p, true);
+          final String pledged = this.ksCurrency.format(p.pledged(), p);
+          final String goal = this.ksCurrency.format(p.goal(), p);
           return Pair.create(pledged, goal);
         });
 
@@ -224,7 +223,7 @@ public interface ProjectHolderViewModel {
         .map(Category::name);
 
       this.goalStringForTextView = project
-        .map(p -> this.ksCurrency.formatWithUserPreference(p.goal(), p, RoundingMode.DOWN));
+        .map(p -> this.ksCurrency.formatWithUserPreference(p.goal(), p));
 
       this.locationTextViewText = project
         .map(Project::location)
@@ -239,7 +238,7 @@ public interface ProjectHolderViewModel {
       this.playButtonIsGone = project.map(Project::hasVideo).map(BooleanUtils::negate);
 
       this.pledgedTextViewText = project
-        .map(p -> this.ksCurrency.formatWithUserPreference(p.pledged(), p, RoundingMode.DOWN));
+        .map(p -> this.ksCurrency.formatWithUserPreference(p.pledged(), p));
 
       this.projectDisclaimerGoalReachedDateTime = project
         .filter(Project::isFunded)
@@ -247,7 +246,7 @@ public interface ProjectHolderViewModel {
 
       this.projectDisclaimerGoalNotReachedString = project
         .filter(p -> p.deadline() != null && p.isLive() && !p.isFunded())
-        .map(p -> Pair.create(this.ksCurrency.format(p.goal(), p, true), p.deadline()));
+        .map(p -> Pair.create(this.ksCurrency.format(p.goal(), p), p.deadline()));
 
       this.projectDisclaimerTextViewIsGone = project.map(p -> p.deadline() == null || !p.isLive());
 

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewModel.java
@@ -159,7 +159,7 @@ public interface RewardViewModel {
         .map(BooleanUtils::negate);
 
       this.conversionTextViewText = this.projectAndReward
-        .map(pr -> this.ksCurrency.formatWithUserPreference(pr.second.minimum(), pr.first, RoundingMode.HALF_UP, 0));
+        .map(pr -> this.ksCurrency.formatWithUserPreference(pr.second.minimum(), pr.first, RoundingMode.HALF_UP));
 
       this.descriptionTextViewText = reward.map(Reward::description);
 

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewModel.java
@@ -159,7 +159,7 @@ public interface RewardViewModel {
         .map(BooleanUtils::negate);
 
       this.conversionTextViewText = this.projectAndReward
-        .map(pr -> this.ksCurrency.formatWithUserPreference(pr.second.minimum(), pr.first, RoundingMode.HALF_UP));
+        .map(pr -> this.ksCurrency.formatWithUserPreference(pr.second.minimum(), pr.first, RoundingMode.HALF_UP, 0));
 
       this.descriptionTextViewText = reward.map(Reward::description);
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModel.kt
@@ -19,7 +19,6 @@ interface ShippingRuleViewHolderViewModel {
     }
 
     interface Outputs {
-
         /** Returns the Shipping Rule text. */
         fun shippingRuleText(): Observable<String>
     }
@@ -29,6 +28,8 @@ interface ShippingRuleViewHolderViewModel {
         private val shippingRuleAndProject = PublishSubject.create<Pair<ShippingRule, Project>>()
 
         private val shippingRuleText = BehaviorSubject.create<String>()
+
+        private val ksCurrency = this.environment.ksCurrency()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -49,7 +50,7 @@ interface ShippingRuleViewHolderViewModel {
             val displayableName = shippingRule.location().displayableName()
             val cost = shippingRule.cost()
 
-            val formattedCost = this.environment.ksCurrency().format(cost, project, true).toString()
+            val formattedCost = this.ksCurrency.format(cost, project)
 
             return "$displayableName $formattedCost"
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModel.kt
@@ -3,8 +3,6 @@ package com.kickstarter.viewmodels
 import android.util.Pair
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
-import com.kickstarter.libs.KSCurrency
-import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.models.Project
 import com.kickstarter.models.ShippingRule
@@ -12,7 +10,6 @@ import com.kickstarter.ui.viewholders.ShippingRuleViewHolder
 import rx.Observable
 import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
-import java.math.RoundingMode
 
 interface ShippingRuleViewHolderViewModel {
 
@@ -52,8 +49,7 @@ interface ShippingRuleViewHolderViewModel {
             val displayableName = shippingRule.location().displayableName()
             val cost = shippingRule.cost()
 
-            val formattedCost = KSCurrency(this.environment.currentConfig())
-                    .formatWithProjectCurrency(cost, project, RoundingMode.UP, 2).toString()
+            val formattedCost = this.environment.ksCurrency().format(cost, project, true).toString()
 
             return "$displayableName $formattedCost"
         }

--- a/app/src/test/java/com/kickstarter/KSCurrencyTest.java
+++ b/app/src/test/java/com/kickstarter/KSCurrencyTest.java
@@ -3,14 +3,13 @@ package com.kickstarter;
 import com.kickstarter.libs.Config;
 import com.kickstarter.libs.CurrentConfigType;
 import com.kickstarter.libs.KSCurrency;
+import com.kickstarter.libs.models.Country;
 import com.kickstarter.mock.MockCurrentConfig;
 import com.kickstarter.mock.factories.ConfigFactory;
 import com.kickstarter.mock.factories.ProjectFactory;
 import com.kickstarter.models.Project;
 
 import junit.framework.TestCase;
-
-import org.junit.Test;
 
 import java.math.RoundingMode;
 
@@ -20,12 +19,12 @@ public class KSCurrencyTest extends TestCase {
 
   public void testFormatCurrency_withUserInUS() {
     final KSCurrency currency = createKSCurrency("US");
-    assertEquals("$100", currency.format(100.1f, ProjectFactory.project(), RoundingMode.DOWN));
-    assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.DOWN));
-    assertEquals("£100", currency.format(100.1f, ProjectFactory.ukProject(), RoundingMode.DOWN));
-    assertEquals("$100", currency.format(100.9f, ProjectFactory.project(), RoundingMode.DOWN));
-    assertEquals("CA$ 100", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.DOWN));
-    assertEquals("£100", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.DOWN));
+    assertEquals("$100", currency.format(100.1f, ProjectFactory.project()));
+    assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject()));
+    assertEquals("£100", currency.format(100.1f, ProjectFactory.ukProject()));
+    assertEquals("$100", currency.format(100.9f, ProjectFactory.project()));
+    assertEquals("CA$ 100", currency.format(100.9f, ProjectFactory.caProject()));
+    assertEquals("£100", currency.format(100.9f, ProjectFactory.ukProject()));
 
     assertEquals("$100", currency.format(100.1f, ProjectFactory.project(), RoundingMode.HALF_UP));
     assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
@@ -35,15 +34,14 @@ public class KSCurrencyTest extends TestCase {
     assertEquals("£101", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
   }
 
-  @Test
   public void testFormatCurrency_withUserInCA() {
     final KSCurrency currency = createKSCurrency("CA");
-    assertEquals("US$ 100", currency.format(100.9f, ProjectFactory.project(), RoundingMode.DOWN));
-    assertEquals("CA$ 100", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.DOWN));
-    assertEquals("£100", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.DOWN));
-    assertEquals("US$ 100", currency.format(100.1f, ProjectFactory.project(), RoundingMode.DOWN));
-    assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.DOWN));
-    assertEquals("£100", currency.format(100.1f, ProjectFactory.ukProject(), RoundingMode.DOWN));
+    assertEquals("US$ 100", currency.format(100.9f, ProjectFactory.project()));
+    assertEquals("CA$ 100", currency.format(100.9f, ProjectFactory.caProject()));
+    assertEquals("£100", currency.format(100.9f, ProjectFactory.ukProject()));
+    assertEquals("US$ 100", currency.format(100.1f, ProjectFactory.project()));
+    assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject()));
+    assertEquals("£100", currency.format(100.1f, ProjectFactory.ukProject()));
 
     assertEquals("US$ 100", currency.format(100.1f, ProjectFactory.project(), RoundingMode.HALF_UP));
     assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
@@ -53,15 +51,14 @@ public class KSCurrencyTest extends TestCase {
     assertEquals("£101", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
   }
 
-  @Test
   public void testFormatCurrency_withUserInUK() {
     final KSCurrency currency = createKSCurrency("UK");
-    assertEquals("US$ 100", currency.format(100.1f, ProjectFactory.project(), RoundingMode.DOWN));
-    assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.DOWN));
-    assertEquals("£100", currency.format(100.1f, ProjectFactory.ukProject(), RoundingMode.DOWN));
-    assertEquals("US$ 100", currency.format(100.9f, ProjectFactory.project(), RoundingMode.DOWN));
-    assertEquals("CA$ 100", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.DOWN));
-    assertEquals("£100", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.DOWN));
+    assertEquals("US$ 100", currency.format(100.1f, ProjectFactory.project()));
+    assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject()));
+    assertEquals("£100", currency.format(100.1f, ProjectFactory.ukProject()));
+    assertEquals("US$ 100", currency.format(100.9f, ProjectFactory.project()));
+    assertEquals("CA$ 100", currency.format(100.9f, ProjectFactory.caProject()));
+    assertEquals("£100", currency.format(100.9f, ProjectFactory.ukProject()));
 
     assertEquals("US$ 100", currency.format(100.1f, ProjectFactory.project(), RoundingMode.HALF_UP));
     assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
@@ -71,13 +68,18 @@ public class KSCurrencyTest extends TestCase {
     assertEquals("£101", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
   }
 
-  @Test
   public void testFormatCurrency_withUserInUnlaunchedCountry() {
     final KSCurrency currency = createKSCurrency("XX");
-    assertEquals("US$ 100", currency.format(100.9f, ProjectFactory.project(), RoundingMode.DOWN));
-    assertEquals("CA$ 100", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.DOWN));
-    assertEquals("£100", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.DOWN));
+    assertEquals("US$ 100", currency.format(100.1f, ProjectFactory.project()));
+    assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject()));
+    assertEquals("£100", currency.format(100.1f, ProjectFactory.ukProject()));
+    assertEquals("US$ 100", currency.format(100.9f, ProjectFactory.project()));
+    assertEquals("CA$ 100", currency.format(100.9f, ProjectFactory.caProject()));
+    assertEquals("£100", currency.format(100.9f, ProjectFactory.ukProject()));
 
+    assertEquals("US$ 100", currency.format(100.1f, ProjectFactory.project(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
+    assertEquals("£100", currency.format(100.1f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
     assertEquals("US$ 101", currency.format(100.9f, ProjectFactory.project(), RoundingMode.HALF_UP));
     assertEquals("CA$ 101", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
     assertEquals("£101", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
@@ -91,28 +93,37 @@ public class KSCurrencyTest extends TestCase {
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
 
-    assertEquals("$100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.DOWN));
-    assertEquals("$100", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.DOWN));
-    assertEquals("$100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP));
-    assertEquals("$101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP));
+    assertEquals("$100", currency.formatWithUserPreference(100.1f, preferUSD_USProject));
+    assertEquals("$100", currency.formatWithUserPreference(100.9f, preferUSD_USProject));
+
+    assertEquals("$100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("$100.10", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP, 2));
+    assertEquals("$101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("$100.90", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP, 2));
 
     final Project preferUSD_CAProject = ProjectFactory.caProject()
       .toBuilder()
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("$75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.DOWN));
-    assertEquals("$75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.DOWN));
-    assertEquals("$75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP));
-    assertEquals("$76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP));
+    assertEquals("$75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject));
+    assertEquals("$75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject));
+
+    assertEquals("$75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("$75.07", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP, 2));
+    assertEquals("$76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("$75.68", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP, 2));
 
     final Project preferUSD_UKProject = ProjectFactory.ukProject()
       .toBuilder()
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("$150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.DOWN));
-    assertEquals("$150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.DOWN));
-    assertEquals("$150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP));
-    assertEquals("$152", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP));
+    assertEquals("$150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject));
+    assertEquals("$150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject));
+
+    assertEquals("$150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("$150.15", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP, 2));
+    assertEquals("$151", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("$151.35", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP, 2));
   }
 
   public void testPreferUSD_withUserInCA() {
@@ -123,30 +134,39 @@ public class KSCurrencyTest extends TestCase {
       .fxRate(1f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.DOWN));
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.DOWN));
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP));
-    assertEquals("US$ 101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.9f, preferUSD_USProject));
+
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 100.10", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP, 2));
+    assertEquals("US$ 101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 100.90", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP, 2));
 
     final Project preferUSD_CAProject = ProjectFactory.caProject()
       .toBuilder()
       .fxRate(.75f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.DOWN));
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.DOWN));
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP));
-    assertEquals("US$ 76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject));
+
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 75.07", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP, 2));
+    assertEquals("US$ 76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 75.68", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP, 2));
 
     final Project preferUSD_UKProject = ProjectFactory.ukProject()
       .toBuilder()
       .fxRate(1.5f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.DOWN));
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.DOWN));
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP));
-    assertEquals("US$ 152", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject));
+
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 150.15", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP, 2));
+    assertEquals("US$ 151", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 151.35", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP, 2));
   }
 
   public void testPreferUSD_withUserInUK() {
@@ -157,30 +177,39 @@ public class KSCurrencyTest extends TestCase {
       .fxRate(1f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.DOWN));
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.DOWN));
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP));
-    assertEquals("US$ 101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.9f, preferUSD_USProject));
+
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 100.10", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP, 2));
+    assertEquals("US$ 101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 100.90", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP, 2));
 
     final Project preferUSD_CAProject = ProjectFactory.caProject()
       .toBuilder()
       .fxRate(.75f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.DOWN));
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.DOWN));
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP));
-    assertEquals("US$ 76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject));
+
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 75.07", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP, 2));
+    assertEquals("US$ 76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 75.68", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP, 2));
 
     final Project preferUSD_UKProject = ProjectFactory.ukProject()
       .toBuilder()
       .fxRate(1.5f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.DOWN));
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.DOWN));
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP));
-    assertEquals("US$ 152", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject));
+
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 150.15", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP, 2));
+    assertEquals("US$ 151", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 151.35", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP, 2));
   }
 
   public void testPreferUSD_withUserInUnlaunchedCountry() {
@@ -191,30 +220,39 @@ public class KSCurrencyTest extends TestCase {
       .fxRate(1f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.DOWN));
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.DOWN));
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP));
-    assertEquals("US$ 101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.9f, preferUSD_USProject));
+
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 100.10", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP, 2));
+    assertEquals("US$ 101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 100.90", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP, 2));
 
     final Project preferUSD_CAProject = ProjectFactory.caProject()
       .toBuilder()
       .fxRate(.75f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.DOWN));
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.DOWN));
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP));
-    assertEquals("US$ 76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject));
+
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 75.07", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP, 2));
+    assertEquals("US$ 76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 75.68", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP, 2));
 
     final Project preferUSD_UKProject = ProjectFactory.ukProject()
       .toBuilder()
       .fxRate(1.5f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.DOWN));
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.DOWN));
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP));
-    assertEquals("US$ 152", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject));
+
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 150.15", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP, 2));
+    assertEquals("US$ 151", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 151.35", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP, 2));
   }
 
   public void testPreferCAD_withUserInCA() {
@@ -225,30 +263,39 @@ public class KSCurrencyTest extends TestCase {
       .fxRate(1.5f)
       .currentCurrency(CurrencyCode.CAD.rawValue())
       .build();
-    assertEquals("CA$ 150", currency.formatWithUserPreference(100.1f, preferCAD_USProject, RoundingMode.DOWN));
-    assertEquals("CA$ 150", currency.formatWithUserPreference(100.9f, preferCAD_USProject, RoundingMode.DOWN));
-    assertEquals("CA$ 150", currency.formatWithUserPreference(100.1f, preferCAD_USProject, RoundingMode.HALF_UP));
-    assertEquals("CA$ 152", currency.formatWithUserPreference(100.9f, preferCAD_USProject, RoundingMode.HALF_UP));
+    assertEquals("CA$ 150", currency.formatWithUserPreference(100.1f, preferCAD_USProject));
+    assertEquals("CA$ 150", currency.formatWithUserPreference(100.9f, preferCAD_USProject));
+
+    assertEquals("CA$ 150", currency.formatWithUserPreference(100.1f, preferCAD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("CA$ 150.15", currency.formatWithUserPreference(100.1f, preferCAD_USProject, RoundingMode.HALF_UP, 2));
+    assertEquals("CA$ 151", currency.formatWithUserPreference(100.9f, preferCAD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("CA$ 151.35", currency.formatWithUserPreference(100.9f, preferCAD_USProject, RoundingMode.HALF_UP, 2));
 
     final Project preferCAD_CAProject = ProjectFactory.caProject()
       .toBuilder()
       .fxRate(1f)
       .currentCurrency(CurrencyCode.CAD.rawValue())
       .build();
-    assertEquals("CA$ 100", currency.formatWithUserPreference(100.1f, preferCAD_CAProject, RoundingMode.DOWN));
-    assertEquals("CA$ 100", currency.formatWithUserPreference(100.9f, preferCAD_CAProject, RoundingMode.DOWN));
-    assertEquals("CA$ 100", currency.formatWithUserPreference(100.1f, preferCAD_CAProject, RoundingMode.HALF_UP));
-    assertEquals("CA$ 101", currency.formatWithUserPreference(100.9f, preferCAD_CAProject, RoundingMode.HALF_UP));
+    assertEquals("CA$ 100", currency.formatWithUserPreference(100.1f, preferCAD_CAProject));
+    assertEquals("CA$ 100", currency.formatWithUserPreference(100.9f, preferCAD_CAProject));
+
+    assertEquals("CA$ 100", currency.formatWithUserPreference(100.1f, preferCAD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("CA$ 100.10", currency.formatWithUserPreference(100.1f, preferCAD_CAProject, RoundingMode.HALF_UP, 2));
+    assertEquals("CA$ 101", currency.formatWithUserPreference(100.9f, preferCAD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("CA$ 100.90", currency.formatWithUserPreference(100.9f, preferCAD_CAProject, RoundingMode.HALF_UP, 2));
 
     final Project preferCAD_UKProject = ProjectFactory.ukProject()
       .toBuilder()
       .fxRate(.75f)
       .currentCurrency(CurrencyCode.CAD.rawValue())
       .build();
-    assertEquals("CA$ 75", currency.formatWithUserPreference(100.1f, preferCAD_UKProject, RoundingMode.DOWN));
-    assertEquals("CA$ 75", currency.formatWithUserPreference(100.9f, preferCAD_UKProject, RoundingMode.DOWN));
-    assertEquals("CA$ 75", currency.formatWithUserPreference(100.1f, preferCAD_UKProject, RoundingMode.HALF_UP));
-    assertEquals("CA$ 76", currency.formatWithUserPreference(100.9f, preferCAD_UKProject, RoundingMode.HALF_UP));
+    assertEquals("CA$ 75", currency.formatWithUserPreference(100.1f, preferCAD_UKProject));
+    assertEquals("CA$ 75", currency.formatWithUserPreference(100.9f, preferCAD_UKProject));
+
+    assertEquals("CA$ 75", currency.formatWithUserPreference(100.1f, preferCAD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("CA$ 75.07", currency.formatWithUserPreference(100.1f, preferCAD_UKProject, RoundingMode.HALF_UP, 2));
+    assertEquals("CA$ 76", currency.formatWithUserPreference(100.9f, preferCAD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("CA$ 75.68", currency.formatWithUserPreference(100.9f, preferCAD_UKProject, RoundingMode.HALF_UP, 2));
   }
 
   public void testPreferGBP_withUserInUK() {
@@ -259,30 +306,39 @@ public class KSCurrencyTest extends TestCase {
       .fxRate(.75f)
       .currentCurrency(CurrencyCode.GBP.rawValue())
       .build();
-    assertEquals("£75", currency.formatWithUserPreference(100.1f, preferGBP_USProject, RoundingMode.DOWN));
-    assertEquals("£75", currency.formatWithUserPreference(100.9f, preferGBP_USProject, RoundingMode.DOWN));
-    assertEquals("£75", currency.formatWithUserPreference(100.1f, preferGBP_USProject, RoundingMode.HALF_UP));
-    assertEquals("£76", currency.formatWithUserPreference(100.9f, preferGBP_USProject, RoundingMode.HALF_UP));
+    assertEquals("£75", currency.formatWithUserPreference(100.1f, preferGBP_USProject));
+    assertEquals("£75", currency.formatWithUserPreference(100.9f, preferGBP_USProject));
+
+    assertEquals("£75", currency.formatWithUserPreference(100.1f, preferGBP_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("£75.07", currency.formatWithUserPreference(100.1f, preferGBP_USProject, RoundingMode.HALF_UP, 2));
+    assertEquals("£76", currency.formatWithUserPreference(100.9f, preferGBP_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("£75.68", currency.formatWithUserPreference(100.9f, preferGBP_USProject, RoundingMode.HALF_UP, 2));
 
     final Project preferGBP_CAProject = ProjectFactory.caProject()
       .toBuilder()
       .fxRate(1.5f)
       .currentCurrency(CurrencyCode.GBP.rawValue())
       .build();
-    assertEquals("£150", currency.formatWithUserPreference(100.1f, preferGBP_CAProject, RoundingMode.DOWN));
-    assertEquals("£150", currency.formatWithUserPreference(100.9f, preferGBP_CAProject, RoundingMode.DOWN));
-    assertEquals("£150", currency.formatWithUserPreference(100.1f, preferGBP_CAProject, RoundingMode.HALF_UP));
-    assertEquals("£152", currency.formatWithUserPreference(100.9f, preferGBP_CAProject, RoundingMode.HALF_UP));
+    assertEquals("£150", currency.formatWithUserPreference(100.1f, preferGBP_CAProject));
+    assertEquals("£150", currency.formatWithUserPreference(100.9f, preferGBP_CAProject));
+
+    assertEquals("£150", currency.formatWithUserPreference(100.1f, preferGBP_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("£150.15", currency.formatWithUserPreference(100.1f, preferGBP_CAProject, RoundingMode.HALF_UP, 2));
+    assertEquals("£151", currency.formatWithUserPreference(100.9f, preferGBP_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("£151.35", currency.formatWithUserPreference(100.9f, preferGBP_CAProject, RoundingMode.HALF_UP, 2));
 
     final Project preferGBP_UKProject = ProjectFactory.ukProject()
       .toBuilder()
       .fxRate(1f)
       .currentCurrency(CurrencyCode.GBP.rawValue())
       .build();
-    assertEquals("£100", currency.formatWithUserPreference(100.1f, preferGBP_UKProject, RoundingMode.DOWN));
-    assertEquals("£100", currency.formatWithUserPreference(100.9f, preferGBP_UKProject, RoundingMode.DOWN));
-    assertEquals("£100", currency.formatWithUserPreference(100.1f, preferGBP_UKProject, RoundingMode.HALF_UP));
-    assertEquals("£101", currency.formatWithUserPreference(100.9f, preferGBP_UKProject, RoundingMode.HALF_UP));
+    assertEquals("£100", currency.formatWithUserPreference(100.1f, preferGBP_UKProject));
+    assertEquals("£100", currency.formatWithUserPreference(100.9f, preferGBP_UKProject));
+
+    assertEquals("£100", currency.formatWithUserPreference(100.1f, preferGBP_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("£100.10", currency.formatWithUserPreference(100.1f, preferGBP_UKProject, RoundingMode.HALF_UP, 2));
+    assertEquals("£101", currency.formatWithUserPreference(100.9f, preferGBP_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("£100.90", currency.formatWithUserPreference(100.9f, preferGBP_UKProject, RoundingMode.HALF_UP, 2));
   }
 
   public void testFormatCurrency_withCurrencyCodeExcluded() {
@@ -292,12 +348,50 @@ public class KSCurrencyTest extends TestCase {
     assertEquals("CA$ 100", caCurrency.format(100.0f, ProjectFactory.caProject(), true));
     assertEquals("CA$ 100", caCurrency.format(100.0f, ProjectFactory.caProject(), false));
 
-
     final KSCurrency usCurrency = createKSCurrency("US");
     assertEquals("$100", usCurrency.format(100.0f, ProjectFactory.project(), true));
     assertEquals("US$ 100", usCurrency.format(100.0f, ProjectFactory.project(), false));
     assertEquals("CA$ 100", usCurrency.format(100.0f, ProjectFactory.caProject(), true));
     assertEquals("CA$ 100", usCurrency.format(100.0f, ProjectFactory.caProject(), false));
+  }
+
+  public void testCurrencyNeedsCode() {
+    final KSCurrency usCurrency = createKSCurrency("US");
+    assertFalse(usCurrency.currencyNeedsCode(Country.US, true));
+    assertTrue(usCurrency.currencyNeedsCode(Country.US, false));
+
+    final KSCurrency caCurrency = createKSCurrency("CA");
+    assertTrue(caCurrency.currencyNeedsCode(Country.US, true));
+    assertTrue(caCurrency.currencyNeedsCode(Country.US, false));
+
+    final KSCurrency unlaunchedCurrency = createKSCurrency("XX");
+    assertTrue(unlaunchedCurrency.currencyNeedsCode(Country.US, true));
+    assertTrue(unlaunchedCurrency.currencyNeedsCode(Country.US, false));
+  }
+
+
+  public void testGetSymbolForCurrency() {
+    final KSCurrency usCurrency = createKSCurrency("US");
+    // US people looking at US currency just get the currency symbol.
+    assertEquals("$", usCurrency.getCurrencySymbol(Country.US, true));
+    assertEquals("\u00A0US$\u00A0", usCurrency.getCurrencySymbol(Country.US, false));
+    // Singapore projects get a special currency prefix
+    assertEquals("\u00A0S$\u00A0", usCurrency.getCurrencySymbol(Country.SG, false));
+    // Kroner projects use the currency code prefix
+    assertEquals("\u00A0CHF\u00A0", usCurrency.getCurrencySymbol(Country.CH, false));
+    assertEquals("\u00A0DKK\u00A0", usCurrency.getCurrencySymbol(Country.DK, false));
+    assertEquals("\u00A0NOK\u00A0", usCurrency.getCurrencySymbol(Country.NO, false));
+    assertEquals("\u00A0SEK\u00A0", usCurrency.getCurrencySymbol(Country.SE, false));
+    // Everything else
+    assertEquals("\u00A0MX$\u00A0", usCurrency.getCurrencySymbol(Country.MX, false));
+
+    final KSCurrency caCurrency = createKSCurrency("CA");
+    assertEquals("\u00A0US$\u00A0", caCurrency.getCurrencySymbol(Country.US, true));
+    assertEquals("\u00A0US$\u00A0", caCurrency.getCurrencySymbol(Country.US, false));
+
+    final KSCurrency unlaunchedCurrency = createKSCurrency("XX");
+    assertEquals("\u00A0US$\u00A0", unlaunchedCurrency.getCurrencySymbol(Country.US, true));
+    assertEquals("\u00A0US$\u00A0", unlaunchedCurrency.getCurrencySymbol(Country.US, false));
   }
 
   private static KSCurrency createKSCurrency(final String countryCode) {

--- a/app/src/test/java/com/kickstarter/KSCurrencyTest.java
+++ b/app/src/test/java/com/kickstarter/KSCurrencyTest.java
@@ -91,28 +91,28 @@ public class KSCurrencyTest extends TestCase {
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
 
-    assertEquals("$100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.DOWN, 0));
-    assertEquals("$100", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.DOWN, 0));
-    assertEquals("$100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
-    assertEquals("$101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("$100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.DOWN));
+    assertEquals("$100", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.DOWN));
+    assertEquals("$100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP));
+    assertEquals("$101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP));
 
     final Project preferUSD_CAProject = ProjectFactory.caProject()
       .toBuilder()
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("$75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.DOWN, 0));
-    assertEquals("$75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.DOWN, 0));
-    assertEquals("$75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
-    assertEquals("$76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("$75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.DOWN));
+    assertEquals("$75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.DOWN));
+    assertEquals("$75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP));
+    assertEquals("$76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP));
 
     final Project preferUSD_UKProject = ProjectFactory.ukProject()
       .toBuilder()
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("$150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.DOWN, 0));
-    assertEquals("$150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.DOWN, 0));
-    assertEquals("$150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
-    assertEquals("$152", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("$150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.DOWN));
+    assertEquals("$150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.DOWN));
+    assertEquals("$150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP));
+    assertEquals("$152", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP));
   }
 
   public void testPreferUSD_withUserInCA() {
@@ -123,30 +123,30 @@ public class KSCurrencyTest extends TestCase {
       .fxRate(1f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
-    assertEquals("US$ 101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.DOWN));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.DOWN));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP));
 
     final Project preferUSD_CAProject = ProjectFactory.caProject()
       .toBuilder()
       .fxRate(.75f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
-    assertEquals("US$ 76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.DOWN));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.DOWN));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP));
 
     final Project preferUSD_UKProject = ProjectFactory.ukProject()
       .toBuilder()
       .fxRate(1.5f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
-    assertEquals("US$ 152", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.DOWN));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.DOWN));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 152", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP));
   }
 
   public void testPreferUSD_withUserInUK() {
@@ -157,30 +157,30 @@ public class KSCurrencyTest extends TestCase {
       .fxRate(1f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
-    assertEquals("US$ 101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.DOWN));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.DOWN));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP));
 
     final Project preferUSD_CAProject = ProjectFactory.caProject()
       .toBuilder()
       .fxRate(.75f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
-    assertEquals("US$ 76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.DOWN));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.DOWN));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP));
 
     final Project preferUSD_UKProject = ProjectFactory.ukProject()
       .toBuilder()
       .fxRate(1.5f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
-    assertEquals("US$ 152", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.DOWN));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.DOWN));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 152", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP));
   }
 
   public void testPreferUSD_withUserInUnlaunchedCountry() {
@@ -191,30 +191,30 @@ public class KSCurrencyTest extends TestCase {
       .fxRate(1f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
-    assertEquals("US$ 101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.DOWN));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.DOWN));
+    assertEquals("US$ 100", currency.formatWithUserPreference(100.1f, preferUSD_USProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 101", currency.formatWithUserPreference(100.9f, preferUSD_USProject, RoundingMode.HALF_UP));
 
     final Project preferUSD_CAProject = ProjectFactory.caProject()
       .toBuilder()
       .fxRate(.75f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
-    assertEquals("US$ 76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.DOWN));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.DOWN));
+    assertEquals("US$ 75", currency.formatWithUserPreference(100.1f, preferUSD_CAProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 76", currency.formatWithUserPreference(100.9f, preferUSD_CAProject, RoundingMode.HALF_UP));
 
     final Project preferUSD_UKProject = ProjectFactory.ukProject()
       .toBuilder()
       .fxRate(1.5f)
       .currentCurrency(CurrencyCode.USD.rawValue())
       .build();
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.DOWN, 0));
-    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
-    assertEquals("US$ 152", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.DOWN));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.DOWN));
+    assertEquals("US$ 150", currency.formatWithUserPreference(100.1f, preferUSD_UKProject, RoundingMode.HALF_UP));
+    assertEquals("US$ 152", currency.formatWithUserPreference(100.9f, preferUSD_UKProject, RoundingMode.HALF_UP));
   }
 
   public void testPreferCAD_withUserInCA() {
@@ -225,30 +225,30 @@ public class KSCurrencyTest extends TestCase {
       .fxRate(1.5f)
       .currentCurrency(CurrencyCode.CAD.rawValue())
       .build();
-    assertEquals("CA$ 150", currency.formatWithUserPreference(100.1f, preferCAD_USProject, RoundingMode.DOWN, 0));
-    assertEquals("CA$ 150", currency.formatWithUserPreference(100.9f, preferCAD_USProject, RoundingMode.DOWN, 0));
-    assertEquals("CA$ 150", currency.formatWithUserPreference(100.1f, preferCAD_USProject, RoundingMode.HALF_UP, 0));
-    assertEquals("CA$ 152", currency.formatWithUserPreference(100.9f, preferCAD_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("CA$ 150", currency.formatWithUserPreference(100.1f, preferCAD_USProject, RoundingMode.DOWN));
+    assertEquals("CA$ 150", currency.formatWithUserPreference(100.9f, preferCAD_USProject, RoundingMode.DOWN));
+    assertEquals("CA$ 150", currency.formatWithUserPreference(100.1f, preferCAD_USProject, RoundingMode.HALF_UP));
+    assertEquals("CA$ 152", currency.formatWithUserPreference(100.9f, preferCAD_USProject, RoundingMode.HALF_UP));
 
     final Project preferCAD_CAProject = ProjectFactory.caProject()
       .toBuilder()
       .fxRate(1f)
       .currentCurrency(CurrencyCode.CAD.rawValue())
       .build();
-    assertEquals("CA$ 100", currency.formatWithUserPreference(100.1f, preferCAD_CAProject, RoundingMode.DOWN, 0));
-    assertEquals("CA$ 100", currency.formatWithUserPreference(100.9f, preferCAD_CAProject, RoundingMode.DOWN, 0));
-    assertEquals("CA$ 100", currency.formatWithUserPreference(100.1f, preferCAD_CAProject, RoundingMode.HALF_UP, 0));
-    assertEquals("CA$ 101", currency.formatWithUserPreference(100.9f, preferCAD_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("CA$ 100", currency.formatWithUserPreference(100.1f, preferCAD_CAProject, RoundingMode.DOWN));
+    assertEquals("CA$ 100", currency.formatWithUserPreference(100.9f, preferCAD_CAProject, RoundingMode.DOWN));
+    assertEquals("CA$ 100", currency.formatWithUserPreference(100.1f, preferCAD_CAProject, RoundingMode.HALF_UP));
+    assertEquals("CA$ 101", currency.formatWithUserPreference(100.9f, preferCAD_CAProject, RoundingMode.HALF_UP));
 
     final Project preferCAD_UKProject = ProjectFactory.ukProject()
       .toBuilder()
       .fxRate(.75f)
       .currentCurrency(CurrencyCode.CAD.rawValue())
       .build();
-    assertEquals("CA$ 75", currency.formatWithUserPreference(100.1f, preferCAD_UKProject, RoundingMode.DOWN, 0));
-    assertEquals("CA$ 75", currency.formatWithUserPreference(100.9f, preferCAD_UKProject, RoundingMode.DOWN, 0));
-    assertEquals("CA$ 75", currency.formatWithUserPreference(100.1f, preferCAD_UKProject, RoundingMode.HALF_UP, 0));
-    assertEquals("CA$ 76", currency.formatWithUserPreference(100.9f, preferCAD_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("CA$ 75", currency.formatWithUserPreference(100.1f, preferCAD_UKProject, RoundingMode.DOWN));
+    assertEquals("CA$ 75", currency.formatWithUserPreference(100.9f, preferCAD_UKProject, RoundingMode.DOWN));
+    assertEquals("CA$ 75", currency.formatWithUserPreference(100.1f, preferCAD_UKProject, RoundingMode.HALF_UP));
+    assertEquals("CA$ 76", currency.formatWithUserPreference(100.9f, preferCAD_UKProject, RoundingMode.HALF_UP));
   }
 
   public void testPreferGBP_withUserInUK() {
@@ -259,30 +259,30 @@ public class KSCurrencyTest extends TestCase {
       .fxRate(.75f)
       .currentCurrency(CurrencyCode.GBP.rawValue())
       .build();
-    assertEquals("£75", currency.formatWithUserPreference(100.1f, preferGBP_USProject, RoundingMode.DOWN, 0));
-    assertEquals("£75", currency.formatWithUserPreference(100.9f, preferGBP_USProject, RoundingMode.DOWN, 0));
-    assertEquals("£75", currency.formatWithUserPreference(100.1f, preferGBP_USProject, RoundingMode.HALF_UP, 0));
-    assertEquals("£76", currency.formatWithUserPreference(100.9f, preferGBP_USProject, RoundingMode.HALF_UP, 0));
+    assertEquals("£75", currency.formatWithUserPreference(100.1f, preferGBP_USProject, RoundingMode.DOWN));
+    assertEquals("£75", currency.formatWithUserPreference(100.9f, preferGBP_USProject, RoundingMode.DOWN));
+    assertEquals("£75", currency.formatWithUserPreference(100.1f, preferGBP_USProject, RoundingMode.HALF_UP));
+    assertEquals("£76", currency.formatWithUserPreference(100.9f, preferGBP_USProject, RoundingMode.HALF_UP));
 
     final Project preferGBP_CAProject = ProjectFactory.caProject()
       .toBuilder()
       .fxRate(1.5f)
       .currentCurrency(CurrencyCode.GBP.rawValue())
       .build();
-    assertEquals("£150", currency.formatWithUserPreference(100.1f, preferGBP_CAProject, RoundingMode.DOWN, 0));
-    assertEquals("£150", currency.formatWithUserPreference(100.9f, preferGBP_CAProject, RoundingMode.DOWN, 0));
-    assertEquals("£150", currency.formatWithUserPreference(100.1f, preferGBP_CAProject, RoundingMode.HALF_UP, 0));
-    assertEquals("£152", currency.formatWithUserPreference(100.9f, preferGBP_CAProject, RoundingMode.HALF_UP, 0));
+    assertEquals("£150", currency.formatWithUserPreference(100.1f, preferGBP_CAProject, RoundingMode.DOWN));
+    assertEquals("£150", currency.formatWithUserPreference(100.9f, preferGBP_CAProject, RoundingMode.DOWN));
+    assertEquals("£150", currency.formatWithUserPreference(100.1f, preferGBP_CAProject, RoundingMode.HALF_UP));
+    assertEquals("£152", currency.formatWithUserPreference(100.9f, preferGBP_CAProject, RoundingMode.HALF_UP));
 
     final Project preferGBP_UKProject = ProjectFactory.ukProject()
       .toBuilder()
       .fxRate(1f)
       .currentCurrency(CurrencyCode.GBP.rawValue())
       .build();
-    assertEquals("£100", currency.formatWithUserPreference(100.1f, preferGBP_UKProject, RoundingMode.DOWN, 0));
-    assertEquals("£100", currency.formatWithUserPreference(100.9f, preferGBP_UKProject, RoundingMode.DOWN, 0));
-    assertEquals("£100", currency.formatWithUserPreference(100.1f, preferGBP_UKProject, RoundingMode.HALF_UP, 0));
-    assertEquals("£101", currency.formatWithUserPreference(100.9f, preferGBP_UKProject, RoundingMode.HALF_UP, 0));
+    assertEquals("£100", currency.formatWithUserPreference(100.1f, preferGBP_UKProject, RoundingMode.DOWN));
+    assertEquals("£100", currency.formatWithUserPreference(100.9f, preferGBP_UKProject, RoundingMode.DOWN));
+    assertEquals("£100", currency.formatWithUserPreference(100.1f, preferGBP_UKProject, RoundingMode.HALF_UP));
+    assertEquals("£101", currency.formatWithUserPreference(100.9f, preferGBP_UKProject, RoundingMode.HALF_UP));
   }
 
   public void testFormatCurrency_withCurrencyCodeExcluded() {

--- a/app/src/test/java/com/kickstarter/libs/rx/operators/ApiErrorOperatorTest.java
+++ b/app/src/test/java/com/kickstarter/libs/rx/operators/ApiErrorOperatorTest.java
@@ -29,6 +29,22 @@ public final class ApiErrorOperatorTest extends KSRobolectricTestCase {
   }
 
   @Test
+  public void testNullErrorResponse() {
+    final Gson gson = new Gson();
+
+    final PublishSubject<Response<Integer>> response = PublishSubject.create();
+    final Observable<Integer> result = response.lift(Operators.apiError(gson));
+
+    final TestSubscriber<Integer> resultTest = new TestSubscriber<>();
+    result.subscribe(resultTest);
+
+    response.onError(null);
+
+    resultTest.assertNoValues();
+    assertEquals(1, resultTest.getOnErrorEvents().size());
+  }
+
+  @Test
   public void testSuccessResponse() {
     final Gson gson = new Gson();
 

--- a/app/src/test/java/com/kickstarter/libs/utils/StringUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/StringUtilsTest.java
@@ -42,4 +42,21 @@ public class StringUtilsTest extends KSRobolectricTestCase {
     assertEquals("Snapple apple", StringUtils.sentenceCase("Snapple Apple"));
     assertEquals("Snapple apple snapple", StringUtils.sentenceCase("Snapple Apple Snapple"));
   }
+
+  @Test
+  public void testTrim() {
+    assertEquals("", StringUtils.trim(""));
+    assertEquals("", StringUtils.trim(" "));
+    assertEquals("A", StringUtils.trim(" A"));
+    assertEquals("A", StringUtils.trim("A "));
+    assertEquals("A", StringUtils.trim(" A "));
+    assertEquals("", StringUtils.trim("\u00A0"));
+    assertEquals("A", StringUtils.trim("\u00A0A"));
+    assertEquals("A", StringUtils.trim("A\u00A0"));
+    assertEquals("A", StringUtils.trim("\u00A0A\u00A0"));
+    assertEquals("", StringUtils.trim("\u00A0 "));
+    assertEquals("A", StringUtils.trim("\u00A0 A"));
+    assertEquals("A", StringUtils.trim("A\u00A0 "));
+    assertEquals("A", StringUtils.trim("\u00A0 A \u00A0"));
+  }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/HorizontalRewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/HorizontalRewardViewHolderViewModelTest.kt
@@ -98,9 +98,11 @@ class HorizontalRewardViewHolderViewModelTest: KSRobolectricTestCase() {
 
         // USD conversion should be rounded normally.
         this.vm.inputs.projectAndReward(project, reward)
+        // converts to $0.98
         this.conversionTextViewText.assertValuesAndClear("$1")
 
-        this.vm.inputs.projectAndReward(project, RewardFactory.reward().toBuilder().minimum(1.9).build())
+        this.vm.inputs.projectAndReward(project, RewardFactory.reward().toBuilder().minimum(2.0).build())
+        // converts to $1.50
         this.conversionTextViewText.assertValue("$2")
     }
 
@@ -121,9 +123,11 @@ class HorizontalRewardViewHolderViewModelTest: KSRobolectricTestCase() {
 
         // USD conversion should be rounded normally.
         this.vm.inputs.projectAndReward(project, reward)
+        // converts to $0.98
         this.conversionTextViewText.assertValuesAndClear("US$ 1")
 
-        this.vm.inputs.projectAndReward(project, RewardFactory.reward().toBuilder().minimum(1.9).build())
+        this.vm.inputs.projectAndReward(project, RewardFactory.reward().toBuilder().minimum(2.0).build())
+        // converts to $1.50
         this.conversionTextViewText.assertValue("US$ 2")
     }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -127,7 +127,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment, reward, project)
 
         // the conversion should be hidden.
-        this.conversionText.assertValueCount(1)
+        this.conversionText.assertValue("$50.00")
         this.conversionTextViewIsGone.assertValue(true)
     }
 
@@ -136,13 +136,12 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
 
         // Set the project currency and the user's chosen currency to different values
-        val project = ProjectFactory.project().toBuilder().currency("CAD").currentCurrency("USD").build()
+        val project = ProjectFactory.caProject().toBuilder().currentCurrency("USD").build()
         val reward = RewardFactory.reward()
 
         setUpEnvironment(environment, reward, project)
 
-        // USD conversion should shown.
-        this.conversionText.assertValueCount(1)
+        this.conversionText.assertValue("$37.50")
         this.conversionTextViewIsGone.assertValue(false)
     }
 
@@ -151,7 +150,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
 
         // Set the project currency and the user's chosen currency to different values
-        val project = ProjectFactory.project().toBuilder().currency("USD").currentCurrency("CAD").build()
+        val project = ProjectFactory.project().toBuilder().currentCurrency("CAD").build()
         val reward = RewardFactory.reward()
 
         setUpEnvironment(environment, reward, project)
@@ -160,6 +159,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.decreasePledgeButtonClicked()
         this.conversionText.assertValues("CA$ 50.00", "CA$ 49.00")
+        this.conversionTextViewIsGone.assertValue(false)
     }
 
     @Test
@@ -273,7 +273,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     fun testShippingAmount() {
         val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
         setUpEnvironment(environment)
-        this.shippingAmount.assertValue("$30.00")
+        this.shippingAmount.assertValue("$30")
     }
 
     @Test
@@ -308,11 +308,12 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val defaultRule = ShippingRuleFactory.usShippingRule()
 
         this.selectedShippingRule.assertValues(defaultRule)
+        this.totalAmount.assertValue("$50")
 
         val selectedRule = ShippingRuleFactory.germanyShippingRule()
-
         this.vm.inputs.shippingRuleSelected(selectedRule)
 
+        this.totalAmount.assertValues("$50", "$60")
         this.selectedShippingRule.assertValues(defaultRule, selectedRule)
     }
 
@@ -344,53 +345,33 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testTotalAmountWithShippingRules() {
-        val config = ConfigFactory.configForUSUser()
-        val currentConfig = MockCurrentConfig()
-        currentConfig.config(config)
-
-        val environment = environment().toBuilder()
-                .currentConfig(currentConfig)
-                .build()
-        setUpEnvironment(environment)
-
-        this.totalAmount.assertValues("$50.00")
-    }
-
-    @Test
     fun testTotalAmountWithShippingRules_WhenStepperChangesValue() {
-        val config = ConfigFactory.configForUSUser()
-        val currentConfig = MockCurrentConfig()
-        currentConfig.config(config)
-
-        val environment = environment().toBuilder()
-                .currentConfig(currentConfig)
-                .build()
+        val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
         setUpEnvironment(environment)
 
-        this.totalAmount.assertValues("$50.00")
+        this.totalAmount.assertValues("$50")
         this.vm.decreasePledgeButtonClicked()
-        this.totalAmount.assertValues("$50.00", "$49.00")
+        this.totalAmount.assertValues("$50", "$49")
         this.vm.increasePledgeButtonClicked()
-        this.totalAmount.assertValues("$50.00", "$49.00", "$50.00")
+        this.totalAmount.assertValues("$50", "$49", "$50")
     }
 
     @Test
     fun testTotalAmountWithoutShippingRules() {
         val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.emptyShippingRules())
         setUpEnvironment(environment)
-        this.totalAmount.assertValue("$20.00")
+        this.totalAmount.assertValue("$20")
     }
 
     @Test
     fun testTotalAmountWithoutShippingRules_WhenStepperChangesValue() {
         val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.emptyShippingRules())
         setUpEnvironment(environment)
-        this.totalAmount.assertValue("$20.00")
+        this.totalAmount.assertValue("$20")
         this.vm.decreasePledgeButtonClicked()
-        this.totalAmount.assertValues("$20.00", "$19.00")
+        this.totalAmount.assertValues("$20", "$19")
         this.vm.increasePledgeButtonClicked()
-        this.totalAmount.assertValues("$20.00", "$19.00", "$20.00")
+        this.totalAmount.assertValues("$20", "$19", "$20")
     }
 
     private fun environmentForShippingRules(envelope: ShippingRulesEnvelope): Environment {

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewModelTest.java
@@ -177,9 +177,11 @@ public final class RewardViewModelTest extends KSRobolectricTestCase {
 
     // USD conversion should be rounded normally.
     this.vm.inputs.projectAndReward(project, reward);
+    // converts to $0.98
     this.conversionTextViewText.assertValuesAndClear("$1");
 
-    this.vm.inputs.projectAndReward(project, RewardFactory.reward().toBuilder().minimum(1.9f).build());
+    this.vm.inputs.projectAndReward(project, RewardFactory.reward().toBuilder().minimum(2f).build());
+    // converts to $1.50
     this.conversionTextViewText.assertValue("$2");
   }
 
@@ -200,9 +202,11 @@ public final class RewardViewModelTest extends KSRobolectricTestCase {
 
     // USD conversion should be rounded normally.
     this.vm.inputs.projectAndReward(project, reward);
+    // converts to $0.98
     this.conversionTextViewText.assertValuesAndClear("US$ 1");
 
-    this.vm.inputs.projectAndReward(project, RewardFactory.reward().toBuilder().minimum(1.9f).build());
+    this.vm.inputs.projectAndReward(project, RewardFactory.reward().toBuilder().minimum(2f).build());
+    // converts to $1.50
     this.conversionTextViewText.assertValue("US$ 2");
   }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModelTest.kt
@@ -6,8 +6,6 @@ import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.factories.ConfigFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.ShippingRuleFactory
-import com.kickstarter.mock.factories.ShippingRulesEnvelopeFactory
-import com.kickstarter.models.ShippingRule
 import org.junit.Test
 import rx.observers.TestSubscriber
 
@@ -39,6 +37,6 @@ class ShippingRuleViewHolderViewModelTest : KSRobolectricTestCase() {
         val project = ProjectFactory.project()
 
         this.vm.inputs.configureWith(shippingRule, project)
-        this.shippingRuleText.assertValue("Brooklyn, NY $30.00")
+        this.shippingRuleText.assertValue("Brooklyn, NY $30")
     }
 }


### PR DESCRIPTION
# What ❓
My fourth and hopefully final refactor of `KSCurrency`.

- Added `KSCurrency.currencyNeedsCode` to determine if a country's currency requires the country code and KSCurrency.getCurrencySymbol to return currency symbols for a country. These are helper methods to do the spanned currencies. Currently only shown in the `PledgeFragment`.
- By default, we round `DOWN`, so I created `KSCurrency.format` that only takes in a value and project.
- If we're rounding `DOWN`, we floor the number, or else we just leave it as is.
- There shouldn't be any platform dependent code in unit tests so `KSCurrency` never returns a `SpannableString`.
- Updated `KSCurrencyTest` to show how rounding works and added tests for `formatWithUserPreference` with new precision option.
- Added `StringUtils.trim` to remove trailing white space characters with tests.
- Added `ViewUtils.styleCurrency` to return stylized currency.
- Both examples in `ShippingRuleFactory` returned the same amount so there was no way to actually test that the number updated.
- Updated `*RewardViewModelTests` to show how rounding works.

# How to QA? 🤔
- Currency conversions should match the web.
- Only currencies with a country code should be spanned in `PledgeFragment`.
<img src=https://user-images.githubusercontent.com/1289295/59049563-45bba080-8856-11e9-8c3c-bf5eea03770c.png width=330/>

# Story 📖
This is a refactor that was necessary after #517 was merged without any tests for the currency code.
