### PR TITLE
[👆🏾] NT-566 Pull to refresh support in View/Manage pledge

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -50,7 +50,7 @@ import rx.android.schedulers.AndroidSchedulers
 
 @RequiresActivityViewModel(ProjectViewModel.ViewModel::class)
 class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledgeFragment.CancelPledgeDelegate,
-        NewCardFragment.OnCardSavedListener, PledgeFragment.PledgeDelegate {
+        NewCardFragment.OnCardSavedListener, PledgeFragment.PledgeDelegate, BackingFragment.BackingDelegate {
     private lateinit var adapter: ProjectAdapter
     private lateinit var ksString: KSString
 
@@ -348,6 +348,10 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     override fun cardSaved(storedCard: StoredCard) {
         pledgeFragment()?.cardAdded(storedCard)
         supportFragmentManager.popBackStack()
+    }
+
+    override fun refreshProject() {
+        this.viewModel.inputs.refreshProject()
     }
 
     override fun onNetworkConnectionChanged(isConnected: Boolean) {}

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -11,6 +11,7 @@ import com.kickstarter.R
 import com.kickstarter.extensions.showSnackbar
 import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.Either
+import com.kickstarter.libs.SwipeRefresher
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.transformations.CircleTransformation
@@ -30,6 +31,10 @@ import kotlinx.android.synthetic.main.reward_card_details.*
 
 @RequiresFragmentViewModel(BackingFragmentViewModel.ViewModel::class)
 class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
+
+    interface BackingDelegate {
+        fun refreshProject()
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         super.onCreateView(inflater, container, savedInstanceState)
@@ -73,6 +78,11 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .subscribe { setCardLastFourText(it) }
+
+        this.viewModel.outputs.notifyDelegateToRefreshProject()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe { (activity as BackingDelegate?)?.refreshProject() }
 
         this.viewModel.outputs.paymentMethodIsGone()
                 .compose(bindToLifecycle())
@@ -138,6 +148,10 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .subscribe { total_summary_amount.text = it }
+
+        SwipeRefresher(
+                this, backing_swipe_refresh_layout, { this.viewModel.inputs.refreshProject() }, { this.viewModel.outputs.swipeRefresherProgressIsVisible() }
+        )
 
         RxView.clicks(mark_as_received_checkbox)
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -83,6 +83,9 @@ interface ProjectViewModel {
         /** Call when the user clicks the navigation icon of the pledge toolbar. */
         fun pledgeToolbarNavigationClicked()
 
+        /** Call when the user has triggered a manual refresh of the project. */
+        fun refreshProject()
+
         /** Call when the reload container is clicked.  */
         fun reloadProjectContainerClicked()
 
@@ -258,6 +261,7 @@ interface ProjectViewModel {
         private val pledgeSuccessfullyCreated = PublishSubject.create<Void>()
         private val pledgeSuccessfullyUpdated = PublishSubject.create<Void>()
         private val pledgeToolbarNavigationClicked = PublishSubject.create<Void>()
+        private val refreshProject = PublishSubject.create<Void>()
         private val reloadProjectContainerClicked = PublishSubject.create<Void>()
         private val shareButtonClicked = PublishSubject.create<Void>()
         private val updatePaymentClicked = PublishSubject.create<Void>()
@@ -401,7 +405,8 @@ interface ProjectViewModel {
             val refreshProjectEvent = Observable.merge(this.pledgeSuccessfullyCancelled,
                     this.pledgeSuccessfullyCreated,
                     this.pledgeSuccessfullyUpdated,
-                    this.pledgePaymentSuccessfullyUpdated)
+                    this.pledgePaymentSuccessfullyUpdated,
+                    this.refreshProject)
 
             val refreshedProjectNotification = initialProject
                     .compose(takeWhen<Project, Void>(refreshProjectEvent))
@@ -895,6 +900,10 @@ interface ProjectViewModel {
 
         override fun projectViewHolderUpdatesClicked(viewHolder: ProjectViewHolder) {
             this.updatesTextViewClicked()
+        }
+
+        override fun refreshProject() {
+            this.refreshProject.onNext(null)
         }
 
         override fun reloadProjectContainerClicked() {

--- a/app/src/main/res/layout/fragment_backing.xml
+++ b/app/src/main/res/layout/fragment_backing.xml
@@ -10,190 +10,197 @@
   android:focusable="true"
   android:paddingTop="?android:attr/actionBarSize">
 
-  <androidx.core.widget.NestedScrollView
+  <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+    android:id="@+id/backing_swipe_refresh_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fillViewport="true"
-    android:overScrollMode="never"
-    android:scrollbars="none">
+    android:layout_height="wrap_content">
 
-    <LinearLayout
+    <androidx.core.widget.NestedScrollView
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical"
-      android:paddingBottom="@dimen/grid_4">
+      android:layout_height="match_parent"
+      android:fillViewport="true"
+      android:overScrollMode="never"
+      android:scrollbars="none">
 
       <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/grid_3"
-        android:layout_marginTop="@dimen/grid_4"
-        android:layout_marginEnd="@dimen/grid_3"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/grid_4">
 
         <LinearLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_gravity="center_vertical"
-          android:layout_marginBottom="@dimen/grid_4"
-          android:orientation="horizontal">
-
-          <ImageView
-            android:id="@+id/backing_avatar"
-            android:layout_width="@dimen/grid_9"
-            android:layout_height="@dimen/grid_9"
-            android:focusable="false"
-            android:importantForAccessibility="no"
-            tools:background="@color/ksr_cobalt_500" />
+          android:layout_marginStart="@dimen/grid_3"
+          android:layout_marginTop="@dimen/grid_4"
+          android:layout_marginEnd="@dimen/grid_3"
+          android:orientation="vertical">
 
           <LinearLayout
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/grid_2"
-            android:layout_weight="1"
+            android:layout_gravity="center_vertical"
+            android:layout_marginBottom="@dimen/grid_4"
+            android:orientation="horizontal">
+
+            <ImageView
+              android:id="@+id/backing_avatar"
+              android:layout_width="@dimen/grid_9"
+              android:layout_height="@dimen/grid_9"
+              android:focusable="false"
+              android:importantForAccessibility="no"
+              tools:background="@color/ksr_cobalt_500" />
+
+            <LinearLayout
+              android:layout_width="0dp"
+              android:layout_height="wrap_content"
+              android:layout_marginStart="@dimen/grid_2"
+              android:layout_weight="1"
+              android:orientation="vertical">
+
+              <TextView
+                android:id="@+id/backer_name"
+                style="@style/CalloutPrimaryMedium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="Nathan Squid" />
+
+              <TextView
+                android:id="@+id/backer_number"
+                style="@style/FootnotePrimaryMedium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="@string/backer_modal_backer_number" />
+
+              <TextView
+                android:id="@+id/backing_date"
+                style="@style/FootnoteSecondary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="As of January 1, 2019" />
+            </LinearLayout>
+          </LinearLayout>
+
+          <TextView
+            android:id="@+id/backer_pledge_status"
+            style="@style/BodyPrimary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/grid_4"
+            android:background="@color/ksr_grey_400"
+            android:gravity="center"
+            android:paddingStart="@dimen/grid_4"
+            android:paddingTop="@dimen/grid_2"
+            android:paddingEnd="@dimen/grid_4"
+            android:paddingBottom="@dimen/grid_2"
+            tools:text="@string/If_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline" />
+
+          <include
+            layout="@layout/fragment_pledge_section_summary_pledge"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/grid_3"
+            android:visibility="visible" />
+
+          <include
+            layout="@layout/fragment_pledge_section_summary_shipping"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/grid_3"
+            tools:visibility="visible" />
+
+          <include
+            layout="@layout/fragment_backing_section_summary_total"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/grid_4" />
+
+          <include layout="@layout/horizontal_line_1dp_view" />
+
+          <LinearLayout
+            android:id="@+id/payment_method"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:focusable="true"
             android:orientation="vertical">
 
             <TextView
-              android:id="@+id/backer_name"
               style="@style/CalloutPrimaryMedium"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              tools:text="Nathan Squid" />
+              android:layout_marginTop="@dimen/grid_4"
+              android:layout_marginBottom="@dimen/grid_3"
+              android:text="@string/Payment_method" />
 
-            <TextView
-              android:id="@+id/backer_number"
-              style="@style/FootnotePrimaryMedium"
+            <include
+              layout="@layout/reward_card_details"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              tools:text="@string/backer_modal_backer_number" />
+              android:layout_marginBottom="@dimen/grid_4" />
 
-            <TextView
-              android:id="@+id/backing_date"
-              style="@style/FootnoteSecondary"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              tools:text="As of January 1, 2019" />
+            <include layout="@layout/horizontal_line_1dp_view" />
+
           </LinearLayout>
-        </LinearLayout>
-
-        <TextView
-          android:id="@+id/backer_pledge_status"
-          style="@style/BodyPrimary"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_4"
-          android:background="@color/ksr_grey_400"
-          android:gravity="center"
-          android:paddingStart="@dimen/grid_4"
-          android:paddingTop="@dimen/grid_2"
-          android:paddingEnd="@dimen/grid_4"
-          android:paddingBottom="@dimen/grid_2"
-          tools:text="@string/If_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline" />
-
-        <include
-          layout="@layout/fragment_pledge_section_summary_pledge"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_3"
-          android:visibility="visible" />
-
-        <include
-          layout="@layout/fragment_pledge_section_summary_shipping"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_3"
-          tools:visibility="visible" />
-
-        <include
-          layout="@layout/fragment_backing_section_summary_total"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_4" />
-
-        <include layout="@layout/horizontal_line_1dp_view" />
-
-        <LinearLayout
-          android:id="@+id/payment_method"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:focusable="true"
-          android:orientation="vertical">
 
           <TextView
             style="@style/CalloutPrimaryMedium"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/grid_4"
-            android:layout_marginBottom="@dimen/grid_3"
-            android:text="@string/Payment_method" />
-
-          <include
-            layout="@layout/reward_card_details"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/grid_4" />
-
-          <include layout="@layout/horizontal_line_1dp_view" />
+            android:layout_marginBottom="@dimen/grid_2"
+            android:text="@string/Selected_reward" />
 
         </LinearLayout>
-
-        <TextView
-          style="@style/CalloutPrimaryMedium"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginTop="@dimen/grid_4"
-          android:layout_marginBottom="@dimen/grid_2"
-          android:text="@string/Selected_reward" />
-
-      </LinearLayout>
-
-      <include
-        layout="@layout/item_reward"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        tools:visibility="gone" />
-
-      <LinearLayout
-        android:id="@+id/received_section"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:layout_marginStart="@dimen/grid_3"
-        android:layout_marginEnd="@dimen/grid_3"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/grid_2">
 
         <include
-          layout="@layout/horizontal_line_1dp_view"
+          layout="@layout/item_reward"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_2" />
+          tools:visibility="gone" />
 
         <LinearLayout
+          android:id="@+id/received_section"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:gravity="center_vertical"
-          android:orientation="horizontal">
+          android:layout_gravity="center_vertical"
+          android:layout_marginStart="@dimen/grid_3"
+          android:layout_marginEnd="@dimen/grid_3"
+          android:orientation="vertical"
+          android:paddingBottom="@dimen/grid_2">
 
-          <TextView
-            android:id="@+id/received_label"
-            style="@style/CalloutPrimaryMedium"
-            android:layout_width="0dp"
+          <include
+            layout="@layout/horizontal_line_1dp_view"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/Reward_delivered" />
+            android:layout_marginBottom="@dimen/grid_2" />
 
-          <CheckBox
-            android:id="@+id/mark_as_received_checkbox"
-            android:layout_width="wrap_content"
+          <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent" />
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+              android:id="@+id/received_label"
+              style="@style/CalloutPrimaryMedium"
+              android:layout_width="0dp"
+              android:layout_height="wrap_content"
+              android:layout_weight="1"
+              android:text="@string/Reward_delivered" />
+
+            <CheckBox
+              android:id="@+id/mark_as_received_checkbox"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              app:layout_constraintBottom_toBottomOf="parent" />
+          </LinearLayout>
+
         </LinearLayout>
 
       </LinearLayout>
 
-    </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
 
-  </androidx.core.widget.NestedScrollView>
+  </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/pledge_container.xml
+++ b/app/src/main/res/layout/pledge_container.xml
@@ -12,6 +12,8 @@
   tools:layout_marginTop="620dp"
   tools:showIn="@layout/activity_project">
 
+  <include layout="@layout/project_retry" />
+
   <FrameLayout
     android:id="@+id/pledge_container"
     android:layout_width="match_parent"
@@ -109,7 +111,5 @@
       android:text="@string/project_back_button"
       tools:visibility="visible" />
   </LinearLayout>
-
-  <include layout="@layout/project_retry" />
 
 </androidx.cardview.widget.CardView>

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -27,6 +27,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     private val cardIssuer = TestSubscriber.create<Either<String, Int>>()
     private val cardLastFour = TestSubscriber.create<String>()
     private val cardLogo = TestSubscriber.create<Int>()
+    private val notifyDelegateToRefreshProject = TestSubscriber.create<Void>()
     private val paymentMethodIsGone = TestSubscriber.create<Boolean>()
     private val pledgeAmount = TestSubscriber.create<CharSequence>()
     private val pledgeDate = TestSubscriber.create<String>()
@@ -39,6 +40,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     private val shippingLocation = TestSubscriber.create<String>()
     private val shippingSummaryIsGone = TestSubscriber.create<Boolean>()
     private val showUpdatePledgeSuccess = TestSubscriber.create<Void>()
+    private val swipeRefresherProgressIsVisible = TestSubscriber.create<Boolean>()
     private val totalAmount = TestSubscriber.create<CharSequence>()
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
@@ -50,6 +52,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
         this.vm.outputs.cardIssuer().subscribe(this.cardIssuer)
         this.vm.outputs.cardLastFour().subscribe(this.cardLastFour)
         this.vm.outputs.cardLogo().subscribe(this.cardLogo)
+        this.vm.outputs.notifyDelegateToRefreshProject().subscribe(this.notifyDelegateToRefreshProject)
         this.vm.outputs.paymentMethodIsGone().subscribe(this.paymentMethodIsGone)
         this.vm.outputs.pledgeAmount().map { it.toString() }.subscribe(this.pledgeAmount)
         this.vm.outputs.pledgeDate().subscribe(this.pledgeDate)
@@ -62,6 +65,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
         this.vm.outputs.shippingLocation().subscribe(this.shippingLocation)
         this.vm.outputs.shippingSummaryIsGone().subscribe(this.shippingSummaryIsGone)
         this.vm.outputs.showUpdatePledgeSuccess().subscribe(this.showUpdatePledgeSuccess)
+        this.vm.outputs.swipeRefresherProgressIsVisible().subscribe(this.swipeRefresherProgressIsVisible)
         this.vm.outputs.totalAmount().map { it.toString() }.subscribe(this.totalAmount)
     }
 
@@ -314,6 +318,14 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
 
         this.vm.inputs.project(backedProject)
         this.cardIssuer.assertValue(Either.Left(Card.CardBrand.VISA))
+    }
+
+    @Test
+    fun testNotifyDelegateToRefreshProject() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.refreshProject()
+        this.notifyDelegateToRefreshProject.assertValueCount(1)
     }
 
     @Test
@@ -654,6 +666,21 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
 
         this.vm.inputs.pledgeSuccessfullyUpdated()
         this.showUpdatePledgeSuccess.assertValueCount(1)
+    }
+
+    @Test
+    fun testSwipeRefresherProgressIsVisible() {
+        setUpEnvironment(environment())
+
+        //initial project is loaded
+        this.vm.inputs.project(ProjectFactory.backedProject())
+
+        this.vm.inputs.refreshProject()
+        this.swipeRefresherProgressIsVisible.assertValue(true)
+
+        //Project is refreshed
+        this.vm.inputs.project(ProjectFactory.backedProject())
+        this.swipeRefresherProgressIsVisible.assertValues(true, false)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -1287,6 +1287,19 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.projectAndNativeCheckoutEnabled.assertValueCount(3)
     }
 
+    @Test
+    fun testProjectAndNativeCheckoutEnabled_whenRefreshProjectIsCalled() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        // Start the view model with a backed project
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
+
+        this.projectAndNativeCheckoutEnabled.assertValueCount(2)
+
+        this.vm.inputs.refreshProject()
+        this.projectAndNativeCheckoutEnabled.assertValueCount(3)
+    }
+
     private fun apiClientWithErrorFetchingProject(): MockApiClient {
         return object : MockApiClient() {
             override fun fetchProject(project: Project): Observable<Project> {


### PR DESCRIPTION
# 📲 What
Adds pull to refresh support in view/manage pledge screen.

# 🤔 Why
So users can get their latest backing.

# 🛠 How
## ProjectActivity
- `ProjectActivity` now implements `BackingFragment.BackingDelegate`.
- `ProjectViewModel` refreshes current project when `Input.refreshProject` is called.
- Tests

## BackingFragment
- Added `SwipeRefresherLayout` to `BackingFragment`'s `NestedScrollView`.
- Added `BackingDelegate` that's used to notify when we need to refresh the project (when the user swipes to refresh).
- When the project is refreshed, we hide the `SwipeRefresherLayout` progress.
- Tests

# 👀 See
| After 🦋 |
| --- |
| <img src=https://user-images.githubusercontent.com/1289295/68717636-509cfe80-0575-11ea-8183-10f7707ffa39.gif width=330/> | 

# 📋 QA
View a pledge. Pull to refresh.

# Story 📖
[NT-566]


[NT-566]: https://dripsprint.atlassian.net/browse/NT-566