### PR TITLE
[🍗] Select

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -45,7 +45,7 @@ object RewardViewUtils {
      * Returns the string resource ID of the rewards button based on project and reward status.
      */
     @StringRes
-    fun pledgeButtonAlternateText(project: Project, reward: Reward): Int {
+    fun pledgeButtonText(project: Project, reward: Reward): Int {
         return if (BackingUtils.isBacked(project, reward) && project.isLive) {
             R.string.Manage_your_pledge
         } else if (BackingUtils.isBacked(project, reward) && !project.isLive) {
@@ -55,7 +55,7 @@ object RewardViewUtils {
         } else if (!RewardUtils.isAvailable(project, reward)) {
             R.string.No_longer_available
         } else {
-            throw IllegalStateException()
+            R.string.Select
         }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/NativeCheckoutRewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/NativeCheckoutRewardViewHolder.kt
@@ -84,15 +84,10 @@ class NativeCheckoutRewardViewHolder(private val view: View, val delegate: Deleg
                 .compose(observeForUI())
                 .subscribe { setRemainingRewardsTextView(it) }
 
-        this.viewModel.outputs.alternatePledgeButtonText()
+        this.viewModel.outputs.buttonCTA()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
                 .subscribe { this.view.reward_pledge_button.setText(it) }
-
-        this.viewModel.outputs.minimumAmount()
-                .compose(bindToLifecycle())
-                .compose(observeForUI())
-                .subscribe { setMinimumButtonText(it) }
 
         this.viewModel.outputs.minimumAmountTitle()
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
@@ -27,8 +27,8 @@ interface NativeCheckoutRewardViewHolderViewModel {
     }
 
     interface Outputs {
-        /**  Emits the string resource ID to set the pledge button when not displaying the minimum. */
-        fun alternatePledgeButtonText(): Observable<Int>
+        /**  Emits the string resource ID to set on the pledge button. */
+        fun buttonCTA(): Observable<Int>
 
         /** Emits `true` if pledge button can be clicked, `false` otherwise.  */
         fun buttonIsEnabled(): Observable<Boolean>
@@ -65,9 +65,6 @@ interface NativeCheckoutRewardViewHolderViewModel {
 
         /** Emits `true` if the limits container should be hidden, `false` otherwise. */
         fun limitContainerIsGone(): Observable<Boolean>
-
-        /** Emits the minimum pledge amount in the project's currency.  */
-        fun minimumAmount(): Observable<String>
 
         /** Emits the minimum pledge amount in the project's currency.  */
         fun minimumAmountTitle(): Observable<SpannableString>
@@ -109,7 +106,7 @@ interface NativeCheckoutRewardViewHolderViewModel {
         private val projectAndReward = PublishSubject.create<Pair<Project, Reward>>()
         private val rewardClicked = PublishSubject.create<Void>()
 
-        private val alternatePledgeButtonText: Observable<Int>
+        private val buttonCTA: Observable<Int>
         private val buttonIsEnabled: Observable<Boolean>
         private val buttonIsGone: Observable<Boolean>
         private val buttonTintColor: Observable<Int>
@@ -122,7 +119,6 @@ interface NativeCheckoutRewardViewHolderViewModel {
         private val descriptionIsGone: Observable<Boolean>
         private val endDateSectionIsGone: Observable<Boolean>
         private val limitContainerIsGone: Observable<Boolean>
-        private val minimumAmount: Observable<String>
         private val minimumAmountTitle: Observable<SpannableString>
         private val remaining: Observable<String>
         private val remainingIsGone: Observable<Boolean>
@@ -169,13 +165,8 @@ interface NativeCheckoutRewardViewHolderViewModel {
                     .map { !BackingUtils.isBacked(it.first, it.second) }
                     .distinctUntilChanged()
 
-            this.minimumAmount = this.projectAndReward
-                    .filter { shouldShowMinimum(it) }
-                    .map { this.ksCurrency.format(it.second.minimum(), it.first) }
-
-            this.alternatePledgeButtonText = this.projectAndReward
-                    .filter { shouldShowAlternateText(it.first, it.second) }
-                    .map { RewardViewUtils.pledgeButtonAlternateText(it.first, it.second) }
+            this.buttonCTA = this.projectAndReward
+                    .map { RewardViewUtils.pledgeButtonText(it.first, it.second) }
                     .distinctUntilChanged()
 
             this.conversionIsGone = this.projectAndReward
@@ -265,14 +256,6 @@ interface NativeCheckoutRewardViewHolderViewModel {
             return RewardUtils.isAvailable(project, reward)
         }
 
-        private fun shouldShowAlternateText(project: Project, reward: Reward): Boolean = when {
-            project.isLive -> project.isBacking || !RewardUtils.isAvailable(project, reward)
-            else -> BackingUtils.isBacked(project, reward)
-        }
-
-        private fun shouldShowMinimum(it: Pair<Project, Reward>) =
-                !it.first.isBacking && it.first.isLive && RewardUtils.isAvailable(it.first, it.second)
-
         override fun projectAndReward(@NonNull project: Project, @NonNull reward: Reward) {
             this.projectAndReward.onNext(Pair.create(project, reward))
         }
@@ -282,7 +265,7 @@ interface NativeCheckoutRewardViewHolderViewModel {
         }
 
         @NonNull
-        override fun alternatePledgeButtonText(): Observable<Int> = this.alternatePledgeButtonText
+        override fun buttonCTA(): Observable<Int> = this.buttonCTA
 
         @NonNull
         override fun buttonIsGone(): Observable<Boolean> = this.buttonIsGone
@@ -319,9 +302,6 @@ interface NativeCheckoutRewardViewHolderViewModel {
 
         @NonNull
         override fun limitContainerIsGone(): Observable<Boolean> = this.limitContainerIsGone
-
-        @NonNull
-        override fun minimumAmount(): Observable<String> = this.minimumAmount
 
         @NonNull
         override fun minimumAmountTitle(): Observable<SpannableString> = this.minimumAmountTitle

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -178,7 +178,7 @@
       style="@style/PledgeButton"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      tools:text="Pledge $10 or more" />
+      tools:text="Select" />
 
   </FrameLayout>
 

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
@@ -28,16 +28,17 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeButtonAlternateText() {
-        assertEquals(R.string.No_longer_available, RewardViewUtils.pledgeButtonAlternateText(ProjectFactory.project(), RewardFactory.ended()))
-        assertEquals(R.string.No_longer_available, RewardViewUtils.pledgeButtonAlternateText(ProjectFactory.project(), RewardFactory.limitReached()))
+    fun testPledgeButtonText() {
+        assertEquals(R.string.Select, RewardViewUtils.pledgeButtonText(ProjectFactory.project(), RewardFactory.reward()))
+        assertEquals(R.string.No_longer_available, RewardViewUtils.pledgeButtonText(ProjectFactory.project(), RewardFactory.ended()))
+        assertEquals(R.string.No_longer_available, RewardViewUtils.pledgeButtonText(ProjectFactory.project(), RewardFactory.limitReached()))
         val backedProject = ProjectFactory.backedProject()
         val backedReward = backedProject.backing()?.reward()?: RewardFactory.reward()
-        assertEquals(R.string.Manage_your_pledge, RewardViewUtils.pledgeButtonAlternateText(backedProject, backedReward))
-        assertEquals(R.string.Select_this_instead, RewardViewUtils.pledgeButtonAlternateText(backedProject, RewardFactory.reward()))
+        assertEquals(R.string.Manage_your_pledge, RewardViewUtils.pledgeButtonText(backedProject, backedReward))
+        assertEquals(R.string.Select_this_instead, RewardViewUtils.pledgeButtonText(backedProject, RewardFactory.reward()))
         val backedSuccessfulProject = ProjectFactory.backedProject().toBuilder().state(Project.STATE_SUCCESSFUL).build()
         val backedSuccessfulReward = backedSuccessfulProject.backing()?.reward()?: RewardFactory.reward()
-        assertEquals(R.string.View_your_pledge, RewardViewUtils.pledgeButtonAlternateText(backedSuccessfulProject, backedSuccessfulReward))
+        assertEquals(R.string.View_your_pledge, RewardViewUtils.pledgeButtonText(backedSuccessfulProject, backedSuccessfulReward))
     }
 
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
@@ -21,7 +21,7 @@ import rx.observers.TestSubscriber
 class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var vm: NativeCheckoutRewardViewHolderViewModel.ViewModel
-    private val alternatePledgeButtonText = TestSubscriber.create<Int>()
+    private val buttonCTA = TestSubscriber.create<Int>()
     private val buttonIsEnabled = TestSubscriber<Boolean>()
     private val buttonIsGone = TestSubscriber.create<Boolean>()
     private val buttonTint = TestSubscriber.create<Int>()
@@ -34,7 +34,6 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
     private val descriptionIsGone = TestSubscriber<Boolean>()
     private val endDateSectionIsGone = TestSubscriber<Boolean>()
     private val limitContainerIsGone = TestSubscriber<Boolean>()
-    private val minimumAmount = TestSubscriber<String>()
     private val minimumAmountTitle = TestSubscriber<String>()
     private val remaining = TestSubscriber<String>()
     private val remainingIsGone = TestSubscriber<Boolean>()
@@ -49,7 +48,7 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = NativeCheckoutRewardViewHolderViewModel.ViewModel(environment)
-        this.vm.outputs.alternatePledgeButtonText().subscribe(this.alternatePledgeButtonText)
+        this.vm.outputs.buttonCTA().subscribe(this.buttonCTA)
         this.vm.outputs.buttonIsEnabled().subscribe(this.buttonIsEnabled)
         this.vm.outputs.buttonIsGone().subscribe(this.buttonIsGone)
         this.vm.outputs.buttonTint().subscribe(this.buttonTint)
@@ -64,7 +63,6 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.remaining().subscribe(this.remaining)
         this.vm.outputs.remainingIsGone().subscribe(this.remainingIsGone)
         this.vm.outputs.limitContainerIsGone().subscribe(this.limitContainerIsGone)
-        this.vm.outputs.minimumAmount().map { it.toString() }.subscribe(this.minimumAmount)
         this.vm.outputs.minimumAmountTitle().map { it.toString() }.subscribe(this.minimumAmountTitle)
         this.vm.outputs.reward().subscribe(this.reward)
         this.vm.outputs.rewardItems().subscribe(this.rewardItems)
@@ -87,58 +85,50 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.projectAndReward(project, reward)
         this.buttonIsGone.assertValue(false)
         this.buttonTint.assertValue(R.color.button_pledge_live)
-        this.minimumAmount.assertValuesAndClear("$20")
-        this.alternatePledgeButtonText.assertNoValues()
+        this.buttonCTA.assertValue(R.string.Select)
 
         //Live project, no reward, not backed
         this.vm.inputs.projectAndReward(project, noReward)
         this.buttonIsGone.assertValue(false)
         this.buttonTint.assertValue(R.color.button_pledge_live)
-        this.minimumAmount.assertValuesAndClear("$1")
-        this.alternatePledgeButtonText.assertNoValues()
+        this.buttonCTA.assertValuesAndClear(R.string.Select)
 
         //Live project, unavailable limited reward, not backed
         this.vm.inputs.projectAndReward(project, RewardFactory.limitReached())
         this.buttonIsGone.assertValue(false)
         this.buttonTint.assertValue(R.color.button_pledge_live)
-        this.minimumAmount.assertNoValues()
-        this.alternatePledgeButtonText.assertValue(R.string.No_longer_available)
+        this.buttonCTA.assertValue(R.string.No_longer_available)
 
         //Live project, unavailable expired reward, not backed
         this.vm.inputs.projectAndReward(project, RewardFactory.ended())
         this.buttonIsGone.assertValue(false)
         this.buttonTint.assertValue(R.color.button_pledge_live)
-        this.minimumAmount.assertNoValues()
-        this.alternatePledgeButtonText.assertValuesAndClear(R.string.No_longer_available)
+        this.buttonCTA.assertValuesAndClear(R.string.No_longer_available)
 
         //Live backed project, currently backed reward
         val backedLiveProject = ProjectFactory.backedProject()
         this.vm.inputs.projectAndReward(backedLiveProject, backedLiveProject.backing()?.reward()?: RewardFactory.reward())
         this.buttonIsGone.assertValues(false)
         this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage)
-        this.minimumAmount.assertNoValues()
-        this.alternatePledgeButtonText.assertValuesAndClear(R.string.Manage_your_pledge)
+        this.buttonCTA.assertValuesAndClear(R.string.Manage_your_pledge)
 
         //Live backed project, not backed available reward
         this.vm.inputs.projectAndReward(backedLiveProject, RewardFactory.reward())
         this.buttonIsGone.assertValues(false)
         this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live)
-        this.minimumAmount.assertNoValues()
-        this.alternatePledgeButtonText.assertValuesAndClear(R.string.Select_this_instead)
+        this.buttonCTA.assertValuesAndClear(R.string.Select_this_instead)
 
         //Live backed project, not backed unavailable limited reward
         this.vm.inputs.projectAndReward(backedLiveProject, RewardFactory.limitReached())
         this.buttonIsGone.assertValues(false)
         this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live)
-        this.minimumAmount.assertNoValues()
-        this.alternatePledgeButtonText.assertValue(R.string.No_longer_available)
+        this.buttonCTA.assertValue(R.string.No_longer_available)
 
         //Live backed project, not backed unavailable expired reward
         this.vm.inputs.projectAndReward(backedLiveProject, RewardFactory.limitReached())
         this.buttonIsGone.assertValues(false)
         this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live)
-        this.minimumAmount.assertNoValues()
-        this.alternatePledgeButtonText.assertValuesAndClear(R.string.No_longer_available)
+        this.buttonCTA.assertValuesAndClear(R.string.No_longer_available)
 
         //Ended project, available reward, not backed
         val successfulProject = ProjectFactory.successfulProject()
@@ -148,8 +138,7 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.projectAndReward(successfulProject, reward)
         this.buttonIsGone.assertValues(false, true)
         this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live, R.color.button_pledge_ended)
-        this.minimumAmount.assertNoValues()
-        this.alternatePledgeButtonText.assertNoValues()
+        this.buttonCTA.assertNoValues()
 
         //Ended backed project, not pledged
         val backedSuccessfulProject = ProjectFactory.backedProject()
@@ -159,22 +148,19 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.projectAndReward(backedSuccessfulProject, reward)
         this.buttonIsGone.assertValues(false, true)
         this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live, R.color.button_pledge_ended)
-        this.minimumAmount.assertNoValues()
-        this.alternatePledgeButtonText.assertNoValues()
+        this.buttonCTA.assertNoValues()
 
         //Ended backed project, no reward, not pledged
         this.vm.inputs.projectAndReward(backedSuccessfulProject, noReward)
         this.buttonIsGone.assertValues(false, true)
         this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live, R.color.button_pledge_ended)
-        this.minimumAmount.assertNoValues()
-        this.alternatePledgeButtonText.assertNoValues()
+        this.buttonCTA.assertNoValues()
 
         //Ended backed project, pledged reward
         this.vm.inputs.projectAndReward(backedSuccessfulProject, backedSuccessfulProject.backing()?.reward()?: reward)
         this.buttonIsGone.assertValues(false, true, false)
         this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live, R.color.button_pledge_ended)
-        this.minimumAmount.assertNoValues()
-        this.alternatePledgeButtonText.assertValue(R.string.View_your_pledge)
+        this.buttonCTA.assertValue(R.string.View_your_pledge)
 
         val backedNoRewardSuccessfulProject = ProjectFactory.backedProjectWithNoReward()
                 .toBuilder()
@@ -184,8 +170,7 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.projectAndReward(backedNoRewardSuccessfulProject, noReward)
         this.buttonIsGone.assertValues(false, true, false)
         this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live, R.color.button_pledge_ended)
-        this.minimumAmount.assertNoValues()
-        this.alternatePledgeButtonText.assertValue(R.string.View_your_pledge)
+        this.buttonCTA.assertValue(R.string.View_your_pledge)
     }
 
     @Test
@@ -495,18 +480,6 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.projectAndReward(ProjectFactory.successfulProject(), limitedExpiringReward)
         this.limitContainerIsGone.assertValues(true, false, true)
-    }
-
-    @Test
-    fun testMinimumAmount_whenCAProject() {
-        val project = ProjectFactory.caProject()
-        val reward = RewardFactory.reward().toBuilder()
-                .minimum(10.0)
-                .build()
-        setUpEnvironment(environment())
-
-        this.vm.inputs.projectAndReward(project, reward)
-        this.minimumAmount.assertValue("CA$ 10")
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Native checkout reward pledge button default CTA is `Select`

# 🤔 Why
> Button copy should not be dynamic

# 🛠 How
Native checkout reward pledge buttons now display `Select` as the live, unbacked CTA.
Renamed `RewardViewUtils.pledgeButtonAlternateText` to `pledgeButtonText` since `Select` is now the default value.
Removed `minimum` output from `NativeCheckoutRewardViewHolder` since it's now unused.
Updated tests.

# 👀 See

| Select 🍗 | 
| --- |
| ![screenshot-2019-08-06_152707](https://user-images.githubusercontent.com/1289295/62571156-ac613880-b85e-11e9-9c02-23c3bf06147c.png) | 

# 📋 QA
1️⃣ Live, not backed -> `Select`
2️⃣ Live, backed -> `Manage your pledge`
3️⃣ Ended, backed -> `View your pledge`
4️⃣ Live, sold out/expired (not backed) -> `No longer available`
5️⃣ Live, not backed -> `Select this instead`
6️⃣ Ended, not backed -> Button is gone

# Story 📖
https://dripsprint.atlassian.net/browse/NT-43
