### PR TITLE
Change method name 'param' to 'getID'

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/factories/UpdateFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/UpdateFactory.java
@@ -10,7 +10,7 @@ public final class UpdateFactory {
   public static Update update() {
     final User creator = UserFactory.creator().toBuilder().id(278438049).build();
     final Project project = ProjectFactory.project().toBuilder().creator(creator).build();
-    final String updatesUrl = "https://www.kck.str/projects/" + project.creator().param() + "/" + project.param() + "/posts";
+    final String updatesUrl = "https://www.kck.str/projects/" + project.creator().getID() + "/" + project.param() + "/posts";
 
     final Update.Urls.Web web = Update.Urls.Web.builder()
       .update(updatesUrl + "id")

--- a/app/src/main/java/com/kickstarter/models/User.java
+++ b/app/src/main/java/com/kickstarter/models/User.java
@@ -105,7 +105,7 @@ public abstract class User implements Parcelable, Relay {
     return new AutoParcel_User.Builder();
   }
 
-  public @NonNull String param() {
+  public @NonNull String getID() {
     return String.valueOf(this.id());
   }
 

--- a/app/src/main/java/com/kickstarter/services/ApiClient.java
+++ b/app/src/main/java/com/kickstarter/services/ApiClient.java
@@ -196,7 +196,7 @@ public final class ApiClient implements ApiClientType {
   @Override
   public @NonNull Observable<Backing> fetchProjectBacking(final @NonNull Project project, final @NonNull User user) {
     return this.service
-      .projectBacking(project.param(), user.param())
+      .projectBacking(project.param(), user.getID())
       .lift(apiErrorOperator())
       .subscribeOn(Schedulers.io());
   }


### PR DESCRIPTION
This class is used to manage User.  This method named 'param' is to get user ID. Thus, the method name 'getID' is more intuitive than 'param'.