### PR TITLE
Reward sheet titles

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/ProjectViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/ProjectViewUtils.kt
@@ -3,6 +3,7 @@ package com.kickstarter.libs.utils
 import android.view.View
 import android.widget.Button
 import androidx.annotation.ColorRes
+import androidx.annotation.StringRes
 import com.kickstarter.R
 import com.kickstarter.models.Project
 
@@ -27,6 +28,19 @@ object ProjectViewUtils {
             R.string.Back_this_project
         } else if (project.isBacking && project.isLive) {
             R.string.Manage
+        } else if (project.isBacking && !project.isLive) {
+            R.string.View_your_pledge
+        } else {
+            R.string.View_rewards
+        }
+    }
+
+    @StringRes
+    fun rewardsToolbarTitle(project: Project): Int {
+        return if (!project.isBacking && project.isLive) {
+            R.string.Back_this_project
+        } else if (project.isBacking && project.isLive) {
+            R.string.Manage_your_pledge
         } else if (project.isBacking && !project.isLive) {
             R.string.View_your_pledge
         } else {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -138,6 +138,11 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { project_action_button.setText(it) }
 
+        this.viewModel.outputs.rewardsToolbarTitle()
+                .compose(bindToLifecycle())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe { rewards_toolbar.title = getString(it) }
+
         this.viewModel.outputs.setInitialRewardsContainerY()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
@@ -304,7 +309,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
     private fun setInitialRewardsContainerY() {
         val guideline = rewardsSheetGuideline()
         rewards_container.y = (rewards_container.height - guideline).toFloat()
-//        fragment_container.setPadding(0 , rewards_toolbar.height, 0, 0)
         this.projectRecyclerView.setPadding(0, 0, 0, guideline)
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -304,6 +304,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>() {
     private fun setInitialRewardsContainerY() {
         val guideline = rewardsSheetGuideline()
         rewards_container.y = (rewards_container.height - guideline).toFloat()
+//        fragment_container.setPadding(0 , rewards_toolbar.height, 0, 0)
         this.projectRecyclerView.setPadding(0, 0, 0, guideline)
     }
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -366,7 +366,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
             initMarginX = location.x
             initMarginY = location.y
             finalMarginX = margin
-            finalMarginY = margin
+            finalMarginY = margin + pledge_details.paddingTop
             initWidth = location.width
             initHeight = location.height
             finalWidth = miniRewardWidth
@@ -376,7 +376,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
             setDeliveryParams(miniRewardWidth, margin)
         } else {
             initMarginX = margin
-            initMarginY = margin
+            initMarginY = margin + pledge_details.paddingTop
             finalMarginX = location.x
             finalMarginY = location.y
             initWidth = miniRewardWidth

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -366,7 +366,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
             initMarginX = location.x
             initMarginY = location.y
             finalMarginX = margin
-            finalMarginY = margin + pledge_details.paddingTop
+            finalMarginY = margin
             initWidth = location.width
             initHeight = location.height
             finalWidth = miniRewardWidth
@@ -376,7 +376,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
             setDeliveryParams(miniRewardWidth, margin)
         } else {
             initMarginX = margin
-            initMarginY = margin + pledge_details.paddingTop
+            initMarginY = margin
             finalMarginX = location.x
             finalMarginY = location.y
             initWidth = miniRewardWidth

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -88,6 +88,9 @@ interface ProjectViewModel {
         /** Emits the proper string resource ID for the reward button. */
         fun rewardsButtonText(): Observable<Int>
 
+        /** Emits the proper string resource ID for the rewards toolbar. */
+        fun rewardsToolbarTitle(): Observable<Int>
+
         /** Emits when we should set the Y position of the rewards container. */
         fun setInitialRewardsContainerY(): Observable<Void>
 
@@ -157,6 +160,7 @@ interface ProjectViewModel {
         private val projectAndUserCountry = BehaviorSubject.create<Pair<Project, String>>()
         private val rewardsButtonColor = BehaviorSubject.create<Int>()
         private val rewardsButtonText = BehaviorSubject.create<Int>()
+        private val rewardsToolbarTitle = BehaviorSubject.create<Int>()
         private val setInitialRewardPosition = BehaviorSubject.create<Void>()
         private val showRewardsFragment = BehaviorSubject.create<Boolean>()
         private val startLoginToutActivity = PublishSubject.create<Void>()
@@ -283,8 +287,8 @@ interface ProjectViewModel {
                     .subscribe(this.showRewardsFragment)
 
             val nativeCheckoutProject = Observable.just(this.nativeCheckoutPreference.get())
-                    .filter { BooleanUtils.isTrue(it) }
                     .compose<Pair<Boolean, Project>>(combineLatestPair(currentProject))
+                    .filter { BooleanUtils.isTrue(it.first) }
                     .map<Project> { it.second }
 
             nativeCheckoutProject
@@ -305,6 +309,12 @@ interface ProjectViewModel {
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe { this.rewardsButtonText.onNext(it) }
+
+            nativeCheckoutProject
+                    .map { ProjectViewUtils.rewardsToolbarTitle(it) }
+                    .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.rewardsToolbarTitle)
 
             nativeCheckoutProject
                     .map { ProjectViewUtils.rewardsButtonColor(it) }
@@ -486,6 +496,9 @@ interface ProjectViewModel {
 
         @NonNull
         override fun rewardsButtonText(): Observable<Int> = this.rewardsButtonText
+
+        @NonNull
+        override fun rewardsToolbarTitle(): Observable<Int> = this.rewardsToolbarTitle
 
         @NonNull
         override fun setInitialRewardsContainerY(): Observable<Void> = this.setInitialRewardPosition

--- a/app/src/main/res/layout/activity_project.xml
+++ b/app/src/main/res/layout/activity_project.xml
@@ -42,7 +42,7 @@
     app:cardElevation="@dimen/grid_2"
     tools:layout_marginTop="620dp">
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
+    <FrameLayout
       android:id="@+id/pledge_container"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
@@ -53,8 +53,6 @@
       <FrameLayout
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
-        android:clipToPadding="false"
-        android:clipChildren="false"
         android:layout_height="match_parent">
 
         <fragment
@@ -70,12 +68,10 @@
         android:id="@+id/rewards_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        style="@style/Toolbar"
-        android:elevation=".1dp"
         android:background="@color/transparent"
         app:navigationIcon="@drawable/ic_down" />
 
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    </FrameLayout>
 
     <LinearLayout
       android:id="@+id/action_buttons"
@@ -83,7 +79,6 @@
       android:layout_height="wrap_content"
       android:layout_marginEnd="@dimen/activity_horizontal_margin"
       android:layout_marginStart="@dimen/activity_horizontal_margin"
-      tools:visibility="gone"
       android:orientation="horizontal">
 
       <LinearLayout

--- a/app/src/main/res/layout/activity_project.xml
+++ b/app/src/main/res/layout/activity_project.xml
@@ -42,32 +42,19 @@
     app:cardElevation="@dimen/grid_2"
     tools:layout_marginTop="620dp">
 
-    <LinearLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
       android:id="@+id/pledge_container"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:alpha="0"
-      android:orientation="vertical">
-
-      <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/rewards_appbar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:elevation="0dp">
-
-        <androidx.appcompat.widget.Toolbar
-          android:id="@+id/rewards_toolbar"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:background="@color/ksr_grey_400"
-          app:navigationIcon="@drawable/ic_down"
-          app:title="Back this project" />
-
-      </com.google.android.material.appbar.AppBarLayout>
+      android:orientation="vertical"
+      tools:alpha="0">
 
       <FrameLayout
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
+        android:clipToPadding="false"
+        android:clipChildren="false"
         android:layout_height="match_parent">
 
         <fragment
@@ -79,7 +66,15 @@
 
       </FrameLayout>
 
-    </LinearLayout>
+      <androidx.appcompat.widget.Toolbar
+        android:id="@+id/rewards_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        style="@style/Toolbar"
+        android:background="@color/transparent"
+        app:navigationIcon="@drawable/ic_down" />
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <LinearLayout
       android:id="@+id/action_buttons"
@@ -87,6 +82,7 @@
       android:layout_height="wrap_content"
       android:layout_marginEnd="@dimen/activity_horizontal_margin"
       android:layout_marginStart="@dimen/activity_horizontal_margin"
+      tools:visibility="gone"
       android:orientation="horizontal">
 
       <LinearLayout
@@ -126,12 +122,5 @@
     </LinearLayout>
 
   </androidx.cardview.widget.CardView>
-
-  <androidx.constraintlayout.widget.Guideline
-    android:id="@+id/guideline"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    app:layout_constraintGuide_end="@dimen/reward_fragment_guideline_constraint_end" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_project.xml
+++ b/app/src/main/res/layout/activity_project.xml
@@ -71,6 +71,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         style="@style/Toolbar"
+        android:elevation=".1dp"
         android:background="@color/transparent"
         app:navigationIcon="@drawable/ic_down" />
 

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -11,6 +11,7 @@
   android:fillViewport="true"
   android:focusable="true"
   android:overScrollMode="never"
+  android:paddingTop="?android:attr/actionBarSize"
   android:scrollbars="none"
   android:visibility="invisible"
   tools:visibility="visible">
@@ -59,7 +60,6 @@
     </FrameLayout>
 
     <LinearLayout
-      android:paddingTop="?android:attr/actionBarSize"
       android:id="@+id/pledge_details"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -59,6 +59,7 @@
     </FrameLayout>
 
     <LinearLayout
+      android:paddingTop="?android:attr/actionBarSize"
       android:id="@+id/pledge_details"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
@@ -108,9 +109,9 @@
       <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:clipToPadding="false"
         android:clipChildren="false"
+        android:clipToPadding="false"
+        android:orientation="vertical"
         android:paddingEnd="@dimen/activity_vertical_margin"
         android:paddingStart="@dimen/activity_vertical_margin">
 
@@ -298,8 +299,8 @@
           style="@style/TertiaryButton"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginTop="@dimen/grid_2"
           android:layout_marginBottom="@dimen/grid_4"
+          android:layout_marginTop="@dimen/grid_2"
           android:text="@string/Cancel_pledge" />
 
         <LinearLayout

--- a/app/src/main/res/layout/fragment_rewards.xml
+++ b/app/src/main/res/layout/fragment_rewards.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.recyclerview.widget.RecyclerView
-  android:id="@+id/rewards_recycler"
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:background="@color/ksr_grey_400"
-  android:overScrollMode="never"
-  android:paddingTop="?android:attr/actionBarSize"
-  tools:listitem="@layout/item_reward" />
+  android:paddingTop="?android:attr/actionBarSize">
+
+  <androidx.recyclerview.widget.RecyclerView
+    android:id="@+id/rewards_recycler"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:overScrollMode="never"
+    tools:listitem="@layout/item_reward" />
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_rewards.xml
+++ b/app/src/main/res/layout/fragment_rewards.xml
@@ -7,4 +7,5 @@
   android:layout_height="match_parent"
   android:background="@color/ksr_grey_400"
   android:overScrollMode="never"
+  android:paddingTop="?android:attr/actionBarSize"
   tools:listitem="@layout/item_reward" />

--- a/app/src/test/java/com/kickstarter/libs/utils/ProjectViewUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/ProjectViewUtilsTest.kt
@@ -31,4 +31,16 @@ class ProjectViewUtilsTest : KSRobolectricTestCase() {
                 .build()
         assertEquals(R.string.View_your_pledge, ProjectViewUtils.rewardsButtonText(backedSuccessfulProject))
     }
+
+    @Test
+    fun testRewardsToolbarTitle() {
+        assertEquals(R.string.Back_this_project, ProjectViewUtils.rewardsToolbarTitle(ProjectFactory.project()))
+        assertEquals(R.string.Manage_your_pledge, ProjectViewUtils.rewardsToolbarTitle(ProjectFactory.backedProject()))
+        assertEquals(R.string.View_rewards, ProjectViewUtils.rewardsToolbarTitle(ProjectFactory.successfulProject()))
+        val backedSuccessfulProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .state(Project.STATE_SUCCESSFUL)
+                .build()
+        assertEquals(R.string.View_your_pledge, ProjectViewUtils.rewardsToolbarTitle(backedSuccessfulProject))
+    }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -25,6 +25,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     private val projectTest = TestSubscriber<Project>()
     private val rewardsButtonColor = TestSubscriber<Int>()
     private val rewardsButtonText = TestSubscriber<Int>()
+    private val rewardsToolbarTitle = TestSubscriber<Int>()
     private val showShareSheet = TestSubscriber<Project>()
     private val showSavedPromptTest = TestSubscriber<Void>()
     private val startLoginToutActivity = TestSubscriber<Void>()
@@ -47,6 +48,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.projectAndUserCountry().map { pc -> pc.first }.subscribe(this.projectTest)
         this.vm.outputs.rewardsButtonColor().subscribe(this.rewardsButtonColor)
         this.vm.outputs.rewardsButtonText().subscribe(this.rewardsButtonText)
+        this.vm.outputs.rewardsToolbarTitle().subscribe(this.rewardsToolbarTitle)
         this.vm.outputs.setInitialRewardsContainerY().subscribe(this.setInitialRewardsContainerY)
         this.vm.outputs.showShareSheet().subscribe(this.showShareSheet)
         this.vm.outputs.showRewardsFragment().subscribe(this.showRewardsFragment)
@@ -298,6 +300,38 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.rewardsButtonColor.assertValue(R.color.button_pledge_ended)
         this.rewardsButtonText.assertValue(R.string.View_your_pledge)
+    }
+
+    @Test
+    fun testRewardsToolbarTitle() {
+        val project = ProjectFactory.project()
+        setUpEnvironment(environment())
+
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
+
+        this.rewardsToolbarTitle.assertNoValues()
+
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
+
+        this.rewardsToolbarTitle.assertValuesAndClear(R.string.Back_this_project)
+
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
+
+        this.rewardsToolbarTitle.assertValuesAndClear(R.string.Manage_your_pledge)
+
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.successfulProject()))
+
+        this.rewardsToolbarTitle.assertValuesAndClear(R.string.View_rewards)
+
+        val backedSuccessfulProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .state(Project.STATE_SUCCESSFUL)
+                .build()
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedSuccessfulProject))
+
+        this.rewardsToolbarTitle.assertValue(R.string.View_your_pledge)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Displaying the proper title in the toolbar of the Rewards sheet and fixed the bug with the background color of the toolbar.

# 🤔 Why
So users have context about why they're in the rewards sheet. And to match the designs!

# 🛠 How
- Added `ProjectViewUtils. rewardsToolbarTitle` to determine what the title text should be and tests.
- Added `rewardsToolbarTitle` output to `ProjectViewModel` and tests.
- Added padding to the top of `RewardsFragment` and `PledgeFragment` so the transparent `rewards_toolbar` could inherit their respective background colors.

# 👀 See
| Unbacked Live project | Backed Live Project |
| --- | --- |
| ![screenshot-2019-07-16_150551](https://user-images.githubusercontent.com/1289295/61327919-00d94100-a7e8-11e9-8039-968021735623.png) | ![screenshot-2019-07-16_150528](https://user-images.githubusercontent.com/1289295/61327943-0a62a900-a7e8-11e9-960c-cddc0bb236e2.png) |
| Unbacked Ended project | Backed Ended Project |
 ![screenshot-2019-07-16_150658](https://user-images.githubusercontent.com/1289295/61327979-1c444c00-a7e8-11e9-9cc8-bc7a9166620a.png) | ![screenshot-2019-07-16_150540](https://user-images.githubusercontent.com/1289295/61328003-25351d80-a7e8-11e9-9578-fef85e1c9b95.png) |

| Toolbar background color |
| --- |
| ![device-2019-07-16-150740 2019-07-16 16_41_30](https://user-images.githubusercontent.com/1289295/61328264-a096cf00-a7e8-11e9-9f32-e3146d5bf514.gif) |

# 📋 QA
View projects in these 4 states:
1. Unbacked Live project
2. Backed Live Project
3. Unbacked Ended project
4. Backed Ended Project

# Story 📖
[Trello Story](https://trello.com/c/Rt1PnFTQ/1452-reward-sheet-title-states)
