### PR TITLE
[🐛] NT-455 Fixing bug when viewing rewards of a backed project.

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -450,8 +450,8 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         }
     }
 
-    private fun clearFragmentBackStack() {
-        supportFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+    private fun clearFragmentBackStack() : Boolean {
+        return supportFragmentManager.popBackStackImmediate(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
     }
 
     private fun expandPledgeSheet(expandAndAnimate: Pair<Boolean, Boolean>) {
@@ -605,9 +605,11 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     private fun showBackingFragment(project: Project) {
         val (rewardsFragment, backingFragment) = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment to
                 supportFragmentManager.findFragmentById(R.id.fragment_backing) as BackingFragment
-        if (supportFragmentManager.backStackEntryCount == 0) {
-            rewardsFragment.view?.visibility = View.GONE
-            backingFragment.view?.visibility = View.VISIBLE
+        if(!rewardsFragment.isHidden && supportFragmentManager.backStackEntryCount == 0 && !isFinishing) {
+            supportFragmentManager.beginTransaction()
+                    .show(backingFragment)
+                    .hide(rewardsFragment)
+                    .commitNow()
         }
         renderProject(backingFragment, rewardsFragment, project)
     }
@@ -629,9 +631,11 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     }
 
     private fun showCreatePledgeSuccess(project: Project) {
-        clearFragmentBackStack()
-        startActivity(Intent(this, ThanksActivity::class.java)
-                .putExtra(IntentKey.PROJECT, project))
+        if(clearFragmentBackStack()) {
+            showBackingFragment(project)
+            startActivity(Intent(this, ThanksActivity::class.java)
+                    .putExtra(IntentKey.PROJECT, project))
+        }
     }
 
     private fun showPledgeNotCancelableDialog() {
@@ -661,9 +665,11 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     private fun showRewardsFragment(project: Project) {
         val (rewardsFragment, backingFragment) = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment to
         supportFragmentManager.findFragmentById(R.id.fragment_backing) as BackingFragment
-        if (supportFragmentManager.backStackEntryCount == 0) {
-            rewardsFragment.view?.visibility = View.VISIBLE
-            backingFragment.view?.visibility = View.GONE
+        if(!backingFragment.isHidden && supportFragmentManager.backStackEntryCount == 0 && !isFinishing) {
+            supportFragmentManager.beginTransaction()
+                    .show(rewardsFragment)
+                    .hide(backingFragment)
+                    .commitNow()
         }
         renderProject(backingFragment, rewardsFragment, project)
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -631,7 +631,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     }
 
     private fun showCreatePledgeSuccess(project: Project) {
-        if(clearFragmentBackStack()) {
+        if (clearFragmentBackStack()) {
             showBackingFragment(project)
             startActivity(Intent(this, ThanksActivity::class.java)
                     .putExtra(IntentKey.PROJECT, project))


### PR DESCRIPTION
# 📲 What
Fixes bug where rewards were hidden the first time a user try to view rewards of a backed project

# 🤔 Why
Issa bug fix

# 🛠 How

![image](https://user-images.githubusercontent.com/1289295/67125478-dc17af80-f1c2-11e9-86d3-4aeb118be1fb.png)

**What's my problem this time?**
Okay so, first I noticed a crash due to an `IllegalStateException` when starting the `ThanksActivity` after a pledge was successfully created. I was attempting to commit a `FragmentTransaction` (to show the `RewardsFragment` and hide the `BackingFragment`) after the `onPause` lifecycle method of the `ProjectActivity` was called. You can't do that because it causes state loss.

**First attempt**
I stopped committing a `FragmentTransaction` and just toggled the visibility of the `RewardsFragment` and the `BackingFragment`. That is all good and fine except if you're viewing a backed project, the `RewardsFragment` would initially be hidden.

**This PR, a legit fix**
I had the right idea to show/hide the 2 `Fragments` but it needed 3 tweaks.
1. `clearFragmentBackStack` is now synchronous and I wait until it returns successfully to show the `ThanksActivity`.
2. I also now call `showBackingFragment ` in `showCreatePledgeSuccess` so that when the backed project emits again and `showBackingFragment` is called, `!backingFragment.isHidden` will be `false` so it won't attempt to reshow the `BackingFragment`. 
3. I added `commitNow` to the `FragmentTransaction`s when showing or hiding the `RewardsFragment` and the `BackingFragment` because before we leave the `ProjectActivity`, we want to see the proper UI.

# 👀 See
<img src=https://user-images.githubusercontent.com/1289295/67126267-b390b500-f1c4-11e9-92b0-b3886d70b389.gif width=330/>

# 📋 QA
View rewards of a backed project

# Story 📖
[NT-455]

(Not requesting a review because this is a very Android specific bug)


[NT-455]: https://dripsprint.atlassian.net/browse/NT-455