### PR TITLE
[🆕] Adding client_id as a param for web and graphQL requests

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -252,8 +252,8 @@ public final class ApplicationModule {
   @Provides
   @Singleton
   @NonNull
-  static GraphQLInterceptor provideGraphQLInterceptor(final @NonNull CurrentUserType currentUser) {
-    return new GraphQLInterceptor(currentUser);
+  static GraphQLInterceptor provideGraphQLInterceptor(final @NonNull CurrentUserType currentUser, final @NonNull String clientId) {
+    return new GraphQLInterceptor(currentUser, clientId);
   }
 
   @Provides
@@ -315,8 +315,9 @@ public final class ApplicationModule {
   @Singleton
   @NonNull
   static WebRequestInterceptor provideWebRequestInterceptor(final @NonNull CurrentUserType currentUser,
-    @NonNull @WebEndpoint final String endpoint, final @NonNull InternalToolsType internalTools, final @NonNull Build build, final @NonNull AndroidPayCapability androidPayCapability) {
-    return new WebRequestInterceptor(currentUser, endpoint, internalTools, build, androidPayCapability);
+    @NonNull @WebEndpoint final String endpoint, final @NonNull InternalToolsType internalTools, final @NonNull Build build,
+    final @NonNull AndroidPayCapability androidPayCapability, final @NonNull String clientId) {
+    return new WebRequestInterceptor(currentUser, endpoint, internalTools, build, androidPayCapability, clientId);
   }
 
   @Provides

--- a/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
+++ b/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
@@ -4,13 +4,23 @@ import com.kickstarter.libs.CurrentUserType
 import okhttp3.Interceptor
 import okhttp3.Response
 
-class GraphQLInterceptor(private val currentUser: CurrentUserType) : Interceptor {
-    override fun intercept(chain: Interceptor.Chain?): Response {
-        val original = chain!!.request()
-        val builder = original.newBuilder().method(original.method(), original.body())
+class GraphQLInterceptor(private val currentUser: CurrentUserType, private val clientId: String) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val initialRequest = chain.request()
+
+        val url = initialRequest.url()
+                .newBuilder()
+                .setQueryParameter("client_id", this.clientId)
+                .build()
+
+        val builder = initialRequest.newBuilder()
+                .url(url)
+                .method(initialRequest.method(), initialRequest.body())
+
         if (this.currentUser.exists()) {
-            builder.addHeader("Authorization", "token " + currentUser.accessToken)
+            builder.addHeader("Authorization", "token " + this.currentUser.accessToken)
         }
+
         return chain.proceed(builder.build())
     }
 }

--- a/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
@@ -11,6 +11,7 @@ import com.kickstarter.services.KSUri;
 import java.io.IOException;
 
 import androidx.annotation.NonNull;
+import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -26,15 +27,17 @@ public final class WebRequestInterceptor implements Interceptor {
   private final @NonNull InternalToolsType internalTools;
   private final @NonNull Build build;
   private final @NonNull AndroidPayCapability androidPayCapability;
+  private final String clientId;
 
   public WebRequestInterceptor(final @NonNull CurrentUserType currentUser, final @NonNull String endpoint,
-    final InternalToolsType internalTools, final @NonNull Build build,
-    final @NonNull AndroidPayCapability androidPayCapability) {
+    final @NonNull InternalToolsType internalTools, final @NonNull Build build,
+    final @NonNull AndroidPayCapability androidPayCapability, final @NonNull String clientId) {
     this.currentUser = currentUser;
     this.endpoint = endpoint;
     this.internalTools = internalTools;
     this.build = build;
     this.androidPayCapability = androidPayCapability;
+    this.clientId = clientId;
   }
 
   @Override
@@ -47,7 +50,13 @@ public final class WebRequestInterceptor implements Interceptor {
       return initialRequest;
     }
 
+    final HttpUrl url = initialRequest.url()
+      .newBuilder()
+      .setQueryParameter("client_id", this.clientId)
+      .build();
+
     final Request.Builder requestBuilder = initialRequest.newBuilder()
+      .url(url)
       .header("User-Agent", userAgent(this.build));
 
     final String basicAuthorizationHeader = this.internalTools.basicAuthorizationHeader();


### PR DESCRIPTION
# What ❓
The logged in user is not properly loading in graphQL controllers. Adding the `client_id` as a query param should resolve this.

# How to QA? 🤔
@frewsxcv and I tested on his account that's included in a feature flag.

# Story 📖
[Trello Story](https://trello.com/c/psu4UwzD/1425-pass-kickstarter-clientid-token-in-android-webview-requests)

