### PR TITLE
[💳] NT-416 Improved a11y in Pledge screen

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/ProjectViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/ProjectViewUtils.kt
@@ -88,25 +88,6 @@ object ProjectViewUtils {
     }
 
     /**
-     * Returns a SpannableString representing formatted currency and shrinking the precision if the value is not whole.
-     *
-     */
-    fun styleCurrency(value: Double): SpannableString {
-        val precision = NumberUtils.precision(value, RoundingMode.HALF_UP)
-        val formattedNumber = NumberUtils.format(value.toFloat(), NumberOptions.builder().precision(precision).build())
-        val spannableString = SpannableString(formattedNumber)
-
-        if (precision != 0) {
-            val startOfPrecision = formattedNumber.length - precision - 1
-            val endOfPrecision = formattedNumber.length
-            spannableString.setSpan(RelativeSizeSpan(.5f), startOfPrecision, endOfPrecision, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-            spannableString.setSpan(CenterSpan(), startOfPrecision, endOfPrecision, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        }
-
-        return spannableString
-    }
-
-    /**
      * Returns a Pair of SpannableString and a Boolean where the
      * SpannableString represents a project's currency symbol that shrinks currency symbol if it's necessary and the
      * Boolean represents whether the symbol should be shown at the end or the start of the currency.
@@ -135,6 +116,25 @@ object ProjectViewUtils {
     }
 
     /**
+     * Returns a SpannableString representing formatted currency and shrinking the precision if the value is not whole.
+     *
+     */
+    private fun styleCurrency(value: Double): SpannableString {
+        val precision = NumberUtils.precision(value, RoundingMode.HALF_UP)
+        val formattedNumber = NumberUtils.format(value.toFloat(), NumberOptions.builder().precision(precision).build())
+        val spannableString = SpannableString(formattedNumber)
+
+        if (precision != 0) {
+            val startOfPrecision = formattedNumber.length - precision - 1
+            val endOfPrecision = formattedNumber.length
+            spannableString.setSpan(RelativeSizeSpan(.5f), startOfPrecision, endOfPrecision, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannableString.setSpan(CenterSpan(), startOfPrecision, endOfPrecision, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+
+        return spannableString
+    }
+
+    /**
      * Returns a CharSequence representing a value in a project's currency based on a user's locale.
      * The precision is shrunken and centered if the number is not whole.
      * The currency symbol is shrunken and centered.
@@ -156,10 +156,12 @@ object ProjectViewUtils {
         spannedCurrencySymbol.setSpan(RelativeSizeSpan(.5f), startOfSymbol, endOfSymbol, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         spannedCurrencySymbol.setSpan(CenterSpan(), startOfSymbol, endOfSymbol, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
 
-        return if (formattedCurrency.startsWith(StringUtils.trim(currencySymbolToDisplay))) {
+        val styledCurrency = if (formattedCurrency.startsWith(StringUtils.trim(currencySymbolToDisplay))) {
             TextUtils.concat(spannedCurrencySymbol, spannedDigits)
         } else {
             TextUtils.concat(spannedDigits, spannedCurrencySymbol)
         }
+
+        return styledCurrency.trim()
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -113,7 +113,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.outputs.additionalPledgeAmount()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { additional_pledge_amount.text = it }
+                .subscribe { setPlusTextView(additional_pledge_amount, it) }
 
         this.viewModel.outputs.additionalPledgeAmountIsGone()
                 .compose(bindToLifecycle())
@@ -216,12 +216,12 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.outputs.pledgeTextColor()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { setTextColor(it, pledge_amount, pledge_symbol_start, pledge_symbol_end) }
+                .subscribe { setTextColor(it, pledge_amount) }
 
         this.viewModel.outputs.totalTextColor()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { setTextColor(it, total_amount, total_symbol_start, total_symbol_end) }
+                .subscribe { setTextColor(it, total_amount) }
 
         this.viewModel.outputs.cardsAndProject()
                 .compose(bindToLifecycle())
@@ -263,17 +263,13 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .compose(observeForUI())
                 .subscribe {
                     ViewUtils.setGone(shipping_amount_loading_view, true)
-                    setVisibility(View.VISIBLE, shipping_symbol_start, shipping_symbol_end)
-                    shipping_amount.text = it
+                    setPlusTextView(shipping_amount, it)
                 }
 
         this.viewModel.outputs.shippingSummaryAmount()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe {
-                    shipping_summary_amount.text = it
-                    setVisibility(View.VISIBLE, shipping_summary_symbol_start, shipping_summary_symbol_end)
-                }
+                .subscribe { setPlusTextView(shipping_summary_amount, it) }
 
         this.viewModel.outputs.shippingSummaryLocation()
                 .compose(bindToLifecycle())
@@ -299,10 +295,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.outputs.pledgeSummaryAmount()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe {
-                    pledge_summary_amount.text = it
-                    setVisibility(View.VISIBLE, pledge_summary_symbol_start, pledge_summary_symbol_end)
-                }
+                .subscribe { pledge_summary_amount.text = it }
 
         this.viewModel.outputs.pledgeSummaryIsGone()
                 .compose(bindToLifecycle())
@@ -319,7 +312,6 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .compose(observeForUI())
                 .subscribe {
                     ViewUtils.setGone(total_amount_loading_view, true)
-                    setVisibility(View.VISIBLE, total_symbol_start, total_symbol_end)
                     total_amount.text = it
                 }
 
@@ -485,28 +477,18 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         val symbol = symbolAndStart.first
         val symbolAtStart = symbolAndStart.second
         if (symbolAtStart) {
-            pledge_summary_symbol_start.text = symbol
             pledge_symbol_start.text = symbol
-            shipping_summary_symbol_start.text = symbol
-            shipping_symbol_start.text = symbol
-            total_symbol_start.text = symbol
-            pledge_summary_symbol_end.text = null
             pledge_symbol_end.text = null
-            shipping_summary_symbol_end.text = null
-            shipping_symbol_end.text = null
-            total_symbol_end.text = null
         } else {
-            pledge_summary_symbol_start.text = null
             pledge_symbol_start.text = null
-            shipping_summary_symbol_start.text = null
-            shipping_symbol_start.text = null
-            total_symbol_start.text = null
-            pledge_summary_symbol_end.text = null
             pledge_symbol_end.text = symbol
-            shipping_summary_symbol_end.text = null
-            shipping_symbol_end.text = symbol
-            total_symbol_end.text = symbol
         }
+    }
+
+    private fun setPlusTextView(textView: TextView, localizedAmount: CharSequence) {
+        val ksString = this.viewModel.environment.ksString()
+        textView.contentDescription = ksString.format(getString(R.string.plus_shipping_cost), "shipping_cost", localizedAmount.toString())
+        textView.text = localizedAmount
     }
 
     private fun setTextColor(colorResId: Int, vararg textViews: TextView) {

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -775,6 +775,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
             pledge_root.visibility = View.VISIBLE
             val bitmap = ViewUtils.getBitmap(reward_to_copy, location.width.toInt(), location.height.toInt())
             reward_snapshot.setImageBitmap(bitmap)
+            reward_snapshot.requestFocus()
             reward_to_copy.visibility = View.GONE
         }
     }

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -32,23 +32,24 @@
 
       <include
         android:id="@+id/reward_to_copy"
+        android:importantForAccessibility="noHideDescendants"
         layout="@layout/item_reward"
         tools:visibility="gone" />
 
-      <!-- todo: what's the content description? -->
       <com.kickstarter.ui.views.BottomCropImageView
         android:id="@+id/reward_snapshot"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/activity_horizontal_margin"
+        android:accessibilityTraversalBefore="@id/pledge_details"
         android:contentDescription="@string/View_rewards"
         android:focusable="true"
         android:focusableInTouchMode="true"
+        android:importantForAccessibility="yes"
         tools:background="@color/white"
         tools:layout_height="@dimen/mini_reward_height"
         tools:layout_width="@dimen/mini_reward_width" />
 
-      <!-- todo: what's the content description? -->
       <FrameLayout
         android:id="@+id/expand_icon_container"
         android:layout_width="@dimen/grid_8"
@@ -73,6 +74,7 @@
         android:id="@+id/pledge_details"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:importantForAccessibility="yes"
         android:orientation="vertical">
 
         <include layout="@layout/fragment_pledge_section_delivery" />

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -43,6 +43,8 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/activity_horizontal_margin"
         android:contentDescription="@string/View_rewards"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
         tools:background="@color/white"
         tools:layout_height="@dimen/mini_reward_height"
         tools:layout_width="@dimen/mini_reward_width" />

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -4,10 +4,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  android:clickable="true"
-  android:fillViewport="true"
-  android:focusable="true"
-  android:focusableInTouchMode="true">
+  android:fillViewport="true">
 
   <FrameLayout
     android:id="@+id/pledge_background"
@@ -45,8 +42,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/activity_horizontal_margin"
-        android:contentDescription="@null"
-        android:elevation="@dimen/mini_reward_elevation"
+        android:contentDescription="@string/View_rewards"
         tools:background="@color/white"
         tools:layout_height="@dimen/mini_reward_height"
         tools:layout_width="@dimen/mini_reward_width" />
@@ -58,6 +54,7 @@
         android:layout_height="@dimen/grid_8"
         android:alpha="0"
         android:elevation="@dimen/mini_reward_elevation"
+        android:importantForAccessibility="no"
         app:layout_anchor="@id/reward_snapshot"
         app:layout_anchorGravity="end"
         tools:alpha="1">
@@ -67,7 +64,7 @@
           android:layout_height="wrap_content"
           android:layout_marginStart="@dimen/grid_1"
           android:layout_marginTop="@dimen/grid_2"
-          android:contentDescription="@null"
+          android:importantForAccessibility="no"
           android:src="@drawable/ic_expand" />
       </FrameLayout>
 

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -3,8 +3,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:fillViewport="true">
+  android:layout_height="match_parent">
 
   <FrameLayout
     android:id="@+id/pledge_background"

--- a/app/src/main/res/layout/fragment_pledge_section_payment.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_payment.xml
@@ -25,6 +25,7 @@
     android:src="@drawable/googlepay_button_content"
     android:visibility="gone" />
 
+  <!--  TODO: show this when Google Pay is available -->
   <TextView
     style="@style/FootnoteSecondary"
     android:layout_width="match_parent"
@@ -33,7 +34,8 @@
     android:layout_marginTop="@dimen/grid_3"
     android:layout_marginEnd="@dimen/activity_vertical_margin"
     android:gravity="center"
-    android:text="@string/Other_payment_methods" />
+    android:text="@string/Other_payment_methods"
+    android:visibility="gone"/>
 
   <androidx.recyclerview.widget.RecyclerView
     android:id="@+id/cards_recycler"

--- a/app/src/main/res/layout/fragment_pledge_section_pledge_amount.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_pledge_amount.xml
@@ -21,7 +21,6 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
-  <!-- TODO: Needs final copy for content descriptions -->
   <ImageButton
     android:id="@+id/decrease_pledge"
     android:layout_width="0dp"
@@ -29,7 +28,7 @@
     android:layout_marginTop="@dimen/grid_1"
     android:background="@drawable/bg_decrease"
     android:backgroundTint="@color/white_enabled_gray_disabled"
-    android:contentDescription="@null"
+    android:contentDescription="@string/Decrease_pledge"
     android:src="@drawable/ic_remove"
     android:tint="@color/green_enabled_dark_grey_disabled"
     app:layout_constraintBottom_toBottomOf="parent"
@@ -43,7 +42,7 @@
     android:layout_marginTop="@dimen/grid_1"
     android:background="@drawable/bg_increase"
     android:backgroundTint="@color/white_enabled_gray_disabled"
-    android:contentDescription="@null"
+    android:contentDescription="@string/Increase_pledge"
     android:src="@drawable/ic_add"
     android:tint="@color/green_enabled_dark_grey_disabled"
     app:layout_constraintBottom_toBottomOf="parent"
@@ -67,11 +66,10 @@
     app:layout_constraintStart_toEndOf="@id/increase_pledge"
     app:layout_constraintTop_toBottomOf="@id/pledge_amount_label">
 
-    <!-- todo: needs some a11y plz-->
     <ImageView
       android:layout_width="@dimen/grid_3"
       android:layout_height="@dimen/grid_3"
-      android:contentDescription="@null"
+      android:importantForAccessibility="no"
       android:src="@drawable/ic_add"
       android:tint="@color/ksr_dark_grey_400" />
 

--- a/app/src/main/res/layout/fragment_pledge_section_pledge_amount.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_pledge_amount.xml
@@ -6,6 +6,7 @@
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:layout_marginBottom="@dimen/grid_4"
+  android:focusable="true"
   android:gravity="center_vertical"
   android:orientation="horizontal"
   tools:showIn="@layout/fragment_pledge">
@@ -102,6 +103,7 @@
       style="@style/PledgeCurrencySecondary"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:focusable="true"
       android:gravity="center_vertical"
       tools:text="$" />
 

--- a/app/src/main/res/layout/fragment_pledge_section_shipping.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_shipping.xml
@@ -33,6 +33,7 @@
     android:imeOptions="actionDone"
     android:inputType="text"
     android:maxLines="1"
+    android:nextFocusDown="@id/shipping_amount"
     android:scrollHorizontally="true"
     android:text="@string/Loading"
     android:textColor="@color/ksr_green_500"
@@ -52,24 +53,9 @@
     android:src="@drawable/ic_add"
     android:tint="@color/ksr_dark_grey_400"
     app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toStartOf="@id/shipping_symbol_start"
+    app:layout_constraintEnd_toStartOf="@id/shipping_amount"
     app:layout_constraintStart_toEndOf="@id/shipping_rules"
     app:layout_constraintTop_toBottomOf="@id/shipping_rules_label" />
-
-  <TextView
-    android:id="@+id/shipping_symbol_start"
-    style="@style/PledgeCurrency"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_gravity="end"
-    android:layout_marginTop="@dimen/grid_1"
-    android:visibility="invisible"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toStartOf="@id/shipping_amount"
-    app:layout_constraintStart_toEndOf="@id/shipping_add_symbol"
-    app:layout_constraintTop_toBottomOf="@id/shipping_rules_label"
-    tools:text="$"
-    tools:visibility="visible" />
 
   <TextView
     android:id="@+id/shipping_amount"
@@ -79,27 +65,12 @@
     android:layout_marginTop="@dimen/grid_1"
     android:maxLines="1"
     app:layout_constrainedWidth="true"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toStartOf="@id/shipping_symbol_end"
-    app:layout_constraintStart_toEndOf="@id/shipping_symbol_start"
-    app:layout_constraintTop_toBottomOf="@id/shipping_rules_label"
-    tools:text="20" />
-
-  <TextView
-    android:id="@+id/shipping_symbol_end"
-    style="@style/PledgeCurrency"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_gravity="end"
-    android:layout_marginTop="@dimen/grid_1"
-    android:visibility="invisible"
+    app:layout_constraintHorizontal_bias="1"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintHorizontal_bias="1"
-    app:layout_constraintStart_toEndOf="@id/shipping_amount"
+    app:layout_constraintStart_toEndOf="@id/shipping_add_symbol"
     app:layout_constraintTop_toBottomOf="@id/shipping_rules_label"
-    tools:text="$"
-    tools:visibility="visible" />
+    tools:text="@string/plus_shipping_cost" />
 
   <View
     android:id="@+id/shipping_amount_loading_view"

--- a/app/src/main/res/layout/fragment_pledge_section_shipping.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_shipping.xml
@@ -6,6 +6,7 @@
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:layout_marginBottom="@dimen/grid_4"
+  android:focusable="true"
   android:gravity="center_vertical"
   android:orientation="horizontal"
   tools:showIn="@layout/fragment_pledge">
@@ -70,7 +71,7 @@
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toEndOf="@id/shipping_add_symbol"
     app:layout_constraintTop_toBottomOf="@id/shipping_rules_label"
-    tools:text="@string/plus_shipping_cost" />
+    tools:text="$10" />
 
   <View
     android:id="@+id/shipping_amount_loading_view"

--- a/app/src/main/res/layout/fragment_pledge_section_summary_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_summary_pledge.xml
@@ -5,6 +5,7 @@
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:id="@+id/pledge_summary"
+  android:focusable="true"
   android:visibility="gone"
   tools:visibility="visible"
   android:orientation="vertical">

--- a/app/src/main/res/layout/fragment_pledge_section_summary_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_summary_pledge.xml
@@ -16,50 +16,25 @@
     android:layout_height="wrap_content"
     android:text="@string/Pledge"
     app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toStartOf="@id/pledge_summary_amount_container"
+    app:layout_constraintEnd_toStartOf="@id/pledge_summary_amount"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
-  <LinearLayout
-    android:id="@+id/pledge_summary_amount_container"
+  <TextView
+    android:id="@+id/pledge_summary_amount"
+    style="@style/PledgeCurrencySecondary"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:gravity="center_vertical|end"
+    android:maxLines="1"
     android:orientation="horizontal"
+    android:scrollHorizontally="true"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintHorizontal_bias="1"
     app:layout_constraintStart_toEndOf="@id/pledge_label"
     app:layout_constraintTop_toTopOf="parent"
-    app:layout_constraintVertical_bias="0">
-
-    <TextView
-      android:id="@+id/pledge_summary_symbol_start"
-      style="@style/PledgeCurrencySecondary"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:visibility="invisible"
-      tools:text="$"
-      tools:visibility="visible" />
-
-    <TextView
-      android:id="@+id/pledge_summary_amount"
-      style="@style/PledgeCurrencySecondary"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:maxLines="1"
-      android:scrollHorizontally="true"
-      tools:text="40" />
-
-    <TextView
-      android:id="@+id/pledge_summary_symbol_end"
-      style="@style/PledgeCurrencySecondary"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:visibility="invisible"
-      tools:text="$"
-      tools:visibility="visible" />
-
-  </LinearLayout>
+    app:layout_constraintVertical_bias="0"
+    tools:text="$40" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_pledge_section_summary_shipping.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_summary_shipping.xml
@@ -5,6 +5,7 @@
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:id="@+id/shipping_summary"
+  android:focusable="true"
   android:visibility="gone"
   tools:visibility="visible"
   android:orientation="vertical">

--- a/app/src/main/res/layout/fragment_pledge_section_summary_shipping.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_summary_shipping.xml
@@ -30,23 +30,9 @@
     android:src="@drawable/ic_add"
     android:tint="@color/ksr_dark_grey_400"
     app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toStartOf="@id/shipping_summary_symbol_start"
+    app:layout_constraintEnd_toStartOf="@id/shipping_summary_amount"
     app:layout_constraintStart_toEndOf="@id/shipping_label"
     app:layout_constraintTop_toTopOf="parent" />
-
-
-  <TextView
-    android:id="@+id/shipping_summary_symbol_start"
-    style="@style/PledgeCurrency"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:visibility="invisible"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toStartOf="@id/shipping_summary_amount"
-    app:layout_constraintStart_toEndOf="@id/shipping_summary_add_symbol"
-    app:layout_constraintTop_toTopOf="parent"
-    tools:text="$"
-    tools:visibility="visible" />
 
   <TextView
     android:id="@+id/shipping_summary_amount"
@@ -57,24 +43,11 @@
     android:scrollHorizontally="true"
     app:layout_constrainedWidth="true"
     app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toStartOf="@id/shipping_summary_symbol_end"
-    app:layout_constraintStart_toEndOf="@id/shipping_summary_symbol_start"
-    app:layout_constraintTop_toTopOf="parent"
-    tools:text="40" />
-
-  <TextView
-    android:id="@+id/shipping_summary_symbol_end"
-    style="@style/PledgeCurrency"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:visibility="invisible"
-    app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintHorizontal_bias="1"
-    app:layout_constraintStart_toEndOf="@id/shipping_summary_amount"
+    app:layout_constraintStart_toEndOf="@id/shipping_summary_add_symbol"
     app:layout_constraintTop_toTopOf="parent"
-    tools:text="$"
-    tools:visibility="visible" />
+    tools:text="$40" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_pledge_section_total.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_total.xml
@@ -42,52 +42,27 @@
       android:orientation="vertical"
       app:layout_constraintGuide_percent="0.6" />
 
-    <LinearLayout
-      android:id="@+id/total_container"
-      android:layout_width="0dp"
+    <TextView
+      android:id="@+id/total_amount"
+      style="@style/PledgeCurrencySecondary"
+      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:gravity="center_vertical|end"
-      android:orientation="horizontal"
+      android:maxLines="1"
+      android:scrollHorizontally="true"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintHorizontal_bias="1"
       app:layout_constraintStart_toEndOf="@id/pledge_agreement"
       app:layout_constraintTop_toTopOf="parent"
-      app:layout_constraintVertical_bias="0">
-
-      <TextView
-        android:id="@+id/total_symbol_start"
-        style="@style/PledgeCurrencySecondary"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="invisible"
-        tools:text="$" />
-
-      <TextView
-        android:id="@+id/total_amount"
-        style="@style/PledgeCurrencySecondary"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:maxLines="1"
-        android:scrollHorizontally="true"
-        tools:text="40" />
-
-      <TextView
-        android:id="@+id/total_symbol_end"
-        style="@style/PledgeCurrencySecondary"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="invisible"
-        tools:text="$" />
-
-    </LinearLayout>
+      app:layout_constraintVertical_bias="0"
+      tools:text="40" />
 
     <View
       android:id="@+id/total_amount_loading_view"
       android:layout_width="@dimen/grid_11"
       android:layout_height="@dimen/grid_2"
       android:background="@drawable/pledge_amounts_loading_states"
-      app:layout_constraintBottom_toBottomOf="@id/total_container"
+      app:layout_constraintBottom_toBottomOf="@id/total_amount"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintHorizontal_bias="1"
       app:layout_constraintStart_toEndOf="@id/pledge_agreement"
@@ -104,7 +79,7 @@
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintHorizontal_bias="1"
       app:layout_constraintStart_toEndOf="@id/pledge_agreement"
-      app:layout_constraintTop_toBottomOf="@id/total_container"
+      app:layout_constraintTop_toBottomOf="@id/total_amount"
       app:layout_constraintVertical_bias="0"
       tools:text="About $40.00" />
 

--- a/app/src/main/res/layout/fragment_pledge_section_total.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_total.xml
@@ -6,6 +6,7 @@
   android:id="@+id/total"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
+  android:focusable="true"
   android:orientation="vertical"
   tools:showIn="@layout/fragment_pledge">
 

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -208,6 +208,7 @@
       style="@style/PledgeButton"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:contentDescription="@string/Select_this_reward"
       tools:text="Select" />
 
   </FrameLayout>

--- a/app/src/main/res/values-de/strings_i18n.xml
+++ b/app/src/main/res/values-de/strings_i18n.xml
@@ -135,6 +135,7 @@ Bitte antippen und erneut versuchen.</string>
   <string name="Daily_digest" formatted="false">Tägliche Zusammenfassung</string>
   <string name="Daily_summary" formatted="false">Übersicht (einmal täglich)</string>
   <string name="Data_will_appear_here_once" formatted="false">Info wird hier angezeigt, sobald jemand dein Projekt unterstützt.</string>
+  <string name="Decrease_pledge" formatted="false">Decrease pledge</string>
   <string name="Delete_my_Kickstarter_Account" formatted="false">Mein Kickstarter-Konto löschen</string>
   <string name="Delivered" formatted="false">Verschickt</string>
   <string name="Description" formatted="false">Beschreibung</string>
@@ -240,6 +241,7 @@ Bitte antippen und erneut versuchen.</string>
   <string name="If_you_turn_following_off" formatted="false">Wenn du diese Funktion abwählst, kannst du niemandem mehr folgen und es wird dir auch niemand folgen können. Dein Profil wird den Leuten, denen du gefolgt bist, nicht mehr angezeigt. Dies kann nicht rückgängig gemacht werden.</string>
   <string name="If_your_profile_is_private" formatted="false">Wenn dein Profil privat ist, sind dein Namen und dein Profilbild für Andere sichtbar.</string>
   <string name="If_your_profile_is_public" formatted="false">Wenn dein Profil nicht privat ist, sind außerdem die Projekte, die du unterstützt hast, dein Standort, deine Biografie und deine Websites für Andere sichtbar.</string>
+  <string name="Increase_pledge" formatted="false">Increase pledge</string>
   <string name="Individual_Emails" formatted="false">Individuelle E-Mails</string>
   <string name="Info" formatted="false">Info</string>
   <string name="Introduce_yourself" formatted="false">Stelle dich vor</string>

--- a/app/src/main/res/values-es/strings_i18n.xml
+++ b/app/src/main/res/values-es/strings_i18n.xml
@@ -135,6 +135,7 @@ Haz clic para volver a intentarlo.</string>
   <string name="Daily_digest" formatted="false">Resumen diario</string>
   <string name="Daily_summary" formatted="false">Resumen diario</string>
   <string name="Data_will_appear_here_once" formatted="false">Los datos aparecerán aquí una vez que alguien patrocine tu proyecto.</string>
+  <string name="Decrease_pledge" formatted="false">Decrease pledge</string>
   <string name="Delete_my_Kickstarter_Account" formatted="false">Eliminar mi cuenta de Kickstarter</string>
   <string name="Delivered" formatted="false">Entregado</string>
   <string name="Description" formatted="false">Descripción</string>
@@ -241,6 +242,7 @@ Haz clic para volver a intentarlo.</string>
   <string name="If_your_profile_is_private" formatted="false">Si tu perfil es privado, otros usuarios podrán ver tu nombre e imagen.\n
 </string>
   <string name="If_your_profile_is_public" formatted="false">Si tu perfil no es privado, otros usuarios también podrán ver los proyectos que has patrocinado, tu ubicación, biografía y sitios web.</string>
+  <string name="Increase_pledge" formatted="false">Increase pledge</string>
   <string name="Individual_Emails" formatted="false">Notificaciones por correo electrónico individuales</string>
   <string name="Info" formatted="false">Información</string>
   <string name="Introduce_yourself" formatted="false">Preséntate</string>

--- a/app/src/main/res/values-fr/strings_i18n.xml
+++ b/app/src/main/res/values-fr/strings_i18n.xml
@@ -135,6 +135,7 @@ contributeurs</string>
   <string name="Daily_digest" formatted="false">Résumé quotidien</string>
   <string name="Daily_summary" formatted="false">Une fois par jour</string>
   <string name="Data_will_appear_here_once" formatted="false">Ces données seront visibles dès que vous aurez reçu votre première contribution.</string>
+  <string name="Decrease_pledge" formatted="false">Decrease pledge</string>
   <string name="Delete_my_Kickstarter_Account" formatted="false">Supprimer mon compte Kickstarter</string>
   <string name="Delivered" formatted="false">Distribué</string>
   <string name="Description" formatted="false">Description</string>
@@ -240,6 +241,7 @@ contributeurs</string>
   <string name="If_you_turn_following_off" formatted="false">Si vous désactivez les fonctionnalités de suivi, vous ne pourrez pas vous abonner aux activités des autres et plus personne ne pourra suivre les vôtres. Votre profil sera déconnecté de tous vos abonnés. Cette action ne pourra pas être annulée.</string>
   <string name="If_your_profile_is_private" formatted="false">Si votre profil est privé, seuls votre nom et votre photo seront visibles.</string>
   <string name="If_your_profile_is_public" formatted="false">Si votre profil n\'est pas privé, les projets que vous avez soutenus, votre bio, votre emplacement géographique et vos sites Web seront également visibles.</string>
+  <string name="Increase_pledge" formatted="false">Increase pledge</string>
   <string name="Individual_Emails" formatted="false">E-mails individuels</string>
   <string name="Info" formatted="false">Info</string>
   <string name="Introduce_yourself" formatted="false">Présentez-vous ici.</string>

--- a/app/src/main/res/values-ja/strings_i18n.xml
+++ b/app/src/main/res/values-ja/strings_i18n.xml
@@ -133,6 +133,7 @@
   <string name="Daily_digest" formatted="false">デイリーダイジェスト</string>
   <string name="Daily_summary" formatted="false">1日1回の概要</string>
   <string name="Data_will_appear_here_once" formatted="false">誰かがプロジェクトをバック（支援）すると、ここにデータが表示されます。</string>
+  <string name="Decrease_pledge" formatted="false">Decrease pledge</string>
   <string name="Delete_my_Kickstarter_Account" formatted="false">Kickstarter アカウントを削除</string>
   <string name="Delivered" formatted="false">発送済</string>
   <string name="Description" formatted="false">説明</string>
@@ -238,6 +239,7 @@
   <string name="If_you_turn_following_off" formatted="false">フォローをオフにすると、あなたは誰もフォローすることができなくなり、また他の人があなたをフォローすることもできなくなります。また、既存のフォロワーとのつながりも絶たれます。この操作は後から元に戻すことはできませんのでご注意ください。</string>
   <string name="If_your_profile_is_private" formatted="false">プロフィールがプライベート (非公開) 設定の場合、あなたの名前と写真が表示されます。</string>
   <string name="If_your_profile_is_public" formatted="false">プロフィールがプライベート (非公開) 設定でない場合は、過去にあなたがバックしたプロジェクトや、あなたの地域情報、あなたの自己紹介欄とウェブサイトも表示されます。</string>
+  <string name="Increase_pledge" formatted="false">Increase pledge</string>
   <string name="Individual_Emails" formatted="false">個人メール</string>
   <string name="Info" formatted="false">インフォメーション</string>
   <string name="Introduce_yourself" formatted="false">自己紹介</string>

--- a/app/src/main/res/values/strings_i18n.xml
+++ b/app/src/main/res/values/strings_i18n.xml
@@ -135,6 +135,7 @@ Please tap to retry.</string>
   <string name="Daily_digest" formatted="false">Daily digest</string>
   <string name="Daily_summary" formatted="false">Daily summary</string>
   <string name="Data_will_appear_here_once" formatted="false">Data will appear here once somebody backs your project.</string>
+  <string name="Decrease_pledge" formatted="false">Decrease pledge</string>
   <string name="Delete_my_Kickstarter_Account" formatted="false">Delete my Kickstarter account</string>
   <string name="Delivered" formatted="false">Delivered</string>
   <string name="Description" formatted="false">Description</string>
@@ -240,6 +241,7 @@ Please tap to retry.</string>
   <string name="If_you_turn_following_off" formatted="false">If you turn following off, you won\'t be able to follow anyone and no one will be able to follow you. Your profile will be disconnected from all of your followers.</string>
   <string name="If_your_profile_is_private" formatted="false">If your profile is private, others can see your name and picture.</string>
   <string name="If_your_profile_is_public" formatted="false">If your profile is not private, others can also see the projects you\'ve backed, your location, bio and websites.</string>
+  <string name="Increase_pledge" formatted="false">Increase pledge</string>
   <string name="Individual_Emails" formatted="false">Individual emails</string>
   <string name="Info" formatted="false">Info</string>
   <string name="Introduce_yourself" formatted="false">Introduce yourself</string>

--- a/app/src/test/java/com/kickstarter/libs/utils/ProjectViewUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/ProjectViewUtilsTest.kt
@@ -59,8 +59,8 @@ class ProjectViewUtilsTest : KSRobolectricTestCase() {
     fun testStyleCurrency_nonUS() {
         val currency = createKSCurrency("DE")
 
-        assertEquals(" US$ 30", ProjectViewUtils.styleCurrency(30.0, ProjectFactory.project(), currency).toString())
-        assertEquals(" US$ 30.50", ProjectViewUtils.styleCurrency(30.5, ProjectFactory.project(), currency).toString())
+        assertEquals("US$ 30", ProjectViewUtils.styleCurrency(30.0, ProjectFactory.project(), currency).toString())
+        assertEquals("US$ 30.50", ProjectViewUtils.styleCurrency(30.5, ProjectFactory.project(), currency).toString())
     }
 
     private fun createKSCurrency(countryCode: String): KSCurrency {

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -52,15 +52,15 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val pledgeAmount = TestSubscriber<String>()
     private val pledgeHint = TestSubscriber<String>()
     private val pledgeSectionIsGone = TestSubscriber<Boolean>()
-    private val pledgeSummaryAmount = TestSubscriber<String>()
+    private val pledgeSummaryAmount = TestSubscriber<CharSequence>()
     private val pledgeSummaryIsGone = TestSubscriber<Boolean>()
     private val pledgeTextColor = TestSubscriber<Int>()
     private val projectCurrencySymbol = TestSubscriber<String>()
     private val selectedShippingRule = TestSubscriber<ShippingRule>()
-    private val shippingAmount = TestSubscriber<String>()
+    private val shippingAmount = TestSubscriber<CharSequence>()
     private val shippingRuleAndProject = TestSubscriber<Pair<List<ShippingRule>, Project>>()
     private val shippingRulesSectionIsGone = TestSubscriber<Boolean>()
-    private val shippingSummaryAmount = TestSubscriber<String>()
+    private val shippingSummaryAmount = TestSubscriber<CharSequence>()
     private val shippingSummaryIsGone = TestSubscriber<Boolean>()
     private val shippingSummaryLocation = TestSubscriber<String>()
     private val showMinimumWarning = TestSubscriber<String>()
@@ -77,7 +77,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val startRewardExpandAnimation = TestSubscriber<Void>()
     private val startRewardShrinkAnimation = TestSubscriber<PledgeData>()
     private val startThanksActivity = TestSubscriber<Project>()
-    private val totalAmount = TestSubscriber<String>()
+    private val totalAmount = TestSubscriber<CharSequence>()
     private val totalDividerIsGone = TestSubscriber<Boolean>()
     private val totalTextColor = TestSubscriber<Int>()
     private val updatePledgeButtonIsEnabled = TestSubscriber<Boolean>()
@@ -108,15 +108,15 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.pledgeAmount().subscribe(this.pledgeAmount)
         this.vm.outputs.pledgeHint().subscribe(this.pledgeHint)
         this.vm.outputs.pledgeSectionIsGone().subscribe(this.pledgeSectionIsGone)
-        this.vm.outputs.pledgeSummaryAmount().subscribe(this.pledgeSummaryAmount)
+        this.vm.outputs.pledgeSummaryAmount().map { it.toString() }.subscribe(this.pledgeSummaryAmount)
         this.vm.outputs.pledgeSummaryIsGone().subscribe(this.pledgeSummaryIsGone)
         this.vm.outputs.pledgeTextColor().subscribe(this.pledgeTextColor)
         this.vm.outputs.projectCurrencySymbol().map { StringUtils.trim(it.first.toString()) }.subscribe(this.projectCurrencySymbol)
         this.vm.outputs.selectedShippingRule().subscribe(this.selectedShippingRule)
-        this.vm.outputs.shippingAmount().subscribe(this.shippingAmount)
+        this.vm.outputs.shippingAmount().map { it.toString() }.subscribe(this.shippingAmount)
         this.vm.outputs.shippingRulesAndProject().subscribe(this.shippingRuleAndProject)
         this.vm.outputs.shippingRulesSectionIsGone().subscribe(this.shippingRulesSectionIsGone)
-        this.vm.outputs.shippingSummaryAmount().subscribe(this.shippingSummaryAmount)
+        this.vm.outputs.shippingSummaryAmount().map { it.toString() }.subscribe(this.shippingSummaryAmount)
         this.vm.outputs.shippingSummaryIsGone().subscribe(this.shippingSummaryIsGone)
         this.vm.outputs.shippingSummaryLocation().subscribe(this.shippingSummaryLocation)
         this.vm.outputs.showMinimumWarning().subscribe(this.showMinimumWarning)
@@ -526,7 +526,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         setUpEnvironment(environment(), reward, backedProject, PledgeReason.UPDATE_PAYMENT)
 
-        this.pledgeSummaryAmount.assertValue("30")
+        this.pledgeSummaryAmount.assertValue("$30")
     }
 
     @Test
@@ -568,7 +568,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
                 .build()
         setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PLEDGE)
 
-        this.totalAmount.assertValue("40")
+        this.totalAmount.assertValue("$40")
     }
 
     @Test
@@ -610,7 +610,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
                 .build()
         setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PAYMENT)
 
-        this.totalAmount.assertValue("40")
+        this.totalAmount.assertValue("$40")
     }
 
     @Test
@@ -621,7 +621,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
         setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_REWARD)
 
-        this.totalAmount.assertValue("50")
+        this.totalAmount.assertValue("$50")
     }
 
     @Test
@@ -662,8 +662,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeAmount.assertValues("20", "21")
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
-        this.shippingAmount.assertValue("30")
-        this.totalAmount.assertValues("50", "51")
+        this.shippingAmount.assertValue("$30")
+        this.totalAmount.assertValues("$50", "$51")
         this.totalTextColor.assertValue(R.color.ksr_green_500)
         this.projectCurrencySymbol.assertValue("$")
         this.additionalPledgeAmount.assertValues("$0", "$1")
@@ -678,8 +678,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeAmount.assertValues("20", "21", "20")
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
-        this.totalAmount.assertValues("50", "51", "50")
-        this.shippingAmount.assertValue("30")
+        this.totalAmount.assertValues("$50", "$51", "$50")
+        this.shippingAmount.assertValue("$30")
         this.projectCurrencySymbol.assertValue("$")
         this.totalTextColor.assertValue(R.color.ksr_green_500)
         this.additionalPledgeAmount.assertValues("$0", "$1", "$0")
@@ -703,8 +703,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeAmount.assertValues("20", "40")
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
-        this.shippingAmount.assertValue("30")
-        this.totalAmount.assertValues("50", "70")
+        this.shippingAmount.assertValue("$30")
+        this.totalAmount.assertValues("$50", "$70")
         this.totalTextColor.assertValue(R.color.ksr_green_500)
         this.projectCurrencySymbol.assertValue("$")
         this.additionalPledgeAmount.assertValues("$0", "$20")
@@ -720,8 +720,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeAmount.assertValues("20", "40", "10")
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValues(R.color.ksr_green_500, R.color.ksr_red_400)
-        this.shippingAmount.assertValue("30")
-        this.totalAmount.assertValues("50", "70", "40")
+        this.shippingAmount.assertValue("$30")
+        this.totalAmount.assertValues("$50", "$70", "$40")
         this.totalTextColor.assertValues(R.color.ksr_green_500, R.color.ksr_red_400)
         this.projectCurrencySymbol.assertValue("$")
         this.additionalPledgeAmount.assertValues("$0", "$20", "$0")
@@ -746,7 +746,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
         this.shippingAmount.assertNoValues()
-        this.totalAmount.assertValues("20", "21")
+        this.totalAmount.assertValues("$20", "$21")
         this.totalTextColor.assertValue(R.color.ksr_green_500)
         this.conversionText.assertValues("$20.00", "$21.00")
         this.conversionTextViewIsGone.assertValues(true)
@@ -765,7 +765,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
         this.shippingAmount.assertNoValues()
-        this.totalAmount.assertValues("20", "21", "20")
+        this.totalAmount.assertValues("$20", "$21", "$20")
         this.totalTextColor.assertValue(R.color.ksr_green_500)
         this.conversionText.assertValues("$20.00", "$21.00", "$20.00")
         this.conversionTextViewIsGone.assertValues(true)
@@ -791,7 +791,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
         this.shippingAmount.assertNoValues()
-        this.totalAmount.assertValues("20", "40")
+        this.totalAmount.assertValues("$20", "$40")
         this.totalTextColor.assertValue(R.color.ksr_green_500)
         this.projectCurrencySymbol.assertValue("$")
         this.additionalPledgeAmount.assertValues("$0", "$20")
@@ -808,7 +808,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValues(R.color.ksr_green_500, R.color.ksr_red_400)
         this.shippingAmount.assertNoValues()
-        this.totalAmount.assertValues("20", "40", "10")
+        this.totalAmount.assertValues("$20", "$40", "$10")
         this.totalTextColor.assertValues(R.color.ksr_green_500, R.color.ksr_red_400)
         this.projectCurrencySymbol.assertValue("$")
         this.additionalPledgeAmount.assertValues("$0", "$20", "$0")
@@ -836,8 +836,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeAmount.assertValues("20")
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValues(R.color.ksr_green_500)
-        this.shippingAmount.assertValues("30", "40")
-        this.totalAmount.assertValues("50", "60")
+        this.shippingAmount.assertValues("$30", "$40")
+        this.totalAmount.assertValues("$50", "$60")
         this.totalTextColor.assertValues(R.color.ksr_green_500)
         this.projectCurrencySymbol.assertValue("$")
         this.additionalPledgeAmount.assertValues("$0")
@@ -862,8 +862,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeAmount.assertValues("20", "30")
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
-        this.shippingAmount.assertValue("30")
-        this.totalAmount.assertValues("50", "60")
+        this.shippingAmount.assertValue("MX$ 30")
+        this.totalAmount.assertValues("MX$ 50", "MX$ 60")
         this.totalTextColor.assertValue(R.color.ksr_green_500)
         this.projectCurrencySymbol.assertValue("MX$")
         this.additionalPledgeAmount.assertValues("MX$ 0", "MX$ 10")
@@ -878,9 +878,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeAmount.assertValues("20", "30", "20")
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
-        this.shippingAmount.assertValue("30")
-        this.totalAmount.assertValues("50", "60", "50")
-        this.shippingAmount.assertValue("30")
+        this.shippingAmount.assertValue("MX$ 30")
+        this.totalAmount.assertValues("MX$ 50", "MX$ 60", "MX$ 50")
         this.totalTextColor.assertValue(R.color.ksr_green_500)
         this.projectCurrencySymbol.assertValue("MX$")
         this.additionalPledgeAmount.assertValues("MX$ 0", "MX$ 10", "MX$ 0")
@@ -905,8 +904,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeAmount.assertValues("20", "40")
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
-        this.shippingAmount.assertValue("30")
-        this.totalAmount.assertValues("50", "70")
+        this.shippingAmount.assertValue("MX$ 30")
+        this.totalAmount.assertValues("MX$ 50", "MX$ 70")
         this.totalTextColor.assertValue(R.color.ksr_green_500)
         this.additionalPledgeAmount.assertValues("MX$ 0", "MX$ 20")
         this.projectCurrencySymbol.assertValue("MX$")
@@ -921,8 +920,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeAmount.assertValues("20", "40", "10")
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValuesAndClear(R.color.ksr_green_500, R.color.ksr_red_400)
-        this.shippingAmount.assertValue("30")
-        this.totalAmount.assertValuesAndClear("50", "70", "40")
+        this.shippingAmount.assertValue("MX$ 30")
+        this.totalAmount.assertValues("MX$ 50", "MX$ 70", "MX$ 40")
         this.totalTextColor.assertValuesAndClear(R.color.ksr_green_500, R.color.ksr_red_400)
         this.additionalPledgeAmount.assertValues("MX$ 0", "MX$ 20", "MX$ 0")
         this.projectCurrencySymbol.assertValue("MX$")
@@ -950,8 +949,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeAmount.assertValues("20")
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
-        this.shippingAmount.assertValues("30", "40")
-        this.totalAmount.assertValues("50", "60")
+        this.shippingAmount.assertValues("MX$ 30", "MX$ 40")
+        this.totalAmount.assertValues("MX$ 50", "MX$ 60")
         this.totalTextColor.assertValue(R.color.ksr_green_500)
         this.projectCurrencySymbol.assertValue("MX$")
         this.additionalPledgeAmount.assertValue("MX$ 0")
@@ -1069,7 +1068,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         setUpEnvironment(environment(), reward, backedProject, PledgeReason.UPDATE_PAYMENT)
 
-        this.shippingSummaryAmount.assertValue("10")
+        this.shippingSummaryAmount.assertValue("$10")
     }
 
     @Test
@@ -1738,6 +1737,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.additionalPledgeAmount.assertValue("MX$ 0")
         this.conversionText.assertValue("$37.50")
         this.conversionTextViewIsGone.assertValues(false)
+        this.shippingAmount.assertValue("MX$ 30")
+        this.totalAmount.assertValues("MX$ 50")
     }
 
     private fun assertInitialPledgeCurrencyStates_WithShipping_USProject() {
@@ -1745,6 +1746,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.additionalPledgeAmount.assertValue("$0")
         this.conversionText.assertValue("$50.00")
         this.conversionTextViewIsGone.assertValues(true)
+        this.shippingAmount.assertValue("$30")
+        this.totalAmount.assertValues("$50")
     }
 
     private fun assertInitialPledgeState_NoShipping() {
@@ -1755,7 +1758,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
         this.shippingAmount.assertNoValues()
-        this.totalAmount.assertValues("20")
+        this.totalAmount.assertValues("$20")
         this.totalTextColor.assertValue(R.color.ksr_green_500)
     }
 
@@ -1766,8 +1769,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeAmount.assertValues("20")
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
-        this.shippingAmount.assertValue("30")
-        this.totalAmount.assertValues("50")
         this.totalTextColor.assertValue(R.color.ksr_green_500)
     }
 


### PR DESCRIPTION
# 📲 What
Improving a11y on Pledge screen.

# 🤔 Why
It's non-negotiable.

# 🛠 How
- Pledge screen is now fully traversable.
  - The screen starts with the mini reward focused so users can jump back to rewards list.
- Currency that can't be edited (shipping, total, pledge summary, shipping summary) now read as one element.
  - `pledgeSummaryAmount`, `shippingAmount`, `shippingSummaryAmount`, and `totalAmount` outputs in the `PledgeFragmentViewModel` are now `CharSequence`s instead of `String`s.
  - Removed currency symbol `TextView`s in shipping section `fragment_pledge_section_shipping.xml`, pledge summary section `fragment_pledge_section_summary_pledge.xml`, shipping summary section `fragment_pledge_section_summary_shipping.xml`, and total section `fragment_pledge_section_total.xml`
  - `ProjectViewUtils. styleCurrency(amount: Double)` (method used to style a currency's precision) is now a private helper method used by `ProjectViewUtils.styleCurrency(value: Double, project: Project, ksCurrency: KSCurrency)`.
  - ProjectViewUtils.styleCurrency(value: Double, project: Project, ksCurrency: KSCurrency) no longer returns currency with trailing or leading white space.
- Added a helper method `PledgeFragment.setPlusTextView` so currency with a + image reads as "plus {currency_amount}"
- Hiding `Other payment methods` label while Google Pay is not supported.
- Reward `Select` button's content description is now `Select this reward`.
- Updated strings.

# 👀 See
Absolutely looks identical!

# 📋 QA
Turn on TalkBack™ and navigate to the pledge screen. The focus should start with the mini reward.

# Story 📖
[NT-416]


[NT-416]: https://dripsprint.atlassian.net/browse/NT-416