### PR TITLE
[🛤] NT-397 Checkout tracking events for canceling a pledge

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -10,8 +10,6 @@ import com.kickstarter.services.apiresponses.PushNotificationEnvelope;
 import com.kickstarter.ui.data.LoginReason;
 import com.kickstarter.ui.data.Mailbox;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -115,7 +113,7 @@ public final class Koala {
     this.client.track(KoalaEvent.VIEWED_PROJECT_PAGE, properties);
   }
 
-  public void trackCancelPledgeButtonClicked(final @NotNull Project project) {
+  public void trackCancelPledgeButtonClicked(final @NonNull Project project) {
     final Map<String, Object> properties = KoalaUtils.projectProperties(project, this.client.loggedInUser());
 
     this.client.track(KoalaEvent.CANCEL_PLEDGE_BUTTON_CLICKED, properties);

--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -10,6 +10,8 @@ import com.kickstarter.services.apiresponses.PushNotificationEnvelope;
 import com.kickstarter.ui.data.LoginReason;
 import com.kickstarter.ui.data.Mailbox;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -111,6 +113,12 @@ public final class Koala {
     this.client.track(KoalaEvent.PROJECT_PAGE, properties);
 
     this.client.track(KoalaEvent.VIEWED_PROJECT_PAGE, properties);
+  }
+
+  public void trackCancelPledgeButtonClicked(final @NotNull Project project) {
+    final Map<String, Object> properties = KoalaUtils.projectProperties(project, this.client.loggedInUser());
+
+    this.client.track(KoalaEvent.CANCEL_PLEDGE_BUTTON_CLICKED, properties);
   }
 
   // PROJECT STAR

--- a/app/src/main/java/com/kickstarter/libs/KoalaEvent.java
+++ b/app/src/main/java/com/kickstarter/libs/KoalaEvent.java
@@ -6,6 +6,7 @@ public final class KoalaEvent {
   public static final String ACTIVITY_LOAD_MORE = "Activity Load More";
   public static final String ACTIVITY_VIEW = "Activity View";
   public static final String ACTIVITY_VIEW_ITEM = "Activity View Item";
+  public static final String CANCEL_PLEDGE_BUTTON_CLICKED = "Cancel Pledge Button Clicked";
   public static final String CHANGED_EMAIL = "Changed Email";
   public static final String CHANGED_PASSWORD = "Changed Password";
   public static final String CLEARED_SEARCH_TERM = "Cleared Search Term";

--- a/app/src/main/java/com/kickstarter/viewmodels/CancelPledgeViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CancelPledgeViewModel.kt
@@ -116,6 +116,11 @@ interface CancelPledgeViewModel {
              this.goBackButtonClicked
                     .compose(bindToLifecycle())
                     .subscribe(this.dismiss)
+
+            project
+                    .compose<Project>(takeWhen(this.confirmCancellationClicked))
+                    .compose(bindToLifecycle())
+                    .subscribe { this.koala.trackCancelPledgeButtonClicked(it) }
         }
 
         private fun cancelBacking(note: String, backing: Backing): Observable<Notification<Any>> {

--- a/app/src/test/java/com/kickstarter/viewmodels/CancelPledgeViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CancelPledgeViewModelTest.kt
@@ -68,7 +68,7 @@ class CancelPledgeViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testServerResponses() {
+    fun testCancelingPledge_whenErrorMessage() {
         setUpEnvironment(environment().toBuilder()
                 .apolloClient(object : MockApolloClient() {
                     override fun cancelBacking(backing: Backing, note: String): Observable<Any> {
@@ -82,7 +82,11 @@ class CancelPledgeViewModelTest : KSRobolectricTestCase() {
         this.showCancelError.assertValuesAndClear("Error")
         this.showServerError.assertNoValues()
         this.success.assertNoValues()
+        this.koalaTest.assertValues("Cancel Pledge Button Clicked")
+    }
 
+    @Test
+    fun testCancelingPledge_whenBackingNotCancelled() {
         setUpEnvironment(environment().toBuilder()
                 .apolloClient(object : MockApolloClient() {
                     override fun cancelBacking(backing: Backing, note: String): Observable<Any> {
@@ -96,7 +100,11 @@ class CancelPledgeViewModelTest : KSRobolectricTestCase() {
         this.showCancelError.assertNoValues()
         this.showServerError.assertValueCount(1)
         this.success.assertNoValues()
+        this.koalaTest.assertValues("Cancel Pledge Button Clicked")
+    }
 
+    @Test
+    fun testCancelingPledge_whenServerError() {
         setUpEnvironment(environment().toBuilder()
                 .apolloClient(object : MockApolloClient() {
                     override fun cancelBacking(backing: Backing, note: String): Observable<Any> {
@@ -108,17 +116,22 @@ class CancelPledgeViewModelTest : KSRobolectricTestCase() {
         this.progressBarIsVisible.assertValuesAndClear(true, false)
         this.cancelButtonIsVisible.assertValuesAndClear(false, true)
         this.showCancelError.assertNoValues()
-        this.showServerError.assertValueCount(2)
+        this.showServerError.assertValueCount(1)
         this.success.assertNoValues()
+        this.koalaTest.assertValues("Cancel Pledge Button Clicked")
+    }
 
+    @Test
+    fun testCancelingPledge_whenSuccessful() {
         setUpEnvironment(environment())
 
         this.vm.inputs.confirmCancellationClicked("")
         this.progressBarIsVisible.assertValuesAndClear(true, false)
         this.cancelButtonIsVisible.assertValuesAndClear(false, true)
         this.showCancelError.assertNoValues()
-        this.showServerError.assertValueCount(2)
+        this.showServerError.assertNoValues()
         this.success.assertValueCount(1)
+        this.koalaTest.assertValues("Cancel Pledge Button Clicked")
     }
 
 }


### PR DESCRIPTION
# 📲 What
Adding tracking events for canceling a pledge.

# 🤔 Why
TRACKING

# 🛠 How
- Added `CANCEL_PLEDGE_BUTTON_CLICKED`  to `KoalaEvent`.
- Tracking `Cancel Pledge Button Clicked` when a user confirms their pledge cancellation.
- Tests.

# 👀 See
nothing 2 c

# 📋 QA
check ur local LogCat
On debug builds, we log the Koala events and their properties.

Canceling a pledge should fire the `Cancel Pledge Button Clicked` event with default project properties.

# Story 📖
[NT-397]

[NT-397]: https://dripsprint.atlassian.net/browse/NT-397