### PR TITLE
Green naming change

### DIFF
--- a/app/src/main/res/color/button_pledge_live.xml
+++ b/app/src/main/res/color/button_pledge_live.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:color="@color/green_alpha_66" android:state_enabled="false"/>
+  <item android:color="@color/ksr_green_200" android:state_enabled="false"/>
   <item android:color="@color/ksr_green_500"/>
 </selector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -18,6 +18,7 @@
   <color name="ksr_dark_grey_400">#9B9E9E</color>
   <color name="ksr_dark_grey_500">#656969</color>
   <color name="ksr_highlighter_green">#05F2BA</color>
+  <color name="ksr_green_200">#57BFA4</color>
   <color name="ksr_green_500">#009E74</color>
   <color name="ksr_green_700">#037362</color>
   <color name="ksr_green_800">#034752</color>
@@ -51,7 +52,6 @@
   <color name="green_alpha_10">#1A009E74</color>
   <color name="green_alpha_20">#33009E74</color>
   <color name="green_alpha_50">#80009E74</color>
-  <color name="green_alpha_66">#57bfa4</color>
   <color name="green_darken_10">@color/soft_black_alpha_17</color>
   <color name="soft_black_alpha_17">#2B282828</color>
   <color name="white_alpha_60">#99ffffff</color>


### PR DESCRIPTION
# 📲 What

Changed the name of a particular shade of green.

# 🤔 Why

This particular shade of green, #57bfa4, is used as the disabled green button fill. I changed the name from `green_alpha_66` to `green_200` because:

- The hex colour does not have any transparency and therefore shouldn't be part of the `_alpha` list
- The `_200` prefix makes it easier to systematically (all platforms) change values and assume usages
- I decided with @cdolm92's help to name this shade `green_200` on iOS, so figured it's nice to have the same on Android for the above reason

# 🛠 How

Changed the variable name in colors.xml and updated its one usage reference.

# 👀 See

See the file changes. Pretty straightforward.