### PR TITLE
[😕] NT-713 Handling null request tags in survey webview and tests

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/SurveyResponseActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/SurveyResponseActivity.java
@@ -58,7 +58,7 @@ public class SurveyResponseActivity extends BaseActivity<SurveyResponseViewModel
 
   private boolean handleProjectUriRequest(final @NonNull Request request, final @NonNull WebView webView) {
     this.viewModel.inputs.projectUriRequest(request);
-    return false;
+    return true;
   }
 
   private boolean handleProjectSurveyUriRequest(final @NonNull Request request, final @NonNull WebView webView) {

--- a/app/src/main/java/com/kickstarter/viewmodels/SurveyResponseViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SurveyResponseViewModel.java
@@ -76,8 +76,8 @@ public interface SurveyResponseViewModel {
      * which indicates a redirect from a successful submit.
      */
     private boolean requestTagUrlIsSurveyUrl(final @NonNull Pair<Request, String> projectRequestAndSurveyUrl) {
-      return ((Request) projectRequestAndSurveyUrl.first.tag()).url().toString()
-        .equals(projectRequestAndSurveyUrl.second);
+      final Request tag = (Request) projectRequestAndSurveyUrl.first.tag();
+      return tag == null || tag.url().toString().equals(projectRequestAndSurveyUrl.second);
     }
 
     private final PublishSubject<Void> okButtonClicked = PublishSubject.create();

--- a/app/src/test/java/com/kickstarter/viewmodels/SurveyResponseViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SurveyResponseViewModelTest.java
@@ -68,6 +68,38 @@ public class SurveyResponseViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
+  public void testSubmitSuccessful_NullTag_ShowConfirmationDialog() {
+    final String surveyUrl = "https://kck.str/projects/param/heyo/surveys/123";
+
+    final SurveyResponse.Urls urlsEnvelope = SurveyResponse.Urls.builder()
+      .web(SurveyResponse.Urls.Web.builder().survey(surveyUrl).build())
+      .build();
+
+    final SurveyResponse surveyResponse = SurveyResponseFactory.surveyResponse()
+      .toBuilder()
+      .urls(urlsEnvelope)
+      .build();
+
+    final Request projectSurveyRequest = new Request.Builder()
+      .url(surveyUrl)
+      .build();
+
+    final Request projectRequest = new Request.Builder()
+      .url("https://kck.str/projects/param/heyo")
+      .build();
+
+    setUpEnvironment(environment());
+    this.vm.intent(new Intent().putExtra(IntentKey.SURVEY_RESPONSE, surveyResponse));
+
+    // Survey loads. Successful submit redirects to project uri.
+    this.vm.inputs.projectSurveyUriRequest(projectSurveyRequest);
+    this.vm.inputs.projectUriRequest(projectRequest);
+
+    // Success confirmation dialog is shown.
+    this.showConfirmationDialog.assertValueCount(1);
+  }
+
+  @Test
   public void testWebViewUrl() {
     final SurveyResponse surveyResponse = SurveyResponseFactory.surveyResponse();
 


### PR DESCRIPTION
# 📲 What
Handling users clicking on project links in the webviews.

# 🤔 Why
So we can stop crashing.

# 🛠 How
- In #157, we attempted to fix the redirect bug after a successful survey submission that took users to the project page. That fix assumed that [`Request.tag`](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-request/tag/) would never be `null`. Around December 10, 2019, it started returning `null`. This PR checks if the tag is `null`.
<img width="1193" alt="Screen Shot 2019-12-16 at 1 52 46 PM" src="https://user-images.githubusercontent.com/1289295/71040495-b04a7480-20f4-11ea-8166-43c709c6e65b.png">

- Previously, we returned `false` in `SurveyResponseActivity.handleProjectUriRequest` which means that we didn't handle the project page URL but since now we do, we return `true` so that the user isn't in an endless loop and the app doesn't crash.

# 👀 See
| Before 🐛 | After 🦋 |
| --- | --- |
| 💥 | ![device-2019-12-17-174027 2019-12-17 17_41_06](https://user-images.githubusercontent.com/1289295/71040347-6bbed900-20f4-11ea-90e3-3193326a2781.gif) |

# 📋 QA
Click a project link in a webview. Submit a survey. Yay webviews.

# Story 📖
[NT-713]
