### PR TITLE
[🔒] Sending client id with custom header on graphql requests

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -251,8 +251,9 @@ public final class ApplicationModule {
   @Provides
   @Singleton
   @NonNull
-  static GraphQLInterceptor provideGraphQLInterceptor(final @NonNull CurrentUserType currentUser) {
-    return new GraphQLInterceptor(currentUser);
+  static GraphQLInterceptor provideGraphQLInterceptor(final @NonNull String clientId,
+    final @NonNull CurrentUserType currentUser) {
+    return new GraphQLInterceptor(clientId, currentUser);
   }
 
   @Provides

--- a/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
+++ b/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
@@ -4,13 +4,14 @@ import com.kickstarter.libs.CurrentUserType
 import okhttp3.Interceptor
 import okhttp3.Response
 
-class GraphQLInterceptor(private val currentUser: CurrentUserType) : Interceptor {
+class GraphQLInterceptor(private val clientId: String, private val currentUser: CurrentUserType) : Interceptor {
     override fun intercept(chain: Interceptor.Chain?): Response {
         val original = chain!!.request()
         val builder = original.newBuilder().method(original.method(), original.body())
         if (this.currentUser.exists()) {
-            builder.addHeader("Authorization", "token " + currentUser.accessToken)
+            builder.addHeader("Authorization", "token " + this.currentUser.accessToken)
         }
+        builder.addHeader("X-KICKSTARTER-CLIENT", this.clientId)
         return chain.proceed(builder.build())
     }
 }


### PR DESCRIPTION
# 📲 What
Sending client id with custom header on graphql requests

# 🤔 Why
2 B SECURE

# 🛠 How
Added `clientId` to `GraphQLInterceptor` constructor.
Sending with every graphQL request with as `"X-KICKSTARTER-CLIENT"` header.

# 👀 See
Nothing 2 c here.

# 📋 QA
👀 if you're on a debug build, this will be in the logz

# Story 📖
https://dripsprint.atlassian.net/browse/NT-87
