### PR TITLE
[🔙] NT-479 Pledge toolbar navigation

### DIFF
--- a/app/src/main/res/drawable/ic_action_icon__arrow_left.xml
+++ b/app/src/main/res/drawable/ic_action_icon__arrow_left.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-  android:height="24dp"
-  android:width="24dp"
-  android:viewportWidth="24"
-  android:viewportHeight="24">
-  <path android:fillColor="#282828" android:pathData="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z" />
-</vector>

--- a/app/src/main/res/drawable/ic_arrow_back.xml
+++ b/app/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#282828"
+      android:pathData="M19,11H7.83l4.88,-4.88c0.39,-0.39 0.39,-1.03 0,-1.42 -0.39,-0.39 -1.02,-0.39 -1.41,0l-6.59,6.59c-0.39,0.39 -0.39,1.02 0,1.41l6.59,6.59c0.39,0.39 1.02,0.39 1.41,0 0.39,-0.39 0.39,-1.02 0,-1.41L7.83,13H19c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_arrow_down.xml
+++ b/app/src/main/res/drawable/ic_arrow_down.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path
-      android:fillColor="#8A000000"
+      android:fillColor="#282828"
       android:pathData="M8.12,9.29L12,13.17l3.88,-3.88c0.39,-0.39 1.02,-0.39 1.41,0 0.39,0.39 0.39,1.02 0,1.41l-4.59,4.59c-0.39,0.39 -1.02,0.39 -1.41,0L6.7,10.7c-0.39,-0.39 -0.39,-1.02 0,-1.41 0.39,-0.38 1.03,-0.39 1.42,0z"/>
 </vector>

--- a/app/src/main/res/layout/creator_dashboard_toolbar.xml
+++ b/app/src/main/res/layout/creator_dashboard_toolbar.xml
@@ -44,15 +44,9 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <ImageButton
-          android:id="@+id/back_button"
-          android:layout_width="wrap_content"
-          android:layout_height="match_parent"
-          android:background="@drawable/click_indicator_light"
-          android:contentDescription="@string/general_navigation_accessibility_button_navigate_back_label"
-          android:focusable="true"
-          android:padding="@dimen/grid_2"
-          android:src="@drawable/ic_action_icon__arrow_left" />
+        <com.kickstarter.ui.views.IconButton
+          style="@style/ToolbarIconBackButton"
+          android:id="@+id/back_button" />
 
         <TextView
           android:id="@+id/creator_dashboard_project_name_small"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -317,7 +317,7 @@
 
   <style name="ToolbarIconBackButton" parent="ToolbarIcon">
     <item name="android:paddingStart">@dimen/grid_2</item>
-    <item name="android:drawableStart">@drawable/ic_action_icon__arrow_left</item>
+    <item name="android:drawableStart">@drawable/ic_arrow_back</item>
     <item name="android:focusable">true</item>
     <item name="android:contentDescription">@string/general_navigation_accessibility_button_navigate_back_label</item>
   </style>


### PR DESCRIPTION
# 📲 What
Reverting #558 logic for how the navigation icon in the pledge toolbar works and updating icon drawable based on fragment back stack count.

# 🤔 Why
Everyone clicks the down icon thinking it'll take them back and it doesn't. GIVE THE PEOPLE WHAT THEY WANT

# 🛠 How
- Added `ic_arrow_back.xml`. We now use this rounded style everywhere. Deleted `ic_action_icon__arrow_left.xml`. 
<img width="118" alt="Screen Shot 2019-11-01 at 3 50 05 PM" src="https://user-images.githubusercontent.com/1289295/68059358-9e427d00-fcd2-11e9-8fe5-45dbe77648a8.png">

- Updated `ic_arrow_down.xml` color to `ksr_soft_black`.
- Renamed `ProjectViewModel` input `collapsePledgeSheet ` to `pledgeToolbarNavigationClicked`.
- Added `pledgeToolbarNavigationIcon` output to `ProjectViewModel`. It emits the down icon drawable when the back stack is empty and the back icon when it's not.
- Added `goBack ` output to `ProjectViewModel`. It emits when the pledge toolbar navigation icon is clicked and there are fragments on the back stack.
  - `expandPledgeSheet` now only emits when the back stack is empty and we need to collapse the sheet.
- Renamed `rewardsToolbarTitle` to `pledgeToolbarTitle`.
- Tests

# 👀 See
| After 🦋 | Before 🐛 |
| --- | --- |
| ![device-2019-11-01-181539 2019-11-01 18_17_15](https://user-images.githubusercontent.com/1289295/68059716-e44c1080-fcd3-11e9-8954-a436d3058485.gif) | ![device-2019-11-01-181626 2019-11-01 18_17_35](https://user-images.githubusercontent.com/1289295/68059717-e4e4a700-fcd3-11e9-81b8-6a1a77a96812.gif) |

# 📋 QA
Navigate through all the pledge screens.

# Story 📖
[NT-479]


[NT-479]: https://dripsprint.atlassian.net/browse/NT-479