### PR TITLE
[𝐐] NT-336 Targeting SDK 29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ base_job: &base_job
   environment:
     TERM: dumb
     ADB_INSTALL_TIMEOUT: 8
-    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError"'
+    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
 
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 base_job: &base_job
   resource_class: xlarge
   docker:
-    - image: circleci/android:api-28-alpha
+    - image: circleci/android:api-29
   working_directory: '~/project'
   environment:
     TERM: dumb

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,13 +34,13 @@ if (file('signing.gradle').exists()) {
 }
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 29
+    buildToolsVersion '29.0.2'
 
     defaultConfig {
         applicationId "com.kickstarter"
         minSdkVersion 23
-        targetSdkVersion 28
+        targetSdkVersion 29
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField "String", "GIT_SHA", "\"${commitSha()}\""


### PR DESCRIPTION
# 📲 What
Continuing my streak 🚀 our compile and target SDKs are now `29` to support Android Q https://developer.android.com/about/versions/10/migration

# 🤔 Why
ALWAYS B UPGRADING

# 🛠 How
- Updated `compileSdkVersion` and `targetSdkVersion` from `28` to `29`
- Updated build tools from `28.0.3` to `29.0.2`
- Changed CircleCI Docker image from `circleci/android:api-28-alpha` to `circleci/android:api-29`
- I also took the liberty of increasing the CircleCI gradle JVM from .5GBs to 2GB. Did it make things go faster? Not really!

# 👀 See
Nothing to see but another one of my fire upgrades
![image](https://user-images.githubusercontent.com/1289295/65629924-62651b00-dfa2-11e9-8afb-7a0dbfb215cf.png)

# 📋 QA
🤔 

# Story 📖
[NT-336]


[NT-336]: https://dripsprint.atlassian.net/browse/NT-336