### PR TITLE
[🛤] NT-622 Go rewardless tracking

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -382,8 +382,8 @@ public final class ApplicationModule {
   @Provides
   @Singleton
   static Koala provideKoala(final @ApplicationContext @NonNull Context context, final @NonNull CurrentUserType currentUser,
-    final @NonNull Build build) {
-    return new Koala(new KoalaTrackingClient(context, currentUser, build));
+    final @NonNull Build build, final @NonNull CurrentConfigType currentConfig) {
+    return new Koala(new KoalaTrackingClient(context, currentUser, build, currentConfig));
   }
 
   @Provides

--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -7,6 +7,7 @@ import com.kickstarter.models.Update;
 import com.kickstarter.models.User;
 import com.kickstarter.services.DiscoveryParams;
 import com.kickstarter.services.apiresponses.PushNotificationEnvelope;
+import com.kickstarter.ui.data.Editorial;
 import com.kickstarter.ui.data.LoginReason;
 import com.kickstarter.ui.data.Mailbox;
 
@@ -72,6 +73,14 @@ public final class Koala {
     this.client.track(KoalaEvent.TRIGGERED_REFRESH, new HashMap<String, Object>() {
       {
         put("type", "swipe");
+      }
+    });
+  }
+
+  public void trackEditorialCardClicked(final @NonNull Editorial editorial) {
+    this.client.track(KoalaEvent.EDITORIAL_CARD_CLICKED, new HashMap<String, Object>() {
+      {
+        put("ref_tag", RefTag.collection(editorial.getTagId()).tag());
       }
     });
   }

--- a/app/src/main/java/com/kickstarter/libs/KoalaEvent.java
+++ b/app/src/main/java/com/kickstarter/libs/KoalaEvent.java
@@ -23,6 +23,7 @@ public final class KoalaEvent {
   public static final String DISCOVER_SEARCH_LEGACY = "Discover Search";
   public static final String DISCOVER_SEARCH_RESULTS_LEGACY = "Discover Search Results";
   public static final String DISCOVER_SEARCH_RESULTS_LOAD_MORE_LEGACY = "Discover Search Results Load More";
+  public static final String EDITORIAL_CARD_CLICKED = "Editorial Card Clicked";
   public static final String ERRORED_DELETE_PAYMENT_METHOD = "Errored Delete Payment Method";
   public static final String ERRORED_USER_LOGIN = "Errored User Login";
   public static final String ERRORED_USER_SIGNUP = "Errored User Signup";

--- a/app/src/main/java/com/kickstarter/libs/RefTag.java
+++ b/app/src/main/java/com/kickstarter/libs/RefTag.java
@@ -43,6 +43,10 @@ public abstract class RefTag implements Parcelable {
     return new AutoParcel_RefTag("city");
   }
 
+  public static @NonNull RefTag collection(final int tagId) {
+    return new AutoParcel_RefTag("android_project_collection_tag_" + tagId);
+  }
+
   public static @NonNull RefTag dashboard() {
     return new AutoParcel_RefTag("dashboard");
   }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -3,6 +3,8 @@ package com.kickstarter.libs;
 import com.kickstarter.libs.utils.KoalaUtils;
 import com.kickstarter.models.User;
 
+import org.json.JSONArray;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,6 +34,7 @@ public abstract class TrackingClientType {
     hashMap.put("device_format", deviceFormat());
     hashMap.put("device_orientation", deviceOrientation());
     hashMap.put("distinct_id", androidUUID());
+    hashMap.put("enabled_feature_flags", enabledFeatureFlags());
     hashMap.put("google_play_services", isGooglePlayServicesAvailable() ? "available" : "unavailable");
     hashMap.put("is_vo_on", isTalkBackOn());
     hashMap.put("koala_lib", "kickstarter_android");
@@ -56,6 +59,7 @@ public abstract class TrackingClientType {
   protected abstract String brand();
   protected abstract String deviceFormat();
   protected abstract String deviceOrientation();
+  protected abstract JSONArray enabledFeatureFlags();
   protected abstract boolean isGooglePlayServicesAvailable();
   protected abstract boolean isTalkBackOn();
   protected abstract User loggedInUser();

--- a/app/src/main/java/com/kickstarter/libs/utils/ConfigUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/ConfigUtils.kt
@@ -1,0 +1,21 @@
+package com.kickstarter.libs.utils
+
+import com.kickstarter.libs.Config
+import org.json.JSONArray
+
+object ConfigUtils {
+    fun enabledFeatureFlags(config: Config?): JSONArray? {
+        return config
+                ?.features()
+                ?.filter { it.key.startsWith("android_") && it.value }
+                ?.keys
+                ?.sorted()
+                ?.let {
+                    JSONArray().apply {
+                        for (feature in it) {
+                            put(feature)
+                        }
+                    }
+                }
+    }
+}

--- a/app/src/main/java/com/kickstarter/libs/utils/DiscoveryParamsUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/DiscoveryParamsUtils.java
@@ -37,6 +37,11 @@ public final class DiscoveryParamsUtils {
       return RefTag.recommended();
     }
 
+    final Integer tagId = params.tagId();
+    if (tagId != null) {
+      return RefTag.collection(tagId);
+    }
+
     if (isNonZero(params.social())) {
       return RefTag.social();
     }

--- a/app/src/main/java/com/kickstarter/mock/factories/ConfigFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/ConfigFactory.java
@@ -4,6 +4,7 @@ import com.kickstarter.libs.Config;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 
 import androidx.annotation.NonNull;
 
@@ -58,6 +59,12 @@ public final class ConfigFactory {
   public static @NonNull Config configWithFeatureEnabled(final @NonNull String featureKey) {
     return config().toBuilder()
       .features(Collections.singletonMap(featureKey, true))
+      .build();
+  }
+
+  public static @NonNull Config configWithFeaturesEnabled(final @NonNull Map<String, Boolean> features) {
+    return config().toBuilder()
+      .features(features)
       .build();
   }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -227,6 +227,10 @@ public interface DiscoveryFragmentViewModel {
         .compose(bindToLifecycle())
         .subscribe(this.startEditorialActivity);
 
+      this.editorialClicked
+        .compose(bindToLifecycle())
+        .subscribe(this.koala::trackEditorialCardClicked);
+
       this.paramsFromActivity
         .compose(combineLatestPair(userIsLoggedIn))
         .map(pu -> isOnboardingVisible(pu.first, pu.second))

--- a/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
+++ b/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
@@ -39,7 +39,8 @@ public abstract class KSRobolectricTestCase extends TestCase {
   public void setUp() throws Exception {
     super.setUp();
 
-    final MockTrackingClient testTrackingClient = new MockTrackingClient(new MockCurrentUser());
+    final MockCurrentConfig mockCurrentConfig = new MockCurrentConfig();
+    final MockTrackingClient testTrackingClient = new MockTrackingClient(new MockCurrentUser(), mockCurrentConfig);
     this.koalaTest = new TestSubscriber<>();
     testTrackingClient.eventNames.subscribe(this.koalaTest);
     DateTimeUtils.setCurrentMillisFixed(new DateTime().getMillis());
@@ -47,7 +48,7 @@ public abstract class KSRobolectricTestCase extends TestCase {
     this.environment = application().component().environment().toBuilder()
       .apiClient(new MockApiClient())
       .apolloClient(new MockApolloClient())
-      .currentConfig(new MockCurrentConfig())
+      .currentConfig(mockCurrentConfig)
       .webClient(new MockWebClient())
       .stripe(new Stripe(context(), Secrets.StripePublishableKey.STAGING))
       .koala(new Koala(testTrackingClient))

--- a/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
@@ -1,13 +1,12 @@
 package com.kickstarter.libs
 
 import com.kickstarter.KSRobolectricTestCase
-import com.kickstarter.mock.factories.CategoryFactory
-import com.kickstarter.mock.factories.LocationFactory
-import com.kickstarter.mock.factories.ProjectFactory
-import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.mock.MockCurrentConfig
+import com.kickstarter.mock.factories.*
 import com.kickstarter.models.User
 import com.kickstarter.services.DiscoveryParams
 import org.joda.time.DateTime
+import org.json.JSONArray
 import org.junit.Test
 import rx.subjects.BehaviorSubject
 
@@ -17,7 +16,7 @@ class KoalaTest : KSRobolectricTestCase() {
 
     @Test
     fun testDefaultProperties() {
-        val client = MockTrackingClient(MockCurrentUser())
+        val client = MockTrackingClient(MockCurrentUser(), mockCurrentConfig())
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -32,7 +31,7 @@ class KoalaTest : KSRobolectricTestCase() {
     @Test
     fun testDefaultProperties_LoggedInUser() {
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user))
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -52,7 +51,7 @@ class KoalaTest : KSRobolectricTestCase() {
     @Test
     fun testDiscoveryProperties() {
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user))
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -77,7 +76,7 @@ class KoalaTest : KSRobolectricTestCase() {
     @Test
     fun testDiscoveryProperties_AllProjects() {
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user))
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -102,7 +101,7 @@ class KoalaTest : KSRobolectricTestCase() {
     @Test
     fun testDiscoveryProperties_NoCategory() {
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user))
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -128,7 +127,7 @@ class KoalaTest : KSRobolectricTestCase() {
     fun testProjectProperties() {
         val project = project()
 
-        val client = MockTrackingClient(MockCurrentUser())
+        val client = MockTrackingClient(MockCurrentUser(), mockCurrentConfig())
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -144,7 +143,7 @@ class KoalaTest : KSRobolectricTestCase() {
     fun testProjectProperties_LoggedInUser() {
         val project = project()
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user))
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -171,7 +170,7 @@ class KoalaTest : KSRobolectricTestCase() {
                 .creator(creator())
                 .build()
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user))
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -194,7 +193,7 @@ class KoalaTest : KSRobolectricTestCase() {
     fun testProjectProperties_LoggedInUser_IsProjectCreator() {
         val project = project().toBuilder().build()
         val creator = creator()
-        val client = MockTrackingClient(MockCurrentUser(creator))
+        val client = MockTrackingClient(MockCurrentUser(creator), mockCurrentConfig())
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -215,7 +214,7 @@ class KoalaTest : KSRobolectricTestCase() {
     fun testProjectProperties_LoggedInUser_HasStarred() {
         val project = project().toBuilder().isStarred(true).build()
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user))
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -243,6 +242,7 @@ class KoalaTest : KSRobolectricTestCase() {
         assertEquals("phone", expectedProperties["device_format"])
         assertEquals("portrait", expectedProperties["device_orientation"])
         assertEquals("uuid", expectedProperties["distinct_id"])
+        assertEquals(JSONArray().put("android_example_feature"), expectedProperties["enabled_feature_flags"])
         assertEquals("unavailable", expectedProperties["google_play_services"])
         assertEquals(false, expectedProperties["is_vo_on"])
         assertEquals("kickstarter_android", expectedProperties["koala_lib"])
@@ -301,5 +301,9 @@ class KoalaTest : KSRobolectricTestCase() {
                     .createdProjectsCount(2)
                     .starredProjectsCount(10)
                     .build()
+
+    private fun mockCurrentConfig() = MockCurrentConfig().apply {
+        config(ConfigFactory.configWithFeatureEnabled("android_example_feature"))
+    }
 
 }

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -1,8 +1,10 @@
 package com.kickstarter.libs;
 
+import com.kickstarter.libs.utils.ConfigUtils;
 import com.kickstarter.models.User;
 
 import org.joda.time.DateTime;
+import org.json.JSONArray;
 
 import java.util.Map;
 
@@ -14,10 +16,11 @@ import rx.subjects.PublishSubject;
 public final class MockTrackingClient extends TrackingClientType {
   private static final long DEFAULT_TIME = DateTime.parse("2018-11-02T18:42:05Z").getMillis() / 1000;
   @Nullable private User loggedInUser;
+  @Nullable private Config config;
 
-
-  public MockTrackingClient(final @NonNull CurrentUserType currentUser) {
+  public MockTrackingClient(final @NonNull CurrentUserType currentUser, final @NonNull CurrentConfigType currentConfig) {
     currentUser.observable().subscribe(u -> this.loggedInUser = u);
+    currentConfig.observable().subscribe(c -> this.config = c);
   }
 
   public static class Event {
@@ -56,6 +59,11 @@ public final class MockTrackingClient extends TrackingClientType {
   @Override
   protected String deviceOrientation() {
     return "portrait";
+  }
+
+  @Override
+  protected JSONArray enabledFeatureFlags() {
+    return ConfigUtils.INSTANCE.enabledFeatureFlags(this.config);
   }
 
   @Override

--- a/app/src/test/java/com/kickstarter/libs/utils/ConfigUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/ConfigUtilsTest.kt
@@ -1,0 +1,33 @@
+package com.kickstarter.libs.utils
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.FeatureKey
+import com.kickstarter.mock.factories.ConfigFactory
+import org.json.JSONArray
+import org.junit.Test
+
+class ConfigUtilsTest : KSRobolectricTestCase() {
+    @Test
+    fun testEnabledFeatureFlags() {
+        assertEquals(null, ConfigUtils.enabledFeatureFlags(ConfigFactory.config().toBuilder().features(null).build()))
+
+        assertEquals(JSONArray(), ConfigUtils.enabledFeatureFlags(ConfigFactory.configWithFeatureEnabled("ios_native_checkout")))
+
+        assertEquals(JSONArray().apply { put("android_go_rewardless") },
+                ConfigUtils.enabledFeatureFlags(ConfigFactory.configWithFeatureEnabled(FeatureKey.ANDROID_GO_REWARDLESS)))
+
+        assertEquals(JSONArray().apply {
+            put("android_go_rewardless")
+            put("android_native_checkout")
+        }, ConfigUtils.enabledFeatureFlags(ConfigFactory.configWithFeaturesEnabled(mapOf(Pair(FeatureKey.ANDROID_GO_REWARDLESS, true),
+                Pair(FeatureKey.ANDROID_NATIVE_CHECKOUT, true),
+                Pair("ios_go_rewardless", true),
+                Pair("ios_native_checkout", true)))))
+
+        assertEquals(JSONArray().apply { put("android_native_checkout") },
+                ConfigUtils.enabledFeatureFlags(ConfigFactory.configWithFeaturesEnabled(mapOf(Pair(FeatureKey.ANDROID_GO_REWARDLESS, false),
+                        Pair(FeatureKey.ANDROID_NATIVE_CHECKOUT, true),
+                        Pair("ios_go_rewardless", true),
+                        Pair("ios_native_checkout", true)))))
+    }
+}

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -376,7 +376,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
 
   @Test
   public void testStartProjectActivity_whenViewingEditorial() {
-    setUpEnvironment(environmentWithGoRewardlessEnabled());
+    setUpEnvironment(environment());
 
     // Load editorial params and root categories from activity.
     final DiscoveryParams editorialParams = DiscoveryParams.builder()
@@ -391,6 +391,21 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.projectCardViewHolderClicked(project);
 
     this.startProjectActivity.assertValue(Pair.create(project, RefTag.collection(518)));
+    this.koalaTest.assertValues("Discover List View");
+  }
+
+  @Test
+  public void testStartProjectActivity_whenViewingAllProjects() {
+    setUpEnvironment(environment());
+
+    // Load initial params and root categories from activity.
+    setUpInitialHomeAllProjectsParams();
+
+    // Click on project
+    final Project project = ProjectFactory.project();
+    this.vm.inputs.projectCardViewHolderClicked(project);
+
+    this.startProjectActivity.assertValue(Pair.create(project, RefTag.discovery()));
     this.koalaTest.assertValues("Discover List View");
   }
 
@@ -417,14 +432,6 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.showLoginTout.assertNoValues();
     this.vm.inputs.discoveryOnboardingViewHolderLoginToutClick(null);
     this.showLoginTout.assertValue(true);
-
-    // Pass in params and sort to fetch projects.
-    this.vm.inputs.paramsFromActivity(DiscoveryParams.builder().build());
-
-    // Clicking on a project card should show project activity.
-    this.startProjectActivity.assertNoValues();
-    this.vm.inputs.projectCardViewHolderClicked(ProjectFactory.project());
-    this.startProjectActivity.assertValueCount(1);
   }
 
   private Environment environmentWithGoRewardlessDisabled() {

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -53,7 +53,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Boolean> showLoginTout = new TestSubscriber<>();
   private final TestSubscriber<Boolean> showProgress = new TestSubscriber<>();
   private final TestSubscriber<Editorial> startEditorialActivity = new TestSubscriber<>();
-  private final TestSubscriber<Pair<Project, RefTag>> showProject = new TestSubscriber<>();
+  private final TestSubscriber<Pair<Project, RefTag>> startProjectActivity = new TestSubscriber<>();
   private final TestSubscriber<Activity> startUpdateActivity = new TestSubscriber<>();
 
   private void setUpEnvironment(final @NonNull Environment environment) {
@@ -68,7 +68,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.showLoginTout().subscribe(this.showLoginTout);
     this.vm.outputs.showProgress().distinctUntilChanged().subscribe(this.showProgress);
     this.vm.outputs.startEditorialActivity().subscribe(this.startEditorialActivity);
-    this.vm.outputs.startProjectActivity().subscribe(this.showProject);
+    this.vm.outputs.startProjectActivity().subscribe(this.startProjectActivity);
     this.vm.outputs.startUpdateActivity().subscribe(this.startUpdateActivity);
   }
 
@@ -371,6 +371,27 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.editorialViewHolderClicked(Editorial.GO_REWARDLESS);
 
     this.startEditorialActivity.assertValue(Editorial.GO_REWARDLESS);
+    this.koalaTest.assertValues("Discover List View", "Editorial Card Clicked");
+  }
+
+  @Test
+  public void testStartProjectActivity_whenViewingEditorial() {
+    setUpEnvironment(environmentWithGoRewardlessEnabled());
+
+    // Load editorial params and root categories from activity.
+    final DiscoveryParams editorialParams = DiscoveryParams.builder()
+      .tagId(Editorial.GO_REWARDLESS.getTagId())
+      .sort(DiscoveryParams.Sort.HOME)
+      .build();
+    this.vm.inputs.paramsFromActivity(editorialParams);
+    this.vm.inputs.rootCategories(CategoryFactory.rootCategories());
+
+    // Click on project
+    final Project project = ProjectFactory.project();
+    this.vm.inputs.projectCardViewHolderClicked(project);
+
+    this.startProjectActivity.assertValue(Pair.create(project, RefTag.collection(518)));
+    this.koalaTest.assertValues("Discover List View");
   }
 
   @Test
@@ -401,9 +422,9 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.paramsFromActivity(DiscoveryParams.builder().build());
 
     // Clicking on a project card should show project activity.
-    this.showProject.assertNoValues();
+    this.startProjectActivity.assertNoValues();
     this.vm.inputs.projectCardViewHolderClicked(ProjectFactory.project());
-    this.showProject.assertValueCount(1);
+    this.startProjectActivity.assertValueCount(1);
   }
 
   private Environment environmentWithGoRewardlessDisabled() {


### PR DESCRIPTION
# 📲 What
^

# 🤔 Why
Metricz

# 🛠 How
- Now sending `enabled_feature_flags` array. It only sends events that are enabled and start with `android_`.
  - `Koala` now takes in a `CurrentConfigType` so we can extract the currently enabled features.
  - Added `ConfigUtils.enabledFeatureFlags ` that returns enabled android features.
- Added event when clicking Editorial tout `Editorial Card Clicked` with additional `ref_tag` property.
- Added support for `RefTag`s from `Editorial`s or `DiscoveryParams` that contain a `tag_id`.
- Tests (there's already a test for extracting a `RefTag` from an `Intent`).

## bug
- `GooglePlayServicesUtil.isGooglePlayServicesAvailable` is deprecated but then I also realized `isGooglePlayServicesAvailable` was returning `unavailable` instead of `available`.

# 👀 See
Nothing to see.

# 📋 QA
Tail your user's events in ktk

# Story 📖
[NT-622]


[NT-622]: https://dripsprint.atlassian.net/browse/NT-622