### PR TITLE
[🎨] NT-473 Pledge currency text styles

### DIFF
--- a/app/src/main/res/layout/fragment_backing_section_summary_total.xml
+++ b/app/src/main/res/layout/fragment_backing_section_summary_total.xml
@@ -19,7 +19,7 @@
 
   <TextView
     android:id="@+id/total_summary_amount"
-    style="@style/PledgeCurrencySecondary"
+    style="@style/PledgeCurrency"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:gravity="center_vertical|end"

--- a/app/src/main/res/layout/fragment_pledge_section_pledge_amount.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_pledge_amount.xml
@@ -89,7 +89,7 @@
 
     <TextView
       android:id="@+id/additional_pledge_amount"
-      style="@style/PledgeCurrency"
+      style="@style/PledgeCurrencySecondary"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:textSize="@dimen/headline"
@@ -113,7 +113,7 @@
 
     <TextView
       android:id="@+id/pledge_symbol_start"
-      style="@style/PledgeCurrencySecondary"
+      style="@style/PledgeCurrencyInput"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:focusable="true"
@@ -122,7 +122,7 @@
 
     <EditText
       android:id="@+id/pledge_amount"
-      style="@style/PledgeCurrencySecondary"
+      style="@style/PledgeCurrencyInput"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:background="@null"
@@ -136,7 +136,7 @@
 
     <TextView
       android:id="@+id/pledge_symbol_end"
-      style="@style/PledgeCurrencySecondary"
+      style="@style/PledgeCurrencyInput"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       tools:text="$" />

--- a/app/src/main/res/layout/fragment_pledge_section_shipping.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_shipping.xml
@@ -60,7 +60,7 @@
 
   <TextView
     android:id="@+id/shipping_amount"
-    style="@style/PledgeCurrency"
+    style="@style/PledgeCurrencySecondary"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/grid_1"

--- a/app/src/main/res/layout/fragment_pledge_section_summary_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_summary_pledge.xml
@@ -23,7 +23,7 @@
 
   <TextView
     android:id="@+id/pledge_summary_amount"
-    style="@style/PledgeCurrencySecondary"
+    style="@style/PledgeCurrency"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:gravity="center_vertical|end"

--- a/app/src/main/res/layout/fragment_pledge_section_summary_shipping.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_summary_shipping.xml
@@ -37,7 +37,7 @@
 
   <TextView
     android:id="@+id/shipping_summary_amount"
-    style="@style/PledgeCurrency"
+    style="@style/PledgeCurrencySecondary"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:maxLines="1"

--- a/app/src/main/res/layout/fragment_pledge_section_total.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_total.xml
@@ -71,11 +71,10 @@
 
     <TextView
       android:id="@+id/total_amount_conversion"
-      style="@style/Caption1Secondary"
+      style="@style/Caption1Primary"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_gravity="bottom|end"
-      android:textSize="@dimen/caption_1"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintHorizontal_bias="1"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -522,12 +522,15 @@
   </style>
 
   <style name="PledgeCurrency" parent="TextPrimary">
-    <item name="android:textColor">@color/ksr_dark_grey_500</item>
     <item name="android:textSize">@dimen/title_1</item>
   </style>
 
   <style name="PledgeCurrencySecondary" parent="PledgeCurrency">
-    <item name="android:textColor">@color/primary</item>
+    <item name="android:textColor">@color/ksr_dark_grey_500</item>
+  </style>
+
+  <style name="PledgeCurrencyInput" parent="PledgeCurrency">
+    <item name="android:textColor">@color/accent</item>
   </style>
 
   <style name="CreditCardExpiration" parent="Caption2SecondaryMedium">


### PR DESCRIPTION
# 📲 What
Updating text colors for currency in the backing and pledge fragments.

# 🤔 Why
🎨 

# 🛠 How
- We now have 3 styles for pledge currency.
  - `PledgeCurrency` `ksr_soft_black`
  - `PledgeCurrencySecondary` `ksr_dark_grey_500`
  - `PledgeCurrencyInput` `ksr_green_500`

# 👀 See
| After pledge screen 🦋| Before pledge screen 🐛 |
| --- | --- |
| ![screenshot-2019-11-06_170457](https://user-images.githubusercontent.com/1289295/68342292-48961800-00b8-11ea-86eb-ed247bead5ca.png) | ![screenshot-2019-11-06_170955](https://user-images.githubusercontent.com/1289295/68342293-48961800-00b8-11ea-86fe-942f1499afe5.png) |
| After view/manage screen 🦋| Before view/mange screen 🐛 |
| ![screenshot-2019-11-06_171126](https://user-images.githubusercontent.com/1289295/68342394-7b401080-00b8-11ea-9b2a-600a0ec9d197.png) | ![screenshot-2019-11-06_162151](https://user-images.githubusercontent.com/1289295/68342406-82ffb500-00b8-11ea-81cd-26df4cd07fdf.png) |

# 📋 QA
Pledge

# Story 📖
[NT-473]


[NT-473]: https://dripsprint.atlassian.net/browse/NT-473