### PR TITLE
Literally native checkout 🙃

### DIFF
--- a/app/src/main/graphql/checkout.graphql
+++ b/app/src/main/graphql/checkout.graphql
@@ -1,0 +1,7 @@
+mutation Checkout($projectId: ID!, $amount: String!,  $paymentSourceId: String!, $locationId: String, $rewardId: ID)  {
+  nativeCheckout(input: { projectId: $projectId, amount: $amount, paymentSourceId: $paymentSourceId, locationId: $locationId, rewardId: $rewardId }) {
+    checkout {
+      state
+    }
+  }
+}

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -290,7 +290,7 @@ public final class ApplicationModule {
   @NonNull
   static HttpLoggingInterceptor provideHttpLoggingInterceptor() {
     final HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
-    interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+    interceptor.setLevel(HttpLoggingInterceptor.Level.HEADERS);
     return interceptor;
   }
 

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -290,7 +290,7 @@ public final class ApplicationModule {
   @NonNull
   static HttpLoggingInterceptor provideHttpLoggingInterceptor() {
     final HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
-    interceptor.setLevel(HttpLoggingInterceptor.Level.HEADERS);
+    interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
     return interceptor;
   }
 

--- a/app/src/main/java/com/kickstarter/libs/utils/ViewUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ViewUtils.java
@@ -92,14 +92,12 @@ public final class ViewUtils {
     if (currencyNeedsCode) {
       final int startOfSymbol = formattedCurrency.indexOf(currencySymbolToDisplay);
       final int endOfSymbol = startOfSymbol + currencySymbolToDisplay.length();
-      final float proportion;
       if (centered) {
-        proportion = .5f;
+        spannableString.setSpan(new RelativeSizeSpan(.5f), startOfSymbol, endOfSymbol, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
         spannableString.setSpan(new CenterSpan(), startOfSymbol, endOfSymbol, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
       } else {
-        proportion = .7f;
+        spannableString.setSpan(new RelativeSizeSpan(.7f), startOfSymbol, endOfSymbol, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
       }
-      spannableString.setSpan(new RelativeSizeSpan(proportion), startOfSymbol, endOfSymbol, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
     }
 
     return spannableString;

--- a/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.java
@@ -18,6 +18,7 @@ public final class RewardFactory {
       .backersCount(123)
       .id(IdFactory.id())
       .description(description)
+      .estimatedDeliveryOn(DateTime.parse("2019-03-26T19:26:09Z"))
       .minimum(20.0f)
       .title("Digital Bundle")
       .build();

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -10,6 +10,7 @@ import UpdateUserPasswordMutation
 import UserPrivacyQuery
 import com.kickstarter.mock.factories.StoredCardFactory
 import com.kickstarter.models.Project
+import com.kickstarter.models.Reward
 import com.kickstarter.models.StoredCard
 import com.kickstarter.models.User
 import com.kickstarter.services.ApolloClientType
@@ -19,6 +20,10 @@ import type.PaymentTypes
 import java.util.*
 
 open class MockApolloClient : ApolloClientType {
+
+    override fun checkout(project: Project, amount: String, paymentSourceId: String, locationId: String?, reward: Reward?): Observable<Boolean> {
+        return Observable.just(true)
+    }
 
     override fun clearUnseenActivity(): Observable<Long> {
         return Observable.just(0L)

--- a/app/src/main/java/com/kickstarter/models/Reward.java
+++ b/app/src/main/java/com/kickstarter/models/Reward.java
@@ -15,7 +15,7 @@ import static com.kickstarter.libs.utils.IntegerUtils.isZero;
 
 @AutoGson
 @AutoParcel
-public abstract class Reward implements Parcelable {
+public abstract class Reward implements Parcelable, Relay {
   public abstract @Nullable Integer backersCount();
   public abstract @Nullable String description();
   public abstract @Nullable DateTime endsAt();

--- a/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
+++ b/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
@@ -9,6 +9,7 @@ import UpdateUserEmailMutation
 import UpdateUserPasswordMutation
 import UserPrivacyQuery
 import com.kickstarter.models.Project
+import com.kickstarter.models.Reward
 import com.kickstarter.models.StoredCard
 import com.kickstarter.models.User
 import rx.Observable
@@ -16,6 +17,7 @@ import type.CurrencyCode
 import type.PaymentTypes
 
 interface ApolloClientType {
+    fun checkout(project: Project, amount: String, paymentSourceId: String, locationId: String?, reward: Reward?): Observable<Boolean>
 
     fun clearUnseenActivity(): Observable<Long>
 

--- a/app/src/main/java/com/kickstarter/ui/adapters/RewardCardAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/RewardCardAdapter.kt
@@ -5,12 +5,13 @@ import androidx.annotation.NonNull
 import androidx.recyclerview.widget.RecyclerView
 import com.kickstarter.R
 import com.kickstarter.models.StoredCard
+import com.kickstarter.ui.data.CardState
 import com.kickstarter.ui.viewholders.*
 
 class RewardCardAdapter(private val delegate: Delegate) : KSAdapter() {
     interface Delegate : RewardCardViewHolder.Delegate, RewardPledgeCardViewHolder.Delegate, RewardAddCardViewHolder.Delegate
 
-    private var selectedPosition = RecyclerView.NO_POSITION
+    private var selectedPosition = Pair(RecyclerView.NO_POSITION, CardState.SELECT)
 
     init {
         val placeholders = arrayOfNulls<Any>(3).toList()
@@ -22,8 +23,12 @@ class RewardCardAdapter(private val delegate: Delegate) : KSAdapter() {
             R.layout.item_reward_placeholder_card
         } else {
             if (sectionRow.section() == 0) {
-                if (sectionRow.row() == this.selectedPosition) {
-                    return R.layout.item_reward_pledge_card
+                if (sectionRow.row() == this.selectedPosition.first) {
+                    return when {
+                        this.selectedPosition.second == CardState.SELECT -> R.layout.item_reward_credit_card
+                        this.selectedPosition.second == CardState.PLEDGE -> R.layout.item_reward_pledge_card
+                        else -> R.layout.item_reward_loading_card
+                    }
                 }
                 R.layout.item_reward_credit_card
             } else {
@@ -37,6 +42,7 @@ class RewardCardAdapter(private val delegate: Delegate) : KSAdapter() {
             R.layout.item_reward_add_card -> RewardAddCardViewHolder(view, this.delegate)
             R.layout.item_reward_pledge_card -> RewardPledgeCardViewHolder(view, this.delegate)
             R.layout.item_reward_credit_card -> RewardCardViewHolder(view, this.delegate)
+            R.layout.item_reward_loading_card -> RewardLoadingCardViewHolder(view)
             else -> EmptyViewHolder(view)
         }
     }
@@ -48,13 +54,18 @@ class RewardCardAdapter(private val delegate: Delegate) : KSAdapter() {
         notifyDataSetChanged()
     }
 
-    fun setSelectedPosition(position: Int) {
-        this.selectedPosition = position
+    fun setLoadingPosition(position: Int) {
+        this.selectedPosition = Pair(position, CardState.LOADING)
         notifyItemChanged(position)
     }
 
-    fun resetSelectedPosition(position: Int) {
-        this.selectedPosition = RecyclerView.NO_POSITION
+    fun setPledgePosition(position: Int) {
+        this.selectedPosition = Pair(position, CardState.PLEDGE)
+        notifyItemChanged(position)
+    }
+
+    fun resetPledgePosition(position: Int) {
+        this.selectedPosition = Pair(RecyclerView.NO_POSITION, CardState.SELECT)
         notifyItemChanged(position)
     }
 

--- a/app/src/main/java/com/kickstarter/ui/data/CardState.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/CardState.kt
@@ -1,0 +1,5 @@
+package com.kickstarter.ui.data
+
+enum class CardState {
+    SELECT, PLEDGE, LOADING
+}

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -171,7 +171,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .compose(observeForUI())
                 .subscribe {
                     shipping_amount.text = it
-                    ViewUtils.setGone(shipping_amount_container, false)
+                    ViewUtils.setInvisible(shipping_amount_container, false)
                     ViewUtils.setGone(shipping_amount_loading_view, true)
                 }
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -136,7 +136,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.outputs.showPledgeCard()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { updatePledgeCardSelection(it) }
+                .subscribe { updatePledgeCardState(it) }
 
         this.viewModel.outputs.pledgeAmount()
                 .compose(bindToLifecycle())
@@ -236,8 +236,6 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     override fun addNewCardButtonClicked() {
         this.viewModel.inputs.newCardButtonClicked()
     }
-
-
 
     override fun closePledgeButtonClicked(position: Int) {
         this.viewModel.inputs.closeCardButtonClicked(position)
@@ -463,9 +461,9 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         pledge_details.y = pledge_root.height.toFloat()
     }
 
-    private fun updatePledgeCardSelection(positionAndSelected: Pair<Int, CardState>) {
-        val position = positionAndSelected.first
-        val cardState = positionAndSelected.second
+    private fun updatePledgeCardState(positionAndCardState: Pair<Int, CardState>) {
+        val position = positionAndCardState.first
+        val cardState = positionAndCardState.second
         val rewardCardAdapter = cards_recycler.adapter as RewardCardAdapter
 
         val freezeLinearLayoutManager = cards_recycler.layoutManager as FreezeLinearLayoutManager

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -35,6 +35,7 @@ import com.kickstarter.ui.activities.NewCardActivity
 import com.kickstarter.ui.activities.ThanksActivity
 import com.kickstarter.ui.adapters.RewardCardAdapter
 import com.kickstarter.ui.adapters.ShippingRulesAdapter
+import com.kickstarter.ui.data.CardState
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.ScreenLocation
 import com.kickstarter.ui.itemdecorations.RewardCardItemDecoration
@@ -234,6 +235,8 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     override fun addNewCardButtonClicked() {
         this.viewModel.inputs.newCardButtonClicked()
     }
+
+
 
     override fun closePledgeButtonClicked(position: Int) {
         this.viewModel.inputs.closeCardButtonClicked(position)
@@ -459,17 +462,24 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         pledge_details.y = pledge_root.height.toFloat()
     }
 
-    private fun updatePledgeCardSelection(positionAndSelected: Pair<Int, Boolean>) {
+    private fun updatePledgeCardSelection(positionAndSelected: Pair<Int, CardState>) {
         val position = positionAndSelected.first
-        val selected = positionAndSelected.second
+        val cardState = positionAndSelected.second
         val rewardCardAdapter = cards_recycler.adapter as RewardCardAdapter
-        if (selected) {
-            rewardCardAdapter.setSelectedPosition(position)
-            cards_recycler.scrollToPosition(position)
+
+        val freezeLinearLayoutManager = cards_recycler.layoutManager as FreezeLinearLayoutManager
+        if (cardState == CardState.SELECT) {
+            rewardCardAdapter.resetPledgePosition(position)
+            freezeLinearLayoutManager.setFrozen(false)
         } else {
-            rewardCardAdapter.resetSelectedPosition(position)
+            if (cardState == CardState.PLEDGE) {
+                rewardCardAdapter.setPledgePosition(position)
+            } else {
+                rewardCardAdapter.setLoadingPosition(position)
+            }
+            cards_recycler.scrollToPosition(position)
+            freezeLinearLayoutManager.setFrozen(true)
         }
-        (cards_recycler.layoutManager as FreezeLinearLayoutManager).setFrozen(selected)
     }
 
     companion object {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardLoadingCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardLoadingCardViewHolder.kt
@@ -1,0 +1,61 @@
+package com.kickstarter.ui.viewholders
+
+import android.view.View
+import com.kickstarter.R
+import com.kickstarter.libs.KSString
+import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
+import com.kickstarter.libs.utils.AnimationUtils
+import com.kickstarter.models.StoredCard
+import com.kickstarter.viewmodels.RewardCardViewHolderViewModel
+import kotlinx.android.synthetic.main.item_reward_loading_card.view.*
+
+class RewardLoadingCardViewHolder(val view: View) : KSViewHolder(view) {
+
+    private val viewModel: RewardCardViewHolderViewModel.ViewModel = RewardCardViewHolderViewModel.ViewModel(environment())
+    private val ksString: KSString = environment().ksString()
+
+    private val creditCardExpirationString = this.context().getString(R.string.Credit_card_expiration)
+    private val cardEndingInString = this.context().getString(R.string.Card_ending_in_last_four)
+
+    init {
+
+        this.viewModel.outputs.expirationDate()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { setExpirationDateTextView(it) }
+
+        this.viewModel.outputs.issuerImage()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.reward_loading_card_logo.setImageResource(it) }
+
+        this.viewModel.outputs.lastFour()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { setLastFourTextView(it) }
+
+        this.viewModel.outputs.id()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { animateProgressBar() }
+    }
+
+    private fun animateProgressBar() {
+        AnimationUtils.fadeInAndScale(this.view.reward_loading_progress_bar, 120L).start()
+    }
+
+    override fun bindData(data: Any?) {
+        val card = requireNotNull(data as StoredCard)
+        this.viewModel.inputs.configureWith(card)
+    }
+
+    private fun setExpirationDateTextView(date: String) {
+        this.view.reward_loading_card_expiration_date.text = this.ksString.format(this.creditCardExpirationString,
+                "expiration_date", date)
+    }
+
+    private fun setLastFourTextView(lastFour: String) {
+        this.view.reward_loading_card_last_four.text = this.ksString.format(this.cardEndingInString, "last_four", lastFour)
+    }
+
+}

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardLoadingCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardLoadingCardViewHolder.kt
@@ -6,12 +6,12 @@ import com.kickstarter.libs.KSString
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.AnimationUtils
 import com.kickstarter.models.StoredCard
-import com.kickstarter.viewmodels.RewardCardViewHolderViewModel
+import com.kickstarter.viewmodels.RewardLoadingCardViewHolderViewModel
 import kotlinx.android.synthetic.main.item_reward_loading_card.view.*
 
 class RewardLoadingCardViewHolder(val view: View) : KSViewHolder(view) {
 
-    private val viewModel: RewardCardViewHolderViewModel.ViewModel = RewardCardViewHolderViewModel.ViewModel(environment())
+    private val viewModel: RewardLoadingCardViewHolderViewModel.ViewModel = RewardLoadingCardViewHolderViewModel.ViewModel(environment())
     private val ksString: KSString = environment().ksString()
 
     private val creditCardExpirationString = this.context().getString(R.string.Credit_card_expiration)

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardPledgeCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardPledgeCardViewHolder.kt
@@ -8,10 +8,10 @@ import com.kickstarter.models.StoredCard
 import com.kickstarter.viewmodels.RewardPledgeCardViewHolderViewModel
 import kotlinx.android.synthetic.main.item_reward_pledge_card.view.*
 
-class RewardPledgeCardViewHolder(val view : View, val delegate : RewardPledgeCardViewHolder.Delegate) : KSViewHolder(view) {
+class RewardPledgeCardViewHolder(val view : View, val delegate : Delegate) : KSViewHolder(view) {
 
     interface Delegate {
-        fun pledgeButtonClicked(viewHolder: RewardPledgeCardViewHolder)
+        fun pledgeButtonClicked(id: String)
         fun closePledgeButtonClicked(position: Int)
     }
 
@@ -38,9 +38,14 @@ class RewardPledgeCardViewHolder(val view : View, val delegate : RewardPledgeCar
                 .compose(observeForUI())
                 .subscribe { setLastFourTextView(it) }
 
-        this.view.pledge_button.setOnClickListener {
-            this.delegate.pledgeButtonClicked(this)
-        }
+        this.viewModel.outputs.id()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe {id ->
+                    this.view.pledge_button.setOnClickListener {
+                        this.delegate.pledgeButtonClicked(id)
+                    }
+                }
 
         this.view.close_pledge.setOnClickListener {
             this.delegate.closePledgeButtonClicked(adapterPosition)

--- a/app/src/main/java/com/kickstarter/viewmodels/BaseRewardCardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BaseRewardCardViewHolderViewModel.kt
@@ -17,6 +17,9 @@ interface BaseRewardCardViewHolderViewModel {
     }
 
     interface Outputs {
+        /** Emits the id of the stored card. */
+        fun id(): Observable<String>
+
         /** Emits the expiration date for a credit card. */
         fun expirationDate(): Observable<String>
 
@@ -30,13 +33,17 @@ interface BaseRewardCardViewHolderViewModel {
     abstract class ViewModel(val environment: Environment) : ActivityViewModel<KSViewHolder>(environment), Inputs, Outputs {
         private val card = PublishSubject.create<StoredCard>()
 
-        private val issuerImage = BehaviorSubject.create<Int>()
         private val expirationDate = BehaviorSubject.create<String>()
+        private val id = BehaviorSubject.create<String>()
+        private val issuerImage = BehaviorSubject.create<Int>()
         private val lastFour = BehaviorSubject.create<String>()
 
         private val sdf = SimpleDateFormat(StoredCard.DATE_FORMAT, Locale.getDefault())
 
         init {
+            this.card.map { it.id() }
+                    .subscribe(this.id)
+
             this.card.map { it.expiration() }
                     .map { sdf.format(it).toString() }
                     .subscribe { this.expirationDate.onNext(it) }
@@ -50,6 +57,8 @@ interface BaseRewardCardViewHolderViewModel {
 
         }
         override fun configureWith(storedCard: StoredCard) = this.card.onNext(storedCard)
+
+        override fun id(): Observable<String> = this.id
 
         override fun issuerImage(): Observable<Int> = this.issuerImage
 

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -311,6 +311,7 @@ interface PledgeFragmentViewModel {
                     .compose<Pair<Double, Reward>>(combineLatestPair(reward))
                     .filter { RewardUtils.isNoReward(it.second) || !RewardUtils.isShippable(it.second) }
                     .map<Double> { it.first }
+                    .distinctUntilChanged()
 
             val shippableTotal = basePledgeAmount
                     .compose<Pair<Double, Double>>(combineLatestPair(shippingAmount))
@@ -318,6 +319,7 @@ interface PledgeFragmentViewModel {
                     .compose<Pair<Double, Reward>>(combineLatestPair(reward))
                     .filter { RewardUtils.isReward(it.second) && RewardUtils.isShippable(it.second) }
                     .map<Double> { it.first }
+                    .distinctUntilChanged()
 
             val total = Observable.merge(unshippableTotal, shippableTotal)
                     .compose<Pair<Double, Project>>(combineLatestPair(project))

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -187,7 +187,7 @@ interface PledgeFragmentViewModel {
                     .filter { ObjectUtils.isNotNull(it) }
                     .map { dateTime -> dateTime?.let { DateTimeUtils.estimatedDeliveryOn(it) } }
                     .compose(bindToLifecycle())
-                    .subscribe { this.estimatedDelivery.onNext(it) }
+                    .subscribe(this.estimatedDelivery)
 
             val projectAndReward = project
                     .compose<Pair<Project, Reward>>(combineLatestPair(reward))
@@ -196,9 +196,9 @@ interface PledgeFragmentViewModel {
                     .compose(bindToLifecycle())
 
             projectAndReward
-                    .map { p -> p.first.currency() != p.first.currentCurrency() }
+                    .map { it.first.currency() != it.first.currentCurrency() }
                     .map { BooleanUtils.negate(it) }
-                    .subscribe { this.conversionTextViewIsGone.onNext(it) }
+                    .subscribe(this.conversionTextViewIsGone)
 
             val rewardMinimum = reward
                     .map { it.minimum() }
@@ -207,7 +207,7 @@ interface PledgeFragmentViewModel {
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
                     .map<SpannableString> { ViewUtils.styleCurrency(it.first, it.second, this.ksCurrency) }
                     .compose(bindToLifecycle())
-                    .subscribe { this.pledgeAmount.onNext(it) }
+                    .subscribe(this.pledgeAmount)
 
             val shippingRules = project
                     .compose<Pair<Project, Reward>>(combineLatestPair(reward))
@@ -223,15 +223,14 @@ interface PledgeFragmentViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.shippingRulesAndProject)
 
-            val rewardNotShippable = reward
+            reward
                     .map { RewardUtils.isShippable(it) }
                     .map { BooleanUtils.negate(it) }
-
-            rewardNotShippable
                     .compose(bindToLifecycle())
                     .subscribe(this.shippingRulesSectionIsGone)
 
-            rewardNotShippable
+            reward
+                    .map { ObjectUtils.isNull(it.estimatedDeliveryOn()) || RewardUtils.isNoReward(it) }
                     .compose(bindToLifecycle())
                     .subscribe(this.estimatedDeliveryInfoIsGone)
 
@@ -332,7 +331,7 @@ interface PledgeFragmentViewModel {
             total
                     .map { this.ksCurrency.formatWithUserPreference(it.first, it.second, RoundingMode.UP, 2) }
                     .compose(bindToLifecycle())
-                    .subscribe { this.conversionText.onNext(it) }
+                    .subscribe(this.conversionText)
 
             userIsLoggedIn
                     .filter { BooleanUtils.isTrue(it) }
@@ -369,7 +368,7 @@ interface PledgeFragmentViewModel {
                     .filter(ActivityResult::isOk)
                     .switchMap { getListOfStoredCards() }
                     .compose(bindToLifecycle())
-                    .subscribe { this.cards.onNext(it) }
+                    .subscribe(this.cards)
 
             val location: Observable<Location?> = Observable.merge(Observable.just(null as Location?), shippingRule.map { it.location() })
 

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardLoadingCardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardLoadingCardViewHolderViewModel.kt
@@ -1,0 +1,14 @@
+package com.kickstarter.viewmodels
+
+import com.kickstarter.libs.Environment
+
+interface RewardLoadingCardViewHolderViewModel : BaseRewardCardViewHolderViewModel {
+
+    interface Inputs : BaseRewardCardViewHolderViewModel.Inputs
+    interface Outputs : BaseRewardCardViewHolderViewModel.Outputs
+
+    class ViewModel(environment: Environment) : BaseRewardCardViewHolderViewModel.ViewModel(environment), Inputs, Outputs  {
+        val inputs: Inputs = this
+        val outputs: Outputs = this
+    }
+}

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -26,13 +26,13 @@
 
       <include
         android:id="@+id/reward_layout"
-        android:visibility="invisible"
-        layout="@layout/item_reward" />
+        layout="@layout/item_reward"
+        android:visibility="invisible" />
 
       <include
         android:id="@+id/no_reward_layout"
-        android:visibility="invisible"
-        layout="@layout/item_no_reward" />
+        layout="@layout/item_no_reward"
+        android:visibility="invisible" />
     </FrameLayout>
 
     <!-- todo: what's the content description? -->
@@ -107,6 +107,7 @@
             tools:text="December 2019" />
 
         </LinearLayout>
+
         <LinearLayout
           android:id="@+id/accountability"
           android:layout_width="wrap_content"
@@ -258,26 +259,28 @@
 
             <LinearLayout
               android:id="@+id/shipping_amount_container"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:visibility="gone"
-              android:orientation="horizontal">
-
-            <ImageView
-              android:layout_width="@dimen/grid_3"
-              android:layout_height="@dimen/grid_3"
-              android:layout_gravity="start|center_vertical"
-              android:contentDescription="@null"
-              android:src="@drawable/ic_add"
-              android:tint="@color/ksr_dark_grey_400" />
-
-            <TextView
-              android:id="@+id/shipping_amount"
-              style="@style/PledgeCurrency"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_gravity="end"
-              tools:text="$20.00" />
+              android:orientation="horizontal"
+              android:visibility="invisible"
+              tools:visibility="visible">
+
+              <ImageView
+                android:layout_width="@dimen/grid_3"
+                android:layout_height="@dimen/grid_3"
+                android:layout_gravity="start|center_vertical"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_add"
+                android:tint="@color/ksr_dark_grey_400" />
+
+              <TextView
+                android:id="@+id/shipping_amount"
+                style="@style/PledgeCurrency"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                tools:text="$20" />
             </LinearLayout>
 
             <View

--- a/app/src/main/res/layout/item_reward_loading_card.xml
+++ b/app/src/main/res/layout/item_reward_loading_card.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView
+  android:id="@+id/card_container"
+  style="@style/PledgeStoredCard"
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content">
+
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="@dimen/grid_3">
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:minHeight="@dimen/grid_8"
+      android:orientation="horizontal">
+
+      <!--Content description should be set programmatically in RewardCardsAdapter to the card brand-->
+      <ImageView
+        android:id="@+id/reward_loading_card_logo"
+        android:layout_width="@dimen/credit_card_logo_width"
+        android:layout_height="@dimen/credit_card_logo_height"
+        android:contentDescription="@null"
+        android:scaleType="fitXY"
+        tools:src="@drawable/mastercard_md" />
+
+      <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/grid_2"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+          android:id="@+id/reward_loading_card_last_four"
+          style="@style/CreditCardLastFour"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          tools:text="Card ending in 1234" />
+
+        <TextView
+          android:id="@+id/reward_loading_card_expiration_date"
+          style="@style/CreditCardExpiration"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          tools:text="Expires in 03/2020" />
+      </LinearLayout>
+
+    </LinearLayout>
+
+    <FrameLayout
+      android:layout_width="match_parent"
+      android:layout_marginTop="@dimen/grid_2"
+      android:animateLayoutChanges="true"
+      android:layout_height="wrap_content">
+
+      <Button
+        android:stateListAnimator="@null"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+      <ProgressBar
+        android:id="@+id/reward_loading_progress_bar"
+        android:indeterminate="true"
+        android:indeterminateTintMode="src_in"
+        android:indeterminateTint="@color/white"
+        android:layout_gravity="center"
+        android:scaleX="0"
+        android:scaleY="0"
+        android:alpha="0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    </FrameLayout>
+
+  </LinearLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -224,7 +224,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.paymentContainerIsGone.assertValue(false)
     }
 
-
     @Test
     fun testPaymentForLoggedInUser_whenDigitalReward() {
         val environment = environment()

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -293,8 +293,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     fun testEstimatedDelivery_whenDigitalReward() {
         setUpEnvironment(environment(), reward = RewardFactory.reward())
 
-        this.estimatedDelivery.assertNoValues()
-        this.estimatedDeliveryInfoIsGone.assertValue(true)
+        this.estimatedDelivery.assertValue("March 2019")
+        this.estimatedDeliveryInfoIsGone.assertValue(false)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -19,6 +19,7 @@ import com.kickstarter.models.ShippingRule
 import com.kickstarter.models.StoredCard
 import com.kickstarter.services.apiresponses.ShippingRulesEnvelope
 import com.kickstarter.ui.ArgumentsKey
+import com.kickstarter.ui.adapters.RewardCardAdapter
 import com.kickstarter.ui.data.ActivityResult
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.ScreenLocation
@@ -48,7 +49,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val shippingAmount = TestSubscriber<String>()
     private val shippingRuleAndProject = TestSubscriber<Pair<List<ShippingRule>, Project>>()
     private val shippingRulesSectionIsGone = TestSubscriber<Boolean>()
-    private val showPledgeCard = TestSubscriber<Pair<Int, Boolean>>()
+    private val showPledgeCard = TestSubscriber<Pair<Int, RewardCardAdapter.CardState>>()
     private val startLoginToutActivity = TestSubscriber<Void>()
     private val startNewCardActivity = TestSubscriber<Void>()
     private val totalAmount = TestSubscriber<String>()
@@ -321,10 +322,10 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment())
 
         this.vm.inputs.selectCardButtonClicked(2)
-        this.showPledgeCard.assertValuesAndClear(Pair(2, true))
+        this.showPledgeCard.assertValuesAndClear(Pair(2, RewardCardAdapter.CardState.PLEDGE))
 
         this.vm.inputs.closeCardButtonClicked(2)
-        this.showPledgeCard.assertValue(Pair(2, false))
+        this.showPledgeCard.assertValue(Pair(2, RewardCardAdapter.CardState.SELECT))
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModelTest.kt
@@ -12,7 +12,7 @@ class RewardCardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var vm: RewardCardViewHolderViewModel.ViewModel
 
-    private val estimatedDelivery = TestSubscriber.create<String>()
+    private val expirationDate = TestSubscriber.create<String>()
     private val id = TestSubscriber.create<String>()
     private val issuerImage = TestSubscriber.create<Int>()
     private val lastFour = TestSubscriber.create<String>()
@@ -20,7 +20,7 @@ class RewardCardViewHolderViewModelTest : KSRobolectricTestCase() {
     private fun setUpEnvironment(environment: Environment) {
         this.vm = RewardCardViewHolderViewModel.ViewModel(environment)
 
-        this.vm.outputs.expirationDate().subscribe(this.estimatedDelivery)
+        this.vm.outputs.expirationDate().subscribe(this.expirationDate)
         this.vm.outputs.id().subscribe(this.id)
         this.vm.outputs.issuerImage().subscribe(this.issuerImage)
         this.vm.outputs.lastFour().subscribe(this.lastFour)
@@ -38,7 +38,7 @@ class RewardCardViewHolderViewModelTest : KSRobolectricTestCase() {
                 .build()
         this.vm.inputs.configureWith(creditCard)
 
-        this.estimatedDelivery.assertValue("03/2019")
+        this.expirationDate.assertValue("03/2019")
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardLoadingCardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardLoadingCardViewHolderViewModelTest.kt
@@ -12,7 +12,7 @@ class RewardLoadingCardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var vm: RewardLoadingCardViewHolderViewModel.ViewModel
 
-    private val estimatedDelivery = TestSubscriber.create<String>()
+    private val expirationDate = TestSubscriber.create<String>()
     private val id = TestSubscriber.create<String>()
     private val issuerImage = TestSubscriber.create<Int>()
     private val lastFour = TestSubscriber.create<String>()
@@ -20,7 +20,7 @@ class RewardLoadingCardViewHolderViewModelTest : KSRobolectricTestCase() {
     private fun setUpEnvironment(environment: Environment) {
         this.vm = RewardLoadingCardViewHolderViewModel.ViewModel(environment)
 
-        this.vm.outputs.expirationDate().subscribe(this.estimatedDelivery)
+        this.vm.outputs.expirationDate().subscribe(this.expirationDate)
         this.vm.outputs.id().subscribe(this.id)
         this.vm.outputs.issuerImage().subscribe(this.issuerImage)
         this.vm.outputs.lastFour().subscribe(this.lastFour)
@@ -38,7 +38,7 @@ class RewardLoadingCardViewHolderViewModelTest : KSRobolectricTestCase() {
                 .build()
         this.vm.inputs.configureWith(creditCard)
 
-        this.estimatedDelivery.assertValue("03/2019")
+        this.expirationDate.assertValue("03/2019")
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardLoadingCardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardLoadingCardViewHolderViewModelTest.kt
@@ -8,9 +8,9 @@ import org.junit.Test
 import rx.observers.TestSubscriber
 import java.util.*
 
-class RewardCardViewHolderViewModelTest : KSRobolectricTestCase() {
+class RewardLoadingCardViewHolderViewModelTest : KSRobolectricTestCase() {
 
-    private lateinit var vm: RewardCardViewHolderViewModel.ViewModel
+    private lateinit var vm: RewardLoadingCardViewHolderViewModel.ViewModel
 
     private val estimatedDelivery = TestSubscriber.create<String>()
     private val id = TestSubscriber.create<String>()
@@ -18,7 +18,7 @@ class RewardCardViewHolderViewModelTest : KSRobolectricTestCase() {
     private val lastFour = TestSubscriber.create<String>()
 
     private fun setUpEnvironment(environment: Environment) {
-        this.vm = RewardCardViewHolderViewModel.ViewModel(environment)
+        this.vm = RewardLoadingCardViewHolderViewModel.ViewModel(environment)
 
         this.vm.outputs.expirationDate().subscribe(this.estimatedDelivery)
         this.vm.outputs.id().subscribe(this.id)

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardPledgeCardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardPledgeCardViewHolderViewModelTest.kt
@@ -12,7 +12,7 @@ class RewardPledgeCardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var vm: RewardPledgeCardViewHolderViewModel.ViewModel
 
-    private val estimatedDelivery = TestSubscriber.create<String>()
+    private val expirationDate = TestSubscriber.create<String>()
     private val id = TestSubscriber.create<String>()
     private val issuerImage = TestSubscriber.create<Int>()
     private val lastFour = TestSubscriber.create<String>()
@@ -20,7 +20,7 @@ class RewardPledgeCardViewHolderViewModelTest : KSRobolectricTestCase() {
     private fun setUpEnvironment(environment: Environment) {
         this.vm = RewardPledgeCardViewHolderViewModel.ViewModel(environment)
 
-        this.vm.outputs.expirationDate().subscribe(this.estimatedDelivery)
+        this.vm.outputs.expirationDate().subscribe(this.expirationDate)
         this.vm.outputs.id().subscribe(this.id)
         this.vm.outputs.issuerImage().subscribe(this.issuerImage)
         this.vm.outputs.lastFour().subscribe(this.lastFour)
@@ -38,7 +38,7 @@ class RewardPledgeCardViewHolderViewModelTest : KSRobolectricTestCase() {
                 .build()
         this.vm.inputs.configureWith(creditCard)
 
-        this.estimatedDelivery.assertValue("03/2019")
+        this.expirationDate.assertValue("03/2019")
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardPledgeCardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardPledgeCardViewHolderViewModelTest.kt
@@ -13,6 +13,7 @@ class RewardPledgeCardViewHolderViewModelTest : KSRobolectricTestCase() {
     private lateinit var vm: RewardPledgeCardViewHolderViewModel.ViewModel
 
     private val estimatedDelivery = TestSubscriber.create<String>()
+    private val id = TestSubscriber.create<String>()
     private val issuerImage = TestSubscriber.create<Int>()
     private val lastFour = TestSubscriber.create<String>()
 
@@ -20,6 +21,7 @@ class RewardPledgeCardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm = RewardPledgeCardViewHolderViewModel.ViewModel(environment)
 
         this.vm.outputs.expirationDate().subscribe(this.estimatedDelivery)
+        this.vm.outputs.id().subscribe(this.id)
         this.vm.outputs.issuerImage().subscribe(this.issuerImage)
         this.vm.outputs.lastFour().subscribe(this.lastFour)
     }
@@ -37,6 +39,16 @@ class RewardPledgeCardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(creditCard)
 
         this.estimatedDelivery.assertValue("03/2019")
+    }
+
+    @Test
+    fun testId() {
+        setUpEnvironment(environment())
+        val creditCard = StoredCardFactory.discoverCard()
+
+        this.vm.inputs.configureWith(creditCard)
+
+        this.id.assertValue(creditCard.id())
     }
 
     @Test


### PR DESCRIPTION
# What ❓
Pledging with a `StoredCard`:
- Added mutation for `nativeCheckout`. 
  - It's kind of funky because `projectId` and `rewardId` are relay IDs while `locationId` and `paymentSourceId` are just strings.
  - It returns `Checkout.State` and I consider the call to have been successful if `state == VERIFYING`.
- We needed a 5th loading state `RewardLoadingCardViewHolder` for the stored cards in the `PledgeFragment.` Instead of `showPledgeCard` returning `Pair<Int, Boolean>`, I created an enum `CardState` and that has 3 values: `SELECT`, `PLEDGE`, `LOADING`. 
  - So the normal state is `SELECT`. If a user clicks `"Select"`, its new state will be `PLEDGE` and when they click `"Pledge"`, it'll be `LOADING`. If the pledge call is successful, the state doesn't really matter because we're going to destroy the `ProjectActivity`. But if it's unsuccessful, the state will go back to `PLEDGE` and `showPledgeError` will emit. So `showPledgeCard` now emits `Pair<Int, CardState>`. If successful, `startThanksActivity` emits.
  - (What should happen if a user hits back?)
- The shipping rules API call was missing `neverError()` so it crashed the app every time the call failed.
- UI: 
  - `shipping_amount_container` is `invisible` instead of `gone` so the screen doesn't awkwardly resize when it's visible.
  - Shifted the shipping amount to align with the total.
- Enforcing `RewardUtils.isShippable`  as the arbiter of determining whether we fetch shipping rules as iOS does. It also stops us from making the call unnecessarily.
- Simplified how we get the `total` output. The total is either with shipping or without. If a reward is `shippable`, the total won't emit unless it also has that value.
- Per Danny, we shouldn't load the stored cards until the total has been calculated.
- Tests for no reward, digital and physical rewards.
- Danny pointed out that digital rewards can have delivery dates.

# How to QA? 🤔
Back a project with a stored card 😛 

# Story 📖
[Trello Story](https://trello.com/c/bRloDmly/1363-user-can-back-a-project-using-a-stored-card)

# See 👀
![device-2019-06-10-115121 2019-06-10 11_52_50](https://user-images.githubusercontent.com/1289295/59208029-49ad3280-8b76-11e9-8ab0-7d1520c1e995.gif) ![device-2019-06-10-115457 2019-06-10 11_55_29](https://user-images.githubusercontent.com/1289295/59208238-af012380-8b76-11e9-8fad-4d4d61da2567.gif)

For future consideration: 
- When the call is really fast, the user doesn't see my very nice animation of the progress bar.
- What should the error copy be? What's returned from the server is not user friendly.
- I will find out why the Thanks page is so slow and destroy it.