### PR TITLE
[🔙] Reward buttons, take 2

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -33,7 +33,7 @@ object RewardViewUtils {
     @ColorRes
     fun pledgeButtonColor(project: Project, reward: Reward): Int {
         return if (BackingUtils.isBacked(project, reward) && project.isLive) {
-            R.color.button_pledge_manage
+            R.color.button_pledge_ended
         } else if (!project.isLive) {
             R.color.button_pledge_ended
         } else {
@@ -46,16 +46,10 @@ object RewardViewUtils {
      */
     @StringRes
     fun pledgeButtonText(project: Project, reward: Reward): Int {
-        return if (BackingUtils.isBacked(project, reward) && project.isLive) {
-            R.string.Manage_your_pledge
-        } else if (BackingUtils.isBacked(project, reward) && !project.isLive) {
-            R.string.View_your_pledge
-        } else if (RewardUtils.isAvailable(project, reward) && project.isBacking) {
-            R.string.Select_this_instead
-        } else if (!RewardUtils.isAvailable(project, reward)) {
-            R.string.No_longer_available
-        } else {
-            R.string.Select
+        return when {
+            BackingUtils.isBacked(project, reward) -> R.string.Selected
+            RewardUtils.isAvailable(project, reward) -> R.string.Select
+            else -> R.string.No_longer_available
         }
     }
 

--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -3,8 +3,6 @@ package com.kickstarter.libs.utils
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.style.RelativeSizeSpan
-import androidx.annotation.ColorRes
-import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.kickstarter.R
 import com.kickstarter.libs.KSCurrency
@@ -14,33 +12,6 @@ import com.kickstarter.models.Reward
 import java.math.RoundingMode
 
 object RewardViewUtils {
-
-    /**
-     * Returns the drawable resource ID of the check background based on project status.
-     */
-    @DrawableRes
-    fun checkBackgroundDrawable(project: Project): Int {
-        return if (project.isLive) {
-            R.drawable.circle_blue_alpha_6
-        } else {
-            R.drawable.circle_grey_300
-        }
-    }
-
-    /**
-     * Returns the color resource ID of the rewards button based on project and if user has backed reward.
-     */
-    @ColorRes
-    fun pledgeButtonColor(project: Project, reward: Reward): Int {
-        return if (BackingUtils.isBacked(project, reward) && project.isLive) {
-            R.color.button_pledge_ended
-        } else if (!project.isLive) {
-            R.color.button_pledge_ended
-        } else {
-            R.color.button_pledge_live
-        }
-    }
-
     /**
      * Returns the string resource ID of the rewards button based on project and reward status.
      */

--- a/app/src/main/java/com/kickstarter/ui/viewholders/NativeCheckoutRewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/NativeCheckoutRewardViewHolder.kt
@@ -150,30 +150,10 @@ class NativeCheckoutRewardViewHolder(private val view: View, val delegate: Deleg
                 .compose(observeForUI())
                 .subscribe { this.startBackingActivity(it) }
 
-        this.viewModel.outputs.buttonTint()
-                .compose(bindToLifecycle())
-                .compose(observeForUI())
-                .subscribe { this.view.reward_pledge_button.backgroundTintList = ContextCompat.getColorStateList(context(), it) }
-
         this.viewModel.outputs.buttonIsGone()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
                 .subscribe { setPledgeButtonVisibility(it) }
-
-        this.viewModel.outputs.checkIsInvisible()
-                .compose(bindToLifecycle())
-                .compose(observeForUI())
-                .subscribe { ViewUtils.setInvisible(this.view.reward_check, if (BooleanUtils.isTrue(this.inset)) true else it) }
-
-        this.viewModel.outputs.checkTintColor()
-                .compose(bindToLifecycle())
-                .compose(observeForUI())
-                .subscribe { this.view.reward_check.imageTintList = ContextCompat.getColorStateList(context(), it) }
-
-        this.viewModel.outputs.checkBackgroundDrawable()
-                .compose(bindToLifecycle())
-                .compose(observeForUI())
-                .subscribe { this.view.reward_check.setBackgroundResource(it) }
 
         RxView.clicks(this.view.reward_pledge_button)
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
@@ -267,7 +267,7 @@ interface NativeCheckoutRewardViewHolderViewModel {
 
         private fun isSelectable(@NonNull project: Project, @NonNull reward: Reward): Boolean {
             if (BackingUtils.isBacked(project, reward)) {
-                return true
+                return false
             }
 
             return RewardUtils.isAvailable(project, reward)

--- a/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
@@ -36,18 +36,6 @@ interface NativeCheckoutRewardViewHolderViewModel {
         /** Emits a boolean determining if the pledge button should be shown. */
         fun buttonIsGone(): Observable<Boolean>
 
-        /** Emits the color resource ID to tint the pledge button. */
-        fun buttonTint(): Observable<Int>
-
-        /** Emits the drawable resource ID to set as the check's background. */
-        fun checkBackgroundDrawable(): Observable<Int>
-
-        /** Emits `true` if the backed check should be hidden, `false` otherwise.  */
-        fun checkIsInvisible(): Observable<Boolean>
-
-        /** Emits the color resource ID to tint the check. */
-        fun checkTintColor(): Observable<Int>
-
         /** Emits `true` if the conversion should be hidden, `false` otherwise.  */
         fun conversionIsGone(): Observable<Boolean>
 
@@ -115,10 +103,6 @@ interface NativeCheckoutRewardViewHolderViewModel {
         private val buttonCTA: Observable<Int>
         private val buttonIsEnabled: Observable<Boolean>
         private val buttonIsGone: Observable<Boolean>
-        private val buttonTintColor: Observable<Int>
-        private val checkBackgroundDrawable: Observable<Int>
-        private val checkIsInvisible: Observable<Boolean>
-        private val checkTintColor: Observable<Int>
         private val conversion: Observable<String>
         private val conversionIsGone: Observable<Boolean>
         private val description: Observable<String?>
@@ -153,24 +137,6 @@ interface NativeCheckoutRewardViewHolderViewModel {
             this.buttonIsGone = this.projectAndReward
                     .map { BackingUtils.isBacked(it.first, it.second) || it.first.isLive }
                     .map { BooleanUtils.negate(it) }
-                    .distinctUntilChanged()
-
-            this.buttonTintColor = this.projectAndReward
-                    .map { RewardViewUtils.pledgeButtonColor(it.first, it.second) }
-                    .distinctUntilChanged()
-
-            this.checkTintColor = this.projectAndReward
-                    .filter { BackingUtils.isBacked(it.first, it.second) }
-                    .map { RewardViewUtils.pledgeButtonColor(it.first, it.second) }
-                    .distinctUntilChanged()
-
-            this.checkBackgroundDrawable = this.projectAndReward
-                    .filter { BackingUtils.isBacked(it.first, it.second) }
-                    .map { RewardViewUtils.checkBackgroundDrawable(it.first) }
-                    .distinctUntilChanged()
-
-            this.checkIsInvisible = this.projectAndReward
-                    .map { !BackingUtils.isBacked(it.first, it.second) }
                     .distinctUntilChanged()
 
             this.buttonCTA = this.projectAndReward
@@ -286,18 +252,6 @@ interface NativeCheckoutRewardViewHolderViewModel {
 
         @NonNull
         override fun buttonIsGone(): Observable<Boolean> = this.buttonIsGone
-
-        @NonNull
-        override fun buttonTint(): Observable<Int> = this.buttonTintColor
-
-        @NonNull
-        override fun checkBackgroundDrawable(): Observable<Int> = this.checkBackgroundDrawable
-
-        @NonNull
-        override fun checkIsInvisible(): Observable<Boolean> = this.checkIsInvisible
-
-        @NonNull
-        override fun checkTintColor(): Observable<Int> = this.checkTintColor
 
         @NonNull
         override fun conversionIsGone(): Observable<Boolean> = this.conversionIsGone

--- a/app/src/main/res/color/button_pledge_ended.xml
+++ b/app/src/main/res/color/button_pledge_ended.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:color="@color/ksr_soft_black" android:state_enabled="true"/>
-  <item android:color="@color/ksr_grey_500"/>
+  <item android:color="@color/ksr_grey_500" android:state_enabled="false" />
+  <item android:color="@color/ksr_soft_black" />
 </selector>

--- a/app/src/main/res/color/button_pledge_ended.xml
+++ b/app/src/main/res/color/button_pledge_ended.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:color="@color/ksr_soft_black" android:state_enabled="true"/>
-  <item android:alpha="0.12" android:color="?attr/colorOnSurface"/>
+  <item android:color="@color/ksr_grey_500"/>
 </selector>

--- a/app/src/main/res/color/button_pledge_live.xml
+++ b/app/src/main/res/color/button_pledge_live.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:color="@color/ksr_green_200" android:state_enabled="false"/>
+  <item android:color="@color/ksr_grey_500" android:state_enabled="false" />
   <item android:color="@color/ksr_green_500"/>
 </selector>

--- a/app/src/main/res/color/button_pledge_manage.xml
+++ b/app/src/main/res/color/button_pledge_manage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:color="@color/ksr_cobalt_500" android:state_enabled="true"/>
-  <item android:alpha="0.12" android:color="?attr/colorOnSurface"/>
+  <item android:color="@color/ksr_cobalt_200" />
 </selector>

--- a/app/src/main/res/color/button_pledge_manage.xml
+++ b/app/src/main/res/color/button_pledge_manage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-  <item android:color="@color/ksr_cobalt_500" android:state_enabled="true"/>
-  <item android:color="@color/ksr_cobalt_200" />
+  <item android:color="@color/ksr_grey_500" android:state_enabled="false" />
+  <item android:color="@color/ksr_cobalt_500"/>
 </selector>

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -34,41 +34,22 @@
           android:focusable="true"
           android:orientation="vertical">
 
-          <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+          <TextView
+            android:id="@+id/reward_minimum_text_view"
+            style="@style/Title2Medium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/ksr_green_500"
+            android:textSize="@dimen/title_reward"
+            tools:text="$20" />
 
-            <TextView
-              android:id="@+id/reward_minimum_text_view"
-              style="@style/Title2Medium"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_alignParentStart="true"
-              android:layout_toStartOf="@id/reward_check"
-              android:textColor="@color/ksr_green_500"
-              android:textSize="@dimen/title_reward"
-              tools:text="$20" />
-
-            <TextView
-              android:id="@+id/reward_conversion_text_view"
-              style="@style/FootnotePrimaryMedium"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_below="@id/reward_minimum_text_view"
-              android:textColor="@color/ksr_green_500"
-              tools:text="About $15 USD" />
-
-            <ImageView
-              android:id="@+id/reward_check"
-              android:layout_width="@dimen/grid_5"
-              android:layout_height="@dimen/grid_5"
-              android:layout_alignParentEnd="true"
-              android:background="@drawable/circle_black_alpha"
-              android:contentDescription="@null"
-              android:src="@drawable/icon__check_reward"
-              android:visibility="invisible"
-              tools:visibility="visible" />
-          </RelativeLayout>
+          <TextView
+            android:id="@+id/reward_conversion_text_view"
+            style="@style/FootnotePrimaryMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/ksr_green_500"
+            tools:text="About $15 USD" />
 
           <TextView
             android:id="@+id/reward_title_text_view"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -13,6 +13,7 @@
   <color name="black">@android:color/black</color>
   <color name="ksr_apricot_500">#FFCBA9</color>
   <color name="ksr_apricot_600">#F0AE81</color>
+  <color name="ksr_cobalt_200">#96a8fb</color>
   <color name="ksr_cobalt_500">#4C6CF8</color>
   <color name="ksr_cobalt_600">#395AEB</color>
   <color name="ksr_dark_grey_400">#9B9E9E</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -13,7 +13,6 @@
   <color name="black">@android:color/black</color>
   <color name="ksr_apricot_500">#FFCBA9</color>
   <color name="ksr_apricot_600">#F0AE81</color>
-  <color name="ksr_cobalt_200">#96a8fb</color>
   <color name="ksr_cobalt_500">#4C6CF8</color>
   <color name="ksr_cobalt_600">#395AEB</color>
   <color name="ksr_dark_grey_400">#9B9E9E</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -212,7 +212,6 @@
   <style name="PledgeButton">
     <item name="android:layout_gravity">bottom</item>
     <item name="android:textAllCaps">false</item>
-    <item name="android:textColor">@color/white</item>
     <item name="backgroundTint">@color/button_pledge_live</item>
     <item name="cornerRadius">@dimen/grid_2</item>
     <item name="android:layout_marginBottom">@dimen/grid_3</item>

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
@@ -16,11 +16,11 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
         assertEquals(R.string.No_longer_available, RewardViewUtils.pledgeButtonText(ProjectFactory.project(), RewardFactory.limitReached()))
         val backedProject = ProjectFactory.backedProject()
         val backedReward = backedProject.backing()?.reward()?: RewardFactory.reward()
-        assertEquals(R.string.Manage_your_pledge, RewardViewUtils.pledgeButtonText(backedProject, backedReward))
+        assertEquals(R.string.Selected, RewardViewUtils.pledgeButtonText(backedProject, backedReward))
         assertEquals(R.string.Select, RewardViewUtils.pledgeButtonText(backedProject, RewardFactory.reward()))
         val backedSuccessfulProject = ProjectFactory.backedProject().toBuilder().state(Project.STATE_SUCCESSFUL).build()
         val backedSuccessfulReward = backedSuccessfulProject.backing()?.reward()?: RewardFactory.reward()
-        assertEquals(R.string.View_your_pledge, RewardViewUtils.pledgeButtonText(backedSuccessfulProject, backedSuccessfulReward))
+        assertEquals(R.string.Selected, RewardViewUtils.pledgeButtonText(backedSuccessfulProject, backedSuccessfulReward))
     }
 
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
@@ -10,24 +10,6 @@ import org.junit.Test
 class RewardViewUtilsTest : KSRobolectricTestCase() {
 
     @Test
-    fun testCheckBackgroundDrawable() {
-        assertEquals(R.drawable.circle_blue_alpha_6, RewardViewUtils.checkBackgroundDrawable(ProjectFactory.project()))
-        assertEquals(R.drawable.circle_grey_300, RewardViewUtils.checkBackgroundDrawable(ProjectFactory.successfulProject()))
-    }
-
-    @Test
-    fun testPledgeButtonColor() {
-        assertEquals(R.color.button_pledge_live, RewardViewUtils.pledgeButtonColor(ProjectFactory.project(), RewardFactory.reward()))
-        val backedProject = ProjectFactory.backedProject()
-        val backedReward = backedProject.backing()?.reward()?: RewardFactory.reward()
-        assertEquals(R.color.button_pledge_manage, RewardViewUtils.pledgeButtonColor(backedProject, backedReward))
-        val backedSuccessfulProject = ProjectFactory.backedProject().toBuilder().state(Project.STATE_SUCCESSFUL).build()
-        val backedSuccessfulReward = backedProject.backing()?.reward()?: RewardFactory.reward()
-        assertEquals(R.color.button_pledge_ended, RewardViewUtils.pledgeButtonColor(backedSuccessfulProject, backedSuccessfulReward))
-        assertEquals(R.color.button_pledge_ended, RewardViewUtils.pledgeButtonColor(ProjectFactory.successfulProject(), RewardFactory.reward()))
-    }
-
-    @Test
     fun testPledgeButtonText() {
         assertEquals(R.string.Select, RewardViewUtils.pledgeButtonText(ProjectFactory.project(), RewardFactory.reward()))
         assertEquals(R.string.No_longer_available, RewardViewUtils.pledgeButtonText(ProjectFactory.project(), RewardFactory.ended()))
@@ -35,7 +17,7 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
         val backedProject = ProjectFactory.backedProject()
         val backedReward = backedProject.backing()?.reward()?: RewardFactory.reward()
         assertEquals(R.string.Manage_your_pledge, RewardViewUtils.pledgeButtonText(backedProject, backedReward))
-        assertEquals(R.string.Select_this_instead, RewardViewUtils.pledgeButtonText(backedProject, RewardFactory.reward()))
+        assertEquals(R.string.Select, RewardViewUtils.pledgeButtonText(backedProject, RewardFactory.reward()))
         val backedSuccessfulProject = ProjectFactory.backedProject().toBuilder().state(Project.STATE_SUCCESSFUL).build()
         val backedSuccessfulReward = backedSuccessfulProject.backing()?.reward()?: RewardFactory.reward()
         assertEquals(R.string.View_your_pledge, RewardViewUtils.pledgeButtonText(backedSuccessfulProject, backedSuccessfulReward))

--- a/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
@@ -24,10 +24,6 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
     private val buttonCTA = TestSubscriber.create<Int>()
     private val buttonIsEnabled = TestSubscriber<Boolean>()
     private val buttonIsGone = TestSubscriber.create<Boolean>()
-    private val buttonTint = TestSubscriber.create<Int>()
-    private val checkBackgroundDrawable = TestSubscriber.create<Int>()
-    private val checkIsInvisible = TestSubscriber.create<Boolean>()
-    private val checkTintColor = TestSubscriber.create<Int>()
     private val conversion = TestSubscriber.create<String>()
     private val conversionIsGone = TestSubscriber.create<Boolean>()
     private val description = TestSubscriber<String>()
@@ -53,10 +49,6 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.buttonCTA().subscribe(this.buttonCTA)
         this.vm.outputs.buttonIsEnabled().subscribe(this.buttonIsEnabled)
         this.vm.outputs.buttonIsGone().subscribe(this.buttonIsGone)
-        this.vm.outputs.buttonTint().subscribe(this.buttonTint)
-        this.vm.outputs.checkBackgroundDrawable().subscribe(this.checkBackgroundDrawable)
-        this.vm.outputs.checkIsInvisible().subscribe(this.checkIsInvisible)
-        this.vm.outputs.checkTintColor().subscribe(this.checkTintColor)
         this.vm.outputs.conversion().subscribe(this.conversion)
         this.vm.outputs.conversionIsGone().subscribe(this.conversionIsGone)
         this.vm.outputs.description().subscribe(this.description)
@@ -88,50 +80,42 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         //Live project, available reward, not backed
         this.vm.inputs.projectAndReward(project, reward)
         this.buttonIsGone.assertValue(false)
-        this.buttonTint.assertValue(R.color.button_pledge_live)
         this.buttonCTA.assertValue(R.string.Select)
 
         //Live project, no reward, not backed
         this.vm.inputs.projectAndReward(project, noReward)
         this.buttonIsGone.assertValue(false)
-        this.buttonTint.assertValue(R.color.button_pledge_live)
         this.buttonCTA.assertValuesAndClear(R.string.Select)
 
         //Live project, unavailable limited reward, not backed
         this.vm.inputs.projectAndReward(project, RewardFactory.limitReached())
         this.buttonIsGone.assertValue(false)
-        this.buttonTint.assertValue(R.color.button_pledge_live)
         this.buttonCTA.assertValue(R.string.No_longer_available)
 
         //Live project, unavailable expired reward, not backed
         this.vm.inputs.projectAndReward(project, RewardFactory.ended())
         this.buttonIsGone.assertValue(false)
-        this.buttonTint.assertValue(R.color.button_pledge_live)
         this.buttonCTA.assertValuesAndClear(R.string.No_longer_available)
 
         //Live backed project, currently backed reward
         val backedLiveProject = ProjectFactory.backedProject()
         this.vm.inputs.projectAndReward(backedLiveProject, backedLiveProject.backing()?.reward()?: RewardFactory.reward())
         this.buttonIsGone.assertValues(false)
-        this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage)
-        this.buttonCTA.assertValuesAndClear(R.string.Manage_your_pledge)
+        this.buttonCTA.assertValuesAndClear(R.string.Selected)
 
         //Live backed project, not backed available reward
         this.vm.inputs.projectAndReward(backedLiveProject, RewardFactory.reward())
         this.buttonIsGone.assertValues(false)
-        this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live)
-        this.buttonCTA.assertValuesAndClear(R.string.Select_this_instead)
+        this.buttonCTA.assertValuesAndClear(R.string.Select)
 
         //Live backed project, not backed unavailable limited reward
         this.vm.inputs.projectAndReward(backedLiveProject, RewardFactory.limitReached())
         this.buttonIsGone.assertValues(false)
-        this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live)
         this.buttonCTA.assertValue(R.string.No_longer_available)
 
         //Live backed project, not backed unavailable expired reward
         this.vm.inputs.projectAndReward(backedLiveProject, RewardFactory.limitReached())
         this.buttonIsGone.assertValues(false)
-        this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live)
         this.buttonCTA.assertValuesAndClear(R.string.No_longer_available)
 
         //Ended project, available reward, not backed
@@ -141,7 +125,6 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
                 .build()
         this.vm.inputs.projectAndReward(successfulProject, reward)
         this.buttonIsGone.assertValues(false, true)
-        this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live, R.color.button_pledge_ended)
         this.buttonCTA.assertNoValues()
 
         //Ended backed project, not pledged
@@ -151,20 +134,17 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
                 .build()
         this.vm.inputs.projectAndReward(backedSuccessfulProject, reward)
         this.buttonIsGone.assertValues(false, true)
-        this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live, R.color.button_pledge_ended)
         this.buttonCTA.assertNoValues()
 
         //Ended backed project, no reward, not pledged
         this.vm.inputs.projectAndReward(backedSuccessfulProject, noReward)
         this.buttonIsGone.assertValues(false, true)
-        this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live, R.color.button_pledge_ended)
         this.buttonCTA.assertNoValues()
 
         //Ended backed project, pledged reward
         this.vm.inputs.projectAndReward(backedSuccessfulProject, backedSuccessfulProject.backing()?.reward()?: reward)
         this.buttonIsGone.assertValues(false, true, false)
-        this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live, R.color.button_pledge_ended)
-        this.buttonCTA.assertValue(R.string.View_your_pledge)
+        this.buttonCTA.assertValue(R.string.Selected)
 
         val backedNoRewardSuccessfulProject = ProjectFactory.backedProjectWithNoReward()
                 .toBuilder()
@@ -173,61 +153,7 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         //Ended backed project, no reward, pledged no reward
         this.vm.inputs.projectAndReward(backedNoRewardSuccessfulProject, noReward)
         this.buttonIsGone.assertValues(false, true, false)
-        this.buttonTint.assertValues(R.color.button_pledge_live, R.color.button_pledge_manage, R.color.button_pledge_live, R.color.button_pledge_ended)
-        this.buttonCTA.assertValue(R.string.View_your_pledge)
-    }
-
-    @Test
-    fun testCheckUIOutputs() {
-        setUpEnvironment(environment())
-        val project = ProjectFactory.project()
-        val reward = RewardFactory.reward()
-
-        this.vm.inputs.projectAndReward(project, reward)
-        this.checkIsInvisible.assertValue(true)
-        this.checkBackgroundDrawable.assertNoValues()
-        this.checkTintColor.assertNoValues()
-
-        this.vm.inputs.projectAndReward(project, RewardFactory.limitReached())
-        this.checkIsInvisible.assertValue(true)
-        this.checkBackgroundDrawable.assertNoValues()
-        this.checkTintColor.assertNoValues()
-
-        this.vm.inputs.projectAndReward(project, RewardFactory.ended())
-        this.checkIsInvisible.assertValue(true)
-        this.checkBackgroundDrawable.assertNoValues()
-        this.checkTintColor.assertNoValues()
-
-        this.vm.inputs.projectAndReward(project, RewardFactory.noReward())
-        this.checkIsInvisible.assertValue(true)
-        this.checkBackgroundDrawable.assertNoValues()
-        this.checkTintColor.assertNoValues()
-
-        val backedLiveProject = ProjectFactory.backedProject()
-        this.vm.inputs.projectAndReward(backedLiveProject, backedLiveProject.backing()?.reward()?: RewardFactory.reward())
-        this.checkIsInvisible.assertValues(true, false)
-        this.checkBackgroundDrawable.assertValue(R.drawable.circle_blue_alpha_6)
-        this.checkTintColor.assertValues(R.color.button_pledge_manage)
-
-        this.vm.inputs.projectAndReward(backedLiveProject, RewardFactory.reward())
-        this.checkIsInvisible.assertValues(true, false, true)
-        this.checkBackgroundDrawable.assertValues(R.drawable.circle_blue_alpha_6)
-        this.checkTintColor.assertValues(R.color.button_pledge_manage)
-
-        val successfulProject = ProjectFactory.successfulProject()
-        this.vm.inputs.projectAndReward(successfulProject, reward)
-        this.checkIsInvisible.assertValues(true, false, true)
-        this.checkBackgroundDrawable.assertValues(R.drawable.circle_blue_alpha_6)
-        this.checkTintColor.assertValues(R.color.button_pledge_manage)
-
-        val backedEndedProject = ProjectFactory.backedProject()
-                .toBuilder()
-                .state(Project.STATE_SUCCESSFUL)
-                .build()
-        this.vm.inputs.projectAndReward(backedEndedProject, backedEndedProject.backing()?.reward()?: RewardFactory.reward())
-        this.checkIsInvisible.assertValues(true, false, true, false)
-        this.checkBackgroundDrawable.assertValues(R.drawable.circle_blue_alpha_6, R.drawable.circle_grey_300)
-        this.checkTintColor.assertValues(R.color.button_pledge_manage, R.color.button_pledge_ended)
+        this.buttonCTA.assertValue(R.string.Selected)
     }
 
     @Test
@@ -436,29 +362,29 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
     fun testButtonIsEnabled() {
         setUpEnvironment(environment())
 
-        // A reward from a live project should be enabled.
+        // A reward from a live project that is available should be enabled.
         this.vm.inputs.projectAndReward(ProjectFactory.project(), RewardFactory.reward())
         this.buttonIsEnabled.assertValue(true)
 
         // A reward from a successful project should not be enabled.
         this.vm.inputs.projectAndReward(ProjectFactory.successfulProject(), RewardFactory.reward())
         this.buttonIsEnabled.assertValues(true, false)
-        //
-        // A backed reward from a live project should be enabled.
+
+        // A backed reward from a live project should not be enabled.
         val backedLiveProject = ProjectFactory.backedProject()
         this.vm.inputs.projectAndReward(backedLiveProject, backedLiveProject.backing()?.reward()!!)
-        this.buttonIsEnabled.assertValues(true, false, true)
+        this.buttonIsEnabled.assertValues(true, false)
 
-        // A backed reward from a finished project should be enabled (distinct until changed).
+        // A backed reward from an ended project should not be enabled.
         val backedSuccessfulProject = ProjectFactory.backedProject().toBuilder()
                 .state(Project.STATE_SUCCESSFUL)
                 .build()
         this.vm.inputs.projectAndReward(backedSuccessfulProject, backedSuccessfulProject.backing()?.reward()!!)
-        this.buttonIsEnabled.assertValues(true, false, true)
+        this.buttonIsEnabled.assertValues(true, false)
 
         // A reward with its limit reached should not be enabled.
         this.vm.inputs.projectAndReward(ProjectFactory.project(), RewardFactory.limitReached())
-        this.buttonIsEnabled.assertValues(true, false, true, false)
+        this.buttonIsEnabled.assertValues(true, false)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Backed reward button CTA is now `Selected`.
Unbacked rewards (of a backed project) button CTA is `Select` instead of `Select this instead`.
Backed reward buttons are disabled (because you can't reselect them, ya know).
The disabled background for all reward buttons is `ksr_grey_500` with default Material disabled text color.
Removed check denoting selected reward.

# 🤔 Why
Becauseeeeee opening the rewards sheet no longer takes users directly to the carousel so the colors no longer apply and `Select this instead` copy was awkward.

# 🛠 How
LOVE TO DELETE CODE.
- Removed `RewardViewUtils.checkBackgroundDrawable` and `RewardViewUtils.pledgeButtonColor`.
- Updated `RewardViewUtils.pledgeButtonText` to 
  - backed reward -> `Selected`
  - available, unbacked reward -> `Select`
  - unavailable reward -> `No longer available`
- Removed `NativeCheckoutRewardViewHolderViewModel` outputs: `buttonTint`, `checkBackgroundDrawable`, `checkIsInvisible`, and `checkTintColor` since they are now IRRELEVANT.
- Disabled button color of all pledge buttons is `ksr_grey_500` #DCDEDD. It needs to be opaque so the reward description doesn't show behind it.
- Removed check `ImageView` from `item_reward` layout.
- Removed hardcoded white text color from `PledgeButton` style.
- Fixing the tests that were broken and removed unused.

# 👀 See
## Unavailable rewards
| After 🦋 | Before 🐛 |
| --- | --- |
| ![screenshot-2019-09-06_113742](https://user-images.githubusercontent.com/1289295/64442148-4d7d2200-d09d-11e9-9e7f-9f946a30dbe7.png) | ![screenshot-2019-09-06_115420](https://user-images.githubusercontent.com/1289295/64442149-4d7d2200-d09d-11e9-8291-2a80e12ddac2.png) |

## Manage your pledge
| After 🦋 | Before 🐛 |
| --- | --- |
| ![screenshot-2019-09-06_113754](https://user-images.githubusercontent.com/1289295/64442241-78677600-d09d-11e9-8baf-f866977fde83.png) | ![screenshot-2019-09-06_115441](https://user-images.githubusercontent.com/1289295/64442242-78677600-d09d-11e9-8866-3243f7584a65.png) |
| ![screenshot-2019-09-06_113758](https://user-images.githubusercontent.com/1289295/64442278-85846500-d09d-11e9-8c27-86716de5165f.png) | ![screenshot-2019-09-06_115516](https://user-images.githubusercontent.com/1289295/64442363-a5b42400-d09d-11e9-9a69-df5831457cc0.png) |

## View Your Pledge
| After 🦋 | Before 🐛 |
| --- | --- |
| ![screenshot-2019-09-06_113823](https://user-images.githubusercontent.com/1289295/64442315-9339ea80-d09d-11e9-96c1-ff3ac2390351.png) | ![screenshot-2019-09-06_115453](https://user-images.githubusercontent.com/1289295/64442316-9339ea80-d09d-11e9-9451-838494505bcf.png) |

# 📋 QA
🔙  backed reward -> `Selected`, no check
 🔙 ❔available, unbacked reward -> `Select`, no check
 ⛔️  unavailable reward -> `No longer available`, definitely no check

- Disabled button color of all pledge buttons is `ksr_grey_500` #DCDEDD. It needs to be opaque so the reward description doesn't show behind it.


# Story 📖
https://dripsprint.atlassian.net/browse/NT-232
