### PR TITLE
[🎨] NT-487 Customizing 3DS2 style

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
   Naming guidelines: https://github.com/kickstarter/styleguide/tree/master/android#style-inheritance
   Other resources: https://kickstarter.wiki/pages/android-links.html#styles
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" >
 
   <style name="None">
   </style>
@@ -775,7 +775,7 @@
   </style>
 
   <!-- Stripe 3DS2 override -->
-  <style xmlns:tools="http://schemas.android.com/tools" name="Stripe3DS2Theme" parent="StripeDefault3DS2Theme" tools:override="true">
+  <style name="Stripe3DS2Theme" parent="StripeDefault3DS2Theme" tools:override="true">
     <item name="colorPrimary">@color/primary</item>
     <item name="colorPrimaryDark">@color/primary_dark</item>
     <item name="colorAccent">@color/primary</item>
@@ -790,5 +790,7 @@
     <item name="android:statusBarColor">@color/status_bar</item>
     <item name="android:windowLightStatusBar">true</item>
   </style>
+
+  <style name="Stripe3DS2Button" parent="Button" tools:override="true"/>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -774,4 +774,21 @@
     <item name="android:layout_gravity">bottom</item>
   </style>
 
+  <!-- Stripe 3DS2 override -->
+  <style xmlns:tools="http://schemas.android.com/tools" name="Stripe3DS2Theme" parent="StripeDefault3DS2Theme" tools:override="true">
+    <item name="colorPrimary">@color/primary</item>
+    <item name="colorPrimaryDark">@color/primary_dark</item>
+    <item name="colorAccent">@color/primary</item>
+    <item name="colorSurface">@color/white</item>
+    <item name="android:textColor">@color/text_primary</item>
+    <item name="android:textColorLink">@color/accent</item>
+    <item name="android:textColorPrimary">@color/text_primary</item>
+    <item name="android:textColorSecondary">@color/text_secondary</item>
+    <item name="android:windowBackground">@color/window_background</item>
+    <item name="materialButtonStyle">@style/Button</item>
+    <item name="toolbarStyle">@style/Toolbar</item>
+    <item name="android:statusBarColor">@color/status_bar</item>
+    <item name="android:windowLightStatusBar">true</item>
+  </style>
+
 </resources>


### PR DESCRIPTION
# 📲 What
Styling our native 3DS2 screens.

# 🤔 Why
Consistency is 🔑 

# 🛠 How
- Synced with @colleenmacd on recommendations and overrode [`Stripe3DS2Theme`](https://github.com/stripe/stripe-android/blob/master/example/res/values/themes.xml#L26) and `Stripe3DS2Button` styles.

# 👀 See
You can't take screenshots of these screens!

# 📋 QA
Back a project (on the native HQ) with one of these [cards](https://stripe.com/docs/mobile/android/authentication#testing). 

# Story 📖
[NT-487]


[NT-487]: https://dripsprint.atlassian.net/browse/NT-487