### PR TITLE
⬆️Facebook SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -197,7 +197,6 @@ final butterknife_version = "7.0.1"
 final crashlytics_version = "2.9.6@aar"
 final dagger_version = "2.11"
 final exoplayer_version = "2.9.1"
-final facebook_version = "4.33.0"
 final firebase_version = "16.0.6"
 final firebase_job_dispatcher_version = "0.8.5"
 final firebase_messaging_version = "17.3.4"
@@ -209,7 +208,6 @@ final picasso_version = "2.5.2"
 final phoenix_version = "1.0.2"
 final play_services_version = "16.0.1"
 final retrofit_version = "2.3.0"
-final rx_android_version = "1.2.0"
 final rx_binding_version = "0.4.0"
 final rx_java_version = "1.1.5"
 final rx_lifecycle_version = "0.3.0"
@@ -232,7 +230,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha3'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.browser:browser:1.0.0'
-    implementation "com.facebook.android:facebook-android-sdk:$facebook_version"
+    implementation 'com.facebook.android:facebook-android-sdk:[5,6)'
     implementation "com.github.frankiesardo:auto-parcel:$auto_parcel_version"
     kapt "com.github.frankiesardo:auto-parcel-processor:$auto_parcel_version"
     implementation 'com.google.android.material:material:1.1.0-alpha02'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -252,10 +252,18 @@
     <activity
       android:name="com.facebook.FacebookActivity"
       android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
-      android:label="@string/app_name"
-      android:parentActivityName=".ui.activities.ProjectActivity"
-      android:theme="@android:style/Theme.Translucent.NoTitleBar"
-      tools:replace="android:theme">
+      android:label="@string/app_name" />
+    <activity
+      android:name="com.facebook.CustomTabActivity"
+      android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <data android:scheme="@string/fb_login_protocol_scheme" />
+      </intent-filter>
     </activity>
     <activity android:name=".ui.activities.DeepLinkActivity">
       <intent-filter

--- a/app/src/main/java/com/kickstarter/KSApplication.java
+++ b/app/src/main/java/com/kickstarter/KSApplication.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.text.TextUtils;
 
 import com.crashlytics.android.Crashlytics;
-import com.facebook.FacebookSdk;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.kickstarter.libs.ApiEndpoint;
@@ -68,8 +67,6 @@ public class KSApplication extends MultiDexApplication {
     if (!isInUnitTests()) {
       setVisitorCookie();
     }
-
-    FacebookSdk.sdkInitialize(this);
 
     this.pushNotifications.initialize();
 

--- a/app/src/main/java/com/kickstarter/libs/utils/ApplicationLifecycleUtil.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ApplicationLifecycleUtil.java
@@ -50,7 +50,7 @@ public final class ApplicationLifecycleUtil implements Application.ActivityLifec
       this.koala.trackAppOpen();
 
       // Facebook: logs 'install' and 'app activate' App Events.
-      AppEventsLogger.activateApp(activity);
+      AppEventsLogger.activateApp(activity.getApplication());
 
       // Refresh the config file
       this.client.config()

--- a/app/src/main/java/com/kickstarter/libs/utils/TransitionUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/TransitionUtils.java
@@ -37,4 +37,8 @@ public final class TransitionUtils {
   public static @NonNull Pair<Integer, Integer> slideUpFromBottom() {
     return Pair.create(R.anim.settings_slide_in_from_bottom, R.anim.settings_slide_out_from_top);
   }
+
+  public static @NonNull Pair<Integer, Integer> fadeIn() {
+    return Pair.create(R.anim.fade_in, R.anim.fade_out);
+  }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/LoginToutActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/LoginToutActivity.java
@@ -30,7 +30,7 @@ import butterknife.OnClick;
 import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;
 
-import static com.kickstarter.libs.utils.TransitionUtils.slideInFromRight;
+import static com.kickstarter.libs.utils.TransitionUtils.fadeIn;
 import static com.kickstarter.libs.utils.TransitionUtils.transition;
 
 @RequiresActivityViewModel(LoginToutViewModel.ViewModel.class)
@@ -140,19 +140,19 @@ public final class LoginToutActivity extends BaseActivity<LoginToutViewModel.Vie
       .putExtra(IntentKey.FACEBOOK_USER, facebookUser)
       .putExtra(IntentKey.FACEBOOK_TOKEN, accessTokenString);
     startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW);
-    transition(this, slideInFromRight());
+    transition(this, fadeIn());
   }
 
   private void startLogin() {
     final Intent intent = new Intent(this, LoginActivity.class);
     startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW);
-    transition(this, slideInFromRight());
+    transition(this, fadeIn());
   }
 
   private void startSignup() {
     final Intent intent = new Intent(this, SignupActivity.class);
     startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW);
-    transition(this, slideInFromRight());
+    transition(this, fadeIn());
   }
 
   public void startTwoFactorFacebookChallenge() {
@@ -161,6 +161,6 @@ public final class LoginToutActivity extends BaseActivity<LoginToutViewModel.Vie
       .putExtra(IntentKey.FACEBOOK_TOKEN, AccessToken.getCurrentAccessToken().getToken());
 
     startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW);
-    transition(this, slideInFromRight());
+    transition(this, fadeIn());
   }
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
+++ b/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
@@ -43,6 +43,7 @@ import butterknife.Bind;
 import butterknife.ButterKnife;
 
 import static com.kickstarter.libs.rx.transformers.Transformers.observeForUI;
+import static com.kickstarter.libs.utils.TransitionUtils.fadeIn;
 import static com.kickstarter.libs.utils.TransitionUtils.slideInFromRight;
 import static com.kickstarter.libs.utils.TransitionUtils.transition;
 
@@ -185,7 +186,7 @@ public final class DiscoveryFragment extends BaseFragment<DiscoveryFragmentViewM
     final Intent intent = new Intent(getActivity(), LoginToutActivity.class)
       .putExtra(IntentKey.LOGIN_REASON, LoginReason.DEFAULT);
     startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW);
-    transition(getActivity(), slideInFromRight());
+    transition(getActivity(), fadeIn());
   }
 
   private void startProjectActivity(final @NonNull Project project, final @NonNull RefTag refTag) {

--- a/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
@@ -24,6 +24,7 @@ import com.kickstarter.ui.data.LoginReason;
 import java.util.List;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import rx.Notification;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
@@ -182,7 +183,8 @@ public interface LoginToutViewModel {
       });
     }
 
-    private final PublishSubject<String> facebookAccessToken = PublishSubject.create();
+    @VisibleForTesting
+    final PublishSubject<String> facebookAccessToken = PublishSubject.create();
     private final PublishSubject<Void> loginClick = PublishSubject.create();
     private final PublishSubject<ErrorEnvelope> loginError = PublishSubject.create();
     private final PublishSubject<LoginReason> loginReason = PublishSubject.create();

--- a/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
@@ -186,7 +186,8 @@ public interface LoginToutViewModel {
     @VisibleForTesting
     final PublishSubject<String> facebookAccessToken = PublishSubject.create();
     private final PublishSubject<Void> loginClick = PublishSubject.create();
-    private final PublishSubject<ErrorEnvelope> loginError = PublishSubject.create();
+    @VisibleForTesting
+    final PublishSubject<ErrorEnvelope> loginError = PublishSubject.create();
     private final PublishSubject<LoginReason> loginReason = PublishSubject.create();
     private final PublishSubject<Void> signupClick = PublishSubject.create();
 

--- a/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
@@ -12,6 +12,7 @@ import com.kickstarter.libs.ActivityRequestCodes;
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
+import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.services.ApiClientType;
 import com.kickstarter.services.apiresponses.AccessTokenEnvelope;
 import com.kickstarter.services.apiresponses.ErrorEnvelope;
@@ -23,13 +24,14 @@ import com.kickstarter.ui.data.LoginReason;
 import java.util.List;
 
 import androidx.annotation.NonNull;
+import rx.Notification;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 
 import static com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair;
-import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
-import static com.kickstarter.libs.rx.transformers.Transformers.pipeApiErrorsTo;
+import static com.kickstarter.libs.rx.transformers.Transformers.errors;
+import static com.kickstarter.libs.rx.transformers.Transformers.values;
 
 public interface LoginToutViewModel {
 
@@ -86,7 +88,7 @@ public interface LoginToutViewModel {
 
       registerFacebookCallback();
 
-      final Observable<AccessTokenEnvelope> facebookSuccessTokenEnvelope = this.facebookAccessToken
+      final Observable<Notification<AccessTokenEnvelope>> facebookAccessTokenEnvelope = this.facebookAccessToken
         .switchMap(this::loginWithFacebookAccessToken)
         .share();
 
@@ -110,12 +112,20 @@ public interface LoginToutViewModel {
         .compose(bindToLifecycle())
         .subscribe(this::clearFacebookSession);
 
-      facebookSuccessTokenEnvelope
+      facebookAccessTokenEnvelope
+        .compose(values())
         .compose(bindToLifecycle())
         .subscribe(envelope -> {
           this.currentUser.login(envelope.user(), envelope.accessToken());
           this.finishWithSuccessfulResult.onNext(null);
         });
+
+      facebookAccessTokenEnvelope
+        .compose(errors())
+        .map(ErrorEnvelope::fromThrowable)
+        .filter(ObjectUtils::isNotNull)
+        .compose(bindToLifecycle())
+        .subscribe(this.loginError::onNext);
 
       this.startFacebookConfirmationActivity = this.loginError
         .filter(ErrorEnvelope::isConfirmFacebookSignupError)
@@ -144,22 +154,18 @@ public interface LoginToutViewModel {
       LoginManager.getInstance().logOut();
     }
 
-    private @NonNull Observable<AccessTokenEnvelope> loginWithFacebookAccessToken(final @NonNull String fbAccessToken) {
+    private @NonNull Observable<Notification<AccessTokenEnvelope>> loginWithFacebookAccessToken(final @NonNull String fbAccessToken) {
       return this.client.loginWithFacebook(fbAccessToken)
-        .compose(pipeApiErrorsTo(this.loginError))
-        .compose(neverError());
+        .materialize();
     }
 
     private void registerFacebookCallback() {
-      final PublishSubject<String> fbAccessToken = this.facebookAccessToken;
-      final BehaviorSubject<FacebookException> fbAuthError = this.facebookAuthorizationError;
-
       this.callbackManager = CallbackManager.Factory.create();
 
       LoginManager.getInstance().registerCallback(this.callbackManager, new FacebookCallback<LoginResult>() {
         @Override
         public void onSuccess(final @NonNull LoginResult result) {
-          fbAccessToken.onNext(result.getAccessToken().getToken());
+          ViewModel.this.facebookAccessToken.onNext(result.getAccessToken().getToken());
         }
 
         @Override
@@ -170,7 +176,7 @@ public interface LoginToutViewModel {
         @Override
         public void onError(final @NonNull FacebookException error) {
           if (error instanceof FacebookAuthorizationException) {
-            fbAuthError.onNext(error);
+            ViewModel.this.facebookAuthorizationError.onNext(error);
           }
         }
       });

--- a/app/src/main/res/anim/fade_in.xml
+++ b/app/src/main/res/anim/fade_in.xml
@@ -2,8 +2,8 @@
 <set xmlns:android="http://schemas.android.com/apk/res/android">
   <alpha
     android:interpolator="@android:anim/accelerate_interpolator"
-    android:fromAlpha="1.0"
-    android:toAlpha="0.0"
+    android:fromAlpha="0.0"
+    android:toAlpha="1.0"
     android:duration="@android:integer/config_shortAnimTime" />
 </set>
 

--- a/app/src/main/res/values/strings_config.xml
+++ b/app/src/main/res/values/strings_config.xml
@@ -2,10 +2,10 @@
 <resources>
   <string name="app_name">Kickstarter</string>
   <string name="facebook_app_id">69103156693</string>
+  <string name="fb_login_protocol_scheme">fb69103156693</string>
   <string name="font_family_maison_neue_book">maison-neue-book</string>
   <string name="font_family_sans_serif">sans-serif</string>
   <string name="font_family_sans_serif_medium">sans-serif-medium</string>
-  <string name="woohoo_duration">2000</string>
 
   <string-array name="facebook_permissions_array">
     <item>public_profile</item>

--- a/app/src/test/java/com/kickstarter/TestKSApplication.java
+++ b/app/src/test/java/com/kickstarter/TestKSApplication.java
@@ -1,5 +1,6 @@
 package com.kickstarter;
 
+import com.facebook.FacebookSdk;
 import com.google.android.gms.common.ConnectionResult;
 
 import org.robolectric.shadows.gms.ShadowGooglePlayServicesUtil;
@@ -12,6 +13,8 @@ public class TestKSApplication extends KSApplication {
     // For now we just return that Play Services is disabled.
     ShadowGooglePlayServicesUtil.setIsGooglePlayServicesAvailable(ConnectionResult.SERVICE_DISABLED);
     super.onCreate();
+
+    FacebookSdk.sdkInitialize(this);
   }
 
   @Override

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
@@ -2,21 +2,34 @@ package com.kickstarter.viewmodels;
 
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.libs.Environment;
+import com.kickstarter.libs.MockCurrentUser;
+import com.kickstarter.mock.services.MockApiClient;
+import com.kickstarter.models.User;
+import com.kickstarter.services.apiresponses.AccessTokenEnvelope;
+import com.kickstarter.services.apiresponses.ErrorEnvelope;
 
 import org.junit.Test;
 
 import androidx.annotation.NonNull;
+import rx.Observable;
 import rx.observers.TestSubscriber;
 
 public class LoginToutViewModelTest extends KSRobolectricTestCase {
   private LoginToutViewModel.ViewModel vm;
+  private final TestSubscriber<Void> finishWithSuccessfulResult = new TestSubscriber<>();
+  private final TestSubscriber<ErrorEnvelope> loginError = new TestSubscriber<>();
   private final TestSubscriber<Void> startLoginActivity = new TestSubscriber<>();
   private final TestSubscriber<Void> startSignupActivity = new TestSubscriber<>();
+  private final TestSubscriber<User> currentUser = new TestSubscriber<>();
 
   private void setUpEnvironment(final @NonNull Environment environment) {
     this.vm = new LoginToutViewModel.ViewModel(environment);
-    this.vm.outputs.startSignupActivity().subscribe(startSignupActivity);
-    this.vm.outputs.startLoginActivity().subscribe(startLoginActivity);
+
+    this.vm.outputs.finishWithSuccessfulResult().subscribe(this.finishWithSuccessfulResult);
+    this.vm.loginError.subscribe(this.loginError);
+    this.vm.outputs.startSignupActivity().subscribe(this.startSignupActivity);
+    this.vm.outputs.startLoginActivity().subscribe(this.startLoginActivity);
+    environment.currentUser().observable().subscribe(this.currentUser);
   }
 
   @Test
@@ -40,9 +53,39 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void facebookLoginClick_success() {
-    setUpEnvironment(environment());
+  public void facebookLogin_success() {
+    final MockCurrentUser currentUser = new MockCurrentUser();
+    final Environment environment = environment()
+      .toBuilder()
+      .currentUser(currentUser)
+      .build();
+    setUpEnvironment(environment);
 
-   this.vm.facebookAccessToken.onNext("token");
+    this.currentUser.assertValuesAndClear(null);
+    this.vm.facebookAccessToken.onNext("token");
+    this.currentUser.assertValueCount(1);
+    this.finishWithSuccessfulResult.assertValueCount(1);
+  }
+
+  @Test
+  public void facebookLogin_error() {
+    final MockCurrentUser currentUser = new MockCurrentUser();
+    final Environment environment = environment()
+      .toBuilder()
+      .currentUser(currentUser)
+      .apiClient(new MockApiClient() {
+        @Override
+        public @NonNull Observable<AccessTokenEnvelope> loginWithFacebook(@NonNull String accessToken) {
+          return Observable.error(new Throwable("error"));
+        }
+      })
+      .build();
+
+    setUpEnvironment(environment);
+
+    this.currentUser.assertValuesAndClear(null);
+    this.vm.facebookAccessToken.onNext("token");
+    this.currentUser.assertNoValues();
+    this.finishWithSuccessfulResult.assertNoValues();
   }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
@@ -1,36 +1,48 @@
 package com.kickstarter.viewmodels;
 
 import com.kickstarter.KSRobolectricTestCase;
+import com.kickstarter.libs.Environment;
 
 import org.junit.Test;
 
+import androidx.annotation.NonNull;
 import rx.observers.TestSubscriber;
 
 public class LoginToutViewModelTest extends KSRobolectricTestCase {
+  private LoginToutViewModel.ViewModel vm;
+  private final TestSubscriber<Void> startLoginActivity = new TestSubscriber<>();
+  private final TestSubscriber<Void> startSignupActivity = new TestSubscriber<>();
+
+  private void setUpEnvironment(final @NonNull Environment environment) {
+    this.vm = new LoginToutViewModel.ViewModel(environment);
+    this.vm.outputs.startSignupActivity().subscribe(startSignupActivity);
+    this.vm.outputs.startLoginActivity().subscribe(startLoginActivity);
+  }
 
   @Test
   public void testLoginButtonClicked() {
-    final LoginToutViewModel.ViewModel vm = new LoginToutViewModel.ViewModel(environment());
+    setUpEnvironment(environment());
 
-    final TestSubscriber<Void> startLoginActivity = new TestSubscriber<>();
-    vm.outputs.startLoginActivity().subscribe(startLoginActivity);
+    this.startLoginActivity.assertNoValues();
 
-    startLoginActivity.assertNoValues();
-
-    vm.inputs.loginClick();
-    startLoginActivity.assertValueCount(1);
+    this.vm.inputs.loginClick();
+    this.startLoginActivity.assertValueCount(1);
   }
 
   @Test
   public void testSignupButtonClicked() {
-    final LoginToutViewModel.ViewModel vm = new LoginToutViewModel.ViewModel(environment());
+    setUpEnvironment(environment());
 
-    final TestSubscriber<Void> startSignupActivity = new TestSubscriber<>();
-    vm.outputs.startSignupActivity().subscribe(startSignupActivity);
+    this.startSignupActivity.assertNoValues();
 
-    startSignupActivity.assertNoValues();
+    this.vm.inputs.signupClick();
+    this.startSignupActivity.assertValueCount(1);
+  }
 
-    vm.inputs.signupClick();
-    startSignupActivity.assertValueCount(1);
+  @Test
+  public void facebookLoginClick_success() {
+    setUpEnvironment(environment());
+
+   this.vm.facebookAccessToken.onNext("token");
   }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
@@ -75,7 +75,7 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
       .currentUser(currentUser)
       .apiClient(new MockApiClient() {
         @Override
-        public @NonNull Observable<AccessTokenEnvelope> loginWithFacebook(@NonNull String accessToken) {
+        public @NonNull Observable<AccessTokenEnvelope> loginWithFacebook(final @NonNull String accessToken) {
           return Observable.error(new Throwable("error"));
         }
       })


### PR DESCRIPTION
# What ❓
- Updated Facebook SDK to the dynamic version, per their recommendation https://developers.facebook.com/docs/android/getting-started/
- `LoginToutViewModelTest` only had tests for clicking log in and sign up so I added 2 more for Facebook success and errors but the VM needs some refactoring and more tests.
- The `fade_out` animation used to take .5 seconds, that's a long time. It's now .2 seconds.
- Using fade in/out transition in `LoginToutActivity`.

# How to QA? 🤔
- Log in or sign up with Facebook.

# Story 📖
[Trello Story](https://trello.com/c/uGFzObNM/1406-update-facebook-sdk)

# See 👀
This is what users who have already logged in with Facebook and have the Facebook app installed see:

![device-2019-06-12-155132 2019-06-12 15_53_28](https://user-images.githubusercontent.com/1289295/59381788-4bb7f280-8d2a-11e9-88b8-072d6f9637be.gif)

I don't love it but it's basically what we already have now.
