### PR TITLE
[🔙] Reversing reward animation on back press

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -449,9 +449,10 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         val backStackEntryCount = supportFragmentManager.backStackEntryCount
         val backStackIsNotEmpty = backStackEntryCount > 0
         val topOfStackIndex = backStackEntryCount.minus(1)
+        val pledgeFragmentOnTopOfBackStack = supportFragmentManager.getBackStackEntryAt(topOfStackIndex).name == PledgeFragment::class.java.simpleName
 
         val pledgeReason = when {
-            backStackIsNotEmpty && supportFragmentManager.getBackStackEntryAt(topOfStackIndex).name == PledgeFragment::class.java.simpleName -> {
+            backStackIsNotEmpty && pledgeFragmentOnTopOfBackStack -> {
                 pledgeFragment?.arguments?.getSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON)
             }
             else -> null

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -35,6 +35,7 @@ import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Project
 import com.kickstarter.models.StoredCard
 import com.kickstarter.models.User
+import com.kickstarter.ui.ArgumentsKey
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.adapters.ProjectAdapter
 import com.kickstarter.ui.data.LoginReason
@@ -443,8 +444,22 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
 
     private fun handleNativeCheckoutBackPress() {
         val rewardsSheetIsExpanded = pledge_container.alpha == 1f
+        val pledgeFragment = supportFragmentManager.findFragmentByTag(PledgeFragment::class.java.simpleName) as PledgeFragment?
+
+        val backStackEntryCount = supportFragmentManager.backStackEntryCount
+        val backStackIsNotEmpty = backStackEntryCount > 0
+        val topOfStackIndex = backStackEntryCount.minus(1)
+
+        val pledgeReason = when {
+            backStackIsNotEmpty && supportFragmentManager.getBackStackEntryAt(topOfStackIndex).name == PledgeFragment::class.java.simpleName -> {
+                pledgeFragment?.arguments?.getSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON)
+            }
+            else -> null
+        }
+
         when {
-            supportFragmentManager.backStackEntryCount > 0 && rewardsSheetIsExpanded -> supportFragmentManager.popBackStack()
+            pledgeReason == PledgeReason.PLEDGE || pledgeReason == PledgeReason.UPDATE_REWARD -> pledgeFragment?.backPressed()
+            backStackIsNotEmpty && rewardsSheetIsExpanded -> supportFragmentManager.popBackStack()
             rewardsSheetIsExpanded -> this.viewModel.inputs.collapsePledgeSheet()
             else -> {
                 clearFragmentBackStack()

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -443,9 +443,9 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     }
 
     private fun handleNativeCheckoutBackPress() {
-        val rewardsSheetIsExpanded = pledge_container.alpha == 1f
-        val pledgeFragment = supportFragmentManager.findFragmentByTag(PledgeFragment::class.java.simpleName) as PledgeFragment?
+        val pledgeSheetIsExpanded = pledge_container.alpha == 1f
 
+        val pledgeFragment = supportFragmentManager.findFragmentByTag(PledgeFragment::class.java.simpleName) as PledgeFragment?
         val backStackEntryCount = supportFragmentManager.backStackEntryCount
         val backStackIsNotEmpty = backStackEntryCount > 0
         val topOfStackIndex = backStackEntryCount.minus(1)
@@ -459,8 +459,8 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
 
         when {
             pledgeReason == PledgeReason.PLEDGE || pledgeReason == PledgeReason.UPDATE_REWARD -> pledgeFragment?.backPressed()
-            backStackIsNotEmpty && rewardsSheetIsExpanded -> supportFragmentManager.popBackStack()
-            rewardsSheetIsExpanded -> this.viewModel.inputs.collapsePledgeSheet()
+            backStackIsNotEmpty && pledgeSheetIsExpanded -> supportFragmentManager.popBackStack()
+            pledgeSheetIsExpanded -> this.viewModel.inputs.collapsePledgeSheet()
             else -> {
                 clearFragmentBackStack()
                 super.back()

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -120,10 +120,15 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .compose(observeForUI())
                 .subscribe { ViewUtils.setGone(additional_pledge_amount_container, it) }
 
-        this.viewModel.outputs.animateRewardCard()
+        this.viewModel.outputs.startRewardShrinkAnimation()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { showPledgeSection(it) }
+                .subscribe { revealPledgeSection(it) }
+
+        this.viewModel.outputs.startRewardExpandAnimation()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { hidePledgeSection() }
 
         this.viewModel.outputs.snapshotIsGone()
                 .compose(bindToLifecycle())
@@ -431,7 +436,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     }
 
     fun backPressed() {
-        shrinkRewardCard()
+        this.viewModel.inputs.backPressed()
     }
 
     fun cardAdded(storedCard: StoredCard) {
@@ -587,11 +592,6 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         setClickableHtml(accountabilityWithUrls, accountability)
     }
 
-    private fun shrinkRewardCard() {
-        this@PledgeFragment.animDuration = this@PledgeFragment.defaultAnimationDuration
-        startPledgeAnimatorSet(false)
-    }
-
     private fun showPledgeWarning(rewardMinimum: String) {
         context?.apply {
             val ksString = (this.applicationContext as KSApplication).component().environment().ksString()
@@ -628,11 +628,16 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     }
 
     //Reward card animation helper methods
-    private fun showPledgeSection(pledgeData: PledgeData) {
+    private fun revealPledgeSection(pledgeData: PledgeData) {
         pledgeData.rewardScreenLocation?.let {
             setInitialViewStates(pledgeData)
             startPledgeAnimatorSet(true)
         }
+    }
+
+    private fun hidePledgeSection() {
+        this@PledgeFragment.animDuration = this@PledgeFragment.defaultAnimationDuration
+        startPledgeAnimatorSet(false)
     }
 
     private fun startPledgeAnimatorSet(reveal: Boolean) {
@@ -690,14 +695,14 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         val detailsY = getYAnimator(initY, finalY)
 
         if (reveal) {
-            val shrinkClickListener = View.OnClickListener { v ->
+            val expandRewardClickListener = View.OnClickListener { v ->
                 if (!width.isRunning) {
                     v?.setOnClickListener(null)
-                    shrinkRewardCard()
+                    this.viewModel.inputs.miniRewardClicked()
                 }
             }
-            reward_snapshot.setOnClickListener(shrinkClickListener)
-            expand_icon_container.setOnClickListener(shrinkClickListener)
+            reward_snapshot.setOnClickListener(expandRewardClickListener)
+            expand_icon_container.setOnClickListener(expandRewardClickListener)
         } else {
             width.addUpdateListener {
                 if (it.animatedFraction == 1f) {

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -66,6 +66,7 @@ import kotlinx.android.synthetic.main.fragment_pledge_section_shipping.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_summary_pledge.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_summary_shipping.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_total.*
+import kotlin.math.max
 import kotlin.math.min
 
 @RequiresFragmentViewModel(PledgeFragmentViewModel.ViewModel::class)
@@ -429,6 +430,10 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.inputs.newCardButtonClicked()
     }
 
+    fun backPressed() {
+        shrinkRewardCard()
+    }
+
     fun cardAdded(storedCard: StoredCard) {
         this.viewModel.inputs.cardSaved(storedCard)
     }
@@ -581,6 +586,11 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         setClickableHtml(accountabilityWithUrls, accountability)
     }
 
+    private fun shrinkRewardCard() {
+        this@PledgeFragment.animDuration = this@PledgeFragment.defaultAnimationDuration
+        startPledgeAnimatorSet(false)
+    }
+
     private fun showPledgeWarning(rewardMinimum: String) {
         context?.apply {
             val ksString = (this.applicationContext as KSApplication).component().environment().ksString()
@@ -620,11 +630,11 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     private fun showPledgeSection(pledgeData: PledgeData) {
         pledgeData.rewardScreenLocation?.let {
             setInitialViewStates(pledgeData)
-            startPledgeAnimatorSet(true, it)
+            startPledgeAnimatorSet(true)
         }
     }
 
-    private fun startPledgeAnimatorSet(reveal: Boolean, location: ScreenLocation) {
+    private fun startPledgeAnimatorSet(reveal: Boolean) {
         val initMarginX: Float
         val initMarginY: Float
         val finalMarginX: Float
@@ -636,8 +646,9 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         val initY: Float
         val finalY: Float
 
+        val location = arguments?.getSerializable(ArgumentsKey.PLEDGE_SCREEN_LOCATION) as ScreenLocation
         val margin = this.resources.getDimensionPixelSize(R.dimen.activity_vertical_margin).toFloat()
-        val miniRewardWidth = Math.max(pledge_root.width / 3, this.resources.getDimensionPixelSize(R.dimen.mini_reward_width)).toFloat()
+        val miniRewardWidth = max(pledge_root.width / 3, this.resources.getDimensionPixelSize(R.dimen.mini_reward_width)).toFloat()
         val miniRewardHeight = getMiniRewardHeight(miniRewardWidth, location)
 
         if (reveal) {
@@ -681,8 +692,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
             val shrinkClickListener = View.OnClickListener { v ->
                 if (!width.isRunning) {
                     v?.setOnClickListener(null)
-                    this@PledgeFragment.animDuration = this@PledgeFragment.defaultAnimationDuration
-                    startPledgeAnimatorSet(false, location)
+                    shrinkRewardCard()
                 }
             }
             reward_snapshot.setOnClickListener(shrinkClickListener)
@@ -756,6 +766,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 addUpdateListener {
                     val animatedFraction = it.animatedFraction
                     pledge_details?.alpha = if (finalValue == 0f) animatedFraction else 1 - animatedFraction
+                    pledge_background?.alpha = if (finalValue == 0f) animatedFraction else 1 - animatedFraction
                 }
             }
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -460,6 +460,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         val visibility = if (gone) View.GONE else View.VISIBLE
         setVisibility(visibility, reward_snapshot, reward_to_copy, expand_icon_container)
         ViewUtils.setInvisible(pledge_root, !gone)
+        pledge_background.alpha = if (gone) 1f else 0f
     }
 
     private fun displayShippingRules(shippingRules: List<ShippingRule>, project: Project) {

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels
 
+import android.os.Bundle
 import android.text.SpannableString
 import android.util.Pair
 import androidx.annotation.NonNull
@@ -298,16 +299,19 @@ interface PledgeFragmentViewModel {
             val userIsLoggedIn = this.currentUser.isLoggedIn
                     .distinctUntilChanged()
 
-            val reward = arguments()
+            val arguments = arguments()
+                    .compose<Bundle>(takeWhen(this.onGlobalLayout))
+
+            val reward = arguments
                     .map { it.getParcelable(ArgumentsKey.PLEDGE_REWARD) as Reward }
 
-            val screenLocation = arguments()
+            val screenLocation = arguments
                     .map { it.getSerializable(ArgumentsKey.PLEDGE_SCREEN_LOCATION) as ScreenLocation? }
 
-            val project = arguments()
+            val project = arguments
                     .map { it.getParcelable(ArgumentsKey.PLEDGE_PROJECT) as Project }
 
-            val pledgeReason = arguments()
+            val pledgeReason = arguments
                     .map { it.getSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON) as PledgeReason }
 
             val updatingPayment = pledgeReason
@@ -676,7 +680,7 @@ interface PledgeFragmentViewModel {
             // Payment section
             pledgeReason
                     .map { it == PledgeReason.UPDATE_PLEDGE || it == PledgeReason.UPDATE_REWARD }
-                    .compose<Pair<Boolean, Boolean>>(combineLatestPair(userIsLoggedIn.distinctUntilChanged()))
+                    .compose<Pair<Boolean, Boolean>>(combineLatestPair(userIsLoggedIn))
                     .map { it.first || !it.second }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
@@ -688,8 +692,8 @@ interface PledgeFragmentViewModel {
 
             userIsLoggedIn
                     .filter { BooleanUtils.isTrue(it) }
+                    .compose<Boolean>(waitUntil(total))
                     .switchMap { storedCards() }
-                    .delaySubscription(total)
                     .compose<Pair<List<StoredCard>, Project>>(combineLatestPair(project))
                     .compose(bindToLifecycle())
                     .subscribe(this.cardsAndProject)

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -1,155 +1,171 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView
-  android:id="@+id/pledge_root"
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  android:background="@color/ksr_grey_300"
   android:clickable="true"
   android:fillViewport="true"
   android:focusable="true"
-  android:focusableInTouchMode="true"
-  android:overScrollMode="never"
-  android:paddingTop="?android:attr/actionBarSize"
-  android:scrollbars="none"
-  android:visibility="invisible"
-  tools:visibility="visible">
+  android:focusableInTouchMode="true">
 
-  <androidx.coordinatorlayout.widget.CoordinatorLayout
-    android:id="@+id/pledge_content"
+  <FrameLayout
+    android:id="@+id/pledge_background"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:layout_height="match_parent"
+    android:alpha="0"
+    android:background="@color/ksr_grey_300"
+    tools:alpha="1" />
 
-    <include
-      android:id="@+id/reward_to_copy"
-      layout="@layout/item_reward"
-      tools:visibility="gone" />
+  <androidx.core.widget.NestedScrollView
+    android:id="@+id/pledge_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    android:overScrollMode="never"
+    android:paddingTop="?android:attr/actionBarSize"
+    android:scrollbars="none"
+    android:visibility="invisible"
+    tools:visibility="visible">
 
-    <!-- todo: what's the content description? -->
-    <com.kickstarter.ui.views.BottomCropImageView
-      android:id="@+id/reward_snapshot"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_margin="@dimen/activity_horizontal_margin"
-      android:contentDescription="@null"
-      android:elevation="@dimen/mini_reward_elevation"
-      tools:background="@color/white"
-      tools:layout_height="@dimen/mini_reward_height"
-      tools:layout_width="@dimen/mini_reward_width" />
-
-    <!-- todo: what's the content description? -->
-    <FrameLayout
-      android:id="@+id/expand_icon_container"
-      android:layout_width="@dimen/grid_8"
-      android:layout_height="@dimen/grid_8"
-      android:alpha="0"
-      android:elevation="@dimen/mini_reward_elevation"
-      app:layout_anchor="@id/reward_snapshot"
-      app:layout_anchorGravity="end"
-      tools:alpha="1">
-
-      <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/grid_1"
-        android:layout_marginTop="@dimen/grid_2"
-        android:contentDescription="@null"
-        android:src="@drawable/ic_expand" />
-    </FrameLayout>
-
-    <LinearLayout
-      android:id="@+id/pledge_details"
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+      android:id="@+id/pledge_content"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="vertical">
 
-      <include layout="@layout/fragment_pledge_section_delivery" />
+      <include
+        android:id="@+id/reward_to_copy"
+        layout="@layout/item_reward"
+        tools:visibility="gone" />
+
+      <!-- todo: what's the content description? -->
+      <com.kickstarter.ui.views.BottomCropImageView
+        android:id="@+id/reward_snapshot"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/activity_horizontal_margin"
+        android:contentDescription="@null"
+        android:elevation="@dimen/mini_reward_elevation"
+        tools:background="@color/white"
+        tools:layout_height="@dimen/mini_reward_height"
+        tools:layout_width="@dimen/mini_reward_width" />
+
+      <!-- todo: what's the content description? -->
+      <FrameLayout
+        android:id="@+id/expand_icon_container"
+        android:layout_width="@dimen/grid_8"
+        android:layout_height="@dimen/grid_8"
+        android:alpha="0"
+        android:elevation="@dimen/mini_reward_elevation"
+        app:layout_anchor="@id/reward_snapshot"
+        app:layout_anchorGravity="end"
+        tools:alpha="1">
+
+        <ImageView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="@dimen/grid_1"
+          android:layout_marginTop="@dimen/grid_2"
+          android:contentDescription="@null"
+          android:src="@drawable/ic_expand" />
+      </FrameLayout>
 
       <LinearLayout
+        android:id="@+id/pledge_details"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:clipChildren="false"
-        android:clipToPadding="false"
-        android:orientation="vertical"
-        android:paddingEnd="@dimen/activity_vertical_margin"
-        android:paddingStart="@dimen/activity_vertical_margin">
+        android:orientation="vertical">
 
-        <include
-          android:id="@+id/divider_delivery"
-          layout="@layout/horizontal_line_1dp_view" />
+        <include layout="@layout/fragment_pledge_section_delivery" />
 
-        <include layout="@layout/fragment_pledge_section_pledge_amount" />
-
-        <include layout="@layout/fragment_pledge_section_shipping" />
-
-        <include layout="@layout/fragment_pledge_section_summary_pledge" />
-
-        <include layout="@layout/fragment_pledge_section_summary_shipping" />
-
-        <include
-          android:id="@+id/divider_total"
-          layout="@layout/horizontal_line_1dp_view" />
-
-        <include tools:visibility="gone"
-          layout="@layout/fragment_pledge_section_total" />
-
-        <Button
-          android:id="@+id/continue_to_tout"
+        <LinearLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_gravity="center_horizontal"
-          android:layout_marginBottom="@dimen/grid_3"
-          android:text="@string/Continue"
-          android:visibility="gone"
-          tools:visibility="gone" />
+          android:clipChildren="false"
+          android:clipToPadding="false"
+          android:orientation="vertical"
+          android:paddingStart="@dimen/activity_vertical_margin"
+          android:paddingEnd="@dimen/activity_vertical_margin">
 
-        <FrameLayout
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content">
+          <include
+            android:id="@+id/divider_delivery"
+            layout="@layout/horizontal_line_1dp_view" />
 
-          <com.google.android.material.button.MaterialButton
-            android:id="@+id/update_pledge_button"
+          <include layout="@layout/fragment_pledge_section_pledge_amount" />
+
+          <include layout="@layout/fragment_pledge_section_shipping" />
+
+          <include layout="@layout/fragment_pledge_section_summary_pledge" />
+
+          <include layout="@layout/fragment_pledge_section_summary_shipping" />
+
+          <include
+            android:id="@+id/divider_total"
+            layout="@layout/horizontal_line_1dp_view" />
+
+          <include
+            layout="@layout/fragment_pledge_section_total"
+            tools:visibility="gone" />
+
+          <Button
+            android:id="@+id/continue_to_tout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/grid_4"
-            android:enabled="false"
-            android:text="@string/Update_pledge"
-            android:textColor="@color/white"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginBottom="@dimen/grid_3"
+            android:text="@string/Continue"
             android:visibility="gone"
-            app:backgroundTint="@color/button_pledge_live"
-            tools:visibility="visible" />
+            tools:visibility="gone" />
 
           <FrameLayout
-            android:id="@+id/update_pledge_button_progress"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/grid_4"
-            android:visibility="gone">
+            android:layout_height="wrap_content">
 
-            <Button
+            <com.google.android.material.button.MaterialButton
+              android:id="@+id/update_pledge_button"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
-              android:stateListAnimator="@null" />
+              android:layout_marginBottom="@dimen/grid_4"
+              android:enabled="false"
+              android:text="@string/Update_pledge"
+              android:textColor="@color/white"
+              android:visibility="gone"
+              app:backgroundTint="@color/button_pledge_live"
+              tools:visibility="visible" />
 
-            <ProgressBar
-              android:layout_width="wrap_content"
+            <FrameLayout
+              android:id="@+id/update_pledge_button_progress"
+              android:layout_width="match_parent"
               android:layout_height="wrap_content"
-              android:layout_gravity="center"
-              android:indeterminate="true"
-              android:indeterminateTint="@color/white"
-              android:indeterminateTintMode="src_in" />
+              android:layout_marginBottom="@dimen/grid_4"
+              android:visibility="gone">
 
+              <Button
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:stateListAnimator="@null" />
+
+              <ProgressBar
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:indeterminate="true"
+                android:indeterminateTint="@color/white"
+                android:indeterminateTintMode="src_in" />
+
+            </FrameLayout>
           </FrameLayout>
-        </FrameLayout>
+
+        </LinearLayout>
+
+        <include layout="@layout/fragment_pledge_section_payment" />
 
       </LinearLayout>
 
-      <include layout="@layout/fragment_pledge_section_payment" />
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
-    </LinearLayout>
 
-  </androidx.coordinatorlayout.widget.CoordinatorLayout>
-</androidx.core.widget.NestedScrollView>
+  </androidx.core.widget.NestedScrollView>
+
+</FrameLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -215,6 +215,7 @@
     <item name="android:textColor">@color/white</item>
     <item name="backgroundTint">@color/button_pledge_live</item>
     <item name="cornerRadius">@dimen/grid_2</item>
+    <item name="rippleColor">@null</item>
     <item name="android:layout_marginBottom">@dimen/grid_3</item>
     <item name="android:layout_marginEnd">@dimen/grid_3</item>
     <item name="android:layout_marginStart">@dimen/grid_3</item>

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -31,7 +31,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val addedCard = TestSubscriber<Pair<StoredCard, Project>>()
     private val additionalPledgeAmount = TestSubscriber<String>()
     private val additionalPledgeAmountIsGone = TestSubscriber<Boolean>()
-    private val animateRewardCard = TestSubscriber<PledgeData>()
     private val baseUrlForTerms = TestSubscriber<String>()
     private val cardsAndProject = TestSubscriber<Pair<List<StoredCard>, Project>>()
     private val continueButtonIsGone = TestSubscriber<Boolean>()
@@ -69,6 +68,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val snapshotIsGone = TestSubscriber<Boolean>()
     private val startChromeTab = TestSubscriber<String>()
     private val startLoginToutActivity = TestSubscriber<Void>()
+    private val startRewardExpandAnimation = TestSubscriber<Void>()
+    private val startRewardShrinkAnimation = TestSubscriber<PledgeData>()
     private val startThanksActivity = TestSubscriber<Project>()
     private val totalAmount = TestSubscriber<String>()
     private val totalDividerIsGone = TestSubscriber<Boolean>()
@@ -86,7 +87,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.addedCard().subscribe(this.addedCard)
         this.vm.outputs.additionalPledgeAmount().subscribe(this.additionalPledgeAmount)
         this.vm.outputs.additionalPledgeAmountIsGone().subscribe(this.additionalPledgeAmountIsGone)
-        this.vm.outputs.animateRewardCard().subscribe(this.animateRewardCard)
         this.vm.outputs.baseUrlForTerms().subscribe(this.baseUrlForTerms)
         this.vm.outputs.cardsAndProject().subscribe(this.cardsAndProject)
         this.vm.outputs.continueButtonIsGone().subscribe(this.continueButtonIsGone)
@@ -124,6 +124,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.snapshotIsGone().subscribe(this.snapshotIsGone)
         this.vm.outputs.startChromeTab().subscribe(this.startChromeTab)
         this.vm.outputs.startLoginToutActivity().subscribe(this.startLoginToutActivity)
+        this.vm.outputs.startRewardExpandAnimation().subscribe(this.startRewardExpandAnimation)
+        this.vm.outputs.startRewardShrinkAnimation().subscribe(this.startRewardShrinkAnimation)
         this.vm.outputs.startThanksActivity().subscribe(this.startThanksActivity)
         this.vm.outputs.totalAmount().map { it.toString() }.subscribe(this.totalAmount)
         this.vm.outputs.totalDividerIsGone().subscribe(this.totalDividerIsGone)
@@ -141,7 +143,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.arguments(bundle)
 
         this.vm.inputs.onGlobalLayout()
-        this.animateRewardCard.assertValueCount(1)
+        this.startRewardShrinkAnimation.assertValueCount(1)
     }
 
     @Test
@@ -1382,6 +1384,24 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         //Login tout should not start with a invalid pledge amount, warning should show
         this.startLoginToutActivity.assertValueCount(1)
         this.showMinimumWarning.assertValueCount(1)
+    }
+
+    @Test
+    fun testStartRewardExpandAnimation_whenBackPressed() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.backPressed()
+
+        this.startRewardExpandAnimation.assertValueCount(1)
+    }
+
+    @Test
+    fun testStartRewardExpandAnimation_whenMiniRewardClicked() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.miniRewardClicked()
+
+        this.startRewardExpandAnimation.assertValueCount(1)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -139,11 +139,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         bundle.putParcelable(ArgumentsKey.PLEDGE_REWARD, reward)
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, pledgeReason)
         this.vm.arguments(bundle)
-    }
-
-    @Test
-    fun testAnimateRewardCard() {
-        setUpEnvironment(environment())
 
         this.vm.inputs.onGlobalLayout()
         this.animateRewardCard.assertValueCount(1)
@@ -934,13 +929,16 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeStepping_maxReward() {
+    fun testPledgeStepping_maxReward_USProject() {
         setUpEnvironment(environment(), RewardFactory.maxReward(Country.US))
         this.decreasePledgeButtonIsEnabled.assertValuesAndClear(false)
         this.increasePledgeButtonIsEnabled.assertValuesAndClear(false)
         this.additionalPledgeAmountIsGone.assertValuesAndClear(true)
         this.additionalPledgeAmount.assertValuesAndClear("$0")
+    }
 
+    @Test
+    fun testPledgeStepping_maxReward_MXProject() {
         setUpEnvironment(environment(), RewardFactory.maxReward(Country.MX), ProjectFactory.mxProject())
         this.decreasePledgeButtonIsEnabled.assertValue(false)
         this.increasePledgeButtonIsEnabled.assertValue(false)
@@ -949,7 +947,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeStepping_almostMaxReward() {
+    fun testPledgeStepping_almostMaxReward_USProject() {
         val almostMaxReward = RewardFactory.reward()
                 .toBuilder()
                 .minimum((Country.US.maxPledge - Country.US.minPledge).toDouble())
@@ -967,7 +965,10 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.increasePledgeButtonIsEnabled.assertValuesAndClear(true, false)
         this.additionalPledgeAmountIsGone.assertValuesAndClear(true, false)
         this.additionalPledgeAmount.assertValuesAndClear("$0", "$1")
+    }
 
+    @Test
+    fun testPledgeStepping_almostMaxReward_MXProject() {
         val almostMaxMXReward = RewardFactory.reward()
                 .toBuilder()
                 .minimum((Country.MX.maxPledge - Country.MX.minPledge).toDouble())


### PR DESCRIPTION
# 📲 What
Reversing the reward card animation when the user hits back when viewing the Pledge screen.

# 🤔 Why
It looks more better*

# 🛠 How
- `ProjectActivity.handleNativeCheckoutBackPress` will tell the `PledgeFragment` to reverse the reward animation if it's at the top of the back stack and the card is present.
- The background of the `PledgeFragment` now fades in and out.
- `startPledgeAnimatorSet` no longer takes in a `ScreenLocation` because it can pull it from the `Arguments`.
- Not emitting `PledgeFragmentViewModel.ViewModel.arguments()` until `onGlobalLayout` emits to remove some jank by delaying UI work until the view is laid out.
- Fetching a user's stored cards properly waits until the total has successfully emitted.
- All of the tests in `PledgeFragmentViewModelTest` assert that `animateRewardCard` emits once because `onGlobalLayout` is called.
- Separated tests that called `setUpEnvironment` twice.

# 👀 See
| After 🦋 | Before 🐛 |
| --- | --- |
| ![device-2019-09-09-114752 2019-09-09 11_50_42](https://user-images.githubusercontent.com/1289295/64546154-1e162180-d2f8-11e9-8b9e-ace2f0bc87f9.gif) | ![device-2019-09-09-114847 2019-09-09 11_50_48](https://user-images.githubusercontent.com/1289295/64546155-1e162180-d2f8-11e9-8886-8c88f89f9522.gif) |

# 📋 QA
🔙 Hitting the back button when on the Pledge screen should reverse the reward animation if the mini card is present.
*(I don't love how it works when the user is scrolled on the Pledge screen so see the next section.)

# Story 📖
cc @jamielynnroth can we please add a polish card for the scrolled awkwardness?
