### PR TITLE
[🔥] Update pledge

### DIFF
--- a/app/src/main/graphql/checkout.graphql
+++ b/app/src/main/graphql/checkout.graphql
@@ -13,3 +13,11 @@ mutation CancelBacking($backingId: ID!, $note: String) {
     }
   }
 }
+
+mutation UpdateBacking($backingId: ID!, $amount: String!, $locationId: ID, $rewardId: ID)  {
+  updateBacking(input: { id: $backingId, amount: $amount, locationId: $locationId, rewardId: $rewardId}) {
+    checkout {
+      state
+    }
+  }
+}

--- a/app/src/main/java/com/kickstarter/libs/CurrentConfig.java
+++ b/app/src/main/java/com/kickstarter/libs/CurrentConfig.java
@@ -60,13 +60,6 @@ public final class CurrentConfig implements CurrentConfigType {
     return this.config;
   }
 
-  /**
-   * @return The most recent config.
-   */
-  public @NonNull Config getConfig() {
-    return this.config.getValue();
-  }
-
   public void config(final @NonNull Config config) {
     this.config.onNext(config);
   }

--- a/app/src/main/java/com/kickstarter/libs/CurrentConfigType.java
+++ b/app/src/main/java/com/kickstarter/libs/CurrentConfigType.java
@@ -10,12 +10,6 @@ public interface CurrentConfigType {
   Observable<Config> observable();
 
   /**
-   * @deprecated Use {@link #observable()} instead.
-   */
-  @Deprecated
-  Config getConfig();
-
-  /**
    * Set a new config.
    */
   void config(Config config);

--- a/app/src/main/java/com/kickstarter/libs/KSCurrency.java
+++ b/app/src/main/java/com/kickstarter/libs/KSCurrency.java
@@ -127,7 +127,9 @@ public final class KSCurrency {
    */
   public boolean currencyNeedsCode(final @NonNull Country country, final boolean excludeCurrencyCode) {
     final boolean countryIsUS = country == Country.US;
-    final Config config = this.currentConfig.getConfig();
+    final Config config = this.currentConfig.observable()
+      .toBlocking()
+      .first();
     final boolean currencyNeedsCode = config.currencyNeedsCode(country.getCurrencySymbol());
     final boolean userInUS = config.countryCode().equals(Country.US.getCountryCode());
 

--- a/app/src/main/java/com/kickstarter/mock/MockCurrentConfig.java
+++ b/app/src/main/java/com/kickstarter/mock/MockCurrentConfig.java
@@ -17,11 +17,6 @@ public final class MockCurrentConfig implements CurrentConfigType {
   }
 
   @Override
-  public @NonNull Config getConfig() {
-    return this.config.getValue();
-  }
-
-  @Override
   public void config(final @NonNull Config config) {
     this.config.onNext(config);
   }

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -55,6 +55,10 @@ open class MockApolloClient : ApolloClientType {
                 "12345")))
     }
 
+    override fun updateBacking(backing: Backing, amount: String, locationId: String?, reward: Reward?): Observable<Boolean> {
+        return Observable.just(true)
+    }
+
     override fun updateUserCurrencyPreference(currency: CurrencyCode): Observable<UpdateUserCurrencyMutation.Data> {
         return Observable.just(UpdateUserCurrencyMutation.Data(UpdateUserCurrencyMutation.UpdateUserProfile("",
                 UpdateUserCurrencyMutation.User("", "USD"))))

--- a/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
+++ b/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
@@ -31,6 +31,8 @@ interface ApolloClientType {
 
     fun sendVerificationEmail(): Observable<SendEmailVerificationMutation.Data>
 
+    fun updateBacking(backing: Backing, amount: String, locationId: String?, reward: Reward?): Observable<Boolean>
+
     fun updateUserCurrencyPreference(currency: CurrencyCode): Observable<UpdateUserCurrencyMutation.Data>
 
     fun updateUserEmail(email: String, currentPassword: String): Observable<UpdateUserEmailMutation.Data>

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -47,7 +47,8 @@ import kotlinx.android.synthetic.main.project_layout.*
 import rx.android.schedulers.AndroidSchedulers
 
 @RequiresActivityViewModel(ProjectViewModel.ViewModel::class)
-class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledgeFragment.CancelPledgeDelegate, NewCardFragment.OnCardSavedListener {
+class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledgeFragment.CancelPledgeDelegate,
+        NewCardFragment.OnCardSavedListener, PledgeFragment.PledgeDelegate {
     private lateinit var adapter: ProjectAdapter
     private lateinit var ksString: KSString
     private lateinit var heartIcon: ImageButton
@@ -260,6 +261,11 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { showCancelPledgeSuccess() }
 
+        this.viewModel.outputs.showUpdatePledgeSuccess()
+                .compose(bindToLifecycle())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe { showUpdatePledgeSuccess() }
+
         this.viewModel.outputs.showRewardsFragment()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
@@ -336,6 +342,10 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
 
     override fun pledgeSuccessfullyCancelled() {
         this.viewModel.inputs.pledgeSuccessfullyCancelled()
+    }
+
+    override fun pledgeSuccessfullyUpdated() {
+        this.viewModel.inputs.pledgeSuccessfullyUpdated()
     }
 
     override fun cardSaved(storedCard: StoredCard) {
@@ -527,6 +537,12 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         Handler().postDelayed({
             showSnackbar(snackbar_anchor, getString(R.string.Youve_canceled_your_pledge))
         }, this.animDuration)
+    }
+
+    private fun showUpdatePledgeSuccess() {
+        clearFragmentBackStack()
+        val backingFragment = supportFragmentManager.findFragmentById(R.id.fragment_backing) as BackingFragment
+        backingFragment.pledgeSuccessfullyCancelled()
     }
 
     private fun showPledgeFragment(pledgeDataAndPledgeReason: Pair<PledgeData, PledgeReason>) {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -550,7 +550,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         val tag = PledgeFragment::class.java.simpleName
         supportFragmentManager
                 .beginTransaction()
-                .setCustomAnimations(R.anim.slide_up, 0, 0, R.anim.slide_down)
+                .setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
                 .add(R.id.fragment_container, pledgeFragment, tag)
                 .addToBackStack(tag)
                 .commit()

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -11,7 +11,6 @@ import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.models.Project
 import com.kickstarter.viewmodels.BackingFragmentViewModel
-import kotlinx.android.synthetic.main.fragment_backing.*
 
 @RequiresFragmentViewModel(BackingFragmentViewModel.ViewModel::class)
 class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
@@ -26,7 +25,7 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
         this.viewModel.outputs.showUpdatePledgeSuccess()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
-                .subscribe { showSnackbar(backing_root, getString(R.string.Got_it_your_changes_have_been_saved)) }
+                .subscribe { showSnackbar(view, getString(R.string.Got_it_your_changes_have_been_saved)) }
     }
 
     fun takeProject(project: Project) {

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -5,10 +5,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.kickstarter.R
+import com.kickstarter.extensions.showSnackbar
 import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
+import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.models.Project
 import com.kickstarter.viewmodels.BackingFragmentViewModel
+import kotlinx.android.synthetic.main.fragment_backing.*
 
 @RequiresFragmentViewModel(BackingFragmentViewModel.ViewModel::class)
 class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
@@ -17,8 +20,21 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
         return inflater.inflate(R.layout.fragment_backing, container, false)
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        this.viewModel.outputs.showUpdatePledgeSuccess()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe { showSnackbar(backing_root, getString(R.string.Got_it_your_changes_have_been_saved)) }
+    }
+
     fun takeProject(project: Project) {
         this.viewModel.inputs.project(project)
+    }
+
+    fun pledgeSuccessfullyCancelled() {
+        this.viewModel.inputs.pledgeSuccessfullyUpdated()
     }
 
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -26,6 +26,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.jakewharton.rxbinding.view.RxView
 import com.kickstarter.KSApplication
 import com.kickstarter.R
 import com.kickstarter.extensions.hideKeyboard
@@ -69,6 +70,10 @@ import kotlin.math.min
 
 @RequiresFragmentViewModel(PledgeFragmentViewModel.ViewModel::class)
 class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), RewardCardAdapter.Delegate, ShippingRulesAdapter.Delegate {
+
+    interface PledgeDelegate {
+        fun pledgeSuccessfullyUpdated()
+    }
 
     private val defaultAnimationDuration = 200L
     private var animDuration = defaultAnimationDuration
@@ -345,6 +350,26 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .compose(bindToLifecycle())
                 .subscribe { ViewUtils.setGone(update_pledge_button, it) }
 
+        this.viewModel.outputs.updatePledgeButtonIsEnabled()
+                .compose(observeForUI())
+                .compose(bindToLifecycle())
+                .subscribe { update_pledge_button.isEnabled = it }
+
+        this.viewModel.outputs.updatePledgeProgressIsGone()
+                .compose(observeForUI())
+                .compose(bindToLifecycle())
+                .subscribe { ViewUtils.setGone(update_pledge_button_progress, it) }
+
+        this.viewModel.outputs.showUpdatePledgeError()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { snackbar(pledge_content, getString(R.string.general_error_something_wrong)).show() }
+
+        this.viewModel.outputs.showUpdatePledgeSuccess()
+                .compose(observeForUI())
+                .compose(bindToLifecycle())
+                .subscribe { (activity as PledgeDelegate?)?.pledgeSuccessfullyUpdated() }
+
         this.viewModel.outputs.showMinimumWarning()
                 .compose(observeForUI())
                 .compose(bindToLifecycle())
@@ -378,6 +403,10 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         increase_pledge.setOnClickListener {
             this.viewModel.inputs.increasePledgeButtonClicked()
         }
+
+        RxView.clicks(update_pledge_button)
+                .compose(bindToLifecycle())
+                .subscribe { this.viewModel.inputs.updatePledgeButtonClicked() }
     }
 
     override fun onDetach() {

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -11,6 +11,9 @@ import rx.subjects.PublishSubject
 
 interface BackingFragmentViewModel {
     interface Inputs {
+        /** Call when the pledge has been successfully updated. */
+        fun pledgeSuccessfullyUpdated()
+
         /** Configure with current project.  */
         fun project(project: Project)
     }
@@ -18,12 +21,17 @@ interface BackingFragmentViewModel {
     interface Outputs {
         /** Emits the current project. */
         fun project(): Observable<Project>
+
+        /** Emits when the backing has successfully been updated. */
+        fun showUpdatePledgeSuccess(): Observable<Void>
     }
 
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<BackingFragment>(environment), Inputs, Outputs {
 
+        private val pledgeSuccessfullyCancelled = PublishSubject.create<Void>()
         private val projectInput = PublishSubject.create<Project>()
 
+        private val showUpdatePledgeSuccess = PublishSubject.create<Void>()
         private val project = BehaviorSubject.create<Project>()
 
         val inputs: Inputs = this
@@ -33,14 +41,25 @@ interface BackingFragmentViewModel {
             this.projectInput
                     .compose(bindToLifecycle())
                     .subscribe(this.project)
+
+            this.pledgeSuccessfullyCancelled
+                    .compose(bindToLifecycle())
+                    .subscribe(this.showUpdatePledgeSuccess)
         }
 
         override fun project(project: Project) {
             this.projectInput.onNext(project)
         }
 
+        override fun pledgeSuccessfullyUpdated() {
+            this.showUpdatePledgeSuccess.onNext(null)
+        }
+
         @NonNull
         override fun project(): Observable<Project> = this.project
+
+        @NonNull
+        override fun showUpdatePledgeSuccess(): Observable<Void> = this.showUpdatePledgeSuccess
 
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -293,8 +293,10 @@ interface ProjectViewModel {
                     .switchMap { this.toggleProjectSave(it) }
                     .share()
 
+            val refreshProjectEvent = Observable.merge(this.pledgeSuccessfullyCancelled, this.pledgeSuccessfullyUpdated )
+
             val refreshedProject = initialProject
-                    .compose(takeWhen<Project, Void>(this.pledgeSuccessfullyCancelled))
+                    .compose(takeWhen<Project, Void>(refreshProjectEvent))
                     .switchMap { project ->
                         this.client.fetchProject(project)
                                 .compose(neverError())

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -70,6 +70,9 @@ interface ProjectViewModel {
         /** Call when the pledge has been successfully canceled.  */
         fun pledgeSuccessfullyCancelled()
 
+        /** Call when the pledge has been successfully updated. */
+        fun pledgeSuccessfullyUpdated()
+
         /** Call when the share button is clicked.  */
         fun shareButtonClicked()
 
@@ -151,6 +154,9 @@ interface ProjectViewModel {
         /** Emits when we should show the [com.kickstarter.ui.fragments.PledgeFragment]. */
         fun showUpdatePledge(): Observable<Pair<PledgeData, PledgeReason>>
 
+        /** Emits when the backing has successfully been updated. */
+        fun showUpdatePledgeSuccess(): Observable<Void>
+
         /** Emits when we should start the [BackingActivity].  */
         fun startBackingActivity(): Observable<Pair<Project, User>>
 
@@ -205,6 +211,7 @@ interface ProjectViewModel {
         private val onGlobalLayout = PublishSubject.create<Void>()
         private val playVideoButtonClicked = PublishSubject.create<Void>()
         private val pledgeSuccessfullyCancelled = PublishSubject.create<Void>()
+        private val pledgeSuccessfullyUpdated = PublishSubject.create<Void>()
         private val shareButtonClicked = PublishSubject.create<Void>()
         private val updatePaymentClicked = PublishSubject.create<Void>()
         private val updatePledgeClicked = PublishSubject.create<Void>()
@@ -232,6 +239,7 @@ interface ProjectViewModel {
         private val showShareSheet = PublishSubject.create<Project>()
         private val showSavedPrompt = PublishSubject.create<Void>()
         private val showUpdatePledge = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
+        private val showUpdatePledgeSuccess = PublishSubject.create<Void>()
         private val startCampaignWebViewActivity = PublishSubject.create<Project>()
         private val startCheckoutActivity = PublishSubject.create<Project>()
         private val startCommentsActivity = PublishSubject.create<Project>()
@@ -461,6 +469,10 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.showCancelPledgeSuccess)
 
+            this.pledgeSuccessfullyUpdated
+                    .compose(bindToLifecycle())
+                    .subscribe(this.showUpdatePledgeSuccess)
+
             this.fragmentStackCount
                     .compose<Pair<Int, Project>>(combineLatestPair(nativeCheckoutProject))
                     .map { if (it.second.isBacking) it.first > 2 else it.first > 1}
@@ -573,6 +585,14 @@ interface ProjectViewModel {
             this.playVideoButtonClicked.onNext(null)
         }
 
+        override fun pledgeSuccessfullyCancelled() {
+            this.pledgeSuccessfullyCancelled.onNext(null)
+        }
+
+        override fun pledgeSuccessfullyUpdated() {
+            this.pledgeSuccessfullyUpdated.onNext(null)
+        }
+
         override fun projectViewHolderBackProjectClicked(viewHolder: ProjectViewHolder) {
             if (this.nativeCheckoutPreference.get()) {
                 this.nativeProjectActionButtonClicked()
@@ -619,10 +639,6 @@ interface ProjectViewModel {
 
         override fun projectViewHolderUpdatesClicked(viewHolder: ProjectViewHolder) {
             this.updatesTextViewClicked()
-        }
-
-        override fun pledgeSuccessfullyCancelled() {
-            this.pledgeSuccessfullyCancelled.onNext(null)
         }
 
         override fun shareButtonClicked() {
@@ -708,6 +724,9 @@ interface ProjectViewModel {
 
         @NonNull
         override fun showUpdatePledge(): Observable<Pair<PledgeData, PledgeReason>> = this.showUpdatePledge
+
+        @NonNull
+        override fun showUpdatePledgeSuccess(): Observable<Void> = this.showUpdatePledgeSuccess
 
         @NonNull
         override fun startBackingActivity(): Observable<Pair<Project, User>> = this.startBackingActivity

--- a/app/src/main/res/layout/fragment_backing.xml
+++ b/app/src/main/res/layout/fragment_backing.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-  android:id="@+id/rewards_recycler"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+id/backing_root"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:background="@color/ksr_grey_300"

--- a/app/src/main/res/layout/fragment_backing.xml
+++ b/app/src/main/res/layout/fragment_backing.xml
@@ -4,5 +4,7 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:background="@color/ksr_grey_300"
+  android:clickable="true"
+  android:focusable="true"
   android:overScrollMode="never"
-  android:paddingTop="?android:attr/actionBarSize"/>
+  android:paddingTop="?android:attr/actionBarSize" />

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -93,7 +93,8 @@
           android:id="@+id/divider_total"
           layout="@layout/horizontal_line_1dp_view" />
 
-        <include layout="@layout/fragment_pledge_section_total" />
+        <include tools:visibility="gone"
+          layout="@layout/fragment_pledge_section_total" />
 
         <Button
           android:id="@+id/continue_to_tout"
@@ -105,17 +106,44 @@
           android:visibility="gone"
           tools:visibility="gone" />
 
-        <com.google.android.material.button.MaterialButton
-          android:id="@+id/update_pledge_button"
+        <FrameLayout
           android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_4"
-          android:enabled="false"
-          android:text="@string/Update_pledge"
-          android:textColor="@color/white"
-          android:visibility="gone"
-          app:backgroundTint="@color/button_pledge_live"
-          tools:visibility="gone" />
+          android:layout_height="wrap_content">
+
+          <com.google.android.material.button.MaterialButton
+            android:id="@+id/update_pledge_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/grid_4"
+            android:enabled="false"
+            android:text="@string/Update_pledge"
+            android:textColor="@color/white"
+            android:visibility="gone"
+            app:backgroundTint="@color/button_pledge_live"
+            tools:visibility="visible" />
+
+          <FrameLayout
+            android:id="@+id/update_pledge_button_progress"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/grid_4"
+            android:visibility="gone">
+
+            <Button
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:stateListAnimator="@null" />
+
+            <ProgressBar
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_gravity="center"
+              android:indeterminate="true"
+              android:indeterminateTint="@color/white"
+              android:indeterminateTintMode="src_in" />
+
+          </FrameLayout>
+        </FrameLayout>
 
       </LinearLayout>
 

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -12,10 +12,12 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     private lateinit var vm: BackingFragmentViewModel.ViewModel
 
     private val project = TestSubscriber.create<Project>()
+    private val showUpdatePledgeSuccess = TestSubscriber.create<Void>()
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = BackingFragmentViewModel.ViewModel(environment)
         this.vm.outputs.project().subscribe(this.project)
+        this.vm.outputs.showUpdatePledgeSuccess().subscribe(this.showUpdatePledgeSuccess)
     }
 
     @Test
@@ -25,6 +27,14 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
 
         this.vm.inputs.project(project)
         this.project.assertValue(project)
+    }
+
+    @Test
+    fun testShowUpdatePledgeSuccess() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.pledgeSuccessfullyUpdated()
+        this.showUpdatePledgeSuccess.assertValueCount(1)
     }
 
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -62,6 +62,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val showNewCardFragment = TestSubscriber<Project>()
     private val showPledgeCard = TestSubscriber<Pair<Int, CardState>>()
     private val showPledgeError = TestSubscriber<Void>()
+    private val showUpdatePledgeError = TestSubscriber<Void>()
+    private val showUpdatePledgeSuccess = TestSubscriber<Void>()
     private val snapshotIsGone = TestSubscriber<Boolean>()
     private val startChromeTab = TestSubscriber<String>()
     private val startLoginToutActivity = TestSubscriber<Void>()
@@ -69,7 +71,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val totalAmount = TestSubscriber<String>()
     private val totalDividerIsGone = TestSubscriber<Boolean>()
     private val totalTextColor = TestSubscriber<Int>()
+    private val updatePledgeButtonIsEnabled = TestSubscriber<Boolean>()
     private val updatePledgeButtonIsGone = TestSubscriber<Boolean>()
+    private val updatePledgeProgressIsGone = TestSubscriber<Boolean>()
 
     private fun setUpEnvironment(environment: Environment,
                                  reward: Reward? = RewardFactory.rewardWithShipping(),
@@ -111,6 +115,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.showNewCardFragment().subscribe(this.showNewCardFragment)
         this.vm.outputs.showPledgeCard().subscribe(this.showPledgeCard)
         this.vm.outputs.showPledgeError().subscribe(this.showPledgeError)
+        this.vm.outputs.showUpdatePledgeError().subscribe(this.showUpdatePledgeError)
+        this.vm.outputs.showUpdatePledgeSuccess().subscribe(this.showUpdatePledgeSuccess)
         this.vm.outputs.snapshotIsGone().subscribe(this.snapshotIsGone)
         this.vm.outputs.startChromeTab().subscribe(this.startChromeTab)
         this.vm.outputs.startLoginToutActivity().subscribe(this.startLoginToutActivity)
@@ -118,7 +124,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.totalAmount().map { it.toString() }.subscribe(this.totalAmount)
         this.vm.outputs.totalDividerIsGone().subscribe(this.totalDividerIsGone)
         this.vm.outputs.totalTextColor().subscribe(this.totalTextColor)
+        this.vm.outputs.updatePledgeButtonIsEnabled().subscribe(this.updatePledgeButtonIsEnabled)
         this.vm.outputs.updatePledgeButtonIsGone().subscribe(this.updatePledgeButtonIsGone)
+        this.vm.outputs.updatePledgeProgressIsGone().subscribe(this.updatePledgeProgressIsGone)
 
         val bundle = Bundle()
         val screenLocation = if (pledgeReason == PledgeReason.PLEDGE || pledgeReason == PledgeReason.UPDATE_REWARD) ScreenLocation(0f, 0f, 0f, 0f) else null
@@ -232,15 +240,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
                 .backing(backing)
                 .build()
 
-        val environment = environmentForLoggedInUser(UserFactory.user())
-                .toBuilder()
-                .apiClient(object : MockApiClient() {
-                    override fun fetchProjectBacking(project: Project, user: User): Observable<Backing> {
-                        return Observable.just(backing)
-                    }
-                })
-                .build()
-        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PLEDGE)
+        setUpEnvironment(environment(), reward, backedProject, PledgeReason.UPDATE_PLEDGE)
 
         this.pledgeAmount.assertValue("30")
     }
@@ -259,7 +259,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertValue(true)
         this.snapshotIsGone.assertValue(false)
         this.totalDividerIsGone.assertValue(false)
+        this.updatePledgeButtonIsEnabled.assertValue(false)
         this.updatePledgeButtonIsGone.assertValue(true)
+        this.updatePledgeProgressIsGone.assertNoValues()
     }
 
     @Test
@@ -276,7 +278,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertValue(true)
         this.snapshotIsGone.assertValue(false)
         this.totalDividerIsGone.assertValue(false)
+        this.updatePledgeButtonIsEnabled.assertValue(false)
         this.updatePledgeButtonIsGone.assertValue(true)
+        this.updatePledgeProgressIsGone.assertNoValues()
     }
 
     @Test
@@ -293,7 +297,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertValue(true)
         this.snapshotIsGone.assertValue(false)
         this.totalDividerIsGone.assertValue(false)
+        this.updatePledgeButtonIsEnabled.assertValue(false)
         this.updatePledgeButtonIsGone.assertValue(true)
+        this.updatePledgeProgressIsGone.assertNoValues()
     }
 
     @Test
@@ -310,7 +316,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertValue(true)
         this.snapshotIsGone.assertValue(false)
         this.totalDividerIsGone.assertValue(false)
+        this.updatePledgeButtonIsEnabled.assertValue(false)
         this.updatePledgeButtonIsGone.assertValue(true)
+        this.updatePledgeProgressIsGone.assertNoValues()
     }
 
     @Test
@@ -337,7 +345,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertValue(true)
         this.snapshotIsGone.assertValue(true)
         this.totalDividerIsGone.assertValue(false)
+        this.updatePledgeButtonIsEnabled.assertValue(false)
         this.updatePledgeButtonIsGone.assertValue(false)
+        this.updatePledgeProgressIsGone.assertNoValues()
     }
 
     @Test
@@ -364,7 +374,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertValue(true)
         this.snapshotIsGone.assertValue(true)
         this.totalDividerIsGone.assertValue(false)
+        this.updatePledgeButtonIsEnabled.assertValue(false)
         this.updatePledgeButtonIsGone.assertValue(false)
+        this.updatePledgeProgressIsGone.assertNoValues()
     }
 
     @Test
@@ -391,7 +403,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertValue(false)
         this.snapshotIsGone.assertValue(true)
         this.totalDividerIsGone.assertValue(true)
+        this.updatePledgeButtonIsEnabled.assertValue(false)
         this.updatePledgeButtonIsGone.assertValue(true)
+        this.updatePledgeProgressIsGone.assertNoValues()
     }
 
     @Test
@@ -418,7 +432,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertValue(true)
         this.snapshotIsGone.assertValue(true)
         this.totalDividerIsGone.assertValue(true)
+        this.updatePledgeButtonIsEnabled.assertValue(false)
         this.updatePledgeButtonIsGone.assertValue(true)
+        this.updatePledgeProgressIsGone.assertNoValues()
     }
 
     @Test
@@ -437,7 +453,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertValue(true)
         this.snapshotIsGone.assertValue(false)
         this.totalDividerIsGone.assertValue(false)
+        this.updatePledgeButtonIsEnabled.assertValue(true)
         this.updatePledgeButtonIsGone.assertValue(false)
+        this.updatePledgeProgressIsGone.assertNoValues()
     }
 
     @Test
@@ -456,7 +474,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertValue(true)
         this.snapshotIsGone.assertValue(false)
         this.totalDividerIsGone.assertValue(false)
+        this.updatePledgeButtonIsEnabled.assertValue(true)
         this.updatePledgeButtonIsGone.assertValue(false)
+        this.updatePledgeProgressIsGone.assertNoValues()
     }
 
     @Test
@@ -473,15 +493,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
                 .backing(backing)
                 .build()
 
-        val environment = environmentForLoggedInUser(UserFactory.user())
-                .toBuilder()
-                .apiClient(object : MockApiClient() {
-                    override fun fetchProjectBacking(project: Project, user: User): Observable<Backing> {
-                        return Observable.just(backing)
-                    }
-                })
-                .build()
-        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PAYMENT)
+        setUpEnvironment(environment(), reward, backedProject, PledgeReason.UPDATE_PAYMENT)
 
         this.pledgeSummaryAmount.assertValue("30")
     }
@@ -518,9 +530,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
                 .toBuilder()
                 .currentUser(MockCurrentUser(UserFactory.user()))
                 .apiClient(object : MockApiClient() {
-                    override fun fetchProjectBacking(project: Project, user: User): Observable<Backing> {
-                        return Observable.just(backing)
-                    }
                     override fun fetchShippingRules(project: Project, reward: Reward): Observable<ShippingRulesEnvelope> {
                         return Observable.just(shippingRulesEnvelope)
                     }
@@ -563,9 +572,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
                 .toBuilder()
                 .currentUser(MockCurrentUser(UserFactory.user()))
                 .apiClient(object : MockApiClient() {
-                    override fun fetchProjectBacking(project: Project, user: User): Observable<Backing> {
-                        return Observable.just(backing)
-                    }
                     override fun fetchShippingRules(project: Project, reward: Reward): Observable<ShippingRulesEnvelope> {
                         return Observable.just(shippingRulesEnvelope)
                     }
@@ -992,15 +998,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
                 .backing(backing)
                 .build()
 
-        val environment = environmentForLoggedInUser(UserFactory.user())
-                .toBuilder()
-                .apiClient(object : MockApiClient() {
-                    override fun fetchProjectBacking(project: Project, user: User): Observable<Backing> {
-                        return Observable.just(backing)
-                    }
-                })
-                .build()
-        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PAYMENT)
+        setUpEnvironment(environment(), reward, backedProject, PledgeReason.UPDATE_PAYMENT)
 
         this.shippingSummaryAmount.assertValue("10")
     }
@@ -1040,9 +1038,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
                 .toBuilder()
                 .currentUser(MockCurrentUser(UserFactory.user()))
                 .apiClient(object : MockApiClient() {
-                    override fun fetchProjectBacking(project: Project, user: User): Observable<Backing> {
-                        return Observable.just(backing)
-                    }
                     override fun fetchShippingRules(project: Project, reward: Reward): Observable<ShippingRulesEnvelope> {
                         return Observable.just(shippingRulesEnvelope)
                     }
@@ -1100,6 +1095,217 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.newCardButtonClicked()
         this.showNewCardFragment.assertValue(project)
+    }
+
+    @Test
+    fun testShowUpdatePledgeError_whenUpdatingPledgeWithShipping() {
+        val reward = RewardFactory.rewardWithShipping()
+        val unitedStates = LocationFactory.unitedStates()
+        val backingShippingRule = ShippingRuleFactory.usShippingRule().toBuilder().location(unitedStates).build()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(40.0)
+                .location(unitedStates)
+                .locationId(unitedStates.id())
+                .reward(reward)
+                .rewardId(reward.id())
+                .shippingAmount(backingShippingRule.cost().toFloat())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        val config = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfig()
+        currentConfig.config(config)
+
+        val germanyShippingRule = ShippingRuleFactory.germanyShippingRule()
+        val shippingRulesEnvelope = ShippingRulesEnvelopeFactory.shippingRules()
+                .toBuilder()
+                .shippingRules(listOf(germanyShippingRule, backingShippingRule))
+                .build()
+
+        val environment = environmentForShippingRules(shippingRulesEnvelope)
+                .toBuilder()
+                .currentUser(MockCurrentUser(UserFactory.user()))
+                .apiClient(object : MockApiClient() {
+                    override fun fetchShippingRules(project: Project, reward: Reward): Observable<ShippingRulesEnvelope> {
+                        return Observable.just(shippingRulesEnvelope)
+                    }
+                })
+                .apolloClient(object : MockApolloClient() {
+                    override fun updateBacking(backing: Backing, amount: String, locationId: String?, reward: Reward?): Observable<Boolean> {
+                        return Observable.just(false)
+                    }
+                })
+                .build()
+
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PLEDGE)
+
+        this.vm.inputs.shippingRuleSelected(germanyShippingRule)
+        this.vm.inputs.updatePledgeButtonClicked()
+
+        this.updatePledgeProgressIsGone.assertValues(false, true)
+        this.showUpdatePledgeError.assertValueCount(1)
+    }
+
+    @Test
+    fun testShowUpdatePledgeError_whenUpdatingPledgeWithNoShipping() {
+        val reward = RewardFactory.noReward()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(30.0)
+                .reward(reward)
+                .rewardId(reward.id())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        val environment = environment().toBuilder()
+                .apolloClient(object : MockApolloClient() {
+                    override fun updateBacking(backing: Backing, amount: String, locationId: String?, reward: Reward?): Observable<Boolean> {
+                        return Observable.just(false)
+                    }
+                })
+                .build()
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PLEDGE)
+
+        this.vm.inputs.pledgeInput("31")
+        this.vm.inputs.updatePledgeButtonClicked()
+
+        this.updatePledgeProgressIsGone.assertValues(false, true)
+        this.showUpdatePledgeError.assertValueCount(1)
+    }
+
+    @Test
+    fun testShowUpdatePledgeError_whenUpdatingRewardWithShipping() {
+        val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
+                .toBuilder()
+                .apolloClient(object : MockApolloClient() {
+                    override fun updateBacking(backing: Backing, amount: String, locationId: String?, reward: Reward?): Observable<Boolean> {
+                        return Observable.just(false)
+                    }
+                })
+                .build()
+        setUpEnvironment(environment, project = ProjectFactory.backedProject(), pledgeReason = PledgeReason.UPDATE_REWARD)
+
+        this.vm.inputs.updatePledgeButtonClicked()
+
+        this.updatePledgeProgressIsGone.assertValues(false, true)
+        this.showUpdatePledgeError.assertValueCount(1)
+    }
+
+    @Test
+    fun testShowUpdatePledgeError_whenUpdatingRewardWithNoShipping() {
+        val environment = environment()
+                .toBuilder()
+                .apolloClient(object : MockApolloClient() {
+                    override fun updateBacking(backing: Backing, amount: String, locationId: String?, reward: Reward?): Observable<Boolean> {
+                        return Observable.just(false)
+                    }
+                })
+                .build()
+        setUpEnvironment(environment, RewardFactory.noReward(), ProjectFactory.backedProject(), PledgeReason.UPDATE_REWARD)
+
+        this.vm.inputs.updatePledgeButtonClicked()
+
+        this.updatePledgeProgressIsGone.assertValues(false, true)
+        this.showUpdatePledgeError.assertValueCount(1)
+    }
+
+    @Test
+    fun testShowUpdatePledgeSuccess_whenUpdatingPledgeWithShipping() {
+        val reward = RewardFactory.rewardWithShipping()
+        val unitedStates = LocationFactory.unitedStates()
+        val backingShippingRule = ShippingRuleFactory.usShippingRule().toBuilder().location(unitedStates).build()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(40.0)
+                .location(unitedStates)
+                .locationId(unitedStates.id())
+                .reward(reward)
+                .rewardId(reward.id())
+                .shippingAmount(backingShippingRule.cost().toFloat())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        val config = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfig()
+        currentConfig.config(config)
+
+        val germanyShippingRule = ShippingRuleFactory.germanyShippingRule()
+        val shippingRulesEnvelope = ShippingRulesEnvelopeFactory.shippingRules()
+                .toBuilder()
+                .shippingRules(listOf(germanyShippingRule, backingShippingRule))
+                .build()
+
+        val environment = environmentForShippingRules(shippingRulesEnvelope)
+                .toBuilder()
+                .currentUser(MockCurrentUser(UserFactory.user()))
+                .apiClient(object : MockApiClient() {
+                    override fun fetchShippingRules(project: Project, reward: Reward): Observable<ShippingRulesEnvelope> {
+                        return Observable.just(shippingRulesEnvelope)
+                    }
+                })
+                .build()
+
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PLEDGE)
+
+        this.vm.inputs.shippingRuleSelected(germanyShippingRule)
+        this.vm.inputs.updatePledgeButtonClicked()
+
+        this.updatePledgeProgressIsGone.assertValues(false)
+        this.showUpdatePledgeSuccess.assertValueCount(1)
+    }
+
+    @Test
+    fun testShowUpdatePledgeSuccess_whenUpdatingPledgeWithNoShipping() {
+        val reward = RewardFactory.noReward()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(30.0)
+                .reward(reward)
+                .rewardId(reward.id())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        setUpEnvironment(environment(), reward, backedProject, PledgeReason.UPDATE_PLEDGE)
+
+        this.vm.inputs.pledgeInput("31")
+        this.vm.inputs.updatePledgeButtonClicked()
+
+        this.updatePledgeProgressIsGone.assertValues(false)
+        this.showUpdatePledgeSuccess.assertValueCount(1)
+    }
+
+    @Test
+    fun testShowUpdatePledgeSuccess_whenUpdatingRewardWithShipping() {
+        val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
+        setUpEnvironment(environment, project = ProjectFactory.backedProject(), pledgeReason = PledgeReason.UPDATE_REWARD)
+
+        this.vm.inputs.updatePledgeButtonClicked()
+
+        this.updatePledgeProgressIsGone.assertValues(false)
+        this.showUpdatePledgeSuccess.assertValueCount(1)
+    }
+
+    @Test
+    fun testShowUpdatePledgeSuccess_whenUpdatingRewardWithNoShipping() {
+        setUpEnvironment(environment(), RewardFactory.noReward(), ProjectFactory.backedProject(), PledgeReason.UPDATE_REWARD)
+
+        this.vm.inputs.updatePledgeButtonClicked()
+
+        this.updatePledgeProgressIsGone.assertValues(false)
+        this.showUpdatePledgeSuccess.assertValueCount(1)
     }
 
     @Test
@@ -1286,6 +1492,84 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeCard.assertValuesAndClear(Pair(0, CardState.LOADING), Pair(0, CardState.PLEDGE))
         this.startThanksActivity.assertNoValues()
         this.showPledgeError.assertValueCount(1)
+    }
+
+    @Test
+    fun testUpdatePledgeButtonIsEnabled_UpdatingPledge_whenAmountChanged() {
+        val reward = RewardFactory.noReward()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(30.0)
+                .reward(reward)
+                .rewardId(reward.id())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        setUpEnvironment(environment(), reward, backedProject, PledgeReason.UPDATE_PLEDGE)
+
+        this.updatePledgeButtonIsEnabled.assertValues(false)
+
+        this.vm.inputs.pledgeInput("31")
+        this.updatePledgeButtonIsEnabled.assertValues(false, true)
+
+        this.vm.inputs.pledgeInput("30")
+        this.updatePledgeButtonIsEnabled.assertValues(false, true, false)
+    }
+
+    @Test
+    fun testUpdatePledgeButtonIsEnabled_UpdatingPledge_whenShippingChanged() {
+        val reward = RewardFactory.rewardWithShipping()
+        val unitedStates = LocationFactory.unitedStates()
+        val backingShippingRule = ShippingRuleFactory.usShippingRule().toBuilder().location(unitedStates).build()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(40.0)
+                .location(unitedStates)
+                .locationId(unitedStates.id())
+                .reward(reward)
+                .rewardId(reward.id())
+                .shippingAmount(backingShippingRule.cost().toFloat())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        val config = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfig()
+        currentConfig.config(config)
+
+        val germanyShippingRule = ShippingRuleFactory.germanyShippingRule()
+        val shippingRulesEnvelope = ShippingRulesEnvelopeFactory.shippingRules()
+                .toBuilder()
+                .shippingRules(listOf(germanyShippingRule, backingShippingRule))
+                .build()
+
+        val environment = environmentForShippingRules(shippingRulesEnvelope)
+                .toBuilder()
+                .currentUser(MockCurrentUser(UserFactory.user()))
+                .apiClient(object : MockApiClient() {
+                    override fun fetchShippingRules(project: Project, reward: Reward): Observable<ShippingRulesEnvelope> {
+                        return Observable.just(shippingRulesEnvelope)
+                    }
+                })
+                .build()
+
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PLEDGE)
+
+        this.updatePledgeButtonIsEnabled.assertValues(false)
+
+        this.vm.inputs.shippingRuleSelected(germanyShippingRule)
+        this.updatePledgeButtonIsEnabled.assertValues(false, true)
+
+        this.vm.inputs.shippingRuleSelected(backingShippingRule)
+        this.updatePledgeButtonIsEnabled.assertValues(false, true, false)
+
+        this.vm.inputs.pledgeInput("500")
+        this.updatePledgeButtonIsEnabled.assertValues(false, true, false, true)
     }
 
     private fun assertInitialPledgeCurrencyStates_NoShipping_USProject() {

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -667,10 +667,14 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     fun testShowUpdatePledgeSuccess() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
 
+        // Start the view model with a backed project
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
+
+        this.projectTest.assertValueCount(2)
 
         this.vm.inputs.pledgeSuccessfullyUpdated()
         this.showUpdatePledgeSuccess.assertValueCount(1)
+        this.projectTest.assertValueCount(3)
     }
 
     private fun environmentWithNativeCheckoutEnabled() : Environment {

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -43,6 +43,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     private val showSavedPromptTest = TestSubscriber<Void>()
     private val showShareSheet = TestSubscriber<Project>()
     private val showUpdatePledge = TestSubscriber<Pair<PledgeData, PledgeReason>>()
+    private val showUpdatePledgeSuccess = TestSubscriber<Void>()
     private val startBackingActivity = TestSubscriber<Pair<Project, User>>()
     private val startCampaignWebViewActivity = TestSubscriber<Project>()
     private val startCommentsActivity = TestSubscriber<Project>()
@@ -73,6 +74,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.showSavedPrompt().subscribe(this.showSavedPromptTest)
         this.vm.outputs.showShareSheet().subscribe(this.showShareSheet)
         this.vm.outputs.showUpdatePledge().subscribe(this.showUpdatePledge)
+        this.vm.outputs.showUpdatePledgeSuccess().subscribe(this.showUpdatePledgeSuccess)
         this.vm.outputs.startLoginToutActivity().subscribe(this.startLoginToutActivity)
         this.vm.outputs.projectAndUserCountry().map { pc -> pc.first.isStarred }.subscribe(this.savedTest)
         this.vm.outputs.startBackingActivity().subscribe(this.startBackingActivity)
@@ -659,6 +661,16 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.updatePaymentClicked()
         this.showUpdatePledge.assertValuesAndClear(Pair(PledgeData(reward, backedProject), PledgeReason.UPDATE_PAYMENT))
+    }
+
+    @Test
+    fun testShowUpdatePledgeSuccess() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
+
+        this.vm.inputs.pledgeSuccessfullyUpdated()
+        this.showUpdatePledgeSuccess.assertValueCount(1)
     }
 
     private fun environmentWithNativeCheckoutEnabled() : Environment {


### PR DESCRIPTION
# 📲 What
Users can now modify their pledge amount, shipping, and selected reward in the native checkout flow.

# 🤔 Why
Cuz people change their minds sometimez.

# 🛠 How
Added `UpdateBacking` mutation.
`CurrentConfigType.getConfig` was deprecated so I decided to officially retire it because it was causing crashes when it returned null. I am curious to see if it causes any lag.
While the `updateBacking` mutation is executing, a progress state is visible.
When a pledge is successfully updated, the `ProjectActivity` pops the back stack, refreshes the project, and delegates the success to the `BackingFragment`. The `BackingFragment` shows a `Snackbar` with a success message.
When a pledge is unsuccessfully updated, the `PledgeFragment` shows a `Snackbar` with an error message.
The `Update Pledge` button in the `PledgeFragment` is only enabled when the user is updating their pledge and changed their shipping or pledge amount. It's always enabled when they are updating their reward.
Changed the root of `fragment_backing` to a `CoordinatorLayout` so the error `Snackbar` displays correctly.
Tests :)

# 👀 See
| Update pledge | Updating reward |
| --- | --- |
| ![device-2019-08-23-181719 2019-08-23 18_18_08](https://user-images.githubusercontent.com/1289295/63626735-659b6e80-c5d2-11e9-834b-996dcc707c79.gif) | ![device-2019-08-23-182206 2019-08-23 18_22_54](https://user-images.githubusercontent.com/1289295/63626883-0b4edd80-c5d3-11e9-9d4d-3aa450e34836.gif) | 

# 📋 QA
Notez 2 QA: You can test this on the `native` HQ. The checkout object was not being returned in the mutation on master. https://github.com/kickstarter/kickstarter/pull/17025
The server is also returning a success but I don't see my changes reflected when I refresh the project.

# Story 📖
https://dripsprint.atlassian.net/browse/NT-180
https://dripsprint.atlassian.net/browse/NT-93
