### PR TITLE
[🐛] NT-689 Fetching projects by "tag_id" and not "tad_id"

### DIFF
--- a/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
+++ b/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
@@ -308,7 +308,7 @@ public abstract class DiscoveryParams implements Parcelable {
         retVal = retVal.similarTo(other.similarTo());
       }
       if (other.tagId() != null) {
-        retVal = retVal.term(other.term());
+        retVal = retVal.tagId(other.tagId());
       }
       if (other.term() != null) {
         retVal = retVal.term(other.term());
@@ -398,7 +398,7 @@ public abstract class DiscoveryParams implements Parcelable {
 
         final Integer tagId = tagId();
         if (tagId != null) {
-          put("tad_id", tagId.toString());
+          put("tag_id", tagId.toString());
         }
 
         if (term() != null) {


### PR DESCRIPTION
# 📲 What
Fixes bug where the incorrect projects for a collection were shown.

# 🤔 Why
Go rewardless was showing the wrong projects.

# 🛠 How
- V1 disco always returns something even if you send it garbo like `tad_id`. Fixed the typo as `tag_id`.
- Also fixed some copy pasta when merging params.

# 👀 See
<img src=https://user-images.githubusercontent.com/1289295/70448456-64515d00-1a6e-11ea-816e-076a7821db2d.png width=330/>

# 📋 QA
The projects shown in the Go Rewardless editorial should be the same as those shown here: https://www.kickstarter.com/discover/tags/back-it-because-you-believe-in-it?ref=believe-in-it

# Story 📖
[NT-689]

[NT-689]: https://dripsprint.atlassian.net/browse/NT-689