### PR TITLE
[😴] Hiding payment method in BackingFragment when it's null

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -232,18 +232,19 @@ interface BackingFragmentViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.totalAmount)
 
-            val paymentSource = backing
+            backing
                     .map { it.paymentSource() }
-                    .filter { it != null }
-                    .ofType(Backing.PaymentSource::class.java)
-
-            paymentSource
-                    .map { CreditCardPaymentType.safeValueOf(it.paymentType()) }
+                    .map { CreditCardPaymentType.safeValueOf(it?.paymentType()) }
                     .map { it == CreditCardPaymentType.ANDROID_PAY || it == CreditCardPaymentType.APPLE_PAY || it == CreditCardPaymentType.CREDIT_CARD }
                     .map { BooleanUtils.negate(it) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.paymentMethodIsGone)
+
+            val paymentSource = backing
+                    .map { it.paymentSource() }
+                    .filter { it != null }
+                    .ofType(Backing.PaymentSource::class.java)
 
             val simpleDateFormat = SimpleDateFormat(StoredCard.DATE_FORMAT, Locale.getDefault())
 

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -141,6 +141,23 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     }
 
     @Test
+    fun testPaymentMethodIsGone_whenNull() {
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .paymentSource(null)
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        setUpEnvironment(environment())
+
+        this.vm.inputs.project(backedProject)
+        this.paymentMethodIsGone.assertValue(true)
+    }
+
+    @Test
     fun testPaymentMethodIsGone_whenApplePay() {
         val paymentSource = PaymentSourceFactory.applePay()
         val backing = BackingFactory.backing()


### PR DESCRIPTION
# 📲 What
Hiding payment method section in BackingFragment when it's `null`.

# 🤔 Why
Canceled projects return `null` for `project.backing.paymentMethod`.

# 🛠 How
- If the `paymentType` is not `ANDROID_PAY`, `APPLE_PAY`, or `CREDIT_CARD`, `BackingFragmentViewModel.output.paymentMethodIsGone` emits `true`.

# 👀 See
| After 🦋 |
| --- |
| <img src=https://user-images.githubusercontent.com/1289295/68880811-f7021480-06d9-11ea-9f05-ea655f191db6.png width=330/> |

# 📋 QA
View the pledge of a canceled project.

# Story 📖
🔜 
