### PR TITLE
[🔁] Revert manage pledge

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/factories/LocationFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/LocationFactory.java
@@ -9,7 +9,7 @@ public final class LocationFactory {
 
   public static @NonNull Location germany() {
     return Location.builder()
-      .id(638242)
+      .id(1L)
       .displayableName("Berlin, Germany")
       .name("Berlin")
       .state("Berlin")
@@ -20,7 +20,7 @@ public final class LocationFactory {
 
   public static @NonNull Location mexico() {
     return Location.builder()
-      .id(638242)
+      .id(2L)
       .displayableName("Mexico City, Mexico")
       .name("Mexico City")
       .state("Mexico")
@@ -31,7 +31,7 @@ public final class LocationFactory {
 
   public static @NonNull Location nigeria() {
     return Location.builder()
-      .id(638242)
+      .id(3L)
       .displayableName("Nigeria")
       .name("Nigeria")
       .state("Imo State")
@@ -42,7 +42,7 @@ public final class LocationFactory {
 
   public static @NonNull Location sydney() {
     return Location.builder()
-      .id(1105779)
+      .id(4L)
       .name("Sydney")
       .displayableName("Sydney, AU")
       .country("AU")
@@ -54,7 +54,7 @@ public final class LocationFactory {
 
   public static @NonNull Location unitedStates() {
     return Location.builder()
-      .id(12589335)
+      .id(5L)
       .displayableName("Brooklyn, NY")
       .name("Brooklyn")
       .state("NY")

--- a/app/src/main/java/com/kickstarter/mock/factories/LocationFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/LocationFactory.java
@@ -29,6 +29,17 @@ public final class LocationFactory {
       .build();
   }
 
+  public static @NonNull Location nigeria() {
+    return Location.builder()
+      .id(638242)
+      .displayableName("Nigeria")
+      .name("Nigeria")
+      .state("Imo State")
+      .country("NG")
+      .expandedCountry("Nigeria")
+      .build();
+  }
+
   public static @NonNull Location sydney() {
     return Location.builder()
       .id(1105779)

--- a/app/src/main/java/com/kickstarter/mock/factories/ShippingRulesEnvelopeFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/ShippingRulesEnvelopeFactory.kt
@@ -1,6 +1,5 @@
 package com.kickstarter.mock.factories
 
-import com.kickstarter.models.ShippingRule
 import com.kickstarter.services.apiresponses.ShippingRulesEnvelope
 
 class ShippingRulesEnvelopeFactory private constructor() {

--- a/app/src/main/java/com/kickstarter/ui/ArgumentsKey.java
+++ b/app/src/main/java/com/kickstarter/ui/ArgumentsKey.java
@@ -3,10 +3,11 @@ package com.kickstarter.ui;
 public final class ArgumentsKey {
   private ArgumentsKey() {}
   public static final String CANCEL_PLEDGE_PROJECT = "com.kickstarter.ui.fragments.CancelPledgeFragment.project";
+  public static final String DISCOVERY_SORT_POSITION = "argument_discovery_position";
   public static final String NEW_CARD_MODAL = "com.kickstarter.ui.fragments.NewCardFragment.modal";
   public static final String NEW_CARD_PROJECT = "com.kickstarter.ui.fragments.NewCardFragment.project";
+  public static final String PLEDGE_PLEDGE_REASON = "com.kickstarter.ui.fragments.PledgeFragment.pledge_reason";
+  public static final String PLEDGE_PROJECT = "com.kickstarter.ui.fragments.PledgeFragment.project";
   public static final String PLEDGE_REWARD = "com.kickstarter.ui.fragments.PledgeFragment.reward";
   public static final String PLEDGE_SCREEN_LOCATION = "com.kickstarter.ui.fragments.PledgeFragment.screen_location";
-  public static final String PLEDGE_PROJECT = "com.kickstarter.ui.fragments.PledgeFragment.project";
-  public static final String DISCOVERY_SORT_POSITION = "argument_discovery_position";
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -498,7 +498,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     }
 
     private fun showPledgeFragment(pledgeDataAndPledgeReason: Pair<PledgeData, PledgeReason>) {
-        val pledgeFragment = PledgeFragment.newInstance(pledgeDataAndPledgeReason.first)
+        val pledgeFragment = PledgeFragment.newInstance(pledgeDataAndPledgeReason.first, pledgeDataAndPledgeReason.second)
         val tag = PledgeFragment::class.java.simpleName
         supportFragmentManager
                 .beginTransaction()

--- a/app/src/main/java/com/kickstarter/ui/data/PledgeReason.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/PledgeReason.kt
@@ -1,5 +1,5 @@
 package com.kickstarter.ui.data
 
 enum class PledgeReason {
-    PLEDGE, UPDATE_PAYMENT, UPDATE_PLEDGE
+    PLEDGE, UPDATE_PAYMENT, UPDATE_PLEDGE, UPDATE_REWARD
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -121,12 +121,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.outputs.snapshotIsGone()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe {
-                    ViewUtils.setGone(reward_to_copy, it)
-                    ViewUtils.setGone(reward_snapshot, it)
-                    ViewUtils.setGone(expand_icon_container, it)
-                    ViewUtils.setInvisible(pledge_root, !it)
-                }
+                .subscribe { configureUIBySnapshotVisibility(it) }
 
         this.viewModel.outputs.pledgeSectionIsGone()
                 .compose(bindToLifecycle())
@@ -156,10 +151,12 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.outputs.deliverySectionIsGone()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe {
-                    ViewUtils.setGone(delivery, it)
-                    ViewUtils.setGone(divider_delivery, it)
-                }
+                .subscribe { ViewUtils.setGone(delivery, it) }
+
+        this.viewModel.outputs.deliveryDividerIsGone()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { ViewUtils.setGone(divider_delivery, it) }
 
         this.viewModel.outputs.continueButtonIsGone()
                 .compose(bindToLifecycle())
@@ -298,10 +295,12 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.outputs.pledgeSummaryIsGone()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe {
-                    ViewUtils.setGone(pledge_summary, it)
-                    ViewUtils.setGone(divider_total, !it)
-                }
+                .subscribe { ViewUtils.setGone(pledge_summary, it) }
+
+        this.viewModel.outputs.totalDividerIsGone()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { ViewUtils.setGone(divider_total, it) }
 
         this.viewModel.outputs.totalAmount()
                 .compose(bindToLifecycle())
@@ -410,6 +409,12 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
 
     override fun selectCardButtonClicked(position: Int) {
         this.viewModel.inputs.selectCardButtonClicked(position)
+    }
+
+    private fun configureUIBySnapshotVisibility(gone: Boolean) {
+        val visibility = if (gone) View.GONE else View.VISIBLE
+        setVisibility(visibility, reward_snapshot, reward_to_copy, expand_icon_container)
+        ViewUtils.setInvisible(pledge_root, !gone)
     }
 
     private fun displayShippingRules(shippingRules: List<ShippingRule>, project: Project) {

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -282,37 +282,10 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .compose(bindToLifecycle())
                 .subscribe { setHtmlStrings(it) }
 
-        this.viewModel.outputs.cancelPledgeButtonIsGone()
-                .compose(observeForUI())
-                .compose(bindToLifecycle())
-                .subscribe { ViewUtils.setGone(cancel_pledge_button, it) }
-
-        this.viewModel.outputs.changePaymentMethodButtonIsGone()
-                .compose(observeForUI())
-                .compose(bindToLifecycle())
-                .subscribe { ViewUtils.setGone(change_payment_method_button, it) }
-
         this.viewModel.outputs.updatePledgeButtonIsGone()
                 .compose(observeForUI())
                 .compose(bindToLifecycle())
                 .subscribe { ViewUtils.setGone(update_pledge_button, it) }
-
-        this.viewModel.outputs.totalContainerIsGone()
-                .compose(observeForUI())
-                .compose(bindToLifecycle())
-                .subscribe { ViewUtils.setGone(total, it) }
-
-        this.viewModel.outputs.showCancelPledge()
-                .compose(observeForUI())
-                .compose(bindToLifecycle())
-                .subscribe {
-                    fragmentManager
-                            ?.beginTransaction()
-                            ?.setCustomAnimations(R.anim.slide_up, 0, 0, R.anim.slide_down)
-                            ?.add(R.id.secondary_container, CancelPledgeFragment.newInstance(it), CancelPledgeFragment::class.java.simpleName)
-                            ?.addToBackStack(CancelPledgeFragment::class.java.simpleName)
-                            ?.commit()
-                }
 
         this.viewModel.outputs.showMinimumWarning()
                 .compose(observeForUI())
@@ -346,10 +319,6 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
 
         increase_pledge.setOnClickListener {
             this.viewModel.inputs.increasePledgeButtonClicked()
-        }
-
-        cancel_pledge_button.setOnClickListener {
-            this.viewModel.inputs.cancelPledgeButtonClicked()
         }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -52,6 +52,7 @@ import com.kickstarter.ui.adapters.RewardCardAdapter
 import com.kickstarter.ui.adapters.ShippingRulesAdapter
 import com.kickstarter.ui.data.CardState
 import com.kickstarter.ui.data.PledgeData
+import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ScreenLocation
 import com.kickstarter.ui.itemdecorations.RewardCardItemDecoration
 import com.kickstarter.ui.viewholders.NativeCheckoutRewardViewHolder
@@ -516,6 +517,8 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
             reward_snapshot.visibility = View.GONE
             expand_icon_container.visibility = View.GONE
             pledge_root.visibility = View.VISIBLE
+            delivery.visibility = View.GONE
+            divider_delivery.visibility = View.GONE
         }
     }
 
@@ -689,12 +692,13 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
 
     companion object {
 
-        fun newInstance(pledgeData: PledgeData): PledgeFragment {
+        fun newInstance(pledgeData: PledgeData, pledgeReason: PledgeReason): PledgeFragment {
             val fragment = PledgeFragment()
             val argument = Bundle()
             argument.putParcelable(ArgumentsKey.PLEDGE_REWARD, pledgeData.reward)
             argument.putParcelable(ArgumentsKey.PLEDGE_PROJECT, pledgeData.project)
             argument.putSerializable(ArgumentsKey.PLEDGE_SCREEN_LOCATION, pledgeData.rewardScreenLocation)
+            argument.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, pledgeReason)
             fragment.arguments = argument
             return fragment
         }

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -15,6 +15,7 @@ import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.adapters.NativeCheckoutRewardsAdapter
 import com.kickstarter.ui.data.PledgeData
+import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ScreenLocation
 import com.kickstarter.viewmodels.RewardsFragmentViewModel
 import kotlinx.android.synthetic.main.fragment_rewards.*
@@ -46,7 +47,7 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Nati
         this.viewModel.outputs.showPledgeFragment()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { showPledgeFragment(it) }
+                .subscribe { showPledgeFragment(it.first, it.second) }
 
         this.viewModel.outputs.rewardsCount()
                 .compose(bindToLifecycle())
@@ -96,9 +97,9 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Nati
         addItemDecorator()
     }
 
-    private fun showPledgeFragment(pledgeData: PledgeData) {
+    private fun showPledgeFragment(pledgeData: PledgeData, pledgeReason: PledgeReason) {
         if (this.fragmentManager?.findFragmentByTag(PledgeFragment::class.java.simpleName) == null) {
-            val pledgeFragment = PledgeFragment.newInstance(pledgeData)
+            val pledgeFragment = PledgeFragment.newInstance(pledgeData, pledgeReason)
             this.fragmentManager?.beginTransaction()
                     ?.add(R.id.fragment_container,
                             pledgeFragment,

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -376,7 +376,12 @@ interface PledgeFragmentViewModel {
                     .map { it.maxPledge }
                     .compose<Pair<Int, Double>>(combineLatestPair(rewardMinimum))
 
-            val pledgeInput = Observable.merge(rewardMinimum, this.pledgeInput.map { NumberUtils.parse(it) })
+            val initialAmount = rewardMinimum
+                    .compose<Pair<Double, PledgeReason>>(combineLatestPair(pledgeReason))
+                    .filter { it.second == PledgeReason.PLEDGE || it.second == PledgeReason.UPDATE_REWARD }
+                    .map { it.first }
+
+            val pledgeInput = Observable.merge(initialAmount, this.pledgeInput.map { NumberUtils.parse(it) })
                     .distinctUntilChanged()
                     .compose<Pair<Double, Country>>(combineLatestPair(country.distinctUntilChanged()))
                     .map { min(it.first, it.second.maxPledge.toDouble()) }
@@ -423,12 +428,7 @@ interface PledgeFragmentViewModel {
             backingAmount
                     .compose<Pair<Double, PledgeReason>>(combineLatestPair(pledgeReason))
 
-            val initialAmount = rewardMinimum
-                    .compose<Pair<Double, PledgeReason>>(combineLatestPair(pledgeReason))
-                    .filter { it.second == PledgeReason.PLEDGE || it.second == PledgeReason.UPDATE_REWARD }
-                    .map { it.first }
-
-            val pledgeAmount = Observable.merge(initialAmount, backingAmount, pledgeInput)
+            val pledgeAmount = Observable.merge(backingAmount, pledgeInput)
                     .distinctUntilChanged()
 
             pledgeAmount

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -29,9 +29,6 @@ interface PledgeFragmentViewModel {
         /** Call when a card has been inserted into the stored cards list. */
         fun addedCardPosition(position: Int)
 
-        /** Call when user clicks the cancel pledge button. */
-        fun cancelPledgeButtonClicked()
-
         /** Call when a card has successfully saved. */
         fun cardSaved(storedCard: StoredCard)
 
@@ -85,14 +82,8 @@ interface PledgeFragmentViewModel {
         /** Emits the base URL to build terms URLs. */
         fun baseUrlForTerms(): Observable<String>
 
-        /** Emits a boolean determining if the cancel pledge button should be hidden. */
-        fun cancelPledgeButtonIsGone(): Observable<Boolean>
-
         /** Emits a list of stored cards for a user. */
         fun cardsAndProject(): Observable<Pair<List<StoredCard>, Project>>
-
-        /** Emits a boolean determining if the change payment method pledge button should be hidden. */
-        fun changePaymentMethodButtonIsGone(): Observable<Boolean>
 
         /** Emits a boolean determining if the continue button should be hidden. */
         fun continueButtonIsGone(): Observable<Boolean>
@@ -142,9 +133,6 @@ interface PledgeFragmentViewModel {
         /** Emits when the shipping rules section should be hidden. */
         fun shippingRulesSectionIsGone(): Observable<Boolean>
 
-        /** Emits when we should start the [com.kickstarter.ui.fragments.CancelPledgeFragment]. */
-        fun showCancelPledge(): Observable<Project>
-
         /** Emits when we should the user a warning about not satisfying the reward's minimum. */
         fun showMinimumWarning(): Observable<String>
 
@@ -169,9 +157,6 @@ interface PledgeFragmentViewModel {
         /** Emits the total amount string of the pledge. */
         fun totalAmount(): Observable<SpannableString>
 
-        /** Emits a boolean determining if the total container should be hidden. */
-        fun totalContainerIsGone(): Observable<Boolean>
-
         /** Emits the color resource ID of the total amount. */
         fun totalTextColor(): Observable<Int>
 
@@ -182,7 +167,6 @@ interface PledgeFragmentViewModel {
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<PledgeFragment>(environment), Inputs, Outputs {
 
         private val addedCardPosition = PublishSubject.create<Int>()
-        private val cancelPledgeButtonClicked = PublishSubject.create<Void>()
         private val cardSaved = PublishSubject.create<StoredCard>()
         private val closeCardButtonClicked = PublishSubject.create<Int>()
         private val continueButtonClicked = PublishSubject.create<Void>()
@@ -201,9 +185,7 @@ interface PledgeFragmentViewModel {
         private val additionalPledgeAmountIsGone = BehaviorSubject.create<Boolean>()
         private val animateRewardCard = BehaviorSubject.create<PledgeData>()
         private val baseUrlForTerms = BehaviorSubject.create<String>()
-        private val cancelPledgeButtonIsGone = BehaviorSubject.create<Boolean>()
         private val cardsAndProject = BehaviorSubject.create<Pair<List<StoredCard>, Project>>()
-        private val changePaymentMethodButtonIsGone = BehaviorSubject.create<Boolean>()
         private val continueButtonIsGone = BehaviorSubject.create<Boolean>()
         private val conversionText = BehaviorSubject.create<String>()
         private val conversionTextViewIsGone = BehaviorSubject.create<Boolean>()
@@ -220,7 +202,6 @@ interface PledgeFragmentViewModel {
         private val shippingAmount = BehaviorSubject.create<String>()
         private val shippingRulesAndProject = BehaviorSubject.create<Pair<List<ShippingRule>, Project>>()
         private val shippingRulesSectionIsGone = BehaviorSubject.create<Boolean>()
-        private val showCancelPledge = PublishSubject.create<Project>()
         private val showMinimumWarning = PublishSubject.create<String>()
         private val showNewCardFragment = PublishSubject.create<Project>()
         private val showPledgeCard = BehaviorSubject.create<Pair<Int, CardState>>()
@@ -229,7 +210,6 @@ interface PledgeFragmentViewModel {
         private val startLoginToutActivity = PublishSubject.create<Void>()
         private val startThanksActivity = PublishSubject.create<Project>()
         private val totalAmount = BehaviorSubject.create<SpannableString>()
-        private val totalContainerIsGone = BehaviorSubject.create<Boolean>()
         private val totalTextColor = BehaviorSubject.create<Int>()
         private val updatePledgeButtonIsGone = BehaviorSubject.create<Boolean>()
 
@@ -482,28 +462,6 @@ interface PledgeFragmentViewModel {
                     .distinctUntilChanged()
                     .subscribe(this.updatePledgeButtonIsGone)
 
-            projectAndReward
-                    .map { it.first.isLive && BackingUtils.isBacked(it.first, it.second) }
-                    .map { BooleanUtils.negate(it) }
-                    .distinctUntilChanged()
-                    .subscribe(this.changePaymentMethodButtonIsGone)
-
-            projectAndReward
-                    .map { it.first.isLive && BackingUtils.isBacked(it.first, it.second) }
-                    .map { BooleanUtils.negate(it) }
-                    .distinctUntilChanged()
-                    .subscribe(this.cancelPledgeButtonIsGone)
-
-            projectAndReward
-                    .map { it.first.isLive && it.first.isBacking && BackingUtils.isBacked(it.first, it.second) }
-                    .distinctUntilChanged()
-                    .subscribe(this.totalContainerIsGone)
-
-            project
-                    .compose<Project>(takeWhen(this.cancelPledgeButtonClicked))
-                    .compose(bindToLifecycle())
-                    .subscribe(this.showCancelPledge)
-
             // Payment section
             userIsLoggedIn
                     .compose<Pair<Boolean, Pair<Project, Reward>>>(combineLatestPair(projectAndReward))
@@ -644,8 +602,6 @@ interface PledgeFragmentViewModel {
 
         override fun addedCardPosition(position: Int) = this.addedCardPosition.onNext(position)
 
-        override fun cancelPledgeButtonClicked() = this.cancelPledgeButtonClicked.onNext(null)
-
         override fun cardSaved(storedCard: StoredCard) = this.cardSaved.onNext(storedCard)
 
         override fun closeCardButtonClicked(position: Int) = this.closeCardButtonClicked.onNext(position)
@@ -686,13 +642,7 @@ interface PledgeFragmentViewModel {
         override fun baseUrlForTerms(): Observable<String> = this.baseUrlForTerms
 
         @NonNull
-        override fun cancelPledgeButtonIsGone(): Observable<Boolean> = this.cancelPledgeButtonIsGone
-
-        @NonNull
         override fun cardsAndProject(): Observable<Pair<List<StoredCard>, Project>> = this.cardsAndProject
-
-        @NonNull
-        override fun changePaymentMethodButtonIsGone(): Observable<Boolean> = this.changePaymentMethodButtonIsGone
 
         @NonNull
         override fun continueButtonIsGone(): Observable<Boolean> = this.continueButtonIsGone
@@ -743,9 +693,6 @@ interface PledgeFragmentViewModel {
         override fun shippingRulesSectionIsGone(): Observable<Boolean> = this.shippingRulesSectionIsGone
 
         @NonNull
-        override fun showCancelPledge(): Observable<Project> = this.showCancelPledge
-
-        @NonNull
         override fun showMinimumWarning(): Observable<String> = this.showMinimumWarning
 
         @NonNull
@@ -768,9 +715,6 @@ interface PledgeFragmentViewModel {
 
         @NonNull
         override fun totalAmount(): Observable<SpannableString> = this.totalAmount
-
-        @NonNull
-        override fun totalContainerIsGone(): Observable<Boolean> = this.totalContainerIsGone
 
         @NonNull
         override fun totalTextColor(): Observable<Int> = this.totalTextColor

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -9,6 +9,7 @@ import com.kickstarter.libs.utils.BackingUtils
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.data.PledgeData
+import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ScreenLocation
 import com.kickstarter.ui.fragments.RewardsFragment
 import rx.Observable
@@ -35,7 +36,7 @@ class RewardsFragmentViewModel {
         fun rewardsCount(): Observable<Int>
 
         /** Emits when we should show the [com.kickstarter.ui.fragments.PledgeFragment].  */
-        fun showPledgeFragment(): Observable<PledgeData>
+        fun showPledgeFragment(): Observable<Pair<PledgeData, PledgeReason>>
     }
 
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<RewardsFragment>(environment), Inputs, Outputs {
@@ -46,7 +47,7 @@ class RewardsFragmentViewModel {
         private val backedRewardPosition = PublishSubject.create<Int>()
         private val project = BehaviorSubject.create<Project>()
         private val rewardsCount = BehaviorSubject.create<Int>()
-        private val showPledgeFragment = PublishSubject.create<PledgeData>()
+        private val showPledgeFragment = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -65,7 +66,7 @@ class RewardsFragmentViewModel {
 
             this.projectInput
                     .compose<Pair<Project, Pair<ScreenLocation, Reward>>>(Transformers.takePairWhen(this.rewardClicked))
-                    .map { PledgeData(it.second.first, it.second.second, it.first) }
+                    .map { Pair(PledgeData(it.second.first, it.second.second, it.first), if (it.first.isBacking) PledgeReason.UPDATE_REWARD else PledgeReason.PLEDGE) }
                     .compose(bindToLifecycle())
                     .subscribe(this.showPledgeFragment)
 
@@ -105,6 +106,6 @@ class RewardsFragmentViewModel {
         override fun rewardsCount(): Observable<Int> = this.rewardsCount
 
         @NonNull
-        override fun showPledgeFragment(): Observable<PledgeData> = this.showPledgeFragment
+        override fun showPledgeFragment(): Observable<Pair<PledgeData, PledgeReason>> = this.showPledgeFragment
     }
 }

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -78,7 +78,9 @@
         android:paddingEnd="@dimen/activity_vertical_margin"
         android:paddingStart="@dimen/activity_vertical_margin">
 
-        <include layout="@layout/horizontal_line_1dp_view" />
+        <include
+          android:id="@+id/divider_delivery"
+          layout="@layout/horizontal_line_1dp_view" />
 
         <TextView
           android:id="@+id/pledge_amount_label"

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -57,8 +57,7 @@
         android:layout_marginStart="@dimen/grid_1"
         android:layout_marginTop="@dimen/grid_2"
         android:contentDescription="@null"
-        android:src="@drawable/ic_expand"
-        />
+        android:src="@drawable/ic_expand" />
     </FrameLayout>
 
     <LinearLayout
@@ -82,28 +81,17 @@
           android:id="@+id/divider_delivery"
           layout="@layout/horizontal_line_1dp_view" />
 
-        <TextView
-          android:id="@+id/pledge_amount_label"
-          style="@style/CalloutPrimaryMedium"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_1"
-          android:layout_marginTop="@dimen/grid_4"
-          android:text="@string/Your_pledge_amount" />
-
         <include layout="@layout/fragment_pledge_section_pledge_amount" />
-
-        <TextView
-          android:id="@+id/shipping_rules_section_text_view"
-          style="@style/CalloutPrimaryMedium"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_1"
-          android:text="@string/Your_shipping_location" />
 
         <include layout="@layout/fragment_pledge_section_shipping" />
 
-        <include layout="@layout/horizontal_line_1dp_view" />
+        <include layout="@layout/fragment_pledge_section_summary_pledge" />
+
+        <include layout="@layout/fragment_pledge_section_summary_shipping" />
+
+        <include
+          android:id="@+id/divider_total"
+          layout="@layout/horizontal_line_1dp_view" />
 
         <include layout="@layout/fragment_pledge_section_total" />
 
@@ -115,7 +103,7 @@
           android:layout_marginBottom="@dimen/grid_3"
           android:text="@string/Continue"
           android:visibility="gone"
-          tools:visibility="visible" />
+          tools:visibility="gone" />
 
         <com.google.android.material.button.MaterialButton
           android:id="@+id/update_pledge_button"
@@ -125,7 +113,9 @@
           android:enabled="false"
           android:text="@string/Update_pledge"
           android:textColor="@color/white"
-          app:backgroundTint="@color/button_pledge_live" />
+          android:visibility="gone"
+          app:backgroundTint="@color/button_pledge_live"
+          tools:visibility="gone" />
 
       </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -100,35 +100,7 @@
 
         <include layout="@layout/fragment_pledge_section_shipping" />
 
-        <com.google.android.material.button.MaterialButton
-          android:id="@+id/update_pledge_button"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_4"
-          android:enabled="false"
-          android:text="@string/Update_pledge"
-          android:textColor="@color/white"
-          app:backgroundTint="@color/button_pledge_live" />
-
         <include layout="@layout/horizontal_line_1dp_view" />
-
-        <com.google.android.material.button.MaterialButton
-          android:id="@+id/change_payment_method_button"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginTop="@dimen/grid_4"
-          android:enabled="false"
-          android:text="@string/Change_payment_method"
-          app:backgroundTint="@color/button_pledge_ended" />
-
-        <com.google.android.material.button.MaterialButton
-          android:id="@+id/cancel_pledge_button"
-          style="@style/TertiaryButton"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_4"
-          android:layout_marginTop="@dimen/grid_2"
-          android:text="@string/Cancel_pledge" />
 
         <include layout="@layout/fragment_pledge_section_total" />
 
@@ -141,6 +113,16 @@
           android:text="@string/Continue"
           android:visibility="gone"
           tools:visibility="visible" />
+
+        <com.google.android.material.button.MaterialButton
+          android:id="@+id/update_pledge_button"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginBottom="@dimen/grid_4"
+          android:enabled="false"
+          android:text="@string/Update_pledge"
+          android:textColor="@color/white"
+          app:backgroundTint="@color/button_pledge_live" />
 
       </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_pledge_section_pledge_amount.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_pledge_amount.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/pledge_container"
   android:layout_width="match_parent"
@@ -11,11 +10,23 @@
   android:orientation="horizontal"
   tools:showIn="@layout/fragment_pledge">
 
+  <TextView
+    android:id="@+id/pledge_amount_label"
+    style="@style/CalloutPrimaryMedium"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/grid_4"
+    android:text="@string/Your_pledge_amount"
+    app:layout_constraintBottom_toTopOf="@id/decrease_pledge"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
+
   <!-- TODO: Needs final copy for content descriptions -->
   <ImageButton
     android:id="@+id/decrease_pledge"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/grid_1"
     android:background="@drawable/bg_decrease"
     android:backgroundTint="@color/white_enabled_gray_disabled"
     android:contentDescription="@null"
@@ -23,12 +34,13 @@
     android:tint="@color/green_enabled_dark_grey_disabled"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
+    app:layout_constraintTop_toBottomOf="@id/pledge_amount_label" />
 
   <ImageButton
     android:id="@+id/increase_pledge"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/grid_1"
     android:background="@drawable/bg_increase"
     android:backgroundTint="@color/white_enabled_gray_disabled"
     android:contentDescription="@null"
@@ -36,12 +48,13 @@
     android:tint="@color/green_enabled_dark_grey_disabled"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintStart_toEndOf="@id/decrease_pledge"
-    app:layout_constraintTop_toTopOf="parent" />
+    app:layout_constraintTop_toBottomOf="@id/pledge_amount_label" />
 
   <LinearLayout
     android:id="@+id/additional_pledge_amount_container"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/grid_1"
     android:layout_marginEnd="@dimen/grid_2"
     android:animateLayoutChanges="true"
     android:focusable="true"
@@ -52,7 +65,7 @@
     app:layout_constraintHorizontal_bias="1"
     app:layout_constraintHorizontal_chainStyle="packed"
     app:layout_constraintStart_toEndOf="@id/increase_pledge"
-    app:layout_constraintTop_toTopOf="parent">
+    app:layout_constraintTop_toBottomOf="@id/pledge_amount_label">
 
     <!-- todo: needs some a11y plz-->
     <ImageView
@@ -75,6 +88,7 @@
     android:id="@+id/pledge_amount_container"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/grid_1"
     android:background="@drawable/rect_white_rounded"
     android:gravity="center_vertical"
     android:orientation="horizontal"
@@ -83,7 +97,7 @@
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintHorizontal_bias="1"
     app:layout_constraintStart_toEndOf="@id/additional_pledge_amount_container"
-    app:layout_constraintTop_toTopOf="parent">
+    app:layout_constraintTop_toBottomOf="@id/pledge_amount_label">
 
     <TextView
       android:id="@+id/pledge_symbol_start"

--- a/app/src/main/res/layout/fragment_pledge_section_shipping.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_shipping.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-  android:id="@+id/shipping_rules_row"
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/shipping_rules_row"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:layout_marginBottom="@dimen/grid_4"
@@ -11,11 +10,22 @@
   android:orientation="horizontal"
   tools:showIn="@layout/fragment_pledge">
 
+  <TextView
+    android:id="@+id/shipping_rules_label"
+    style="@style/CalloutPrimaryMedium"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/Your_shipping_location"
+    app:layout_constraintBottom_toTopOf="@id/shipping_rules"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
+
   <AutoCompleteTextView
     android:id="@+id/shipping_rules"
     style="@style/AutocompleteStyle"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/grid_1"
     android:layout_marginEnd="@dimen/grid_3"
     android:ellipsize="end"
     android:enabled="false"
@@ -29,7 +39,7 @@
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toStartOf="@id/shipping_add_symbol"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/shipping_rules_label"
     tools:text="United States" />
 
   <ImageView
@@ -37,13 +47,14 @@
     android:layout_width="@dimen/grid_3"
     android:layout_height="@dimen/grid_3"
     android:layout_gravity="start|center_vertical"
+    android:layout_marginTop="@dimen/grid_1"
     android:contentDescription="@null"
     android:src="@drawable/ic_add"
     android:tint="@color/ksr_dark_grey_400"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toStartOf="@id/shipping_symbol_start"
     app:layout_constraintStart_toEndOf="@id/shipping_rules"
-    app:layout_constraintTop_toTopOf="parent" />
+    app:layout_constraintTop_toBottomOf="@id/shipping_rules_label" />
 
   <TextView
     android:id="@+id/shipping_symbol_start"
@@ -51,11 +62,12 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="end"
+    android:layout_marginTop="@dimen/grid_1"
     android:visibility="invisible"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toStartOf="@id/shipping_amount"
     app:layout_constraintStart_toEndOf="@id/shipping_add_symbol"
-    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/shipping_rules_label"
     tools:text="$"
     tools:visibility="visible" />
 
@@ -64,12 +76,13 @@
     style="@style/PledgeCurrency"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/grid_1"
     android:maxLines="1"
     app:layout_constrainedWidth="true"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toStartOf="@id/shipping_symbol_end"
     app:layout_constraintStart_toEndOf="@id/shipping_symbol_start"
-    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/shipping_rules_label"
     tools:text="20" />
 
   <TextView
@@ -78,12 +91,13 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="end"
+    android:layout_marginTop="@dimen/grid_1"
     android:visibility="invisible"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintHorizontal_bias="1"
     app:layout_constraintStart_toEndOf="@id/shipping_amount"
-    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/shipping_rules_label"
     tools:text="$"
     tools:visibility="visible" />
 
@@ -92,11 +106,12 @@
     android:layout_width="0dp"
     android:layout_height="@dimen/grid_2"
     android:layout_gravity="center|end"
+    android:layout_marginTop="@dimen/grid_1"
     android:background="@drawable/pledge_amounts_loading_states"
-    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintBottom_toBottomOf="@id/shipping_amount"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintHorizontal_bias="1"
     app:layout_constraintStart_toEndOf="@id/shipping_add_symbol"
-    app:layout_constraintTop_toTopOf="parent" />
+    app:layout_constraintTop_toBottomOf="@id/shipping_rules_label" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_pledge_section_summary_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_summary_pledge.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:id="@+id/pledge_summary"
+  android:visibility="gone"
+  tools:visibility="visible"
+  android:orientation="vertical">
+
+  <TextView
+    android:id="@+id/pledge_label"
+    style="@style/CalloutSecondaryMedium"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/Pledge"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toStartOf="@id/pledge_summary_amount_container"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
+
+  <LinearLayout
+    android:id="@+id/pledge_summary_amount_container"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical|end"
+    android:orientation="horizontal"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintHorizontal_bias="1"
+    app:layout_constraintStart_toEndOf="@id/pledge_label"
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintVertical_bias="0">
+
+    <TextView
+      android:id="@+id/pledge_summary_symbol_start"
+      style="@style/PledgeCurrencySecondary"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:visibility="invisible"
+      tools:text="$"
+      tools:visibility="visible" />
+
+    <TextView
+      android:id="@+id/pledge_summary_amount"
+      style="@style/PledgeCurrencySecondary"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:maxLines="1"
+      android:scrollHorizontally="true"
+      tools:text="40" />
+
+    <TextView
+      android:id="@+id/pledge_summary_symbol_end"
+      style="@style/PledgeCurrencySecondary"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:visibility="invisible"
+      tools:text="$"
+      tools:visibility="visible" />
+
+  </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_pledge_section_summary_shipping.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_summary_shipping.xml
@@ -15,13 +15,13 @@
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toStartOf="@id/shipping_add_symbol"
+    app:layout_constraintEnd_toStartOf="@id/shipping_summary_add_symbol"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"
     tools:text="Shipping: United States" />
 
   <ImageView
-    android:id="@+id/shipping_add_symbol"
+    android:id="@+id/shipping_summary_add_symbol"
     android:layout_width="@dimen/grid_3"
     android:layout_height="@dimen/grid_3"
     android:layout_gravity="start|center_vertical"
@@ -42,7 +42,7 @@
     android:visibility="invisible"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toStartOf="@id/shipping_summary_amount"
-    app:layout_constraintStart_toEndOf="@id/shipping_add_symbol"
+    app:layout_constraintStart_toEndOf="@id/shipping_summary_add_symbol"
     app:layout_constraintTop_toTopOf="parent"
     tools:text="$"
     tools:visibility="visible" />

--- a/app/src/main/res/layout/fragment_pledge_section_summary_shipping.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_summary_shipping.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:id="@+id/shipping_summary"
+  android:visibility="gone"
+  tools:visibility="visible"
+  android:orientation="vertical">
+
+  <TextView
+    android:id="@+id/shipping_label"
+    style="@style/CalloutSecondaryMedium"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toStartOf="@id/shipping_add_symbol"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:text="Shipping: United States" />
+
+  <ImageView
+    android:id="@+id/shipping_add_symbol"
+    android:layout_width="@dimen/grid_3"
+    android:layout_height="@dimen/grid_3"
+    android:layout_gravity="start|center_vertical"
+    android:contentDescription="@null"
+    android:src="@drawable/ic_add"
+    android:tint="@color/ksr_dark_grey_400"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toStartOf="@id/shipping_summary_symbol_start"
+    app:layout_constraintStart_toEndOf="@id/shipping_label"
+    app:layout_constraintTop_toTopOf="parent" />
+
+
+  <TextView
+    android:id="@+id/shipping_summary_symbol_start"
+    style="@style/PledgeCurrencySecondary"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:visibility="invisible"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toStartOf="@id/shipping_summary_amount"
+    app:layout_constraintStart_toEndOf="@id/shipping_add_symbol"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:text="$"
+    tools:visibility="visible" />
+
+  <TextView
+    android:id="@+id/shipping_summary_amount"
+    style="@style/PledgeCurrencySecondary"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:maxLines="1"
+    android:scrollHorizontally="true"
+    app:layout_constrainedWidth="true"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toStartOf="@id/shipping_summary_symbol_end"
+    app:layout_constraintStart_toEndOf="@id/shipping_summary_symbol_start"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:text="40" />
+
+  <TextView
+    android:id="@+id/shipping_summary_symbol_end"
+    style="@style/PledgeCurrencySecondary"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:visibility="invisible"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintHorizontal_bias="1"
+    app:layout_constraintStart_toEndOf="@id/shipping_summary_amount"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:text="$"
+    tools:visibility="visible" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/app/src/main/res/layout/fragment_pledge_section_summary_shipping.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_summary_shipping.xml
@@ -36,7 +36,7 @@
 
   <TextView
     android:id="@+id/shipping_summary_symbol_start"
-    style="@style/PledgeCurrencySecondary"
+    style="@style/PledgeCurrency"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:visibility="invisible"
@@ -49,7 +49,7 @@
 
   <TextView
     android:id="@+id/shipping_summary_amount"
-    style="@style/PledgeCurrencySecondary"
+    style="@style/PledgeCurrency"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:maxLines="1"
@@ -63,7 +63,7 @@
 
   <TextView
     android:id="@+id/shipping_summary_symbol_end"
-    style="@style/PledgeCurrencySecondary"
+    style="@style/PledgeCurrency"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:visibility="invisible"

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -35,9 +35,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val additionalPledgeAmountIsGone = TestSubscriber<Boolean>()
     private val animateRewardCard = TestSubscriber<PledgeData>()
     private val baseUrlForTerms = TestSubscriber<String>()
-    private val cancelPledgeButtonIsGone = TestSubscriber<Boolean>()
     private val cardsAndProject = TestSubscriber<Pair<List<StoredCard>, Project>>()
-    private val changePaymentMethodButtonIsGone = TestSubscriber<Boolean>()
     private val continueButtonIsGone = TestSubscriber<Boolean>()
     private val conversionText = TestSubscriber<String>()
     private val conversionTextViewIsGone = TestSubscriber<Boolean>()
@@ -54,7 +52,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val shippingAmount = TestSubscriber<String>()
     private val shippingRuleAndProject = TestSubscriber<Pair<List<ShippingRule>, Project>>()
     private val shippingRulesSectionIsGone = TestSubscriber<Boolean>()
-    private val showCancelPledge = TestSubscriber<Project>()
     private val showMinimumWarning = TestSubscriber<String>()
     private val showNewCardFragment = TestSubscriber<Project>()
     private val showPledgeCard = TestSubscriber<Pair<Int, CardState>>()
@@ -63,7 +60,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val startLoginToutActivity = TestSubscriber<Void>()
     private val startThanksActivity = TestSubscriber<Project>()
     private val totalAmount = TestSubscriber<String>()
-    private val totalContainerIsGone = TestSubscriber<Boolean>()
     private val totalTextColor = TestSubscriber<Int>()
     private val updatePledgeButtonIsGone = TestSubscriber<Boolean>()
 
@@ -76,9 +72,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.additionalPledgeAmountIsGone().subscribe(this.additionalPledgeAmountIsGone)
         this.vm.outputs.animateRewardCard().subscribe(this.animateRewardCard)
         this.vm.outputs.baseUrlForTerms().subscribe(this.baseUrlForTerms)
-        this.vm.outputs.cancelPledgeButtonIsGone().subscribe(this.cancelPledgeButtonIsGone)
         this.vm.outputs.cardsAndProject().subscribe(this.cardsAndProject)
-        this.vm.outputs.changePaymentMethodButtonIsGone().subscribe(this.changePaymentMethodButtonIsGone)
         this.vm.outputs.continueButtonIsGone().subscribe(this.continueButtonIsGone)
         this.vm.outputs.conversionText().subscribe(this.conversionText)
         this.vm.outputs.conversionTextViewIsGone().subscribe(this.conversionTextViewIsGone)
@@ -95,7 +89,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.shippingAmount().subscribe(this.shippingAmount)
         this.vm.outputs.shippingRulesAndProject().subscribe(this.shippingRuleAndProject)
         this.vm.outputs.shippingRulesSectionIsGone().subscribe(this.shippingRulesSectionIsGone)
-        this.vm.outputs.showCancelPledge().subscribe(this.showCancelPledge)
         this.vm.outputs.showMinimumWarning().subscribe(this.showMinimumWarning)
         this.vm.outputs.showPledgeCard().subscribe(this.showPledgeCard)
         this.vm.outputs.showPledgeError().subscribe(this.showPledgeError)
@@ -104,7 +97,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.showNewCardFragment().subscribe(this.showNewCardFragment)
         this.vm.outputs.startThanksActivity().subscribe(this.startThanksActivity)
         this.vm.outputs.totalAmount().map { it.toString() }.subscribe(this.totalAmount)
-        this.vm.outputs.totalContainerIsGone().subscribe(this.totalContainerIsGone)
         this.vm.outputs.totalTextColor().subscribe(this.totalTextColor)
         this.vm.outputs.updatePledgeButtonIsGone().subscribe(this.updatePledgeButtonIsGone)
 
@@ -279,51 +271,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.estimatedDelivery.assertNoValues()
         this.estimatedDeliveryInfoIsGone.assertValue(true)
-    }
-
-    @Test
-    fun testManageYourPledgeUIOutputs() {
-        setUpEnvironment(environment())
-        this.cancelPledgeButtonIsGone.assertValuesAndClear(true)
-        this.continueButtonIsGone.assertValuesAndClear(false)
-        this.changePaymentMethodButtonIsGone.assertValuesAndClear(true)
-        this.paymentContainerIsGone.assertValuesAndClear(true)
-        this.totalContainerIsGone.assertValuesAndClear(false)
-        this.updatePledgeButtonIsGone.assertValuesAndClear(true)
-
-        val environmentWithLoggedInUser = environment().toBuilder()
-                .currentUser(MockCurrentUser(UserFactory.user()))
-                .build()
-
-        setUpEnvironment(environmentWithLoggedInUser)
-        this.cancelPledgeButtonIsGone.assertValuesAndClear(true)
-        this.continueButtonIsGone.assertValuesAndClear(true)
-        this.changePaymentMethodButtonIsGone.assertValuesAndClear(true)
-        this.paymentContainerIsGone.assertValuesAndClear(false)
-        this.totalContainerIsGone.assertValuesAndClear(false)
-        this.updatePledgeButtonIsGone.assertValuesAndClear(true)
-
-        val backing = BackingFactory.backing()
-        val backedReward = backing.reward()
-        val backedProject = ProjectFactory.backedProject()
-                .toBuilder()
-                .backing(backing)
-                .build()
-        setUpEnvironment(environmentWithLoggedInUser, RewardFactory.reward(), backedProject)
-        this.cancelPledgeButtonIsGone.assertValuesAndClear(true)
-        this.continueButtonIsGone.assertValuesAndClear(true)
-        this.changePaymentMethodButtonIsGone.assertValuesAndClear(true)
-        this.paymentContainerIsGone.assertValuesAndClear(false)
-        this.totalContainerIsGone.assertValuesAndClear(false)
-        this.updatePledgeButtonIsGone.assertValuesAndClear(true)
-
-        setUpEnvironment(environmentWithLoggedInUser, backedReward, backedProject)
-        this.cancelPledgeButtonIsGone.assertValuesAndClear(false)
-        this.continueButtonIsGone.assertValuesAndClear(true)
-        this.changePaymentMethodButtonIsGone.assertValuesAndClear(false)
-        this.paymentContainerIsGone.assertValuesAndClear(true)
-        this.totalContainerIsGone.assertValuesAndClear(true)
-        this.updatePledgeButtonIsGone.assertValuesAndClear(false)
     }
 
     @Test
@@ -740,17 +687,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingRulesSectionIsGone.assertValues(false)
         this.shippingRuleAndProject.assertNoValues()
         this.totalAmount.assertNoValues()
-    }
-
-    @Test
-    fun testShowCancelPledge() {
-        val backedProject = ProjectFactory.backedProject()
-        val backing = backedProject.backing() ?: BackingFactory.backing()
-        val reward = backing.reward() ?: RewardFactory.reward()
-        setUpEnvironment(environment(), reward, backedProject)
-
-        this.vm.inputs.cancelPledgeButtonClicked()
-        this.showCancelPledge.assertValue(backedProject)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -12,14 +12,12 @@ import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.factories.*
 import com.kickstarter.mock.services.MockApiClient
 import com.kickstarter.mock.services.MockApolloClient
-import com.kickstarter.models.Project
-import com.kickstarter.models.Reward
-import com.kickstarter.models.ShippingRule
-import com.kickstarter.models.StoredCard
+import com.kickstarter.models.*
 import com.kickstarter.services.apiresponses.ShippingRulesEnvelope
 import com.kickstarter.ui.ArgumentsKey
 import com.kickstarter.ui.data.CardState
 import com.kickstarter.ui.data.PledgeData
+import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ScreenLocation
 import org.junit.Test
 import rx.Observable
@@ -40,22 +38,30 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val conversionText = TestSubscriber<String>()
     private val conversionTextViewIsGone = TestSubscriber<Boolean>()
     private val decreasePledgeButtonIsEnabled = TestSubscriber<Boolean>()
+    private val deliverySectionIsGone = TestSubscriber<Boolean>()
     private val estimatedDelivery = TestSubscriber<String>()
     private val estimatedDeliveryInfoIsGone = TestSubscriber<Boolean>()
     private val increasePledgeButtonIsEnabled = TestSubscriber<Boolean>()
     private val paymentContainerIsGone = TestSubscriber<Boolean>()
     private val pledgeAmount = TestSubscriber<String>()
     private val pledgeHint = TestSubscriber<String>()
+    private val pledgeSectionIsGone = TestSubscriber<Boolean>()
+    private val pledgeSummaryAmount = TestSubscriber<String>()
+    private val pledgeSummaryIsGone = TestSubscriber<Boolean>()
     private val pledgeTextColor = TestSubscriber<Int>()
     private val projectCurrencySymbol = TestSubscriber<String>()
     private val selectedShippingRule = TestSubscriber<ShippingRule>()
     private val shippingAmount = TestSubscriber<String>()
     private val shippingRuleAndProject = TestSubscriber<Pair<List<ShippingRule>, Project>>()
     private val shippingRulesSectionIsGone = TestSubscriber<Boolean>()
+    private val shippingSummaryAmount = TestSubscriber<String>()
+    private val shippingSummaryIsGone = TestSubscriber<Boolean>()
+    private val shippingSummaryLocation = TestSubscriber<String>()
     private val showMinimumWarning = TestSubscriber<String>()
     private val showNewCardFragment = TestSubscriber<Project>()
     private val showPledgeCard = TestSubscriber<Pair<Int, CardState>>()
     private val showPledgeError = TestSubscriber<Void>()
+    private val snapshotIsGone = TestSubscriber<Boolean>()
     private val startChromeTab = TestSubscriber<String>()
     private val startLoginToutActivity = TestSubscriber<Void>()
     private val startThanksActivity = TestSubscriber<Project>()
@@ -63,8 +69,10 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val totalTextColor = TestSubscriber<Int>()
     private val updatePledgeButtonIsGone = TestSubscriber<Boolean>()
 
-    private fun setUpEnvironment(environment: Environment, reward: Reward? = RewardFactory.rewardWithShipping(),
-                                 project: Project? = ProjectFactory.project()) {
+    private fun setUpEnvironment(environment: Environment,
+                                 reward: Reward? = RewardFactory.rewardWithShipping(),
+                                 project: Project? = ProjectFactory.project(),
+                                 pledgeReason: PledgeReason? = PledgeReason.PLEDGE) {
         this.vm = PledgeFragmentViewModel.ViewModel(environment)
 
         this.vm.outputs.addedCard().subscribe(this.addedCard)
@@ -77,33 +85,43 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.conversionText().subscribe(this.conversionText)
         this.vm.outputs.conversionTextViewIsGone().subscribe(this.conversionTextViewIsGone)
         this.vm.outputs.decreasePledgeButtonIsEnabled().subscribe(this.decreasePledgeButtonIsEnabled)
+        this.vm.outputs.deliverySectionIsGone().subscribe(this.deliverySectionIsGone)
         this.vm.outputs.estimatedDelivery().subscribe(this.estimatedDelivery)
         this.vm.outputs.estimatedDeliveryInfoIsGone().subscribe(this.estimatedDeliveryInfoIsGone)
         this.vm.outputs.increasePledgeButtonIsEnabled().subscribe(this.increasePledgeButtonIsEnabled)
         this.vm.outputs.paymentContainerIsGone().subscribe(this.paymentContainerIsGone)
         this.vm.outputs.pledgeAmount().subscribe(this.pledgeAmount)
         this.vm.outputs.pledgeHint().subscribe(this.pledgeHint)
+        this.vm.outputs.pledgeSectionIsGone().subscribe(this.pledgeSectionIsGone)
+        this.vm.outputs.pledgeSummaryAmount().subscribe(this.pledgeSummaryAmount)
+        this.vm.outputs.pledgeSummaryIsGone().subscribe(this.pledgeSummaryIsGone)
         this.vm.outputs.pledgeTextColor().subscribe(this.pledgeTextColor)
         this.vm.outputs.projectCurrencySymbol().map { StringUtils.trim(it.first.toString()) }.subscribe(this.projectCurrencySymbol)
         this.vm.outputs.selectedShippingRule().subscribe(this.selectedShippingRule)
         this.vm.outputs.shippingAmount().subscribe(this.shippingAmount)
         this.vm.outputs.shippingRulesAndProject().subscribe(this.shippingRuleAndProject)
         this.vm.outputs.shippingRulesSectionIsGone().subscribe(this.shippingRulesSectionIsGone)
+        this.vm.outputs.shippingSummaryAmount().subscribe(this.shippingSummaryAmount)
+        this.vm.outputs.shippingSummaryIsGone().subscribe(this.shippingSummaryIsGone)
+        this.vm.outputs.shippingSummaryLocation().subscribe(this.shippingSummaryLocation)
         this.vm.outputs.showMinimumWarning().subscribe(this.showMinimumWarning)
+        this.vm.outputs.showNewCardFragment().subscribe(this.showNewCardFragment)
         this.vm.outputs.showPledgeCard().subscribe(this.showPledgeCard)
         this.vm.outputs.showPledgeError().subscribe(this.showPledgeError)
+        this.vm.outputs.snapshotIsGone().subscribe(this.snapshotIsGone)
         this.vm.outputs.startChromeTab().subscribe(this.startChromeTab)
         this.vm.outputs.startLoginToutActivity().subscribe(this.startLoginToutActivity)
-        this.vm.outputs.showNewCardFragment().subscribe(this.showNewCardFragment)
         this.vm.outputs.startThanksActivity().subscribe(this.startThanksActivity)
         this.vm.outputs.totalAmount().map { it.toString() }.subscribe(this.totalAmount)
         this.vm.outputs.totalTextColor().subscribe(this.totalTextColor)
         this.vm.outputs.updatePledgeButtonIsGone().subscribe(this.updatePledgeButtonIsGone)
 
         val bundle = Bundle()
-        bundle.putSerializable(ArgumentsKey.PLEDGE_SCREEN_LOCATION, ScreenLocation(0f, 0f, 0f, 0f))
+        val screenLocation = if (pledgeReason == PledgeReason.PLEDGE || pledgeReason == PledgeReason.UPDATE_REWARD) ScreenLocation(0f, 0f, 0f, 0f) else null
+        bundle.putSerializable(ArgumentsKey.PLEDGE_SCREEN_LOCATION, screenLocation)
         bundle.putParcelable(ArgumentsKey.PLEDGE_PROJECT, project)
         bundle.putParcelable(ArgumentsKey.PLEDGE_REWARD, reward)
+        bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, pledgeReason)
         this.vm.arguments(bundle)
     }
 
@@ -194,10 +212,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testPaymentForLoggedInUser_whenDigitalReward() {
-        val environment = environment()
-                .toBuilder()
-                .currentUser(MockCurrentUser(UserFactory.user()))
-                .build()
+        val environment = environmentForLoggedInUser(UserFactory.user())
         setUpEnvironment(environment, RewardFactory.reward())
 
         this.cardsAndProject.assertValueCount(1)
@@ -248,6 +263,308 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.cardsAndProject.assertValueCount(1)
         this.continueButtonIsGone.assertValues(false, true)
         this.paymentContainerIsGone.assertValues(true, false)
+    }
+
+    @Test
+    fun testPledgeAmount_whenUpdatingPledge() {
+        val reward = RewardFactory.rewardWithShipping()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(40.0)
+                .shippingAmount(10f)
+                .reward(reward)
+                .rewardId(reward.id())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        val environment = environmentForLoggedInUser(UserFactory.user())
+                .toBuilder()
+                .apiClient(object : MockApiClient() {
+                    override fun fetchProjectBacking(project: Project, user: User): Observable<Backing> {
+                        return Observable.just(backing)
+                    }
+                })
+                .build()
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PLEDGE)
+
+        this.pledgeAmount.assertValue("30")
+    }
+
+    @Test
+    fun testPledgeScreenConfiguration_whenPledgingAndNotLoggedIn() {
+        setUpEnvironment(environment())
+
+        this.deliverySectionIsGone.assertValue(false)
+        this.pledgeSectionIsGone.assertValue(false)
+        this.pledgeSummaryIsGone.assertValue(true)
+        this.shippingSummaryIsGone.assertValue(true)
+        this.snapshotIsGone.assertValue(false)
+        this.updatePledgeButtonIsGone.assertValue(true)
+    }
+
+    @Test
+    fun testPledgeScreenConfiguration_whenPledgingAndLoggedIn() {
+        setUpEnvironment(environmentForLoggedInUser(UserFactory.user()))
+
+        this.deliverySectionIsGone.assertValue(false)
+        this.pledgeSectionIsGone.assertValue(false)
+        this.pledgeSummaryIsGone.assertValue(true)
+        this.shippingSummaryIsGone.assertValue(true)
+        this.snapshotIsGone.assertValue(false)
+        this.updatePledgeButtonIsGone.assertValue(true)
+    }
+
+    @Test
+    fun testPledgeScreenConfiguration_whenUpdatingPledgeOfShippableReward() {
+        val shippableReward = RewardFactory.rewardWithShipping()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .reward(shippableReward)
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        setUpEnvironment(environmentForLoggedInUser(UserFactory.user()), shippableReward, backedProject, PledgeReason.UPDATE_PLEDGE)
+
+        this.deliverySectionIsGone.assertValue(true)
+        this.pledgeSectionIsGone.assertValue(false)
+        this.pledgeSummaryIsGone.assertValue(true)
+        this.shippingRulesSectionIsGone.assertValue(false)
+        this.shippingSummaryIsGone.assertValue(true)
+        this.snapshotIsGone.assertValue(true)
+        this.updatePledgeButtonIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testPledgeScreenConfiguration_whenUpdatingPledgeOfDigitalReward() {
+        val noReward = RewardFactory.noReward()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .reward(noReward)
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        setUpEnvironment(environmentForLoggedInUser(UserFactory.user()), noReward, backedProject, PledgeReason.UPDATE_PLEDGE)
+
+        this.deliverySectionIsGone.assertValue(true)
+        this.pledgeSectionIsGone.assertValue(false)
+        this.pledgeSummaryIsGone.assertValue(true)
+        this.shippingRulesSectionIsGone.assertValue(true)
+        this.shippingSummaryIsGone.assertValue(true)
+        this.snapshotIsGone.assertValue(true)
+        this.updatePledgeButtonIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testPledgeScreenConfiguration_whenUpdatingPaymentOfShippableReward() {
+        val shippableReward = RewardFactory.rewardWithShipping()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .reward(shippableReward)
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        setUpEnvironment(environmentForLoggedInUser(UserFactory.user()), shippableReward, backedProject, PledgeReason.UPDATE_PAYMENT)
+
+        this.deliverySectionIsGone.assertValue(true)
+        this.pledgeSectionIsGone.assertValue(true)
+        this.pledgeSummaryIsGone.assertValue(false)
+        this.shippingRulesSectionIsGone.assertValue(true)
+        this.shippingSummaryIsGone.assertValue(false)
+        this.snapshotIsGone.assertValue(true)
+        this.updatePledgeButtonIsGone.assertValue(true)
+    }
+
+    @Test
+    fun testPledgeScreenConfiguration_whenUpdatingPaymentOfDigitalReward() {
+        val noReward = RewardFactory.noReward()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .reward(noReward)
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        setUpEnvironment(environmentForLoggedInUser(UserFactory.user()), noReward, backedProject, PledgeReason.UPDATE_PAYMENT)
+
+        this.deliverySectionIsGone.assertValue(true)
+        this.pledgeSectionIsGone.assertValue(true)
+        this.pledgeSummaryIsGone.assertValue(false)
+        this.shippingRulesSectionIsGone.assertValue(true)
+        this.shippingSummaryIsGone.assertValue(true)
+        this.snapshotIsGone.assertValue(true)
+        this.updatePledgeButtonIsGone.assertValue(true)
+    }
+
+    @Test
+    fun testPledgeScreenConfiguration_whenUpdatingRewardToShippableReward() {
+        val shippableReward = RewardFactory.rewardWithShipping()
+
+        setUpEnvironment(environmentForLoggedInUser(UserFactory.user()), shippableReward, ProjectFactory.backedProject(), PledgeReason.UPDATE_PLEDGE)
+
+        this.deliverySectionIsGone.assertValue(true)
+        this.pledgeSectionIsGone.assertValue(false)
+        this.pledgeSummaryIsGone.assertValue(true)
+        this.shippingRulesSectionIsGone.assertValue(false)
+        this.shippingSummaryIsGone.assertValue(true)
+        this.snapshotIsGone.assertValue(true)
+        this.updatePledgeButtonIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testPledgeScreenConfiguration_whenUpdatingRewardToDigitalReward() {
+        val noReward = RewardFactory.noReward()
+
+        setUpEnvironment(environmentForLoggedInUser(UserFactory.user()), noReward, ProjectFactory.backedProject(), PledgeReason.UPDATE_PLEDGE)
+
+        this.deliverySectionIsGone.assertValue(true)
+        this.pledgeSectionIsGone.assertValue(false)
+        this.pledgeSummaryIsGone.assertValue(true)
+        this.shippingRulesSectionIsGone.assertValue(true)
+        this.shippingSummaryIsGone.assertValue(true)
+        this.snapshotIsGone.assertValue(true)
+        this.updatePledgeButtonIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testPledgeSummaryAmount() {
+        val reward = RewardFactory.noReward()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(30.0)
+                .reward(reward)
+                .rewardId(reward.id())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        val environment = environmentForLoggedInUser(UserFactory.user())
+                .toBuilder()
+                .apiClient(object : MockApiClient() {
+                    override fun fetchProjectBacking(project: Project, user: User): Observable<Backing> {
+                        return Observable.just(backing)
+                    }
+                })
+                .build()
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PAYMENT)
+
+        this.pledgeSummaryAmount.assertValue("30")
+    }
+
+    @Test
+    fun testTotalAmount_whenUpdatingPledge() {
+        val reward = RewardFactory.rewardWithShipping()
+        val unitedStates = LocationFactory.unitedStates()
+        val shippingRule = ShippingRuleFactory.usShippingRule().toBuilder().location(unitedStates).build()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(40.0)
+                .location(unitedStates)
+                .locationId(unitedStates.id())
+                .reward(reward)
+                .rewardId(reward.id())
+                .shippingAmount(shippingRule.cost().toFloat())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        val config = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfig()
+        currentConfig.config(config)
+
+        val shippingRulesEnvelope = ShippingRulesEnvelopeFactory.shippingRules()
+                .toBuilder()
+                .shippingRules(listOf(ShippingRuleFactory.germanyShippingRule(), shippingRule))
+                .build()
+
+        val environment = environmentForShippingRules(shippingRulesEnvelope)
+                .toBuilder()
+                .currentUser(MockCurrentUser(UserFactory.user()))
+                .apiClient(object : MockApiClient() {
+                    override fun fetchProjectBacking(project: Project, user: User): Observable<Backing> {
+                        return Observable.just(backing)
+                    }
+                    override fun fetchShippingRules(project: Project, reward: Reward): Observable<ShippingRulesEnvelope> {
+                        return Observable.just(shippingRulesEnvelope)
+                    }
+                })
+                .build()
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PLEDGE)
+
+        this.totalAmount.assertValue("40")
+    }
+
+    @Test
+    fun testTotalAmount_whenUpdatingPayment() {
+        val reward = RewardFactory.rewardWithShipping()
+        val unitedStates = LocationFactory.unitedStates()
+        val shippingRule = ShippingRuleFactory.usShippingRule().toBuilder().location(unitedStates).build()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(40.0)
+                .location(unitedStates)
+                .locationId(unitedStates.id())
+                .reward(reward)
+                .rewardId(reward.id())
+                .shippingAmount(shippingRule.cost().toFloat())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        val config = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfig()
+        currentConfig.config(config)
+
+        val shippingRulesEnvelope = ShippingRulesEnvelopeFactory.shippingRules()
+                .toBuilder()
+                .shippingRules(listOf(ShippingRuleFactory.germanyShippingRule(), shippingRule))
+                .build()
+
+        val environment = environmentForShippingRules(shippingRulesEnvelope)
+                .toBuilder()
+                .currentUser(MockCurrentUser(UserFactory.user()))
+                .apiClient(object : MockApiClient() {
+                    override fun fetchProjectBacking(project: Project, user: User): Observable<Backing> {
+                        return Observable.just(backing)
+                    }
+                    override fun fetchShippingRules(project: Project, reward: Reward): Observable<ShippingRulesEnvelope> {
+                        return Observable.just(shippingRulesEnvelope)
+                    }
+                })
+                .build()
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PAYMENT)
+
+        this.totalAmount.assertValue("40")
+    }
+
+    @Test
+    fun testTotalAmount_whenUpdatingReward() {
+        val reward = RewardFactory.rewardWithShipping()
+        val backedProject = ProjectFactory.backedProject()
+
+        val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_REWARD)
+
+        this.totalAmount.assertValue("50")
     }
 
     @Test
@@ -641,9 +958,58 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShippingAmount() {
-        val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
-        setUpEnvironment(environment)
+    fun testShippingSummaryAmount() {
+        val reward = RewardFactory.rewardWithShipping()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(30.0)
+                .shippingAmount(10f)
+                .reward(reward)
+                .rewardId(reward.id())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        val environment = environmentForLoggedInUser(UserFactory.user())
+                .toBuilder()
+                .apiClient(object : MockApiClient() {
+                    override fun fetchProjectBacking(project: Project, user: User): Observable<Backing> {
+                        return Observable.just(backing)
+                    }
+                })
+                .build()
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PAYMENT)
+
+        this.shippingSummaryAmount.assertValue("10")
+    }
+
+    @Test
+    fun testShippingSummaryLocation() {
+        val reward = RewardFactory.rewardWithShipping()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .location(LocationFactory.nigeria())
+                .reward(reward)
+                .rewardId(reward.id())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        val environment = environmentForLoggedInUser(UserFactory.user())
+                .toBuilder()
+                .apiClient(object : MockApiClient() {
+                    override fun fetchProjectBacking(project: Project, user: User): Observable<Backing> {
+                        return Observable.just(backing)
+                    }
+                })
+                .build()
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PAYMENT)
+
+        this.shippingSummaryLocation.assertValue("Nigeria")
     }
 
     @Test
@@ -927,6 +1293,13 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingAmount.assertValue("30")
         this.totalAmount.assertValues("50")
         this.totalTextColor.assertValue(R.color.ksr_green_500)
+    }
+
+    private fun environmentForLoggedInUser(user: User) : Environment {
+        return environment()
+                .toBuilder()
+                .currentUser(MockCurrentUser(user))
+                .build()
     }
 
     private fun environmentForShippingRules(envelope: ShippingRulesEnvelope): Environment {

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels
 
+import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
@@ -8,6 +9,7 @@ import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.models.Project
 import com.kickstarter.ui.data.PledgeData
+import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ScreenLocation
 import org.junit.Test
 import rx.observers.TestSubscriber
@@ -18,7 +20,7 @@ class RewardsFragmentViewModelTest: KSRobolectricTestCase() {
     private val backedRewardPosition = TestSubscriber.create<Int>()
     private val project = TestSubscriber.create<Project>()
     private val rewardsCount = TestSubscriber.create<Int>()
-    private val showPledgeFragment = TestSubscriber<PledgeData>()
+    private val showPledgeFragment = TestSubscriber<Pair<PledgeData, PledgeReason>>()
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = RewardsFragmentViewModel.ViewModel(environment)
@@ -66,7 +68,7 @@ class RewardsFragmentViewModelTest: KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShowPledgeFragment() {
+    fun testShowPledgeFragment_whenLiveProject() {
         val project = ProjectFactory.project()
         setUpEnvironment(environment())
 
@@ -75,7 +77,20 @@ class RewardsFragmentViewModelTest: KSRobolectricTestCase() {
         val screenLocation = ScreenLocation(0f, 0f, 0f, 0f)
         val reward = RewardFactory.reward()
         this.vm.inputs.rewardClicked(screenLocation, reward)
-        this.showPledgeFragment.assertValue(PledgeData(screenLocation, reward, project))
+        this.showPledgeFragment.assertValue(Pair(PledgeData(screenLocation, reward, project), PledgeReason.PLEDGE))
+    }
+
+    @Test
+    fun testShowPledgeFragment_whenBackedProject() {
+        val project = ProjectFactory.backedProject()
+        setUpEnvironment(environment())
+
+        this.vm.inputs.project(project)
+
+        val screenLocation = ScreenLocation(0f, 0f, 0f, 0f)
+        val reward = RewardFactory.reward()
+        this.vm.inputs.rewardClicked(screenLocation, reward)
+        this.showPledgeFragment.assertValue(Pair(PledgeData(screenLocation, reward, project), PledgeReason.UPDATE_REWARD))
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
@@ -68,7 +68,7 @@ class RewardsFragmentViewModelTest: KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShowPledgeFragment_whenLiveProject() {
+    fun testShowPledgeFragment_whenBackingProject() {
         val project = ProjectFactory.project()
         setUpEnvironment(environment())
 
@@ -81,7 +81,7 @@ class RewardsFragmentViewModelTest: KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShowPledgeFragment_whenBackedProject() {
+    fun testShowPledgeFragment_whenManagingPledge() {
         val project = ProjectFactory.backedProject()
         setUpEnvironment(environment())
 


### PR DESCRIPTION
# 📲 What
Displaying the proper UI in the Pledge screen when managing your pledge.

# 🤔 Why
The Designs Changed™: An Autobiography  

# 🛠 How
`PledgeFragment` now requires a `PledgeReason` to be instantiated. It uses that to configure the UI.
Added `LocationFactory.nigeria` to test the shipping summary output.
Moved stepper and shipping labels out of root pledge XML so they could easily be hidden.
Added layouts for pledge and shipping summaries.
Tests....so many tests.

# 👀 See
| Unbacked project | Updating payment method  |
| --- | --- |
| ![screenshot-2019-08-20_184045](https://user-images.githubusercontent.com/1289295/63389540-0e9b5c80-c37a-11e9-9463-7513a975af31.png) | ![screenshot-2019-08-22_145918](https://user-images.githubusercontent.com/1289295/63542066-73c38f00-c4ed-11e9-8205-96657d1e3b0b.png) |
| Updating pledge | Updating reward  |
| ![screenshot-2019-08-20_184010](https://user-images.githubusercontent.com/1289295/63389537-0e02c600-c37a-11e9-8447-bcde116b4532.png) | ![screenshot-2019-08-20_184026](https://user-images.githubusercontent.com/1289295/63389539-0e9b5c80-c37a-11e9-8a0e-e8c984a4ef0b.png) |

# 📋 QA
0️⃣ Unbacked project
- Mini reward section is visible
- Pledge amount is visible with reward minimum
- Shipping chooser is visible (if reward is shippable)
- Pledge amount summary is not visible
- Shipping summary is not visible
- Update pledge button button is not visible
- Payment methods are visible (if logged in)

1️⃣Updating payment method
- Mini reward section is not visible
- Pledge amount is not visible
- Shipping chooser is not visible 
- Pledge amount summary is visible
- Shipping summary is visible
- Update pledge button button is not visible

2️⃣ Updating pledge
- Mini reward section is not visible
- Pledge amount is visible with backed amount
- Shipping chooser is visible with selected shipping (if reward is shippable)
- Pledge amount summary is not visible
- Shipping summary is not visible
- Update pledge button button is visible (but not enabled, soon come)
- Payment methods are not visible

3️⃣ Updating reward
- Mini reward section is visible
- Pledge amount is visible
- Shipping chooser is visible (if reward is shippable)
- Pledge amount summary is not visible
- Shipping summary is not visible
- Update pledge button button is visible (but not enabled, soon come)
- Payment methods are not visible

# Story 📖
https://dripsprint.atlassian.net/browse/NT-180 UI only
https://dripsprint.atlassian.net/browse/NT-93 UI only
https://dripsprint.atlassian.net/browse/NT-47 UI only
