### PR TITLE
[📱] Adding KSRequestInterceptor to graphQL client

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -168,10 +168,11 @@ public final class ApplicationModule {
   @Singleton
   @NonNull
   static ApolloClient provideApolloClient(final @NonNull Build build, final @NonNull HttpLoggingInterceptor httpLoggingInterceptor,
-    final @NonNull GraphQLInterceptor graphQLInterceptor, @NonNull @WebEndpoint final String webEndpoint) {
+    final @NonNull GraphQLInterceptor graphQLInterceptor, @NonNull @WebEndpoint final String webEndpoint, final @NonNull KSRequestInterceptor ksRequestInterceptor) {
 
     final OkHttpClient.Builder builder = new OkHttpClient.Builder()
-      .addInterceptor(graphQLInterceptor);
+      .addInterceptor(graphQLInterceptor)
+      .addInterceptor(ksRequestInterceptor);
 
     // Only log in debug mode to avoid leaking sensitive information.
     if (build.isDebug()) {


### PR DESCRIPTION
# 📲 What
Adding headers to distinguish graphQL requests coming from Android

# 🤔 Why
So the backend doesn't ignore our RefTags

# 🛠 How
- Added a [`KSRequestInterceptor`](https://github.com/kickstarter/android-oss/blob/master/app/src/main/java/com/kickstarter/services/interceptors/KSRequestInterceptor.java) to the ` in `ApplicationModule.provideApolloClient`.

# 👀 See
Nothing to see

# 📋 QA
@walterbm and I paired on this by adding some logs in the native HQ

# Story 📖
🔜 
