### PR TITLE
[💧] NT-653 Set up additional tracking client to hit the Data Lake™ 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -322,6 +322,13 @@
         <action android:name="com.firebase.jobdispatcher.ACTION_EXECUTE" />
       </intent-filter>
     </service>
+    <service
+      android:name=".services.LakeBackgroundService"
+      android:exported="false">
+      <intent-filter>
+        <action android:name="com.firebase.jobdispatcher.ACTION_EXECUTE" />
+      </intent-filter>
+    </service>
 
     <!-- Unsubscribes the device from Firebase. -->
     <service

--- a/app/src/main/java/com/kickstarter/ApplicationGraph.java
+++ b/app/src/main/java/com/kickstarter/ApplicationGraph.java
@@ -4,6 +4,7 @@ import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.KoalaTrackingClient;
 import com.kickstarter.libs.utils.ApplicationLifecycleUtil;
 import com.kickstarter.services.KoalaBackgroundService;
+import com.kickstarter.services.LakeBackgroundService;
 import com.kickstarter.services.firebase.MessageService;
 import com.kickstarter.services.firebase.RegisterService;
 import com.kickstarter.ui.views.AppRatingDialog;
@@ -19,6 +20,7 @@ public interface ApplicationGraph {
   void inject(KoalaTrackingClient __);
   void inject(KSWebView __);
   void inject(KSApplication __);
+  void inject(LakeBackgroundService __);
   void inject(MessageService __);
   void inject(RegisterService __);
 }

--- a/app/src/main/java/com/kickstarter/libs/ActivityViewModel.java
+++ b/app/src/main/java/com/kickstarter/libs/ActivityViewModel.java
@@ -26,9 +26,11 @@ public class ActivityViewModel<ViewType extends ActivityLifecycleType> {
 
   private final PublishSubject<Intent> intent = PublishSubject.create();
   protected final Koala koala;
+  protected final Koala lake;
 
   public ActivityViewModel(final @NonNull Environment environment) {
     this.koala = environment.koala();
+    this.lake = environment.lake();
   }
 
   /**

--- a/app/src/main/java/com/kickstarter/libs/Environment.java
+++ b/app/src/main/java/com/kickstarter/libs/Environment.java
@@ -35,6 +35,7 @@ public abstract class Environment implements Parcelable {
   public abstract Koala koala();
   public abstract KSCurrency ksCurrency();
   public abstract KSString ksString();
+  public abstract Koala lake();
   public abstract Logout logout();
   public abstract BooleanPreferenceType nativeCheckoutPreference();
   public abstract PlayServicesCapability playServicesCapability();
@@ -62,6 +63,7 @@ public abstract class Environment implements Parcelable {
     public abstract Builder koala(Koala __);
     public abstract Builder ksCurrency(KSCurrency __);
     public abstract Builder ksString(KSString __);
+    public abstract Builder lake(Koala __);
     public abstract Builder logout(Logout __);
     public abstract Builder nativeCheckoutPreference(BooleanPreferenceType __);
     public abstract Builder playServicesCapability(PlayServicesCapability __);

--- a/app/src/main/java/com/kickstarter/libs/FragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/libs/FragmentViewModel.java
@@ -25,9 +25,11 @@ public class FragmentViewModel<ViewType extends FragmentLifecycleType> {
   private final PublishSubject<ActivityResult> activityResult = PublishSubject.create();
   private final PublishSubject<Bundle> arguments = PublishSubject.create();
   protected final Koala koala;
+  protected final Koala lake;
 
   public FragmentViewModel(final @NonNull Environment environment) {
     this.koala = environment.koala();
+    this.lake = environment.lake();
   }
 
   @CallSuper

--- a/app/src/main/java/com/kickstarter/libs/KoalaTrackingClient.java
+++ b/app/src/main/java/com/kickstarter/libs/KoalaTrackingClient.java
@@ -1,21 +1,12 @@
 package com.kickstarter.libs;
 
 import android.content.Context;
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.accessibility.AccessibilityManager;
 
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.util.Base64Utils;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.kickstarter.BuildConfig;
-import com.kickstarter.R;
 import com.kickstarter.libs.qualifiers.ApplicationContext;
-import com.kickstarter.libs.utils.ConfigUtils;
 import com.kickstarter.libs.utils.MapUtils;
-import com.kickstarter.models.User;
 import com.kickstarter.services.KoalaBackgroundService;
 import com.kickstarter.services.firebase.DispatcherKt;
 import com.kickstarter.ui.IntentKey;
@@ -29,17 +20,14 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import io.fabric.sdk.android.Fabric;
 import timber.log.Timber;
 
-public final class KoalaTrackingClient extends TrackingClientType {
+public final class KoalaTrackingClient extends TrackingClient {
   private static final String TAG = KoalaTrackingClient.class.getSimpleName();
   @Inject CurrentUserType currentUser;
   @Inject Build build;
   @Inject CurrentConfigType currentConfig;
-  @Nullable private User loggedInUser;
-  @Nullable private Config config;
   private final @NonNull Context context;
 
   public KoalaTrackingClient(
@@ -47,17 +35,12 @@ public final class KoalaTrackingClient extends TrackingClientType {
     final @NonNull CurrentUserType currentUser,
     final @NonNull Build build,
     final @NonNull CurrentConfigType currentConfig) {
+    super(context, currentUser, build, currentConfig);
 
     this.context = context;
     this.currentUser = currentUser;
     this.build = build;
     this.currentConfig = currentConfig;
-
-    // Cache the most recent logged in user for default Koala properties.
-    this.currentUser.observable().subscribe(u -> this.loggedInUser = u);
-
-    // Cache the most recent config for default Koala properties.
-    this.currentConfig.observable().subscribe(c -> this.config = c);
   }
 
   @Override
@@ -100,80 +83,8 @@ public final class KoalaTrackingClient extends TrackingClientType {
   }
 
   @Override
-  protected String androidUUID() {
-    return FirebaseInstanceId.getInstance().getId();
-  }
-
-  @Override
-  protected String brand() {
-    return android.os.Build.BRAND;
-  }
-
-  @Override
   protected boolean cleanPropertiesOnly() {
     return false;
-  }
-  /**
-   * Derives the device's orientation (portrait/landscape) from the `context`.
-   */
-  protected @NonNull String deviceOrientation() {
-    if (this.context.getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
-      return "landscape";
-    }
-    return "portrait";
-  }
-
-  @NonNull
-  protected String deviceFormat() {
-    return this.context.getResources().getBoolean(R.bool.isTablet) ? "tablet" : "phone";
-  }
-
-  @Override
-  protected JSONArray enabledFeatureFlags() {
-    return ConfigUtils.INSTANCE.enabledFeatureFlags(this.config);
-  }
-
-  /**
-   * Derives the availability of google play services from the `context`.
-   */
-  protected boolean isGooglePlayServicesAvailable() {
-    return GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(this.context) == ConnectionResult.SUCCESS;
-  }
-
-  @Override
-  protected boolean isTalkBackOn() {
-    final AccessibilityManager am = (AccessibilityManager) this.context.getSystemService(Context.ACCESSIBILITY_SERVICE);
-    return am != null && am.isTouchExplorationEnabled();
-  }
-
-  @Override
-  protected String manufacturer() {
-    return android.os.Build.MANUFACTURER;
-  }
-
-  @Override
-  protected String model() {
-    return android.os.Build.MODEL;
-  }
-
-  @Override
-  protected String OSVersion() {
-    return android.os.Build.VERSION.RELEASE;
-  }
-
-  @Override
-  protected Long time() {
-    return System.currentTimeMillis() / 1000;
-  }
-
-  @Override
-  protected User loggedInUser() {
-    return this.loggedInUser;
-  }
-
-  @Override
-  protected String versionName() {
-    return BuildConfig.VERSION_NAME;
   }
 
 }

--- a/app/src/main/java/com/kickstarter/libs/KoalaTrackingClient.java
+++ b/app/src/main/java/com/kickstarter/libs/KoalaTrackingClient.java
@@ -109,6 +109,10 @@ public final class KoalaTrackingClient extends TrackingClientType {
     return android.os.Build.BRAND;
   }
 
+  @Override
+  protected boolean cleanPropertiesOnly() {
+    return false;
+  }
   /**
    * Derives the device's orientation (portrait/landscape) from the `context`.
    */

--- a/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
@@ -1,0 +1,151 @@
+package com.kickstarter.libs
+
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Bundle
+import android.util.Log
+import android.view.accessibility.AccessibilityManager
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.firebase.iid.FirebaseInstanceId
+import com.kickstarter.BuildConfig
+import com.kickstarter.R
+import com.kickstarter.libs.qualifiers.ApplicationContext
+import com.kickstarter.libs.utils.ConfigUtils
+import com.kickstarter.libs.utils.MapUtils
+import com.kickstarter.models.User
+import com.kickstarter.services.LakeBackgroundService
+import com.kickstarter.services.firebase.dispatchJob
+import com.kickstarter.ui.IntentKey
+import io.fabric.sdk.android.Fabric
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+import timber.log.Timber
+import java.util.*
+import javax.inject.Inject
+
+class LakeTrackingClient(
+        @param:ApplicationContext private val context: Context,
+        @set:Inject var currentUser: CurrentUserType,
+        @set:Inject var build: Build,
+        @set:Inject var currentConfig: CurrentConfigType) : TrackingClientType() {
+    private var loggedInUser: User? = null
+    private var config: Config? = null
+
+    init {
+
+        // Cache the most recent logged in user for default Lake properties.
+        this.currentUser.observable().subscribe { u -> this.loggedInUser = u }
+
+        // Cache the most recent config for default Lake properties.
+        this.currentConfig.observable().subscribe { c -> this.config = c }
+    }
+
+    override fun track(eventName: String, additionalProperties: Map<String, Any>) {
+        try {
+            val trackingData = getTrackingData(eventName, combinedProperties(additionalProperties))
+            val bundle = Bundle()
+            bundle.putString(IntentKey.LAKE_EVENT_NAME, eventName)
+            bundle.putString(IntentKey.LAKE_EVENT, trackingData)
+
+            val uniqueJobName = LakeBackgroundService.BASE_JOB_NAME + System.currentTimeMillis()
+            dispatchJob(this.context, LakeBackgroundService::class.java, uniqueJobName, bundle)
+            if (this.build.isDebug) {
+                Log.d(TAG, "Queued event:$trackingData")
+            }
+        } catch (e: JSONException) {
+            if (this.build.isDebug) {
+                Timber.e("Failed to encode event: $eventName")
+            }
+            Fabric.getLogger().e(TAG, "Failed to encode event: $eventName")
+        }
+
+    }
+
+    @Throws(JSONException::class)
+    private fun getTrackingData(eventName: String, newProperties: Map<String, Any>): String {
+        val data = JSONObject()
+        data.put("event", eventName)
+
+        val compactProperties = MapUtils.compact(newProperties)
+        val propertiesJSON = JSONObject()
+        for ((key, value) in compactProperties) {
+            propertiesJSON.put(key, value)
+        }
+        data.put("properties", propertiesJSON)
+
+        val record = JSONObject()
+        record.put("partition-key", UUID.randomUUID().toString())
+        record.put("data", data)
+        return record.toString()
+    }
+
+    override fun androidUUID(): String {
+        return FirebaseInstanceId.getInstance().id
+    }
+
+    override fun brand(): String {
+        return android.os.Build.BRAND
+    }
+
+    override fun cleanPropertiesOnly(): Boolean = true
+
+    /**
+     * Derives the device's orientation (portrait/landscape) from the `context`.
+     */
+    override fun deviceOrientation(): String {
+        return if (this.context.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            "landscape"
+        } else "portrait"
+    }
+
+    override fun deviceFormat(): String {
+        return if (this.context.resources.getBoolean(R.bool.isTablet)) "tablet" else "phone"
+    }
+
+    override fun enabledFeatureFlags(): JSONArray? {
+        return ConfigUtils.enabledFeatureFlags(this.config)
+    }
+
+    /**
+     * Derives the availability of google play services from the `context`.
+     */
+    override fun isGooglePlayServicesAvailable(): Boolean {
+        return GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(this.context) == ConnectionResult.SUCCESS
+    }
+
+    override fun isTalkBackOn(): Boolean {
+        val am = this.context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager?
+        return am?.isTouchExplorationEnabled ?: false
+    }
+
+    override fun manufacturer(): String {
+        return android.os.Build.MANUFACTURER
+    }
+
+    override fun model(): String {
+        return android.os.Build.MODEL
+    }
+
+    override fun OSVersion(): String {
+        return android.os.Build.VERSION.RELEASE
+    }
+
+    override fun time(): Long {
+        return System.currentTimeMillis() / 1000
+    }
+
+    override fun loggedInUser(): User? {
+        return this.loggedInUser
+    }
+
+    override fun versionName(): String {
+        return BuildConfig.VERSION_NAME
+    }
+
+    companion object {
+        private val TAG = LakeTrackingClient::class.java.simpleName
+    }
+
+}

--- a/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
@@ -1,35 +1,25 @@
 package com.kickstarter.libs
 
 import android.content.Context
-import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
-import android.view.accessibility.AccessibilityManager
-import com.google.android.gms.common.ConnectionResult
-import com.google.android.gms.common.GoogleApiAvailability
-import com.google.firebase.iid.FirebaseInstanceId
-import com.kickstarter.BuildConfig
-import com.kickstarter.R
 import com.kickstarter.libs.qualifiers.ApplicationContext
-import com.kickstarter.libs.utils.ConfigUtils
 import com.kickstarter.libs.utils.MapUtils
 import com.kickstarter.models.User
 import com.kickstarter.services.LakeBackgroundService
 import com.kickstarter.services.firebase.dispatchJob
 import com.kickstarter.ui.IntentKey
 import io.fabric.sdk.android.Fabric
-import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import timber.log.Timber
 import java.util.*
-import javax.inject.Inject
 
 class LakeTrackingClient(
         @param:ApplicationContext private val context: Context,
-        @set:Inject var currentUser: CurrentUserType,
-        @set:Inject var build: Build,
-        @set:Inject var currentConfig: CurrentConfigType) : TrackingClientType() {
+        currentUser: CurrentUserType,
+        build: Build,
+        currentConfig: CurrentConfigType) : TrackingClient(context, currentUser, build, currentConfig) {
     private var loggedInUser: User? = null
     private var config: Config? = null
 
@@ -81,68 +71,7 @@ class LakeTrackingClient(
         return record.toString()
     }
 
-    override fun androidUUID(): String {
-        return FirebaseInstanceId.getInstance().id
-    }
-
-    override fun brand(): String {
-        return android.os.Build.BRAND
-    }
-
     override fun cleanPropertiesOnly(): Boolean = true
-
-    /**
-     * Derives the device's orientation (portrait/landscape) from the `context`.
-     */
-    override fun deviceOrientation(): String {
-        return if (this.context.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            "landscape"
-        } else "portrait"
-    }
-
-    override fun deviceFormat(): String {
-        return if (this.context.resources.getBoolean(R.bool.isTablet)) "tablet" else "phone"
-    }
-
-    override fun enabledFeatureFlags(): JSONArray? {
-        return ConfigUtils.enabledFeatureFlags(this.config)
-    }
-
-    /**
-     * Derives the availability of google play services from the `context`.
-     */
-    override fun isGooglePlayServicesAvailable(): Boolean {
-        return GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(this.context) == ConnectionResult.SUCCESS
-    }
-
-    override fun isTalkBackOn(): Boolean {
-        val am = this.context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager?
-        return am?.isTouchExplorationEnabled ?: false
-    }
-
-    override fun manufacturer(): String {
-        return android.os.Build.MANUFACTURER
-    }
-
-    override fun model(): String {
-        return android.os.Build.MODEL
-    }
-
-    override fun OSVersion(): String {
-        return android.os.Build.VERSION.RELEASE
-    }
-
-    override fun time(): Long {
-        return System.currentTimeMillis() / 1000
-    }
-
-    override fun loggedInUser(): User? {
-        return this.loggedInUser
-    }
-
-    override fun versionName(): String {
-        return BuildConfig.VERSION_NAME
-    }
 
     companion object {
         private val TAG = LakeTrackingClient::class.java.simpleName

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -1,0 +1,97 @@
+package com.kickstarter.libs
+
+import android.content.Context
+import android.content.res.Configuration
+import android.view.accessibility.AccessibilityManager
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.firebase.iid.FirebaseInstanceId
+import com.kickstarter.BuildConfig
+import com.kickstarter.R
+import com.kickstarter.libs.qualifiers.ApplicationContext
+import com.kickstarter.libs.utils.ConfigUtils
+import com.kickstarter.models.User
+import org.json.JSONArray
+import javax.inject.Inject
+
+abstract class TrackingClient(@param:ApplicationContext private val context: Context,
+                     @set:Inject var currentUser: CurrentUserType,
+                     @set:Inject var build: Build,
+                     @set:Inject var currentConfig: CurrentConfigType) : TrackingClientType() {
+
+    private var loggedInUser: User? = null
+    private var config: Config? = null
+
+    init {
+
+        // Cache the most recent logged in user for default Lake properties.
+        this.currentUser.observable().subscribe { u -> this.loggedInUser = u }
+
+        // Cache the most recent config for default Lake properties.
+        this.currentConfig.observable().subscribe { c -> this.config = c }
+    }
+
+    override fun androidUUID(): String {
+        return FirebaseInstanceId.getInstance().id
+    }
+
+    override fun brand(): String {
+        return android.os.Build.BRAND
+    }
+
+    override fun cleanPropertiesOnly(): Boolean = true
+
+    /**
+     * Derives the device's orientation (portrait/landscape) from the `context`.
+     */
+    override fun deviceOrientation(): String {
+        return if (this.context.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            "landscape"
+        } else "portrait"
+    }
+
+    override fun deviceFormat(): String {
+        return if (this.context.resources.getBoolean(R.bool.isTablet)) "tablet" else "phone"
+    }
+
+    override fun enabledFeatureFlags(): JSONArray? {
+        return ConfigUtils.enabledFeatureFlags(this.config)
+    }
+
+    /**
+     * Derives the availability of google play services from the `context`.
+     */
+    override fun isGooglePlayServicesAvailable(): Boolean {
+        return GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(this.context) == ConnectionResult.SUCCESS
+    }
+
+    override fun isTalkBackOn(): Boolean {
+        val am = this.context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager?
+        return am?.isTouchExplorationEnabled ?: false
+    }
+
+    override fun manufacturer(): String {
+        return android.os.Build.MANUFACTURER
+    }
+
+    override fun model(): String {
+        return android.os.Build.MODEL
+    }
+
+    override fun OSVersion(): String {
+        return android.os.Build.VERSION.RELEASE
+    }
+
+    override fun time(): Long {
+        return System.currentTimeMillis() / 1000
+    }
+
+    override fun loggedInUser(): User? {
+        return this.loggedInUser
+    }
+
+    override fun versionName(): String {
+        return BuildConfig.VERSION_NAME
+    }
+
+}

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -17,6 +17,17 @@ public abstract class TrackingClientType {
     track(eventName, new HashMap<>());
   }
 
+  private @NonNull Map<String, Object> cleanProperties() {
+    final Map<String, Object> hashMap = new HashMap<>();
+
+    final boolean userIsLoggedIn = loggedInUser() != null;
+
+    hashMap.put("time", time());
+    hashMap.put("user_logged_in", userIsLoggedIn);
+
+    return hashMap;
+  }
+
   private @NonNull Map<String, Object> defaultProperties() {
     final Map<String, Object> hashMap = new HashMap<>();
 
@@ -51,12 +62,17 @@ public abstract class TrackingClientType {
 
   @NonNull Map<String, Object> combinedProperties(final @NonNull Map<String, Object> additionalProperties) {
     final Map<String, Object> combinedProperties = new HashMap<>(additionalProperties);
-    combinedProperties.putAll(defaultProperties());
+    if (cleanPropertiesOnly()) {
+      combinedProperties.putAll(cleanProperties());
+    } else {
+      combinedProperties.putAll(defaultProperties());
+    }
     return combinedProperties;
   }
 
   protected abstract String androidUUID();
   protected abstract String brand();
+  protected abstract boolean cleanPropertiesOnly();
   protected abstract String deviceFormat();
   protected abstract String deviceOrientation();
   protected abstract JSONArray enabledFeatureFlags();

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -82,6 +82,6 @@ public abstract class TrackingClientType {
   protected abstract String manufacturer();
   protected abstract String model();
   protected abstract String OSVersion();
-  protected abstract Long time();
+  protected abstract long time();
   protected abstract String versionName();
 }

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/KoalaTracker.kt
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/KoalaTracker.kt
@@ -1,0 +1,6 @@
+package com.kickstarter.libs.qualifiers
+
+import javax.inject.Qualifier
+
+@Qualifier
+annotation class KoalaTracker

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/LakeEndpoint.kt
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/LakeEndpoint.kt
@@ -1,0 +1,6 @@
+package com.kickstarter.libs.qualifiers
+
+import javax.inject.Qualifier
+
+@Qualifier
+annotation class LakeEndpoint

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/LakeRetrofit.kt
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/LakeRetrofit.kt
@@ -1,0 +1,6 @@
+package com.kickstarter.libs.qualifiers
+
+import javax.inject.Qualifier
+
+@Qualifier
+annotation class LakeRetrofit

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/LakeTracker.kt
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/LakeTracker.kt
@@ -1,0 +1,6 @@
+package com.kickstarter.libs.qualifiers
+
+import javax.inject.Qualifier
+
+@Qualifier
+annotation class LakeTracker

--- a/app/src/main/java/com/kickstarter/libs/utils/ApplicationLifecycleUtil.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ApplicationLifecycleUtil.java
@@ -12,6 +12,8 @@ import com.kickstarter.libs.CurrentConfigType;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Koala;
 import com.kickstarter.libs.Logout;
+import com.kickstarter.libs.qualifiers.KoalaTracker;
+import com.kickstarter.libs.qualifiers.LakeTracker;
 import com.kickstarter.libs.rx.transformers.Transformers;
 import com.kickstarter.services.ApiClientType;
 import com.kickstarter.services.apiresponses.ErrorEnvelope;
@@ -22,7 +24,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 public final class ApplicationLifecycleUtil implements Application.ActivityLifecycleCallbacks, ComponentCallbacks2 {
-  protected @Inject Koala koala;
+  protected @Inject @KoalaTracker Koala koala;
+  protected @Inject @LakeTracker Koala lake;
   protected @Inject ApiClientType client;
   protected @Inject CurrentConfigType config;
   protected @Inject CurrentUserType currentUser;
@@ -48,6 +51,7 @@ public final class ApplicationLifecycleUtil implements Application.ActivityLifec
   public void onActivityResumed(final @NonNull Activity activity) {
     if(this.isInBackground){
       this.koala.trackAppOpen();
+      this.lake.trackAppOpen();
 
       // Facebook: logs 'install' and 'app activate' App Events.
       AppEventsLogger.activateApp(activity.getApplication());
@@ -119,6 +123,7 @@ public final class ApplicationLifecycleUtil implements Application.ActivityLifec
   public void onTrimMemory(final int i) {
     if(i == ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
       this.koala.trackAppClose();
+      this.lake.trackAppClose();
       this.isInBackground = true;
     }
   }

--- a/app/src/main/java/com/kickstarter/libs/utils/Secrets.java.example
+++ b/app/src/main/java/com/kickstarter/libs/utils/Secrets.java.example
@@ -29,6 +29,11 @@ public final class Secrets {
     public static final String PRODUCTION = "https://koala.dev";
   }
 
+  public static final class LakeEndpoint {
+    public static final String STAGING = "https://lake.dev";
+    public static final String PRODUCTION = "https://lake.dev";
+  }
+
   public static final class RegExpPattern {
     public static final Pattern API = Pattern.compile("\\Aapi\\z");
     public static final Pattern HIVEQUEEN = Pattern.compile("\\Adev\\z");

--- a/app/src/main/java/com/kickstarter/services/LakeBackgroundService.kt
+++ b/app/src/main/java/com/kickstarter/services/LakeBackgroundService.kt
@@ -20,7 +20,6 @@ class LakeBackgroundService : JobService() {
     @Inject
     lateinit var build: Build
 
-
     override fun onCreate() {
         super.onCreate()
         (applicationContext as KSApplication).component().inject(this)

--- a/app/src/main/java/com/kickstarter/services/LakeBackgroundService.kt
+++ b/app/src/main/java/com/kickstarter/services/LakeBackgroundService.kt
@@ -1,0 +1,71 @@
+package com.kickstarter.services
+
+import android.util.Log
+import com.crashlytics.android.Crashlytics
+import com.firebase.jobdispatcher.JobParameters
+import com.firebase.jobdispatcher.JobService
+import com.kickstarter.KSApplication
+import com.kickstarter.libs.Build
+import com.kickstarter.ui.IntentKey
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import okhttp3.ResponseBody
+import retrofit2.Response
+import rx.schedulers.Schedulers
+import javax.inject.Inject
+
+class LakeBackgroundService : JobService() {
+    @Inject
+    lateinit var lakeService: LakeService
+    @Inject
+    lateinit var build: Build
+
+
+    override fun onCreate() {
+        super.onCreate()
+        (applicationContext as KSApplication).component().inject(this)
+    }
+
+    override fun onStartJob(job: JobParameters?): Boolean {
+        val extras = job?.extras
+        val eventName = extras?.get(IntentKey.LAKE_EVENT_NAME) as String
+        lakeService.track(RequestBody.create(MediaType.parse("application/json"), extras.get(IntentKey.LAKE_EVENT) as String))
+                .subscribeOn(Schedulers.io())
+                .subscribe({
+                    logResponse(it, eventName)
+                    jobFinished(job, !it.isSuccessful)
+
+                }, {
+                    logTrackingError(eventName)
+                    jobFinished(job, false)
+                })
+        return true
+    }
+
+    override fun onStopJob(job: JobParameters?): Boolean {
+        return true
+    }
+
+    private fun logResponse(it: Response<ResponseBody>, eventName: String) {
+        if (it.isSuccessful) {
+            if (this.build.isDebug) {
+                Log.d(TAG, "Successfully tracked event: $eventName")
+            }
+            Crashlytics.log(eventName)
+        } else {
+            logTrackingError(eventName)
+        }
+    }
+
+    private fun logTrackingError(eventName: String) {
+        if (this.build.isDebug) {
+            Log.e(TAG, "Failed to track event: $eventName")
+        }
+        Crashlytics.logException(Exception("Failed to track event: $eventName"))
+    }
+
+    companion object {
+        const val BASE_JOB_NAME = "Lake-Background-Service"
+        val TAG = LakeBackgroundService::class.java.simpleName +" \uD83D\uDCA7"
+    }
+}

--- a/app/src/main/java/com/kickstarter/services/LakeService.kt
+++ b/app/src/main/java/com/kickstarter/services/LakeService.kt
@@ -1,0 +1,16 @@
+package com.kickstarter.services
+
+import okhttp3.RequestBody
+import okhttp3.ResponseBody
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.Headers
+import retrofit2.http.PUT
+import rx.Observable
+
+interface LakeService {
+
+    @Headers("Content-Type: application/json")
+    @PUT("record")
+    fun track(@Body body: RequestBody) : Observable<Response<ResponseBody>>
+}

--- a/app/src/main/java/com/kickstarter/ui/IntentKey.java
+++ b/app/src/main/java/com/kickstarter/ui/IntentKey.java
@@ -20,8 +20,9 @@ public final class IntentKey {
   public static final String KOALA_CONTEXT = "com.kickstarter.kickstarter.intent_koala_context";
   public static final String KOALA_EVENT = "com.kickstarter.kickstarter.intent_koala_event";
   public static final String KOALA_EVENT_NAME = "com.kickstarter.kickstarter.intent_koala_event_name";
+  public static final String LAKE_EVENT = "com.kickstarter.kickstarter.intent_koala_event";
+  public static final String LAKE_EVENT_NAME = "com.kickstarter.kickstarter.intent_koala_event_name";
   public static final String LOGIN_REASON = "com.kickstarter.kickstarter.intent_login_reason";
-  public static final String MASKED_WALLET = "com.kickstarter.kickstarter.masked_wallet";
   public static final String MESSAGE_THREAD = "com.kickstarter.kickstarter.intent_message_thread";
   public static final String NATIVE_CHECKOUT_ENABLED = "com.kickstarter.kickstarter.intent_native_checkout_enabled";
   public static final String PASSWORD = "com.kickstarter.kickstarter.intent_password";

--- a/app/src/main/java/com/kickstarter/ui/views/AppRatingDialog.java
+++ b/app/src/main/java/com/kickstarter/ui/views/AppRatingDialog.java
@@ -10,6 +10,7 @@ import com.kickstarter.R;
 import com.kickstarter.libs.Koala;
 import com.kickstarter.libs.preferences.BooleanPreferenceType;
 import com.kickstarter.libs.qualifiers.AppRatingPreference;
+import com.kickstarter.libs.qualifiers.KoalaTracker;
 import com.kickstarter.libs.utils.ViewUtils;
 
 import javax.inject.Inject;
@@ -23,7 +24,7 @@ import butterknife.OnClick;
 
 public class AppRatingDialog extends AppCompatDialog {
   protected @Inject @AppRatingPreference BooleanPreferenceType hasSeenAppRatingPreference;
-  protected @Inject Koala koala;
+  protected @Inject @KoalaTracker Koala koala;
 
   protected @Bind(R.id.no_thanks_button) Button noThanksButton;
   protected @Bind(R.id.remind_button) Button remindButton;

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -276,10 +276,16 @@ public interface DiscoveryFragmentViewModel {
         .map(paramsAndPage -> paramsAndPage.first.toBuilder().page(paramsAndPage.second).build())
         .compose(combineLatestPair(userIsLoggedIn))
         .compose(bindToLifecycle())
-        .subscribe(paramsAndLoggedIn -> this.koala.trackDiscovery(
-          paramsAndLoggedIn.first,
-          isOnboardingVisible(paramsAndLoggedIn.first, paramsAndLoggedIn.second)
-        ));
+        .subscribe(paramsAndLoggedIn -> {
+          this.koala.trackDiscovery(
+            paramsAndLoggedIn.first,
+            isOnboardingVisible(paramsAndLoggedIn.first, paramsAndLoggedIn.second)
+          );
+          this.lake.trackDiscovery(
+            paramsAndLoggedIn.first,
+            isOnboardingVisible(paramsAndLoggedIn.first, paramsAndLoggedIn.second)
+          );
+        });
 
       this.startUpdateActivity
         .map(Activity::project)

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -274,7 +274,10 @@ public interface DiscoveryViewModel {
       this.openDrawer
         .filter(BooleanUtils::isTrue)
         .compose(bindToLifecycle())
-        .subscribe(__ -> this.koala.trackDiscoveryFilters());
+        .subscribe(__ -> {
+          this.koala.trackDiscoveryFilters();
+          this.lake.trackDiscoveryFilters();
+        });
 
       intent()
         .filter(IntentMapper::appBannerIsSet)

--- a/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
+++ b/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
@@ -32,6 +32,7 @@ import rx.observers.TestSubscriber;
 public abstract class KSRobolectricTestCase extends TestCase {
   private TestKSApplication application;
   public TestSubscriber<String> koalaTest;
+  public TestSubscriber<String> lakeTest;
   private Environment environment;
 
   @Override
@@ -40,9 +41,12 @@ public abstract class KSRobolectricTestCase extends TestCase {
     super.setUp();
 
     final MockCurrentConfig mockCurrentConfig = new MockCurrentConfig();
-    final MockTrackingClient testTrackingClient = new MockTrackingClient(new MockCurrentUser(), mockCurrentConfig);
+    final MockTrackingClient koalaTrackingClient = new MockTrackingClient(new MockCurrentUser(), mockCurrentConfig, false);
+    final MockTrackingClient lakeTrackingClient = new MockTrackingClient(new MockCurrentUser(), mockCurrentConfig, true);
     this.koalaTest = new TestSubscriber<>();
-    testTrackingClient.eventNames.subscribe(this.koalaTest);
+    this.lakeTest = new TestSubscriber<>();
+    koalaTrackingClient.eventNames.subscribe(this.koalaTest);
+    lakeTrackingClient.eventNames.subscribe(this.lakeTest);
     DateTimeUtils.setCurrentMillisFixed(new DateTime().getMillis());
 
     this.environment = application().component().environment().toBuilder()
@@ -51,7 +55,8 @@ public abstract class KSRobolectricTestCase extends TestCase {
       .currentConfig(mockCurrentConfig)
       .webClient(new MockWebClient())
       .stripe(new Stripe(context(), Secrets.StripePublishableKey.STAGING))
-      .koala(new Koala(testTrackingClient))
+      .koala(new Koala(koalaTrackingClient))
+      .lake(new Koala(lakeTrackingClient))
       .build();
   }
 

--- a/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
@@ -16,7 +16,7 @@ class KoalaTest : KSRobolectricTestCase() {
 
     @Test
     fun testDefaultProperties() {
-        val client = MockTrackingClient(MockCurrentUser(), mockCurrentConfig())
+        val client = MockTrackingClient(MockCurrentUser(), mockCurrentConfig(), false)
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -31,7 +31,7 @@ class KoalaTest : KSRobolectricTestCase() {
     @Test
     fun testDefaultProperties_LoggedInUser() {
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), false)
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -51,7 +51,7 @@ class KoalaTest : KSRobolectricTestCase() {
     @Test
     fun testDiscoveryProperties() {
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), false)
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -76,7 +76,7 @@ class KoalaTest : KSRobolectricTestCase() {
     @Test
     fun testDiscoveryProperties_AllProjects() {
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), false)
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -101,7 +101,7 @@ class KoalaTest : KSRobolectricTestCase() {
     @Test
     fun testDiscoveryProperties_NoCategory() {
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), false)
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -127,7 +127,7 @@ class KoalaTest : KSRobolectricTestCase() {
     fun testProjectProperties() {
         val project = project()
 
-        val client = MockTrackingClient(MockCurrentUser(), mockCurrentConfig())
+        val client = MockTrackingClient(MockCurrentUser(), mockCurrentConfig(), false)
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -143,7 +143,7 @@ class KoalaTest : KSRobolectricTestCase() {
     fun testProjectProperties_LoggedInUser() {
         val project = project()
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), false)
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -170,7 +170,7 @@ class KoalaTest : KSRobolectricTestCase() {
                 .creator(creator())
                 .build()
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), false)
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -193,7 +193,7 @@ class KoalaTest : KSRobolectricTestCase() {
     fun testProjectProperties_LoggedInUser_IsProjectCreator() {
         val project = project().toBuilder().build()
         val creator = creator()
-        val client = MockTrackingClient(MockCurrentUser(creator), mockCurrentConfig())
+        val client = MockTrackingClient(MockCurrentUser(creator), mockCurrentConfig(), false)
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
@@ -214,7 +214,7 @@ class KoalaTest : KSRobolectricTestCase() {
     fun testProjectProperties_LoggedInUser_HasStarred() {
         val project = project().toBuilder().isStarred(true).build()
         val user = user()
-        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig())
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), false)
         client.eventNames.subscribe(this.koalaTest)
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -1,0 +1,64 @@
+package com.kickstarter.libs
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.mock.MockCurrentConfig
+import com.kickstarter.mock.factories.ConfigFactory
+import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.models.User
+import org.joda.time.DateTime
+import org.junit.Test
+import rx.subjects.BehaviorSubject
+
+class LakeTest : KSRobolectricTestCase() {
+
+    private val propertiesTest = BehaviorSubject.create<Map<String, Any>>()
+
+    @Test
+    fun testDefaultProperties() {
+        val client = MockTrackingClient(MockCurrentUser(), mockCurrentConfig(), true)
+        client.eventNames.subscribe(this.lakeTest)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val lake = Koala(client)
+
+        lake.trackAppOpen()
+
+        this.lakeTest.assertValue("App Open")
+
+        assertDefaultProperties(null)
+    }
+
+    @Test
+    fun testDefaultProperties_LoggedInUser() {
+        val user = user()
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), true)
+        client.eventNames.subscribe(this.lakeTest)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val lake = Koala(client)
+
+        lake.trackAppOpen()
+
+        this.lakeTest.assertValue("App Open")
+
+        assertDefaultProperties(user)
+    }
+
+    private fun assertDefaultProperties(user: User?) {
+        val expectedProperties = propertiesTest.value
+        assertEquals(DateTime.parse("2018-11-02T18:42:05Z").millis / 1000, expectedProperties["time"])
+        assertEquals(user != null, expectedProperties["user_logged_in"])
+    }
+
+    private fun mockCurrentConfig() = MockCurrentConfig().apply {
+        config(ConfigFactory.configWithFeatureEnabled("android_example_feature"))
+    }
+
+    private fun user() =
+            UserFactory.user()
+                    .toBuilder()
+                    .id(15)
+                    .backedProjectsCount(3)
+                    .createdProjectsCount(2)
+                    .starredProjectsCount(10)
+                    .build()
+
+}

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -99,7 +99,7 @@ public final class MockTrackingClient extends TrackingClientType {
   }
 
   @Override
-  protected Long time() {
+  protected long time() {
     return DEFAULT_TIME;
   }
 

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -15,10 +15,12 @@ import rx.subjects.PublishSubject;
 
 public final class MockTrackingClient extends TrackingClientType {
   private static final long DEFAULT_TIME = DateTime.parse("2018-11-02T18:42:05Z").getMillis() / 1000;
+  private final boolean cleanPropertiesOnly;
   @Nullable private User loggedInUser;
   @Nullable private Config config;
 
-  public MockTrackingClient(final @NonNull CurrentUserType currentUser, final @NonNull CurrentConfigType currentConfig) {
+  public MockTrackingClient(final @NonNull CurrentUserType currentUser, final @NonNull CurrentConfigType currentConfig, final boolean cleanPropertiesOnly) {
+    this.cleanPropertiesOnly = cleanPropertiesOnly;
     currentUser.observable().subscribe(u -> this.loggedInUser = u);
     currentConfig.observable().subscribe(c -> this.config = c);
   }
@@ -49,6 +51,11 @@ public final class MockTrackingClient extends TrackingClientType {
   @Override
   protected String brand() {
     return "Google";
+  }
+
+  @Override
+  protected boolean cleanPropertiesOnly() {
+    return this.cleanPropertiesOnly;
   }
 
   @Override

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -87,11 +87,13 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     // Should emit current fragment's projects.
     this.hasProjects.assertValues(true);
     this.koalaTest.assertValues("Discover List View");
+    this.lakeTest.assertValues("Discover List View");
 
     //Page is refreshed
     this.vm.inputs.refresh();
     this.hasProjects.assertValues(true, true);
     this.koalaTest.assertValues("Discover List View", "Triggered Refresh");
+    this.lakeTest.assertValues("Discover List View");
   }
 
   @Test
@@ -116,6 +118,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     // New projects load with new params.
     this.hasProjects.assertValues(true, true, true);
     this.koalaTest.assertValues("Discover List View", "Discover List View");
+    this.lakeTest.assertValues("Discover List View", "Discover List View");
 
     this.vm.inputs.clearPage();
     this.hasProjects.assertValues(true, true, true, false);
@@ -130,11 +133,13 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
 
     this.projects.assertValueCount(1);
     this.koalaTest.assertValues("Discover List View");
+    this.lakeTest.assertValues("Discover List View");
 
     // Popular tab clicked.
     this.vm.inputs.paramsFromActivity(DiscoveryParams.builder().sort(DiscoveryParams.Sort.POPULAR).build());
     this.projects.assertValueCount(3);
     this.koalaTest.assertValues("Discover List View", "Discover List View");
+    this.lakeTest.assertValues("Discover List View", "Discover List View");
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -83,6 +83,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.navigationDrawerDataEmitted.assertValueCount(1);
     this.drawerIsOpen.assertNoValues();
     this.koalaTest.assertNoValues();
+    this.lakeTest.assertNoValues();
 
     // Open drawer and click the top PWL filter.
     this.vm.inputs.openDrawer(true);
@@ -96,6 +97,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.navigationDrawerDataEmitted.assertValueCount(2);
     this.drawerIsOpen.assertValues(true, false);
     this.koalaTest.assertValues("Discover Switch Modal", "Discover Modal Selected Filter");
+    this.lakeTest.assertValue("Discover Switch Modal");
 
     // Open drawer and click a child filter.
     this.vm.inputs.openDrawer(true);
@@ -114,6 +116,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.drawerIsOpen.assertValues(true, false, true, false);
     this.koalaTest.assertValues("Discover Switch Modal", "Discover Modal Selected Filter", "Discover Switch Modal",
       "Discover Modal Selected Filter");
+    this.lakeTest.assertValues("Discover Switch Modal", "Discover Switch Modal");
   }
 
   @Test


### PR DESCRIPTION
# 📲 What
Added additional tracking client to send events to the Data Lake™ 

# 🤔 Why
We're cleaning up our event tracking.

# 🛠 How
- Abstracted reusable parts `KoalaTrackingClient` to `TrackingClient` so now `KoalaTrackingClient` is an extension of a `TrackingClient`.
- Added `LakeTrackingClient` which is an extension of a `TrackingClient` to the `Environment`.
  - Added `LakeBackgroundService` to handle background task of sending tracking event requests.
  - Added `LakeService` as API interface. It currently only sends a `PUT` request to the `record` endpoint with a `"Content-Type: application/json"` header.
  - Added `@LakeEndpoint`, `@LakeRetrofit`, `@LakeTracker`, and `@KoalaTracker` qualifiers so our dependency injection can differentiate between clients.
- Added fake values for `Secrets.LakeEndpoint.Staging` and `Secrets.LakeEndpoint.Production`. **Note:** I'm currently only sending events to staging until the events are fully finalized.

## what's getting tracked?
- I'm currently only tracking `App Open`, `App Close` and `Discover List View` events with the properties `time` and `user_logged_in` because those are whitelisted.
- These new events are being tested 🤓 

# 👀 See
I'm going surfing
<img width="540" alt="Screen Shot 2019-12-03 at 7 45 11 PM" src="https://user-images.githubusercontent.com/1289295/70186654-5c826900-16ba-11ea-8d55-8c7fcc62f3d0.png">

# 📋 QA
ktk the staging data lake endpoint

# Story 📖
[NT-653]

[NT-653]: https://dripsprint.atlassian.net/browse/NT-653