### PR TITLE
Manage my pledge (project state)

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/ProjectUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ProjectUtils.java
@@ -136,8 +136,7 @@ public final class ProjectUtils {
    */
   public static @ColorRes int pledgeButtonColor(final @NonNull Project project) {
     if (project.isBacking() && project.isLive()) {
-      //todo: manage my pledge will be blue
-      return R.color.button_pledge_live;
+      return R.color.button_manage_pledge;
     } else if (project.isBacking() && !project.isLive()) {
       //todo: view rewards will be black
       return R.color.button_pledge_ended;

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -392,7 +392,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
     override fun back() {
         when {
             supportFragmentManager.backStackEntryCount > 0 -> supportFragmentManager.popBackStack()
-            native_project_action_button.visibility == View.GONE -> this.viewModel.inputs.hideRewardsFragmentClicked()
+            action_buttons.visibility == View.GONE -> this.viewModel.inputs.hideRewardsFragmentClicked()
             else -> super.back()
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -100,7 +100,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
         this.viewModel.outputs.rewardsButtonColor()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { native_back_this_project_button.backgroundTintList = ContextCompat.getColorStateList(this@ProjectActivity, it) }
+                .subscribe { native_project_action_button.backgroundTintList = ContextCompat.getColorStateList(this@ProjectActivity, it) }
 
         this.viewModel.outputs.rewardsButtonText()
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -181,7 +181,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
         }
 
         native_project_action_button.setOnClickListener {
-            this.viewModel.inputs.nativeCheckoutBackProjectButtonClicked()
+            this.viewModel.inputs.nativeProjectActionButtonClicked()
         }
 
         manage_pledge_button.setOnClickListener {
@@ -392,6 +392,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
     override fun back() {
         when {
             supportFragmentManager.backStackEntryCount > 0 -> supportFragmentManager.popBackStack()
+            native_project_action_button.visibility == View.GONE -> this.viewModel.inputs.hideRewardsFragmentClicked()
             else -> super.back()
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -9,6 +9,7 @@ import android.util.Pair
 import android.view.View
 import android.view.ViewTreeObserver
 import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.kickstarter.R
 import com.kickstarter.extensions.hideKeyboard
@@ -375,7 +376,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
     override fun back() {
         when {
             supportFragmentManager.backStackEntryCount > 0 -> supportFragmentManager.popBackStack()
-            native_back_this_project_button.visibility == View.GONE -> this.viewModel.inputs.hideRewardsFragmentClicked()
             else -> super.back()
         }
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -44,11 +44,8 @@ interface ProjectViewModel {
         /** Call when the manage pledge button is clicked.  */
         fun managePledgeButtonClicked()
 
-        /** Call when the native back project button is clicked.  */
-        fun nativeCheckoutBackProjectButtonClicked()
-
-        /** Call when the native manage pledge button is clicked  */
-        fun nativeCheckoutManagePledgeButtonClicked()
+        /** Call when the native_project_action_button is clicked.  */
+        fun nativeProjectActionButtonClicked()
 
         /** Call when the view has been laid out. */
         fun onGlobalLayout()
@@ -144,8 +141,7 @@ interface ProjectViewModel {
         private val heartButtonClicked = PublishSubject.create<Void>()
         private val hideRewardsFragment = PublishSubject.create<Void>()
         private val managePledgeButtonClicked = PublishSubject.create<Void>()
-        private val nativeCheckoutBackProjectButtonClicked = PublishSubject.create<Void>()
-        private val nativeCheckoutManagePledgeButtonClicked = PublishSubject.create<Void>()
+        private val nativeProjectActionButtonClicked = PublishSubject.create<Void>()
         private val onGlobalLayout = PublishSubject.create<Void>()
         private val playVideoButtonClicked = PublishSubject.create<Void>()
         private val shareButtonClicked = PublishSubject.create<Void>()
@@ -285,7 +281,7 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.setInitialRewardPosition)
 
-            Observable.merge(this.nativeCheckoutBackProjectButtonClicked, this.nativeCheckoutManagePledgeButtonClicked)
+            this.nativeProjectActionButtonClicked
                     .map { true }
                     .compose(bindToLifecycle())
                     .subscribe(this.showRewardsFragment)
@@ -401,12 +397,8 @@ interface ProjectViewModel {
             this.managePledgeButtonClicked.onNext(null)
         }
 
-        override fun nativeCheckoutBackProjectButtonClicked() {
-            this.nativeCheckoutBackProjectButtonClicked.onNext(null)
-        }
-
-        override fun nativeCheckoutManagePledgeButtonClicked() {
-            this.nativeCheckoutManagePledgeButtonClicked.onNext(null)
+        override fun nativeProjectActionButtonClicked() {
+            this.nativeProjectActionButtonClicked.onNext(null)
         }
 
         override fun onGlobalLayout() {

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -555,18 +555,6 @@ interface ProjectViewModel {
             }
         }
 
-        private fun getRewardButtonColor(project: Project): Int? {
-            return if (!project.isBacking && project.isLive) {
-                R.color.primary
-            } else if (project.isBacking && project.isLive) {
-                R.color.ksr_cobalt_500
-            } else if (project.isBacking && !project.isLive) {
-                R.color.black
-            } else {
-                return null
-            }
-        }
-
         private fun saveProject(project: Project): Observable<Project> {
             return this.client.saveProject(project)
                     .compose(neverError())

--- a/app/src/main/res/color/button_manage_pledge.xml
+++ b/app/src/main/res/color/button_manage_pledge.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:color="@color/ksr_cobalt_500" android:state_enabled="true"/>
+  <item android:alpha="0.12" android:color="?attr/colorOnSurface"/>
+</selector>

--- a/app/src/main/res/layout/project_layout.xml
+++ b/app/src/main/res/layout/project_layout.xml
@@ -24,7 +24,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:focusable="true"
-    android:visibility="gone"
     tools:visibility="visible"
     android:layout_alignParentBottom="true">
 
@@ -95,6 +94,56 @@
           tools:layout="@layout/fragment_rewards" />
 
       </FrameLayout>
+
+    </LinearLayout>
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal"
+      android:layout_marginTop="@dimen/grid_3"
+      android:layout_marginStart="@dimen/activity_horizontal_margin"
+      android:layout_marginEnd="@dimen/activity_horizontal_margin"
+      >
+
+    <LinearLayout
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:layout_gravity="center_vertical"
+      android:layout_weight="1"
+     >
+
+      <TextView
+        android:id="@+id/you_backer_text"
+        style="@style/CalloutPrimaryMedium"
+        android:textStyle="bold"
+        android:layout_width="wrap_content"
+        android:textSize="@dimen/grid_5_half"
+        android:layout_height="match_parent"
+        android:text="@string/Youre_a_backer"/>
+
+      <TextView
+        android:id="@+id/reward_infos"
+        style="@style/CalloutPrimaryMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:textColor="@color/ksr_dark_grey_500"
+        android:textSize="@dimen/grid_2"
+        android:lines="1"
+        android:text="$20 . Funky Reward Title..."/>
+    </LinearLayout>
+
+      <com.google.android.material.button.MaterialButton
+        android:id="@+id/native_manage_pledge_button"
+        style="@style/ProjectActionButton"
+        app:cornerRadius="@dimen/grid_2"
+        android:layout_width="@dimen/grid_16"
+        android:layout_height="@dimen/grid_8"
+        android:layout_gravity="end"
+        android:backgroundTint="@color/blue_darken_10"
+        android:textAllCaps="false"
+        android:text="@string/Manage" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/project_layout.xml
+++ b/app/src/main/res/layout/project_layout.xml
@@ -100,21 +100,20 @@
     </LinearLayout>
 
     <LinearLayout
-      android:id="@+id/manage_pledge_container"
+      android:id="@+id/action_buttons"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginEnd="@dimen/activity_horizontal_margin"
       android:layout_marginStart="@dimen/activity_horizontal_margin"
-      android:layout_marginTop="@dimen/grid_3"
-      android:orientation="horizontal"
-      android:visibility="gone"
-      tools:visibility="visible">
+      android:orientation="horizontal">
 
       <LinearLayout
+        android:id="@+id/backing_details"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
         android:layout_weight="1"
+        android:layout_gravity="center_vertical"
+        android:visibility="gone"
         android:orientation="vertical">
 
         <TextView
@@ -135,28 +134,14 @@
       </LinearLayout>
 
       <com.google.android.material.button.MaterialButton
-        android:id="@+id/native_manage_pledge_button"
-        style="@style/ProjectActionButton"
-        android:layout_width="@dimen/grid_16"
-        android:layout_height="@dimen/grid_8"
-        android:layout_gravity="end"
-        android:backgroundTint="@color/blue_darken_10"
-        android:text="@string/Manage"
+        android:id="@+id/native_project_action_button"
+        style="@style/ExtendedFab"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/project_back_button"
         android:textAllCaps="false"
-        app:cornerRadius="@dimen/grid_2" />
-
+        tools:visibility="visible"/>
     </LinearLayout>
-
-    <com.google.android.material.button.MaterialButton
-      android:id="@+id/native_back_this_project_button"
-      style="@style/ExtendedFab"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginEnd="@dimen/activity_horizontal_margin"
-      android:layout_marginStart="@dimen/activity_horizontal_margin"
-      android:text="@string/project_back_button"
-      android:textAllCaps="false"
-      android:visibility="gone" />
 
   </androidx.cardview.widget.CardView>
 

--- a/app/src/main/res/layout/project_layout.xml
+++ b/app/src/main/res/layout/project_layout.xml
@@ -98,9 +98,11 @@
     </LinearLayout>
 
     <LinearLayout
+      android:id="@+id/manage_pledge_container"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="horizontal"
+      android:visibility="gone"
       android:layout_marginTop="@dimen/grid_3"
       android:layout_marginStart="@dimen/activity_horizontal_margin"
       android:layout_marginEnd="@dimen/activity_horizontal_margin"
@@ -153,6 +155,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:textAllCaps="false"
+      android:visibility="gone"
       android:layout_marginEnd="@dimen/activity_horizontal_margin"
       android:layout_marginStart="@dimen/activity_horizontal_margin"
       android:text="@string/project_back_button" />

--- a/app/src/main/res/layout/project_layout.xml
+++ b/app/src/main/res/layout/project_layout.xml
@@ -15,17 +15,17 @@
     android:id="@+id/project_recycler_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:clipToPadding="false"
     android:layout_above="@+id/project_action_buttons"
-    android:layout_below="@id/project_toolbar"/>
+    android:layout_below="@id/project_toolbar"
+    android:clipToPadding="false" />
 
   <RelativeLayout
     android:id="@+id/project_action_buttons"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_alignParentBottom="true"
     android:focusable="true"
-    tools:visibility="visible"
-    android:layout_alignParentBottom="true">
+    tools:visibility="visible">
 
     <Button
       android:id="@+id/back_project_button"
@@ -54,6 +54,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:visibility="invisible"
+    tools:visibility="visible"
     app:cardBackgroundColor="@color/white"
     app:cardCornerRadius="30dp"
     app:cardElevation="@dimen/grid_2">
@@ -63,6 +64,7 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:alpha="0"
+      tools:alpha="1"
       android:orientation="vertical">
 
       <com.google.android.material.appbar.AppBarLayout
@@ -101,51 +103,47 @@
       android:id="@+id/manage_pledge_container"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:layout_marginEnd="@dimen/activity_horizontal_margin"
+      android:layout_marginStart="@dimen/activity_horizontal_margin"
+      android:layout_marginTop="@dimen/grid_3"
       android:orientation="horizontal"
       android:visibility="gone"
-      android:layout_marginTop="@dimen/grid_3"
-      android:layout_marginStart="@dimen/activity_horizontal_margin"
-      android:layout_marginEnd="@dimen/activity_horizontal_margin"
-      >
+      tools:visibility="visible">
 
-    <LinearLayout
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:orientation="vertical"
-      android:layout_gravity="center_vertical"
-      android:layout_weight="1"
-     >
+      <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_weight="1"
+        android:orientation="vertical">
 
-      <TextView
-        android:id="@+id/you_backer_text"
-        style="@style/CalloutPrimaryMedium"
-        android:textStyle="bold"
-        android:layout_width="wrap_content"
-        android:textSize="@dimen/grid_5_half"
-        android:layout_height="match_parent"
-        android:text="@string/Youre_a_backer"/>
+        <TextView
+          android:id="@+id/you_backer_text"
+          style="@style/SubheadlineMedium"
+          android:layout_width="wrap_content"
+          android:layout_height="match_parent"
+          android:text="@string/Youre_a_backer" />
 
-      <TextView
-        android:id="@+id/reward_infos"
-        style="@style/CalloutPrimaryMedium"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:textColor="@color/ksr_dark_grey_500"
-        android:textSize="@dimen/grid_2"
-        android:lines="1"
-        android:text="$20 . Funky Reward Title..."/>
-    </LinearLayout>
+        <TextView
+          android:id="@+id/reward_infos"
+          style="@style/Caption1Secondary"
+          android:layout_width="wrap_content"
+          android:layout_height="match_parent"
+          android:ellipsize="end"
+          android:lines="1"
+          tools:text="$20 . Funky Reward Title..." />
+      </LinearLayout>
 
       <com.google.android.material.button.MaterialButton
         android:id="@+id/native_manage_pledge_button"
         style="@style/ProjectActionButton"
-        app:cornerRadius="@dimen/grid_2"
         android:layout_width="@dimen/grid_16"
         android:layout_height="@dimen/grid_8"
         android:layout_gravity="end"
         android:backgroundTint="@color/blue_darken_10"
+        android:text="@string/Manage"
         android:textAllCaps="false"
-        android:text="@string/Manage" />
+        app:cornerRadius="@dimen/grid_2" />
 
     </LinearLayout>
 
@@ -154,11 +152,11 @@
       style="@style/ExtendedFab"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:textAllCaps="false"
-      android:visibility="gone"
       android:layout_marginEnd="@dimen/activity_horizontal_margin"
       android:layout_marginStart="@dimen/activity_horizontal_margin"
-      android:text="@string/project_back_button" />
+      android:text="@string/project_back_button"
+      android:textAllCaps="false"
+      android:visibility="gone" />
 
   </androidx.cardview.widget.CardView>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -453,6 +453,10 @@
     <item name="android:textSize">@dimen/subheadline</item>
   </style>
 
+  <style name="SubheadlineMedium" parent="Subheadline">
+    <item name="android:textStyle">bold</item>
+  </style>
+
   <style name="Headline" parent="TextPrimary">
     <item name="android:textSize">@dimen/headline</item>
     <item name="android:fontFamily">@string/font_family_sans_serif_medium</item>

--- a/app/src/test/java/com/kickstarter/libs/utils/ProjectUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/ProjectUtilsTest.java
@@ -70,7 +70,7 @@ public final class ProjectUtilsTest extends KSRobolectricTestCase {
   @Test
   public void testPledgeButtonColor() {
     assertEquals(R.color.button_pledge_live, ProjectUtils.pledgeButtonColor(ProjectFactory.project()));
-    assertEquals(R.color.button_pledge_live, ProjectUtils.pledgeButtonColor(ProjectFactory.backedProject()));
+    assertEquals(R.color.button_manage_pledge, ProjectUtils.pledgeButtonColor(ProjectFactory.backedProject()));
     assertEquals(R.color.button_pledge_live, ProjectUtils.pledgeButtonColor(ProjectFactory.successfulProject()));
     final Project backedSuccessfulProject = ProjectFactory.backedProject()
       .toBuilder()

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -382,9 +382,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testProjectViewModel_ShowRewardsFragment() {
         this.initializeViewModelWithProject(ProjectFactory.project())
-        this.vm.inputs.nativeCheckoutBackProjectButtonClicked()
+        this.vm.inputs.nativeProjectActionButtonClicked()
         this.showRewardsFragment.assertValue(true)
-        this.vm.inputs.nativeCheckoutManagePledgeButtonClicked()
+        this.vm.inputs.nativeProjectActionButtonClicked()
         this.showRewardsFragment.assertValues(true, true)
     }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -368,7 +368,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         // Start the view model with a project.
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
 
-        this.rewardsButtonColor.assertValue(R.color.ksr_cobalt_500)
+        this.rewardsButtonColor.assertValue(R.color.button_manage_pledge)
         this.rewardsButtonText.assertValue(R.string.Manage)
     }
 


### PR DESCRIPTION
# What ❓
- Shows the manage pledge container on the project page when user taps to see a `backed` and `live` project.

# How to QA? 🤔
I go to profile and select a backed and live project:
- [ ] If I backed a project with a reward, I should see the `you're a backer!` text and the amount + reward title:
```
You're a backer!
$5 • Snicky Snack 
```

- [ ] If I backed a project with `No Reward`, I should see the `you're a backer!` text and the amount only:
```
You're a backer!
$5
```

# Story 📖

[Manage my pledge (project state)](https://trello.com/c/ejojWhwB/1279-manage-my-pledge-project-state)

# See 👀
| With Reward | No Reward |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/3709676/59518897-b08f5c00-8e94-11e9-9537-e432e53ab5a4.png"> | <img src="https://user-images.githubusercontent.com/3709676/59518925-bc7b1e00-8e94-11e9-96b6-360c7d40fc72.png"> | 

