### PR TITLE
Manage your pledge, pledged reward UI

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -236,6 +236,26 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .compose(bindToLifecycle())
                 .subscribe { setHtmlStrings(it) }
 
+        this.viewModel.outputs.cancelPledgeButtonIsGone()
+                .compose(observeForUI())
+                .compose(bindToLifecycle())
+                .subscribe { ViewUtils.setGone(cancel_pledge_button, it) }
+
+        this.viewModel.outputs.changePaymentMethodButtonIsGone()
+                .compose(observeForUI())
+                .compose(bindToLifecycle())
+                .subscribe { ViewUtils.setGone(change_payment_method_button, it) }
+
+        this.viewModel.outputs.updatePledgeButtonIsGone()
+                .compose(observeForUI())
+                .compose(bindToLifecycle())
+                .subscribe { ViewUtils.setGone(update_pledge_button, it) }
+
+        this.viewModel.outputs.totalContainerIsGone()
+                .compose(observeForUI())
+                .compose(bindToLifecycle())
+                .subscribe { ViewUtils.setGone(total, it) }
+
         shipping_rules.setOnClickListener { shipping_rules.showDropDown() }
 
         continue_to_tout.setOnClickListener {

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -22,7 +22,8 @@
 
     <include
       android:id="@+id/reward_to_copy"
-      layout="@layout/item_reward" />
+      layout="@layout/item_reward"
+      tools:visibility="gone" />
 
     <!-- todo: what's the content description? -->
     <com.kickstarter.ui.views.BottomCropImageView
@@ -108,6 +109,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        android:clipToPadding="false"
+        android:clipChildren="false"
         android:paddingEnd="@dimen/activity_vertical_margin"
         android:paddingStart="@dimen/activity_vertical_margin">
 
@@ -269,61 +272,97 @@
 
         </LinearLayout>
 
-        <include layout="@layout/horizontal_line_1dp_view" />
-
-        <TextView
-          style="@style/CalloutPrimaryMedium"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_1"
-          android:layout_marginTop="@dimen/grid_4"
-          android:text="@string/dashboard_graphs_funding_total" />
-
-        <LinearLayout
+        <com.google.android.material.button.MaterialButton
+          android:id="@+id/update_pledge_button"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginBottom="@dimen/grid_4"
-          android:orientation="horizontal"
-          android:weightSum="1.1">
+          android:enabled="false"
+          android:text="@string/Update_pledge"
+          android:textColor="@color/white"
+          app:backgroundTint="@color/button_pledge_live" />
+
+        <include layout="@layout/horizontal_line_1dp_view" />
+
+        <com.google.android.material.button.MaterialButton
+          android:id="@+id/change_payment_method_button"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/grid_4"
+          android:enabled="false"
+          android:text="@string/Change_payment_method"
+          app:backgroundTint="@color/button_pledge_ended" />
+
+        <com.google.android.material.button.MaterialButton
+          android:id="@+id/cancel_pledge_button"
+          style="@style/TertiaryButton"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/grid_2"
+          android:layout_marginBottom="@dimen/grid_4"
+          android:text="@string/Cancel_pledge" />
+
+        <LinearLayout
+          android:id="@+id/total"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="vertical">
 
           <TextView
-            android:id="@+id/pledge_agreement"
-            style="@style/FootnoteSecondary"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            tools:text="@string/By_pledging_you_agree" />
-
-          <FrameLayout
+            style="@style/CalloutPrimaryMedium"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight=".1">
+            android:layout_marginBottom="@dimen/grid_1"
+            android:layout_marginTop="@dimen/grid_4"
+            android:text="@string/dashboard_graphs_funding_total" />
+
+          <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/grid_4"
+            android:orientation="horizontal"
+            android:weightSum="1.1">
 
             <TextView
-              android:id="@+id/total_amount"
-              style="@style/PledgeCurrencySecondary"
+              android:id="@+id/pledge_agreement"
+              style="@style/FootnoteSecondary"
+              android:layout_width="0dp"
+              android:layout_height="wrap_content"
+              android:layout_weight="1"
+              tools:text="@string/By_pledging_you_agree_to_Kickstarters_Terms_of_Use_Privacy_Policy_and_Cookie_Policy" />
+
+            <FrameLayout
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              android:layout_gravity="end"
-              tools:text="$40.00" />
+              android:layout_weight=".1">
 
-            <View
-              android:id="@+id/total_amount_loading_view"
-              android:layout_width="@dimen/grid_11"
-              android:layout_height="@dimen/grid_2"
-              android:layout_gravity="center|end"
-              android:background="@drawable/pledge_amounts_loading_states" />
+              <TextView
+                android:id="@+id/total_amount"
+                style="@style/PledgeCurrencySecondary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                tools:text="$40.00" />
 
-            <TextView
-              android:id="@+id/total_amount_conversion"
-              style="@style/Caption1Secondary"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_gravity="bottom|end"
-              android:layout_marginTop="@dimen/grid_6"
-              android:textSize="@dimen/caption_1"
-              tools:text="About $40.00" />
-          </FrameLayout>
+              <View
+                android:id="@+id/total_amount_loading_view"
+                android:layout_width="@dimen/grid_11"
+                android:layout_height="@dimen/grid_2"
+                android:layout_gravity="center|end"
+                android:background="@drawable/pledge_amounts_loading_states" />
+
+              <TextView
+                android:id="@+id/total_amount_conversion"
+                style="@style/Caption1Secondary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom|end"
+                android:layout_marginTop="@dimen/grid_6"
+                android:textSize="@dimen/caption_1"
+                tools:text="About $40.00" />
+            </FrameLayout>
+
+          </LinearLayout>
 
         </LinearLayout>
 

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -36,7 +36,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val additionalPledgeAmountIsGone = TestSubscriber<Boolean>()
     private val animateRewardCard = TestSubscriber<PledgeData>()
     private val baseUrlForTerms = TestSubscriber<String>()
+    private val cancelPledgeButtonIsGone = TestSubscriber<Boolean>()
     private val cards = TestSubscriber<List<StoredCard>>()
+    private val changePaymentMethodButtonIsGone = TestSubscriber<Boolean>()
     private val continueButtonIsGone = TestSubscriber<Boolean>()
     private val conversionText = TestSubscriber<String>()
     private val conversionTextViewIsGone = TestSubscriber<Boolean>()
@@ -57,6 +59,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val startNewCardActivity = TestSubscriber<Void>()
     private val startThanksActivity = TestSubscriber<Project>()
     private val totalAmount = TestSubscriber<String>()
+    private val totalContainerIsGone = TestSubscriber<Boolean>()
+    private val updatePledgeButtonIsGone = TestSubscriber<Boolean>()
 
     private fun setUpEnvironment(environment: Environment, reward: Reward? = RewardFactory.rewardWithShipping(),
                                  project: Project? = ProjectFactory.project()) {
@@ -66,7 +70,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.additionalPledgeAmountIsGone().subscribe(this.additionalPledgeAmountIsGone)
         this.vm.outputs.animateRewardCard().subscribe(this.animateRewardCard)
         this.vm.outputs.baseUrlForTerms().subscribe(this.baseUrlForTerms)
+        this.vm.outputs.cancelPledgeButtonIsGone().subscribe(this.cancelPledgeButtonIsGone)
         this.vm.outputs.cards().subscribe(this.cards)
+        this.vm.outputs.changePaymentMethodButtonIsGone().subscribe(this.changePaymentMethodButtonIsGone)
         this.vm.outputs.continueButtonIsGone().subscribe(this.continueButtonIsGone)
         this.vm.outputs.conversionText().subscribe(this.conversionText)
         this.vm.outputs.conversionTextViewIsGone().subscribe(this.conversionTextViewIsGone)
@@ -87,6 +93,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.startNewCardActivity().subscribe(this.startNewCardActivity)
         this.vm.outputs.startThanksActivity().subscribe(this.startThanksActivity)
         this.vm.outputs.totalAmount().map { it.toString() }.subscribe(this.totalAmount)
+        this.vm.outputs.totalContainerIsGone().subscribe(this.totalContainerIsGone)
+        this.vm.outputs.updatePledgeButtonIsGone().subscribe(this.updatePledgeButtonIsGone)
 
         val bundle = Bundle()
         bundle.putSerializable(ArgumentsKey.PLEDGE_SCREEN_LOCATION, ScreenLocation(0f, 0f, 0f, 0f))
@@ -316,6 +324,51 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.estimatedDelivery.assertNoValues()
         this.estimatedDeliveryInfoIsGone.assertValue(true)
+    }
+
+    @Test
+    fun testManageYourPledgeUIOutputs() {
+        setUpEnvironment(environment())
+        this.cancelPledgeButtonIsGone.assertValuesAndClear(true)
+        this.continueButtonIsGone.assertValuesAndClear(false)
+        this.changePaymentMethodButtonIsGone.assertValuesAndClear(true)
+        this.paymentContainerIsGone.assertValuesAndClear(true)
+        this.totalContainerIsGone.assertValuesAndClear(false)
+        this.updatePledgeButtonIsGone.assertValuesAndClear(true)
+
+        val environmentWithLoggedInUser = environment().toBuilder()
+                .currentUser(MockCurrentUser(UserFactory.user()))
+                .build()
+
+        setUpEnvironment(environmentWithLoggedInUser)
+        this.cancelPledgeButtonIsGone.assertValuesAndClear(true)
+        this.continueButtonIsGone.assertValuesAndClear(true)
+        this.changePaymentMethodButtonIsGone.assertValuesAndClear(true)
+        this.paymentContainerIsGone.assertValuesAndClear(false)
+        this.totalContainerIsGone.assertValuesAndClear(false)
+        this.updatePledgeButtonIsGone.assertValuesAndClear(true)
+
+        val backing = BackingFactory.backing()
+        val backedReward = backing.reward()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+        setUpEnvironment(environmentWithLoggedInUser, RewardFactory.reward(), backedProject)
+        this.cancelPledgeButtonIsGone.assertValuesAndClear(true)
+        this.continueButtonIsGone.assertValuesAndClear(true)
+        this.changePaymentMethodButtonIsGone.assertValuesAndClear(true)
+        this.paymentContainerIsGone.assertValuesAndClear(false)
+        this.totalContainerIsGone.assertValuesAndClear(false)
+        this.updatePledgeButtonIsGone.assertValuesAndClear(true)
+
+        setUpEnvironment(environmentWithLoggedInUser, backedReward, backedProject)
+        this.cancelPledgeButtonIsGone.assertValuesAndClear(false)
+        this.continueButtonIsGone.assertValuesAndClear(true)
+        this.changePaymentMethodButtonIsGone.assertValuesAndClear(false)
+        this.paymentContainerIsGone.assertValuesAndClear(true)
+        this.totalContainerIsGone.assertValuesAndClear(true)
+        this.updatePledgeButtonIsGone.assertValuesAndClear(false)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Pledge screen UI and tests for managing currently pledged reward.

# 🤔 Why
The first step in cancel pledge work.

# 🛠 How
- Reorganized `PledgeFragmentViewModel` with commented sections since it's getting Hectic ™
- Added 4 new outputs: `cancelPledgeButtonIsGone`, `changePaymentMethodButtonIsGone`, `totalContainerIsGone` and `updatePledgeButtonIsGone`.
- `Update pledge` and `Change payment method` buttons are disabled for now.

# 👀 See
| After 🦋 |
| --- |
| <img src=https://user-images.githubusercontent.com/1289295/60631451-74815400-9dcd-11e9-972f-a944f58ef26d.png width=330/> | 

# 📋 QA
On a live project you've backed, open the rewards sheet and click `Manage your pledge`.

# Story 📖
[Trello Story](https://trello.com/c/qY7q7T9B/1435-user-can-cancel-pledge)
