### PR TITLE
[🔗] NT-337 Adding ref tag when sharing projects

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/RefTag.java
+++ b/app/src/main/java/com/kickstarter/libs/RefTag.java
@@ -55,6 +55,10 @@ public abstract class RefTag implements Parcelable {
     return new AutoParcel_RefTag("pledge_info");
   }
 
+  public static @NonNull RefTag projectShare() {
+    return new AutoParcel_RefTag("native_android_project_share");
+  }
+
   public static @NonNull RefTag push() {
     return new AutoParcel_RefTag("push");
   }

--- a/app/src/main/java/com/kickstarter/libs/RefTag.java
+++ b/app/src/main/java/com/kickstarter/libs/RefTag.java
@@ -56,7 +56,7 @@ public abstract class RefTag implements Parcelable {
   }
 
   public static @NonNull RefTag projectShare() {
-    return new AutoParcel_RefTag("native_android_project_share");
+    return new AutoParcel_RefTag("android_project_share");
   }
 
   public static @NonNull RefTag push() {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -209,7 +209,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         this.viewModel.outputs.showShareSheet()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { this.startShareIntent(it) }
+                .subscribe { startShareIntent(it) }
 
         this.viewModel.outputs.startCampaignWebViewActivity()
                 .compose(bindToLifecycle())
@@ -666,13 +666,14 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 
-    // todo: limit the apps you can share to
-    private fun startShareIntent(project: Project) {
-        val shareMessage = this.ksString.format(getString(this.projectShareCopyString), "project_title", project.name())
+    private fun startShareIntent(projectNameAndShareUrl: Pair<String, String>) {
+        val name = projectNameAndShareUrl.first
+        val shareMessage = this.ksString.format(getString(this.projectShareCopyString), "project_title", name)
 
+        val url = projectNameAndShareUrl.second
         val intent = Intent(Intent.ACTION_SEND)
                 .setType("text/plain")
-                .putExtra(Intent.EXTRA_TEXT, shareMessage + " " + project.webProjectUrl())
+                .putExtra(Intent.EXTRA_TEXT, "$shareMessage $url")
         startActivity(Intent.createChooser(intent, getString(this.projectShareLabelString)))
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -167,8 +167,8 @@ interface ProjectViewModel {
         /** Emits when the success prompt for saving should be displayed.  */
         fun showSavedPrompt(): Observable<Void>
 
-        /** Emits when we should show the share sheet.  */
-        fun showShareSheet(): Observable<Project>
+        /** Emits when we should show the share sheet with the name of the project and share URL.  */
+        fun showShareSheet(): Observable<Pair<String, String>>
 
         /** Emits when we should show the [com.kickstarter.ui.fragments.PledgeFragment]. */
         fun showUpdatePledge(): Observable<Pair<PledgeData, PledgeReason>>
@@ -261,7 +261,7 @@ interface ProjectViewModel {
         private val showCancelPledgeSuccess = PublishSubject.create<Void>()
         private val showPledgeNotCancelableDialog = PublishSubject.create<Void>()
         private val showRewardsFragment = BehaviorSubject.create<Project>()
-        private val showShareSheet = PublishSubject.create<Project>()
+        private val showShareSheet = PublishSubject.create<Pair<String, String>>()
         private val showSavedPrompt = PublishSubject.create<Void>()
         private val showUpdatePledge = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
         private val showUpdatePledgeSuccess = PublishSubject.create<Void>()
@@ -379,6 +379,7 @@ interface ProjectViewModel {
 
             currentProject
                     .compose<Project>(takeWhen(this.shareButtonClicked))
+                    .map { Pair(it.name(), UrlUtils.appendRefTag(it.webProjectUrl(), RefTag.projectShare().tag())) }
                     .compose(bindToLifecycle())
                     .subscribe(this.showShareSheet)
 
@@ -575,7 +576,8 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.scrimIsVisible)
 
-            this.showShareSheet
+            currentProject
+                    .compose<Project>(takeWhen(this.showShareSheet))
                     .compose(bindToLifecycle())
                     .subscribe { this.koala.trackShowProjectShareSheet(it) }
 
@@ -841,7 +843,7 @@ interface ProjectViewModel {
         override fun showSavedPrompt(): Observable<Void> = this.showSavedPrompt
 
         @NonNull
-        override fun showShareSheet(): Observable<Project> = this.showShareSheet
+        override fun showShareSheet(): Observable<Pair<String, String>> = this.showShareSheet
 
         @NonNull
         override fun showUpdatePledge(): Observable<Pair<PledgeData, PledgeReason>> = this.showUpdatePledge

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -203,7 +203,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     fun testShowShareSheet() {
         val creator = UserFactory.creator()
         val slug = "best-project-2k19"
-        val projectUrl = "https://www.kickstarter.com/projects/" + creator.id().toString() + "/" + slug
+        val projectUrl = "https://www.kck.str/projects/" + creator.id().toString() + "/" + slug
 
         val webUrls = Project.Urls.Web.builder()
                 .project(projectUrl)
@@ -222,7 +222,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.shareButtonClicked()
         val expectedName = "Best Project 2K19"
-        val expectedShareUrl = "https://www.kickstarter.com/projects/" + creator.id().toString() + "/" + slug + "?ref=native_android_project_share"
+        val expectedShareUrl = "https://www.kck.str/projects/" + creator.id().toString() + "/" + slug + "?ref=android_project_share"
         this.showShareSheet.assertValues(Pair(expectedName, expectedShareUrl))
         this.koalaTest.assertValues(
                 KoalaEvent.PROJECT_PAGE, KoalaEvent.VIEWED_PROJECT_PAGE,

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -45,7 +45,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     private val showCancelPledgeSuccess = TestSubscriber<Void>()
     private val showPledgeNotCancelableDialog = TestSubscriber<Void>()
     private val showSavedPromptTest = TestSubscriber<Void>()
-    private val showShareSheet = TestSubscriber<Project>()
+    private val showShareSheet = TestSubscriber<Pair<String, String>>()
     private val showUpdatePledge = TestSubscriber<Pair<PledgeData, PledgeReason>>()
     private val showUpdatePledgeSuccess = TestSubscriber<Void>()
     private val startBackingActivity = TestSubscriber<Pair<Project, User>>()
@@ -201,14 +201,29 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowShareSheet() {
-        val project = ProjectFactory.project()
-        val user = UserFactory.user()
+        val creator = UserFactory.creator()
+        val slug = "best-project-2k19"
+        val projectUrl = "https://www.kickstarter.com/projects/" + creator.id().toString() + "/" + slug
 
-        setUpEnvironment(environment().toBuilder().currentUser(MockCurrentUser(user)).build())
+        val webUrls = Project.Urls.Web.builder()
+                .project(projectUrl)
+                .rewards("$projectUrl/rewards")
+                .updates("$projectUrl/posts")
+                .build()
+
+        val project = ProjectFactory.project()
+                .toBuilder()
+                .name("Best Project 2K19")
+                .urls(Project.Urls.builder().web(webUrls).build())
+                .build()
+
+        setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
 
         this.vm.inputs.shareButtonClicked()
-        this.showShareSheet.assertValues(project)
+        val expectedName = "Best Project 2K19"
+        val expectedShareUrl = "https://www.kickstarter.com/projects/" + creator.id().toString() + "/" + slug + "?ref=native_android_project_share"
+        this.showShareSheet.assertValues(Pair(expectedName, expectedShareUrl))
         this.koalaTest.assertValues(
                 KoalaEvent.PROJECT_PAGE, KoalaEvent.VIEWED_PROJECT_PAGE,
                 KoalaEvent.PROJECT_SHOW_SHARE_SHEET_LEGACY, KoalaEvent.SHOWED_SHARE_SHEET


### PR DESCRIPTION
# 📲 What
Adding a ref tag when sharing a project.

# 🤔 Why
So we know if users navigated to the project page via a link shared from the Android app!

# 🛠 How
- Added `RefTag.projectShare` which has a value of `android_project_share`.
- The `showShareSheet` output in ProjectViewModel is now a `Pair<String, String>` representing the project's name and the share URL instead of just the project so we can properly test that the tag is set!
- Tests!

# 👀 See
| Before 🐛 | After 🦋 |
| --- | --- |
| Don't Go Without Me by Rosemary Valero-O'Connell, via @Kickstarter https://kickstarter.com/projects/shortbox/dont-go-without-me-by-rosemary-valero-oconnell | Don't Go Without Me by Rosemary Valero-O'Connell, via @Kickstarter https://kickstarter.com/projects/shortbox/dont-go-without-me-by-rosemary-valero-oconnell?ref=android_project_share |

# 📋 QA
Click the share icon in the project page and check out that SWEET ref tag.

# Story 📖
[NT-337]


[NT-337]: https://dripsprint.atlassian.net/browse/NT-337