### PR TITLE
[🐞] NT-566 Refreshing project page bug

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -417,10 +417,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
 
         AnimatorSet().apply {
             playTogether(showRewardsFragmentAnimator, hideRewardsFragmentAnimator, pledgeContainerYAnimator)
-            duration = when {
-                animate -> animDuration
-                else -> 0L
-            }
+            duration = animDuration
 
             addListener(object : Animator.AnimatorListener {
                 override fun onAnimationRepeat(animation: Animator?) {}
@@ -445,7 +442,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 override fun onAnimationStart(animation: Animator?) {
                     if (expand) {
                         pledge_container.visibility = View.VISIBLE
-                    } else {
+                    } else if (animate){
                         pledge_action_buttons.visibility = View.VISIBLE
                     }
                 }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -23,6 +23,7 @@ import type.CreditCardPaymentType
 import type.CreditCardTypes
 import java.text.SimpleDateFormat
 import java.util.*
+import java.util.concurrent.TimeUnit
 
 interface BackingFragmentViewModel {
     interface Inputs {
@@ -310,8 +311,10 @@ interface BackingFragmentViewModel {
                         this.swipeRefresherProgressIsVisible.onNext(true)
                     }
 
-            backedProject
-                    .skip(1)
+            val refreshTimeout = this.notifyDelegateToRefreshProject
+                    .delay(10, TimeUnit.SECONDS)
+
+            Observable.merge(refreshTimeout, backedProject.skip(1))
                     .map { false }
                     .compose(bindToLifecycle())
                     .subscribe(this.swipeRefresherProgressIsVisible)

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -355,9 +355,16 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.horizontalProgressBarIsGone)
 
+            val pledgeSheetExpanded = this.expandPledgeSheet
+                    .map { it.first }
+                    .startWith(false)
+
             progressBarIsGone
                     .compose<Pair<Boolean, Boolean>>(combineLatestPair(nativeCheckoutEnabled))
                     .filter { BooleanUtils.isTrue(it.second) }
+                    .map { it.first }
+                    .compose<Pair<Boolean, Boolean>>(combineLatestPair(pledgeSheetExpanded))
+                    .filter { BooleanUtils.isFalse(it.second) }
                     .map { it.first }
                     .compose(bindToLifecycle())
                     .subscribe(this.retryProgressBarIsGone)
@@ -415,10 +422,10 @@ interface ProjectViewModel {
                         it.slug()?.let { slug ->
                             this.client.fetchProject(slug)
                                     .doOnSubscribe {
-                                        this.retryProgressBarIsGone.onNext(false)
+                                        progressBarIsGone.onNext(false)
                                     }
                                     .doAfterTerminate {
-                                        this.retryProgressBarIsGone.onNext(true)
+                                        progressBarIsGone.onNext(true)
                                     }
                                     .materialize()
                         }
@@ -542,12 +549,14 @@ interface ProjectViewModel {
                     .filter { BooleanUtils.isTrue(it.second) }
                     .map { it.first }
 
-            val projectHasRewards = currentProjectWhenFeatureEnabled
+            val projectHasRewardsAndSheetCollapsed = currentProjectWhenFeatureEnabled
                     .map { it.hasRewards() }
                     .distinctUntilChanged()
-                    .takeUntil(this.expandPledgeSheet)
+                    .compose<Pair<Boolean, Boolean>>(combineLatestPair(pledgeSheetExpanded))
+                    .filter { BooleanUtils.isFalse(it.second) }
+                    .map { it.first }
 
-            val rewardsLoaded = projectHasRewards
+            val rewardsLoaded = projectHasRewardsAndSheetCollapsed
                     .filter { BooleanUtils.isTrue(it) }
                     .map { true }
 
@@ -560,8 +569,10 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.reloadProjectContainerIsGone)
 
-            projectHasRewards
-                    .map { BooleanUtils.negate(it) }
+            projectHasRewardsAndSheetCollapsed
+                    .compose<Pair<Boolean, Boolean>>(combineLatestPair(this.retryProgressBarIsGone))
+                    .map { BooleanUtils.negate(it.first && it.second) }
+                    .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.pledgeActionButtonContainerIsGone)
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -412,14 +412,16 @@ interface ProjectViewModel {
             val refreshedProjectNotification = initialProject
                     .compose(takeWhen<Project, Void>(refreshProjectEvent))
                     .switchMap {
-                        this.client.fetchProject(it)
-                            .doOnSubscribe {
-                                this.retryProgressBarIsGone.onNext(false)
-                            }
-                            .doAfterTerminate {
-                                this.retryProgressBarIsGone.onNext(true)
-                            }
-                            .materialize()
+                        it.slug()?.let { slug ->
+                            this.client.fetchProject(slug)
+                                    .doOnSubscribe {
+                                        this.retryProgressBarIsGone.onNext(false)
+                                    }
+                                    .doAfterTerminate {
+                                        this.retryProgressBarIsGone.onNext(true)
+                                    }
+                                    .materialize()
+                        }
                     }
                     .share()
 

--- a/app/src/main/res/layout/activity_project.xml
+++ b/app/src/main/res/layout/activity_project.xml
@@ -28,6 +28,7 @@
     android:layout_below="@id/project_app_bar_layout"
     android:layout_marginTop="-6dp"
     android:indeterminate="true"
+    android:visibility="gone"
     app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
 
   <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/pledge_container.xml
+++ b/app/src/main/res/layout/pledge_container.xml
@@ -12,8 +12,6 @@
   tools:layout_marginTop="620dp"
   tools:showIn="@layout/activity_project">
 
-  <include layout="@layout/project_retry" />
-
   <FrameLayout
     android:id="@+id/pledge_container"
     android:layout_width="match_parent"
@@ -67,6 +65,8 @@
     android:id="@+id/secondary_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />
+
+  <include layout="@layout/project_retry" />
 
   <LinearLayout
     android:id="@+id/pledge_action_buttons"

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -325,7 +325,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.intent(intent)
 
         this.horizontalProgressBarIsGone.assertNoValues()
-        this.pledgeActionButtonContainerIsGone.assertValues(false)
+        this.pledgeActionButtonContainerIsGone.assertValues(true, false)
         this.pledgeContainerIsGone.assertValue(false)
         this.prelaunchUrl.assertNoValues()
         this.projectActionButtonContainerIsGone.assertValue(true)
@@ -370,7 +370,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.reloadProjectContainerClicked()
 
         this.horizontalProgressBarIsGone.assertNoValues()
-        this.pledgeActionButtonContainerIsGone.assertValues(false)
+        this.pledgeActionButtonContainerIsGone.assertValues(true, false)
         this.pledgeContainerIsGone.assertValue(false)
         this.prelaunchUrl.assertNoValues()
         this.projectActionButtonContainerIsGone.assertValue(true)


### PR DESCRIPTION
# 📲 What
Pull to refresh bug.

# 🤔 Why
TIL (it was yesterday) that calling `ApiClient.fetchProject(final @NonNull Project project)` emits the initial project first... this meant that doing PTR would sometimes flicker in the view/manage pledge screen.

# 🛠 How
- Now calling `ApiClient.fetchProject(final @NonNull String slug)` instead of `ApiClient.fetchProject(final @NonNull Project project)` to refresh project.
- Refreshing the project now hides the pledge action button (so the user won't see the `ProgressBar` and the action button at the same time).
  - The non native checkout `ProgressBar` initially starts as `GONE`.
- Pull to refresh times out after 10 seconds if it fails so the user can retry.
- The retry button was blocked from being clicked so it not lives on top of the pledge fragments.
- Updated tests.

# 👀 See
| After refreshing 🦋 | Before refreshing 🐛 |
| --- | --- |
| ![device-2019-11-20-122550 2019-11-20 12_28_31](https://user-images.githubusercontent.com/1289295/69262474-86ec0680-0b91-11ea-819d-f8c674dc6c5e.gif) | ![device-2019-11-20-122427 2019-11-20 12_28_56](https://user-images.githubusercontent.com/1289295/69262488-8ce1e780-0b91-11ea-8f52-ab0580d0b15b.gif) |
| After canceling | Before canceling |
| ![device-2019-11-20-122608 2019-11-20 12_29_07](https://user-images.githubusercontent.com/1289295/69262411-6de35580-0b91-11ea-9b7b-0d7eadfab192.gif) | ![device-2019-11-20-122647 2019-11-20 12_29_03](https://user-images.githubusercontent.com/1289295/69262380-6623b100-0b91-11ea-99a8-734f1e082406.gif) |

# 📋 QA
Back an unbacked project and pull to refresh -> no more flickering.
Cancel a pledge -> see the progress when the project is reloaded

# Story 📖
[NT-566]

[NT-566]: https://dripsprint.atlassian.net/browse/NT-566