### PR TITLE
[🏴] NT-691 Go rewardless flag, take 2

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/FeatureKey.java
+++ b/app/src/main/java/com/kickstarter/libs/FeatureKey.java
@@ -3,7 +3,7 @@ package com.kickstarter.libs;
 public final class FeatureKey {
   private FeatureKey() {}
 
-  public static final String ANDROID_GO_REWARDLESS = "android_go_rewardless";
+  public static final String ANDROID_GO_REWARDLESS = "android_go_rewardless_2";
   public static final String ANDROID_NATIVE_CHECKOUT = "android_native_checkout";
 
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/ConfigUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/ConfigUtilsTest.kt
@@ -13,11 +13,11 @@ class ConfigUtilsTest : KSRobolectricTestCase() {
 
         assertEquals(JSONArray(), ConfigUtils.enabledFeatureFlags(ConfigFactory.configWithFeatureEnabled("ios_native_checkout")))
 
-        assertEquals(JSONArray().apply { put("android_go_rewardless") },
+        assertEquals(JSONArray().apply { put("android_go_rewardless_2") },
                 ConfigUtils.enabledFeatureFlags(ConfigFactory.configWithFeatureEnabled(FeatureKey.ANDROID_GO_REWARDLESS)))
 
         assertEquals(JSONArray().apply {
-            put("android_go_rewardless")
+            put("android_go_rewardless_2")
             put("android_native_checkout")
         }, ConfigUtils.enabledFeatureFlags(ConfigFactory.configWithFeaturesEnabled(mapOf(Pair(FeatureKey.ANDROID_GO_REWARDLESS, true),
                 Pair(FeatureKey.ANDROID_NATIVE_CHECKOUT, true),

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -410,7 +410,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
 
   private Environment environmentWithGoRewardlessDisabled() {
     final MockCurrentConfig mockCurrentConfig = new MockCurrentConfig();
-    mockCurrentConfig.config(ConfigFactory.config().toBuilder().features(null).build());
+    mockCurrentConfig.config(ConfigFactory.config());
     return environment()
       .toBuilder()
       .currentConfig(mockCurrentConfig)

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -410,7 +410,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
 
   private Environment environmentWithGoRewardlessDisabled() {
     final MockCurrentConfig mockCurrentConfig = new MockCurrentConfig();
-    mockCurrentConfig.config(ConfigFactory.config());
+    mockCurrentConfig.config(ConfigFactory.config().toBuilder().features(null).build());
     return environment()
       .toBuilder()
       .currentConfig(mockCurrentConfig)


### PR DESCRIPTION
# 📲 What
Updating key for go rewardless flag.

# 🤔 Why
`android_go_rewardless` has been deprecated due to #693 in favor of `android_go_rewardless_2` https://github.com/kickstarter/kickstarter/pull/18369

# 🛠 How
- Updated value of `FeatureKey.ANDROID_GO_REWARDLESS` to `android_go_rewardless_2`.
- Updated broken tests. 

# 📋 QA
Go rewardless is only enabled on external builds that have `android_go_rewardless_2` enabled.

# Story 📖
[NT-691]


[NT-691]: https://dripsprint.atlassian.net/browse/NT-691