### PR TITLE
[💳] NT-457 A11y label for backing payment method

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Either.kt
+++ b/app/src/main/java/com/kickstarter/libs/Either.kt
@@ -66,4 +66,15 @@ sealed class Either<out A, out B> {
     is Left -> Left(transform(this.left))
     is Right -> Right(this.right)
   }
+
+  override fun equals(other: Any?): Boolean {
+    return when {
+      other == null || javaClass != other.javaClass -> false
+      this === other -> true
+      else -> {
+        val that = other as Either<*, *>
+        this.left() == that.left() && this.right() == that.right()
+      }
+    }
+  }
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -9,6 +9,7 @@ import com.jakewharton.rxbinding.view.RxView
 import com.kickstarter.R
 import com.kickstarter.extensions.showSnackbar
 import com.kickstarter.libs.BaseFragment
+import com.kickstarter.libs.Either
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ViewUtils
@@ -48,6 +49,11 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .subscribe { setCardExpirationText(it) }
+
+        this.viewModel.outputs.cardIssuer()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe { setCardIssuerContentDescription(it) }
 
         this.viewModel.outputs.cardLastFour()
                 .compose(bindToLifecycle())
@@ -136,6 +142,12 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
     private fun setCardExpirationText(expiration: String) {
         reward_card_expiration_date.text = this.viewModel.ksString.format(getString(R.string.Credit_card_expiration),
                 "expiration_date", expiration)
+    }
+
+    private fun setCardIssuerContentDescription(cardIssuerOrStringRes: Either<String, Int>) {
+        val cardIssuer = cardIssuerOrStringRes.left()
+        val stringRes = cardIssuerOrStringRes.right()
+        reward_card_logo.contentDescription = stringRes?.let { getString(it) }?: cardIssuer
     }
 
     private fun setCardLastFourText(lastFour: String) {

--- a/app/src/main/res/layout/fragment_backing.xml
+++ b/app/src/main/res/layout/fragment_backing.xml
@@ -72,6 +72,7 @@
           android:id="@+id/payment_method"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
+          android:focusable="true"
           android:orientation="vertical">
 
           <TextView

--- a/app/src/main/res/values/apple_pay_strings.xml
+++ b/app/src/main/res/values/apple_pay_strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="apple_pay_content_description">Apple Pay</string>
+</resources>


### PR DESCRIPTION
# 📲 What
Adds content description for payment method in view/manage pledge.

# 🤔 Why
So the user knows what their payment method is.

# 🛠 How
- Added proper `equals` method to `Either` class. It compares the `left` and `right` values.
- Added `cardIssuer` output to `BackingFragmentViewModel`. It's an `Either<String, Int>` representing the card brand or the string resource of the description.
- Added Apple Pay content description string.
- The payment method section in the `BackingFragment` is now focusable so it reads all at once.
- Tests.

# 👀 See
<img src=https://user-images.githubusercontent.com/1289295/67310912-9d3c6f00-f4cc-11e9-9c67-045da0afbd54.png width=330/>

# 📋 QA
Turn on TalkBack and focus on a backing's payment method.

# Story 📖
[NT-457]


[NT-457]: https://dripsprint.atlassian.net/browse/NT-457