### PR TITLE
[💳] NT-414 Improved a11y support for stored cards

### DIFF
--- a/app/src/main/java/com/kickstarter/models/StoredCard.kt
+++ b/app/src/main/java/com/kickstarter/models/StoredCard.kt
@@ -3,6 +3,7 @@ package com.kickstarter.models
 import android.os.Parcelable
 import auto.parcel.AutoParcel
 import com.kickstarter.R
+import com.stripe.android.model.Card
 import type.CreditCardTypes
 import java.util.*
 
@@ -30,19 +31,6 @@ abstract class StoredCard : Parcelable {
             return AutoParcel_StoredCard.Builder()
         }
 
-        private val allowedCardTypes = listOf(CreditCardTypes.AMEX,
-                CreditCardTypes.DINERS,
-                CreditCardTypes.DISCOVER,
-                CreditCardTypes.JCB,
-                CreditCardTypes.MASTERCARD,
-                CreditCardTypes.UNION_PAY,
-                CreditCardTypes.VISA)
-
-        val usdCardTypes = allowedCardTypes;
-        val nonUsdCardTypes = listOf(CreditCardTypes.AMEX,
-                CreditCardTypes.MASTERCARD,
-                CreditCardTypes.VISA)
-
         internal fun getCardTypeDrawable(cardType: CreditCardTypes): Int {
             return when (cardType) {
                 CreditCardTypes.AMEX -> R.drawable.amex_md
@@ -53,6 +41,19 @@ abstract class StoredCard : Parcelable {
                 CreditCardTypes.UNION_PAY -> R.drawable.union_pay_md
                 CreditCardTypes.VISA -> R.drawable.visa_md
                 else -> R.drawable.generic_bank_md
+            }
+        }
+
+        internal fun issuer(cardType: CreditCardTypes): String {
+            return when (cardType) {
+                CreditCardTypes.AMEX -> Card.CardBrand.AMERICAN_EXPRESS
+                CreditCardTypes.DINERS -> Card.CardBrand.DINERS_CLUB
+                CreditCardTypes.DISCOVER -> Card.CardBrand.DISCOVER
+                CreditCardTypes.JCB -> Card.CardBrand.JCB
+                CreditCardTypes.MASTERCARD -> Card.CardBrand.MASTERCARD
+                CreditCardTypes.UNION_PAY -> Card.CardBrand.UNIONPAY
+                CreditCardTypes.VISA -> Card.CardBrand.VISA
+                else -> Card.CardBrand.UNKNOWN
             }
         }
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/PaymentMethodsViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/PaymentMethodsViewHolder.kt
@@ -22,10 +22,10 @@ class PaymentMethodsViewHolder(@NonNull view: View, @NonNull val delegate: Deleg
 
     init {
 
-        this.vm.outputs.cardIssuer()
+        this.vm.outputs.issuerImage()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { itemView.credit_card_logo.setImageResource(it) }
+                .subscribe { this.itemView.credit_card_logo.setImageResource(it) }
 
         this.vm.outputs.expirationDate()
                 .compose(bindToLifecycle())
@@ -42,7 +42,12 @@ class PaymentMethodsViewHolder(@NonNull view: View, @NonNull val delegate: Deleg
                 .compose(observeForUI())
                 .subscribe { setLastFourTextView(it) }
 
-        itemView.delete_card.setOnClickListener { this.vm.inputs.deleteIconClicked() }
+        this.vm.outputs.issuer()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.itemView.credit_card_logo.contentDescription = it }
+
+        this.itemView.delete_card.setOnClickListener { this.vm.inputs.deleteIconClicked() }
 
     }
 
@@ -52,12 +57,12 @@ class PaymentMethodsViewHolder(@NonNull view: View, @NonNull val delegate: Deleg
     }
 
     private fun setExpirationDateTextView(date: String) {
-        itemView.credit_card_expiration_date.text = this.ksString.format(this.creditCardExpirationString,
+        this.itemView.credit_card_expiration_date.text = this.ksString.format(this.creditCardExpirationString,
                 "expiration_date", date)
     }
 
     private fun setLastFourTextView(lastFour: String) {
-        itemView.credit_card_last_four_digits.text = this.ksString.format(this.cardEndingInString, "last_four", lastFour)
+        this.itemView.credit_card_last_four_digits.text = this.ksString.format(this.cardEndingInString, "last_four", lastFour)
     }
 
 }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardCardViewHolder.kt
@@ -78,10 +78,6 @@ class RewardCardViewHolder(val view : View, val delegate : Delegate) : KSViewHol
         this.viewModel.inputs.configureWith(cardAndProject)
     }
 
-    override fun onClick(view: View) {
-        this.delegate.selectCardButtonClicked(adapterPosition)
-    }
-
     private fun setCardNotAllowedWarningText(country: String) {
         this.view.card_not_allowed_warning.text = this.ksString.format(this.cardNotAllowedString,
                 "project_country", country)

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardCardViewHolder.kt
@@ -37,6 +37,11 @@ class RewardCardViewHolder(val view : View, val delegate : Delegate) : KSViewHol
                 .compose(observeForUI())
                 .subscribe { this.view.reward_card_logo.setImageResource(it) }
 
+        this.viewModel.outputs.issuer()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.reward_card_logo.contentDescription = it }
+
         this.viewModel.outputs.lastFour()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
@@ -71,6 +76,10 @@ class RewardCardViewHolder(val view : View, val delegate : Delegate) : KSViewHol
         @Suppress("UNCHECKED_CAST")
         val cardAndProject = requireNotNull(data) as Pair<StoredCard, Project>
         this.viewModel.inputs.configureWith(cardAndProject)
+    }
+
+    override fun onClick(view: View) {
+        this.delegate.selectCardButtonClicked(adapterPosition)
     }
 
     private fun setCardNotAllowedWarningText(country: String) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardLoadingCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardLoadingCardViewHolder.kt
@@ -32,6 +32,11 @@ class RewardLoadingCardViewHolder(val view: View) : KSViewHolder(view) {
                 .compose(observeForUI())
                 .subscribe { this.view.reward_card_logo.setImageResource(it) }
 
+        this.viewModel.outputs.issuer()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.reward_card_logo.contentDescription = it }
+
         this.viewModel.outputs.lastFour()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardPledgeCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardPledgeCardViewHolder.kt
@@ -36,6 +36,11 @@ class RewardPledgeCardViewHolder(val view : View, val delegate : Delegate) : KSV
                 .compose(observeForUI())
                 .subscribe { this.view.reward_card_logo.setImageResource(it) }
 
+        this.viewModel.outputs.issuer()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.reward_card_logo.contentDescription = it }
+
         this.viewModel.outputs.lastFour()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())

--- a/app/src/main/res/layout/item_payment_method.xml
+++ b/app/src/main/res/layout/item_payment_method.xml
@@ -54,7 +54,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center_vertical"
-    android:contentDescription="@null"
+    android:contentDescription="@string/Remove_this_card"
     android:foreground="@drawable/circular_click_indicator_light"
     android:padding="@dimen/grid_2"
     android:src="@drawable/icon_trash" />

--- a/app/src/main/res/layout/item_reward_loading_card.xml
+++ b/app/src/main/res/layout/item_reward_loading_card.xml
@@ -21,6 +21,7 @@
       android:layout_height="wrap_content">
 
       <Button
+        android:contentDescription="@string/Loading"
         android:stateListAnimator="@null"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/item_reward_pledge_card.xml
+++ b/app/src/main/res/layout/item_reward_pledge_card.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView
+<androidx.cardview.widget.CardView xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/card_container"
   style="@style/PledgeStoredCard"
   xmlns:android="http://schemas.android.com/apk/res/android"
@@ -24,15 +24,23 @@
         android:layout_height="wrap_content"
         android:layout_weight="1" />
 
-      <!--todo what should the content description be?-->
-      <!--todo this button is too smol-->
-      <ImageButton
+      <FrameLayout
         android:id="@+id/close_pledge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:background="@drawable/circle_black_alpha"
-        android:contentDescription="@null"
-        android:src="@drawable/ic_close" />
+        android:contentDescription="@string/Cancel"
+        android:paddingStart="@dimen/grid_2"
+        android:paddingBottom="@dimen/grid_2"
+        tools:ignore="RtlSymmetry">
+
+        <ImageButton
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:background="@drawable/circle_black_alpha"
+          android:contentDescription="@null"
+          android:src="@drawable/ic_close" />
+
+      </FrameLayout>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/item_reward_pledge_card.xml
+++ b/app/src/main/res/layout/item_reward_pledge_card.xml
@@ -32,13 +32,14 @@
         android:contentDescription="@string/Cancel"
         android:paddingStart="@dimen/grid_2"
         android:paddingBottom="@dimen/grid_2"
+        android:descendantFocusability="blocksDescendants"
         tools:ignore="RtlSymmetry">
 
         <ImageButton
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:background="@drawable/circle_black_alpha"
-          android:contentDescription="@null"
+          android:importantForAccessibility="no"
           android:src="@drawable/ic_close" />
 
       </FrameLayout>

--- a/app/src/main/res/layout/item_reward_pledge_card.xml
+++ b/app/src/main/res/layout/item_reward_pledge_card.xml
@@ -15,6 +15,7 @@
     <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:baselineAligned="false"
       android:minHeight="@dimen/grid_8"
       android:orientation="horizontal">
 

--- a/app/src/test/java/com/kickstarter/viewmodels/PaymentMethodsViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PaymentMethodsViewHolderViewModelTest.kt
@@ -4,6 +4,7 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.libs.Environment
 import com.kickstarter.mock.factories.StoredCardFactory
+import com.stripe.android.model.Card
 import org.junit.Test
 import rx.observers.TestSubscriber
 import java.util.*
@@ -12,20 +13,24 @@ class PaymentMethodsViewHolderViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var vm: PaymentMethodsViewHolderViewModel.ViewModel
 
-    private val cardIssuer = TestSubscriber<Int>()
+    private val id = TestSubscriber<String>()
+    private val issuer = TestSubscriber<String>()
+    private val issuerImage = TestSubscriber<Int>()
     private val expirationDate = TestSubscriber<String>()
     private val lastFour = TestSubscriber<String>()
 
     private fun setUpEnvironment(environment: Environment) {
         this.vm = PaymentMethodsViewHolderViewModel.ViewModel(environment)
 
-        this.vm.outputs.cardIssuer().subscribe(this.cardIssuer)
+        this.vm.outputs.id().subscribe(this.id)
+        this.vm.outputs.issuer().subscribe(this.issuer)
+        this.vm.outputs.issuerImage().subscribe(this.issuerImage)
         this.vm.outputs.expirationDate().subscribe(this.expirationDate)
         this.vm.outputs.lastFour().subscribe(this.lastFour)
     }
 
     @Test
-    fun testCardExpirationDate() {
+    fun testExpirationDate() {
         setUpEnvironment(environment())
         val calendar = GregorianCalendar(2019, 2, 1)
         val date: Date = calendar.time
@@ -41,7 +46,7 @@ class PaymentMethodsViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testCardLastFourDigits() {
+    fun testLastFour() {
         setUpEnvironment(environment())
         val creditCard = StoredCardFactory.discoverCard()
 
@@ -51,12 +56,22 @@ class PaymentMethodsViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testCardType() {
+    fun testIssuer() {
         setUpEnvironment(environment())
         val creditCard = StoredCardFactory.discoverCard()
 
         this.vm.inputs.card(creditCard)
 
-        this.cardIssuer.assertValue(R.drawable.discover_md)
+        this.issuer.assertValue(Card.CardBrand.DISCOVER)
+    }
+
+    @Test
+    fun testIssuerImage() {
+        setUpEnvironment(environment())
+        val creditCard = StoredCardFactory.discoverCard()
+
+        this.vm.inputs.card(creditCard)
+
+        this.issuerImage.assertValue(R.drawable.discover_md)
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModelTest.kt
@@ -8,6 +8,7 @@ import com.kickstarter.mock.factories.BackingFactory
 import com.kickstarter.mock.factories.PaymentSourceFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.StoredCardFactory
+import com.stripe.android.model.Card
 import org.junit.Test
 import rx.observers.TestSubscriber
 import java.util.*
@@ -20,6 +21,7 @@ class RewardCardViewHolderViewModelTest : KSRobolectricTestCase() {
     private val buttonEnabled = TestSubscriber.create<Boolean>()
     private val expirationDate = TestSubscriber.create<String>()
     private val id = TestSubscriber.create<String>()
+    private val issuer = TestSubscriber.create<String>()
     private val issuerImage = TestSubscriber.create<Int>()
     private val lastFour = TestSubscriber.create<String>()
     private val notAvailableCopyIsVisible = TestSubscriber.create<Boolean>()
@@ -32,6 +34,7 @@ class RewardCardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.buttonEnabled().subscribe(this.buttonEnabled)
         this.vm.outputs.expirationDate().subscribe(this.expirationDate)
         this.vm.outputs.id().subscribe(this.id)
+        this.vm.outputs.issuer().subscribe(this.issuer)
         this.vm.outputs.issuerImage().subscribe(this.issuerImage)
         this.vm.outputs.lastFour().subscribe(this.lastFour)
         this.vm.outputs.notAvailableCopyIsVisible().subscribe(this.notAvailableCopyIsVisible)
@@ -188,6 +191,16 @@ class RewardCardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(Pair(creditCard, ProjectFactory.project()))
 
         this.id.assertValue(creditCard.id())
+    }
+
+    @Test
+    fun testIssuer() {
+        setUpEnvironment(environment())
+        val creditCard = StoredCardFactory.discoverCard()
+
+        this.vm.inputs.configureWith(Pair(creditCard, ProjectFactory.project()))
+
+        this.issuer.assertValue(Card.CardBrand.DISCOVER)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardLoadingCardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardLoadingCardViewHolderViewModelTest.kt
@@ -6,6 +6,7 @@ import com.kickstarter.R
 import com.kickstarter.libs.Environment
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.StoredCardFactory
+import com.stripe.android.model.Card
 import org.junit.Test
 import rx.observers.TestSubscriber
 import java.util.*
@@ -16,6 +17,7 @@ class RewardLoadingCardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     private val expirationDate = TestSubscriber.create<String>()
     private val id = TestSubscriber.create<String>()
+    private val issuer = TestSubscriber.create<String>()
     private val issuerImage = TestSubscriber.create<Int>()
     private val lastFour = TestSubscriber.create<String>()
 
@@ -24,6 +26,7 @@ class RewardLoadingCardViewHolderViewModelTest : KSRobolectricTestCase() {
 
         this.vm.outputs.expirationDate().subscribe(this.expirationDate)
         this.vm.outputs.id().subscribe(this.id)
+        this.vm.outputs.issuer().subscribe(this.issuer)
         this.vm.outputs.issuerImage().subscribe(this.issuerImage)
         this.vm.outputs.lastFour().subscribe(this.lastFour)
     }
@@ -61,6 +64,16 @@ class RewardLoadingCardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(Pair(creditCard, ProjectFactory.project()))
 
         this.issuerImage.assertValue(R.drawable.discover_md)
+    }
+
+    @Test
+    fun testIssuer() {
+        setUpEnvironment(environment())
+        val creditCard = StoredCardFactory.discoverCard()
+
+        this.vm.inputs.configureWith(Pair(creditCard, ProjectFactory.project()))
+
+        this.issuer.assertValue(Card.CardBrand.DISCOVER)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardPledgeCardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardPledgeCardViewHolderViewModelTest.kt
@@ -6,6 +6,7 @@ import com.kickstarter.R
 import com.kickstarter.libs.Environment
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.StoredCardFactory
+import com.stripe.android.model.Card
 import org.junit.Test
 import rx.observers.TestSubscriber
 import java.util.*
@@ -16,6 +17,7 @@ class RewardPledgeCardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     private val expirationDate = TestSubscriber.create<String>()
     private val id = TestSubscriber.create<String>()
+    private val issuer = TestSubscriber.create<String>()
     private val issuerImage = TestSubscriber.create<Int>()
     private val lastFour = TestSubscriber.create<String>()
 
@@ -24,6 +26,7 @@ class RewardPledgeCardViewHolderViewModelTest : KSRobolectricTestCase() {
 
         this.vm.outputs.expirationDate().subscribe(this.expirationDate)
         this.vm.outputs.id().subscribe(this.id)
+        this.vm.outputs.issuer().subscribe(this.issuer)
         this.vm.outputs.issuerImage().subscribe(this.issuerImage)
         this.vm.outputs.lastFour().subscribe(this.lastFour)
     }
@@ -61,6 +64,16 @@ class RewardPledgeCardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(Pair(creditCard, ProjectFactory.project()))
 
         this.issuerImage.assertValue(R.drawable.discover_md)
+    }
+
+    @Test
+    fun testIssuer() {
+        setUpEnvironment(environment())
+        val creditCard = StoredCardFactory.discoverCard()
+
+        this.vm.inputs.configureWith(Pair(creditCard, ProjectFactory.project()))
+
+        this.issuer.assertValue(Card.CardBrand.DISCOVER)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Supporting visual and mobility impaired users in stored cards.

# 🤔 Why
SUPPORT ALL THE USERS

# 🛠 How
- Added `StoredCard.issuer` to return card brand for a11y descriptors (from Stripe).
- Added issuer content description in payment methods list and in checkout.
- Added more padding around cancel card button (when you've selected a card).
- Added content description for loading card.
- Tests.

# 👀 See
Nothing 2 c

# 📋 QA
Turn on TalkBack™ and focus on the stored cards in Settings -> Account -> Payment Methods. 
Turn on TalkBack™ and focus on the stored cards when pledging to a project. 

# Story 📖
[NT-414]


[NT-414]: https://dripsprint.atlassian.net/browse/NT-414