### PR TITLE
[📱] NT-690 Sending custom User Agent header with graphQL requests

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -235,8 +235,8 @@ public final class ApplicationModule {
   @Singleton
   @NonNull
   static GraphQLInterceptor provideGraphQLInterceptor(final @NonNull String clientId,
-    final @NonNull CurrentUserType currentUser) {
-    return new GraphQLInterceptor(clientId, currentUser);
+    final @NonNull CurrentUserType currentUser, final @NonNull Build build) {
+    return new GraphQLInterceptor(clientId, currentUser, build);
   }
 
   @Provides

--- a/app/src/main/java/com/kickstarter/libs/utils/WebUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/WebUtils.kt
@@ -1,0 +1,16 @@
+package com.kickstarter.libs.utils
+
+import com.kickstarter.libs.Build
+
+object WebUtils {
+    fun userAgent(build: Build): String {
+         return StringBuilder()
+                .append("Kickstarter Android Mobile Variant/")
+                .append(build.variant())
+                .append(" Code/")
+                .append(build.versionCode())
+                .append(" Version/")
+                .append(build.versionName())
+                .toString()
+    }
+}

--- a/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
+++ b/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
@@ -1,17 +1,22 @@
 package com.kickstarter.services.interceptors
 
+import com.kickstarter.libs.Build
 import com.kickstarter.libs.CurrentUserType
 import okhttp3.Interceptor
 import okhttp3.Response
 
-class GraphQLInterceptor(private val clientId: String, private val currentUser: CurrentUserType) : Interceptor {
+class GraphQLInterceptor(private val clientId: String,
+                         private val currentUser: CurrentUserType,
+                         private val build: Build) : Interceptor {
     override fun intercept(chain: Interceptor.Chain?): Response {
         val original = chain!!.request()
         val builder = original.newBuilder().method(original.method(), original.body())
-        if (this.currentUser.exists()) {
-            builder.addHeader("Authorization", "token " + this.currentUser.accessToken)
+        val accessToken = this.currentUser.accessToken
+        if (accessToken != null) {
+            builder.addHeader("Authorization", "token $accessToken")
         }
-        builder.addHeader("X-KICKSTARTER-CLIENT", this.clientId)
+        builder.addHeader("User-Agent", WebRequestInterceptor.userAgent(this.build))
+                .addHeader("X-KICKSTARTER-CLIENT", this.clientId)
         return chain.proceed(builder.build())
     }
 }

--- a/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
+++ b/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
@@ -2,6 +2,7 @@ package com.kickstarter.services.interceptors
 
 import com.kickstarter.libs.Build
 import com.kickstarter.libs.CurrentUserType
+import com.kickstarter.libs.utils.WebUtils
 import okhttp3.Interceptor
 import okhttp3.Response
 
@@ -11,11 +12,10 @@ class GraphQLInterceptor(private val clientId: String,
     override fun intercept(chain: Interceptor.Chain?): Response {
         val original = chain!!.request()
         val builder = original.newBuilder().method(original.method(), original.body())
-        val accessToken = this.currentUser.accessToken
-        if (accessToken != null) {
-            builder.addHeader("Authorization", "token $accessToken")
+        if (this.currentUser.exists()) {
+            builder.addHeader("Authorization", "token " + this.currentUser.accessToken)
         }
-        builder.addHeader("User-Agent", WebRequestInterceptor.userAgent(this.build))
+        builder.addHeader("User-Agent", WebUtils.userAgent(this.build))
                 .addHeader("X-KICKSTARTER-CLIENT", this.clientId)
         return chain.proceed(builder.build())
     }

--- a/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import com.kickstarter.libs.Build;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.InternalToolsType;
+import com.kickstarter.libs.utils.WebUtils;
 import com.kickstarter.services.KSUri;
 
 import java.io.IOException;
@@ -44,7 +45,7 @@ public final class WebRequestInterceptor implements Interceptor {
     }
 
     final Request.Builder requestBuilder = initialRequest.newBuilder()
-      .header("User-Agent", userAgent(this.build));
+      .header("User-Agent", WebUtils.INSTANCE.userAgent(this.build));
 
     final String basicAuthorizationHeader = this.internalTools.basicAuthorizationHeader();
     if (this.currentUser.exists()) {
@@ -67,17 +68,4 @@ public final class WebRequestInterceptor implements Interceptor {
     final Uri initialRequestUri = Uri.parse(request.url().toString());
     return KSUri.isHivequeenUri(initialRequestUri, this.endpoint) || KSUri.isStagingUri(initialRequestUri, this.endpoint);
   }
-
-  public static @NonNull String userAgent(final @NonNull Build build) {
-    // TODO: Check whether device is mobile or tablet, append to user agent
-    return new StringBuilder()
-      .append("Kickstarter Android Mobile Variant/")
-      .append(build.variant())
-      .append(" Code/")
-      .append(build.versionCode())
-      .append(" Version/")
-      .append(build.versionName())
-      .toString();
-  }
 }
-

--- a/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.java
@@ -23,7 +23,7 @@ import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.Build;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
 import com.kickstarter.libs.rx.transformers.Transformers;
-import com.kickstarter.services.interceptors.WebRequestInterceptor;
+import com.kickstarter.libs.utils.WebUtils;
 import com.kickstarter.viewmodels.VideoViewModel;
 import com.trello.rxlifecycle.ActivityEvent;
 
@@ -112,7 +112,7 @@ public final class VideoActivity extends BaseActivity<VideoViewModel.ViewModel> 
   }
 
   private MediaSource getMediaSource(final @NonNull String videoUrl) {
-    final DefaultHttpDataSourceFactory dataSourceFactory = new DefaultHttpDataSourceFactory(WebRequestInterceptor.userAgent(this.build));
+    final DefaultHttpDataSourceFactory dataSourceFactory = new DefaultHttpDataSourceFactory(WebUtils.INSTANCE.userAgent(this.build));
     final Uri videoUri = Uri.parse(videoUrl);
     final int fileType = Util.inferContentType(videoUri);
 

--- a/app/src/test/java/com/kickstarter/libs/utils/WebUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/WebUtilsTest.kt
@@ -1,0 +1,25 @@
+package com.kickstarter.libs.utils
+
+import com.kickstarter.BuildConfig
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Build
+import org.junit.Test
+import java.util.*
+
+class WebUtilsTest : KSRobolectricTestCase() {
+
+    @Test
+    fun testUserAgent() {
+        val packageManager = context().packageManager
+
+        val packageInfo = packageManager.getPackageInfo(context().applicationContext.packageName, 0)
+        val variant = StringBuilder().append(BuildConfig.FLAVOR)
+                .append(BuildConfig.BUILD_TYPE.substring(0, 1).toUpperCase(Locale.US))
+                .append(BuildConfig.BUILD_TYPE.substring(1))
+                .toString()
+        val versionCode = packageInfo.versionCode
+        val versionName = packageInfo.versionName
+        assertEquals("Kickstarter Android Mobile Variant/$variant Code/$versionCode Version/$versionName",
+                WebUtils.userAgent(Build(packageInfo)))
+    }
+}


### PR DESCRIPTION
# 📲 What
Sending custom User Agent header with graphQL requests.

# 🤔 Why
Android pledges currently have a `null` backing `Channel`. The UA is used to determine the pledge came from a `phone`.

# 🛠 How
- Created `WebUtils.userAgent` and tests.
- Adds `User-Agent` header to `GraphQLInterceptor`,

# 👀 See
<img width="845" alt="Screen Shot 2019-12-09 at 1 30 21 PM" src="https://user-images.githubusercontent.com/1289295/70462237-7e983480-1a88-11ea-9c25-f549eb949869.png">

# 📋 QA
View your logs in a debug build or verify that backings created from the app have the channel `phone`.

# Story 📖
[NT-690]


[NT-690]: https://dripsprint.atlassian.net/browse/NT-690