### PR TITLE
Fix NPE at app start with mock users

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/IntegerUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/IntegerUtils.java
@@ -25,4 +25,11 @@ public final class IntegerUtils {
   public static int intValueOrZero(final @Nullable Integer value) {
     return value != null ? value : 0;
   }
+
+  /**
+   * Returns `true` if `value` is null or zero, and false otherwise.
+   */
+  public static boolean isNullOrZero(final @Nullable Integer value) {
+    return value == null || value == 0;
+  }
 }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/discoverydrawer/LoggedInViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/discoverydrawer/LoggedInViewHolder.kt
@@ -47,7 +47,7 @@ class LoggedInViewHolder(@NonNull view: View, @NonNull private val delegate: Del
                 .compose(observeForUI())
                 .subscribe {
                     view.unread_messages_count.text = when {
-                        IntegerUtils.isZero(it) -> null
+                        IntegerUtils.isNullOrZero(it) -> null
                         else -> NumberUtils.format(it)
                     }
                 }
@@ -57,7 +57,7 @@ class LoggedInViewHolder(@NonNull view: View, @NonNull private val delegate: Del
                 .compose(observeForUI())
                 .subscribe {
                     view.unseen_activity_count.text = when {
-                        IntegerUtils.isZero(it) -> null
+                        IntegerUtils.isNullOrZero(it) -> null
                         else -> NumberUtils.format(it)
                     }
                 }

--- a/app/src/test/java/com/kickstarter/libs/utils/IntegerUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/IntegerUtilsTest.java
@@ -22,4 +22,11 @@ public class IntegerUtilsTest extends TestCase {
     assertEquals(5, IntegerUtils.intValueOrZero(5));
     assertEquals(0, IntegerUtils.intValueOrZero(null));
   }
+
+  public void testIsNullOrZero() {
+    assertFalse(IntegerUtils.isNullOrZero(1));
+    assertFalse(IntegerUtils.isNullOrZero(-1));
+    assertTrue(IntegerUtils.isNullOrZero(0));
+    assertTrue(IntegerUtils.isNullOrZero(null));
+  }
 }


### PR DESCRIPTION
# What ❓

- Fixed a crash that happens at app start when I'm logged in with a mocked user account. 

The `unreadMessagesCount` and `unseenActivityCount` are null because of how the mock user object is created with minimum fields. Since they are nullable fields anyway, I made the caller code perform null-check.

# How to QA? 🤔

1. Log in with a mock account with the `IS_OSS` build.
2. Close the app and reopen.
3. Crashes as soon as the app launches.