### PR TITLE
[🐞] NT-661 Removing secondary ProgressBar in Discovery

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
+++ b/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.java
@@ -61,7 +61,6 @@ public final class DiscoveryFragment extends BaseFragment<DiscoveryFragmentViewM
   protected @Bind(R.id.discovery_empty_heart_outline) ImageView heartOutline;
   protected @Bind(R.id.discovery_empty_view) View emptyView;
   protected @Bind(R.id.discovery_hearts_container) View heartsContainer;
-  protected @Bind(R.id.discovery_progress_bar) View progressBar;
   protected @Bind(R.id.discovery_recycler_view) RecyclerView recyclerView;
   protected @Bind(R.id.discovery_swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayout;
 
@@ -150,11 +149,6 @@ public final class DiscoveryFragment extends BaseFragment<DiscoveryFragmentViewM
     RxView.clicks(this.heartsContainer)
       .compose(bindToLifecycle())
       .subscribe(__ -> this.viewModel.inputs.heartContainerClicked());
-
-    this.viewModel.outputs.showProgress()
-      .compose(bindToLifecycle())
-      .compose(observeForUI())
-      .subscribe(show -> ViewUtils.setGone(this.progressBar, !show));
 
     return view;
   }

--- a/app/src/main/res/layout/fragment_discovery.xml
+++ b/app/src/main/res/layout/fragment_discovery.xml
@@ -70,22 +70,4 @@
       android:text="@string/Tap_the_heart_on_a_project_to_get_notified" />
 
   </LinearLayout>
-
-  <LinearLayout
-    android:id="@+id/discovery_progress_bar"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_gravity="center"
-    android:gravity="center"
-    android:orientation="vertical"
-    android:background="@color/white_alpha_60"
-    android:visibility="gone"
-    tools:visibility="visible">
-
-    <ProgressBar
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:gravity="center"/>
-
-  </LinearLayout>
 </FrameLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -51,7 +51,6 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Boolean> shouldShowOnboardingViewTest = new TestSubscriber<>();
   private final TestSubscriber<Boolean> showActivityFeed = new TestSubscriber<>();
   private final TestSubscriber<Boolean> showLoginTout = new TestSubscriber<>();
-  private final TestSubscriber<Boolean> showProgress = new TestSubscriber<>();
   private final TestSubscriber<Editorial> startEditorialActivity = new TestSubscriber<>();
   private final TestSubscriber<Pair<Project, RefTag>> startProjectActivity = new TestSubscriber<>();
   private final TestSubscriber<Activity> startUpdateActivity = new TestSubscriber<>();
@@ -66,7 +65,6 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.shouldShowOnboardingView().subscribe(this.shouldShowOnboardingViewTest);
     this.vm.outputs.showActivityFeed().subscribe(this.showActivityFeed);
     this.vm.outputs.showLoginTout().subscribe(this.showLoginTout);
-    this.vm.outputs.showProgress().distinctUntilChanged().subscribe(this.showProgress);
     this.vm.outputs.startEditorialActivity().subscribe(this.startEditorialActivity);
     this.vm.outputs.startProjectActivity().subscribe(this.startProjectActivity);
     this.vm.outputs.startUpdateActivity().subscribe(this.startUpdateActivity);
@@ -334,30 +332,6 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     // Change params. Activity sampler should not be shown.
     this.vm.inputs.paramsFromActivity(DiscoveryParams.builder().build());
     this.activityTest.assertValues(null, activity, null);
-  }
-
-  @Test
-  public void testShowProgress() {
-    setUpEnvironment(environment());
-
-    // Load initial params and root categories from activity.
-    setUpInitialHomeAllProjectsParams();
-
-    this.showProgress.assertValuesAndClear(true, false);
-
-    // Select a new category.
-    this.vm.inputs.paramsFromActivity(
-      DiscoveryParams.builder()
-        .category(CategoryFactory.artCategory())
-        .sort(DiscoveryParams.Sort.HOME)
-        .build()
-    );
-
-    this.showProgress.assertValuesAndClear(true, false);
-
-    //Page is refreshed and progress bar doesn't show
-    this.vm.inputs.refresh();
-    this.showProgress.assertNoValues();
   }
 
   @Test


### PR DESCRIPTION
# 📲 What
Removing secondary `ProgressBar` in Discovery because it shows up randomly.

# 🤔 Why
No ProgressBar, no problems.

# 🛠 How
- Removed the second `ProgressBar` in the `DiscoveryFragment`. (We already have a `ProgressBar` on this screen via pull to refresh.) After the `onStop` lifecycle method is called, it becomes visible so when you return to the screen, it looks like something is happening; surprise, nothing is happening. You can click behind it and it goes away if you pull to refresh but it's visually disturbing.
- Fixed another bug where `isFetchingProjects` never emitted if the project list was empty.
- Removed tests.

# 👀 See
| Before 🐛 | After 🦋 |
| --- | --- |
| ![device-2019-12-03-180746 2019-12-03 18_11_33](https://user-images.githubusercontent.com/1289295/70097865-68a5f200-15f8-11ea-866b-dde91ccf15b2.gif) | ![device-2019-12-03-180841 2019-12-03 18_11_31](https://user-images.githubusercontent.com/1289295/70097866-68a5f200-15f8-11ea-8f88-0ba5a16fae44.gif) |
| ![device-2019-12-03-182610 2019-12-03 18_27_12](https://user-images.githubusercontent.com/1289295/70098623-8c6a3780-15fa-11ea-8695-47f4811b3891.gif) | ![device-2019-12-03-182514 2019-12-03 18_26_56](https://user-images.githubusercontent.com/1289295/70098613-82483900-15fa-11ea-8e8c-eebac032c6c2.gif) |

# 📋 QA
View projects

# Story 📖
NT-661