### PR TITLE
No reward shipping rules hidden

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -168,6 +168,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .compose(observeForUI())
                 .subscribe {
                     shipping_amount.text = it
+                    ViewUtils.setGone(shipping_amount_container, false)
                     ViewUtils.setGone(shipping_amount_loading_view, true)
                 }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -319,56 +319,29 @@ interface PledgeFragmentViewModel {
                     .filter { ObjectUtils.isNull(it.first) || it.first.isEmpty() }
                     .compose<Pair<Pair<List<ShippingRule>, Reward>, Double>>(combineLatestPair(rewardAmountPlusAdditional))
 
-            val initialTotalAmountWithReward = rulesAndRewardAndAdditional
+            val initialAmountWithReward = rulesAndRewardAndAdditional
                     .map { it.second }
-                    .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map<SpannableString> { this.ksCurrency.formatWithProjectCurrency(it.first, it.second, RoundingMode.UP, 2) }
-                    .compose(bindToLifecycle())
 
-            val initialTotalAmountNoReward = rewardAmountPlusAdditional
+            val initialAmountNoReward = rewardAmountPlusAdditional
                     .compose<Pair<Double, Reward>>(combineLatestPair(reward))
                     .filter { RewardUtils.isNoReward(it.second) }
                     .map { it.first }
-                    .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map<SpannableString> { this.ksCurrency.formatWithProjectCurrency(it.first, it.second, RoundingMode.UP, 2) }
-                    .compose(bindToLifecycle())
 
-            val initialTotalAmount = Observable.merge(initialTotalAmountNoReward, initialTotalAmountWithReward)
+            val initialAmount = Observable.merge(initialAmountNoReward, initialAmountWithReward)
 
-            val totalWithShippingRule = rewardAmountPlusAdditional
+            val totalAmount = rewardAmountPlusAdditional
                     .compose<Pair<Double, Double>>(combineLatestPair(shippingAmount))
                     .map { it.first + it.second }
+
+            Observable.merge(initialAmount, totalAmount)
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
                     .map<SpannableString> { this.ksCurrency.formatWithProjectCurrency(it.first, it.second, RoundingMode.UP, 2) }
-                    .compose(bindToLifecycle())
-
-            Observable.merge(initialTotalAmount, totalWithShippingRule)
                     .compose(bindToLifecycle())
                     .subscribe(this.totalAmount)
 
-            val initialTotalConversionAmountNoReward = rewardAmountPlusAdditional
-                    .compose<Pair<Double, Reward>>(combineLatestPair(reward))
-                    .filter { RewardUtils.isNoReward(it.second) }
-                    .map { it.first }
+            Observable.merge(initialAmount, totalAmount)
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
                     .map { this.ksCurrency.formatWithUserPreference(it.first, it.second, RoundingMode.UP, 2) }
-                    .compose(bindToLifecycle())
-
-            val initialTotalConversionAmountWithReward = rulesAndRewardAndAdditional
-                    .map { it.second }
-                    .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map { this.ksCurrency.formatWithUserPreference(it.first, it.second, RoundingMode.UP, 2) }
-                    .compose(bindToLifecycle())
-
-            val initialTotalConversionAmount = Observable.merge(initialTotalConversionAmountNoReward, initialTotalConversionAmountWithReward)
-
-            val totalConversionAmount = rewardAmountPlusAdditional
-                    .compose<Pair<Double, Double>>(combineLatestPair(shippingAmount))
-                    .map { it.first + it.second }
-                    .compose<Pair<Double, Project>>(combineLatestPair(project))
-                    .map { this.ksCurrency.formatWithUserPreference(it.first, it.second, RoundingMode.UP, 2) }
-
-            Observable.merge(initialTotalConversionAmount, totalConversionAmount)
                     .compose(bindToLifecycle())
                     .subscribe { this.conversionText.onNext(it) }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -223,13 +223,13 @@ interface PledgeFragmentViewModel {
                     .filter { RewardUtils.isNoReward(it) }
                     .map { true }
 
-            this.shippingRulesSectionIsGone
-                    .compose(bindToLifecycle())
-                    .subscribe(this.estimatedDeliveryInfoIsGone)
-
             Observable.merge(hasNoShippingRules, isNoReward)
                     .compose(bindToLifecycle())
                     .subscribe(this.shippingRulesSectionIsGone)
+
+            this.shippingRulesSectionIsGone
+                    .compose(bindToLifecycle())
+                    .subscribe(this.estimatedDeliveryInfoIsGone)
 
             val defaultShippingRule = shippingRules
                     .filter { it.isNotEmpty() }

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -189,7 +189,7 @@ interface PledgeFragmentViewModel {
                     .compose(bindToLifecycle())
 
             projectAndReward
-                    .map { p -> p.first.currency() != p.first.currentCurrency() || RewardUtils.isNoReward(p.second) }
+                    .map { p -> p.first.currency() != p.first.currentCurrency() }
                     .map { BooleanUtils.negate(it) }
                     .subscribe { this.conversionTextViewIsGone.onNext(it) }
 

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -256,6 +256,13 @@
             android:layout_height="wrap_content"
             android:layout_weight=".1">
 
+            <LinearLayout
+              android:id="@+id/shipping_amount_container"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:visibility="gone"
+              android:orientation="horizontal">
+
             <ImageView
               android:layout_width="@dimen/grid_3"
               android:layout_height="@dimen/grid_3"
@@ -270,8 +277,8 @@
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_gravity="end"
-              android:layout_marginStart="@dimen/grid_2"
               tools:text="$20.00" />
+            </LinearLayout>
 
             <View
               android:id="@+id/shipping_amount_loading_view"

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -136,7 +136,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
 
         // Set the project currency and the user's chosen currency to different values
-        val project = ProjectFactory.caProject().toBuilder().currentCurrency("USD").build()
+        val project = ProjetFactory.caProject().toBuilder().currentCurrency("USD").build()
         val reward = RewardFactory.reward()
 
         setUpEnvironment(environment, reward, project)

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -204,7 +204,15 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testDelivery_whenNoReward() {
+    fun testEstimatedDelivery_whenNoShippingRules() {
+        val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
+        setUpEnvironment(environment, reward = RewardFactory.reward())
+        this.estimatedDelivery.assertNoValues()
+        this.estimatedDeliveryInfoIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testEstimatedDelivery_whenNoReward() {
         setUpEnvironment(environment(), RewardFactory.noReward())
 
         this.estimatedDelivery.assertNoValues()
@@ -287,14 +295,20 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShippingRuleSelection_NoShippingRules() {
+    fun testShippingRulesSection_NoReward() {
+        setUpEnvironment(environment(), RewardFactory.noReward())
+        this.shippingRulesSectionIsGone.assertValues(true)
+    }
+
+    @Test
+    fun testShippingRulesSection_NoShippingRules() {
         val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.emptyShippingRules())
         setUpEnvironment(environment)
         this.shippingRulesSectionIsGone.assertValues(true)
     }
 
     @Test
-    fun testShippingRuleSelection_WithShippingRules() {
+    fun testShippingRulesSection_WithShippingRules() {
         val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
         setUpEnvironment(environment)
         this.shippingRulesSectionIsGone.assertValues(false)

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -136,7 +136,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
 
         // Set the project currency and the user's chosen currency to different values
-        val project = ProjetFactory.caProject().toBuilder().currentCurrency("USD").build()
+        val project = ProjectFactory.caProject().toBuilder().currentCurrency("USD").build()
         val reward = RewardFactory.reward()
 
         setUpEnvironment(environment, reward, project)


### PR DESCRIPTION
# What ❓
- Hides Delivery Info with rewards has no shipping rules.
- Hides Shipping Rules section when user selects `No Reward`.
- Fixes a bug that didn't hide the `+` icon of the shipping amount when shipping rules were being loaded.

# How to QA? 🤔
- [x] Go to a project and select `No Reward`: the delivery info and shipping rules section should be hidden.
- [x] Go to a project and select `Reward with no shipping rules`: the delivery info and shipping rules section should be hidden.
- [x] Go to a project and select `Reward with shipping rules`: the delivery info and shipping rules section should be shown.

# Story 📖

[Hide Delivery Info if no shipping rules](https://trello.com/c/d96vOW9E/1398-hide-delivery-info-when-user-selects-reward-with-no-shipping-rules)

# See 👀
| No Reward | No Shipping Rules |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/3709676/59118513-60594c80-891e-11e9-91b7-a72eea64d194.png"> | <img src="https://user-images.githubusercontent.com/3709676/59118541-71a25900-891e-11e9-919d-5d0021c29e74.png">
| Shipping Rules |
| <img src="https://user-images.githubusercontent.com/3709676/59118571-7f57de80-891e-11e9-9fd3-98c4b6aba00d.png"> |
