### PR TITLE
[🙈] hiding the rewards count in landscape

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -11,6 +11,7 @@ import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.NumberUtils
 import com.kickstarter.libs.utils.RewardDecoration
+import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.adapters.NativeCheckoutRewardsAdapter
@@ -54,6 +55,9 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Nati
                 .compose(observeForUI())
                 .subscribe { setRewardsCount(it) }
 
+        context?.apply {
+            ViewUtils.setGone(rewards_count, ViewUtils.isLandscape(this))
+        }
     }
 
     private fun scrollToReward(position: Int) {


### PR DESCRIPTION
# 📲 What
Hiding the rewards count footer in landscape.

# 🤔 Why
It's cramped in here.

# 🛠 How
We have this handy method `ViewUtils.isLandscape`. Did all the work for me 😛 

# 👀 See
| Portrait 🤲🏾 | Landscape 👐🏾 |
| --- | --- |
| ![screenshot-2019-09-06_134105](https://user-images.githubusercontent.com/1289295/64449084-2af30500-d0ad-11e9-8c98-05a190630cd1.png) | ![screenshot-2019-09-06_134110](https://user-images.githubusercontent.com/1289295/64449085-2af30500-d0ad-11e9-9342-3a34cdd62fcf.png) |

# 📋 QA
In a Native Checkout Enabled™ project, open the rewards sheet, rotate. 🎩The count is gone. 

# Story 📖
https://dripsprint.atlassian.net/browse/NT-249
