### PR TITLE
[🔄] Refactor of TrackingClient

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/KoalaTrackingClient.java
+++ b/app/src/main/java/com/kickstarter/libs/KoalaTrackingClient.java
@@ -1,16 +1,14 @@
 package com.kickstarter.libs;
 
 import android.content.Context;
-import android.os.Bundle;
-import android.util.Log;
 
-import com.google.android.gms.common.util.Base64Utils;
+import com.firebase.jobdispatcher.JobService;
 import com.kickstarter.libs.qualifiers.ApplicationContext;
 import com.kickstarter.libs.utils.MapUtils;
 import com.kickstarter.services.KoalaBackgroundService;
-import com.kickstarter.services.firebase.DispatcherKt;
 import com.kickstarter.ui.IntentKey;
 
+import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -20,15 +18,11 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import androidx.annotation.NonNull;
-import io.fabric.sdk.android.Fabric;
-import timber.log.Timber;
 
 public final class KoalaTrackingClient extends TrackingClient {
-  private static final String TAG = KoalaTrackingClient.class.getSimpleName();
   @Inject CurrentUserType currentUser;
   @Inject Build build;
   @Inject CurrentConfigType currentConfig;
-  private final @NonNull Context context;
 
   public KoalaTrackingClient(
     final @ApplicationContext @NonNull Context context,
@@ -37,42 +31,44 @@ public final class KoalaTrackingClient extends TrackingClient {
     final @NonNull CurrentConfigType currentConfig) {
     super(context, currentUser, build, currentConfig);
 
-    this.context = context;
     this.currentUser = currentUser;
     this.build = build;
     this.currentConfig = currentConfig;
   }
 
   @Override
-  public void track(final @NonNull String eventName, final @NonNull Map<String, Object> additionalProperties) {
-    try {
-      final String trackingData = getTrackingData(eventName, combinedProperties(additionalProperties));
-      final String encodedTrackingData = Base64Utils.encodeUrlSafe(trackingData
-        .getBytes());
-      final Bundle bundle = new Bundle();
-      bundle.putString(IntentKey.KOALA_EVENT_NAME, eventName);
-      bundle.putString(IntentKey.KOALA_EVENT, encodedTrackingData);
-
-      final String uniqueJobName = KoalaBackgroundService.BASE_JOB_NAME + System.currentTimeMillis();
-      DispatcherKt.dispatchJob(this.context, KoalaBackgroundService.class, uniqueJobName, bundle);
-      if (this.build.isDebug()) {
-        Log.d(TAG, "Queued event:" + trackingData);
-      }
-    } catch (JSONException e) {
-      if (this.build.isDebug()) {
-        Timber.e("Failed to encode event: " + eventName);
-      }
-      Fabric.getLogger().e(KoalaTrackingClient.TAG, "Failed to encode event: " + eventName);
-    }
+  public @NotNull Class<? extends JobService> backgroundServiceClass() {
+    return KoalaBackgroundService.class;
   }
 
-  private String getTrackingData(final @NonNull String eventName, final @NonNull Map<String, Object> newProperties) throws JSONException {
+  @Override
+  protected boolean cleanPropertiesOnly() {
+    return false;
+  }
+
+  @Override
+  public @NotNull String eventKey() {
+    return IntentKey.KOALA_EVENT;
+  }
+
+  @Override
+  public @NotNull String eventNameKey() {
+    return IntentKey.KOALA_EVENT_NAME;
+  }
+
+  @Override
+  public @NotNull String tag() {
+    return KoalaTrackingClient.class.getSimpleName();
+  }
+
+  @Override
+  public @NotNull String trackingData(final @NotNull String eventName, final @NotNull Map<String, ?> newProperties) throws JSONException {
     final JSONObject trackingEvent = new JSONObject();
     trackingEvent.put("event", eventName);
 
-    final Map<String, Object> compactProperties = MapUtils.compact(newProperties);
+    final Map<String, ?> compactProperties = MapUtils.compact(newProperties);
     final JSONObject propertiesJSON = new JSONObject();
-    for (Map.Entry<String, Object> entry : compactProperties.entrySet()) {
+    for (Map.Entry<String, ?> entry : compactProperties.entrySet()) {
       propertiesJSON.put(entry.getKey(), entry.getValue());
     }
     trackingEvent.put("properties", propertiesJSON);
@@ -81,10 +77,4 @@ public final class KoalaTrackingClient extends TrackingClient {
 
     return trackingArray.toString();
   }
-
-  @Override
-  protected boolean cleanPropertiesOnly() {
-    return false;
-  }
-
 }

--- a/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
@@ -1,18 +1,14 @@
 package com.kickstarter.libs
 
 import android.content.Context
-import android.os.Bundle
-import android.util.Log
+import com.firebase.jobdispatcher.JobService
 import com.kickstarter.libs.qualifiers.ApplicationContext
 import com.kickstarter.libs.utils.MapUtils
 import com.kickstarter.models.User
 import com.kickstarter.services.LakeBackgroundService
-import com.kickstarter.services.firebase.dispatchJob
 import com.kickstarter.ui.IntentKey
-import io.fabric.sdk.android.Fabric
 import org.json.JSONException
 import org.json.JSONObject
-import timber.log.Timber
 import java.util.*
 
 class LakeTrackingClient(
@@ -32,29 +28,18 @@ class LakeTrackingClient(
         this.currentConfig.observable().subscribe { c -> this.config = c }
     }
 
-    override fun track(eventName: String, additionalProperties: Map<String, Any>) {
-        try {
-            val trackingData = getTrackingData(eventName, combinedProperties(additionalProperties))
-            val bundle = Bundle()
-            bundle.putString(IntentKey.LAKE_EVENT_NAME, eventName)
-            bundle.putString(IntentKey.LAKE_EVENT, trackingData)
+    override fun backgroundServiceClass(): Class<out JobService> = LakeBackgroundService::class.java
 
-            val uniqueJobName = LakeBackgroundService.BASE_JOB_NAME + System.currentTimeMillis()
-            dispatchJob(this.context, LakeBackgroundService::class.java, uniqueJobName, bundle)
-            if (this.build.isDebug) {
-                Log.d(TAG, "Queued event:$trackingData")
-            }
-        } catch (e: JSONException) {
-            if (this.build.isDebug) {
-                Timber.e("Failed to encode event: $eventName")
-            }
-            Fabric.getLogger().e(TAG, "Failed to encode event: $eventName")
-        }
+    override fun cleanPropertiesOnly(): Boolean = true
 
-    }
+    override fun eventKey(): String = IntentKey.LAKE_EVENT
+
+    override fun eventNameKey(): String = IntentKey.LAKE_EVENT_NAME
+
+    override fun tag(): String = LakeTrackingClient::class.java.simpleName
 
     @Throws(JSONException::class)
-    private fun getTrackingData(eventName: String, newProperties: Map<String, Any>): String {
+    override fun trackingData(eventName: String, newProperties: Map<String, Any?>): String {
         val data = JSONObject()
         data.put("event", eventName)
 
@@ -69,12 +54,6 @@ class LakeTrackingClient(
         record.put("partition-key", UUID.randomUUID().toString())
         record.put("data", data)
         return record.toString()
-    }
-
-    override fun cleanPropertiesOnly(): Boolean = true
-
-    companion object {
-        private val TAG = LakeTrackingClient::class.java.simpleName
     }
 
 }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -2,7 +2,10 @@ package com.kickstarter.libs
 
 import android.content.Context
 import android.content.res.Configuration
+import android.os.Bundle
+import android.util.Log
 import android.view.accessibility.AccessibilityManager
+import com.firebase.jobdispatcher.JobService
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.iid.FirebaseInstanceId
@@ -11,7 +14,11 @@ import com.kickstarter.R
 import com.kickstarter.libs.qualifiers.ApplicationContext
 import com.kickstarter.libs.utils.ConfigUtils
 import com.kickstarter.models.User
+import com.kickstarter.services.firebase.dispatchJob
+import io.fabric.sdk.android.Fabric
 import org.json.JSONArray
+import org.json.JSONException
+import timber.log.Timber
 import javax.inject.Inject
 
 abstract class TrackingClient(@param:ApplicationContext private val context: Context,
@@ -31,6 +38,34 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
         this.currentConfig.observable().subscribe { c -> this.config = c }
     }
 
+    final override fun track(eventName: String, additionalProperties: MutableMap<String, Any?>) {
+        try {
+            val trackingData = trackingData(eventName, combinedProperties(additionalProperties))
+            val bundle = Bundle()
+            bundle.putString(eventNameKey(), eventName)
+            bundle.putString(eventKey(), trackingData)
+
+            val uniqueJobName = backgroundServiceClass().simpleName + System.currentTimeMillis()
+            dispatchJob(this.context, backgroundServiceClass(), uniqueJobName, bundle)
+            if (this.build.isDebug) {
+                Log.d(tag(), "Queued event:$trackingData")
+            }
+        } catch (e: JSONException) {
+            if (this.build.isDebug) {
+                Timber.e("Failed to encode event: $eventName")
+            }
+            Fabric.getLogger().e(tag(), "Failed to encode event: $eventName")
+        }
+    }
+
+    abstract fun backgroundServiceClass() : Class<out JobService>
+    abstract fun eventKey(): String
+    abstract fun eventNameKey(): String
+    abstract fun tag(): String
+    @Throws(JSONException::class)
+    abstract fun trackingData(eventName: String, newProperties: Map<String, Any?>): String
+
+    //Default property values
     override fun androidUUID(): String {
         return FirebaseInstanceId.getInstance().id
     }
@@ -38,8 +73,6 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
     override fun brand(): String {
         return android.os.Build.BRAND
     }
-
-    override fun cleanPropertiesOnly(): Boolean = true
 
     /**
      * Derives the device's orientation (portrait/landscape) from the `context`.
@@ -93,5 +126,4 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
     override fun versionName(): String {
         return BuildConfig.VERSION_NAME
     }
-
 }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -70,9 +70,11 @@ public abstract class TrackingClientType {
     return combinedProperties;
   }
 
+  protected abstract boolean cleanPropertiesOnly();
+
+  //Default properties
   protected abstract String androidUUID();
   protected abstract String brand();
-  protected abstract boolean cleanPropertiesOnly();
   protected abstract String deviceFormat();
   protected abstract String deviceOrientation();
   protected abstract JSONArray enabledFeatureFlags();

--- a/app/src/main/java/com/kickstarter/services/KoalaBackgroundService.kt
+++ b/app/src/main/java/com/kickstarter/services/KoalaBackgroundService.kt
@@ -63,7 +63,6 @@ class KoalaBackgroundService : JobService() {
     }
 
     companion object {
-        const val BASE_JOB_NAME = "Koala-Background-Service"
         val TAG = KoalaBackgroundService::class.java.simpleName +" \uD83D\uDC28"
     }
 }

--- a/app/src/main/java/com/kickstarter/services/KoalaBackgroundService.kt
+++ b/app/src/main/java/com/kickstarter/services/KoalaBackgroundService.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.crashlytics.android.Crashlytics
 import com.firebase.jobdispatcher.JobParameters
 import com.firebase.jobdispatcher.JobService
+import com.google.android.gms.common.util.Base64Utils
 import com.kickstarter.KSApplication
 import com.kickstarter.libs.Build
 import com.kickstarter.ui.IntentKey
@@ -27,12 +28,13 @@ class KoalaBackgroundService : JobService() {
     override fun onStartJob(job: JobParameters?): Boolean {
         val extras = job?.extras
         val eventName = extras?.get(IntentKey.KOALA_EVENT_NAME) as String
-        koala.track(extras.get(IntentKey.KOALA_EVENT) as String)
+        val trackingData = extras.get(IntentKey.KOALA_EVENT) as String
+        val encodedData = Base64Utils.encodeUrlSafe(trackingData.toByteArray())
+        koala.track(encodedData)
                 .subscribeOn(Schedulers.io())
                 .subscribe({
                     logResponse(it, eventName)
                     jobFinished(job, !it.isSuccessful)
-
                 }, {
                     logTrackingError(eventName)
                     jobFinished(job, false)

--- a/app/src/main/java/com/kickstarter/services/LakeBackgroundService.kt
+++ b/app/src/main/java/com/kickstarter/services/LakeBackgroundService.kt
@@ -64,7 +64,6 @@ class LakeBackgroundService : JobService() {
     }
 
     companion object {
-        const val BASE_JOB_NAME = "Lake-Background-Service"
         val TAG = LakeBackgroundService::class.java.simpleName +" \uD83D\uDCA7"
     }
 }

--- a/app/src/main/java/com/kickstarter/services/LakeBackgroundService.kt
+++ b/app/src/main/java/com/kickstarter/services/LakeBackgroundService.kt
@@ -33,7 +33,6 @@ class LakeBackgroundService : JobService() {
                 .subscribe({
                     logResponse(it, eventName)
                     jobFinished(job, !it.isSuccessful)
-
                 }, {
                     logTrackingError(eventName)
                     jobFinished(job, false)


### PR DESCRIPTION
# 📲 What
Extracting shared parts of `LakeTrackingClient` and `KoalaTrackingClient` and moving to `TrackingClient`.

# 🤔 Why
Refactor of #692 per @Scollaco's recommendation.

# 🛠 How
- Created abstract methods in `TrackingClient` for `backgroundServiceClass`, `eventKey`,  `eventNameKey`, `tag`, that are used in the now `final` `track` method.

# 👀 See
Nothing 2 c

# 📋 QA
N/A

# Story 📖
https://github.com/kickstarter/android-oss/pull/692#discussion_r355698774