### PR TITLE
[🏷] NT-343 Adding default ref tag to project deep links that don't have one

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/RefTag.java
+++ b/app/src/main/java/com/kickstarter/libs/RefTag.java
@@ -47,6 +47,10 @@ public abstract class RefTag implements Parcelable {
     return new AutoParcel_RefTag("dashboard");
   }
 
+  public static @NonNull RefTag deepLink() {
+    return new AutoParcel_RefTag("android_deeplink");
+  }
+
   public static @NonNull RefTag discovery() {
     return new AutoParcel_RefTag("discovery");
   }

--- a/app/src/main/java/com/kickstarter/libs/RefTag.java
+++ b/app/src/main/java/com/kickstarter/libs/RefTag.java
@@ -48,7 +48,7 @@ public abstract class RefTag implements Parcelable {
   }
 
   public static @NonNull RefTag deepLink() {
-    return new AutoParcel_RefTag("android_deeplink");
+    return new AutoParcel_RefTag("android_deep_link");
   }
 
   public static @NonNull RefTag discovery() {

--- a/app/src/main/java/com/kickstarter/viewmodels/DeepLinkViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DeepLinkViewModel.java
@@ -8,7 +8,10 @@ import android.util.Pair;
 
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.Environment;
+import com.kickstarter.libs.RefTag;
+import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.libs.utils.Secrets;
+import com.kickstarter.libs.utils.UrlUtils;
 import com.kickstarter.services.KSUri;
 import com.kickstarter.ui.activities.DeepLinkActivity;
 
@@ -72,6 +75,7 @@ public interface DeepLinkViewModel {
       uriFromIntent
         .filter(uri -> KSUri.isProjectUri(uri, Secrets.WebEndpoint.PRODUCTION))
         .filter(uri -> !KSUri.isProjectPreviewUri(uri, Secrets.WebEndpoint.PRODUCTION))
+        .map(this::appendRefTagIfNone)
         .compose(bindToLifecycle())
         .subscribe(this.startProjectActivity::onNext);
 
@@ -115,6 +119,16 @@ public interface DeepLinkViewModel {
         .compose(ignoreValues())
         .compose(bindToLifecycle())
         .subscribe(this.requestPackageManager::onNext);
+    }
+
+    private Uri appendRefTagIfNone(final @NonNull Uri uri) {
+      final String url = uri.toString();
+      final String ref = UrlUtils.INSTANCE.refTag(url);
+      if (ObjectUtils.isNull(ref)) {
+        return Uri.parse(UrlUtils.INSTANCE.appendRefTag(url, RefTag.deepLink().tag()));
+      }
+
+      return uri;
     }
 
     private boolean lastPathSegmentIsProjects(final @NonNull Uri uri) {

--- a/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.java
@@ -5,8 +5,6 @@ import android.net.Uri;
 
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.libs.KoalaEvent;
-import com.kickstarter.libs.RefTag;
-import com.kickstarter.libs.utils.UrlUtils;
 
 import org.junit.Test;
 
@@ -80,7 +78,8 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
     final String url = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap";
     this.vm.intent(intentWithData(url));
 
-    this.startProjectActivity.assertValue(Uri.parse(UrlUtils.INSTANCE.appendRefTag(url, RefTag.deepLink().tag())));
+    final String expectedUrl = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap?ref=android_deeplink";
+    this.startProjectActivity.assertValue(Uri.parse(expectedUrl));
     this.startBrowser.assertNoValues();
     this.requestPackageManager.assertNoValues();
     this.startDiscoveryActivity.assertNoValues();

--- a/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.java
@@ -5,6 +5,8 @@ import android.net.Uri;
 
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.libs.KoalaEvent;
+import com.kickstarter.libs.RefTag;
+import com.kickstarter.libs.utils.UrlUtils;
 
 import org.junit.Test;
 
@@ -58,13 +60,27 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testProjectDeepLink_startsProjectActivity() {
+  public void testProjectDeepLinkWithRefTag_startsProjectActivity() {
+    setUpEnvironment();
+
+    final String url = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap?ref=discovery";
+    this.vm.intent(intentWithData(url));
+
+    this.startProjectActivity.assertValue(Uri.parse(url));
+    this.startBrowser.assertNoValues();
+    this.requestPackageManager.assertNoValues();
+    this.startDiscoveryActivity.assertNoValues();
+    this.koalaTest.assertValues(KoalaEvent.CONTINUE_USER_ACTIVITY, KoalaEvent.OPENED_DEEP_LINK);
+  }
+
+  @Test
+  public void testProjectDeepLinkWithoutRefTag_startsProjectActivity() {
     setUpEnvironment();
 
     final String url = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap";
     this.vm.intent(intentWithData(url));
 
-    this.startProjectActivity.assertValue(Uri.parse(url));
+    this.startProjectActivity.assertValue(Uri.parse(UrlUtils.INSTANCE.appendRefTag(url, RefTag.deepLink().tag())));
     this.startBrowser.assertNoValues();
     this.requestPackageManager.assertNoValues();
     this.startDiscoveryActivity.assertNoValues();

--- a/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.java
@@ -78,7 +78,7 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
     final String url = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap";
     this.vm.intent(intentWithData(url));
 
-    final String expectedUrl = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap?ref=android_deeplink";
+    final String expectedUrl = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap?ref=android_deep_link";
     this.startProjectActivity.assertValue(Uri.parse(expectedUrl));
     this.startBrowser.assertNoValues();
     this.requestPackageManager.assertNoValues();


### PR DESCRIPTION
# 📲 What
Setting a ref tag on project page deep links if they did not initially have one.

# 🤔 Why
┏┓
┃┃╱╲ In this
┃╱╱╲╲ house
╱╱╭╮╲╲ we
▔▏┗┛▕▔ 
╱▔▔▔▔▔▔▔▔▔▔╲
&nbsp;&nbsp;&nbsp;__Attribute our referrers__
╱╱┏┳┓╭╮┏┳┓ ╲╲
▔▏┗┻┛┃┃┗┻┛▕▔

# 🛠 How
- If a project link doesn't have a ref tag, we add the `android_deep_link` ref tag.
- Tests.

# 👀 See
This is a Behind the Scenes™ PR.

# 📋 QA
KTK? 👀 

# Story 📖
[NT-343]


[NT-343]: https://dripsprint.atlassian.net/browse/NT-343