### PR TITLE
fixed the opacity in the disabled reward state

### DIFF
--- a/app/src/main/res/drawable/button_reward_pledge.xml
+++ b/app/src/main/res/drawable/button_reward_pledge.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
 
-  <item android:color="@color/green_alpha_42"
+  <item android:color="@color/green_alpha_66"
     android:state_enabled="false"/>
 
   <item android:color="@color/ksr_green_500"/>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -47,8 +47,8 @@
   <color name="gray_darken_10">@color/ksr_grey_500</color>
   <color name="green_alpha_10">#1A009E74</color>
   <color name="green_alpha_20">#33009E74</color>
-  <color name="green_alpha_42">#6B009e74</color>
   <color name="green_alpha_50">#80009E74</color>
+  <color name="green_alpha_66">#57bfa4</color>
   <color name="green_darken_10">@color/soft_black_alpha_17</color>
   <color name="soft_black_alpha_17">#2B282828</color>
   <color name="white_alpha_60">#99ffffff</color>


### PR DESCRIPTION
# What ❓
- Fixed the opacity for the reward disabled state.

# See 👀
<img src=https://user-images.githubusercontent.com/16387538/59131936-cc00e100-8941-11e9-9470-5c8e73663ada.png width=400/>


