### PR TITLE
[✨] NT-587 Go rewardless carousel treatment

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/NativeCheckoutRewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/NativeCheckoutRewardViewHolder.kt
@@ -38,6 +38,11 @@ class NativeCheckoutRewardViewHolder(private val view: View, val delegate: Deleg
 
         val rewardItemAdapter = setUpRewardItemsAdapter()
 
+        this.viewModel.outputs.background()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.reward_contents.setBackgroundResource(it) }
+
         this.viewModel.outputs.conversionIsGone()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())

--- a/app/src/main/java/com/kickstarter/ui/viewholders/NativeCheckoutRewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/NativeCheckoutRewardViewHolder.kt
@@ -41,7 +41,7 @@ class NativeCheckoutRewardViewHolder(private val view: View, val delegate: Deleg
         this.viewModel.outputs.background()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { this.view.reward_contents.setBackgroundResource(it) }
+                .subscribe { if (!this.inset) this.view.reward_contents.setBackgroundResource(it) }
 
         this.viewModel.outputs.conversionIsGone()
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
@@ -122,9 +122,9 @@ interface NativeCheckoutRewardViewHolderViewModel {
         private val projectAndReward = PublishSubject.create<Pair<Project, Reward>>()
         private val rewardClicked = PublishSubject.create<Int>()
 
-        private val background = BehaviorSubject.create<Int>()
         private val backersCount = BehaviorSubject.create<Int>()
         private val backersCountIsGone = BehaviorSubject.create<Boolean>()
+        private val background = BehaviorSubject.create<Int>()
         private val buttonCTA = BehaviorSubject.create<Int>()
         private val buttonIsEnabled = BehaviorSubject.create<Boolean>()
         private val buttonIsGone = BehaviorSubject.create<Boolean>()
@@ -171,7 +171,7 @@ interface NativeCheckoutRewardViewHolderViewModel {
                     .map { it.first?.id() == it.second.creator().id() }
 
             val goRewardlessEnabled = this.currentConfig.observable()
-                    .map { it.features()?.get(FeatureKey.ANDROID_GO_REWARDLESS)?: false}
+                    .map { it.features()?.get(FeatureKey.ANDROID_GO_REWARDLESS) ?: false }
                     .map { Pair.create<Boolean, Boolean>(it, this.goRewardlessPreference.get()) }
                     .map { if (Build.isExternal()) it.first else it.second }
                     .distinctUntilChanged()

--- a/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModel.kt
@@ -4,10 +4,8 @@ import android.text.SpannableString
 import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.R
-import com.kickstarter.libs.ActivityViewModel
-import com.kickstarter.libs.CurrentUserType
-import com.kickstarter.libs.Environment
-import com.kickstarter.libs.KSCurrency
+import com.kickstarter.libs.*
+import com.kickstarter.libs.preferences.BooleanPreferenceType
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
 import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
 import com.kickstarter.libs.utils.*
@@ -38,6 +36,9 @@ interface NativeCheckoutRewardViewHolderViewModel {
 
         /** Emits a boolean determining if the backers count should be shown. */
         fun backersCountIsGone(): Observable<Boolean>
+
+        /**  Emits the drawable resource ID of the reward contents. */
+        fun background(): Observable<Int>
 
         /**  Emits the string resource ID to set on the pledge button. */
         fun buttonCTA(): Observable<Int>
@@ -113,12 +114,15 @@ interface NativeCheckoutRewardViewHolderViewModel {
     }
 
     class ViewModel(@NonNull environment: Environment) : ActivityViewModel<NativeCheckoutRewardViewHolder>(environment), Inputs, Outputs {
+        private val currentConfig: CurrentConfigType = environment.currentConfig()
         private val currentUser: CurrentUserType = environment.currentUser()
+        private val goRewardlessPreference: BooleanPreferenceType = environment.goRewardlessPreference()
         private val ksCurrency: KSCurrency = environment.ksCurrency()
 
         private val projectAndReward = PublishSubject.create<Pair<Project, Reward>>()
         private val rewardClicked = PublishSubject.create<Int>()
 
+        private val background = BehaviorSubject.create<Int>()
         private val backersCount = BehaviorSubject.create<Int>()
         private val backersCountIsGone = BehaviorSubject.create<Boolean>()
         private val buttonCTA = BehaviorSubject.create<Int>()
@@ -166,6 +170,20 @@ interface NativeCheckoutRewardViewHolderViewModel {
                     .compose<Pair<User?, Project>>(combineLatestPair(project))
                     .map { it.first?.id() == it.second.creator().id() }
 
+            val goRewardlessEnabled = this.currentConfig.observable()
+                    .map { it.features()?.get(FeatureKey.ANDROID_GO_REWARDLESS)?: false}
+                    .map { Pair.create<Boolean, Boolean>(it, this.goRewardlessPreference.get()) }
+                    .map { if (Build.isExternal()) it.first else it.second }
+                    .distinctUntilChanged()
+
+            reward
+                    .map { RewardUtils.isNoReward(it) }
+                    .compose<Pair<Boolean, Boolean>>(combineLatestPair(goRewardlessEnabled))
+                    .map { if (it.first && it.second) R.drawable.bg_go_rewardless else 0 }
+                    .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.background)
+
             this.projectAndReward
                     .compose<Pair<Pair<Project, Reward>, Boolean>>(combineLatestPair(userCreatedProject))
                     .map { buttonIsGone(it.first.first, it.first.second, it.second) }
@@ -192,10 +210,12 @@ interface NativeCheckoutRewardViewHolderViewModel {
 
             this.projectAndReward
                     .filter { RewardUtils.isNoReward(it.second) }
+                    .map { BackingUtils.isBacked(it.first, it.second) }
+                    .compose<Pair<Boolean, Boolean>>(combineLatestPair(goRewardlessEnabled))
                     .map {
-                        val backed = BackingUtils.isBacked(it.first, it.second)
                         when {
-                            backed -> R.string.Thanks_for_bringing_this_project_one_step_closer_to_becoming_a_reality
+                            it.first -> R.string.Thanks_for_bringing_this_project_one_step_closer_to_becoming_a_reality
+                            it.second -> R.string.This_holiday_season_support_a_project_for_no_reward
                             else -> R.string.Back_it_because_you_believe_in_it
                         }
                     }
@@ -271,10 +291,12 @@ interface NativeCheckoutRewardViewHolderViewModel {
 
             this.projectAndReward
                     .filter { RewardUtils.isNoReward(it.second) }
+                    .map { BackingUtils.isBacked(it.first, it.second) }
+                    .compose<Pair<Boolean, Boolean>>(combineLatestPair(goRewardlessEnabled))
                     .map {
-                        val backed = BackingUtils.isBacked(it.first, it.second)
                         when {
-                            backed -> R.string.You_pledged_without_a_reward
+                            it.first -> R.string.You_pledged_without_a_reward
+                            it.second -> R.string.Back_it_because_you_believe_in_it
                             else -> R.string.Pledge_without_a_reward
                         }
                     }
@@ -377,6 +399,9 @@ interface NativeCheckoutRewardViewHolderViewModel {
 
         @NonNull
         override fun backersCountIsGone(): Observable<Boolean> = this.backersCountIsGone
+
+        @NonNull
+        override fun background(): Observable<Int> = this.background
 
         @NonNull
         override fun buttonCTA(): Observable<Int> = this.buttonCTA

--- a/app/src/main/res/drawable/bg_go_rewardless.xml
+++ b/app/src/main/res/drawable/bg_go_rewardless.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+  android:shape="rectangle">
+  <stroke
+    android:width="2dp"
+    android:color="@color/white" />
+  <corners android:radius="@dimen/reward_card_radius" />
+  <gradient
+    android:angle="90"
+    android:endColor="#DBE7FF"
+    android:startColor="#FFF2EC" />
+</shape>

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -200,7 +200,7 @@
 
     <View
       android:layout_width="match_parent"
-      android:layout_height="@dimen/grid_20"
+      android:layout_height="@dimen/grid_15"
       android:background="@drawable/white_gradient_background" />
 
     <com.google.android.material.button.MaterialButton

--- a/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
@@ -118,8 +118,17 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testBackground_whenReward() {
+    fun testBackground_whenReward_goRewardlessDisabled() {
         setUpEnvironment(environmentWithGoRewardlessDisabled())
+
+        this.vm.inputs.projectAndReward(ProjectFactory.project(), RewardFactory.reward())
+
+        this.background.assertValue(0)
+    }
+
+    @Test
+    fun testBackground_whenReward_goRewardlessEnabled() {
+        setUpEnvironment(environmentWithGoRewardlessEnabled())
 
         this.vm.inputs.projectAndReward(ProjectFactory.project(), RewardFactory.reward())
 
@@ -390,8 +399,20 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testDescriptionOutputs_whenReward_hasDescription() {
-        setUpEnvironment(environment())
+    fun testDescriptionOutputs_whenReward_hasDescription_goRewardlessDisabled() {
+        setUpEnvironment(environmentWithGoRewardlessDisabled())
+
+        //Reward with description
+        val reward = RewardFactory.reward()
+        this.vm.inputs.projectAndReward(ProjectFactory.project(), reward)
+        this.descriptionForNoReward.assertNoValues()
+        this.descriptionForReward.assertValue(reward.description())
+        this.descriptionIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testDescriptionOutputs_whenReward_hasDescription_goRewardlessEnabled() {
+        setUpEnvironment(environmentWithGoRewardlessEnabled())
 
         //Reward with description
         val reward = RewardFactory.reward()
@@ -424,8 +445,27 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testDescriptionOutputs_whenNoReward_backed() {
+    fun testDescriptionOutputs_whenBackedNoReward_goRewardlessDisabled() {
         setUpEnvironment(environmentWithGoRewardlessDisabled())
+
+        val noRewardBacking = BackingFactory.backing()
+                .toBuilder()
+                .reward(RewardFactory.noReward())
+                .rewardId(null)
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(noRewardBacking)
+                .build()
+        this.vm.inputs.projectAndReward(backedProject, RewardFactory.noReward())
+        this.descriptionForNoReward.assertValue(R.string.Thanks_for_bringing_this_project_one_step_closer_to_becoming_a_reality)
+        this.descriptionForReward.assertNoValues()
+        this.descriptionIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testDescriptionOutputs_whenBackedNoReward_goRewardlessEnabled() {
+        setUpEnvironment(environmentWithGoRewardlessEnabled())
 
         val noRewardBacking = BackingFactory.backing()
                 .toBuilder()

--- a/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/NativeCheckoutRewardViewHolderViewModelTest.kt
@@ -52,7 +52,7 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm = NativeCheckoutRewardViewHolderViewModel.ViewModel(environment)
         this.vm.outputs.backersCount().subscribe(this.backersCount)
         this.vm.outputs.backersCountIsGone().subscribe(this.backersCountIsGone)
-        this.vm.outputs.background().subscribe(this.backersCount)
+        this.vm.outputs.background().subscribe(this.background)
         this.vm.outputs.buttonCTA().subscribe(this.buttonCTA)
         this.vm.outputs.buttonIsEnabled().subscribe(this.buttonIsEnabled)
         this.vm.outputs.buttonIsGone().subscribe(this.buttonIsGone)
@@ -119,7 +119,7 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testBackground_whenReward() {
-        setUpEnvironment(environment())
+        setUpEnvironment(environmentWithGoRewardlessDisabled())
 
         this.vm.inputs.projectAndReward(ProjectFactory.project(), RewardFactory.reward())
 
@@ -128,7 +128,7 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testBackground_whenNoReward_goRewardlessDisabled() {
-        setUpEnvironment(environment())
+        setUpEnvironment(environmentWithGoRewardlessDisabled())
 
         this.vm.inputs.projectAndReward(ProjectFactory.project(), RewardFactory.noReward())
 
@@ -137,8 +137,7 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testBackground_whenNoReward_goRewardlessEnabled() {
-        val environment = environmentWithGoRewardlessEnabled()
-        setUpEnvironment(environment)
+        setUpEnvironment(environmentWithGoRewardlessEnabled())
 
         this.vm.inputs.projectAndReward(ProjectFactory.project(), RewardFactory.noReward())
 
@@ -186,7 +185,8 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment())
 
         val backedLiveProject = ProjectFactory.backedProject()
-        this.vm.inputs.projectAndReward(backedLiveProject, backedLiveProject.backing()?.reward()?: RewardFactory.reward())
+        this.vm.inputs.projectAndReward(backedLiveProject, backedLiveProject.backing()?.reward()
+                ?: RewardFactory.reward())
         this.buttonIsGone.assertValue(false)
         this.buttonCTA.assertValuesAndClear(R.string.Selected)
     }
@@ -265,7 +265,8 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
                 .state(Project.STATE_SUCCESSFUL)
                 .build()
 
-        this.vm.inputs.projectAndReward(backedSuccessfulProject, backedSuccessfulProject.backing()?.reward()?: RewardFactory.reward())
+        this.vm.inputs.projectAndReward(backedSuccessfulProject, backedSuccessfulProject.backing()?.reward()
+                ?: RewardFactory.reward())
         this.buttonIsGone.assertValue(false)
         this.buttonCTA.assertValue(R.string.Selected)
     }
@@ -402,7 +403,7 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testDescriptionOutputs_whenNoReward_goRewardlessDisabled() {
-        setUpEnvironment(environment())
+        setUpEnvironment(environmentWithGoRewardlessDisabled())
 
         //No reward
         this.vm.inputs.projectAndReward(ProjectFactory.project(), RewardFactory.noReward())
@@ -424,7 +425,7 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testDescriptionOutputs_whenNoReward_backed() {
-        setUpEnvironment(environment())
+        setUpEnvironment(environmentWithGoRewardlessDisabled())
 
         val noRewardBacking = BackingFactory.backing()
                 .toBuilder()
@@ -775,12 +776,12 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testTitleOutputs_whenNoReward_goRewardlessDisabled() {
-        setUpEnvironment(environment())
+        setUpEnvironment(environmentWithGoRewardlessDisabled())
 
         this.vm.inputs.projectAndReward(ProjectFactory.project(), RewardFactory.noReward())
         this.titleIsGone.assertValues(false)
         this.titleForReward.assertNoValues()
-        this.titleForNoReward.assertValue(R.string.Back_it_because_you_believe_in_it)
+        this.titleForNoReward.assertValue(R.string.Pledge_without_a_reward)
     }
 
     @Test
@@ -790,12 +791,12 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.projectAndReward(ProjectFactory.project(), RewardFactory.noReward())
         this.titleIsGone.assertValue(false)
         this.titleForReward.assertNoValues()
-        this.titleForNoReward.assertValuesAndClear(R.string.You_pledged_without_a_reward)
+        this.titleForNoReward.assertValuesAndClear(R.string.Back_it_because_you_believe_in_it)
     }
 
     @Test
     fun testTitleOutputs_whenNoReward_backed() {
-        setUpEnvironment(environment())
+        setUpEnvironment(environmentWithGoRewardlessDisabled())
 
         val noRewardBacking = BackingFactory.backing()
                 .toBuilder()
@@ -809,7 +810,17 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.projectAndReward(backedProject, RewardFactory.noReward())
         this.titleIsGone.assertValue(false)
         this.titleForReward.assertNoValues()
-        this.titleForNoReward.assertValuesAndClear(R.string.You_pledged_without_a_reward)
+        this.titleForNoReward.assertValue(R.string.You_pledged_without_a_reward)
+    }
+
+    private fun environmentWithGoRewardlessDisabled(): Environment {
+        val mockCurrentConfig = MockCurrentConfig()
+        mockCurrentConfig.config(ConfigFactory.config())
+        return environment()
+                .toBuilder()
+                .currentConfig(mockCurrentConfig)
+                .goRewardlessPreference(MockBooleanPreference(false))
+                .build()
     }
 
     private fun environmentWithGoRewardlessEnabled(): Environment {


### PR DESCRIPTION
# 📲 What
Go rewardless carousel treatment

# 🤔 Why
So users are ENCOURAGED to go rewardless.

# 🛠 How
- Added `background` output to `NativeCheckoutRewardViewHolderViewModel` that emits a `Int` representing the background of the reward contents. [`0`](https://developer.android.com/reference/android/view/View#setBackgroundResource(int)) is how you clear the background.
  - Added `bg_go_rewardless` as the special go rewardless background `Drawable`.
- Added special go rewardless copy when a user is viewing `No reward` and they haven't backed `No reward`.
- Decreased the size of the gradient behind the `Select` button for readability.
- Tests

# 👀 See
| Enabled ✔️  | Disabled ✖️  |
| --- | --- |
| ![screenshot-2019-11-25_171021](https://user-images.githubusercontent.com/1289295/69582430-9a8ad900-0fa6-11ea-9986-5716b3fde1a6.png) | ![screenshot-2019-11-25_171010](https://user-images.githubusercontent.com/1289295/69582428-9a8ad900-0fa6-11ea-966b-096725ce16d7.png) |

# 📋 QA
View no reward when go rewardless is enabled.

# Story 📖
[NT-587]


[NT-587]: https://dripsprint.atlassian.net/browse/NT-587