### PR TITLE
[🆕] Adding expandedCountry to location model

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/factories/LocationFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/LocationFactory.java
@@ -14,6 +14,7 @@ public final class LocationFactory {
       .name("Berlin")
       .state("Berlin")
       .country("DE")
+      .expandedCountry("Germany")
       .build();
   }
 
@@ -24,6 +25,7 @@ public final class LocationFactory {
       .name("Mexico City")
       .state("Mexico")
       .country("MX")
+      .expandedCountry("Mexico")
       .build();
   }
 
@@ -35,6 +37,7 @@ public final class LocationFactory {
       .country("AU")
       .state("NSW")
       .projectsCount(33)
+      .expandedCountry("Australia")
       .build();
   }
 
@@ -45,6 +48,7 @@ public final class LocationFactory {
       .name("Brooklyn")
       .state("NY")
       .country("US")
+      .expandedCountry("United States")
       .build();
   }
 }

--- a/app/src/main/java/com/kickstarter/models/Location.java
+++ b/app/src/main/java/com/kickstarter/models/Location.java
@@ -11,21 +11,23 @@ import auto.parcel.AutoParcel;
 @AutoParcel
 public abstract class Location implements Parcelable {
   public abstract long id();
-  public abstract String displayableName();
-  public abstract String name();
   public abstract @Nullable String city();
-  public abstract @Nullable String state();
   public abstract String country();
+  public abstract String displayableName();
+  public abstract @Nullable String expandedCountry();
+  public abstract String name();
   public abstract @Nullable Integer projectsCount();
+  public abstract @Nullable String state();
 
   @AutoParcel.Builder
   public abstract static class Builder {
     public abstract Builder displayableName(String __);
     public abstract Builder id(long __);
-    public abstract Builder name(String __);
     public abstract Builder city(String __);
-    public abstract Builder state(String __);
     public abstract Builder country(String __);
+    public abstract Builder expandedCountry(String __);
+    public abstract Builder name(String __);
+    public abstract Builder state(String __);
     public abstract Builder projectsCount(Integer __);
     public abstract Location build();
   }

--- a/app/src/main/java/com/kickstarter/ui/fragments/NewCardFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/NewCardFragment.kt
@@ -191,8 +191,8 @@ class NewCardFragment : BaseFragment<NewCardFragmentViewModel.ViewModel>() {
                 allowed_card_warning.setText(it)
             } else {
                 val ksString = this.viewModel.environment.ksString()
-                val projectLocation = project.location()?.displayableName()
-                allowed_card_warning.text = ksString.format(getString(it), "project_country", projectLocation)
+                val country = project.location()?.expandedCountry()
+                allowed_card_warning.text = ksString.format(getString(it), "project_country", country)
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModel.kt
@@ -60,7 +60,7 @@ interface RewardCardViewHolderViewModel : BaseRewardCardViewHolderViewModel {
                     .filter { !it }
                     .compose<Pair<Boolean, Project>>(combineLatestPair(project))
                     .map { it.second }
-                    .map { it.location()?.displayableName() }
+                    .map { it.location()?.expandedCountry()?: "" }
                     .compose(bindToLifecycle())
                     .subscribe(this.projectCountry)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModelTest.kt
@@ -165,7 +165,7 @@ class RewardCardViewHolderViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.configureWith(Pair(creditCard, ProjectFactory.mxProject()))
 
-        this.projectCountry.assertValue("Mexico City, Mexico")
+        this.projectCountry.assertValue("Mexico")
     }
 
 }


### PR DESCRIPTION
# 📲 What
Added `expandedCountry` to the `Location` model.

# 🤔 Why
So we can tell users why a credit card isn't allowed.

# 🛠 How
- Alphabetized `Location` model (after `id`).
- Added `expandedCountry` to the `Location` model.
- Updated `NewCardFragment` and `RewardCardViewHolderViewModel` to use value.
- Tests.

# 👀 See
| Before 🐛 | After 🦋 |
| --- | --- |
| ![screenshot-2019-08-05_113355](https://user-images.githubusercontent.com/1289295/63118664-4d8d7480-bf6c-11e9-8e38-c77e5fc02b8e.png) | ![screenshot-2019-08-15_144836](https://user-images.githubusercontent.com/1289295/63118568-20d95d00-bf6c-11e9-8882-6634cd8ff911.png) |
| --- | --- |
|  ![screenshot-2019-08-06_120413](https://user-images.githubusercontent.com/1289295/63118614-38b0e100-bf6c-11e9-9d97-75d8fb4eab1f.png) | ![screenshot-2019-08-15_144851](https://user-images.githubusercontent.com/1289295/63118569-20d95d00-bf6c-11e9-936c-2d9b3d763448.png) |

# 📋 QA
💵 All (accepted) cards should be available for projects that are in USD.
🚫 💵 Non USD projects only allow AMEX™, Mastercard™, and Visa™.

# Story 📖
https://dripsprint.atlassian.net/browse/NT-149
