### PR TITLE
[📛] NT-536 Added current user's name and avatar to view/manage pledge

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/factories/AvatarFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/AvatarFactory.java
@@ -13,4 +13,12 @@ public final class AvatarFactory {
       .thumb(baseUrl + "thumb.jpg")
       .build();
   }
+
+  public static Avatar avatar(final String baseUrl) {
+    return Avatar.builder()
+      .medium(baseUrl + "medium.jpg")
+      .small(baseUrl + "small.jpg")
+      .thumb(baseUrl + "thumb.jpg")
+      .build();
+  }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -9,10 +9,7 @@ import com.kickstarter.libs.FragmentViewModel
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.rx.transformers.Transformers.*
 import com.kickstarter.libs.utils.*
-import com.kickstarter.models.Backing
-import com.kickstarter.models.Project
-import com.kickstarter.models.Reward
-import com.kickstarter.models.StoredCard
+import com.kickstarter.models.*
 import com.kickstarter.ui.fragments.BackingFragment
 import com.stripe.android.model.Card
 import rx.Observable
@@ -36,6 +33,12 @@ interface BackingFragmentViewModel {
     }
 
     interface Outputs {
+        /** Emits the backer's avatar URL. */
+        fun backerAvatar(): Observable<String>
+
+        /** Emits the backer's name. */
+        fun backerName(): Observable<String>
+
         /** Emits the backer's sequence. */
         fun backerNumber(): Observable<String>
 
@@ -94,6 +97,8 @@ interface BackingFragmentViewModel {
         private val projectInput = PublishSubject.create<Project>()
         private val receivedCheckboxToggled = PublishSubject.create<Boolean>()
 
+        private val backerAvatar = BehaviorSubject.create<String>()
+        private val backerName = BehaviorSubject.create<String>()
         private val backerNumber = BehaviorSubject.create<String>()
         private val cardExpiration = BehaviorSubject.create<String>()
         private val cardIssuer = BehaviorSubject.create<Either<String, Int>>()
@@ -113,6 +118,7 @@ interface BackingFragmentViewModel {
         private val totalAmount = BehaviorSubject.create<CharSequence>()
 
         private val apiClient = this.environment.apiClient()
+        private val currentUser = this.environment.currentUser()
         private val ksCurrency = this.environment.ksCurrency()
         val ksString: KSString = this.environment.ksString()
 
@@ -131,6 +137,21 @@ interface BackingFragmentViewModel {
             val backing = backedProject
                     .map { it.backing() }
                     .ofType(Backing::class.java)
+
+            val backer = backing
+                    .map { it.backer() }
+                    .compose<Pair<User?, User>>(combineLatestPair(this.currentUser.observable()))
+                    .map { ObjectUtils.coalesce(it.first, it.second) }
+
+            backer
+                    .map { it.name() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.backerName)
+
+            backer
+                    .map { it.avatar().medium() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.backerAvatar)
 
             backedProject
                     .map { project -> project.rewards()?.firstOrNull { BackingUtils.isBacked(project, it) }?.let { Pair(project, it) } }
@@ -288,6 +309,10 @@ interface BackingFragmentViewModel {
         override fun receivedCheckboxToggled(checked: Boolean) {
             this.receivedCheckboxToggled.onNext(checked)
         }
+
+        override fun backerAvatar(): Observable<String> = this.backerAvatar
+
+        override fun backerName(): Observable<String> = this.backerName
 
         override fun backerNumber(): Observable<String> = this.backerNumber
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -9,7 +9,10 @@ import com.kickstarter.libs.FragmentViewModel
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.rx.transformers.Transformers.*
 import com.kickstarter.libs.utils.*
-import com.kickstarter.models.*
+import com.kickstarter.models.Backing
+import com.kickstarter.models.Project
+import com.kickstarter.models.Reward
+import com.kickstarter.models.StoredCard
 import com.kickstarter.ui.fragments.BackingFragment
 import com.stripe.android.model.Card
 import rx.Observable
@@ -138,10 +141,7 @@ interface BackingFragmentViewModel {
                     .map { it.backing() }
                     .ofType(Backing::class.java)
 
-            val backer = backing
-                    .map { it.backer() }
-                    .compose<Pair<User?, User>>(combineLatestPair(this.currentUser.observable()))
-                    .map { ObjectUtils.coalesce(it.first, it.second) }
+            val backer = this.currentUser.loggedInUser()
 
             backer
                     .map { it.name() }

--- a/app/src/main/res/layout/fragment_backing.xml
+++ b/app/src/main/res/layout/fragment_backing.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout android:id="@+id/backing_root"
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/backing_root"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:background="@color/ksr_grey_300"
   android:clickable="true"
   android:focusable="true"
-  android:paddingTop="?android:attr/actionBarSize"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
+  android:paddingTop="?android:attr/actionBarSize">
 
   <androidx.core.widget.NestedScrollView
     android:layout_width="match_parent"
@@ -20,8 +20,8 @@
     <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:paddingBottom="@dimen/grid_4"
-      android:orientation="vertical">
+      android:orientation="vertical"
+      android:paddingBottom="@dimen/grid_4">
 
       <LinearLayout
         android:layout_width="match_parent"
@@ -31,27 +31,58 @@
         android:layout_marginEnd="@dimen/grid_3"
         android:orientation="vertical">
 
-        <TextView
-          android:id="@+id/backer_number"
-          style="@style/CalloutPrimaryMedium"
-          android:layout_width="wrap_content"
+        <LinearLayout
+          android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          tools:text="@string/backer_modal_backer_number" />
-
-        <TextView
-          android:id="@+id/backing_date"
-          style="@style/Caption1Secondary"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
+          android:layout_gravity="center_vertical"
           android:layout_marginBottom="@dimen/grid_3"
-          tools:text="As of January 1, 2019" />
+          android:orientation="horizontal">
+
+          <ImageView
+            android:id="@+id/backing_avatar"
+            android:layout_width="@dimen/grid_9"
+            android:layout_height="@dimen/grid_9"
+            android:focusable="false"
+            android:importantForAccessibility="no"
+            tools:background="@color/ksr_cobalt_500" />
+
+          <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/grid_2"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+              android:id="@+id/backer_name"
+              style="@style/CalloutPrimaryMedium"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              tools:text="Nathan Squid" />
+
+            <TextView
+              android:id="@+id/backer_number"
+              style="@style/FootnotePrimaryMedium"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              tools:text="@string/backer_modal_backer_number" />
+
+            <TextView
+              android:id="@+id/backing_date"
+              style="@style/FootnoteSecondary"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              tools:text="As of January 1, 2019" />
+          </LinearLayout>
+        </LinearLayout>
+
 
         <include
           layout="@layout/fragment_pledge_section_summary_pledge"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:visibility="visible"
-          android:layout_marginBottom="@dimen/grid_3" />
+          android:layout_marginBottom="@dimen/grid_3"
+          android:visibility="visible" />
 
         <include
           layout="@layout/fragment_pledge_section_summary_shipping"
@@ -83,10 +114,11 @@
             android:layout_marginBottom="@dimen/grid_3"
             android:text="@string/Payment_method" />
 
-          <include layout="@layout/reward_card_details"
-            android:layout_height="wrap_content"
+          <include
+            layout="@layout/reward_card_details"
             android:layout_width="wrap_content"
-            android:layout_marginBottom="@dimen/grid_4"/>
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/grid_4" />
 
           <include layout="@layout/horizontal_line_1dp_view" />
 

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -6,6 +6,7 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.libs.Either
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.MockCurrentUser
 import com.kickstarter.mock.factories.*
 import com.kickstarter.models.Backing
 import com.kickstarter.models.Project
@@ -18,6 +19,8 @@ import rx.observers.TestSubscriber
 class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     private lateinit var vm: BackingFragmentViewModel.ViewModel
 
+    private val backerAvatar = TestSubscriber.create<String>()
+    private val backerName = TestSubscriber.create<String>()
     private val backerNumber = TestSubscriber.create<String>()
     private val cardExpiration = TestSubscriber.create<String>()
     private val cardIssuer = TestSubscriber.create<Either<String, Int>>()
@@ -38,6 +41,8 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = BackingFragmentViewModel.ViewModel(environment)
+        this.vm.outputs.backerAvatar().subscribe(this.backerAvatar)
+        this.vm.outputs.backerName().subscribe(this.backerName)
         this.vm.outputs.backerNumber().subscribe(this.backerNumber)
         this.vm.outputs.cardExpiration().subscribe(this.cardExpiration)
         this.vm.outputs.cardIssuer().subscribe(this.cardIssuer)
@@ -55,6 +60,38 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
         this.vm.outputs.shippingSummaryIsGone().subscribe(this.shippingSummaryIsGone)
         this.vm.outputs.showUpdatePledgeSuccess().subscribe(this.showUpdatePledgeSuccess)
         this.vm.outputs.totalAmount().map { it.toString() }.subscribe(this.totalAmount)
+    }
+
+    @Test
+    fun testBackerAvatar() {
+        val user = UserFactory.user()
+                .toBuilder()
+                .avatar(AvatarFactory.avatar("www.avatars.com/"))
+                .build()
+        val environment = environment()
+                .toBuilder()
+                .currentUser(MockCurrentUser(user))
+                .build()
+        setUpEnvironment(environment)
+
+        this.vm.inputs.project(ProjectFactory.backedProject())
+        this.backerAvatar.assertValue("www.avatars.com/medium.jpg")
+    }
+
+    @Test
+    fun testBackerName() {
+        val user = UserFactory.user()
+                .toBuilder()
+                .name("Nathan Squid")
+                .build()
+        val environment = environment()
+                .toBuilder()
+                .currentUser(MockCurrentUser(user))
+                .build()
+        setUpEnvironment(environment)
+
+        this.vm.inputs.project(ProjectFactory.backedProject())
+        this.backerName.assertValue("Nathan Squid")
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Added current user's name and avatar to view/manage pledge

# 🤔 Why
The first step in a sticky new feature.

# 🛠 How
- Added `backerAvatar` output to `BackingFragmentViewModel`. It emits the current user's backing medium avatar.
- Added `backerName` output to `BackingFragmentViewModel`. It emits the current user's name.
- Alphabetized subscribed outputs in `BackingFragment`.
- Tests

# 👀 See
| After 🦋 | Before 🐛 |
| --- | --- |
| ![screenshot-2019-11-06_162136](https://user-images.githubusercontent.com/1289295/68338954-99564280-00b1-11ea-93d0-bd13155ae9e9.png) | ![screenshot-2019-11-06_162151](https://user-images.githubusercontent.com/1289295/68339238-2d280e80-00b2-11ea-8956-a7cb5948e30c.png) |

# 📋 QA
View your pledge.

# Story 📖
[NT-536]


[NT-536]: https://dripsprint.atlassian.net/browse/NT-536