### PR TITLE
[🆕] NT-567 Special manage pledge menu for backings in preauth state

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -9,6 +9,7 @@ import com.kickstarter.libs.*
 import com.kickstarter.libs.preferences.BooleanPreferenceType
 import com.kickstarter.libs.rx.transformers.Transformers.*
 import com.kickstarter.libs.utils.*
+import com.kickstarter.models.Backing
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.User
@@ -777,7 +778,10 @@ interface ProjectViewModel {
             val count = projectAndFragmentStackCount.second
             return when {
                 !project.isBacking || IntegerUtils.isNonZero(count) -> null
-                project.isLive -> R.menu.manage_pledge_live
+                project.isLive -> when {
+                    project.backing()?.status() == Backing.STATUS_PREAUTH -> R.menu.manage_pledge_preauth
+                    else -> R.menu.manage_pledge_live
+                }
                 else -> R.menu.manage_pledge_ended
             }
         }

--- a/app/src/main/res/menu/manage_pledge_preauth.xml
+++ b/app/src/main/res/menu/manage_pledge_preauth.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+  <item android:id="@+id/contact_creator"
+    android:title="@string/Contact_creator"
+    app:showAsAction="never"/>
+</menu>

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -13,6 +13,7 @@ import com.kickstarter.libs.preferences.MockBooleanPreference
 import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.factories.*
 import com.kickstarter.mock.services.MockApiClient
+import com.kickstarter.models.Backing
 import com.kickstarter.models.Project
 import com.kickstarter.models.User
 import com.kickstarter.ui.IntentKey
@@ -1017,13 +1018,31 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testManagePledgeMenu_whenProjectBackedAndLive() {
+    fun testManagePledgeMenu_whenProjectBackedAndLive_backingIsPledged() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
 
         // Start the view model with a backed project
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
 
         this.managePledgeMenu.assertValue(R.menu.manage_pledge_live)
+    }
+
+    @Test
+    fun testManagePledgeMenu_whenProjectBackedAndLive_backingIsPreauth() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        // Start the view model with a backed project
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .status(Backing.STATUS_PREAUTH)
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedProject))
+
+        this.managePledgeMenu.assertValue(R.menu.manage_pledge_preauth)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Showing a special menu when users are managing their preauth pledge.

# 🤔 Why
Users can't make any changes to their pledge while it's being verified. 

# 🛠 How
- Created a new menu with an option to only contact the creator `manage_pledge_preauth.xml`.
- `ProjectViewModel.Outputs.managePledgeMenu` now emits `manage_pledge_preauth.xml` when a backed `Project` is _live_ and the status of the `Backing` is `preauth`.
- Added a test and renamed original test.

# 👀 See
<img width="327" alt="Screen Shot 2019-11-12 at 6 29 26 PM" src="https://user-images.githubusercontent.com/1289295/68719741-f141ed00-057a-11ea-85b3-5a1a4073b5c9.png">

# 📋 QA
🔜 

# Story 📖
[NT-567]


[NT-567]: https://dripsprint.atlassian.net/browse/NT-567