### PR TITLE
[💥] NT-625 No Crash Zone™ 

### DIFF
--- a/app/src/main/java/com/kickstarter/services/KoalaBackgroundService.kt
+++ b/app/src/main/java/com/kickstarter/services/KoalaBackgroundService.kt
@@ -1,12 +1,12 @@
 package com.kickstarter.services
 
 import android.util.Log
+import com.crashlytics.android.Crashlytics
 import com.firebase.jobdispatcher.JobParameters
 import com.firebase.jobdispatcher.JobService
 import com.kickstarter.KSApplication
 import com.kickstarter.libs.Build
 import com.kickstarter.ui.IntentKey
-import io.fabric.sdk.android.Fabric
 import okhttp3.ResponseBody
 import retrofit2.Response
 import rx.schedulers.Schedulers
@@ -49,6 +49,7 @@ class KoalaBackgroundService : JobService() {
             if (this.build.isDebug) {
                 Log.d(TAG, "Successfully tracked event: $eventName")
             }
+            Crashlytics.log(eventName)
         } else {
             logTrackingError(eventName)
         }
@@ -58,7 +59,7 @@ class KoalaBackgroundService : JobService() {
         if (this.build.isDebug) {
             Log.e(TAG, "Failed to track event: $eventName")
         }
-        Fabric.getLogger().e(TAG, "Failed to track event: $eventName")
+        Crashlytics.logException(Exception("Failed to track event: $eventName"))
     }
 
     companion object {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -774,7 +774,9 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
 
     private fun updateFragments(project: Project) {
         try {
-            safeLet(rewardsFragment(), backingFragment()) { rewardsFragment, backingFragment ->
+            val rewardsFragment = rewardsFragment()
+            val backingFragment = backingFragment()
+            if (rewardsFragment != null && backingFragment != null) {
                 when {
                     supportFragmentManager.backStackEntryCount == 0 -> when {
                         project.isBacking -> if (!rewardsFragment.isHidden) {
@@ -793,16 +795,8 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 }
                 renderProject(backingFragment, rewardsFragment, project)
             }
-        } catch (e :IllegalStateException) {
+        } catch (e: IllegalStateException) {
             Crashlytics.logException(e)
-        }
-    }
-
-    private fun <T1 : Any, T2 : Any> safeLet(p1: T1?, p2: T2?, block: (T1, T2) -> Unit) {
-        if (p1 != null && p2 != null) {
-            run {
-                block(p1, p2)
-            }
         }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -19,6 +19,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.crashlytics.android.Crashlytics
 import com.kickstarter.R
 import com.kickstarter.extensions.hideKeyboard
 import com.kickstarter.extensions.showSnackbar
@@ -390,6 +391,8 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         }
     }
 
+    private fun backingFragment() = supportFragmentManager.findFragmentById(R.id.fragment_backing) as BackingFragment?
+
     private fun clearFragmentBackStack(): Boolean {
         return supportFragmentManager.popBackStackImmediate(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
     }
@@ -519,14 +522,17 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     }
 
     private fun revealRewardsFragment() {
-        val rewardsFragment = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment
-        supportFragmentManager
-                .beginTransaction()
-                .setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
-                .show(rewardsFragment)
-                .addToBackStack(RewardsFragment::class.java.simpleName)
-                .commit()
+        rewardsFragment()?.let {
+            supportFragmentManager
+                    .beginTransaction()
+                    .setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
+                    .show(it)
+                    .addToBackStack(RewardsFragment::class.java.simpleName)
+                    .commit()
+        }
     }
+
+    private fun rewardsFragment() = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment?
 
     private fun rewardsSheetGuideline(): Int = resources.getDimensionPixelSize(R.dimen.reward_fragment_guideline_constraint_end)
 
@@ -657,8 +663,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
 
     private fun showUpdatePledgeSuccess() {
         clearFragmentBackStack()
-        val backingFragment = supportFragmentManager.findFragmentById(R.id.fragment_backing) as BackingFragment
-        backingFragment.pledgeSuccessfullyUpdated()
+        backingFragment()?.pledgeSuccessfullyUpdated()
     }
 
     private fun startCampaignWebViewActivity(project: Project) {
@@ -768,27 +773,38 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     }
 
     private fun updateFragments(project: Project) {
-        val (rewardsFragment, backingFragment) = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment to
-                supportFragmentManager.findFragmentById(R.id.fragment_backing) as BackingFragment
-        when {
-            supportFragmentManager.backStackEntryCount == 0 -> when {
-                project.isBacking -> if (!rewardsFragment.isHidden) {
-                    supportFragmentManager.beginTransaction()
-                            .show(backingFragment)
-                            .hide(rewardsFragment)
-                            .commitNow()
+        try {
+            safeLet(rewardsFragment(), backingFragment()) { rewardsFragment, backingFragment ->
+                when {
+                    supportFragmentManager.backStackEntryCount == 0 -> when {
+                        project.isBacking -> if (!rewardsFragment.isHidden) {
+                            supportFragmentManager.beginTransaction()
+                                    .show(backingFragment)
+                                    .hide(rewardsFragment)
+                                    .commitNow()
+                        }
+                        else -> if (!backingFragment.isHidden) {
+                            supportFragmentManager.beginTransaction()
+                                    .show(rewardsFragment)
+                                    .hide(backingFragment)
+                                    .commitNow()
+                        }
+                    }
                 }
-                else -> if (!backingFragment.isHidden) {
-                    supportFragmentManager.beginTransaction()
-                            .show(rewardsFragment)
-                            .hide(backingFragment)
-                            .commitNow()
-                }
+                renderProject(backingFragment, rewardsFragment, project)
             }
+        } catch (e :IllegalStateException) {
+            Crashlytics.logException(e)
         }
-        renderProject(backingFragment, rewardsFragment, project)
     }
 
+    private fun <T1 : Any, T2 : Any> safeLet(p1: T1?, p2: T2?, block: (T1, T2) -> Unit) {
+        if (p1 != null && p2 != null) {
+            run {
+                block(p1, p2)
+            }
+        }
+    }
 
     private fun updateManagePledgeMenu(@MenuRes menu: Int?) {
         menu?.let {


### PR DESCRIPTION
# 📲 What
Adding some bumpers in the Project page.

# 🤔 Why
So we don't crash!

# 🛠 How
- Added tracking breadcrumbs to Crashlytics in `KoalaBackgroundService`
- Since `FragmentManager.findFragmentById` returns nullable `Fragment`s, safely unwrapping `BackingFragment` and `RewardsFragment`.

# 👀 See
Check out these sweet breadcrumbs https://fabric.io/kickstarter2/android/apps/com.kickstarter.kickstarter.internal.debug/issues/60f1455fd23c9568a2e1edd61e889530/sessions/5DDDB6990210000116C5F000C2B933B0_DNE_0_v2?

# 📋 QA
I can't replicate these crashes IRL so smash the crash button in Internal Tools and check out the tracking breadcrumbs.

# Story 📖
[NT-625]


[NT-625]: https://dripsprint.atlassian.net/browse/NT-625