### PR TITLE
[💰] Always showing the total pledge amount in the pledge summary

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -771,22 +771,16 @@ interface ProjectViewModel {
         override fun startVideoActivity(): Observable<Project> = this.startVideoActivity
 
         private fun backingDetails(project: Project): String {
-            project.backing()?.let { backing ->
+            return project.backing()?.let { backing ->
                 val reward = project.rewards()?.firstOrNull { it.id() == backing.rewardId() }
                 val title = reward?.let { "• ${it.title()}" } ?: ""
 
-                val backingAmount = reward?.let {
-                    when {
-                        RewardUtils.isReward(it) -> it.minimum()
-                        else -> backing.amount()
-                    }
-                } ?: backing.amount()
+                val backingAmount = backing.amount()
 
                 val formattedAmount = this.ksCurrency.format(backingAmount, project, RoundingMode.HALF_UP)
 
                 return "$formattedAmount $title".trim()
-            }
-            return ""
+            } ?: ""
         }
 
         private fun saveProject(project: Project): Observable<Project> {

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -432,24 +432,16 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testBackingDetailsOutputs() {
+    fun testBackingDetails_whenProjectNotBacked() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
         this.backingDetailsIsVisible.assertValue(false)
         this.backingDetails.assertNoValues()
+    }
 
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.successfulProject()))
-        this.backingDetailsIsVisible.assertValue(false)
-        this.backingDetails.assertNoValues()
-
-        val backedSuccessfulProject = ProjectFactory.backedProject()
-                .toBuilder()
-                .state(Project.STATE_SUCCESSFUL)
-                .build()
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedSuccessfulProject))
-        this.backingDetailsIsVisible.assertValuesAndClear(false)
-        this.backingDetails.assertNoValues()
-
+    @Test
+    fun testBackingDetails_whenShippableRewardBacked() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
         val reward = RewardFactory.reward()
                 .toBuilder()
                 .id(4)
@@ -458,6 +450,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         val backing = BackingFactory.backing()
                 .toBuilder()
                 .amount(34.0)
+                .shippingAmount(4f)
                 .rewardId(4)
                 .build()
 
@@ -468,37 +461,26 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
                 .build()
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedProject))
-        this.backingDetails.assertValuesAndClear("$20 • Digital Bundle")
+        this.backingDetails.assertValuesAndClear("$34 • Digital Bundle")
         this.backingDetailsIsVisible.assertValue(true)
+    }
 
+    @Test
+    fun testBackingDetails_whenDigitalReward() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
         val noRewardBacking = BackingFactory.backing()
                 .toBuilder()
                 .amount(13.5)
                 .reward(RewardFactory.noReward())
                 .build()
 
-        val backedProjectdNoReward = ProjectFactory.backedProject()
+        val backedProject = ProjectFactory.backedProject()
                 .toBuilder()
                 .backing(noRewardBacking)
                 .build()
 
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedProjectdNoReward))
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedProject))
         this.backingDetails.assertValuesAndClear("$13.50")
-        this.backingDetailsIsVisible.assertValue(true)
-
-        val noRewardWholeBacking = BackingFactory.backing()
-                .toBuilder()
-                .amount(15.0)
-                .reward(RewardFactory.noReward())
-                .build()
-
-        val backedProjectNoRewardWhole = ProjectFactory.backedProject()
-                .toBuilder()
-                .backing(noRewardWholeBacking)
-                .build()
-
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedProjectNoRewardWhole))
-        this.backingDetails.assertValue("$15")
         this.backingDetailsIsVisible.assertValue(true)
     }
 


### PR DESCRIPTION
# 📲 What
Previously we showed the total amount pledged if you backed no reward and the reward minimum if you backed an actual reward. This PR makes it so we always show the total pledge amount in the pledge summary of a backed live project.

# 🤔 Why
So the amount is unambiguous. 

# 🛠 How
Removed special logic for no reward and updated tests.

# 👀 See
| Reward minimum | Total amount pledged (includes shipping) 🆕 |
| --- | --- |
| ![screenshot-2019-08-29_134909](https://user-images.githubusercontent.com/1289295/63963857-e4295d80-ca63-11e9-9481-4b8f91fb5cb2.png) | ![screenshot-2019-08-28_193405](https://user-images.githubusercontent.com/1289295/63899419-d83d8d00-c9ca-11e9-9016-b8386301c8de.png) |

# 📋 QA
Back a project! Or view a backed live project (check your profile!). 
The backing summary in the collapsed pledge sheet should show the total amount backed.

# Story 📖
https://dripsprint.atlassian.net/browse/NT-183
