### PR TITLE
[📦] Native checkout shipping summaries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -239,6 +239,7 @@ dependencies {
     implementation "com.google.firebase:firebase-messaging:$firebase_messaging_version"
     implementation "com.google.android.gms:play-services-wallet:$play_services_version"
     implementation "com.google.android.exoplayer:exoplayer:$exoplayer_version"
+    implementation 'com.google.android:flexbox:1.1.0'
     implementation "com.google.dagger:dagger:$dagger_version"
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
     implementation "com.jakewharton:butterknife:$butterknife_version"

--- a/app/src/main/java/com/kickstarter/ui/viewholders/NativeCheckoutRewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/NativeCheckoutRewardViewHolder.kt
@@ -89,6 +89,16 @@ class NativeCheckoutRewardViewHolder(private val view: View, val delegate: Deleg
                 .compose(observeForUI())
                 .subscribe { this.view.reward_pledge_button.setText(it) }
 
+        this.viewModel.outputs.shippingSummary()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.reward_shipping_summary.text = it }
+
+        this.viewModel.outputs.shippingSummaryIsGone()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { ViewUtils.setGone(this.view.reward_shipping_summary, it)}
+
         this.viewModel.outputs.minimumAmount()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())

--- a/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
@@ -255,7 +255,7 @@ interface NativeCheckoutRewardViewHolderViewModel {
                     .filter { RewardUtils.isShippable(it) }
                     .map { it.shippingSummary() }
 
-            this.shippingSummaryIsGone = projectAndReward
+            this.shippingSummaryIsGone = this.projectAndReward
                     .map { it.first.isLive && RewardUtils.isShippable(it.second) }
                     .map { BooleanUtils.negate(it) }
                     .distinctUntilChanged()

--- a/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
@@ -87,6 +87,12 @@ interface NativeCheckoutRewardViewHolderViewModel {
         /** Emits `true` if the items section should be hidden, `false` otherwise.  */
         fun rewardItemsAreGone(): Observable<Boolean>
 
+        /** Returns `true` if the shipping summary should be hidden, `false` otherwise.  */
+        fun shippingSummaryIsGone(): Observable<Boolean>
+
+        /** Set the shipping summary TextView's text.  */
+        fun shippingSummary(): Observable<String>
+
         /** Show [com.kickstarter.ui.fragments.PledgeFragment] with the project's reward selected.  */
         fun showPledgeFragment(): Observable<Pair<Project, Reward>>
 
@@ -129,6 +135,8 @@ interface NativeCheckoutRewardViewHolderViewModel {
         private val reward: Observable<Reward>
         private val rewardItems: Observable<List<RewardsItem>>
         private val rewardItemsAreGone: Observable<Boolean>
+        private val shippingSummary: Observable<String>
+        private val shippingSummaryIsGone: Observable<Boolean>
         private val showPledgeFragment: Observable<Pair<Project, Reward>>
         private val startBackingActivity: Observable<Project>
         private val titleForNoReward: Observable<Int>
@@ -227,11 +235,6 @@ interface NativeCheckoutRewardViewHolderViewModel {
                     .map { expirationDateIsGone(it.first, it.second) }
                     .distinctUntilChanged()
 
-            this.limitContainerIsGone = Observable.combineLatest(this.endDateSectionIsGone, this.remainingIsGone)
-            { endDateGone, remainingGone  -> Pair(endDateGone, remainingGone)}
-                    .map { it.first && it.second }
-                    .distinctUntilChanged()
-
             this.showPledgeFragment = this.projectAndReward
                     .filter { isSelectable(it.first, it.second) && it.first.isLive }
                     .compose<Pair<Project, Reward>>(takeWhen<Pair<Project, Reward>, Void>(this.rewardClicked))
@@ -247,6 +250,20 @@ interface NativeCheckoutRewardViewHolderViewModel {
             this.titleIsGone = reward
                     .map {  RewardUtils.isReward(it) && it.title().isNullOrEmpty() }
                     .distinctUntilChanged()
+
+            this.shippingSummary = reward
+                    .filter { RewardUtils.isShippable(it) }
+                    .map { it.shippingSummary() }
+
+            this.shippingSummaryIsGone = projectAndReward
+                    .map { it.first.isLive && RewardUtils.isShippable(it.second) }
+                    .map { BooleanUtils.negate(it) }
+                    .distinctUntilChanged()
+
+            this.limitContainerIsGone = Observable.combineLatest(this.endDateSectionIsGone, this.remainingIsGone, this.shippingSummaryIsGone)
+            { endDateGone, remainingGone, shippingGone  -> endDateGone && remainingGone && shippingGone }
+                    .distinctUntilChanged()
+
         }
 
         private fun expirationDateIsGone(project: Project, reward: Reward): Boolean {
@@ -340,6 +357,12 @@ interface NativeCheckoutRewardViewHolderViewModel {
 
         @NonNull
         override fun rewardItemsAreGone(): Observable<Boolean> = this.rewardItemsAreGone
+
+        @NonNull
+        override fun shippingSummary(): Observable<String> = this.shippingSummary
+
+        @NonNull
+        override fun shippingSummaryIsGone(): Observable<Boolean> = this.shippingSummaryIsGone
 
         @NonNull
         override fun showPledgeFragment(): Observable<Pair<Project, Reward>> = this.showPledgeFragment

--- a/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
@@ -87,11 +87,11 @@ interface NativeCheckoutRewardViewHolderViewModel {
         /** Emits `true` if the items section should be hidden, `false` otherwise.  */
         fun rewardItemsAreGone(): Observable<Boolean>
 
-        /** Returns `true` if the shipping summary should be hidden, `false` otherwise.  */
-        fun shippingSummaryIsGone(): Observable<Boolean>
-
         /** Set the shipping summary TextView's text.  */
         fun shippingSummary(): Observable<String>
+
+        /** Returns `true` if the shipping summary should be hidden, `false` otherwise.  */
+        fun shippingSummaryIsGone(): Observable<Boolean>
 
         /** Show [com.kickstarter.ui.fragments.PledgeFragment] with the project's reward selected.  */
         fun showPledgeFragment(): Observable<Pair<Project, Reward>>

--- a/app/src/main/res/drawable/divider_grid_1.xml
+++ b/app/src/main/res/drawable/divider_grid_1.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+  <size
+    android:width="@dimen/grid_1"
+    android:height="@dimen/grid_1" />
+</shape>

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -116,37 +116,40 @@
             tools:text="@string/Pledge_any_amount_to_help_bring_this_project_to_life" />
         </LinearLayout>
 
-        <LinearLayout
+        <com.google.android.flexbox.FlexboxLayout
           android:id="@+id/reward_limit_container"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginTop="@dimen/grid_3"
           android:orientation="horizontal"
           android:visibility="gone"
+          app:showDivider="middle"
+          app:dividerDrawable="@drawable/divider_grid_1"
+          app:flexWrap="wrap"
           tools:visibility="visible">
 
-          <TextView
+        <TextView
             android:id="@+id/reward_ending_text_view"
+            style="@style/RewardPill"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/grid_1"
-            android:background="@drawable/rect_green_alpha_6"
-            android:padding="@dimen/grid_1"
-            android:textColor="@color/ksr_green_500"
-            android:textStyle="bold"
             tools:text="3 days left" />
 
           <TextView
-            android:id="@+id/reward_remaining_text_view"
+            android:id="@+id/reward_shipping_summary"
+            style="@style/RewardPill"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:background="@drawable/rect_green_alpha_6"
-            android:padding="@dimen/grid_1"
-            android:textColor="@color/ksr_green_500"
-            android:textStyle="bold"
+            tools:text="Anywhere in the world" />
+
+          <TextView
+            android:id="@+id/reward_remaining_text_view"
+            style="@style/RewardPill"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             tools:text="30 left" />
 
-        </LinearLayout>
+        </com.google.android.flexbox.FlexboxLayout>
 
         <com.google.android.material.button.MaterialButton
           android:id="@+id/reward_button_placeholder"

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -136,18 +136,18 @@
             tools:text="3 days left" />
 
           <TextView
-            android:id="@+id/reward_shipping_summary"
-            style="@style/RewardPill"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            tools:text="Anywhere in the world" />
-
-          <TextView
             android:id="@+id/reward_remaining_text_view"
             style="@style/RewardPill"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             tools:text="30 left" />
+
+          <TextView
+            android:id="@+id/reward_shipping_summary"
+            style="@style/RewardPill"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="Anywhere in the world" />
 
         </com.google.android.flexbox.FlexboxLayout>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -583,6 +583,15 @@
     <item name="android:letterSpacing">.2</item>
   </style>
 
+  <style name="RewardPill" parent="FootnoteAccentMedium">
+    <item name="android:paddingTop">@dimen/grid_3_half</item>
+    <item name="android:paddingBottom">@dimen/grid_3_half</item>
+    <item name="android:paddingStart">@dimen/grid_2</item>
+    <item name="android:paddingEnd">@dimen/grid_2</item>
+    <item name="android:background">@drawable/rect_green_alpha_6</item>
+  </style>
+
+
   <!-- Creator Dashboard -->
   <style name="CreatorDashboardTableRowContainer">
     <item name="android:layout_width">match_parent</item>
@@ -748,14 +757,6 @@
     <item name="android:layout_marginEnd">@dimen/grid_1</item>
     <item name="android:layout_marginStart">@dimen/grid_1</item>
     <item name="android:foreground">@drawable/click_indicator_light</item>
-  </style>
-
-  <style name="RewardPill" parent="FootnoteAccentMedium">
-    <item name="android:paddingTop">@dimen/grid_3_half</item>
-    <item name="android:paddingBottom">@dimen/grid_3_half</item>
-    <item name="android:paddingStart">@dimen/grid_2</item>
-    <item name="android:paddingEnd">@dimen/grid_2</item>
-    <item name="android:background">@drawable/rect_green_alpha_6</item>
   </style>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -351,6 +351,12 @@
     <item name="android:fontFamily">@string/font_family_sans_serif</item>
   </style>
 
+  <style name="TextAccent">
+    <item name="android:textColor">@color/accent</item>
+    <item name="android:textStyle">normal</item>
+    <item name="android:fontFamily">@string/font_family_sans_serif</item>
+  </style>
+
   <style name="TextWhite">
     <item name="android:textColor">@color/white</item>
     <item name="android:textStyle">normal</item>
@@ -403,6 +409,14 @@
 
   <style name="FootnoteSecondaryMedium" parent="FootnoteSecondary">
     <item name="android:fontFamily">@string/font_family_sans_serif_medium</item>
+  </style>
+
+  <style name="FootnoteAccent" parent="TextAccent">
+    <item name="android:textSize">@dimen/footnote</item>
+  </style>
+
+  <style name="FootnoteAccentMedium" parent="FootnoteAccent">
+    <item name="android:textStyle">bold</item>
   </style>
 
   <style name="ProjectCardFootnote" parent="FootnoteSecondaryMedium">
@@ -734,6 +748,14 @@
     <item name="android:layout_marginEnd">@dimen/grid_1</item>
     <item name="android:layout_marginStart">@dimen/grid_1</item>
     <item name="android:foreground">@drawable/click_indicator_light</item>
+  </style>
+
+  <style name="RewardPill" parent="FootnoteAccentMedium">
+    <item name="android:paddingTop">@dimen/grid_3_half</item>
+    <item name="android:paddingBottom">@dimen/grid_3_half</item>
+    <item name="android:paddingStart">@dimen/grid_2</item>
+    <item name="android:paddingEnd">@dimen/grid_2</item>
+    <item name="android:background">@drawable/rect_green_alpha_6</item>
   </style>
 
 </resources>

--- a/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
@@ -41,6 +41,8 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
     private val reward = TestSubscriber<Reward>()
     private val rewardItems = TestSubscriber<List<RewardsItem>>()
     private val rewardItemsAreGone = TestSubscriber<Boolean>()
+    private val shippingSummary = TestSubscriber<String>()
+    private val shippingSummaryIsGone = TestSubscriber<Boolean>()
     private val showPledgeFragment = TestSubscriber<Pair<Project, Reward>>()
     private val startBackingActivity = TestSubscriber<Project>()
     private val titleForNoReward = TestSubscriber<Int>()
@@ -69,6 +71,8 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.reward().subscribe(this.reward)
         this.vm.outputs.rewardItems().subscribe(this.rewardItems)
         this.vm.outputs.rewardItemsAreGone().subscribe(this.rewardItemsAreGone)
+        this.vm.outputs.shippingSummary().subscribe(this.shippingSummary)
+        this.vm.outputs.shippingSummaryIsGone().subscribe(this.shippingSummaryIsGone)
         this.vm.outputs.showPledgeFragment().subscribe(this.showPledgeFragment)
         this.vm.outputs.startBackingActivity().subscribe(this.startBackingActivity)
         this.vm.outputs.titleForNoReward().subscribe(this.titleForNoReward)
@@ -486,6 +490,9 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.projectAndReward(project, RewardFactory.endingSoon())
         this.limitContainerIsGone.assertValues(true, false)
 
+        this.vm.inputs.projectAndReward(project, RewardFactory.rewardWithShipping())
+        this.limitContainerIsGone.assertValues(true, false)
+
         val limitedExpiringReward = RewardFactory.endingSoon().toBuilder()
                 .limit(10)
                 .remaining(5)
@@ -493,6 +500,15 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.projectAndReward(project, limitedExpiringReward)
         this.limitContainerIsGone.assertValues(true, false)
 
+        val limitedExpiringWithShippingReward = RewardFactory.rewardWithShipping().toBuilder()
+                .endsAt(DateTime.now().plusDays(2))
+                .limit(10)
+                .remaining(5)
+                .build()
+        this.vm.inputs.projectAndReward(project, limitedExpiringWithShippingReward)
+        this.limitContainerIsGone.assertValues(true, false)
+
+        //Ended project doesn't show limits
         this.vm.inputs.projectAndReward(ProjectFactory.successfulProject(), limitedExpiringReward)
         this.limitContainerIsGone.assertValues(true, false, true)
     }
@@ -575,6 +591,22 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.projectAndReward(project, itemizedReward)
         this.rewardItemsAreGone.assertValues(true, false)
         this.rewardItems.assertValues(itemizedReward.rewardsItems())
+    }
+
+    @Test
+    fun testShippingSummary() {
+        val project = ProjectFactory.project()
+        setUpEnvironment(environment())
+
+        // Summary should be hidden when reward is not shippable.
+        this.vm.inputs.projectAndReward(project, RewardFactory.reward())
+        this.shippingSummaryIsGone.assertValue(true)
+        this.shippingSummary.assertNoValues()
+
+        val shippableReward = RewardFactory.rewardWithShipping()
+        this.vm.inputs.projectAndReward(project, shippableReward)
+        this.shippingSummaryIsGone.assertValues(true, false)
+        this.shippingSummary.assertValues(shippableReward.shippingSummary())
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
@@ -477,40 +477,48 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testLimitContainerIsGone() {
+    fun testLimitContainerIsGone_noLimits() {
         val project = ProjectFactory.project()
         setUpEnvironment(environment())
 
         this.vm.inputs.projectAndReward(project, RewardFactory.reward())
         this.limitContainerIsGone.assertValue(true)
+    }
+
+    @Test
+    fun testLimitContainerIsGone_whenLimited() {
+        val project = ProjectFactory.project()
+        setUpEnvironment(environment())
 
         this.vm.inputs.projectAndReward(project, RewardFactory.limited())
-        this.limitContainerIsGone.assertValues(true, false)
+        this.limitContainerIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testLimitContainerIsGone_whenEndingSoon() {
+        val project = ProjectFactory.project()
+        setUpEnvironment(environment())
 
         this.vm.inputs.projectAndReward(project, RewardFactory.endingSoon())
-        this.limitContainerIsGone.assertValues(true, false)
+        this.limitContainerIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testLimitContainerIsGone_withShipping() {
+        val project = ProjectFactory.project()
+        setUpEnvironment(environment())
 
         this.vm.inputs.projectAndReward(project, RewardFactory.rewardWithShipping())
-        this.limitContainerIsGone.assertValues(true, false)
+        this.limitContainerIsGone.assertValue(false)
+    }
 
-        val limitedExpiringReward = RewardFactory.endingSoon().toBuilder()
-                .limit(10)
-                .remaining(5)
-                .build()
-        this.vm.inputs.projectAndReward(project, limitedExpiringReward)
-        this.limitContainerIsGone.assertValues(true, false)
+    @Test
+    fun testLimitContainerIsGone_endedProject() {
+        val project = ProjectFactory.successfulProject()
+        setUpEnvironment(environment())
 
-        val limitedExpiringWithShippingReward = RewardFactory.rewardWithShipping().toBuilder()
-                .endsAt(DateTime.now().plusDays(2))
-                .limit(10)
-                .remaining(5)
-                .build()
-        this.vm.inputs.projectAndReward(project, limitedExpiringWithShippingReward)
-        this.limitContainerIsGone.assertValues(true, false)
-
-        //Ended project doesn't show limits
-        this.vm.inputs.projectAndReward(ProjectFactory.successfulProject(), limitedExpiringReward)
-        this.limitContainerIsGone.assertValues(true, false, true)
+        this.vm.inputs.projectAndReward(project, RewardFactory.rewardWithShipping())
+        this.limitContainerIsGone.assertValue(true)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Displaying shipping restrictions.

# 🤔 Why
So users know where a reward can be shipped.

# 🛠 How
- Added `FlexboxLayout` so the limits section wraps if necessary.
- Added a style `RewardPill`  for reward pills since it's used in 3 places.
- Tests.

# 👀 See
| Ended Project 👻 | Live Project 🐥 | Flexing 💪🏾 |
| --- | --- | --- |
| ![screenshot-2019-08-06_145311](https://user-images.githubusercontent.com/1289295/62568004-58eceb80-b85a-11e9-8952-78b902707e81.png) | ![screenshot-2019-08-06_145311](https://user-images.githubusercontent.com/1289295/62567799-f72c8180-b859-11e9-86c7-4179362fd39f.png) | ![screenshot-2019-08-06_145405](https://user-images.githubusercontent.com/1289295/62567876-1a573100-b85a-11e9-8f9e-c431beef2ab5.png) |

# 📋 QA
👻 Ended projects don't show any limits because you can't pledge to it so they're irrelevant.
🐥Live projects display shipping summaries for rewards that are `shippable`.

# Story 📖
https://dripsprint.atlassian.net/browse/NT-42
