### PR TITLE
[🐜] Fixes crash on API 23 for AnimatedVectorDrawables

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
@@ -1,7 +1,7 @@
 package com.kickstarter.ui.activities;
 
 import android.content.Intent;
-import android.graphics.drawable.AnimatedVectorDrawable;
+import android.graphics.drawable.Animatable;
 import android.os.Bundle;
 import android.widget.ImageButton;
 
@@ -216,7 +216,7 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel.Vie
   private void showMenuIconWithIndicator(final boolean withIndicator) {
     if (withIndicator) {
       this.menuImageButton.setImageResource(R.drawable.ic_menu_indicator);
-      final AnimatedVectorDrawable menuDrawable = (AnimatedVectorDrawable) this.menuImageButton.getDrawable();
+      final Animatable menuDrawable = (Animatable) this.menuImageButton.getDrawable();
       menuDrawable.start();
     } else {
       this.menuImageButton.setImageResource(R.drawable.ic_menu);


### PR DESCRIPTION
# What ❓
Showing the animated hamburger crashes on API 23 (not on every phone 🤕).

https://stackoverflow.com/questions/46261325/cannot-cast-to-animatedvectordrawablecompat-in-nougat
> Long answer:
> 
> I was having the same problem when I was trying to loop an animated vector drawable. Until I found out the support library returns different classes (AnimatedVectorDrawable and AnimatedVectorDrawableCompat) on different SDK levels.
> 
> It was not documented anywhere except this wonderful blog post of Nick Butcher:
> 
> https://medium.com/androiddevelopers/re-animation-7869722af206

Casting it to an `Animatable` fixes this issue.

# How to QA? 🤔
Log in and verify the hamburger animates if you have unread activity.
#527 


