### PR TITLE
[ℹ️] NT-236 Reward IA additions

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
@@ -13,7 +13,9 @@ import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.RewardsItem
 import com.kickstarter.ui.viewholders.NativeCheckoutRewardViewHolder
+import org.joda.time.DateTime
 import rx.Observable
+import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
 import java.math.RoundingMode
 
@@ -27,6 +29,12 @@ interface NativeCheckoutRewardViewHolderViewModel {
     }
 
     interface Outputs {
+        /**  Emits the count of backers who have pledged this reward. */
+        fun backersCount(): Observable<Int>
+
+        /** Emits a boolean determining if the backers count should be shown. */
+        fun backersCountIsGone(): Observable<Boolean>
+
         /**  Emits the string resource ID to set on the pledge button. */
         fun buttonCTA(): Observable<Int>
 
@@ -53,6 +61,12 @@ interface NativeCheckoutRewardViewHolderViewModel {
 
         /** Emits `true` if the reward end date should be hidden,`false` otherwise. */
         fun endDateSectionIsGone(): Observable<Boolean>
+
+        /**  Emits the reward's localized estimated delivery date. */
+        fun estimatedDelivery(): Observable<String>
+
+        /** Emits a boolean determining if the estimated delivery should be shown. */
+        fun estimatedDeliveryIsGone(): Observable<Boolean>
 
         /** Emits `true` if the limits container should be hidden, `false` otherwise. */
         fun limitContainerIsGone(): Observable<Boolean>
@@ -103,58 +117,71 @@ interface NativeCheckoutRewardViewHolderViewModel {
         private val projectAndReward = PublishSubject.create<Pair<Project, Reward>>()
         private val rewardClicked = PublishSubject.create<Void>()
 
-        private val buttonCTA: Observable<Int>
-        private val buttonIsEnabled: Observable<Boolean>
-        private val buttonIsGone: Observable<Boolean>
-        private val conversion: Observable<String>
-        private val conversionIsGone: Observable<Boolean>
-        private val descriptionForNoReward: Observable<Int>
-        private val descriptionForReward: Observable<String?>
-        private val descriptionIsGone: Observable<Boolean>
-        private val endDateSectionIsGone: Observable<Boolean>
-        private val limitContainerIsGone: Observable<Boolean>
-        private val minimumAmountTitle: Observable<SpannableString>
-        private val remaining: Observable<String>
-        private val remainingIsGone: Observable<Boolean>
-        private val reward: Observable<Reward>
-        private val rewardItems: Observable<List<RewardsItem>>
-        private val rewardItemsAreGone: Observable<Boolean>
-        private val shippingSummary: Observable<String>
-        private val shippingSummaryIsGone: Observable<Boolean>
-        private val showPledgeFragment: Observable<Pair<Project, Reward>>
-        private val startBackingActivity: Observable<Project>
-        private val titleForNoReward: Observable<Int>
-        private val titleForReward: Observable<String?>
-        private val titleIsGone: Observable<Boolean>
+        private val backersCount = BehaviorSubject.create<Int>()
+        private val backersCountIsGone = BehaviorSubject.create<Boolean>()
+        private val buttonCTA = BehaviorSubject.create<Int>()
+        private val buttonIsEnabled = BehaviorSubject.create<Boolean>()
+        private val buttonIsGone = BehaviorSubject.create<Boolean>()
+        private val conversion = BehaviorSubject.create<String>()
+        private val conversionIsGone = BehaviorSubject.create<Boolean>()
+        private val descriptionForNoReward = BehaviorSubject.create<Int>()
+        private val descriptionForReward = BehaviorSubject.create<String?>()
+        private val descriptionIsGone = BehaviorSubject.create<Boolean>()
+        private val estimatedDelivery = BehaviorSubject.create<String>()
+        private val estimatedDeliveryIsGone = BehaviorSubject.create<Boolean>()
+        private val endDateSectionIsGone = BehaviorSubject.create<Boolean>()
+        private val limitContainerIsGone = BehaviorSubject.create<Boolean>()
+        private val minimumAmountTitle = PublishSubject.create<SpannableString>()
+        private val remaining = BehaviorSubject.create<String>()
+        private val remainingIsGone = BehaviorSubject.create<Boolean>()
+        private val reward = BehaviorSubject.create<Reward>()
+        private val rewardItems = BehaviorSubject.create<List<RewardsItem>>()
+        private val rewardItemsAreGone = BehaviorSubject.create<Boolean>()
+        private val shippingSummary = BehaviorSubject.create<String>()
+        private val shippingSummaryIsGone = BehaviorSubject.create<Boolean>()
+        private val showPledgeFragment = PublishSubject.create<Pair<Project, Reward>>()
+        private val startBackingActivity = PublishSubject.create<Project>()
+        private val titleForNoReward = BehaviorSubject.create<Int>()
+        private val titleForReward = BehaviorSubject.create<String?>()
+        private val titleIsGone = BehaviorSubject.create<Boolean>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
 
         init {
 
-            this.minimumAmountTitle = this.projectAndReward
+             this.projectAndReward
                     .map { RewardViewUtils.styleCurrency(it.second.minimum(), it.first, this.ksCurrency) }
+                    .subscribe(this.minimumAmountTitle)
 
             val reward = this.projectAndReward
                     .map { it.second }
 
-            this.buttonIsGone = this.projectAndReward
+            this.projectAndReward
                     .map { BackingUtils.isBacked(it.first, it.second) || it.first.isLive }
                     .map { BooleanUtils.negate(it) }
                     .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.buttonIsGone)
 
-            this.buttonCTA = this.projectAndReward
+            this.projectAndReward
                     .map { RewardViewUtils.pledgeButtonText(it.first, it.second) }
                     .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.buttonCTA)
 
-            this.conversionIsGone = this.projectAndReward
+            this.projectAndReward
                     .map { it.first.currency() != it.first.currentCurrency() }
                     .map { BooleanUtils.negate(it) }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.conversionIsGone)
 
-            this.conversion = this.projectAndReward
+            this.projectAndReward
                     .map { this.ksCurrency.format(it.second.convertedMinimum(), it.first, true, RoundingMode.HALF_UP, true) }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.conversion)
 
-            this.descriptionForNoReward = this.projectAndReward
+            this.projectAndReward
                     .filter { RewardUtils.isNoReward(it.second) }
                     .map {
                         val backed = BackingUtils.isBacked(it.first, it.second)
@@ -163,54 +190,77 @@ interface NativeCheckoutRewardViewHolderViewModel {
                             else -> R.string.Back_it_because_you_believe_in_it
                         }
                     }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.descriptionForNoReward)
 
-            this.descriptionForReward = reward
+            reward
                     .filter { RewardUtils.isReward(it) }
                     .map { it.description() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.descriptionForReward)
 
-            this.descriptionIsGone = this.projectAndReward
+            this.projectAndReward
                     .map { RewardUtils.isReward(it.second) && it.second.description().isNullOrEmpty() }
                     .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.descriptionIsGone)
 
-            this.buttonIsEnabled = this.projectAndReward
+            this.projectAndReward
                     .map { isSelectable(it.first, it.second) }
                     .distinctUntilChanged()
+                    .subscribe(this.buttonIsEnabled)
 
-            this.startBackingActivity = this.projectAndReward
+            this.projectAndReward
                     .compose<Pair<Project, Reward>>(takeWhen<Pair<Project, Reward>, Void>(this.rewardClicked))
                     .filter { ProjectUtils.isCompleted(it.first) && BackingUtils.isBacked(it.first, it.second) }
                     .map { it.first }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.startBackingActivity)
 
-            this.remainingIsGone = this.projectAndReward
-                    .map<Boolean> { it.first.isLive && RewardUtils.isLimited(it.second) }
-                    .map<Boolean> { BooleanUtils.negate(it) }
+            this.projectAndReward
+                    .map { it.first.isLive && RewardUtils.isLimited(it.second) }
+                    .map { BooleanUtils.negate(it) }
                     .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.remainingIsGone)
 
-            this.remaining = reward
+            reward
                     .filter { RewardUtils.isLimited(it) }
                     .map { it.remaining() }
                     .map { remaining -> remaining?.let { NumberUtils.format(it) } }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.remaining)
 
-            this.rewardItems = reward
+            reward
                     .filter { RewardUtils.isItemized(it) }
                     .map { it.rewardsItems() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.rewardItems)
 
-            this.rewardItemsAreGone = reward
-                    .map<Boolean> { RewardUtils.isItemized(it) }
-                    .map<Boolean> { BooleanUtils.negate(it) }
+            reward
+                    .map { RewardUtils.isItemized(it) }
+                    .map { BooleanUtils.negate(it) }
                     .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.rewardItemsAreGone)
 
-            this.reward = reward
+            reward
+                    .compose(bindToLifecycle())
+                    .subscribe(this.reward)
 
-            this.endDateSectionIsGone = this.projectAndReward
+            this.projectAndReward
                     .map { expirationDateIsGone(it.first, it.second) }
                     .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.endDateSectionIsGone)
 
-            this.showPledgeFragment = this.projectAndReward
+            this.projectAndReward
                     .filter { isSelectable(it.first, it.second) && it.first.isLive }
                     .compose<Pair<Project, Reward>>(takeWhen<Pair<Project, Reward>, Void>(this.rewardClicked))
+                    .compose(bindToLifecycle())
+                    .subscribe(this.showPledgeFragment)
 
-            this.titleForNoReward = this.projectAndReward
+            this.projectAndReward
                     .filter { RewardUtils.isNoReward(it.second) }
                     .map {
                         val backed = BackingUtils.isBacked(it.first, it.second)
@@ -219,27 +269,64 @@ interface NativeCheckoutRewardViewHolderViewModel {
                             else -> R.string.Pledge_without_a_reward
                         }
                     }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.titleForNoReward)
 
-            this.titleForReward = reward
+            reward
                     .filter { RewardUtils.isReward(it) }
                     .map { it.title() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.titleForReward)
 
-            this.titleIsGone = reward
+            reward
                     .map { RewardUtils.isReward(it) && it.title().isNullOrEmpty() }
                     .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.titleIsGone)
 
-            this.shippingSummary = reward
+            reward
                     .filter { RewardUtils.isShippable(it) }
                     .map { it.shippingSummary() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.shippingSummary)
 
-            this.shippingSummaryIsGone = this.projectAndReward
+            this.projectAndReward
                     .map { it.first.isLive && RewardUtils.isShippable(it.second) }
                     .map { BooleanUtils.negate(it) }
                     .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.shippingSummaryIsGone)
 
-            this.limitContainerIsGone = Observable.combineLatest(this.endDateSectionIsGone, this.remainingIsGone, this.shippingSummaryIsGone)
-            { endDateGone, remainingGone, shippingGone  -> endDateGone && remainingGone && shippingGone }
+            Observable.combineLatest(this.endDateSectionIsGone, this.remainingIsGone, this.shippingSummaryIsGone)
+            { endDateGone, remainingGone, shippingGone -> endDateGone && remainingGone && shippingGone }
                     .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.limitContainerIsGone)
+
+            reward
+                    .map { RewardUtils.isNoReward(it) || !RewardUtils.hasBackers(it) }
+                    .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.backersCountIsGone)
+
+            reward
+                    .filter { RewardUtils.isReward(it) && RewardUtils.hasBackers(it) }
+                    .map { it.backersCount() as Int }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.backersCount)
+
+            reward
+                    .map { RewardUtils.isNoReward(it) || ObjectUtils.isNull(it.estimatedDeliveryOn()) }
+                    .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.estimatedDeliveryIsGone)
+
+            reward
+                    .filter { RewardUtils.isReward(it) && ObjectUtils.isNotNull(it.estimatedDeliveryOn()) }
+                    .map<DateTime> { it.estimatedDeliveryOn() }
+                    .map { DateTimeUtils.estimatedDeliveryOn(it) }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.estimatedDelivery)
 
         }
 
@@ -268,6 +355,12 @@ interface NativeCheckoutRewardViewHolderViewModel {
         }
 
         @NonNull
+        override fun backersCount(): Observable<Int> = this.backersCount
+
+        @NonNull
+        override fun backersCountIsGone(): Observable<Boolean> = this.backersCountIsGone
+
+        @NonNull
         override fun buttonCTA(): Observable<Int> = this.buttonCTA
 
         @NonNull
@@ -277,10 +370,10 @@ interface NativeCheckoutRewardViewHolderViewModel {
         override fun buttonIsGone(): Observable<Boolean> = this.buttonIsGone
 
         @NonNull
-        override fun conversionIsGone(): Observable<Boolean> = this.conversionIsGone
+        override fun conversion(): Observable<String> = this.conversion
 
         @NonNull
-        override fun conversion(): Observable<String> = this.conversion
+        override fun conversionIsGone(): Observable<Boolean> = this.conversionIsGone
 
         @NonNull
         override fun descriptionForNoReward(): Observable<Int> = this.descriptionForNoReward
@@ -293,6 +386,12 @@ interface NativeCheckoutRewardViewHolderViewModel {
 
         @NonNull
         override fun endDateSectionIsGone(): Observable<Boolean> = this.endDateSectionIsGone
+
+        @NonNull
+        override fun estimatedDelivery(): Observable<String> = this.estimatedDelivery
+
+        @NonNull
+        override fun estimatedDeliveryIsGone(): Observable<Boolean> = this.estimatedDeliveryIsGone
 
         @NonNull
         override fun limitContainerIsGone(): Observable<Boolean> = this.limitContainerIsGone

--- a/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
@@ -150,8 +150,9 @@ interface NativeCheckoutRewardViewHolderViewModel {
 
         init {
 
-             this.projectAndReward
+            this.projectAndReward
                     .map { RewardViewUtils.styleCurrency(it.second.minimum(), it.first, this.ksCurrency) }
+                    .compose(bindToLifecycle())
                     .subscribe(this.minimumAmountTitle)
 
             val reward = this.projectAndReward
@@ -208,6 +209,7 @@ interface NativeCheckoutRewardViewHolderViewModel {
             this.projectAndReward
                     .map { isSelectable(it.first, it.second) }
                     .distinctUntilChanged()
+                    .compose(bindToLifecycle())
                     .subscribe(this.buttonIsEnabled)
 
             this.projectAndReward

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -61,6 +61,33 @@
             android:textStyle="bold"
             tools:text="Make a pledge without a reward" />
 
+          <TextView
+            style="@style/RewardPill"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/grid_3"
+            tools:text="327 backers" />
+
+          <LinearLayout
+            android:id="@+id/reward_description_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+              style="@style/RewardSectionTitle"
+              android:layout_marginTop="@dimen/grid_3"
+              android:text="@string/Description" />
+
+            <TextView
+              android:id="@+id/reward_description_text_view"
+              style="@style/BodyPrimary"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_marginTop="@dimen/grid_1"
+              tools:text="@string/Pledge_any_amount_to_help_bring_this_project_to_life" />
+          </LinearLayout>
+
         </LinearLayout>
 
         <LinearLayout
@@ -93,7 +120,7 @@
           android:orientation="vertical">
 
           <LinearLayout
-            android:id="@+id/reward_description_container"
+            android:id="@+id/reward_estimated_delivery_date_section"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
@@ -101,15 +128,15 @@
             <TextView
               style="@style/RewardSectionTitle"
               android:layout_marginTop="@dimen/grid_3"
-              android:text="@string/Description" />
+              android:text="@string/Estimated_delivery" />
 
             <TextView
-              android:id="@+id/reward_description_text_view"
+              android:id="@+id/reward_estimated_delivery"
               style="@style/BodyPrimary"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:layout_marginTop="@dimen/grid_1"
-              tools:text="@string/Pledge_any_amount_to_help_bring_this_project_to_life" />
+              tools:text="December 2019" />
           </LinearLayout>
 
         <com.google.android.flexbox.FlexboxLayout

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -63,6 +63,7 @@
 
           <TextView
             style="@style/RewardPill"
+            android:id="@+id/reward_backers_count"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/grid_3"
@@ -120,7 +121,7 @@
           android:orientation="vertical">
 
           <LinearLayout
-            android:id="@+id/reward_estimated_delivery_date_section"
+            android:id="@+id/reward_estimated_delivery_section"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">

--- a/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
@@ -18,6 +18,8 @@ import rx.observers.TestSubscriber
 class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var vm: NativeCheckoutRewardViewHolderViewModel.ViewModel
+    private val backersCount = TestSubscriber.create<Int>()
+    private val backersCountIsGone = TestSubscriber.create<Boolean>()
     private val buttonCTA = TestSubscriber.create<Int>()
     private val buttonIsEnabled = TestSubscriber<Boolean>()
     private val buttonIsGone = TestSubscriber.create<Boolean>()
@@ -27,6 +29,8 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
     private val descriptionForReward = TestSubscriber<String?>()
     private val descriptionIsGone = TestSubscriber<Boolean>()
     private val endDateSectionIsGone = TestSubscriber<Boolean>()
+    private val estimatedDelivery = TestSubscriber<String>()
+    private val estimatedDeliveryIsGone = TestSubscriber<Boolean>()
     private val limitContainerIsGone = TestSubscriber<Boolean>()
     private val minimumAmountTitle = TestSubscriber<String>()
     private val remaining = TestSubscriber<String>()
@@ -44,6 +48,8 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = NativeCheckoutRewardViewHolderViewModel.ViewModel(environment)
+        this.vm.outputs.backersCount().subscribe(this.backersCount)
+        this.vm.outputs.backersCountIsGone().subscribe(this.backersCountIsGone)
         this.vm.outputs.buttonCTA().subscribe(this.buttonCTA)
         this.vm.outputs.buttonIsEnabled().subscribe(this.buttonIsEnabled)
         this.vm.outputs.buttonIsGone().subscribe(this.buttonIsGone)
@@ -53,6 +59,8 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.descriptionForReward().subscribe(this.descriptionForReward)
         this.vm.outputs.descriptionIsGone().subscribe(this.descriptionIsGone)
         this.vm.outputs.endDateSectionIsGone().subscribe(this.endDateSectionIsGone)
+        this.vm.outputs.estimatedDelivery().subscribe(this.estimatedDelivery)
+        this.vm.outputs.estimatedDeliveryIsGone().subscribe(this.estimatedDeliveryIsGone)
         this.vm.outputs.remaining().subscribe(this.remaining)
         this.vm.outputs.remainingIsGone().subscribe(this.remainingIsGone)
         this.vm.outputs.limitContainerIsGone().subscribe(this.limitContainerIsGone)
@@ -67,6 +75,44 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.titleForNoReward().subscribe(this.titleForNoReward)
         this.vm.outputs.titleForReward().subscribe(this.titleForReward)
         this.vm.outputs.titleIsGone().subscribe(this.titleIsGone)
+    }
+
+    @Test
+    fun testBackersCount_whenReward_withBackers() {
+        setUpEnvironment(environment())
+
+        val reward = RewardFactory.reward()
+                .toBuilder()
+                .backersCount(30)
+                .build()
+        this.vm.inputs.projectAndReward(ProjectFactory.project(), reward)
+
+        this.backersCount.assertValue(30)
+        this.backersCountIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testBackersCount_whenReward_withNoBackers() {
+        setUpEnvironment(environment())
+
+        val reward = RewardFactory.reward()
+                .toBuilder()
+                .backersCount(0)
+                .build()
+        this.vm.inputs.projectAndReward(ProjectFactory.project(), reward)
+
+        this.backersCount.assertNoValues()
+        this.backersCountIsGone.assertValue(true)
+    }
+
+    @Test
+    fun testBackersCount_whenNoReward() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.projectAndReward(ProjectFactory.project(), RewardFactory.noReward())
+
+        this.backersCount.assertNoValues()
+        this.backersCountIsGone.assertValue(true)
     }
 
     @Test
@@ -196,8 +242,6 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testDescriptionOutputs() {
-        setUpEnvironment(environment())
-
         val project = ProjectFactory.project()
         val reward = RewardFactory.reward()
         setUpEnvironment(environment())
@@ -272,6 +316,30 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.projectAndReward(ProjectFactory.successfulProject(), expiringReward)
         this.endDateSectionIsGone.assertValues(true, false, true)
+    }
+
+    @Test
+    fun testEstimatedDelivery_whenReward() {
+        setUpEnvironment(environment())
+
+        val reward = RewardFactory.reward()
+                .toBuilder()
+                .estimatedDeliveryOn(DateTime.parse("2019-09-11T20:12:47+00:00"))
+                .build()
+        this.vm.inputs.projectAndReward(ProjectFactory.project(), reward)
+
+        this.estimatedDelivery.assertValue("September 2019")
+        this.estimatedDeliveryIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testEstimatedDelivery_whenNoReward() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.projectAndReward(ProjectFactory.project(), RewardFactory.noReward())
+
+        this.estimatedDelivery.assertNoValues()
+        this.estimatedDeliveryIsGone.assertValue(true)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Updating the information presented on the reward card.

# 🤔 Why
So users get that sweet reward info.

# 🛠 How
- Did some refactoring of `NativeCheckoutRewardViewHolder` to not use generic `Observable`s but explicit `BehaviorSubject`s and `PublishSubject`s.
- Added pill for backers count.
- Moved description above the rewards items.
- Added section for estimated delivery.

# 👀 See
| After 🦋 | Before 🐛 |
| --- | --- |
| ![device-2019-09-11-163352](https://user-images.githubusercontent.com/1289295/64733417-bbb55080-d4b2-11e9-9493-a5a06f4ea029.png) | ![device-2019-09-11-163338](https://user-images.githubusercontent.com/1289295/64733416-bbb55080-d4b2-11e9-8fa1-2881fa813bd5.png) |
| ![device-2019-09-11-164305](https://user-images.githubusercontent.com/1289295/64733803-69286400-d4b3-11e9-8b66-3dfd778632cd.png) | ![device-2019-09-11-164338](https://user-images.githubusercontent.com/1289295/64733804-69286400-d4b3-11e9-9c8a-fdb66511a9e4.png) |

# 📋 QA
🗒 The reward description appears below the title 
📦 Estimated delivery appears as its own heading and the delivery date appears below with regular formatting
🔢 I see “X backers” for each reward (except No reward) under the reward title with the section header styling when the reward has backers

# Story 📖
[NT-236]
