### PR TITLE
[🐛] NPE when saving card unsuccessfully in settings

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/NewCardFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/NewCardFragment.kt
@@ -83,7 +83,7 @@ class NewCardFragment : BaseFragment<NewCardFragmentViewModel.ViewModel>() {
         this.viewModel.outputs.error()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { showSnackbar(new_card_root, getString(R.string.Something_went_wrong_please_try_again)) }
+                .subscribe { showSnackbar(new_card_toolbar, getString(R.string.Something_went_wrong_please_try_again)) }
 
         this.viewModel.outputs.modalError()
                 .compose(bindToLifecycle())


### PR DESCRIPTION
# 📲 What
Fixes NPE when unsuccessfully saving a card in settings.

# 🤔 Why
Ideally...we would not crash.

# 🛠 How
- `new_card_root` is `null` when the `NewCardFragment` is not shown modally.

# 📋 QA
Stripe will still crash if you attempt to save a card without a network connection so I'm not sure how to test.

# Story 📖
[NT-225]


[NT-225]: https://dripsprint.atlassian.net/browse/NT-225