### PR TITLE
[👷🏾‍♀️] Fixes documentation with signing.gradle credentials

### DIFF
--- a/app/signing.gradle.example
+++ b/app/signing.gradle.example
@@ -1,4 +1,4 @@
-// Details from Passpack entry `Android - Keystore`.
+// Details from 1Password entry `Android Keystore`.
 ext.signing = [
     storeFilePath : "kickstarter.keystore",
     storePassword : "",

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -67,7 +67,7 @@ fi
 
 if [ ! -e "app/signing.gradle" ]; then
   say "File \`app/signing.gradle\` does not exist, this will prevent you from creating release builds."
-  say "To fix this, copy the example keystore from \`app/signing.gradle.example\` to \`app/signing.gradle\` then fill out the file with the correct credentials. These can be found in passpack under the entry Android - Keystore.\n"
+  say "To fix this, copy the example keystore from \`app/signing.gradle.example\` to \`app/signing.gradle\` then fill out the file with the correct credentials. These can be found in 1Password under the entry Android Keystore.\n"
 fi
 
 say "Bootstrap complete!"


### PR DESCRIPTION
# 📲 What
Fixes documentation with signing.gradle credentials.

# 🤔 Why
Recently @Scollaco tried to build an external release and was unsuccessful because the documentation was outdated! Now that the instructions are up to date, future generations will know how to cut an external release!
