### PR TITLE
[🔗] NT-342 Adding ref tag when sharing updates

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/RefTag.java
+++ b/app/src/main/java/com/kickstarter/libs/RefTag.java
@@ -100,6 +100,6 @@ public abstract class RefTag implements Parcelable {
   }
 
   public static @NonNull RefTag updateShare() {
-    return new AutoParcel_RefTag("native_android_update_share");
+    return new AutoParcel_RefTag("android_update_share");
   }
 }

--- a/app/src/main/java/com/kickstarter/libs/RefTag.java
+++ b/app/src/main/java/com/kickstarter/libs/RefTag.java
@@ -98,4 +98,8 @@ public abstract class RefTag implements Parcelable {
   public static @NonNull RefTag update() {
     return new AutoParcel_RefTag("update");
   }
+
+  public static @NonNull RefTag updateShare() {
+    return new AutoParcel_RefTag("native_android_update_share");
+  }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.java
@@ -126,14 +126,16 @@ public class UpdateActivity extends BaseActivity<UpdateViewModel.ViewModel> impl
     startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }
 
-  private void startShareIntent(final @NonNull Update update) {
+  private void startShareIntent(final @NonNull Pair<Update, String> updateAndShareUrl) {
+    final Update update = updateAndShareUrl.first;
+    final String shareUrl = updateAndShareUrl.second;
     final String shareMessage = this.ksString.format(this.shareUpdateCountString, "update_count", NumberUtils.format(update.sequence()))
       + ": " + update.title();
 
     final Intent intent = new Intent(Intent.ACTION_SEND)
       .setType("text/plain")
-      .putExtra(Intent.EXTRA_TEXT, shareMessage + " " + update.urls().web().update());
-    startActivity(intent);
+      .putExtra(Intent.EXTRA_TEXT, shareMessage + " " + shareUrl);
+    startActivity(Intent.createChooser(intent, getString(R.string.Share_update)));
   }
 
   @Override

--- a/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.java
@@ -7,6 +7,7 @@ import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.KoalaContext;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.utils.NumberUtils;
+import com.kickstarter.libs.utils.UrlUtils;
 import com.kickstarter.models.Project;
 import com.kickstarter.models.Update;
 import com.kickstarter.services.ApiClientType;
@@ -44,7 +45,7 @@ public interface UpdateViewModel {
 
   interface Outputs {
     /** Emits when we should start the share intent to show the share sheet. */
-    Observable<Update> startShareIntent();
+    Observable<Pair<Update, String>> startShareIntent();
 
     /** Emits an update to start the comments activity with. */
     Observable<Update> startCommentsActivity();
@@ -96,6 +97,7 @@ public interface UpdateViewModel {
 
       currentUpdate
         .compose(takeWhen(this.shareButtonClicked))
+        .map(update -> Pair.create(update, UrlUtils.INSTANCE.appendRefTag(update.urls().web().update(), RefTag.updateShare().tag())))
         .compose(bindToLifecycle())
         .subscribe(this.startShareIntent::onNext);
 
@@ -139,7 +141,7 @@ public interface UpdateViewModel {
     private final PublishSubject<Request> goToUpdateRequest = PublishSubject.create();
     private final PublishSubject<Void> shareButtonClicked = PublishSubject.create();
 
-    private final PublishSubject<Update> startShareIntent = PublishSubject.create();
+    private final PublishSubject<Pair<Update, String>> startShareIntent = PublishSubject.create();
     private final PublishSubject<Update> startCommentsActivity = PublishSubject.create();
     private final PublishSubject<Pair<Project, RefTag>> startProjectActivity = PublishSubject.create();
     private final BehaviorSubject<String> updateSequence = BehaviorSubject.create();
@@ -164,7 +166,7 @@ public interface UpdateViewModel {
       this.shareButtonClicked.onNext(null);
     }
 
-    @Override public Observable<Update> startShareIntent() {
+    @Override public Observable<Pair<Update, String>> startShareIntent() {
       return this.startShareIntent;
     }
     @Override public @NonNull Observable<Update> startCommentsActivity() {

--- a/app/src/test/java/com/kickstarter/viewmodels/UpdateViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/UpdateViewModelTest.java
@@ -176,7 +176,7 @@ public final class UpdateViewModelTest extends KSRobolectricTestCase {
     vm.inputs.shareIconButtonClicked();
 
     final String expectedShareUrl = "https://www.kck.str/projects/" + project.creator().param() +
-      "/" + project.param() + "/posts/" + id + "?ref=native_android_update_share";
+      "/" + project.param() + "/posts/" + id + "?ref=android_update_share";
     startShareIntent.assertValue(Pair.create(update, expectedShareUrl));
   }
 


### PR DESCRIPTION
# 📲 What
Adding a ref tag when sharing an update.

# 🤔 Why
So we know if users navigated to an update page via a link shared from the Android app!

# 🛠 How
- Added `RefTag.updateShare` which has a value of `android_update_share`.
- The `startShareIntent` output in `UpdateViewModel` now outputs a pair of an update and the share url string.
- Updated intent share style in `UpdateActivity`.
- Tests.

# 👀 See
| Before 🐛 | After 🦋 |
| --- | --- |
| Update #31: A calm before the storm: daily unlock! WIPs! https://www.kickstarter.com/projects/1492106834/aeon-trespass-odyssey/posts/2635180 | Update #31: A calm before the storm: daily unlock! WIPs! https://www.kickstarter.com/projects/1492106834/aeon-trespass-odyssey/posts/2635180?ref=android_update_share |
| <img src=https://user-images.githubusercontent.com/1289295/65721280-bc83e000-e077-11e9-993c-124d90d53aad.png width=330/> | <img src=https://user-images.githubusercontent.com/1289295/65721838-deca2d80-e078-11e9-8544-12f4dc3c84ee.png width=330/> |

# 📋 QA
Click the share icon in an update page and check out that SWEET ref tag.

# Story 📖
[NT-342]


[NT-342]: https://dripsprint.atlassian.net/browse/NT-342