### PR TITLE
[🔁] Cancel Pledge redesign

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -484,7 +484,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         val tag = CancelPledgeFragment::class.java.simpleName
         supportFragmentManager
                 .beginTransaction()
-                .setCustomAnimations(R.anim.slide_up, 0, 0, R.anim.slide_down)
+                .setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
                 .add(R.id.fragment_container, cancelPledgeFragment, tag)
                 .addToBackStack(tag)
                 .commit()

--- a/app/src/main/java/com/kickstarter/ui/fragments/CancelPledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/CancelPledgeFragment.kt
@@ -1,14 +1,18 @@
 package com.kickstarter.ui.fragments
 
+import android.graphics.Typeface
 import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.StyleSpan
 import android.util.Pair
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.FragmentManager
-import com.google.android.material.snackbar.Snackbar
 import com.kickstarter.KSApplication
 import com.kickstarter.R
+import com.kickstarter.extensions.snackbar
 import com.kickstarter.extensions.text
 import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
@@ -42,12 +46,12 @@ class CancelPledgeFragment : BaseFragment<CancelPledgeViewModel.ViewModel>() {
         this.viewModel.outputs.showServerError()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
-                .subscribe { Snackbar.make(snackbar_anchor, R.string.Something_went_wrong_please_try_again, Snackbar.LENGTH_SHORT).show() }
+                .subscribe { snackbar(cancel_pledge_root, getString(R.string.Something_went_wrong_please_try_again)).show() }
 
         this.viewModel.outputs.showCancelError()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
-                .subscribe { Snackbar.make(snackbar_anchor, it, Snackbar.LENGTH_SHORT).show() }
+                .subscribe { snackbar(cancel_pledge_root, it).show() }
 
         this.viewModel.outputs.dismiss()
                 .compose(bindToLifecycle())
@@ -76,10 +80,11 @@ class CancelPledgeFragment : BaseFragment<CancelPledgeViewModel.ViewModel>() {
         no_cancel_pledge_button.setOnClickListener {
             this.viewModel.inputs.goBackButtonClicked()
         }
+    }
 
-        cancel_pledge_toolbar.setNavigationOnClickListener {
-            this.viewModel.inputs.closeButtonClicked()
-        }
+    private fun addBoldSpan(spannableString: SpannableString, substring: String) {
+        val indexOfAmount = spannableString.indexOf(substring)
+        spannableString.setSpan(StyleSpan(Typeface.BOLD), indexOfAmount, indexOfAmount + substring.length, Spannable.SPAN_INCLUSIVE_INCLUSIVE)
     }
 
     private fun dismiss() {
@@ -90,8 +95,15 @@ class CancelPledgeFragment : BaseFragment<CancelPledgeViewModel.ViewModel>() {
         val ksString = (activity?.applicationContext as KSApplication).component().environment().ksString()
         val amount = amountAndProjectName.first
         val name = amountAndProjectName.second
-        cancel_prompt.text = ksString.format(getString(R.string.Are_you_sure_you_wish_to_cancel_your_amount_pledge_to_project_name),
+        val formattedString = ksString.format(getString(R.string.Are_you_sure_you_wish_to_cancel_your_amount_pledge_to_project_name),
                 "amount", amount, "project_name", name)
+
+        val spannableString = SpannableString(formattedString)
+
+        addBoldSpan(spannableString, amount)
+        addBoldSpan(spannableString, name)
+
+        cancel_prompt.text = spannableString
     }
 
     companion object {

--- a/app/src/main/java/com/kickstarter/viewmodels/CancelPledgeViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CancelPledgeViewModel.kt
@@ -17,9 +17,6 @@ import java.math.RoundingMode
 
 interface CancelPledgeViewModel {
     interface Inputs {
-        /** Call when user clicks the close button. */
-        fun closeButtonClicked()
-
         /** Call when user clicks the confirmation button. */
         fun confirmCancellationClicked(note: String)
 
@@ -52,16 +49,15 @@ interface CancelPledgeViewModel {
 
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<CancelPledgeFragment>(environment), Inputs, Outputs {
 
-        private val closeButtonClicked = PublishSubject.create<Void>()
         private val confirmCancellationClicked = PublishSubject.create<String>()
         private val goBackButtonClicked = PublishSubject.create<Void>()
 
         private val cancelButtonIsVisible = BehaviorSubject.create<Boolean>()
         private val dismiss = BehaviorSubject.create<Void>()
         private val pledgeAmountAndProjectName = BehaviorSubject.create<Pair<String, String>>()
-        private val progressBarIsVisible = PublishSubject.create<Boolean>()
-        private val showCancelError = BehaviorSubject.create<String>()
-        private val showServerError = BehaviorSubject.create<Void>()
+        private val progressBarIsVisible = BehaviorSubject.create<Boolean>()
+        private val showCancelError = PublishSubject.create<String>()
+        private val showServerError = PublishSubject.create<Void>()
         private val success = BehaviorSubject.create<Void>()
 
         private val apolloClient = environment.apolloClient()
@@ -117,7 +113,7 @@ interface CancelPledgeViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.showCancelError)
 
-            Observable.merge(this.closeButtonClicked, this.goBackButtonClicked)
+             this.goBackButtonClicked
                     .compose(bindToLifecycle())
                     .subscribe(this.dismiss)
         }
@@ -132,10 +128,6 @@ interface CancelPledgeViewModel {
                         this.progressBarIsVisible.onNext(false)
                         this.cancelButtonIsVisible.onNext(true)
                     }.materialize()
-        }
-
-        override fun closeButtonClicked() {
-            this.closeButtonClicked.onNext(null)
         }
 
         override fun confirmCancellationClicked(note: String) {

--- a/app/src/main/res/layout/fragment_cancel_pledge.xml
+++ b/app/src/main/res/layout/fragment_cancel_pledge.xml
@@ -1,130 +1,102 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView android:id="@+id/cancel_pledge_root"
-  style="@style/CardViewFragment"
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/cancel_pledge_root"
   android:layout_width="match_parent"
-  android:layout_height="wrap_content">
+  android:layout_height="match_parent"
+  android:background="@color/ksr_grey_300"
+  android:paddingTop="?android:attr/actionBarSize">
 
-  <androidx.coordinatorlayout.widget.CoordinatorLayout
+  <ScrollView
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    android:overScrollMode="never"
+    android:scrollbars="none">
 
-    <com.google.android.material.appbar.AppBarLayout
+    <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      app:elevation="0dp">
+      android:gravity="center"
+      android:orientation="vertical"
+      android:paddingStart="@dimen/activity_horizontal_margin"
+      android:paddingTop="@dimen/activity_vertical_margin"
+      android:paddingEnd="@dimen/activity_horizontal_margin"
+      android:paddingBottom="@dimen/activity_vertical_margin">
 
-      <androidx.appcompat.widget.Toolbar
-        android:id="@+id/cancel_pledge_toolbar"
-        style="@style/Toolbar"
+      <TextView
+        android:id="@+id/cancel_prompt"
+        style="@style/CalloutPrimary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/grid_5"
+        android:gravity="center"
+        tools:text="@string/Are_you_sure_you_wish_to_cancel_your_amount_pledge_to_project_name" />
+
+      <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/white"
-        app:navigationIcon="@drawable/ic_close"
-        app:tint="@color/ksr_soft_black"
-        app:title="@string/Cancel_your_pledge" />
+        android:hint="@string/Tell_us_why_optional">
 
-    </com.google.android.material.appbar.AppBarLayout>
-
-    <ScrollView
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:overScrollMode="never"
-      android:scrollbars="none"
-      app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
-
-      <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_horizontal"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/grid_15"
-        android:paddingEnd="@dimen/grid_4"
-        android:paddingStart="@dimen/grid_4">
-
-        <TextView
-          android:id="@+id/cancel_prompt"
-          style="@style/CalloutPrimary"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_5"
-          android:layout_marginTop="@dimen/grid_14"
-          android:gravity="center"
-          tools:text="@string/Are_you_sure_you_wish_to_cancel_your_amount_pledge_to_project_name" />
-
-        <com.google.android.material.textfield.TextInputLayout
-          style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        <com.google.android.material.textfield.TextInputEditText
+          android:id="@+id/cancellation_note"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:hint="@string/Tell_us_why_optional">
+          android:inputType="textMultiLine|textCapSentences"
+          android:maxLines="3" />
 
-          <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/cancellation_note"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:inputType="textMultiLine|textCapSentences"
-            android:maxLines="3" />
+      </com.google.android.material.textfield.TextInputLayout>
 
-        </com.google.android.material.textfield.TextInputLayout>
+      <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/grid_1"
+        android:layout_marginBottom="@dimen/grid_10"
+        android:gravity="center"
+        android:text="@string/We_wont_share_this_with_the_creator" />
 
-        <TextView
-          android:layout_width="wrap_content"
+      <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <Button
+          android:id="@+id/yes_cancel_pledge_button"
+          android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_10"
-          android:layout_marginTop="@dimen/grid_1"
-          android:gravity="center"
-          android:text="@string/We_wont_share_this_with_the_creator" />
+          android:text="@string/Yes_cancel_my_pledge"
+          app:backgroundTint="@color/ksr_red_400" />
 
         <FrameLayout
+          android:id="@+id/progress_bar"
           android:layout_width="match_parent"
           android:layout_height="wrap_content">
 
           <Button
-            android:id="@+id/yes_cancel_pledge_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/Yes_cancel_my_pledge"
+            android:stateListAnimator="@null"
             app:backgroundTint="@color/ksr_red_400" />
 
-          <FrameLayout
-            android:id="@+id/progress_bar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <Button
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:stateListAnimator="@null"
-              app:backgroundTint="@color/ksr_red_400" />
-
-            <ProgressBar
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_gravity="center"
-              android:indeterminateTint="@color/white" />
-          </FrameLayout>
-
+          <ProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:indeterminateTint="@color/white" />
         </FrameLayout>
 
-        <Button
-          android:id="@+id/no_cancel_pledge_button"
-          style="@style/TertiaryButton"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_15"
-          android:text="@string/No_go_back" />
+      </FrameLayout>
 
-      </LinearLayout>
+      <Button
+        android:id="@+id/no_cancel_pledge_button"
+        style="@style/TertiaryButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/No_go_back" />
 
-    </ScrollView>
-  </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    </LinearLayout>
 
-  <androidx.coordinatorlayout.widget.CoordinatorLayout
-    android:id="@+id/snackbar_anchor"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_marginBottom="@dimen/grid_5" />
+  </ScrollView>
 
-</androidx.cardview.widget.CardView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/CancelPledgeViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CancelPledgeViewModelTest.kt
@@ -47,11 +47,8 @@ class CancelPledgeViewModelTest : KSRobolectricTestCase() {
     fun testDismiss() {
         setUpEnvironment(environment())
 
-        this.vm.inputs.closeButtonClicked()
-        this.dismiss.assertValueCount(1)
-
         this.vm.inputs.goBackButtonClicked()
-        this.dismiss.assertValueCount(2)
+        this.dismiss.assertValueCount(1)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Implementation of the cancel pledge redesign.

# 🤔 Why
Redesign™

# 🛠 How
- Changed background color to `ksr_grey_300`.
- Removed toolbar.
- The pledge amount and project name are now **bold**.
- There were some `BehaviorSubject`s that should've been `PublishSubject`s, you know how it goes.
- It now animates horizontally, instead of vertically.

# 👀 See
| After 🦋 | Before 🐛| 
| --- | --- |
| ![screenshot-2019-08-21_114404](https://user-images.githubusercontent.com/1289295/63448067-2e2e9580-c40b-11e9-93fa-eade249b2685.png) | ![screenshot-2019-07-12_153909](https://user-images.githubusercontent.com/1289295/63448124-51594500-c40b-11e9-97f4-54af41d940f3.png) |
| ![device-2019-08-21-114534 2019-08-21 11_46_02](https://user-images.githubusercontent.com/1289295/63448156-6209bb00-c40b-11e9-9c6c-0a40af68c3b8.gif) | ![cancelpledge](https://user-images.githubusercontent.com/1289295/63448145-5b7b4380-c40b-11e9-812c-b79b8cf13f65.gif) |

# 📋 QA
Notes 2 u, the QA individual: 
1️⃣ Tertiary (gray) buttons are `ksr_grey_400` and not `ksr_grey_500` so it does not match the Abstract.
2️⃣ [Outlined text fields](https://material.io/design/components/text-fields.html#outlined-text-field) do not have a fill. We can switch to the [filled text fields](https://material.io/design/components/text-fields.html#filled-text-field) if desired.
3️⃣ Regression test: you should still be able to cancel your pledge or dismiss the screen.

# Story 📖
https://dripsprint.atlassian.net/browse/NT-200
