### PR TITLE
[🆕] Manage pledge menu

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -35,10 +35,7 @@ import com.kickstarter.models.User
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.adapters.ProjectAdapter
 import com.kickstarter.ui.data.LoginReason
-import com.kickstarter.ui.fragments.CancelPledgeFragment
-import com.kickstarter.ui.fragments.NewCardFragment
-import com.kickstarter.ui.fragments.PledgeFragment
-import com.kickstarter.ui.fragments.RewardsFragment
+import com.kickstarter.ui.fragments.*
 import com.kickstarter.viewmodels.ProjectViewModel
 import com.stripe.android.view.StripeEditText
 import kotlinx.android.synthetic.main.activity_project.*
@@ -97,6 +94,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 this.supportFragmentManager.addOnBackStackChangedListener {
                     this.viewModel.inputs.fragmentStackCount(this.supportFragmentManager.backStackEntryCount)
                 }
+
             }
             else -> {
                 project_action_buttons.visibility = when {
@@ -231,6 +229,16 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { showCancelPledgeSuccess() }
+
+        this.viewModel.outputs.showRewardsFragment()
+                .compose(bindToLifecycle())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe { showRewardsFragment(it) }
+
+        this.viewModel.outputs.showBackingFragment()
+                .compose(bindToLifecycle())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe { showBackingFragment(it) }
 
         this.heartIcon.setOnClickListener {
             this.viewModel.inputs.heartButtonClicked()
@@ -390,9 +398,30 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         this.projectRecyclerView.setPadding(0, 0, 0, guideline)
     }
 
-    private fun setupRewardsFragment(project: Project) {
-        val rewardsFragment = supportFragmentManager.findFragmentByTag(RewardsFragment.) as RewardsFragment?: RewardsFragment()
+    private fun showRewardsFragment(project: Project) {
+        val tag = RewardsFragment::class.java.simpleName
+        val rewardsFragment = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment
+        val backingFragment = supportFragmentManager.findFragmentById(R.id.fragment_backing) as BackingFragment
+        if(!backingFragment.isHidden) {
+            supportFragmentManager.beginTransaction()
+                    .show(rewardsFragment)
+                    .hide(backingFragment)
+                    .commit()
+        }
         rewardsFragment.takeProject(project)
+    }
+
+    private fun showBackingFragment(project: Project) {
+        val tag = RewardsFragment::class.java.simpleName
+        val rewardsFragment = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment
+        val backingFragment = supportFragmentManager.findFragmentById(R.id.fragment_backing) as BackingFragment
+        if(!rewardsFragment.isHidden) {
+            supportFragmentManager.beginTransaction()
+                    .show(backingFragment)
+                    .hide(rewardsFragment)
+                    .commit()
+        }
+        backingFragment.takeProject(project)
     }
 
     private fun showCancelPledgeSuccess() {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -162,7 +162,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { setInitialRewardsContainerY() }
 
-        this.viewModel.outputs.showRewardsFragment()
+        this.viewModel.outputs.expandPledgeSheet()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { animateRewards(it) }
@@ -376,8 +376,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         this.adapter.takeProject(project, country, environment().nativeCheckoutPreference().get())
         if (!environment().nativeCheckoutPreference().get()) {
             ProjectViewUtils.setActionButton(project, this.back_project_button, this.manage_pledge_button, this.view_pledge_button, null)
-        } else {
-            setupRewardsFragment(project)
         }
     }
 
@@ -393,8 +391,8 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     }
 
     private fun setupRewardsFragment(project: Project) {
-        val rewardsFragment = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment?
-        rewardsFragment?.takeProject(project)
+        val rewardsFragment = supportFragmentManager.findFragmentByTag(RewardsFragment.) as RewardsFragment?: RewardsFragment()
+        rewardsFragment.takeProject(project)
     }
 
     private fun showCancelPledgeSuccess() {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -91,7 +91,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 }
 
                 rewards_toolbar.setNavigationOnClickListener {
-                    this.viewModel.inputs.hideRewardsSheetClicked()
+                    this.viewModel.inputs.collapsePledgeSheet()
                 }
 
                 rewards_toolbar.setOnMenuItemClickListener {
@@ -424,7 +424,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         val rewardsSheetIsExpanded = pledge_container.alpha == 1f
         when {
             supportFragmentManager.backStackEntryCount > 0 && rewardsSheetIsExpanded -> supportFragmentManager.popBackStack()
-            rewardsSheetIsExpanded -> this.viewModel.inputs.hideRewardsSheetClicked()
+            rewardsSheetIsExpanded -> this.viewModel.inputs.collapsePledgeSheet()
             else -> {
                 clearFragmentBackStack()
                 super.back()
@@ -467,40 +467,9 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         this.projectRecyclerView.setPadding(0, 0, 0, guideline)
     }
 
-    private fun showRewardsFragment(project: Project) {
-        val (rewardsFragment, backingFragment) = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment to
-        supportFragmentManager.findFragmentById(R.id.fragment_backing) as BackingFragment
-        if(!backingFragment.isHidden && supportFragmentManager.backStackEntryCount == 0) {
-            supportFragmentManager.beginTransaction()
-                    .show(rewardsFragment)
-                    .hide(backingFragment)
-                    .commit()
-        }
-        renderProject(backingFragment, rewardsFragment,project)
-    }
-
-    private fun showCancelPledgeFragment(project: Project) {
-        supportFragmentManager
-                .beginTransaction()
-                .setCustomAnimations(R.anim.slide_up, 0, 0, R.anim.slide_down)
-                .add(R.id.fragment_container, CancelPledgeFragment.newInstance(project), CancelPledgeFragment::class.java.simpleName)
-                .addToBackStack(CancelPledgeFragment::class.java.simpleName)
-                .commit()
-    }
-
-    private fun showPledgeFragment(pledgeDataAndPledgeReason: Pair<PledgeData, PledgeReason>) {
-        val pledgeFragment = PledgeFragment.newInstance(pledgeDataAndPledgeReason.first)
-        supportFragmentManager
-                .beginTransaction()
-                .setCustomAnimations(R.anim.slide_up, 0, 0, R.anim.slide_down)
-                .add(R.id.fragment_container, pledgeFragment, PledgeFragment::class.java.simpleName)
-                .addToBackStack(PledgeFragment::class.java.simpleName)
-                .commit()
-    }
-
     private fun showBackingFragment(project: Project) {
         val (rewardsFragment, backingFragment) = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment to
-        supportFragmentManager.findFragmentById(R.id.fragment_backing) as BackingFragment
+                supportFragmentManager.findFragmentById(R.id.fragment_backing) as BackingFragment
         if(!rewardsFragment.isHidden && supportFragmentManager.backStackEntryCount == 0) {
             supportFragmentManager.beginTransaction()
                     .show(backingFragment)
@@ -510,11 +479,49 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         renderProject(backingFragment, rewardsFragment, project)
     }
 
+    private fun showCancelPledgeFragment(project: Project) {
+        val cancelPledgeFragment = CancelPledgeFragment.newInstance(project)
+        val tag = CancelPledgeFragment::class.java.simpleName
+        supportFragmentManager
+                .beginTransaction()
+                .setCustomAnimations(R.anim.slide_up, 0, 0, R.anim.slide_down)
+                .add(R.id.fragment_container, cancelPledgeFragment, tag)
+                .addToBackStack(tag)
+                .commit()
+    }
+
     private fun showCancelPledgeSuccess() {
         clearFragmentBackStack()
         Handler().postDelayed({
             showSnackbar(snackbar_anchor, getString(R.string.Youve_canceled_your_pledge))
         }, this.animDuration)
+    }
+
+    private fun showPledgeFragment(pledgeDataAndPledgeReason: Pair<PledgeData, PledgeReason>) {
+        val pledgeFragment = PledgeFragment.newInstance(pledgeDataAndPledgeReason.first)
+        val tag = PledgeFragment::class.java.simpleName
+        supportFragmentManager
+                .beginTransaction()
+                .setCustomAnimations(R.anim.slide_up, 0, 0, R.anim.slide_down)
+                .add(R.id.fragment_container, pledgeFragment, tag)
+                .addToBackStack(tag)
+                .commit()
+    }
+
+    private fun showRewardsFragment(project: Project) {
+        val (rewardsFragment, backingFragment) = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment to
+        supportFragmentManager.findFragmentById(R.id.fragment_backing) as BackingFragment
+        if(!backingFragment.isHidden && supportFragmentManager.backStackEntryCount == 0) {
+            supportFragmentManager.beginTransaction()
+                    .show(rewardsFragment)
+                    .hide(backingFragment)
+                    .commit()
+        }
+        renderProject(backingFragment, rewardsFragment, project)
+    }
+
+    private fun showStarToast() {
+        ViewUtils.showToastFromTop(this, getString(this.projectStarConfirmationString), 0, resources.getDimensionPixelSize(R.dimen.grid_8))
     }
 
     private fun startCampaignWebViewActivity(project: Project) {
@@ -532,10 +539,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         val intent = Intent(this, ProjectUpdatesActivity::class.java)
                 .putExtra(IntentKey.PROJECT, project)
         startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
-    }
-
-    private fun showStarToast() {
-        ViewUtils.showToastFromTop(this, getString(this.projectStarConfirmationString), 0, resources.getDimensionPixelSize(R.dimen.grid_8))
     }
 
     private fun startCheckoutActivity(project: Project) {

--- a/app/src/main/java/com/kickstarter/ui/data/PledgeData.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/PledgeData.kt
@@ -3,4 +3,6 @@ package com.kickstarter.ui.data
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 
-data class PledgeData(val rewardScreenLocation: ScreenLocation, val reward: Reward, val project: Project)
+data class PledgeData(val rewardScreenLocation: ScreenLocation?, val reward: Reward, val project: Project) {
+    constructor(reward: Reward, project: Project) : this(null, reward, project)
+}

--- a/app/src/main/java/com/kickstarter/ui/data/PledgeReason.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/PledgeReason.kt
@@ -1,0 +1,5 @@
+package com.kickstarter.ui.data
+
+enum class PledgeReason {
+    PLEDGE, UPDATE_PAYMENT, UPDATE_PLEDGE
+}

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -1,0 +1,18 @@
+package com.kickstarter.ui.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.kickstarter.R
+import com.kickstarter.libs.BaseFragment
+import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
+import com.kickstarter.viewmodels.BackingFragmentViewModel
+
+@RequiresFragmentViewModel(BackingFragmentViewModel.ViewModel::class)
+class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        super.onCreateView(inflater, container, savedInstanceState)
+        return inflater.inflate(R.layout.fragment_backing, container, false)
+    }
+}

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -18,7 +18,7 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
     }
 
     fun takeProject(project: Project) {
-//        this.viewModel.inputs.project(project)
+        this.viewModel.inputs.project(project)
     }
 
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import com.kickstarter.R
 import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
+import com.kickstarter.models.Project
 import com.kickstarter.viewmodels.BackingFragmentViewModel
 
 @RequiresFragmentViewModel(BackingFragmentViewModel.ViewModel::class)
@@ -15,4 +16,9 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
         super.onCreateView(inflater, container, savedInstanceState)
         return inflater.inflate(R.layout.fragment_backing, container, false)
     }
+
+    fun takeProject(project: Project) {
+//        this.viewModel.inputs.project(project)
+    }
+
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -39,6 +39,7 @@ import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.UrlUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Project
+import com.kickstarter.models.Reward
 import com.kickstarter.models.ShippingRule
 import com.kickstarter.models.StoredCard
 import com.kickstarter.models.chrome.ChromeTabsHelperActivity
@@ -61,6 +62,7 @@ import kotlinx.android.synthetic.main.fragment_pledge_section_payment.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_pledge_amount.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_shipping.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_total.*
+import kotlin.math.min
 
 @RequiresFragmentViewModel(PledgeFragmentViewModel.ViewModel::class)
 class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), RewardCardAdapter.Delegate, ShippingRulesAdapter.Delegate {
@@ -537,8 +539,15 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
 
     //Reward card animation helper methods
     private fun showPledgeSection(pledgeData: PledgeData) {
-        setInitialViewStates(pledgeData)
-        startPledgeAnimatorSet(true, pledgeData.rewardScreenLocation)
+        pledgeData.rewardScreenLocation?.let {
+            setInitialViewStates(pledgeData)
+            startPledgeAnimatorSet(true, it)
+        }?: run {
+            reward_to_copy.visibility = View.GONE
+            reward_snapshot.visibility = View.GONE
+            expand_icon_container.visibility = View.GONE
+            pledge_root.visibility = View.VISIBLE
+        }
     }
 
     private fun startPledgeAnimatorSet(reveal: Boolean, location: ScreenLocation) {
@@ -654,7 +663,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     private fun getMiniRewardHeight(miniRewardWidth: Float, location: ScreenLocation): Float {
         val scale = miniRewardWidth / location.width
         val scaledHeight = (location.height * scale).toInt()
-        return Math.min(resources.getDimensionPixelSize(R.dimen.mini_reward_height), scaledHeight).toFloat()
+        return min(resources.getDimensionPixelSize(R.dimen.mini_reward_height), scaledHeight).toFloat()
     }
 
     private fun getWidthAnimator(initialValue: Float, finalValue: Float) =
@@ -676,10 +685,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 }
             }
 
-    private fun positionRewardSnapshot(pledgeData: PledgeData) {
-        val location = pledgeData.rewardScreenLocation
-        val reward = pledgeData.reward
-        val project = pledgeData.project
+    private fun positionRewardSnapshot(location: ScreenLocation, reward: Reward, project: Project) {
         val rewardParams = reward_snapshot.layoutParams as CoordinatorLayout.LayoutParams
         rewardParams.leftMargin = location.x.toInt()
         rewardParams.topMargin = location.y.toInt()
@@ -708,7 +714,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     }
 
     private fun setInitialViewStates(pledgeData: PledgeData) {
-        positionRewardSnapshot(pledgeData)
+        pledgeData.rewardScreenLocation?.let { positionRewardSnapshot(it, pledgeData.reward, pledgeData.project) }
         pledge_details.y = pledge_root.height.toFloat()
     }
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -16,11 +16,11 @@ import com.kickstarter.models.Reward
 import com.kickstarter.ui.adapters.NativeCheckoutRewardsAdapter
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.ScreenLocation
-import com.kickstarter.viewmodels.RewardFragmentViewModel
+import com.kickstarter.viewmodels.RewardsFragmentViewModel
 import kotlinx.android.synthetic.main.fragment_rewards.*
 
-@RequiresFragmentViewModel(RewardFragmentViewModel.ViewModel::class)
-class RewardsFragment : BaseFragment<RewardFragmentViewModel.ViewModel>(), NativeCheckoutRewardsAdapter.Delegate {
+@RequiresFragmentViewModel(RewardsFragmentViewModel.ViewModel::class)
+class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), NativeCheckoutRewardsAdapter.Delegate {
 
     private var rewardsAdapter = NativeCheckoutRewardsAdapter(this)
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -1,0 +1,23 @@
+package com.kickstarter.viewmodels
+
+import androidx.annotation.NonNull
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.FragmentViewModel
+import com.kickstarter.ui.fragments.BackingFragment
+
+interface BackingFragmentViewModel {
+    interface Inputs {
+
+    }
+
+    interface Outputs {
+
+    }
+
+    class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<BackingFragment>(environment), Inputs, Outputs {
+
+        init {
+
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -3,21 +3,44 @@ package com.kickstarter.viewmodels
 import androidx.annotation.NonNull
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.FragmentViewModel
+import com.kickstarter.models.Project
 import com.kickstarter.ui.fragments.BackingFragment
+import rx.Observable
+import rx.subjects.BehaviorSubject
+import rx.subjects.PublishSubject
 
 interface BackingFragmentViewModel {
     interface Inputs {
-
+        /** Configure with current project.  */
+        fun project(project: Project)
     }
 
     interface Outputs {
-
+        /** Emits the current project. */
+        fun project(): Observable<Project>
     }
 
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<BackingFragment>(environment), Inputs, Outputs {
 
-        init {
+        private val projectInput = PublishSubject.create<Project>()
 
+        private val project = BehaviorSubject.create<Project>()
+
+        val inputs: Inputs = this
+        val outputs: Outputs = this
+
+        init {
+            this.projectInput
+                    .compose(bindToLifecycle())
+                    .subscribe(this.project)
         }
+
+        override fun project(project: Project) {
+            this.projectInput.onNext(project)
+        }
+
+        @NonNull
+        override fun project(): Observable<Project> = this.project
+
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -251,7 +251,7 @@ interface PledgeFragmentViewModel {
                     .map { it.getParcelable(ArgumentsKey.PLEDGE_REWARD) as Reward }
 
             val screenLocation = arguments()
-                    .map { it.getSerializable(ArgumentsKey.PLEDGE_SCREEN_LOCATION) as ScreenLocation }
+                    .map { it.getSerializable(ArgumentsKey.PLEDGE_SCREEN_LOCATION) as ScreenLocation? }
 
             val project = arguments()
                     .map { it.getParcelable(ArgumentsKey.PLEDGE_PROJECT) as Project }
@@ -271,7 +271,7 @@ interface PledgeFragmentViewModel {
             Observable.combineLatest(screenLocation, reward, project, ::PledgeData)
                     .compose<PledgeData>(takeWhen(this.onGlobalLayout))
                     .compose(bindToLifecycle())
-                    .subscribe { this.animateRewardCard.onNext(it) }
+                    .subscribe(this.animateRewardCard)
 
             // Estimated delivery section
             reward

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -189,8 +189,8 @@ interface ProjectViewModel {
         private val setInitialRewardPosition = BehaviorSubject.create<Void>()
         private val showCancelPledgeSuccess = PublishSubject.create<Void>()
         private val expandPledgeSheet = BehaviorSubject.create<Boolean>()
-        private val showBackingFragment = PublishSubject.create<Project>()
-        private val showRewardsFragment = PublishSubject.create<Project>()
+        private val showBackingFragment = BehaviorSubject.create<Project>()
+        private val showRewardsFragment = BehaviorSubject.create<Project>()
         private val showShareSheet = PublishSubject.create<Project>()
         private val showSavedPrompt = PublishSubject.create<Void>()
         private val startCampaignWebViewActivity = PublishSubject.create<Project>()
@@ -329,13 +329,13 @@ interface ProjectViewModel {
                     .map<Project> { it.first }
 
             nativeCheckoutProject
-                    .filter { it.isBacking }
+                    .filter { it.isBacking && it.hasRewards() }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.showBackingFragment)
 
             nativeCheckoutProject
-                    .filter { !it.isBacking }
+                    .filter { !it.isBacking && it.hasRewards() }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.showRewardsFragment)

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -53,7 +53,7 @@ interface ProjectViewModel {
         fun heartButtonClicked()
 
         /** Call when horizontal rewards sheet should hide. */
-        fun hideRewardsSheetClicked()
+        fun collapsePledgeSheet()
 
         /** Call when the manage pledge button is clicked.  */
         fun managePledgeButtonClicked()
@@ -73,14 +73,14 @@ interface ProjectViewModel {
         /** Call when the share button is clicked.  */
         fun shareButtonClicked()
 
-        /** Call when the updates button is clicked.  */
-        fun updatesTextViewClicked()
-
         /** Call when the update payment option is clicked.  */
         fun updatePaymentClicked()
 
         /** Call when the update pledge option is clicked.  */
         fun updatePledgeClicked()
+
+        /** Call when the updates button is clicked.  */
+        fun updatesTextViewClicked()
 
         /** Call when the view pledge button is clicked.  */
         fun viewPledgeButtonClicked()
@@ -191,22 +191,22 @@ interface ProjectViewModel {
         private val backProjectButtonClicked = PublishSubject.create<Void>()
         private val blurbTextViewClicked = PublishSubject.create<Void>()
         private val cancelPledgeClicked = PublishSubject.create<Void>()
+        private val collapsePledgeSheet = PublishSubject.create<Void>()
         private val commentsTextViewClicked = PublishSubject.create<Void>()
         private val contactCreatorClicked = PublishSubject.create<Void>()
         private val creatorNameTextViewClicked = PublishSubject.create<Void>()
         private val fragmentStackCount = PublishSubject.create<Int>()
         private val heartButtonClicked = PublishSubject.create<Void>()
-        private val collapsePledgeSheet = PublishSubject.create<Void>()
         private val managePledgeButtonClicked = PublishSubject.create<Void>()
         private val nativeProjectActionButtonClicked = PublishSubject.create<Void>()
         private val onGlobalLayout = PublishSubject.create<Void>()
         private val playVideoButtonClicked = PublishSubject.create<Void>()
         private val pledgeSuccessfullyCancelled = PublishSubject.create<Void>()
         private val shareButtonClicked = PublishSubject.create<Void>()
-        private val showRewardsClicked = PublishSubject.create<Void>()
         private val updatePaymentClicked = PublishSubject.create<Void>()
         private val updatePledgeClicked = PublishSubject.create<Void>()
         private val updatesTextViewClicked = PublishSubject.create<Void>()
+        private val viewRewardsClicked = PublishSubject.create<Void>()
         private val viewPledgeButtonClicked = PublishSubject.create<Void>()
 
         private val backingDetails = BehaviorSubject.create<String>()
@@ -221,9 +221,9 @@ interface ProjectViewModel {
         private val rewardsToolbarTitle = BehaviorSubject.create<Int>()
         private val scrimIsVisible = BehaviorSubject.create<Boolean>()
         private val setInitialRewardPosition = BehaviorSubject.create<Void>()
+        private val showBackingFragment = BehaviorSubject.create<Project>()
         private val showCancelPledgeFragment = PublishSubject.create<Project>()
         private val showCancelPledgeSuccess = PublishSubject.create<Void>()
-        private val showBackingFragment = BehaviorSubject.create<Project>()
         private val showRewardsFragment = BehaviorSubject.create<Project>()
         private val showShareSheet = PublishSubject.create<Project>()
         private val showSavedPrompt = PublishSubject.create<Void>()
@@ -409,7 +409,7 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.showUpdatePledge)
 
-            this.showRewardsClicked
+            this.viewRewardsClicked
                     .compose(bindToLifecycle())
                     .subscribe(this.revealRewardsFragment)
 
@@ -520,6 +520,10 @@ interface ProjectViewModel {
             this.cancelPledgeClicked.onNext(null)
         }
 
+        override fun collapsePledgeSheet() {
+            this.collapsePledgeSheet.onNext(null)
+        }
+
         override fun commentsTextViewClicked() {
             this.commentsTextViewClicked.onNext(null)
         }
@@ -538,10 +542,6 @@ interface ProjectViewModel {
 
         override fun heartButtonClicked() {
             this.heartButtonClicked.onNext(null)
-        }
-
-        override fun hideRewardsSheetClicked() {
-            this.collapsePledgeSheet.onNext(null)
         }
 
         override fun managePledgeButtonClicked() {
@@ -633,7 +633,7 @@ interface ProjectViewModel {
         }
 
         override fun viewRewardsClicked() {
-            this.showRewardsClicked.onNext(null)
+            this.viewRewardsClicked.onNext(null)
         }
 
         @NonNull

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -37,6 +37,9 @@ interface ProjectViewModel {
         /** Call when the cancel pledge option is clicked.  */
         fun cancelPledgeClicked()
 
+        /** Call when horizontal rewards sheet should collapse. */
+        fun collapsePledgeSheet()
+
         /** Call when the comments text view is clicked.  */
         fun commentsTextViewClicked()
 
@@ -51,9 +54,6 @@ interface ProjectViewModel {
 
         /** Call when the heart button is clicked.  */
         fun heartButtonClicked()
-
-        /** Call when horizontal rewards sheet should hide. */
-        fun collapsePledgeSheet()
 
         /** Call when the manage pledge button is clicked.  */
         fun managePledgeButtonClicked()

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -7,16 +7,16 @@ import com.kickstarter.R
 import com.kickstarter.libs.*
 import com.kickstarter.libs.preferences.BooleanPreferenceType
 import com.kickstarter.libs.rx.transformers.Transformers.*
-import com.kickstarter.libs.utils.BooleanUtils
-import com.kickstarter.libs.utils.ProjectViewUtils
-import com.kickstarter.libs.utils.RefTagUtils
-import com.kickstarter.libs.utils.RewardUtils
+import com.kickstarter.libs.utils.*
 import com.kickstarter.models.Project
+import com.kickstarter.models.Reward
 import com.kickstarter.models.User
 import com.kickstarter.services.ApiClientType
 import com.kickstarter.ui.activities.BackingActivity
 import com.kickstarter.ui.activities.ProjectActivity
 import com.kickstarter.ui.adapters.ProjectAdapter
+import com.kickstarter.ui.data.PledgeData
+import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.intentmappers.IntentMapper
 import com.kickstarter.ui.intentmappers.ProjectIntentMapper
 import com.kickstarter.ui.viewholders.ProjectViewHolder
@@ -34,8 +34,14 @@ interface ProjectViewModel {
         /** Call when the blurb view is clicked.  */
         fun blurbTextViewClicked()
 
+        /** Call when the cancel pledge option is clicked.  */
+        fun cancelPledgeClicked()
+
         /** Call when the comments text view is clicked.  */
         fun commentsTextViewClicked()
+
+        /** Call when the contact creator option is clicked.  */
+        fun contactCreatorClicked()
 
         /** Call when the creator name is clicked.  */
         fun creatorNameTextViewClicked()
@@ -70,8 +76,17 @@ interface ProjectViewModel {
         /** Call when the updates button is clicked.  */
         fun updatesTextViewClicked()
 
+        /** Call when the update payment option is clicked.  */
+        fun updatePaymentClicked()
+
+        /** Call when the update pledge option is clicked.  */
+        fun updatePledgeClicked()
+
         /** Call when the view pledge button is clicked.  */
         fun viewPledgeButtonClicked()
+
+        /** Call when the view rewards option is clicked.  */
+        fun viewRewardsClicked()
     }
 
     interface Outputs {
@@ -81,15 +96,21 @@ interface ProjectViewModel {
         /** Emits a boolean that determines if the backing details should be visible. */
         fun backingDetailsIsVisible(): Observable<Boolean>
 
+        /** Emits when rewards sheet should expand. */
+        fun expandPledgeSheet(): Observable<Boolean>
+
         /** Emits a drawable id that corresponds to whether the project is saved. */
         fun heartDrawableId(): Observable<Int>
 
-        /** . */
+        /** Emits a boolean that determines if the manage pledge menu should be visible. */
         fun managePledgeMenuIsVisible(): Observable<Boolean>
 
         /** Emits a project and country when a new value is available. If the view model is created with a full project
          * model, this observable will emit that project immediately, and then again when it has updated from the api.  */
         fun projectAndUserCountry(): Observable<Pair<Project, String>>
+
+        /** Emits when we should reveal the [com.kickstarter.ui.fragments.RewardsFragment] with an animation. */
+        fun revealRewardsFragment(): Observable<Void>
 
         /** Emits the color resource ID for the reward button based on (View, Manage, or Back this project). */
         fun rewardsButtonColor(): Observable<Int>
@@ -106,16 +127,16 @@ interface ProjectViewModel {
         /** Emits when we should set the Y position of the rewards container. */
         fun setInitialRewardsContainerY(): Observable<Void>
 
+        /** Emits when we should show the [com.kickstarter.ui.fragments.CancelPledgeFragment]. */
+        fun showCancelPledgeFragment(): Observable<Project>
+
         /** Emits when the backing has successfully been canceled. */
         fun showCancelPledgeSuccess(): Observable<Void>
 
-        /** Emits when rewards sheet should expand. */
-        fun expandPledgeSheet(): Observable<Boolean>
-
-        /**  */
+        /** Emits when we should reveal the [com.kickstarter.ui.fragments.BackingFragment]. */
         fun showBackingFragment(): Observable<Project>
 
-        /**  */
+        /** Emits when we should reveal the [com.kickstarter.ui.fragments.RewardsFragment]. */
         fun showRewardsFragment(): Observable<Project>
 
         /** Emits when the success prompt for saving should be displayed.  */
@@ -123,6 +144,9 @@ interface ProjectViewModel {
 
         /** Emits when we should show the share sheet.  */
         fun showShareSheet(): Observable<Project>
+
+        /** Emits when we should show the [com.kickstarter.ui.fragments.PledgeFragment]. */
+        fun showUpdatePledge(): Observable<Pair<PledgeData, PledgeReason>>
 
         /** Emits when we should start the [BackingActivity].  */
         fun startBackingActivity(): Observable<Pair<Project, User>>
@@ -145,6 +169,9 @@ interface ProjectViewModel {
         /** Emits when we should start the [com.kickstarter.ui.activities.CheckoutActivity] to manage the pledge.  */
         fun startManagePledgeActivity(): Observable<Project>
 
+        /** Emits when we should show the [com.kickstarter.ui.activities.MessagesActivity]. */
+        fun startMessagesActivity(): Observable<Project>
+
         /** Emits when we should start [com.kickstarter.ui.activities.ProjectUpdatesActivity].  */
         fun startProjectUpdatesActivity(): Observable<Project>
 
@@ -163,7 +190,9 @@ interface ProjectViewModel {
 
         private val backProjectButtonClicked = PublishSubject.create<Void>()
         private val blurbTextViewClicked = PublishSubject.create<Void>()
+        private val cancelPledgeClicked = PublishSubject.create<Void>()
         private val commentsTextViewClicked = PublishSubject.create<Void>()
+        private val contactCreatorClicked = PublishSubject.create<Void>()
         private val creatorNameTextViewClicked = PublishSubject.create<Void>()
         private val fragmentStackCount = PublishSubject.create<Int>()
         private val heartButtonClicked = PublishSubject.create<Void>()
@@ -174,31 +203,38 @@ interface ProjectViewModel {
         private val playVideoButtonClicked = PublishSubject.create<Void>()
         private val pledgeSuccessfullyCancelled = PublishSubject.create<Void>()
         private val shareButtonClicked = PublishSubject.create<Void>()
+        private val showRewardsClicked = PublishSubject.create<Void>()
+        private val updatePaymentClicked = PublishSubject.create<Void>()
+        private val updatePledgeClicked = PublishSubject.create<Void>()
         private val updatesTextViewClicked = PublishSubject.create<Void>()
         private val viewPledgeButtonClicked = PublishSubject.create<Void>()
 
         private val backingDetails = BehaviorSubject.create<String>()
         private val backingDetailsIsVisible = BehaviorSubject.create<Boolean>()
+        private val expandPledgeSheet = BehaviorSubject.create<Boolean>()
         private val heartDrawableId = BehaviorSubject.create<Int>()
         private val managePledgeMenuIsVisible = BehaviorSubject.create<Boolean>()
         private val projectAndUserCountry = BehaviorSubject.create<Pair<Project, String>>()
+        private val revealRewardsFragment = PublishSubject.create<Void>()
         private val rewardsButtonColor = BehaviorSubject.create<Int>()
         private val rewardsButtonText = BehaviorSubject.create<Int>()
         private val rewardsToolbarTitle = BehaviorSubject.create<Int>()
         private val scrimIsVisible = BehaviorSubject.create<Boolean>()
         private val setInitialRewardPosition = BehaviorSubject.create<Void>()
+        private val showCancelPledgeFragment = PublishSubject.create<Project>()
         private val showCancelPledgeSuccess = PublishSubject.create<Void>()
-        private val expandPledgeSheet = BehaviorSubject.create<Boolean>()
         private val showBackingFragment = BehaviorSubject.create<Project>()
         private val showRewardsFragment = BehaviorSubject.create<Project>()
         private val showShareSheet = PublishSubject.create<Project>()
         private val showSavedPrompt = PublishSubject.create<Void>()
+        private val showUpdatePledge = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
         private val startCampaignWebViewActivity = PublishSubject.create<Project>()
         private val startCheckoutActivity = PublishSubject.create<Project>()
         private val startCommentsActivity = PublishSubject.create<Project>()
         private val startCreatorBioWebViewActivity = PublishSubject.create<Project>()
         private val startLoginToutActivity = PublishSubject.create<Void>()
         private val startManagePledgeActivity = PublishSubject.create<Project>()
+        private val startMessagesActivity = PublishSubject.create<Project>()
         private val startProjectUpdatesActivity = PublishSubject.create<Project>()
         private val startVideoActivity = PublishSubject.create<Project>()
         private val startBackingActivity = PublishSubject.create<Pair<Project, User>>()
@@ -341,6 +377,43 @@ interface ProjectViewModel {
                     .subscribe(this.showRewardsFragment)
 
             nativeCheckoutProject
+                    .compose<Pair<Project, Int>>(combineLatestPair(this.fragmentStackCount.startWith(0)))
+                    .map { it.first.isBacking && IntegerUtils.isZero(it.second) }
+                    .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.managePledgeMenuIsVisible)
+
+            nativeCheckoutProject
+                    .compose<Project>(takeWhen(this.cancelPledgeClicked))
+                    .compose(bindToLifecycle())
+                    .subscribe(this.showCancelPledgeFragment)
+
+            nativeCheckoutProject
+                    .compose<Project>(takeWhen(this.contactCreatorClicked))
+                    .compose(bindToLifecycle())
+                    .subscribe(this.startMessagesActivity)
+
+            val projectAndBackedReward = nativeCheckoutProject
+                    .map { project -> Pair(project, project.rewards()?.firstOrNull { BackingUtils.isBacked(project, it) }) }
+                    .map { projectAndReward -> projectAndReward.second?.let { Pair(projectAndReward.first, it) } }
+
+            projectAndBackedReward
+                    .compose(takeWhen<Pair<Project, Reward>, Void>(this.updatePaymentClicked))
+                    .map { Pair(PledgeData(reward = it.second, project = it.first), PledgeReason.UPDATE_PAYMENT) }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.showUpdatePledge)
+
+            projectAndBackedReward
+                    .compose(takeWhen<Pair<Project, Reward>, Void>(this.updatePledgeClicked))
+                    .map { Pair(PledgeData(reward = it.second, project = it.first), PledgeReason.UPDATE_PLEDGE) }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.showUpdatePledge)
+
+            this.showRewardsClicked
+                    .compose(bindToLifecycle())
+                    .subscribe(this.revealRewardsFragment)
+
+            nativeCheckoutProject
                     .map { it.isBacking && it.isLive }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
@@ -376,10 +449,8 @@ interface ProjectViewModel {
                     .subscribe(this.showCancelPledgeSuccess)
 
             this.fragmentStackCount
-                    .compose<Pair<Int, Boolean>>(combineLatestPair(Observable.just(this.nativeCheckoutPreference.get())))
-                    .filter { it.second }
-                    .map { it.first }
-                    .map { it > 1 }
+                    .compose<Pair<Int, Project>>(combineLatestPair(nativeCheckoutProject))
+                    .map { if (it.second.isBacking) it.first > 2 else it.first > 1}
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.scrimIsVisible)
@@ -445,8 +516,16 @@ interface ProjectViewModel {
             this.blurbTextViewClicked.onNext(null)
         }
 
+        override fun cancelPledgeClicked() {
+            this.cancelPledgeClicked.onNext(null)
+        }
+
         override fun commentsTextViewClicked() {
             this.commentsTextViewClicked.onNext(null)
+        }
+
+        override fun contactCreatorClicked() {
+            this.contactCreatorClicked.onNext(null)
         }
 
         override fun creatorNameTextViewClicked() {
@@ -537,6 +616,13 @@ interface ProjectViewModel {
             this.shareButtonClicked.onNext(null)
         }
 
+        override fun updatePaymentClicked() {
+            this.updatePaymentClicked.onNext(null)
+        }
+
+        override fun updatePledgeClicked() {
+            this.updatePledgeClicked.onNext(null)
+        }
 
         override fun updatesTextViewClicked() {
             this.updatesTextViewClicked.onNext(null)
@@ -544,6 +630,10 @@ interface ProjectViewModel {
 
         override fun viewPledgeButtonClicked() {
             this.viewPledgeButtonClicked.onNext(null)
+        }
+
+        override fun viewRewardsClicked() {
+            this.showRewardsClicked.onNext(null)
         }
 
         @NonNull
@@ -565,6 +655,9 @@ interface ProjectViewModel {
         override fun projectAndUserCountry(): Observable<Pair<Project, String>> = this.projectAndUserCountry
 
         @NonNull
+        override fun revealRewardsFragment(): Observable<Void> = this.revealRewardsFragment
+
+        @NonNull
         override fun rewardsButtonColor(): Observable<Int> = this.rewardsButtonColor
 
         @NonNull
@@ -580,10 +673,13 @@ interface ProjectViewModel {
         override fun setInitialRewardsContainerY(): Observable<Void> = this.setInitialRewardPosition
 
         @NonNull
-        override fun showCancelPledgeSuccess(): Observable<Void> = this.showCancelPledgeSuccess
+        override fun showBackingFragment(): Observable<Project> = this.showBackingFragment
 
         @NonNull
-        override fun showBackingFragment(): Observable<Project> = this.showBackingFragment
+        override fun showCancelPledgeFragment(): Observable<Project> = this.showCancelPledgeFragment
+
+        @NonNull
+        override fun showCancelPledgeSuccess(): Observable<Void> = this.showCancelPledgeSuccess
 
         @NonNull
         override fun showRewardsFragment(): Observable<Project> = this.showRewardsFragment
@@ -593,6 +689,9 @@ interface ProjectViewModel {
 
         @NonNull
         override fun showShareSheet(): Observable<Project> = this.showShareSheet
+
+        @NonNull
+        override fun showUpdatePledge(): Observable<Pair<PledgeData, PledgeReason>> = this.showUpdatePledge
 
         @NonNull
         override fun startBackingActivity(): Observable<Pair<Project, User>> = this.startBackingActivity
@@ -614,6 +713,9 @@ interface ProjectViewModel {
 
         @NonNull
         override fun startManagePledgeActivity(): Observable<Project> = this.startManagePledgeActivity
+
+        @NonNull
+        override fun startMessagesActivity(): Observable<Project> = this.startMessagesActivity
 
         @NonNull
         override fun startProjectUpdatesActivity(): Observable<Project> = this.startProjectUpdatesActivity

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -15,7 +15,7 @@ import rx.Observable
 import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
 
-class RewardFragmentViewModel {
+class RewardsFragmentViewModel {
     interface Inputs {
         /** Configure with current project.  */
         fun project(project: Project)

--- a/app/src/main/res/layout/activity_project.xml
+++ b/app/src/main/res/layout/activity_project.xml
@@ -55,12 +55,19 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-<!--        <fragment-->
-<!--          android:id="@+id/fragment_rewards"-->
-<!--          android:name="com.kickstarter.ui.fragments.RewardsFragment"-->
-<!--          android:layout_width="match_parent"-->
-<!--          android:layout_height="match_parent"-->
-<!--          tools:layout="@layout/fragment_rewards" />-->
+        <fragment
+          android:id="@+id/fragment_backing"
+          android:name="com.kickstarter.ui.fragments.BackingFragment"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
+          tools:layout="@layout/fragment_backing" />
+
+        <fragment
+          android:id="@+id/fragment_rewards"
+          android:name="com.kickstarter.ui.fragments.RewardsFragment"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
+          tools:layout="@layout/fragment_rewards" />
 
       </FrameLayout>
 

--- a/app/src/main/res/layout/activity_project.xml
+++ b/app/src/main/res/layout/activity_project.xml
@@ -55,12 +55,12 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <fragment
-          android:id="@+id/fragment_rewards"
-          android:name="com.kickstarter.ui.fragments.RewardsFragment"
-          android:layout_width="match_parent"
-          android:layout_height="match_parent"
-          tools:layout="@layout/fragment_rewards" />
+<!--        <fragment-->
+<!--          android:id="@+id/fragment_rewards"-->
+<!--          android:name="com.kickstarter.ui.fragments.RewardsFragment"-->
+<!--          android:layout_width="match_parent"-->
+<!--          android:layout_height="match_parent"-->
+<!--          tools:layout="@layout/fragment_rewards" />-->
 
       </FrameLayout>
 

--- a/app/src/main/res/layout/fragment_backing.xml
+++ b/app/src/main/res/layout/fragment_backing.xml
@@ -1,77 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/rewards_recycler"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:background="@color/ksr_grey_300"
   android:overScrollMode="never"
-  android:paddingTop="?android:attr/actionBarSize">
-
-  <androidx.constraintlayout.widget.ConstraintLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_margin="@dimen/activity_horizontal_margin">
-
-    <!-- todo: what's the content description? -->
-    <com.kickstarter.ui.views.BottomCropImageView
-      android:id="@+id/reward_snapshot"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:contentDescription="@null"
-      android:elevation="@dimen/mini_reward_elevation"
-      app:layout_constraintEnd_toStartOf="@id/delivery"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent"
-      tools:background="@color/white"
-      tools:layout_height="@dimen/mini_reward_height"
-      tools:layout_width="@dimen/mini_reward_width" />
-
-    <include
-      layout="@layout/fragment_pledge_section_delivery"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toEndOf="@id/reward_snapshot" />
-
-    <include
-      android:id="@+id/divider_delivery"
-      layout="@layout/horizontal_line_1dp_view"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="@dimen/grid_4"
-      app:layout_constraintBottom_toTopOf="@id/backing_date"
-      app:layout_constraintTop_toBottomOf="@id/reward_snapshot" />
-
-    <TextView
-      android:layout_marginTop="@dimen/grid_4"
-      android:id="@+id/backing_date"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintHorizontal_bias="0"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/divider_delivery"
-      tools:text="You pledged on 28 January 2018." />
-
-    <Button
-      android:id="@+id/contact_creator"
-      android:layout_marginTop="@dimen/grid_2"
-      style="@style/AlternatePrimaryButton"
-      android:text="@string/Contact_creator"
-      app:layout_constraintTop_toBottomOf="@id/backing_date"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"/>
-
-    <TextView
-      app:layout_constraintTop_toBottomOf="@id/contact_creator"
-      android:text="@string/Pledge"
-      android:layout_width="wrap_content"
-      app:layout_constraintStart_toStartOf="parent"
-      android:layout_height="wrap_content"/>
-
-
-  </androidx.constraintlayout.widget.ConstraintLayout>
-
-</ScrollView>
+  android:paddingTop="?android:attr/actionBarSize"/>

--- a/app/src/main/res/layout/fragment_backing.xml
+++ b/app/src/main/res/layout/fragment_backing.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/rewards_recycler"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:background="@color/ksr_grey_300"
+  android:overScrollMode="never"
+  android:paddingTop="?android:attr/actionBarSize">
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/activity_horizontal_margin">
+
+    <!-- todo: what's the content description? -->
+    <com.kickstarter.ui.views.BottomCropImageView
+      android:id="@+id/reward_snapshot"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:contentDescription="@null"
+      android:elevation="@dimen/mini_reward_elevation"
+      app:layout_constraintEnd_toStartOf="@id/delivery"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      tools:background="@color/white"
+      tools:layout_height="@dimen/mini_reward_height"
+      tools:layout_width="@dimen/mini_reward_width" />
+
+    <include
+      layout="@layout/fragment_pledge_section_delivery"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toEndOf="@id/reward_snapshot" />
+
+    <include
+      android:id="@+id/divider_delivery"
+      layout="@layout/horizontal_line_1dp_view"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="@dimen/grid_4"
+      app:layout_constraintBottom_toTopOf="@id/backing_date"
+      app:layout_constraintTop_toBottomOf="@id/reward_snapshot" />
+
+    <TextView
+      android:layout_marginTop="@dimen/grid_4"
+      android:id="@+id/backing_date"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintHorizontal_bias="0"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/divider_delivery"
+      tools:text="You pledged on 28 January 2018." />
+
+    <Button
+      android:id="@+id/contact_creator"
+      android:layout_marginTop="@dimen/grid_2"
+      style="@style/AlternatePrimaryButton"
+      android:text="@string/Contact_creator"
+      app:layout_constraintTop_toBottomOf="@id/backing_date"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"/>
+
+    <TextView
+      app:layout_constraintTop_toBottomOf="@id/contact_creator"
+      android:text="@string/Pledge"
+      android:layout_width="wrap_content"
+      app:layout_constraintStart_toStartOf="parent"
+      android:layout_height="wrap_content"/>
+
+
+  </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>

--- a/app/src/main/res/menu/manage_pledge.xml
+++ b/app/src/main/res/menu/manage_pledge.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+  <item android:id="@+id/update_pledge"
+    android:title="@string/Update_pledge"
+    app:showAsAction="never"/>
+  <item android:id="@+id/update_payment"
+    android:title="@string/Change_payment_method"
+    app:showAsAction="never"/>
+  <item android:id="@+id/rewards"
+    android:title="@string/View_rewards"
+    app:showAsAction="never"/>
+  <item android:id="@+id/cancel_pledge"
+    android:title="@string/Cancel_pledge"
+    app:showAsAction="never"/>
+  <item android:id="@+id/contact_creator"
+    android:title="@string/Contact_creator"
+    app:showAsAction="never"/>
+</menu>

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -1,0 +1,30 @@
+package com.kickstarter.viewmodels
+
+import androidx.annotation.NonNull
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Environment
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.models.Project
+import org.junit.Test
+import rx.observers.TestSubscriber
+
+class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
+    private lateinit var vm: BackingFragmentViewModel.ViewModel
+
+    private val project = TestSubscriber.create<Project>()
+
+    private fun setUpEnvironment(@NonNull environment: Environment) {
+        this.vm = BackingFragmentViewModel.ViewModel(environment)
+        this.vm.outputs.project().subscribe(this.project)
+    }
+
+    @Test
+    fun testProject() {
+        val project = ProjectFactory.backedProject()
+        setUpEnvironment(environment())
+
+        this.vm.inputs.project(project)
+        this.project.assertValue(project)
+    }
+
+}

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -54,7 +54,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.scrimIsVisible().subscribe(this.scrimIsVisible)
         this.vm.outputs.setInitialRewardsContainerY().subscribe(this.setInitialRewardsContainerY)
         this.vm.outputs.showCancelPledgeSuccess().subscribe(this.showCancelPledgeSuccess)
-        this.vm.outputs.showRewardsFragment().subscribe(this.showRewardsFragment)
+        this.vm.outputs.expandPledgeSheet().subscribe(this.showRewardsFragment)
         this.vm.outputs.showSavedPrompt().subscribe(this.showSavedPromptTest)
         this.vm.outputs.showShareSheet().subscribe(this.showShareSheet)
         this.vm.outputs.startLoginToutActivity().subscribe(this.startLoginToutActivity)

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -14,6 +14,8 @@ import com.kickstarter.mock.factories.*
 import com.kickstarter.models.Project
 import com.kickstarter.models.User
 import com.kickstarter.ui.IntentKey
+import com.kickstarter.ui.data.PledgeData
+import com.kickstarter.ui.data.PledgeReason
 import org.junit.Test
 import rx.observers.TestSubscriber
 
@@ -22,23 +24,28 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     private val backingDetails = TestSubscriber<String>()
     private val backingDetailsIsVisible = TestSubscriber<Boolean>()
     private val heartDrawableId = TestSubscriber<Int>()
+    private val expandPledgeSheet = TestSubscriber<Boolean>()
+    private val managePledgeMenuIsVisible = TestSubscriber<Boolean>()
     private val projectTest = TestSubscriber<Project>()
+    private val revealRewardsFragment = TestSubscriber<Void>()
     private val rewardsButtonColor = TestSubscriber<Int>()
     private val rewardsButtonText = TestSubscriber<Int>()
     private val rewardsToolbarTitle = TestSubscriber<Int>()
-    private val showShareSheet = TestSubscriber<Project>()
-    private val showSavedPromptTest = TestSubscriber<Void>()
-    private val startLoginToutActivity = TestSubscriber<Void>()
     private val savedTest = TestSubscriber<Boolean>()
     private val scrimIsVisible = TestSubscriber<Boolean>()
     private val setInitialRewardsContainerY = TestSubscriber<Void>()
+    private val showCancelPledgeFragment = TestSubscriber<Project>()
     private val showCancelPledgeSuccess = TestSubscriber<Void>()
-    private val showRewardsFragment = TestSubscriber<Boolean>()
+    private val showShareSheet = TestSubscriber<Project>()
+    private val showSavedPromptTest = TestSubscriber<Void>()
+    private val showUpdatePledge = TestSubscriber<Pair<PledgeData, PledgeReason>>()
     private val startBackingActivity = TestSubscriber<Pair<Project, User>>()
     private val startCampaignWebViewActivity = TestSubscriber<Project>()
     private val startCommentsActivity = TestSubscriber<Project>()
     private val startCreatorBioWebViewActivity = TestSubscriber<Project>()
+    private val startLoginToutActivity = TestSubscriber<Void>()
     private val startManagePledgeActivity = TestSubscriber<Project>()
+    private val startMessagesActivity = TestSubscriber<Project>()
     private val startProjectUpdatesActivity = TestSubscriber<Project>()
     private val startVideoActivity = TestSubscriber<Project>()
 
@@ -46,17 +53,22 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm = ProjectViewModel.ViewModel(environment)
         this.vm.outputs.backingDetails().subscribe(this.backingDetails)
         this.vm.outputs.backingDetailsIsVisible().subscribe(this.backingDetailsIsVisible)
+        this.vm.outputs.expandPledgeSheet().subscribe(this.expandPledgeSheet)
         this.vm.outputs.heartDrawableId().subscribe(this.heartDrawableId)
+        this.vm.outputs.managePledgeMenuIsVisible().subscribe(this.managePledgeMenuIsVisible)
         this.vm.outputs.projectAndUserCountry().map { pc -> pc.first }.subscribe(this.projectTest)
+        this.vm.outputs.revealRewardsFragment().subscribe(this.revealRewardsFragment)
         this.vm.outputs.rewardsButtonColor().subscribe(this.rewardsButtonColor)
         this.vm.outputs.rewardsButtonText().subscribe(this.rewardsButtonText)
         this.vm.outputs.rewardsToolbarTitle().subscribe(this.rewardsToolbarTitle)
         this.vm.outputs.scrimIsVisible().subscribe(this.scrimIsVisible)
         this.vm.outputs.setInitialRewardsContainerY().subscribe(this.setInitialRewardsContainerY)
+        this.vm.outputs.showCancelPledgeFragment().subscribe(this.showCancelPledgeFragment)
         this.vm.outputs.showCancelPledgeSuccess().subscribe(this.showCancelPledgeSuccess)
-        this.vm.outputs.expandPledgeSheet().subscribe(this.showRewardsFragment)
+        this.vm.outputs.startMessagesActivity().subscribe(this.startMessagesActivity)
         this.vm.outputs.showSavedPrompt().subscribe(this.showSavedPromptTest)
         this.vm.outputs.showShareSheet().subscribe(this.showShareSheet)
+        this.vm.outputs.showUpdatePledge().subscribe(this.showUpdatePledge)
         this.vm.outputs.startLoginToutActivity().subscribe(this.startLoginToutActivity)
         this.vm.outputs.projectAndUserCountry().map { pc -> pc.first.isStarred }.subscribe(this.savedTest)
         this.vm.outputs.startBackingActivity().subscribe(this.startBackingActivity)
@@ -339,21 +351,21 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testHideRewardsFragment() {
+    fun testExpandPledgeSheet_whenHiding() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
         this.vm.inputs.hideRewardsSheetClicked()
-        this.showRewardsFragment.assertValue(false)
+        this.expandPledgeSheet.assertValue(false)
     }
 
     @Test
-    fun testShowRewardsFragment() {
+    fun testExpandPledgeSheet_whenShowing() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
         this.vm.inputs.nativeProjectActionButtonClicked()
-        this.showRewardsFragment.assertValue(true)
+        this.expandPledgeSheet.assertValue(true)
         this.vm.inputs.nativeProjectActionButtonClicked()
-        this.showRewardsFragment.assertValues(true, true)
+        this.expandPledgeSheet.assertValues(true, true)
     }
 
     @Test
@@ -435,13 +447,18 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testScrimIsVisible() {
+    fun testScrimIsVisible_whenNativeCheckoutDisabled() {
         setUpEnvironment(environment())
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
         this.vm.inputs.fragmentStackCount(0)
         this.scrimIsVisible.assertNoValues()
+    }
 
+    @Test
+    fun testScrimIsVisible_whenNotBackedProject() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
         this.vm.inputs.fragmentStackCount(0)
         this.scrimIsVisible.assertValue(false)
@@ -457,6 +474,27 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testScrimIsVisible_whenBackedProject() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
+
+        this.vm.inputs.fragmentStackCount(0)
+        this.scrimIsVisible.assertValue(false)
+
+        this.vm.inputs.fragmentStackCount(1)
+        this.scrimIsVisible.assertValue(false)
+
+        this.vm.inputs.fragmentStackCount(2)
+        this.scrimIsVisible.assertValues(false)
+
+        this.vm.inputs.fragmentStackCount(3)
+        this.scrimIsVisible.assertValues(false, true)
+
+        this.vm.inputs.fragmentStackCount(2)
+        this.scrimIsVisible.assertValues(false, true, false)
+    }
+
+    @Test
     fun testCancelPledgeSuccess() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
 
@@ -466,9 +504,107 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.projectTest.assertValueCount(2)
 
         this.vm.inputs.pledgeSuccessfullyCancelled()
-        this.showRewardsFragment.assertValue(false)
+        this.expandPledgeSheet.assertValue(false)
         this.showCancelPledgeSuccess.assertValueCount(1)
         this.projectTest.assertValueCount(3)
+    }
+
+    @Test
+    fun testManagePledgeMenuIsVisible_whenProjectBacked() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        // Start the view model with a backed project
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
+
+        this.managePledgeMenuIsVisible.assertValue(true)
+    }
+
+    @Test
+    fun testManagePledgeMenuIsVisible_whenProjectNotBacked() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        // Start the view model with a backed project
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
+
+        this.managePledgeMenuIsVisible.assertValue(false)
+    }
+
+    @Test
+    fun testManagePledgeMenuIsVisible_whenManaging() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        // Start the view model with a backed project
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
+
+        this.managePledgeMenuIsVisible.assertValue(true)
+
+        this.vm.inputs.cancelPledgeClicked()
+        this.vm.inputs.fragmentStackCount(1)
+        this.managePledgeMenuIsVisible.assertValues(true, false)
+
+        this.vm.inputs.fragmentStackCount(0)
+        this.managePledgeMenuIsVisible.assertValues(true, false, true)
+    }
+
+    @Test
+    fun testShowCancelPledgeFragment() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        // Start the view model with a backed project
+        val backedProject = ProjectFactory.backedProject()
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedProject))
+
+        this.vm.inputs.cancelPledgeClicked()
+        this.showCancelPledgeFragment.assertValue(backedProject)
+    }
+
+    @Test
+    fun testShowConversation() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        // Start the view model with a backed project
+        val backedProject = ProjectFactory.backedProject()
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedProject))
+
+        this.vm.inputs.contactCreatorClicked()
+        this.startMessagesActivity.assertValue(backedProject)
+    }
+
+    @Test
+    fun testRevealRewardsFragment() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        // Start the view model with a backed project
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
+
+        this.vm.inputs.viewRewardsClicked()
+        this.revealRewardsFragment.assertValueCount(1)
+    }
+
+    @Test
+    fun testShowUpdatePledge() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        // Start the view model with a backed project
+        val reward = RewardFactory.reward()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(BackingFactory.backing()
+                        .toBuilder()
+                        .rewardId(reward.id())
+                        .build())
+                .rewards(listOf(RewardFactory.noReward(), reward))
+                .build()
+
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedProject))
+
+        this.showUpdatePledge.assertNoValues()
+
+        this.vm.inputs.updatePledgeClicked()
+        this.showUpdatePledge.assertValuesAndClear(Pair(PledgeData(reward, backedProject), PledgeReason.UPDATE_PLEDGE))
+
+        this.vm.inputs.updatePaymentClicked()
+        this.showUpdatePledge.assertValuesAndClear(Pair(PledgeData(reward, backedProject), PledgeReason.UPDATE_PAYMENT))
     }
 
     private fun environmentWithNativeCheckoutEnabled() : Environment {

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -23,8 +23,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     private lateinit var vm: ProjectViewModel.ViewModel
     private val backingDetails = TestSubscriber<String>()
     private val backingDetailsIsVisible = TestSubscriber<Boolean>()
-    private val heartDrawableId = TestSubscriber<Int>()
     private val expandPledgeSheet = TestSubscriber<Boolean>()
+    private val heartDrawableId = TestSubscriber<Int>()
     private val managePledgeMenuIsVisible = TestSubscriber<Boolean>()
     private val projectTest = TestSubscriber<Project>()
     private val revealRewardsFragment = TestSubscriber<Void>()
@@ -36,8 +36,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     private val setInitialRewardsContainerY = TestSubscriber<Void>()
     private val showCancelPledgeFragment = TestSubscriber<Project>()
     private val showCancelPledgeSuccess = TestSubscriber<Void>()
-    private val showShareSheet = TestSubscriber<Project>()
     private val showSavedPromptTest = TestSubscriber<Void>()
+    private val showShareSheet = TestSubscriber<Project>()
     private val showUpdatePledge = TestSubscriber<Pair<PledgeData, PledgeReason>>()
     private val startBackingActivity = TestSubscriber<Pair<Project, User>>()
     private val startCampaignWebViewActivity = TestSubscriber<Project>()
@@ -65,7 +65,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.setInitialRewardsContainerY().subscribe(this.setInitialRewardsContainerY)
         this.vm.outputs.showCancelPledgeFragment().subscribe(this.showCancelPledgeFragment)
         this.vm.outputs.showCancelPledgeSuccess().subscribe(this.showCancelPledgeSuccess)
-        this.vm.outputs.startMessagesActivity().subscribe(this.startMessagesActivity)
         this.vm.outputs.showSavedPrompt().subscribe(this.showSavedPromptTest)
         this.vm.outputs.showShareSheet().subscribe(this.showShareSheet)
         this.vm.outputs.showUpdatePledge().subscribe(this.showUpdatePledge)
@@ -76,6 +75,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.startCommentsActivity().subscribe(this.startCommentsActivity)
         this.vm.outputs.startCreatorBioWebViewActivity().subscribe(this.startCreatorBioWebViewActivity)
         this.vm.outputs.startManagePledgeActivity().subscribe(this.startManagePledgeActivity)
+        this.vm.outputs.startMessagesActivity().subscribe(this.startMessagesActivity)
         this.vm.outputs.startProjectUpdatesActivity().subscribe(this.startProjectUpdatesActivity)
         this.vm.outputs.startVideoActivity().subscribe(this.startVideoActivity)
     }
@@ -351,15 +351,15 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testExpandPledgeSheet_whenHiding() {
+    fun testExpandPledgeSheet_whenCollapsingSheet() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
-        this.vm.inputs.hideRewardsSheetClicked()
+        this.vm.inputs.collapsePledgeSheet()
         this.expandPledgeSheet.assertValue(false)
     }
 
     @Test
-    fun testExpandPledgeSheet_whenShowing() {
+    fun testExpandPledgeSheet_whenExpandingSheet() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
         this.vm.inputs.nativeProjectActionButtonClicked()

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
@@ -13,15 +13,15 @@ import org.junit.Test
 import rx.observers.TestSubscriber
 import java.util.*
 
-class RewardFragmentViewModelTest: KSRobolectricTestCase() {
+class RewardsFragmentViewModelTest: KSRobolectricTestCase() {
 
-    private lateinit var vm: RewardFragmentViewModel.ViewModel
+    private lateinit var vm: RewardsFragmentViewModel.ViewModel
     private val backedRewardPosition = TestSubscriber.create<Int>()
     private val project = TestSubscriber.create<Project>()
     private val showPledgeFragment = TestSubscriber<PledgeData>()
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
-        this.vm = RewardFragmentViewModel.ViewModel(environment)
+        this.vm = RewardsFragmentViewModel.ViewModel(environment)
         this.vm.outputs.backedRewardPosition().subscribe(this.backedRewardPosition)
         this.vm.outputs.project().subscribe(this.project)
         this.vm.outputs.showPledgeFragment().subscribe(this.showPledgeFragment)


### PR DESCRIPTION
# 📲 What
Showing an interstitial screen with menu options when the pledge sheet is expanded and the user has backed the project.

# 🤔 Why
MANAGE UR PLEDGE

# 🛠 How
- `ProjectActivity` displays `BackingFragment` as the primary screen when the pledge sheet is opened.
  - When it's visible, an options menu is present in the rewards toolbar.
  - The menu has options for `Update pledge`, `Change payment method`, `View rewards`, `Cancel pledge` and `Contact creator`
- Added `PledgeReason` that will be used to configure `PledgeFragment` UI
- `PledgeData.screenLocation` is now optional.
- `PledgeFragment` hides mini reward if no `ScreenLocation`.
- Renamed `RewardFragment` to `RewardsFragment`.
- Renamed `RewardFragmentViewModel` to `RewardsFragmentViewModel`.
- Testz

# 👀 See
| Menu❓  | Update pledge | Change payment method |
| --- | --- | --- |
| <img src="https://user-images.githubusercontent.com/1289295/63059411-583d0080-bebd-11e9-809b-b2a1eb4e1689.png" width="330"/> | ![update](https://user-images.githubusercontent.com/1289295/63059849-840cb600-bebe-11e9-83c3-82aa7b70966d.gif) | ![payment](https://user-images.githubusercontent.com/1289295/63059848-840cb600-bebe-11e9-9cd7-0df0ac3f7b3d.gif) |
| View rewards | Cancel Pledge | Contact creator | 
| ![viewrewards](https://user-images.githubusercontent.com/1289295/63059850-840cb600-bebe-11e9-8f4f-c36bf9e7b514.gif) | ![cancelpledge](https://user-images.githubusercontent.com/1289295/63059846-840cb600-bebe-11e9-87f2-18c0672548a4.gif) | ![contact](https://user-images.githubusercontent.com/1289295/63059847-840cb600-bebe-11e9-99da-946fc482f355.gif) |

# 📋 QA
1️⃣When a user has backed a live project, clicking `Manage` reveals the Manage Your Pledge screen (it's blank for now) with an options menu.
2️⃣ The menu contains `Update pledge`, `Change payment method`, `View rewards`, `Cancel pledge` and `Contact creator`.
3️⃣ `Update pledge` -> Pledge screen (not currently configured)
4️⃣ `Change payment method` -> Pledge screen (not currently configured)
5️⃣ `View rewards` -> Rewards screen (scrolled to current reward)
6️⃣ `Cancel pledge` -> Cancel modal (needs new UI)
7️⃣ `Contact creator` -> Conversation with creator 

# Story 📖
https://dripsprint.atlassian.net/browse/NT-108
