### PR TITLE
[🏷] Adding helper methods for setting/getting ref tags from URLs

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/UrlUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/UrlUtils.kt
@@ -17,9 +17,16 @@ object UrlUtils {
         return builder.build()
     }
 
-    fun buildUrl(baseUrl: String, path: String): String {
+    fun appendPath(baseUrl: String, path: String): String {
         val uriBuilder = Uri.parse(baseUrl).buildUpon()
         uriBuilder.appendEncodedPath(path)
+
+        return uriBuilder.build().toString()
+    }
+
+    fun appendQueryParameter(baseUrl: String, key: String, value: String): String {
+        val uriBuilder = Uri.parse(baseUrl).buildUpon()
+        uriBuilder.appendQueryParameter(key, value)
 
         return uriBuilder.build().toString()
     }

--- a/app/src/main/java/com/kickstarter/libs/utils/UrlUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/UrlUtils.kt
@@ -8,14 +8,7 @@ import com.kickstarter.R
 
 object UrlUtils {
 
-    fun baseCustomTabsIntent(context: Context): CustomTabsIntent {
-        val builder = CustomTabsIntent.Builder()
-
-        builder.setShowTitle(true)
-        builder.setToolbarColor(ContextCompat.getColor(context, R.color.primary))
-
-        return builder.build()
-    }
+    private const val KEY_REF = "ref"
 
     fun appendPath(baseUrl: String, path: String): String {
         val uriBuilder = Uri.parse(baseUrl).buildUpon()
@@ -29,5 +22,22 @@ object UrlUtils {
         uriBuilder.appendQueryParameter(key, value)
 
         return uriBuilder.build().toString()
+    }
+
+    fun appendRefTag(baseUrl: String, tag: String): String {
+        return appendQueryParameter(baseUrl, KEY_REF, tag)
+    }
+
+    fun baseCustomTabsIntent(context: Context): CustomTabsIntent {
+        val builder = CustomTabsIntent.Builder()
+
+        builder.setShowTitle(true)
+        builder.setToolbarColor(ContextCompat.getColor(context, R.color.primary))
+
+        return builder.build()
+    }
+
+    fun refTag(url: String): String? {
+        return Uri.parse(url).getQueryParameter(KEY_REF)
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.java
@@ -9,6 +9,7 @@ import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
 import com.kickstarter.libs.utils.ApplicationUtils;
+import com.kickstarter.libs.utils.UrlUtils;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.viewmodels.DeepLinkViewModel;
 
@@ -54,7 +55,7 @@ public final class DeepLinkActivity extends BaseActivity<DeepLinkViewModel.ViewM
   private void startProjectActivity(final @NonNull Uri uri) {
     final Intent projectIntent = new Intent(this, ProjectActivity.class)
       .setData(uri);
-    final String ref = uri.getQueryParameter("ref");
+    final String ref = UrlUtils.INSTANCE.refTag(uri.toString());
     if (ref != null) {
       projectIntent.putExtra(IntentKey.REF_TAG, RefTag.from(ref));
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/HelpSettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/HelpSettingsActivity.kt
@@ -67,7 +67,7 @@ class HelpSettingsActivity : BaseActivity<HelpSettingsViewModel.ViewModel>() {
     }
 
     private fun buildWebEndpointUrl(path: String): String {
-        return UrlUtils.buildUrl(this.environment().webEndpoint(), path)
+        return UrlUtils.appendPath(this.environment().webEndpoint(), path)
     }
 
     private fun composeContactEmail(user: User?) {

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -572,9 +572,9 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     }
 
     private fun setHtmlStrings(baseUrl: String) {
-        val termsOfUseUrl = UrlUtils.buildUrl(baseUrl, HelpActivity.TERMS_OF_USE)
-        val cookiePolicyUrl = UrlUtils.buildUrl(baseUrl, HelpActivity.COOKIES)
-        val privacyPolicyUrl = UrlUtils.buildUrl(baseUrl, HelpActivity.PRIVACY)
+        val termsOfUseUrl = UrlUtils.appendPath(baseUrl, HelpActivity.TERMS_OF_USE)
+        val cookiePolicyUrl = UrlUtils.appendPath(baseUrl, HelpActivity.COOKIES)
+        val privacyPolicyUrl = UrlUtils.appendPath(baseUrl, HelpActivity.PRIVACY)
 
         val ksString = (activity?.applicationContext as KSApplication).component().environment().ksString()
         val byPledgingYouAgree = getString(R.string.By_pledging_you_agree_to_Kickstarters_Terms_of_Use_Privacy_Policy_and_Cookie_Policy)
@@ -584,7 +584,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
 
         setClickableHtml(agreementWithUrls, pledge_agreement)
 
-        val trustUrl = UrlUtils.buildUrl(baseUrl, "trust")
+        val trustUrl = UrlUtils.appendPath(baseUrl, "trust")
 
         val kickstarterIsNotAStore = getString(R.string.Kickstarter_is_not_a_store_Its_a_way_to_bring_creative_projects_to_life_Learn_more_about_accountability)
         val accountabilityWithUrls = ksString.format(kickstarterIsNotAStore, "trust_link", trustUrl)

--- a/app/src/test/java/com/kickstarter/libs/utils/UrlUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/UrlUtilsTest.kt
@@ -15,9 +15,9 @@ class UrlUtilsTest : KSRobolectricTestCase() {
 
     @Test
     fun testAppendQueryParameter() {
-        assertEquals("www.test.com/path?key=value", UrlUtils.appendQueryParameter("www.test.com", "key", "value"))
+        assertEquals("www.test.com?key=value", UrlUtils.appendQueryParameter("www.test.com", "key", "value"))
         assertEquals("www.test.com/path/to?key=value", UrlUtils.appendQueryParameter("www.test.com/path/to", "key", "value"))
-        assertEquals("http://www.test.com/path?key=value", UrlUtils.appendQueryParameter("http://www.test.com", "key", "value"))
+        assertEquals("http://www.test.com?key=value", UrlUtils.appendQueryParameter("http://www.test.com", "key", "value"))
         assertEquals("http://www.test.com/path/to?key=value", UrlUtils.appendQueryParameter("http://www.test.com/path/to", "key", "value"))
     }
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/UrlUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/UrlUtilsTest.kt
@@ -1,17 +1,10 @@
 package com.kickstarter.libs.utils
 
 import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.RefTag
 import org.junit.Test
 
 class UrlUtilsTest : KSRobolectricTestCase() {
-
-    @Test
-    fun testAppendPath() {
-        assertEquals("www.test.com/path", UrlUtils.appendPath("www.test.com", "path"))
-        assertEquals("www.test.com/path/to/path", UrlUtils.appendPath("www.test.com/path/to", "path"))
-        assertEquals("http://www.test.com/path", UrlUtils.appendPath("http://www.test.com", "path"))
-        assertEquals("http://www.test.com/path/to/path", UrlUtils.appendPath("http://www.test.com/path/to", "path"))
-    }
 
     @Test
     fun testAppendQueryParameter() {
@@ -19,5 +12,40 @@ class UrlUtilsTest : KSRobolectricTestCase() {
         assertEquals("www.test.com/path/to?key=value", UrlUtils.appendQueryParameter("www.test.com/path/to", "key", "value"))
         assertEquals("http://www.test.com?key=value", UrlUtils.appendQueryParameter("http://www.test.com", "key", "value"))
         assertEquals("http://www.test.com/path/to?key=value", UrlUtils.appendQueryParameter("http://www.test.com/path/to", "key", "value"))
+        assertEquals("https://www.test.com?key=value", UrlUtils.appendQueryParameter("https://www.test.com", "key", "value"))
+        assertEquals("https://www.test.com/path/to?key=value", UrlUtils.appendQueryParameter("https://www.test.com/path/to", "key", "value"))
+    }
+    @Test
+    fun testAppendPath() {
+        assertEquals("www.test.com/path", UrlUtils.appendPath("www.test.com", "path"))
+        assertEquals("www.test.com/path/to/path", UrlUtils.appendPath("www.test.com/path/to", "path"))
+        assertEquals("http://www.test.com/path", UrlUtils.appendPath("http://www.test.com", "path"))
+        assertEquals("http://www.test.com/path/to/path", UrlUtils.appendPath("http://www.test.com/path/to", "path"))
+        assertEquals("https://www.test.com/path", UrlUtils.appendPath("https://www.test.com", "path"))
+        assertEquals("https://www.test.com/path/to/path", UrlUtils.appendPath("https://www.test.com/path/to", "path"))
+    }
+
+    @Test
+    fun testAppendRefTag() {
+        assertEquals("www.test.com?ref=activity", UrlUtils.appendRefTag("www.test.com", RefTag.activity().tag()))
+        assertEquals("www.test.com/path/to?ref=activity", UrlUtils.appendRefTag("www.test.com/path/to", RefTag.activity().tag()))
+        assertEquals("http://www.test.com?ref=activity", UrlUtils.appendRefTag("http://www.test.com", RefTag.activity().tag()))
+        assertEquals("http://www.test.com/path/to?ref=activity", UrlUtils.appendRefTag("http://www.test.com/path/to", RefTag.activity().tag()))
+        assertEquals("https://www.test.com?ref=activity", UrlUtils.appendRefTag("https://www.test.com", RefTag.activity().tag()))
+        assertEquals("https://www.test.com/path/to?ref=activity", UrlUtils.appendRefTag("https://www.test.com/path/to", RefTag.activity().tag()))
+    }
+
+    @Test
+    fun testRefTag() {
+        assertEquals(null, UrlUtils.refTag("www.test.com"))
+        assertEquals("activity", UrlUtils.refTag("www.test.com?ref=activity"))
+        assertEquals(null, UrlUtils.refTag("www.test.com/path/to"))
+        assertEquals("activity", UrlUtils.refTag("www.test.com/path/to?ref=activity"))
+        assertEquals(null, UrlUtils.refTag("http://www.test.com"))
+        assertEquals("activity", UrlUtils.refTag("http://www.test.com?ref=activity"))
+        assertEquals(null, UrlUtils.refTag("http://www.test.com/path/to"))
+        assertEquals("activity", UrlUtils.refTag("http://www.test.com/path/to?ref=activity"))
+        assertEquals(null, UrlUtils.refTag("https://www.test.com/path/to"))
+        assertEquals("activity", UrlUtils.refTag("https://www.test.com/path/to?ref=activity"))
     }
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/UrlUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/UrlUtilsTest.kt
@@ -6,10 +6,18 @@ import org.junit.Test
 class UrlUtilsTest : KSRobolectricTestCase() {
 
     @Test
-    fun testBuildUrl() {
-        assertEquals("www.test.com/path", UrlUtils.buildUrl("www.test.com", "path"))
-        assertEquals("www.test.com/path/to/path", UrlUtils.buildUrl("www.test.com/path/to", "path"))
-        assertEquals("http://www.test.com/path", UrlUtils.buildUrl("http://www.test.com", "path"))
-        assertEquals("http://www.test.com/path/to/path", UrlUtils.buildUrl("http://www.test.com/path/to", "path"))
+    fun testAppendPath() {
+        assertEquals("www.test.com/path", UrlUtils.appendPath("www.test.com", "path"))
+        assertEquals("www.test.com/path/to/path", UrlUtils.appendPath("www.test.com/path/to", "path"))
+        assertEquals("http://www.test.com/path", UrlUtils.appendPath("http://www.test.com", "path"))
+        assertEquals("http://www.test.com/path/to/path", UrlUtils.appendPath("http://www.test.com/path/to", "path"))
+    }
+
+    @Test
+    fun testAppendQueryParameter() {
+        assertEquals("www.test.com/path?key=value", UrlUtils.appendQueryParameter("www.test.com", "key", "value"))
+        assertEquals("www.test.com/path/to?key=value", UrlUtils.appendQueryParameter("www.test.com/path/to", "key", "value"))
+        assertEquals("http://www.test.com/path?key=value", UrlUtils.appendQueryParameter("http://www.test.com", "key", "value"))
+        assertEquals("http://www.test.com/path/to?key=value", UrlUtils.appendQueryParameter("http://www.test.com/path/to", "key", "value"))
     }
 }


### PR DESCRIPTION
# 📲 What
First step in full ref tag support!
There's not much Android happening here, just BUSINESS!

# 🤔 Why
So we can track users' comings and goings.

# 🛠 How
- Renamed `UrlUtils. buildUrl` to `UrlUtils.appendPath` for clarity.
- Added `UrlUtils. appendQueryParameter ` as a helper method to add a query param to a URL.
- Added `UrlUtils. appendRefTag ` as a helper method to add a ref tag to a URL.
- Added `UrlUtils. refTag ` as a helper method to get a ref tag from a URL.
- Beautiful tests.

# 👀 See
Nothing 2 c
![image](https://user-images.githubusercontent.com/1289295/65702792-a06d4800-e051-11e9-970f-2e0af6d056b4.png)

# 📋 QA
Nothing to QA

# Story 📖
[NT-338]


[NT-338]: https://dripsprint.atlassian.net/browse/NT-338