### PR TITLE
Reward minimum span

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/ViewUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ViewUtils.java
@@ -69,25 +69,7 @@ public final class ViewUtils {
    *
    */
   public static @NotNull SpannableString styleCurrency(final double value, final Project project, final @NonNull KSCurrency ksCurrency) {
-    final String formattedCurrency = ksCurrency.format(value, project, RoundingMode.HALF_UP);
-    final SpannableString spannableString = new SpannableString(formattedCurrency);
-
-    final Country country = Country.findByCurrencyCode(project.currency());
-    if (country == null) {
-      return spannableString;
-    }
-
-    final boolean currencyNeedsCode = ksCurrency.currencyNeedsCode(country, true);
-    final String currencySymbolToDisplay = StringUtils.trim(ksCurrency.getCurrencySymbol(country, true));
-
-    if (currencyNeedsCode) {
-      final int startOfSymbol = formattedCurrency.indexOf(currencySymbolToDisplay);
-      final int endOfSymbol = startOfSymbol + currencySymbolToDisplay.length();
-      spannableString.setSpan(new RelativeSizeSpan(.5f), startOfSymbol, endOfSymbol, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
-      spannableString.setSpan(new CenterSpan(), startOfSymbol, endOfSymbol, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
-    }
-
-    return spannableString;
+    return styleCurrency(value, project, ksCurrency, true);
   }
 
   /**
@@ -95,7 +77,7 @@ public final class ViewUtils {
    * Special case: US people looking at US currency just get the currency symbol.
    *
    */
-  public static @NotNull SpannableString styleCurrencyBottom(final double value, final Project project, final @NonNull KSCurrency ksCurrency) {
+  public static @NotNull SpannableString styleCurrency(final double value, final Project project, final @NonNull KSCurrency ksCurrency, final boolean centered) {
     final String formattedCurrency = ksCurrency.format(value, project, RoundingMode.HALF_UP);
     final SpannableString spannableString = new SpannableString(formattedCurrency);
 
@@ -110,7 +92,14 @@ public final class ViewUtils {
     if (currencyNeedsCode) {
       final int startOfSymbol = formattedCurrency.indexOf(currencySymbolToDisplay);
       final int endOfSymbol = startOfSymbol + currencySymbolToDisplay.length();
-      spannableString.setSpan(new RelativeSizeSpan(.7f), startOfSymbol, endOfSymbol, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
+      final float proportion;
+      if (centered) {
+        proportion = .5f;
+        spannableString.setSpan(new CenterSpan(), startOfSymbol, endOfSymbol, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
+      } else {
+        proportion = .7f;
+      }
+      spannableString.setSpan(new RelativeSizeSpan(proportion), startOfSymbol, endOfSymbol, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
     }
 
     return spannableString;

--- a/app/src/main/java/com/kickstarter/libs/utils/ViewUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ViewUtils.java
@@ -90,6 +90,32 @@ public final class ViewUtils {
     return spannableString;
   }
 
+  /**
+   * Returns a SpannableString that shrinks currency code if it's necessary.
+   * Special case: US people looking at US currency just get the currency symbol.
+   *
+   */
+  public static @NotNull SpannableString styleCurrencyBottom(final double value, final Project project, final @NonNull KSCurrency ksCurrency) {
+    final String formattedCurrency = ksCurrency.format(value, project, RoundingMode.HALF_UP);
+    final SpannableString spannableString = new SpannableString(formattedCurrency);
+
+    final Country country = Country.findByCurrencyCode(project.currency());
+    if (country == null) {
+      return spannableString;
+    }
+
+    final boolean currencyNeedsCode = ksCurrency.currencyNeedsCode(country, true);
+    final String currencySymbolToDisplay = StringUtils.trim(ksCurrency.getCurrencySymbol(country, true));
+
+    if (currencyNeedsCode) {
+      final int startOfSymbol = formattedCurrency.indexOf(currencySymbolToDisplay);
+      final int endOfSymbol = startOfSymbol + currencySymbolToDisplay.length();
+      spannableString.setSpan(new RelativeSizeSpan(.7f), startOfSymbol, endOfSymbol, Spanned.SPAN_INCLUSIVE_INCLUSIVE);
+    }
+
+    return spannableString;
+  }
+
   public static boolean isFontScaleLarge(final @NonNull Context context) {
     return context.getResources().getConfiguration().fontScale > 1.5f;
   }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/HorizontalRewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/HorizontalRewardViewHolder.kt
@@ -151,23 +151,18 @@ class HorizontalRewardViewHolder(private val view: View, val delegate: Delegate?
     }
 
     private fun setConversionTextView(@NonNull amount: String) {
-        this.view.horizontal_reward_usd_conversion_text_view.text = (this.ksString.format(
-                this.currencyConversionString,
-                "reward_amount", amount
-        ))
+        this.view.horizontal_reward_usd_conversion_text_view.text = this.ksString.format(this.currencyConversionString,
+                "reward_amount", amount)
     }
 
     private fun setMinimumButtonText(@NonNull minimum: String) {
-        this.view.horizontal_reward_pledge_button.text = (this.ksString.format(
-                this.pledgeRewardCurrencyOrMoreString,
-                "reward_currency", minimum
-        ))
+        this.view.horizontal_reward_pledge_button.text = this.ksString.format(this.pledgeRewardCurrencyOrMoreString,
+                "reward_currency", minimum)
     }
 
     private fun setRemainingRewardsTextView(@NonNull remaining: String) {
-        this.view.horizontal_reward_remaining_text_view.text = (this.ksString.format(
-                this.remainingRewardsString, "left_count", remaining
-        ))
+        this.view.horizontal_reward_remaining_text_view.text = this.ksString.format(this.remainingRewardsString,
+                "left_count", remaining)
     }
 
     private fun setUpRewardItemsAdapter(): RewardItemsAdapter {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/HorizontalRewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/HorizontalRewardViewHolder.kt
@@ -30,11 +30,10 @@ class HorizontalRewardViewHolder(private val view: View, val delegate: Delegate?
     }
 
     private val ksString = environment().ksString()
-    private lateinit var reward: Reward
     private var viewModel = HorizontalRewardViewHolderViewModel.ViewModel(environment())
 
     private val currencyConversionString = context().getString(R.string.About_reward_amount)
-    private val noLongerAvailbleString = context().getString(R.string.No_longer_available)
+    private val noLongerAvailableString = context().getString(R.string.No_longer_available)
     private val pledgeRewardCurrencyOrMoreString = context().getString(R.string.rewards_title_pledge_reward_currency_or_more)
     private val remainingRewardsString = context().getString(R.string.Left_count_left_few)
 
@@ -72,13 +71,20 @@ class HorizontalRewardViewHolder(private val view: View, val delegate: Delegate?
                 .compose(observeForUI())
                 .subscribe { setRemainingRewardsTextView(it.second) }
 
-        this.viewModel.outputs.minimumText()
+        this.viewModel.outputs.limitReachedButtonTextIsVisible()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe {
-                    setMinimumText(it)
-                    setMinimumButtonText(it)
-                }
+                .subscribe { this.view.horizontal_reward_pledge_button.text = this.noLongerAvailableString }
+
+        this.viewModel.outputs.minimumAmount()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { setMinimumButtonText(it) }
+
+        this.viewModel.outputs.minimumAmountTitle()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.horizontal_reward_minimum_text_view.text = it }
 
         this.viewModel.outputs.reward()
                 .compose(bindToLifecycle())
@@ -113,7 +119,7 @@ class HorizontalRewardViewHolder(private val view: View, val delegate: Delegate?
         this.viewModel.outputs.showPledgeFragment()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { this.delegate?.rewardClicked(ViewUtils.getScreenLocation(this.itemView), this.reward) }
+                .subscribe { this.delegate?.rewardClicked(ViewUtils.getScreenLocation(this.itemView), it.second) }
 
         this.viewModel.outputs.startBackingActivity()
                 .compose(bindToLifecycle())
@@ -128,9 +134,9 @@ class HorizontalRewardViewHolder(private val view: View, val delegate: Delegate?
     override fun bindData(data: Any?) {
         val projectAndReward = requireNonNull(data as Pair<Project, Reward>)
         val project = requireNonNull(projectAndReward.first, Project::class.java)
-        this.reward = requireNonNull(projectAndReward.second, Reward::class.java)
+        val reward = requireNonNull(projectAndReward.second, Reward::class.java)
 
-        this.viewModel.inputs.projectAndReward(project, this.reward)
+        this.viewModel.inputs.projectAndReward(project, reward)
     }
 
     private fun configureRewardButton(isRewardAvailable: Boolean) {
@@ -144,14 +150,6 @@ class HorizontalRewardViewHolder(private val view: View, val delegate: Delegate?
         return "$value $detail"
     }
 
-    private fun getScreenLocationOfReward(): ScreenLocation {
-        val x = this.itemView.left.toFloat()
-        val y = this.itemView.top.toFloat()
-        val height = this.itemView.height
-        val width = this.itemView.width
-        return ScreenLocation(x, y, height.toFloat(), width.toFloat())
-    }
-
     private fun setConversionTextView(@NonNull amount: String) {
         this.view.horizontal_reward_usd_conversion_text_view.text = (this.ksString.format(
                 this.currencyConversionString,
@@ -159,19 +157,11 @@ class HorizontalRewardViewHolder(private val view: View, val delegate: Delegate?
         ))
     }
 
-    private fun setMinimumText(@NonNull minimum: String) {
-        this.view.horizontal_reward_minimum_text_view.text = minimum
-    }
-
     private fun setMinimumButtonText(@NonNull minimum: String) {
-        if (RewardUtils.isLimitReached(this.reward)) {
-            this.view.horizontal_reward_pledge_button.text = noLongerAvailbleString
-        } else {
-            this.view.horizontal_reward_pledge_button.text = (this.ksString.format(
-                    this.pledgeRewardCurrencyOrMoreString,
-                    "reward_currency", minimum
-            ))
-        }
+        this.view.horizontal_reward_pledge_button.text = (this.ksString.format(
+                this.pledgeRewardCurrencyOrMoreString,
+                "reward_currency", minimum
+        ))
     }
 
     private fun setRemainingRewardsTextView(@NonNull remaining: String) {

--- a/app/src/main/java/com/kickstarter/viewmodels/HorizontalRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/HorizontalRewardViewHolderViewModel.kt
@@ -97,11 +97,11 @@ interface HorizontalRewardViewHolderViewModel {
         private val conversionTextViewIsGone: Observable<Boolean>
         private val descriptionText: Observable<String>
         private val isClickable: Observable<Boolean>
-        private val isLimitReachedButtonTextVisible: Observable<Void>
         private val limitAndBackersSeparatorIsGone: Observable<Boolean>
         private val limitAndRemainingTextViewIsGone: Observable<Boolean>
         private val limitAndRemainingText: Observable<Pair<String, String>>
         private val limitHeaderIsGone: Observable<Boolean>
+        private val limitReachedButtonTextIsVisible: Observable<Void>
         private val minimumAmount: Observable<String>
         private val minimumAmountStyled: Observable<SpannableString>
         private val reward: Observable<Reward>
@@ -125,7 +125,7 @@ interface HorizontalRewardViewHolderViewModel {
             val reward = this.projectAndReward
                     .map { it.second }
 
-            this.isLimitReachedButtonTextVisible = reward
+            this.limitReachedButtonTextIsVisible = reward
                     .filter { RewardUtils.isLimitReached(it) }
                     .compose(ignoreValues())
 
@@ -248,9 +248,6 @@ interface HorizontalRewardViewHolderViewModel {
         override fun isClickable(): Observable<Boolean> = this.isClickable
 
         @NonNull
-        override fun limitReachedButtonTextIsVisible(): Observable<Void> = this.isLimitReachedButtonTextVisible
-
-        @NonNull
         override fun limitAndRemainingTextViewIsGone(): Observable<Boolean> = this.limitAndRemainingTextViewIsGone
 
         @NonNull
@@ -258,6 +255,9 @@ interface HorizontalRewardViewHolderViewModel {
 
         @NonNull
         override fun limitHeaderIsGone(): Observable<Boolean> = this.limitHeaderIsGone
+
+        @NonNull
+        override fun limitReachedButtonTextIsVisible(): Observable<Void> = this.limitReachedButtonTextIsVisible
 
         @NonNull
         override fun minimumAmount(): Observable<String> = this.minimumAmount

--- a/app/src/main/java/com/kickstarter/viewmodels/HorizontalRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/HorizontalRewardViewHolderViewModel.kt
@@ -120,7 +120,7 @@ interface HorizontalRewardViewHolderViewModel {
         init {
 
             this.minimumAmountStyled = this.projectAndReward
-                    .map { ViewUtils.styleCurrencyBottom(it.second.minimum(), it.first, this.ksCurrency) }
+                    .map { ViewUtils.styleCurrency(it.second.minimum(), it.first, this.ksCurrency, false) }
 
             val reward = this.projectAndReward
                     .map { it.second }

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -33,13 +33,13 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:textColor="@color/ksr_green_500"
-          android:textSize="@dimen/title_3"
+          android:textSize="@dimen/title_reward"
           android:textStyle="bold"
           tools:text="$20" />
 
         <TextView
           android:id="@+id/horizontal_reward_usd_conversion_text_view"
-          style="@style/Caption1Secondary"
+          style="@style/FootnotePrimary"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:textColor="@color/ksr_green_500"

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -145,5 +145,4 @@
 
   </FrameLayout>
 
-
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/HorizontalRewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/HorizontalRewardViewHolderViewModelTest.kt
@@ -24,7 +24,9 @@ class HorizontalRewardViewHolderViewModelTest: KSRobolectricTestCase() {
     private val isClickable = TestSubscriber<Boolean>()
     private val limitAndRemainingTextViewIsGone = TestSubscriber<Boolean>()
     private val limitAndRemainingTextViewText = TestSubscriber<Pair<String, String>>()
-    private val minimumTextViewText = TestSubscriber<String>()
+    private val limitReachedButtonTextIsVisible = TestSubscriber<Void>()
+    private val minimumAmount = TestSubscriber<String>()
+    private val minimumAmountTitle = TestSubscriber<String>()
     private val reward = TestSubscriber<Reward>()
     private val rewardDescriptionIsGone = TestSubscriber<Boolean>()
     private val rewardEndDateSectionIsGone = TestSubscriber<Boolean>()
@@ -43,7 +45,9 @@ class HorizontalRewardViewHolderViewModelTest: KSRobolectricTestCase() {
         this.vm.outputs.isClickable().subscribe(this.isClickable)
         this.vm.outputs.limitAndRemainingText().subscribe(this.limitAndRemainingTextViewText)
         this.vm.outputs.limitAndRemainingTextViewIsGone().subscribe(this.limitAndRemainingTextViewIsGone)
-        this.vm.outputs.minimumText().subscribe(this.minimumTextViewText)
+        this.vm.outputs.limitReachedButtonTextIsVisible().subscribe(this.limitReachedButtonTextIsVisible)
+        this.vm.outputs.minimumAmount().map { it.toString() }.subscribe(this.minimumAmount)
+        this.vm.outputs.minimumAmountTitle().map { it.toString() }.subscribe(this.minimumAmountTitle)
         this.vm.outputs.reward().subscribe(this.reward)
         this.vm.outputs.rewardDescriptionIsGone().subscribe(this.rewardDescriptionIsGone)
         this.vm.outputs.rewardEndDateSectionIsGone().subscribe(this.rewardEndDateSectionIsGone)
@@ -264,7 +268,7 @@ class HorizontalRewardViewHolderViewModelTest: KSRobolectricTestCase() {
     }
 
     @Test
-    fun testMinimumTextViewText() {
+    fun testMinimumAmount_whenAvailable() {
         val project = ProjectFactory.project()
         val reward = RewardFactory.reward().toBuilder()
                 .minimum(10.0)
@@ -272,11 +276,23 @@ class HorizontalRewardViewHolderViewModelTest: KSRobolectricTestCase() {
         setUpEnvironment(environment())
 
         this.vm.inputs.projectAndReward(project, reward)
-        this.minimumTextViewText.assertValue("$10")
+        this.minimumAmount.assertValue("$10")
+        this.limitReachedButtonTextIsVisible.assertNoValues()
     }
 
     @Test
-    fun testMinimumTextViewTextCAD() {
+    fun testMinimumAmount_whenUnavailable() {
+        val project = ProjectFactory.project()
+        val reward = RewardFactory.limitReached()
+        setUpEnvironment(environment())
+
+        this.vm.inputs.projectAndReward(project, reward)
+        this.minimumAmount.assertNoValues()
+        this.limitReachedButtonTextIsVisible.assertValueCount(1)
+    }
+
+    @Test
+    fun testMinimumAmount_whenCAProject() {
         val project = ProjectFactory.caProject()
         val reward = RewardFactory.reward().toBuilder()
                 .minimum(10.0)
@@ -284,7 +300,27 @@ class HorizontalRewardViewHolderViewModelTest: KSRobolectricTestCase() {
         setUpEnvironment(environment())
 
         this.vm.inputs.projectAndReward(project, reward)
-        this.minimumTextViewText.assertValue("CA$ 10")
+        this.minimumAmount.assertValue("CA$ 10")
+    }
+
+    @Test
+    fun testMinimumAmountTitle() {
+        val project = ProjectFactory.project()
+        val reward = RewardFactory.reward()
+        setUpEnvironment(environment())
+
+        this.vm.inputs.projectAndReward(project, reward)
+        this.minimumAmountTitle.assertValue("$20")
+    }
+
+    @Test
+    fun testMinimumAmountTitle_whenUKProject() {
+        val project = ProjectFactory.ukProject()
+        val reward = RewardFactory.reward()
+        setUpEnvironment(environment())
+
+        this.vm.inputs.projectAndReward(project, reward)
+        this.minimumAmountTitle.assertValue("£20")
     }
 
     @Test


### PR DESCRIPTION
# What ❓
Rewards should only show the minimum amount with the mini currency code if it requires the country code.
- Added `ViewUtils.styleCurrency` that takes in a boolean to determine the style of shrunken currency code. 
  -  If we're just not centering it, we shrink the currency code to 70% (currency code is `17sp`  and the amount is `24sp`).
- Added `minimumAmountTitle` output for styled reward minimum.
- Added separate output for showing the unavailable button `limitReachedButtonTextIsVisible`.
- `HorizontalRewardViewHolderViewModel` is written in Kotlin so it can make use of the implicit parameter `it`.
- Tests.

# How to QA? 🤔
| Currency with country code | Currency without|
| --- | --- |
| <img src="https://user-images.githubusercontent.com/1289295/59227518-880d1680-8ba3-11e9-9247-93d885c27dd4.png" width="330"/> | <img src="https://user-images.githubusercontent.com/1289295/59227519-880d1680-8ba3-11e9-9f70-0b152fc54ee4.png" width="330"/> |

# Story 📖
[Trello](https://trello.com/c/Y8IWJpgZ/1403-reward-cell-amount-formatting-android)



