### PR TITLE
Added decimals for NoReward pledges on project page

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/KSCurrency.java
+++ b/app/src/main/java/com/kickstarter/libs/KSCurrency.java
@@ -72,8 +72,8 @@ public final class KSCurrency {
     final NumberOptions numberOptions = NumberOptions.builder()
       .currencyCode(currencyOptions.currencyCode())
       .currencySymbol(currencyOptions.currencySymbol())
-      .precision(getPrecision(roundingMode))
       .roundingMode(roundingMode)
+      .precision(getPrecision(initialValue, roundingMode))
       .build();
 
     return StringUtils.trim(NumberUtils.format(currencyOptions.value(), numberOptions));
@@ -167,10 +167,24 @@ public final class KSCurrency {
   /**
    * Returns a precision based on the RoundingMode.
    *
-   * @param roundingMode When this is UNNECESSARY, we return 2, otherwise we return 0.
+   * @param amount When this is a whole number, we return 0, otherwise we return 2.
+   * @param roundingMode When this is not HALF_UP, we return 0, otherwise we return 2.
    */
-  private static int getPrecision(final @NonNull RoundingMode roundingMode) {
-    return roundingMode == RoundingMode.UNNECESSARY ? 2 : 0;
+  private static int getPrecision(final @NonNull Double amount, final @NonNull RoundingMode roundingMode) {
+    if (roundingMode != RoundingMode.HALF_UP || isWholeNumber(amount)) {
+      return 0;
+    } else {
+      return 2;
+    }
+  }
+
+  /**
+   * Returns a boolean that determines if a Double is a whole number.
+   *
+   * @param value a Double to be verified if it is a whole number.
+   */
+  private static Boolean isWholeNumber(final @NonNull Double value) {
+    return value == Math.round(value);
   }
 
   /**

--- a/app/src/main/java/com/kickstarter/libs/KSCurrency.java
+++ b/app/src/main/java/com/kickstarter/libs/KSCurrency.java
@@ -73,14 +73,8 @@ public final class KSCurrency {
       .currencyCode(currencyOptions.currencyCode())
       .currencySymbol(currencyOptions.currencySymbol())
       .precision(getPrecision(roundingMode))
+      .roundingMode(roundingMode)
       .build();
-
-    if (roundingMode != RoundingMode.UNNECESSARY) {
-      numberOptions
-        .toBuilder()
-        .roundingMode(roundingMode)
-        .build();
-    }
 
     return StringUtils.trim(NumberUtils.format(currencyOptions.value(), numberOptions));
   }

--- a/app/src/main/java/com/kickstarter/libs/KSCurrency.java
+++ b/app/src/main/java/com/kickstarter/libs/KSCurrency.java
@@ -72,8 +72,15 @@ public final class KSCurrency {
     final NumberOptions numberOptions = NumberOptions.builder()
       .currencyCode(currencyOptions.currencyCode())
       .currencySymbol(currencyOptions.currencySymbol())
-      .roundingMode(roundingMode)
+      .precision(getPrecision(roundingMode))
       .build();
+
+    if (roundingMode != RoundingMode.UNNECESSARY) {
+      numberOptions
+        .toBuilder()
+        .roundingMode(roundingMode)
+        .build();
+    }
 
     return StringUtils.trim(NumberUtils.format(currencyOptions.value(), numberOptions));
   }
@@ -161,6 +168,15 @@ public final class KSCurrency {
     } else {
       return (float) initialValue;
     }
+  }
+
+  /**
+   * Returns a precision based on the RoundingMode.
+   *
+   * @param roundingMode When this is UNNECESSARY, we return 2, otherwise we return 0.
+   */
+  private static int getPrecision(final @NonNull RoundingMode roundingMode) {
+    return roundingMode == RoundingMode.UNNECESSARY ? 2 : 0;
   }
 
   /**

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -545,26 +545,22 @@ interface ProjectViewModel {
             val backing = project.backing()
             when {
                 backing != null -> backing.let {
-                    val backingAmount = it.amount() - it.shippingAmount()
                     val reward = project.rewards()?.firstOrNull { it.id() == backing.rewardId() }
                     val title = reward?.let { "• ${it.title()}" }?: ""
 
-                    val roundingMode: RoundingMode = when {
-                        ObjectUtils.isNotNull(reward) -> RoundingMode.DOWN
-                        this.isWholeNumber(backingAmount) -> RoundingMode.DOWN
-                        else -> RoundingMode.UNNECESSARY
-                    }
+                    val backingAmount = reward?.let {
+                        when {
+                            RewardUtils.isReward(it) -> it.minimum()
+                            else -> backing.amount()
+                        }
+                    } ?: it.amount()
 
-                    val formattedAmount = this.ksCurrency.format(backingAmount, project, roundingMode)
+                    val formattedAmount = this.ksCurrency.format(backingAmount, project, RoundingMode.HALF_UP)
 
                     return "$formattedAmount $title"
                 }
                 else -> return ""
             }
-        }
-
-        private fun isWholeNumber(value: Double): Boolean {
-            return value.toLong() == Math.round(value)
         }
 
         private fun saveProject(project: Project): Observable<Project> {

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -21,6 +21,7 @@ import com.kickstarter.ui.viewholders.ProjectViewHolder
 import rx.Observable
 import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
+import java.math.RoundingMode
 import java.net.CookieManager
 
 interface ProjectViewModel {
@@ -547,12 +548,23 @@ interface ProjectViewModel {
                     val backingAmount = it.amount() - it.shippingAmount()
                     val reward = project.rewards()?.firstOrNull { it.id() == backing.rewardId() }
                     val title = reward?.let { "• ${it.title()}" }?: ""
-                    val formattedAmount = this.ksCurrency.format(backingAmount, project)
+
+                    val roundingMode: RoundingMode = when {
+                        ObjectUtils.isNotNull(reward) -> RoundingMode.DOWN
+                        this.isWholeNumber(backingAmount) -> RoundingMode.DOWN
+                        else -> RoundingMode.UNNECESSARY
+                    }
+
+                    val formattedAmount = this.ksCurrency.format(backingAmount, project, roundingMode)
 
                     return "$formattedAmount $title"
                 }
                 else -> return ""
             }
+        }
+
+        private fun isWholeNumber(value: Double): Boolean {
+            return value.toLong() == Math.round(value)
         }
 
         private fun saveProject(project: Project): Observable<Project> {

--- a/app/src/test/java/com/kickstarter/KSCurrencyTest.java
+++ b/app/src/test/java/com/kickstarter/KSCurrencyTest.java
@@ -26,14 +26,15 @@ public class KSCurrencyTest extends TestCase {
     assertEquals("CA$ 100", currency.format(100.9f, ProjectFactory.caProject()));
     assertEquals("£100", currency.format(100.9f, ProjectFactory.ukProject()));
 
-    assertEquals("$100", currency.format(100.1f, ProjectFactory.project(), RoundingMode.HALF_UP));
-    assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
-    assertEquals("£100", currency.format(100.1f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
-    assertEquals("$101", currency.format(100.9f, ProjectFactory.project(), RoundingMode.HALF_UP));
-    assertEquals("CA$ 101", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
-    assertEquals("£101", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
-    assertEquals("CA$ 100.90", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.UNNECESSARY));
-    assertEquals("£100.90", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.UNNECESSARY));
+    assertEquals("$100.10", currency.format(100.1f, ProjectFactory.project(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100.10", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
+    assertEquals("£100.10", currency.format(100.1f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
+    assertEquals("$100.90", currency.format(100.9f, ProjectFactory.project(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100.90", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
+    assertEquals("£100.90", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
+    assertEquals("$100", currency.format(100f, ProjectFactory.project(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100", currency.format(100f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
+    assertEquals("£100", currency.format(100f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
   }
 
   public void testFormatCurrency_withUserInCA() {
@@ -45,14 +46,15 @@ public class KSCurrencyTest extends TestCase {
     assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject()));
     assertEquals("£100", currency.format(100.1f, ProjectFactory.ukProject()));
 
-    assertEquals("US$ 100", currency.format(100.1f, ProjectFactory.project(), RoundingMode.HALF_UP));
-    assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
-    assertEquals("£100", currency.format(100.1f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
-    assertEquals("US$ 101", currency.format(100.9f, ProjectFactory.project(), RoundingMode.HALF_UP));
-    assertEquals("CA$ 101", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
-    assertEquals("£101", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
-    assertEquals("CA$ 100.90", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.UNNECESSARY));
-    assertEquals("£100.90", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.UNNECESSARY));
+    assertEquals("US$ 100.10", currency.format(100.1f, ProjectFactory.project(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100.10", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
+    assertEquals("£100.10", currency.format(100.1f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
+    assertEquals("US$ 100.90", currency.format(100.9f, ProjectFactory.project(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100.90", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
+    assertEquals("£100.90", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
+    assertEquals("US$ 100", currency.format(100f, ProjectFactory.project(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100", currency.format(100f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
+    assertEquals("£100", currency.format(100f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
   }
 
   public void testFormatCurrency_withUserInUK() {
@@ -64,14 +66,15 @@ public class KSCurrencyTest extends TestCase {
     assertEquals("CA$ 100", currency.format(100.9f, ProjectFactory.caProject()));
     assertEquals("£100", currency.format(100.9f, ProjectFactory.ukProject()));
 
-    assertEquals("US$ 100", currency.format(100.1f, ProjectFactory.project(), RoundingMode.HALF_UP));
-    assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
-    assertEquals("£100", currency.format(100.1f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
-    assertEquals("US$ 101", currency.format(100.9f, ProjectFactory.project(), RoundingMode.HALF_UP));
-    assertEquals("CA$ 101", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
-    assertEquals("£101", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
-    assertEquals("CA$ 100.90", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.UNNECESSARY));
-    assertEquals("£100.90", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.UNNECESSARY));
+    assertEquals("US$ 100.10", currency.format(100.1f, ProjectFactory.project(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100.10", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
+    assertEquals("£100.10", currency.format(100.1f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
+    assertEquals("US$ 100.90", currency.format(100.9f, ProjectFactory.project(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100.90", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
+    assertEquals("£100.90", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
+    assertEquals("US$ 100", currency.format(100f, ProjectFactory.project(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100", currency.format(100f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
+    assertEquals("£100", currency.format(100f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
   }
 
   public void testFormatCurrency_withUserInUnlaunchedCountry() {
@@ -83,14 +86,15 @@ public class KSCurrencyTest extends TestCase {
     assertEquals("CA$ 100", currency.format(100.9f, ProjectFactory.caProject()));
     assertEquals("£100", currency.format(100.9f, ProjectFactory.ukProject()));
 
-    assertEquals("US$ 100", currency.format(100.1f, ProjectFactory.project(), RoundingMode.HALF_UP));
-    assertEquals("CA$ 100", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
-    assertEquals("£100", currency.format(100.1f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
-    assertEquals("US$ 101", currency.format(100.9f, ProjectFactory.project(), RoundingMode.HALF_UP));
-    assertEquals("CA$ 101", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
-    assertEquals("£101", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
-    assertEquals("CA$ 100.90", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.UNNECESSARY));
-    assertEquals("£100.90", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.UNNECESSARY));
+    assertEquals("US$ 100.10", currency.format(100.1f, ProjectFactory.project(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100.10", currency.format(100.1f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
+    assertEquals("£100.10", currency.format(100.1f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
+    assertEquals("US$ 100.90", currency.format(100.9f, ProjectFactory.project(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100.90", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
+    assertEquals("£100.90", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
+    assertEquals("US$ 100", currency.format(100f, ProjectFactory.project(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100", currency.format(100f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
+    assertEquals("£100", currency.format(100f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
   }
 
   public void testPreferUSD_withUserInUS() {

--- a/app/src/test/java/com/kickstarter/KSCurrencyTest.java
+++ b/app/src/test/java/com/kickstarter/KSCurrencyTest.java
@@ -32,6 +32,8 @@ public class KSCurrencyTest extends TestCase {
     assertEquals("$101", currency.format(100.9f, ProjectFactory.project(), RoundingMode.HALF_UP));
     assertEquals("CA$ 101", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
     assertEquals("£101", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100.90", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.UNNECESSARY));
+    assertEquals("£100.90", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.UNNECESSARY));
   }
 
   public void testFormatCurrency_withUserInCA() {
@@ -49,6 +51,8 @@ public class KSCurrencyTest extends TestCase {
     assertEquals("US$ 101", currency.format(100.9f, ProjectFactory.project(), RoundingMode.HALF_UP));
     assertEquals("CA$ 101", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
     assertEquals("£101", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100.90", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.UNNECESSARY));
+    assertEquals("£100.90", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.UNNECESSARY));
   }
 
   public void testFormatCurrency_withUserInUK() {
@@ -66,6 +70,8 @@ public class KSCurrencyTest extends TestCase {
     assertEquals("US$ 101", currency.format(100.9f, ProjectFactory.project(), RoundingMode.HALF_UP));
     assertEquals("CA$ 101", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
     assertEquals("£101", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100.90", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.UNNECESSARY));
+    assertEquals("£100.90", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.UNNECESSARY));
   }
 
   public void testFormatCurrency_withUserInUnlaunchedCountry() {
@@ -83,6 +89,8 @@ public class KSCurrencyTest extends TestCase {
     assertEquals("US$ 101", currency.format(100.9f, ProjectFactory.project(), RoundingMode.HALF_UP));
     assertEquals("CA$ 101", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.HALF_UP));
     assertEquals("£101", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.HALF_UP));
+    assertEquals("CA$ 100.90", currency.format(100.9f, ProjectFactory.caProject(), RoundingMode.UNNECESSARY));
+    assertEquals("£100.90", currency.format(100.9f, ProjectFactory.ukProject(), RoundingMode.UNNECESSARY));
   }
 
   public void testPreferUSD_withUserInUS() {

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -415,7 +415,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
                 .build()
 
         this.initializeViewModelWithProject(project)
-        this.backingDetails.assertValues("$14 • Digital Bundle")
+        this.backingDetails.assertValues("$20 • Digital Bundle")
     }
 
     @Test
@@ -438,7 +438,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
                 .build()
 
         this.initializeViewModelWithProject(project)
-        this.backingDetails.assertValues("$14 • Digital Bundle")
+        this.backingDetails.assertValues("$20 • Digital Bundle")
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -396,7 +396,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testProjectViewModel_ManagePledgeViewText_WithReward_AmountIsWholeNumber() {
+    fun testProjectViewModel_ManagePledgeViewText_WithReward_ShowsMinimumAmount() {
         val reward = RewardFactory.reward()
                 .toBuilder()
                 .id(4)
@@ -404,30 +404,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         val backing = BackingFactory.backing()
                 .toBuilder()
-                .amount(14.0)
-                .rewardId(4)
-                .build()
-
-        val project = ProjectFactory.backedProject()
-                .toBuilder()
-                .backing(backing)
-                .rewards(listOf(reward))
-                .build()
-
-        this.initializeViewModelWithProject(project)
-        this.backingDetails.assertValues("$20 • Digital Bundle")
-    }
-
-    @Test
-    fun testProjectViewModel_ManagePledgeViewText_WithReward_AmountWithDecimals() {
-        val reward = RewardFactory.reward()
-                .toBuilder()
-                .id(4)
-                .build()
-
-        val backing = BackingFactory.backing()
-                .toBuilder()
-                .amount(14.5)
+                .amount(34.0)
                 .rewardId(4)
                 .build()
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -396,7 +396,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testProjectViewModel_ManagePledgeViewText_WithReward() {
+    fun testProjectViewModel_ManagePledgeViewText_WithReward_AmountIsWholeNumber() {
         val reward = RewardFactory.reward()
                 .toBuilder()
                 .id(4)
@@ -404,6 +404,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         val backing = BackingFactory.backing()
                 .toBuilder()
+                .amount(14.0)
                 .rewardId(4)
                 .build()
 
@@ -414,11 +415,34 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
                 .build()
 
         this.initializeViewModelWithProject(project)
-        this.backingDetails.assertValues("$10 • Digital Bundle")
+        this.backingDetails.assertValues("$14 • Digital Bundle")
     }
 
     @Test
-    fun testProjectViewModel_ManagePledgeViewText_WithNoReward() {
+    fun testProjectViewModel_ManagePledgeViewText_WithReward_AmountWithDecimals() {
+        val reward = RewardFactory.reward()
+                .toBuilder()
+                .id(4)
+                .build()
+
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(14.5)
+                .rewardId(4)
+                .build()
+
+        val project = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .rewards(listOf(reward))
+                .build()
+
+        this.initializeViewModelWithProject(project)
+        this.backingDetails.assertValues("$14 • Digital Bundle")
+    }
+
+    @Test
+    fun testProjectViewModel_ManagePledgeViewText_WithNoReward_AmountIsWholeNumber() {
 
         val reward = RewardFactory.noReward()
 
@@ -435,6 +459,26 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.initializeViewModelWithProject(project)
         this.backingDetails.assertValues("$15 ")
+    }
+
+    @Test
+    fun testProjectViewModel_ManagePledgeViewText_WithNoReward_AmountWithDecimals() {
+
+        val reward = RewardFactory.noReward()
+
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(13.5)
+                .reward(reward)
+                .build()
+
+        val project = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        this.initializeViewModelWithProject(project)
+        this.backingDetails.assertValues("$13.50 ")
     }
 
     @Test


### PR DESCRIPTION
# What ❓
- Changes the format of pledge amount on the `ProjectPage`
- We now show decimals if the pledge amount is not a whole number and the backing is `No Reward`.
- On the `KSCurrency` class, the `format(initialValue: project: excludeCurrencyCode: roundingMode:)` function was tweaked to only add roundingMode to the `numberOptions` variable if the roundingMode not `UNNECESSARY`.
- Some tests were included in order to insure the changes mentioned above didn't break anything.

# How to QA? 🤔
- [ ] If I choose a `No Reward` and pledge `$10.50`, the pledge amount on the ProjectPage should show `$10.50`

- [ ] If I choose a `No Reward` and pledge `$10.00`, the pledge amount on the ProjectPage should show `$10`

- [ ] If I choose a `Reward` and pledge `$10.50`, the pledge amount on the ProjectPage should show `$10`

# Story 📖

[Manage Pledge - Pledge amount format](https://trello.com/c/Zrlmfb0t/1428-manage-pledge-pledge-amount-format

# See 👀
| No Reward - Number w/ decimals | No Reward - Whole Number | Reward |
| --- | --- | --- |
| <img src="https://user-images.githubusercontent.com/3709676/59876534-e7241580-9371-11e9-87c6-76c2a84a77cc.png"> | <img src="https://user-images.githubusercontent.com/3709676/59876484-c5c32980-9371-11e9-9e14-75241498b5f8.png"> | <img src="https://user-images.githubusercontent.com/3709676/59876518-d96e9000-9371-11e9-91a6-18f0d4ea2b22.png"> |


