### PR TITLE
[🔜] Prelaunch project MVP

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
@@ -285,4 +285,19 @@ public final class ProjectFactory {
       .staffPick(true)
       .build();
   }
+
+  public static Project prelaunchProject(String projectUrl) {
+
+    final Project.Urls.Web web = Project.Urls.Web.builder()
+      .project(projectUrl)
+      .rewards(projectUrl + "/rewards")
+      .updates(projectUrl + "/posts")
+      .build();
+
+    return project()
+      .toBuilder()
+      .prelaunchActivated(true)
+      .urls(Project.Urls.builder().web(web).build())
+      .build();
+  }
 }

--- a/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
@@ -286,7 +286,7 @@ public final class ProjectFactory {
       .build();
   }
 
-  public static Project prelaunchProject(String projectUrl) {
+  public static Project prelaunchProject(final String projectUrl) {
 
     final Project.Urls.Web web = Project.Urls.Web.builder()
       .project(projectUrl)

--- a/app/src/main/java/com/kickstarter/models/Project.java
+++ b/app/src/main/java/com/kickstarter/models/Project.java
@@ -50,6 +50,7 @@ public abstract class Project implements Parcelable, Relay {
   public abstract @Nullable List<Permission> permissions();
   public abstract double pledged();
   public abstract @Nullable Photo photo();
+  public abstract @Nullable Boolean prelaunchActivated();
   public abstract @Nullable List<Reward> rewards();
   public abstract @Nullable String slug();
   public abstract @Nullable Boolean staffPick();
@@ -92,6 +93,7 @@ public abstract class Project implements Parcelable, Relay {
     public abstract Builder permissions(List<Permission> __);
     public abstract Builder pledged(double __);
     public abstract Builder photo(Photo __);
+    public abstract Builder prelaunchActivated(Boolean __);
     public abstract Builder rewards(List<Reward> __);
     public abstract Builder slug(String __);
     public abstract Builder staffPick(Boolean __);

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -377,7 +377,28 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     }
 
     private fun openProjectAndFinish(url: String) {
-        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        val uri = Uri.parse(url)
+
+        val fakeUri = Uri.parse("http://www.kickstarter.com")
+        val browserIntent = Intent(Intent.ACTION_VIEW, fakeUri)
+        val queryIntentActivities = packageManager.queryIntentActivities(browserIntent, 0)
+        val targetIntents = queryIntentActivities
+                .filter { !it.activityInfo.packageName.contains("com.kickstarter") }
+                .map { resolveInfo ->
+                    val intent = Intent(Intent.ACTION_VIEW, uri)
+                    intent.setPackage(resolveInfo.activityInfo.packageName)
+                    intent
+                }
+                .toMutableList()
+
+        if (targetIntents.isNotEmpty()) {
+            /* We need to remove the first intent so it's not duplicated
+            when we add the EXTRA_INITIAL_INTENTS intents. */
+            val chooserIntent = Intent.createChooser(targetIntents.removeAt(0), "")
+            chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, targetIntents.toTypedArray())
+            startActivity(chooserIntent)
+        }
+
         finish()
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -6,6 +6,7 @@ import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
 import android.content.Intent
 import android.graphics.Rect
+import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.util.Pair
@@ -232,6 +233,11 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { showCancelPledgeSuccess() }
 
+        this.viewModel.outputs.openProjectExternally()
+                .compose(bindToLifecycle())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe { openProjectAndFinish(it) }
+
         this.heartIcon.setOnClickListener {
             this.viewModel.inputs.heartButtonClicked()
         }
@@ -368,6 +374,11 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 super.back()
             }
         }
+    }
+
+    private fun openProjectAndFinish(url: String) {
+        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        finish()
     }
 
     private fun renderProject(projectAndCountry: Pair<Project, String>) {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -233,7 +233,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { showCancelPledgeSuccess() }
 
-        this.viewModel.outputs.openProjectExternally()
+        this.viewModel.outputs.prelaunchUrl()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { openProjectAndFinish(it) }

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -7,10 +7,7 @@ import com.kickstarter.R
 import com.kickstarter.libs.*
 import com.kickstarter.libs.preferences.BooleanPreferenceType
 import com.kickstarter.libs.rx.transformers.Transformers.*
-import com.kickstarter.libs.utils.BooleanUtils
-import com.kickstarter.libs.utils.ProjectViewUtils
-import com.kickstarter.libs.utils.RefTagUtils
-import com.kickstarter.libs.utils.RewardUtils
+import com.kickstarter.libs.utils.*
 import com.kickstarter.models.Project
 import com.kickstarter.models.User
 import com.kickstarter.services.ApiClientType
@@ -83,6 +80,9 @@ interface ProjectViewModel {
 
         /** Emits a drawable id that corresponds to whether the project is saved. */
         fun heartDrawableId(): Observable<Int>
+
+        /**  */
+        fun openProjectExternally(): Observable<String>
 
         /** Emits a project and country when a new value is available. If the view model is created with a full project
          * model, this observable will emit that project immediately, and then again when it has updated from the api.  */
@@ -171,6 +171,7 @@ interface ProjectViewModel {
         private val backingDetails = BehaviorSubject.create<String>()
         private val backingDetailsIsVisible = BehaviorSubject.create<Boolean>()
         private val heartDrawableId = BehaviorSubject.create<Int>()
+        private val openProjectExternally = PublishSubject.create<String>()
         private val projectAndUserCountry = BehaviorSubject.create<Pair<Project, String>>()
         private val rewardsButtonColor = BehaviorSubject.create<Int>()
         private val rewardsButtonText = BehaviorSubject.create<Int>()
@@ -196,9 +197,18 @@ interface ProjectViewModel {
 
         init {
 
-            val initialProject = intent()
+            val mappedProject = intent()
                     .flatMap { i -> ProjectIntentMapper.project(i, this.client) }
                     .share()
+
+            mappedProject
+                    .filter { ObjectUtils.coalesce(it.prelaunchActivated(), false) }
+                    .map { it.webProjectUrl() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.openProjectExternally)
+
+            val initialProject = mappedProject
+                    .filter { !ObjectUtils.coalesce(it.prelaunchActivated(), false) }
 
             // An observable of the ref tag stored in the cookie for the project. Can emit `null`.
             val cookieRefTag = initialProject
@@ -533,6 +543,9 @@ interface ProjectViewModel {
 
         @NonNull
         override fun heartDrawableId(): Observable<Int> = this.heartDrawableId
+
+        @NonNull
+        override fun openProjectExternally(): Observable<String> = this.openProjectExternally
 
         @NonNull
         override fun projectAndUserCountry(): Observable<Pair<Project, String>> = this.projectAndUserCountry

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -51,7 +51,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.backingDetails().subscribe(this.backingDetails)
         this.vm.outputs.backingDetailsIsVisible().subscribe(this.backingDetailsIsVisible)
         this.vm.outputs.heartDrawableId().subscribe(this.heartDrawableId)
-        this.vm.outputs.openProjectExternally().subscribe(this.openProjectExternally)
+        this.vm.outputs.prelaunchUrl().subscribe(this.openProjectExternally)
         this.vm.outputs.projectAndUserCountry().map { pc -> pc.first }.subscribe(this.projectTest)
         this.vm.outputs.rewardsButtonColor().subscribe(this.rewardsButtonColor)
         this.vm.outputs.rewardsButtonText().subscribe(this.rewardsButtonText)

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -29,7 +29,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     private val expandPledgeSheet = TestSubscriber<Boolean>()
     private val heartDrawableId = TestSubscriber<Int>()
     private val managePledgeMenuIsVisible = TestSubscriber<Boolean>()
-    private val openProjectExternally = TestSubscriber<String>()
+    private val prelaunchUrl = TestSubscriber<String>()
     private val projectTest = TestSubscriber<Project>()
     private val revealRewardsFragment = TestSubscriber<Void>()
     private val rewardsButtonColor = TestSubscriber<Int>()
@@ -60,7 +60,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.expandPledgeSheet().subscribe(this.expandPledgeSheet)
         this.vm.outputs.heartDrawableId().subscribe(this.heartDrawableId)
         this.vm.outputs.managePledgeMenuIsVisible().subscribe(this.managePledgeMenuIsVisible)
-        this.vm.outputs.prelaunchUrl().subscribe(this.openProjectExternally)
+        this.vm.outputs.prelaunchUrl().subscribe(this.prelaunchUrl)
         this.vm.outputs.projectAndUserCountry().map { pc -> pc.first }.subscribe(this.projectTest)
         this.vm.outputs.revealRewardsFragment().subscribe(this.revealRewardsFragment)
         this.vm.outputs.rewardsButtonColor().subscribe(this.rewardsButtonColor)
@@ -118,7 +118,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.intent(Intent(Intent.ACTION_VIEW, uri))
 
         this.projectTest.assertValues(project)
-        this.openProjectExternally.assertNoValues()
+        this.prelaunchUrl.assertNoValues()
         this.koalaTest.assertValues(KoalaEvent.PROJECT_PAGE, KoalaEvent.VIEWED_PROJECT_PAGE)
     }
 
@@ -143,7 +143,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.intent(Intent(Intent.ACTION_VIEW, uri))
 
         this.projectTest.assertNoValues()
-        this.openProjectExternally.assertValue(url)
+        this.prelaunchUrl.assertValue(url)
         this.koalaTest.assertNoValues()
     }
 


### PR DESCRIPTION
# 📲 What
Prelaunch projects open in the browser 🌍 

# 🤔 Why
So users are taken to the prelaunch webpage when it's #activated.

# 🛠 How
- One does not simply _open a URL in the browser_, especially if that link is identical to a deep link it supports because then it just creates a very sad feedback loop. So, I had to use the same logic in the `DeepLinkActivity`; by creating an `Intent` chooser to present the user with options to open the link, not including the app they're already in!
- When the API returns a project where `prelaunchActivated` is `true`, the project opens in the browser.
- When the API returns a project where `prelaunchActivated` is `false`, the project opens natively.
- Tests ❤️ 

# 👀 See
| Pretend this project is prelaunchActivated~ | 
| --- |
| ![device-2019-08-12-145520 2019-08-12 14_56_15](https://user-images.githubusercontent.com/1289295/62890573-c04ee380-bd11-11e9-8c42-81e22f318b41.gif) | 

# 📋 QA
🔙 Regression test:  Projects that are not prelaunch activated should deep link normally.
🔜 Prelaunch projects should present the user with options of how to open the link. If you only have one browser installed, it'll just open it.

# Story 📖
https://dripsprint.atlassian.net/browse/NT-97

cc @kickstarter/procomm 