### PR TITLE
[🙈] NT-466 Pledge summary visibility in the view/manage pledge screen

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -79,6 +79,11 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
                 .compose(Transformers.observeForUI())
                 .subscribe { pledge_summary_amount.text = it }
 
+        this.viewModel.outputs.pledgeSummaryIsGone()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe { ViewUtils.setGone(pledge_summary, it) }
+
         this.viewModel.outputs.shippingAmount()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -55,6 +55,9 @@ interface BackingFragmentViewModel {
         /** Emits the date the backing was pledged on. */
         fun pledgeDate(): Observable<String>
 
+        /** Emits a boolean determining if the pledge summary should be visible. */
+        fun pledgeSummaryIsGone(): Observable<Boolean>
+
         /** Emits the project and currently backed reward. */
         fun projectAndReward(): Observable<Pair<Project, Reward>>
 
@@ -93,6 +96,7 @@ interface BackingFragmentViewModel {
         private val paymentMethodIsGone = BehaviorSubject.create<Boolean>()
         private val pledgeAmount = BehaviorSubject.create<CharSequence>()
         private val pledgeDate = BehaviorSubject.create<String>()
+        private val pledgeSummaryIsGone = BehaviorSubject.create<Boolean>()
         private val projectAndReward = BehaviorSubject.create<Pair<Project, Reward>>()
         private val receivedCheckboxChecked = BehaviorSubject.create<Boolean>()
         private val receivedSectionIsGone = BehaviorSubject.create<Boolean>()
@@ -151,7 +155,10 @@ interface BackingFragmentViewModel {
                     .map { ObjectUtils.isNull(it.locationId()) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
-                    .subscribe(this.shippingSummaryIsGone)
+                    .subscribe {
+                        this.pledgeSummaryIsGone.onNext(it)
+                        this.shippingSummaryIsGone.onNext(it)
+                    }
 
             backing
                     .map { it.shippingAmount() }
@@ -274,6 +281,8 @@ interface BackingFragmentViewModel {
         override fun pledgeAmount(): Observable<CharSequence> = this.pledgeAmount
 
         override fun pledgeDate(): Observable<String> = this.pledgeDate
+
+        override fun pledgeSummaryIsGone(): Observable<Boolean> = this.pledgeSummaryIsGone
 
         override fun projectAndReward(): Observable<Pair<Project, Reward>> = this.projectAndReward
 

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -255,7 +255,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeSummaryIsGone_whenDigitalReward() {
+    fun testPledgeSummaryIsGone_whenLocationId_isNull() {
         val backing = BackingFactory.backing()
                 .toBuilder()
                 .locationId(null)
@@ -272,7 +272,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeSummaryIsGone_whenShippableReward() {
+    fun testPledgeSummaryIsGone_whenLocationId_isNotNull() {
         val backing = BackingFactory.backing()
                 .toBuilder()
                 .locationId(4L)
@@ -429,7 +429,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShippingSummaryIsGone_whenDigitalReward() {
+    fun testShippingSummaryIsGone_whenLocationId_isNull() {
         val backing = BackingFactory.backing()
                 .toBuilder()
                 .locationId(null)
@@ -446,7 +446,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShippingSummaryIsGone_whenShippableReward() {
+    fun testShippingSummaryIsGone_whenLocationId_isNotNull() {
         val backing = BackingFactory.backing()
                 .toBuilder()
                 .locationId(4L)

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -23,6 +23,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     private val paymentMethodIsGone = TestSubscriber.create<Boolean>()
     private val pledgeAmount = TestSubscriber.create<CharSequence>()
     private val pledgeDate = TestSubscriber.create<String>()
+    private val pledgeSummaryIsGone = TestSubscriber.create<Boolean>()
     private val projectAndReward = TestSubscriber.create<Pair<Project, Reward>>()
     private val receivedCheckboxChecked = TestSubscriber.create<Boolean>()
     private val receivedSectionIsGone = TestSubscriber.create<Boolean>()
@@ -41,6 +42,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
         this.vm.outputs.paymentMethodIsGone().subscribe(this.paymentMethodIsGone)
         this.vm.outputs.pledgeAmount().map { it.toString() }.subscribe(this.pledgeAmount)
         this.vm.outputs.pledgeDate().subscribe(this.pledgeDate)
+        this.vm.outputs.pledgeSummaryIsGone().subscribe(this.pledgeSummaryIsGone)
         this.vm.outputs.projectAndReward().subscribe(this.projectAndReward)
         this.vm.outputs.receivedCheckboxChecked().subscribe(this.receivedCheckboxChecked)
         this.vm.outputs.receivedSectionIsGone().subscribe(this.receivedSectionIsGone)
@@ -250,6 +252,40 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
 
         this.vm.inputs.project(backedProject)
         this.pledgeDate.assertValue("August 28, 2019")
+    }
+
+    @Test
+    fun testPledgeSummaryIsGone_whenDigitalReward() {
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .locationId(null)
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        setUpEnvironment(environment())
+
+        this.vm.inputs.project(backedProject)
+        this.pledgeSummaryIsGone.assertValue(true)
+    }
+
+    @Test
+    fun testPledgeSummaryIsGone_whenShippableReward() {
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .locationId(4L)
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        setUpEnvironment(environment())
+
+        this.vm.inputs.project(backedProject)
+        this.pledgeSummaryIsGone.assertValue(false)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Hiding the pledge summary in the view/manage pledge screen when a backing doesn't have a location.

# 🤔 Why
The pledge amount is the same as the total.

# 🛠 How
- Added `pledgeSummaryIsGone` output to the `BackingFragmentViewModel`. It  uses the same logic as the `shippingSummaryIsGone` output. They're both hidden if the backing does not have a `locationId`.

# 👀 See
| After 🦋 | Before 🐛 |
| --- | --- |
| ![screenshot-2019-10-23_140012](https://user-images.githubusercontent.com/1289295/67421247-1ce63e80-f59e-11e9-99b2-ca376baddb16.png) | ![screenshot-2019-10-23_135949](https://user-images.githubusercontent.com/1289295/67421245-1ce63e80-f59e-11e9-8084-e58b79c521d0.png) |

# 📋 QA
View a pledge with no shipping!

# Story 📖
[NT-466]

[NT-466]: https://dripsprint.atlassian.net/browse/NT-466