### PR TITLE
[👷🏾‍♀️] NT-584 Go rewardless feature flag support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -183,7 +183,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation "androidx.preference:preference:1.1.0"
+    implementation 'androidx.preference:preference:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0-beta01'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -183,6 +183,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
+    implementation "androidx.preference:preference:1.1.0"
     implementation 'androidx.recyclerview:recyclerview:1.1.0-beta01'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'

--- a/app/src/internal/java/com/kickstarter/ui/activities/FeatureFlagsActivity.kt
+++ b/app/src/internal/java/com/kickstarter/ui/activities/FeatureFlagsActivity.kt
@@ -32,9 +32,9 @@ class FeatureFlagsActivity : BaseActivity<FeatureFlagsViewModel.ViewModel>() {
                 .subscribe { featureFlagAdapter.takeFlags(it) }
 
         displayPreference(R.string.Native_Checkout, environment().nativeCheckoutPreference(), native_checkout)
+        displayPreference(R.string.Go_Rewardless, environment().goRewardlessPreference(), go_rewardless)
     }
 
-    @Suppress("SameParameterValue")
     private fun displayPreference(@StringRes labelRes: Int, booleanPreferenceType: BooleanPreferenceType, overrideContainer: View) {
         overrideContainer.override_label.setText(labelRes)
 

--- a/app/src/internal/res/layout/activity_feature_flags.xml
+++ b/app/src/internal/res/layout/activity_feature_flags.xml
@@ -46,6 +46,10 @@
         android:text="@string/Overrides"/>
 
       <include
+        android:id="@+id/go_rewardless"
+        layout="@layout/item_feature_flag_override"/>
+
+      <include
         android:id="@+id/native_checkout"
         layout="@layout/item_feature_flag_override"/>
     </LinearLayout>

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -7,7 +7,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
-import android.preference.PreferenceManager;
 
 import com.apollographql.apollo.ApolloClient;
 import com.google.gson.FieldNamingPolicy;
@@ -48,6 +47,7 @@ import com.kickstarter.libs.qualifiers.AppRatingPreference;
 import com.kickstarter.libs.qualifiers.ApplicationContext;
 import com.kickstarter.libs.qualifiers.ConfigPreference;
 import com.kickstarter.libs.qualifiers.GamesNewsletterPreference;
+import com.kickstarter.libs.qualifiers.GoRewardlessPreference;
 import com.kickstarter.libs.qualifiers.KoalaEndpoint;
 import com.kickstarter.libs.qualifiers.KoalaRetrofit;
 import com.kickstarter.libs.qualifiers.NativeCheckoutPreference;
@@ -83,6 +83,7 @@ import java.net.CookieManager;
 import javax.inject.Singleton;
 
 import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
 import dagger.Module;
 import dagger.Provides;
 import okhttp3.CookieJar;
@@ -114,6 +115,7 @@ public final class ApplicationModule {
     final @NonNull CookieManager cookieManager,
     final @NonNull CurrentConfigType currentConfig,
     final @NonNull CurrentUserType currentUser,
+    final @NonNull @GoRewardlessPreference BooleanPreferenceType goRewardlessPreference,
     final @NonNull Gson gson,
     final @NonNull @AppRatingPreference BooleanPreferenceType hasSeenAppRatingPreference,
     final @NonNull @GamesNewsletterPreference BooleanPreferenceType hasSeenGamesNewsletterPreference,
@@ -139,6 +141,7 @@ public final class ApplicationModule {
       .cookieManager(cookieManager)
       .currentConfig(currentConfig)
       .currentUser(currentUser)
+      .goRewardlessPreference(goRewardlessPreference)
       .gson(gson)
       .hasSeenAppRatingPreference(hasSeenAppRatingPreference)
       .hasSeenGamesNewsletterPreference(hasSeenGamesNewsletterPreference)
@@ -378,6 +381,14 @@ public final class ApplicationModule {
   @NonNull
   static BooleanPreferenceType provideNativeCheckoutPreference(final @NonNull SharedPreferences sharedPreferences) {
     return new BooleanPreference(sharedPreferences, SharedPreferenceKey.NATIVE_CHECKOUT);
+  }
+
+  @Provides
+  @Singleton
+  @GoRewardlessPreference
+  @NonNull
+  static BooleanPreferenceType provideGoRewardlessPreference(final @NonNull SharedPreferences sharedPreferences) {
+    return new BooleanPreference(sharedPreferences, SharedPreferenceKey.GO_REWARDLESS);
   }
 
   @Provides

--- a/app/src/main/java/com/kickstarter/libs/Environment.java
+++ b/app/src/main/java/com/kickstarter/libs/Environment.java
@@ -27,6 +27,7 @@ public abstract class Environment implements Parcelable {
   public abstract CookieManager cookieManager();
   public abstract CurrentConfigType currentConfig();
   public abstract CurrentUserType currentUser();
+  public abstract BooleanPreferenceType goRewardlessPreference();
   public abstract Gson gson();
   public abstract BooleanPreferenceType hasSeenAppRatingPreference();
   public abstract BooleanPreferenceType hasSeenGamesNewsletterPreference();
@@ -53,6 +54,7 @@ public abstract class Environment implements Parcelable {
     public abstract Builder cookieManager(CookieManager __);
     public abstract Builder currentConfig(CurrentConfigType __);
     public abstract Builder currentUser(CurrentUserType __);
+    public abstract Builder goRewardlessPreference(BooleanPreferenceType __);
     public abstract Builder gson(Gson __);
     public abstract Builder hasSeenAppRatingPreference(BooleanPreferenceType __);
     public abstract Builder hasSeenGamesNewsletterPreference(BooleanPreferenceType __);

--- a/app/src/main/java/com/kickstarter/libs/FeatureKey.java
+++ b/app/src/main/java/com/kickstarter/libs/FeatureKey.java
@@ -3,6 +3,7 @@ package com.kickstarter.libs;
 public final class FeatureKey {
   private FeatureKey() {}
 
+  public static final String ANDROID_GO_REWARDLESS = "android_go_rewardless";
   public static final String ANDROID_NATIVE_CHECKOUT = "android_native_checkout";
 
 }

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/GoRewardlessPreference.kt
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/GoRewardlessPreference.kt
@@ -1,0 +1,6 @@
+package com.kickstarter.libs.qualifiers
+
+import javax.inject.Qualifier
+
+@Qualifier
+annotation class GoRewardlessPreference

--- a/app/src/main/java/com/kickstarter/ui/SharedPreferenceKey.java
+++ b/app/src/main/java/com/kickstarter/ui/SharedPreferenceKey.java
@@ -5,6 +5,7 @@ public final class SharedPreferenceKey {
 
   public static final String ACCESS_TOKEN = "access_token";
   public static final String CONFIG = "config";
+  public static final String GO_REWARDLESS = "go_rewardless";
   public static final String HAS_SEEN_APP_RATING = "has_seen_app_rating";
   public static final String HAS_SEEN_GAMES_NEWSLETTER = "has_seen_games_newsletter";
   public static final String LAST_SEEN_ACTIVITY_ID = "last_seen_activity_id";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
   <string name="Enter_the_base_url_of_the_api">Enter the base URL of the API</string>
   <string name="Enter_Hivequeen_name">Enter Hivequeen name (e.g.: christopher)</string>
   <string name="Feature_flags">Feature flags</string>
+  <string name="Go_Rewardless">Go Rewardless</string>
   <string name="Force_a_crash">Force a crash 💥</string>
   <string name="Hivequeen">Hivequeen</string>
   <string name="Instructions">Instructions</string>


### PR DESCRIPTION
# 📲 What
Scaffolding for go rewardless feature flag

# 🤔 Why
Go rewardless prompt coming soon 🚀 

# 🛠 How
- Added `androidx.preference:preference:1.1.0` lib because  [`PreferenceManager.getDefaultSharedPreferences`](https://developer.android.com/reference/android/preference/PreferenceManager.html#getDefaultSharedPreferences(android.content.Context)) is deprecated. It's been superseded by [`PreferenceManager.getDefaultSharedPreferences`](https://developer.android.com/reference/androidx/preference/PreferenceManager.html#getDefaultSharedPreferences(android.content.Context))
- Added `FeatureKey.ANDROID_GO_REWARDLESS` with the value `android_go_rewardless` from https://github.com/kickstarter/kickstarter/pull/18139 (hasn't yet been deployed)
- Added `goRewardlessPreference` field to `Environment`.
- Added `GoRewardlessPreference` qualifier for internal flag.
- Added toggle for `Go Rewardless` internal flag.

# 👀 See
| Feature Flags | 
| --- | 
| <img src=https://user-images.githubusercontent.com/1289295/69174208-55126b80-0acf-11ea-98a5-047f985d28b3.png width=330/> | 

# 📋 QA
View the Feature flags screen and check out the new toggle.

# Story 📖
[NT-584]


[NT-584]: https://dripsprint.atlassian.net/browse/NT-584