### PR TITLE
[🗺] NT-281 Consuming backing.locationName

### DIFF
--- a/app/src/main/java/com/kickstarter/models/Backing.java
+++ b/app/src/main/java/com/kickstarter/models/Backing.java
@@ -26,6 +26,7 @@ public abstract class Backing implements Parcelable, Relay {
   public abstract long id();
   public abstract @Nullable Location location();
   public abstract @Nullable Long locationId();
+  public abstract @Nullable String locationName();
   public abstract @Nullable PaymentSource paymentSource();
   public abstract DateTime pledgedAt();
   public abstract @Nullable Project project();
@@ -48,6 +49,7 @@ public abstract class Backing implements Parcelable, Relay {
     public abstract Builder id(long __);
     public abstract Builder location(Location __);
     public abstract Builder locationId(Long __);
+    public abstract Builder locationName(String __);
     public abstract Builder paymentSource(PaymentSource __);
     public abstract Builder pledgedAt(DateTime __);
     public abstract Builder project(Project __);

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -84,6 +84,11 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
                 .compose(Transformers.observeForUI())
                 .subscribe { shipping_summary_amount.text = it }
 
+        this.viewModel.outputs.shippingLocation()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe { shipping_label.text = String.format("%s: %s", getString(R.string.Shipping), it)  }
+
         this.viewModel.outputs.shippingSummaryIsGone()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -161,8 +161,7 @@ interface BackingFragmentViewModel {
                     .subscribe(this.shippingAmount)
 
             backing
-                    .map { it.location() }
-                    .map { it?.displayableName() }
+                    .map { it.locationName()?.let { name -> name } }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.shippingLocation)

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -307,7 +307,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     fun testShippingLocation() {
         val backing = BackingFactory.backing()
                 .toBuilder()
-                .location(LocationFactory.nigeria())
+                .locationName(LocationFactory.nigeria().displayableName())
                 .build()
         val backedProject = ProjectFactory.backedProject()
                 .toBuilder()


### PR DESCRIPTION
# 📲 What
Using `backing.locationName` to display in View/Manage pledge screen.

# 🤔 Why
So users know what shipping location they chose.

# 🛠 How
- Added `locationName` to `Backing` model.
- Updated test.

# 👀 See

Trello, screenshots, external resources?

| After 🦋 |
| --- |
| <img src=https://user-images.githubusercontent.com/1289295/64562251-968dda00-d31a-11e9-8a47-c93a65d467c4.png width=330/> | 

# 📋 QA
🌍Back a project with shipping, the View/Manage pledge screen should display the location.

# Story 📖
NT-281
