### PR TITLE
[💳] NT-246 Disabling stored cards based on project.availableCardTypes

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/ProjectUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ProjectUtils.java
@@ -5,9 +5,7 @@ import android.util.Pair;
 
 import com.kickstarter.R;
 import com.kickstarter.libs.KSString;
-import com.kickstarter.libs.models.Country;
 import com.kickstarter.models.Project;
-import com.kickstarter.models.StoredCard;
 import com.kickstarter.models.User;
 import com.kickstarter.services.DiscoveryParams;
 
@@ -25,11 +23,8 @@ public final class ProjectUtils {
   private ProjectUtils() {}
 
   public static boolean acceptedCardType(final @NonNull CreditCardTypes type, final @NonNull Project project) {
-    if (project.currency().equals(Country.US.getCurrencyCode())) {
-      return StoredCard.Companion.getUsdCardTypes().contains(type);
-    } else {
-      return StoredCard.Companion.getNonUsdCardTypes().contains(type);
-    }
+    final List<String> availableCardTypes = project.availableCardTypes();
+    return availableCardTypes != null && availableCardTypes.contains(type.rawValue());
   }
 
   public static List<Pair<Project, DiscoveryParams>> combineProjectsAndParams(final @NonNull List<Project> projects, final @NonNull DiscoveryParams params) {

--- a/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
@@ -10,6 +10,7 @@ import org.joda.time.DateTime;
 import java.util.Arrays;
 
 import androidx.annotation.NonNull;
+import type.CreditCardTypes;
 
 public final class ProjectFactory {
   private ProjectFactory() {}
@@ -26,6 +27,13 @@ public final class ProjectFactory {
       .build();
 
     return Project.builder()
+      .availableCardTypes(Arrays.asList(CreditCardTypes.AMEX.rawValue(),
+        CreditCardTypes.DINERS.rawValue(),
+        CreditCardTypes.DISCOVER.rawValue(),
+        CreditCardTypes.JCB.rawValue(),
+        CreditCardTypes.MASTERCARD.rawValue(),
+        CreditCardTypes.UNION_PAY.rawValue(),
+        CreditCardTypes.VISA.rawValue()))
       .backersCount(100)
       .blurb("Some blurb")
       .category(CategoryFactory.category())
@@ -198,6 +206,9 @@ public final class ProjectFactory {
   public static @NonNull Project caProject() {
     return project()
       .toBuilder()
+      .availableCardTypes(Arrays.asList(CreditCardTypes.AMEX.rawValue(),
+        CreditCardTypes.MASTERCARD.rawValue(),
+        CreditCardTypes.VISA.rawValue()))
       .name("caProject")
       .country("CA")
       .currentCurrency("CAD")
@@ -211,6 +222,9 @@ public final class ProjectFactory {
   public static @NonNull Project mxCurrencyCAProject() {
     return project()
       .toBuilder()
+      .availableCardTypes(Arrays.asList(CreditCardTypes.AMEX.rawValue(),
+        CreditCardTypes.MASTERCARD.rawValue(),
+        CreditCardTypes.VISA.rawValue()))
       .name("mxCurrencyCAProject")
       .country("CA")
       .currentCurrency("MXN")
@@ -225,6 +239,9 @@ public final class ProjectFactory {
   public static @NonNull Project mxProject() {
     return project()
       .toBuilder()
+      .availableCardTypes(Arrays.asList(CreditCardTypes.AMEX.rawValue(),
+        CreditCardTypes.MASTERCARD.rawValue(),
+        CreditCardTypes.VISA.rawValue()))
       .name("mxProject")
       .country("MX")
       .currentCurrency("MXN")
@@ -239,6 +256,9 @@ public final class ProjectFactory {
   public static @NonNull Project ukProject() {
     return project()
       .toBuilder()
+      .availableCardTypes(Arrays.asList(CreditCardTypes.AMEX.rawValue(),
+        CreditCardTypes.MASTERCARD.rawValue(),
+        CreditCardTypes.VISA.rawValue()))
       .name("ukProject")
       .country("UK")
       .currentCurrency("GBP")

--- a/app/src/main/java/com/kickstarter/models/Project.java
+++ b/app/src/main/java/com/kickstarter/models/Project.java
@@ -23,6 +23,7 @@ import auto.parcel.AutoParcel;
 @AutoGson
 @AutoParcel
 public abstract class Project implements Parcelable, Relay {
+  public abstract @Nullable List<String> availableCardTypes();
   public abstract int backersCount();
   public abstract String blurb();
   public abstract @Nullable Backing backing();
@@ -66,6 +67,7 @@ public abstract class Project implements Parcelable, Relay {
 
   @AutoParcel.Builder
   public abstract static class Builder {
+    public abstract Builder availableCardTypes(List<String> __);
     public abstract Builder backersCount(int __);
     public abstract Builder blurb(String __);
     public abstract Builder backing(Backing __);


### PR DESCRIPTION
# 📲 What
Disabling stored cards based on `project.availableCardTypes`.

# 🤔 Why
So users can't pledge with an unsupported card.*
*Please note that this doesn't stop them from adding an unsupported card (if we change which cards we support) because the types from the API are not the same as the types from Stripe or Google Pay.

# 🛠 How
- Added `availableCardTypes` to `Project` model.
- Updated `ProjectUtils.acceptedCardType` to use `availableCardTypes`.
- Updated `ProjectFactory` so the tests pass.

# 👀 See
Looks the same

| Disabled cards  |
| --- |
| <img src=https://user-images.githubusercontent.com/1289295/64807196-b6174380-d562-11e9-8c19-536a9e6613bd.png width=330/> | 


# 📋 QA
Cards that are not available for the project should have the unavailable button style and helper copy as seen in Abstract.

# Story 📖
[NT-246]


[NT-246]: https://dripsprint.atlassian.net/browse/NT-246