### PR TITLE
🔜Pre-release prep!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ vendor/native-secrets
 app/src/**/google-services.json
 fabric.properties
 slack.properties
+
+# temporarily ignore prerelease script
+prerelease.sh


### PR DESCRIPTION
# 📲 What
Updating `gitignore` in prep for prerelease

# 🤔 Why
Because we're not ready for the script to be committed yet!

