### PR TITLE
[🐜🕷] Mark as received bug, View pledge bug

### DIFF
--- a/app/src/main/java/com/kickstarter/services/apiresponses/MessageThreadEnvelope.java
+++ b/app/src/main/java/com/kickstarter/services/apiresponses/MessageThreadEnvelope.java
@@ -16,7 +16,7 @@ import auto.parcel.AutoParcel;
 @AutoParcel
 public abstract class MessageThreadEnvelope implements Parcelable {
   public abstract @Nullable List<Message> messages();
-  public abstract MessageThread messageThread();
+  public abstract @Nullable MessageThread messageThread();
   public abstract List<User> participants();
 
   @AutoParcel.Builder

--- a/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
@@ -325,7 +325,7 @@ public interface MessagesViewModel {
         .subscribe(this.backingInfoViewIsGone::onNext);
 
       koalaContext
-        .map(c -> c.equals(KoalaContext.Message.BACKER_MODAL))
+        .map(c -> c.equals(KoalaContext.Message.BACKER_MODAL) || c.equals(KoalaContext.Message.CREATOR_BIO_MODAL))
         .compose(bindToLifecycle())
         .subscribe(this.viewPledgeButtonIsGone::onNext);
 

--- a/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.java
@@ -400,7 +400,7 @@ public interface MessagesViewModel {
       );
     }
 
-    private Pair<Project, User> projectAndBacker(Pair<MessageThreadEnvelope, MessagesData> envelopeAndData) {
+    private Pair<Project, User> projectAndBacker(final @NonNull Pair<MessageThreadEnvelope, MessagesData> envelopeAndData) {
       final Project project = envelopeAndData.second.getProject();
       final User backer = project.isBacking() ? envelopeAndData.second.getCurrentUser() : envelopeAndData.first.messageThread().participant();
       return Pair.create(project, backer);

--- a/app/src/main/res/layout/backing_layout.xml
+++ b/app/src/main/res/layout/backing_layout.xml
@@ -8,7 +8,7 @@
 
   <include layout="@layout/backing_toolbar" />
 
-  <ScrollView
+  <androidx.core.widget.NestedScrollView
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -156,7 +156,9 @@
             <androidx.recyclerview.widget.RecyclerView
               android:id="@+id/backing_rewards_item_recycler_view"
               android:layout_width="match_parent"
-              android:layout_height="wrap_content" />
+              android:layout_height="wrap_content"
+              android:nestedScrollingEnabled="false"
+              android:overScrollMode="never" />
 
           </LinearLayout>
 
@@ -255,6 +257,6 @@
 
     </LinearLayout>
 
-  </ScrollView>
+  </androidx.core.widget.NestedScrollView>
 
 </LinearLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingViewModelTest.java
@@ -196,7 +196,7 @@ public final class BackingViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void getTestEstimatedDeliverySectionIsGone_deliveryNotNull() {
+  public void testEstimatedDeliverySectionIsGone_deliveryNotNull() {
     final Reward reward = RewardFactory.reward().toBuilder()
       .estimatedDeliveryOn(DateTime.now())
       .build();
@@ -305,7 +305,7 @@ public final class BackingViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testReceivedSectionIsGone() {
+  public void testReceivedSectionIsGone_currentUser() {
     setUpEnvironmentAndIntent(BackingFactory.backing(Backing.STATUS_CANCELED));
 
     this.receivedSectionIsGone.assertValuesAndClear(true);

--- a/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
@@ -618,11 +618,20 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testViewPledgeButton_IsGone() {
+  public void testViewPledgeButton_IsGone_backerModal() {
     setUpEnvironment(environment().toBuilder().currentUser(new MockCurrentUser(UserFactory.user())).build());
     this.vm.intent(backerModalContextIntent(BackingFactory.backing(), ProjectFactory.project()));
 
     // View pledge button is hidden when context is from the backer modal.
+    this.viewPledgeButtonIsGone.assertValues(true);
+  }
+
+  @Test
+  public void testViewPledgeButton_IsGone_creatorBioModal() {
+    setUpEnvironment(environment().toBuilder().currentUser(new MockCurrentUser(UserFactory.user())).build());
+    this.vm.intent(creatorBioModalContextIntent(BackingFactory.backing(), ProjectFactory.project()));
+
+    // View pledge button is hidden when context is from the creator bio modal.
     this.viewPledgeButtonIsGone.assertValues(true);
   }
 
@@ -640,6 +649,13 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
       .putExtra(IntentKey.BACKING, backing)
       .putExtra(IntentKey.PROJECT, project)
       .putExtra(IntentKey.KOALA_CONTEXT, KoalaContext.Message.BACKER_MODAL);
+  }
+
+  private static @NonNull Intent creatorBioModalContextIntent(final @NonNull Backing backing, final @NonNull Project project) {
+    return new Intent()
+      .putExtra(IntentKey.BACKING, backing)
+      .putExtra(IntentKey.PROJECT, project)
+      .putExtra(IntentKey.KOALA_CONTEXT, KoalaContext.Message.CREATOR_BIO_MODAL);
   }
 
   private static @NonNull Intent messagesContextIntent(final @NonNull MessageThread messageThread) {

--- a/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/MessagesViewModelTest.java
@@ -501,6 +501,26 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
+  public void testStartBackingActivity_AsBacker_EmptyThread() {
+    final User user = UserFactory.user();
+    final Project project = ProjectFactory.project().toBuilder().isBacking(true).build();
+
+    final MockApiClient apiClient = new MockApiClient() {
+      @Override
+      public @NonNull Observable<MessageThreadEnvelope> fetchMessagesForBacking(final @NonNull Backing backing) {
+        return Observable.just(MessageThreadEnvelopeFactory.empty());
+      }
+    };
+
+    setUpEnvironment(environment().toBuilder().apiClient(apiClient).currentUser(new MockCurrentUser(user)).build());
+
+    this.vm.intent(creatorBioModalContextIntent(BackingFactory.backing(), project));
+    this.vm.inputs.viewPledgeButtonClicked();
+
+    this.startBackingActivity.assertValues(Pair.create(project, user));
+  }
+
+  @Test
   public void testStartBackingActivity_AsCreator() {
     final User backer = UserFactory.user().toBuilder().name("Vanessa").build();
     final User creator = UserFactory.user().toBuilder().name("Jessica").build();
@@ -627,12 +647,12 @@ public final class MessagesViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testViewPledgeButton_IsGone_creatorBioModal() {
+  public void testViewPledgeButton_IsVisible_creatorBioModal() {
     setUpEnvironment(environment().toBuilder().currentUser(new MockCurrentUser(UserFactory.user())).build());
     this.vm.intent(creatorBioModalContextIntent(BackingFactory.backing(), ProjectFactory.project()));
 
-    // View pledge button is hidden when context is from the creator bio modal.
-    this.viewPledgeButtonIsGone.assertValues(true);
+    // View pledge button is shown when context is from the creator bio modal.
+    this.viewPledgeButtonIsGone.assertValues(false);
   }
 
   @Test


### PR DESCRIPTION
# 📲 What
- This PR fixes the bug where the `Mark as received` switch was not visible when backers clicked the `View pledge` button (vs clicking the reward).
- Removing the `View Pledge` button in the `View pledge` screen when the user came from the creator bio.
- Fixes unsightly(!) overscroll in the `View pledge` screen.
- Fixes the crash when backers who try to start a message thread with the creator crashed when they clicked `View Pledge`.

# 🤔 Why
BUGS

# 🛠 How
- Previously~ I foolishly assumed that we'd only supply the `backer` to the `intent` to start the `BackingActivity` when a creator was viewing a backer's pledge not a backer viewing their own pledge... so now I'm just checking if the current user's `id` is the same as the backer's.
- Friendly reminder: If you're going to nest scrolling views, they need to be in a parent that supports nested scrolling or else they make scrolling janky (here I used `NestedScrollView`).
- Related to that, on the reward items list in the backing screen, I set `nestedScrollingEnabled` to `false` and `overscrollMode` to `never`.
- The `MessageViewModel` assumed the thread would never be empty so even though `View Pledge` was visible, the app crashed because we tried to access `messageThread.project` and the `messageThread` was null.
- Updated tests.

# 👀 See
Backer viewing their pledge by clicking `View Pledge` in the project footer

| Before 🐛 | After 🦋 |
| --- | --- |
| ![screenshot-2019-07-25_135859](https://user-images.githubusercontent.com/1289295/61897142-6f9f5400-aee4-11e9-8506-18de9a79a4f5.png) | ![screenshot-2019-07-25_135906](https://user-images.githubusercontent.com/1289295/61897153-76c66200-aee4-11e9-81c3-b719bbe31a5b.png) |
| Ugly overscroll 🐛 | After 🦋|
| ![device-2019-07-25-140226 2019-07-25 14_03_08](https://user-images.githubusercontent.com/1289295/61897502-28659300-aee5-11e9-93b9-91d2f2c6d5d9.gif) | ![device-2019-07-25-140200 2019-07-25 14_04_30](https://user-images.githubusercontent.com/1289295/61897515-2f8ca100-aee5-11e9-906b-5bb86daeb1df.gif) |

# 📋 QA
1. There are 3 ways for a backer to get to the `View Pledge` screen where they should **always** see the mark as received switch:
  a. Clicking the `View Pledge` button at the footer of the project page
  b. Clicking their backed reward on the project page
  c. Clicking the `View Pledge` button from the message screen
2. There is 1 way for a creator to get to the `View Pledge` screen where they should **never** see the mark as received switch:
  a. Clicking the `View Pledge` button from the message screen (Dashboard -> Messages -> Select a message from a backer)

# Story 📖
[Trello Story](https://trello.com/c/OEkPWaY1/1485-bug-android-bug-report-no-longer-able-to-mark-pledges-as-received)
