### PR TITLE
Set maximum width on button

### DIFF
--- a/app/src/main/res/layout/messages_backing_info_view.xml
+++ b/app/src/main/res/layout/messages_backing_info_view.xml
@@ -9,7 +9,6 @@
   android:background="@color/white"
   android:orientation="vertical"
   android:visibility="gone"
-  tools:showIn="@layout/messages_layout"
   tools:visibility="visible">
 
   <LinearLayout
@@ -30,11 +29,16 @@
       android:layout_weight="1"
       tools:text="$42 pledged on June 9, 2017" />
 
+    <Space
+      android:layout_height="match_parent"
+      android:layout_width="@dimen/grid_2"/>
+
     <Button
       style="@style/AlternatePrimaryButton"
       android:id="@+id/messages_view_pledge_button"
-      android:layout_width="wrap_content"
+      android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:layout_weight="1"
       tools:text="View pledge" />
 
   </LinearLayout>


### PR DESCRIPTION
# 📲 What

Set the maximum width of the _View pledge_ button to 50%.

# 🤔 Why

Messages in German (and perhaps other languages) causes the _View pledge_ button to clash with the pledge information text ([image](https://p14.zdusercontent.com/attachment/7902/yiFgNiaV5IeTlSsUYeBmYLsgx?token=eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0..9I8RHPyZJWfkmAT1j3tUXg.N078VVb84C2Rv6V7Z55NxiTKgUrsjRXQ7oIs4uAOv0bifs0i1J1i8TRQV7t2j_ZLKZMFpvfM1nqsBe8eOal7ZcbcqHqSgNa3q4y-jnklgqr_djiSdnE76t_H0C7Z3ZPbl53b4iqI0Q-7VMnz8oSqDFgfQjY2ll4vjjftGYf6U-j_1RcKuXwCoZ2zmKk8sx8XJWnK3yRd9ZbRqQii7EmBGc6JcAh95ajfcgbN3oyJAgcl7ycWARgMp6jja-y4fILltET1irjUwsV3alq0cN67jQ.V-Hi7e7E6aTgBqQ46a2myA)). This is because we didn't set a limit to the size of the button.

The button will now ellipsise instead of pushing the other content to a smidge, until the text gets a better translation. We agreed a button should be concise enough for this not to happen—i.e. a button should be able to share space with another 50% element on the line. 

# 🛠 How

Set both left and right sides to have `android:layout_weight`. Also added a `Space` between the two.

# 👀 See

The screenshot below is a fairly 'light' example of left-side text. Many instances would have a lot more text that needs to be balanced on the left side.

| Before 🐛 | After 🦋 |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/3104761/62155881-edde6a80-b2d7-11e9-94d7-4cb580b9276f.png) | ![after](https://user-images.githubusercontent.com/3104761/62155887-f040c480-b2d7-11e9-8e5d-8886987d7629.png) |

# 📋 QA

1. Log in with a Kickstarter account that has messaged a creator of a project they have backed (i.e. Native Squad)
2. Go to Messages
3. Go to a message thread with a creator of a project they have backed
4. See `View pledge` button match the above _After 🦋_ screenshot

# Story 📖

[broken message view](https://trello.com/c/NJKS3JX0)