### PR TITLE
[🙈] NT-442 Pledge summary visibility in the pledge screen

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -641,11 +641,6 @@ interface PledgeFragmentViewModel {
                     .subscribe(this.pledgeSummaryAmount)
 
             updatingPayment
-                    .map { BooleanUtils.negate(it) }
-                    .compose(bindToLifecycle())
-                    .subscribe(this.pledgeSummaryIsGone)
-
-            updatingPayment
                     .compose(bindToLifecycle())
                     .subscribe(this.totalDividerIsGone)
 
@@ -655,7 +650,10 @@ interface PledgeFragmentViewModel {
                     .map { it.first || !RewardUtils.isShippable(it.second) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
-                    .subscribe(this.shippingSummaryIsGone)
+                    .subscribe{
+                        this.pledgeSummaryIsGone.onNext(it)
+                        this.shippingSummaryIsGone.onNext(it)
+                    }
 
             backing
                     .map { it.shippingAmount().toDouble() }

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -650,7 +650,7 @@ interface PledgeFragmentViewModel {
                     .map { it.first || !RewardUtils.isShippable(it.second) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
-                    .subscribe{
+                    .subscribe {
                         this.pledgeSummaryIsGone.onNext(it)
                         this.shippingSummaryIsGone.onNext(it)
                     }

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -519,7 +519,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeButtonIsEnabled.assertValue(true)
         this.pledgeMaximumIsGone.assertNoValues()
         this.pledgeSectionIsGone.assertValue(true)
-        this.pledgeSummaryIsGone.assertValue(false)
+        this.pledgeSummaryIsGone.assertValue(true)
         this.shippingRulesSectionIsGone.assertValue(true)
         this.shippingSummaryIsGone.assertValue(true)
         this.snapshotIsGone.assertValue(true)


### PR DESCRIPTION
# 📲 What
Hiding the pledge summary in the change payment method screen when a reward is not shippable.

# 🤔 Why
The pledge amount is the same as the total.

# 🛠 How
- The `pledgeSummaryIsGone` output in the `PledgeFragmentViewModel` now uses the same logic as the `shippingSummaryIsGone` output. They're both hidden if the user is not updating their payment method OR the reward is not shippable.

# 👀 See
| After 🦋 | Before 🐛 |
| --- | --- |
| ![screenshot-2019-10-23_131024](https://user-images.githubusercontent.com/1289295/67419777-50739980-f59b-11e9-9399-e3e9b41711d7.png) | ![screenshot-2019-10-23_133328](https://user-images.githubusercontent.com/1289295/67419778-50739980-f59b-11e9-8edb-6b480bdba70e.png) |

# 📋 QA
Change the payment method of a reward without shipping.

# Story 📖
[NT-442]

[NT-442]: https://dripsprint.atlassian.net/browse/NT-442