### PR TITLE
[🛁] Adding new tracking session properties

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Config.java
+++ b/app/src/main/java/com/kickstarter/libs/Config.java
@@ -15,12 +15,14 @@ import auto.parcel.AutoParcel;
 @AutoGson
 @AutoParcel
 public abstract class Config implements Parcelable {
+  public abstract @Nullable Map<String, String> abExperiments();
   public abstract String countryCode();
   public abstract @Nullable Map<String, Boolean> features();
   public abstract List<LaunchedCountry> launchedCountries();
 
   @AutoParcel.Builder
   public abstract static class Builder {
+    public abstract Builder abExperiments(Map<String, String> __);
     public abstract Builder countryCode(String __);
     public abstract Builder features(Map<String, Boolean> __);
     public abstract Builder launchedCountries(List<LaunchedCountry> __);

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -2,6 +2,8 @@ package com.kickstarter.libs
 
 import android.content.Context
 import android.content.res.Configuration
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.Bundle
 import android.util.Log
 import android.view.accessibility.AccessibilityManager
@@ -13,6 +15,7 @@ import com.kickstarter.BuildConfig
 import com.kickstarter.R
 import com.kickstarter.libs.qualifiers.ApplicationContext
 import com.kickstarter.libs.utils.ConfigUtils
+import com.kickstarter.libs.utils.WebUtils
 import com.kickstarter.models.User
 import com.kickstarter.services.firebase.dispatchJob
 import io.fabric.sdk.android.Fabric
@@ -74,13 +77,21 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
         return android.os.Build.BRAND
     }
 
+    override fun buildNumber(): Int {
+        return BuildConfig.VERSION_CODE
+    }
+
+    override fun currentVariants(): JSONArray? {
+        return ConfigUtils.currentVariants(this.config)
+    }
+
     /**
      * Derives the device's orientation (portrait/landscape) from the `context`.
      */
     override fun deviceOrientation(): String {
         return if (this.context.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            "landscape"
-        } else "portrait"
+            "Landscape"
+        } else "Portrait"
     }
 
     override fun deviceFormat(): String {
@@ -123,7 +134,18 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
         return this.loggedInUser
     }
 
+    override fun userAgent(): String {
+        return WebUtils.userAgent(this.build)
+    }
+
     override fun versionName(): String {
         return BuildConfig.VERSION_NAME
+    }
+
+    override fun wifiConnection(): Boolean {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?
+        return cm?.activeNetwork?.let {
+            cm.getNetworkCapabilities(it)?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+        } ?: false
     }
 }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -69,10 +69,6 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
     abstract fun trackingData(eventName: String, newProperties: Map<String, Any?>): String
 
     //Default property values
-    override fun androidUUID(): String {
-        return FirebaseInstanceId.getInstance().id
-    }
-
     override fun brand(): String {
         return android.os.Build.BRAND
     }
@@ -85,6 +81,14 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
         return ConfigUtils.currentVariants(this.config)
     }
 
+    override fun deviceDistinctId(): String {
+        return FirebaseInstanceId.getInstance().id
+    }
+
+    override fun deviceFormat(): String {
+        return if (this.context.resources.getBoolean(R.bool.isTablet)) "tablet" else "phone"
+    }
+
     /**
      * Derives the device's orientation (portrait/landscape) from the `context`.
      */
@@ -92,10 +96,6 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
         return if (this.context.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
             "Landscape"
         } else "Portrait"
-    }
-
-    override fun deviceFormat(): String {
-        return if (this.context.resources.getBoolean(R.bool.isTablet)) "tablet" else "phone"
     }
 
     override fun enabledFeatureFlags(): JSONArray? {

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -32,12 +32,11 @@ public abstract class TrackingClientType {
   private @NonNull Map<String, Object> sessionProperties(final boolean userIsLoggedIn) {
     final Map<String, Object> properties = new HashMap<String, Object>() {
       {
-        put("android_uuid", androidUUID());
         put("app_build_number", buildNumber());
         put("app_release_version", versionName());
         put("client_type", "native");
         put("current_variants", currentVariants());
-        put("device_distinct_id", androidUUID());
+        put("device_distinct_id", deviceDistinctId());
         put("device_format", deviceFormat());
         put("device_manufacturer", manufacturer());
         put("device_model", model());
@@ -64,15 +63,14 @@ public abstract class TrackingClientType {
       hashMap.putAll(KoalaUtils.userProperties(loggedInUser()));
     }
 
-    hashMap.put("android_uuid", androidUUID());
     hashMap.put("app_version", versionName());
     hashMap.put("brand", brand());
     hashMap.put("client_platform", "android");
     hashMap.put("client_type", "native");
-    hashMap.put("device_fingerprint", androidUUID());
+    hashMap.put("device_fingerprint", deviceDistinctId());
     hashMap.put("device_format", deviceFormat());
     hashMap.put("device_orientation", deviceOrientation());
-    hashMap.put("distinct_id", androidUUID());
+    hashMap.put("distinct_id", deviceDistinctId());
     hashMap.put("enabled_feature_flags", enabledFeatureFlags());
     hashMap.put("google_play_services", isGooglePlayServicesAvailable() ? "available" : "unavailable");
     hashMap.put("is_vo_on", isTalkBackOn());
@@ -101,10 +99,10 @@ public abstract class TrackingClientType {
   protected abstract boolean cleanPropertiesOnly();
 
   //Default properties
-  protected abstract String androidUUID();
   protected abstract String brand();
   protected abstract int buildNumber();
   protected abstract JSONArray currentVariants();
+  protected abstract String deviceDistinctId();
   protected abstract String deviceFormat();
   protected abstract String deviceOrientation();
   protected abstract JSONArray enabledFeatureFlags();

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -1,11 +1,13 @@
 package com.kickstarter.libs;
 
 import com.kickstarter.libs.utils.KoalaUtils;
+import com.kickstarter.libs.utils.MapUtils;
 import com.kickstarter.models.User;
 
 import org.json.JSONArray;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import androidx.annotation.NonNull;
@@ -22,10 +24,27 @@ public abstract class TrackingClientType {
 
     final boolean userIsLoggedIn = loggedInUser() != null;
 
+    hashMap.put("android_uuid", androidUUID());
+    hashMap.put("app_build_number", buildNumber());
+    hashMap.put("app_release_version", versionName());
+    hashMap.put("client_type", "native");
+    hashMap.put("current_variants", currentVariants());
+    hashMap.put("device_distinct_id", androidUUID());
+    hashMap.put("device_format", deviceFormat());
+    hashMap.put("device_manufacturer", manufacturer());
+    hashMap.put("device_model", model());
+    hashMap.put("device_orientation", deviceOrientation());
+    hashMap.put("display_language", Locale.getDefault().getLanguage());
+    hashMap.put("enabled_features", enabledFeatureFlags());
+    hashMap.put("is_voiceover_running", isTalkBackOn());
+    hashMap.put("mp_lib", "kickstarter_android");
+    hashMap.put("os_version", String.format("Android %s", OSVersion()));
     hashMap.put("time", time());
+    hashMap.put("user_agent", userAgent());
     hashMap.put("user_logged_in", userIsLoggedIn);
+    hashMap.put("wifi_connection", wifiConnection());
 
-    return hashMap;
+    return MapUtils.prefixKeys(hashMap, "session_");
   }
 
   private @NonNull Map<String, Object> defaultProperties() {
@@ -75,6 +94,8 @@ public abstract class TrackingClientType {
   //Default properties
   protected abstract String androidUUID();
   protected abstract String brand();
+  protected abstract int buildNumber();
+  protected abstract JSONArray currentVariants();
   protected abstract String deviceFormat();
   protected abstract String deviceOrientation();
   protected abstract JSONArray enabledFeatureFlags();
@@ -85,5 +106,7 @@ public abstract class TrackingClientType {
   protected abstract String model();
   protected abstract String OSVersion();
   protected abstract long time();
+  protected abstract String userAgent();
   protected abstract String versionName();
+  protected abstract boolean wifiConnection();
 }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -42,8 +42,7 @@ public abstract class TrackingClientType {
         put("device_manufacturer", manufacturer());
         put("device_model", model());
         put("device_orientation", deviceOrientation());
-        put("display_language", Locale.getDefault().
-          getLanguage());
+        put("display_language", Locale.getDefault().getLanguage());
         put("enabled_features", enabledFeatureFlags());
         put("is_voiceover_running", isTalkBackOn());
         put("mp_lib", "kickstarter_android");

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -39,7 +39,6 @@ public abstract class TrackingClientType {
     hashMap.put("is_voiceover_running", isTalkBackOn());
     hashMap.put("mp_lib", "kickstarter_android");
     hashMap.put("os_version", String.format("Android %s", OSVersion()));
-    hashMap.put("time", time());
     hashMap.put("user_agent", userAgent());
     hashMap.put("user_logged_in", userIsLoggedIn);
     hashMap.put("wifi_connection", wifiConnection());

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -24,26 +24,37 @@ public abstract class TrackingClientType {
 
     final boolean userIsLoggedIn = loggedInUser() != null;
 
-    hashMap.put("android_uuid", androidUUID());
-    hashMap.put("app_build_number", buildNumber());
-    hashMap.put("app_release_version", versionName());
-    hashMap.put("client_type", "native");
-    hashMap.put("current_variants", currentVariants());
-    hashMap.put("device_distinct_id", androidUUID());
-    hashMap.put("device_format", deviceFormat());
-    hashMap.put("device_manufacturer", manufacturer());
-    hashMap.put("device_model", model());
-    hashMap.put("device_orientation", deviceOrientation());
-    hashMap.put("display_language", Locale.getDefault().getLanguage());
-    hashMap.put("enabled_features", enabledFeatureFlags());
-    hashMap.put("is_voiceover_running", isTalkBackOn());
-    hashMap.put("mp_lib", "kickstarter_android");
-    hashMap.put("os_version", String.format("Android %s", OSVersion()));
-    hashMap.put("user_agent", userAgent());
-    hashMap.put("user_logged_in", userIsLoggedIn);
-    hashMap.put("wifi_connection", wifiConnection());
+    hashMap.putAll(sessionProperties(userIsLoggedIn));
 
-    return MapUtils.prefixKeys(hashMap, "session_");
+    return hashMap;
+  }
+
+  private @NonNull Map<String, Object> sessionProperties(final boolean userIsLoggedIn) {
+    final Map<String, Object> properties = new HashMap<String, Object>() {
+      {
+        put("android_uuid", androidUUID());
+        put("app_build_number", buildNumber());
+        put("app_release_version", versionName());
+        put("client_type", "native");
+        put("current_variants", currentVariants());
+        put("device_distinct_id", androidUUID());
+        put("device_format", deviceFormat());
+        put("device_manufacturer", manufacturer());
+        put("device_model", model());
+        put("device_orientation", deviceOrientation());
+        put("display_language", Locale.getDefault().
+          getLanguage());
+        put("enabled_features", enabledFeatureFlags());
+        put("is_voiceover_running", isTalkBackOn());
+        put("mp_lib", "kickstarter_android");
+        put("os_version", String.format("Android %s", OSVersion()));
+        put("user_agent", userAgent());
+        put("user_logged_in", userIsLoggedIn);
+        put("wifi_connection", wifiConnection());
+      }
+    };
+
+    return MapUtils.prefixKeys(properties, "session_");
   }
 
   private @NonNull Map<String, Object> defaultProperties() {

--- a/app/src/main/java/com/kickstarter/libs/utils/ConfigUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/ConfigUtils.kt
@@ -4,6 +4,19 @@ import com.kickstarter.libs.Config
 import org.json.JSONArray
 
 object ConfigUtils {
+    fun currentVariants(config: Config?): JSONArray? {
+        return config
+                ?.abExperiments()
+                ?.toSortedMap()
+                ?.let {
+                    JSONArray().apply {
+                        for (feature in it) {
+                            put("${feature.key}[${feature.value}]")
+                        }
+                    }
+                }
+    }
+
     fun enabledFeatureFlags(config: Config?): JSONArray? {
         return config
                 ?.features()

--- a/app/src/main/java/com/kickstarter/mock/factories/ConfigFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/ConfigFactory.java
@@ -56,6 +56,18 @@ public final class ConfigFactory {
       .build();
   }
 
+  public static @NonNull Config configWithExperiment(final @NonNull String experiment, final @NonNull String variant) {
+    return config().toBuilder()
+      .abExperiments(Collections.singletonMap(experiment, variant))
+      .build();
+  }
+
+  public static @NonNull Config configWithExperiments(final @NonNull Map<String, String> abExperiments) {
+    return config().toBuilder()
+      .abExperiments(abExperiments)
+      .build();
+  }
+
   public static @NonNull Config configWithFeatureEnabled(final @NonNull String featureKey) {
     return config().toBuilder()
       .features(Collections.singletonMap(featureKey, true))

--- a/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
@@ -240,7 +240,7 @@ class KoalaTest : KSRobolectricTestCase() {
         assertEquals("native", expectedProperties["client_type"])
         assertEquals("uuid", expectedProperties["device_fingerprint"])
         assertEquals("phone", expectedProperties["device_format"])
-        assertEquals("portrait", expectedProperties["device_orientation"])
+        assertEquals("Portrait", expectedProperties["device_orientation"])
         assertEquals("uuid", expectedProperties["distinct_id"])
         assertEquals(JSONArray().put("android_example_feature"), expectedProperties["enabled_feature_flags"])
         assertEquals("unavailable", expectedProperties["google_play_services"])

--- a/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
@@ -233,7 +233,6 @@ class KoalaTest : KSRobolectricTestCase() {
 
     private fun assertDefaultProperties(user: User?) {
         val expectedProperties = propertiesTest.value
-        assertEquals("uuid", expectedProperties["android_uuid"])
         assertEquals("9.9.9", expectedProperties["app_version"])
         assertEquals("Google", expectedProperties["brand"])
         assertEquals("android", expectedProperties["client_platform"])

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -6,6 +6,7 @@ import com.kickstarter.mock.factories.ConfigFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.User
 import org.joda.time.DateTime
+import org.json.JSONArray
 import org.junit.Test
 import rx.subjects.BehaviorSubject
 
@@ -44,12 +45,33 @@ class LakeTest : KSRobolectricTestCase() {
 
     private fun assertDefaultProperties(user: User?) {
         val expectedProperties = propertiesTest.value
-        assertEquals(DateTime.parse("2018-11-02T18:42:05Z").millis / 1000, expectedProperties["time"])
-        assertEquals(user != null, expectedProperties["user_logged_in"])
+        assertEquals("uuid", expectedProperties["session_android_uuid"])
+        assertEquals(9999, expectedProperties["session_app_build_number"])
+        assertEquals("9.9.9", expectedProperties["session_app_release_version"])
+        assertEquals("native", expectedProperties["session_client_type"])
+        assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_current_variants"])
+        assertEquals("uuid", expectedProperties["session_device_distinct_id"])
+        assertEquals("phone", expectedProperties["session_device_format"])
+        assertEquals("Google", expectedProperties["session_device_manufacturer"])
+        assertEquals("Pixel 3", expectedProperties["session_device_model"])
+        assertEquals("Portrait", expectedProperties["session_device_orientation"])
+        assertEquals("en", expectedProperties["session_display_language"])
+        assertEquals(JSONArray().put("android_example_feature"), expectedProperties["session_enabled_features"])
+        assertEquals(false, expectedProperties["session_is_voiceover_running"])
+        assertEquals("kickstarter_android", expectedProperties["session_mp_lib"])
+        assertEquals("Android 9", expectedProperties["session_os_version"])
+        assertEquals(DateTime.parse("2018-11-02T18:42:05Z").millis / 1000, expectedProperties["session_time"])
+        assertEquals("agent", expectedProperties["session_user_agent"])
+        assertEquals(user != null, expectedProperties["session_user_logged_in"])
+        assertEquals(false, expectedProperties["session_wifi_connection"])
     }
 
     private fun mockCurrentConfig() = MockCurrentConfig().apply {
-        config(ConfigFactory.configWithFeatureEnabled("android_example_feature"))
+        val config = ConfigFactory.configWithFeatureEnabled("android_example_feature")
+                .toBuilder()
+                .abExperiments(mapOf(Pair("android_example_experiment", "control")))
+                .build()
+        config(config)
     }
 
     private fun user() =

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -5,7 +5,6 @@ import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.factories.ConfigFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.User
-import org.joda.time.DateTime
 import org.json.JSONArray
 import org.junit.Test
 import rx.subjects.BehaviorSubject
@@ -60,7 +59,6 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals(false, expectedProperties["session_is_voiceover_running"])
         assertEquals("kickstarter_android", expectedProperties["session_mp_lib"])
         assertEquals("Android 9", expectedProperties["session_os_version"])
-        assertEquals(DateTime.parse("2018-11-02T18:42:05Z").millis / 1000, expectedProperties["session_time"])
         assertEquals("agent", expectedProperties["session_user_agent"])
         assertEquals(user != null, expectedProperties["session_user_logged_in"])
         assertEquals(false, expectedProperties["session_wifi_connection"])

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -24,7 +24,7 @@ class LakeTest : KSRobolectricTestCase() {
 
         this.lakeTest.assertValue("App Open")
 
-        assertDefaultProperties(null)
+        assertSessionProperties(null)
     }
 
     @Test
@@ -39,12 +39,11 @@ class LakeTest : KSRobolectricTestCase() {
 
         this.lakeTest.assertValue("App Open")
 
-        assertDefaultProperties(user)
+        assertSessionProperties(user)
     }
 
-    private fun assertDefaultProperties(user: User?) {
+    private fun assertSessionProperties(user: User?) {
         val expectedProperties = propertiesTest.value
-        assertEquals("uuid", expectedProperties["session_android_uuid"])
         assertEquals(9999, expectedProperties["session_app_build_number"])
         assertEquals("9.9.9", expectedProperties["session_app_release_version"])
         assertEquals("native", expectedProperties["session_client_type"])

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -50,11 +50,6 @@ public final class MockTrackingClient extends TrackingClientType {
 
   //Default property values
   @Override
-  protected String androidUUID() {
-    return "uuid";
-  }
-
-  @Override
   protected String brand() {
     return "Google";
   }
@@ -67,6 +62,11 @@ public final class MockTrackingClient extends TrackingClientType {
   @Override
   protected JSONArray currentVariants() {
     return ConfigUtils.INSTANCE.currentVariants(this.config);
+  }
+
+  @Override
+  protected String deviceDistinctId() {
+    return "uuid";
   }
 
   @Override

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -39,10 +39,16 @@ public final class MockTrackingClient extends TrackingClientType {
   public final @NonNull Observable<Map<String, Object>> eventProperties = this.events.map(e -> e.properties);
 
   @Override
+  protected boolean cleanPropertiesOnly() {
+    return this.cleanPropertiesOnly;
+  }
+
+  @Override
   public void track(final @NonNull String eventName, final @NonNull Map<String, Object> additionalProperties) {
     this.events.onNext(new Event(eventName, combinedProperties(additionalProperties)));
   }
 
+  //Default property values
   @Override
   protected String androidUUID() {
     return "uuid";
@@ -54,8 +60,13 @@ public final class MockTrackingClient extends TrackingClientType {
   }
 
   @Override
-  protected boolean cleanPropertiesOnly() {
-    return this.cleanPropertiesOnly;
+  protected int buildNumber() {
+    return 9999;
+  }
+
+  @Override
+  protected JSONArray currentVariants() {
+    return ConfigUtils.INSTANCE.currentVariants(this.config);
   }
 
   @Override
@@ -65,7 +76,7 @@ public final class MockTrackingClient extends TrackingClientType {
 
   @Override
   protected String deviceOrientation() {
-    return "portrait";
+    return "Portrait";
   }
 
   @Override
@@ -109,7 +120,17 @@ public final class MockTrackingClient extends TrackingClientType {
   }
 
   @Override
+  protected String userAgent() {
+    return "agent";
+  }
+
+  @Override
   protected String versionName() {
     return "9.9.9";
+  }
+
+  @Override
+  protected boolean wifiConnection() {
+    return false;
   }
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/ConfigUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/ConfigUtilsTest.kt
@@ -5,8 +5,26 @@ import com.kickstarter.libs.FeatureKey
 import com.kickstarter.mock.factories.ConfigFactory
 import org.json.JSONArray
 import org.junit.Test
+import java.util.*
 
 class ConfigUtilsTest : KSRobolectricTestCase() {
+    @Test
+    fun testAbExperiments() {
+        assertEquals(null, ConfigUtils.currentVariants(ConfigFactory.config().toBuilder().abExperiments(null).build()))
+
+        assertEquals(JSONArray(), ConfigUtils.currentVariants(ConfigFactory.configWithExperiments(Collections.emptyMap())))
+
+        assertEquals(JSONArray().apply { put("pledge_button_copy[experiment]") },
+                ConfigUtils.currentVariants(ConfigFactory.configWithExperiment("pledge_button_copy", "experiment")))
+
+        assertEquals(JSONArray().apply {
+            put("add_new_card_vertical[control]")
+            put("pledge_button_copy[experiment]")
+        },
+                ConfigUtils.currentVariants(ConfigFactory.configWithExperiments(mapOf(Pair("pledge_button_copy", "experiment"),
+                        Pair("add_new_card_vertical", "control")))))
+    }
+
     @Test
     fun testEnabledFeatureFlags() {
         assertEquals(null, ConfigUtils.enabledFeatureFlags(ConfigFactory.config().toBuilder().features(null).build()))


### PR DESCRIPTION
# 📲 What
Adding "Session Properties" tracking group.

# 🤔 Why
The first step of many for new tracking events.

# 🛠 How
- Added `abExperiments` property to `Config` model
- Added `ConfigUtils.currentVariants` to return a `JSONArray` of current experiments
- Added new session properties to `TrackingClientType`
- Implemented new session property values in `TrackingClient`
- Testzzzzz

# 👀 See
Nothing 2 c here

# 📋 QA
All events sent to the Lake 💧 should have these properties. This is a WIP so I'm on hitting staging.

# Story 📖
Part of [NT-654]