### PR TITLE
[🛁] Adding new tracking user properties 

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -123,6 +123,10 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
         return this.loggedInUser
     }
 
+    override fun userCountry(user: User): String? {
+        return user.location()?.country() ?: this.config?.countryCode()
+    }
+
     override fun versionName(): String {
         return BuildConfig.VERSION_NAME
     }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -23,8 +23,7 @@ public abstract class TrackingClientType {
     final boolean userIsLoggedIn = loggedInUser() != null;
     if (userIsLoggedIn) {
       hashMap.putAll(KoalaUtils.userProperties(loggedInUser()));
-      hashMap.put("user_country", userCountry(loggedInUser()) );
-
+      hashMap.put("user_country", userCountry(loggedInUser()));
     }
 
     hashMap.put("time", time());

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -21,6 +21,11 @@ public abstract class TrackingClientType {
     final Map<String, Object> hashMap = new HashMap<>();
 
     final boolean userIsLoggedIn = loggedInUser() != null;
+    if (userIsLoggedIn) {
+      hashMap.putAll(KoalaUtils.userProperties(loggedInUser()));
+      hashMap.put("user_country", userCountry(loggedInUser()) );
+
+    }
 
     hashMap.put("time", time());
     hashMap.put("user_logged_in", userIsLoggedIn);
@@ -85,5 +90,6 @@ public abstract class TrackingClientType {
   protected abstract String model();
   protected abstract String OSVersion();
   protected abstract long time();
+  protected abstract String userCountry(User user);
   protected abstract String versionName();
 }

--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -98,10 +98,11 @@ public final class KoalaUtils {
     final Map<String, Object> properties = new HashMap<String, Object>() {
       {
         put("backed_projects_count", user.backedProjectsCount());
-        put("created_projects_count", user.createdProjectsCount());
-        put("starred_projects_count", user.starredProjectsCount());
+        put("facebook_account", BooleanUtils.isTrue(user.facebookConnected()));
+        put("is_admin", BooleanUtils.isTrue(user.isAdmin()));
+        put("launched_projects_count", user.createdProjectsCount());
         put("uid", user.id());
-
+        put("watched_projects_count", user.starredProjectsCount());
       }
     };
 

--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -97,10 +97,11 @@ public final class KoalaUtils {
   public static @NonNull Map<String, Object> userProperties(final @NonNull User user, final @NonNull String prefix) {
     final Map<String, Object> properties = new HashMap<String, Object>() {
       {
-        put("uid", user.id());
         put("backed_projects_count", user.backedProjectsCount());
         put("created_projects_count", user.createdProjectsCount());
         put("starred_projects_count", user.starredProjectsCount());
+        put("uid", user.id());
+
       }
     };
 

--- a/app/src/main/java/com/kickstarter/models/User.java
+++ b/app/src/main/java/com/kickstarter/models/User.java
@@ -20,11 +20,13 @@ public abstract class User implements Parcelable, Relay {
   public abstract Avatar avatar();
   public abstract @Nullable Integer backedProjectsCount();
   public abstract @Nullable Integer createdProjectsCount();
+  public abstract @Nullable Boolean facebookConnected();
   public abstract @Nullable Boolean filmNewsletter();
   public abstract @Nullable Boolean gamesNewsletter();
   public abstract @Nullable Boolean happeningNewsletter();
   public abstract long id();
   public abstract @Nullable Boolean inventNewsletter();
+  public abstract @Nullable Boolean isAdmin();
   public abstract @Nullable Location location();
   public abstract @Nullable Integer memberProjectsCount();
   public abstract @Nullable Boolean musicNewsletter();
@@ -63,10 +65,12 @@ public abstract class User implements Parcelable, Relay {
     public abstract Builder avatar(Avatar __);
     public abstract Builder backedProjectsCount(Integer __);
     public abstract Builder createdProjectsCount(Integer __);
+    public abstract Builder facebookConnected(Boolean __);
     public abstract Builder filmNewsletter(Boolean __);
     public abstract Builder gamesNewsletter(Boolean __);
     public abstract Builder happeningNewsletter(Boolean __);
     public abstract Builder id(long __);
+    public abstract Builder isAdmin(Boolean __);
     public abstract Builder inventNewsletter(Boolean __);
     public abstract Builder location(Location __);
     public abstract Builder memberProjectsCount(Integer __);

--- a/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
@@ -277,7 +277,7 @@ class KoalaTest : KSRobolectricTestCase() {
         assertEquals(3L, expectedProperties["creator_uid"])
         assertEquals(17, expectedProperties["creator_backed_projects_count"])
         assertEquals(5, expectedProperties["creator_launched_projects_count"])
-        assertEquals(2, expectedProperties["creator_starred_projects_count"])
+        assertEquals(2, expectedProperties["creator_watched_projects_count"])
     }
 
     private fun project() =

--- a/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
@@ -44,8 +44,10 @@ class KoalaTest : KSRobolectricTestCase() {
         val expectedProperties = propertiesTest.value
         assertEquals(15L, expectedProperties["user_uid"])
         assertEquals(3, expectedProperties["user_backed_projects_count"])
-        assertEquals(2, expectedProperties["user_created_projects_count"])
-        assertEquals(10, expectedProperties["user_starred_projects_count"])
+        assertEquals(false, expectedProperties["user_facebook_account"])
+        assertEquals(false, expectedProperties["user_is_admin"])
+        assertEquals(2, expectedProperties["user_launched_projects_count"])
+        assertEquals(10, expectedProperties["user_watched_projects_count"])
     }
 
     @Test
@@ -274,7 +276,7 @@ class KoalaTest : KSRobolectricTestCase() {
         assertEquals("recommended", expectedProperties["referrer_credit"])
         assertEquals(3L, expectedProperties["creator_uid"])
         assertEquals(17, expectedProperties["creator_backed_projects_count"])
-        assertEquals(5, expectedProperties["creator_created_projects_count"])
+        assertEquals(5, expectedProperties["creator_launched_projects_count"])
         assertEquals(2, expectedProperties["creator_starred_projects_count"])
     }
 
@@ -299,6 +301,7 @@ class KoalaTest : KSRobolectricTestCase() {
                     .id(15)
                     .backedProjectsCount(3)
                     .createdProjectsCount(2)
+                    .location(LocationFactory.nigeria())
                     .starredProjectsCount(10)
                     .build()
 

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -55,16 +55,16 @@ class LakeTest : KSRobolectricTestCase() {
     fun testDiscoveryProperties_AllProjects() {
         val user = user()
         val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), true)
-        client.eventNames.subscribe(this.koalaTest)
+        client.eventNames.subscribe(this.lakeTest)
         client.eventProperties.subscribe(this.propertiesTest)
-        val koala = Koala(client)
+        val lake = Koala(client)
 
         val params = DiscoveryParams
                 .builder()
                 .sort(DiscoveryParams.Sort.HOME)
                 .build()
 
-        koala.trackDiscovery(params, false)
+        lake.trackDiscovery(params, false)
 
         assertSessionProperties(user)
         val expectedProperties = propertiesTest.value
@@ -87,9 +87,9 @@ class LakeTest : KSRobolectricTestCase() {
     fun testDiscoveryProperties_NoCategory() {
         val user = user()
         val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), true)
-        client.eventNames.subscribe(this.koalaTest)
+        client.eventNames.subscribe(this.lakeTest)
         client.eventProperties.subscribe(this.propertiesTest)
-        val koala = Koala(client)
+        val lake = Koala(client)
 
         val params = DiscoveryParams
                 .builder()
@@ -97,7 +97,7 @@ class LakeTest : KSRobolectricTestCase() {
                 .staffPicks(true)
                 .build()
 
-        koala.trackDiscovery(params, false)
+        lake.trackDiscovery(params, false)
 
         assertSessionProperties(user)
         val expectedProperties = propertiesTest.value
@@ -120,9 +120,9 @@ class LakeTest : KSRobolectricTestCase() {
     fun testDiscoveryProperties_Category() {
         val user = user()
         val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), true)
-        client.eventNames.subscribe(this.koalaTest)
+        client.eventNames.subscribe(this.lakeTest)
         client.eventProperties.subscribe(this.propertiesTest)
-        val koala = Koala(client)
+        val lake = Koala(client)
 
         val params = DiscoveryParams
                 .builder()
@@ -130,7 +130,7 @@ class LakeTest : KSRobolectricTestCase() {
                 .sort(DiscoveryParams.Sort.NEWEST)
                 .build()
 
-        koala.trackDiscovery(params, false)
+        lake.trackDiscovery(params, false)
 
         assertSessionProperties(user)
         val expectedProperties = propertiesTest.value
@@ -163,7 +163,9 @@ class LakeTest : KSRobolectricTestCase() {
         assertSessionProperties(null)
         assertProjectProperties(project)
         this.lakeTest.assertValues("Project Page")
-    }@Test
+    }
+
+    @Test
     fun testProjectProperties_LoggedInUser() {
         val project = project()
         val user = user()

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -3,6 +3,7 @@ package com.kickstarter.libs
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.factories.ConfigFactory
+import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.User
 import org.joda.time.DateTime
@@ -40,6 +41,14 @@ class LakeTest : KSRobolectricTestCase() {
         this.lakeTest.assertValue("App Open")
 
         assertDefaultProperties(user)
+        val expectedProperties = propertiesTest.value
+        assertEquals(15L, expectedProperties["user_uid"])
+        assertEquals(3, expectedProperties["user_backed_projects_count"])
+        assertEquals("NG", expectedProperties["user_country"])
+        assertEquals(false, expectedProperties["user_facebook_account"])
+        assertEquals(false, expectedProperties["user_is_admin"])
+        assertEquals(2, expectedProperties["user_launched_projects_count"])
+        assertEquals(10, expectedProperties["user_watched_projects_count"])
     }
 
     private fun assertDefaultProperties(user: User?) {
@@ -58,6 +67,7 @@ class LakeTest : KSRobolectricTestCase() {
                     .id(15)
                     .backedProjectsCount(3)
                     .createdProjectsCount(2)
+                    .location(LocationFactory.nigeria())
                     .starredProjectsCount(10)
                     .build()
 

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -1,6 +1,7 @@
 package com.kickstarter.libs;
 
 import com.kickstarter.libs.utils.ConfigUtils;
+import com.kickstarter.models.Location;
 import com.kickstarter.models.User;
 
 import org.joda.time.DateTime;
@@ -106,6 +107,13 @@ public final class MockTrackingClient extends TrackingClientType {
   @Override
   protected User loggedInUser() {
     return this.loggedInUser;
+  }
+
+  @Override
+  protected String userCountry(final @NonNull User user) {
+    final Location location = user.location();
+    final String configCountry = this.config != null ? this.config.countryCode() : null;
+    return location != null ? location.country() : configCountry;
   }
 
   @Override


### PR DESCRIPTION
# 📲 What
Adding "User Properties" tracking group.

# 🤔 Why
The next step of many for new tracking events 😛 

# 🛠 How
- Added `facebookConnected` and `isAdmin` fields to `User` model.
- Added new user properties to `TrackingClientType`.
- Implemented new user property values in `TrackingClient`.
- Testz

# 👀 See
Nothing 2 C

# 📋 QA
All logged in user events sent to the Lake 💧 should have these properties. This is a WIP so I'm only hitting staging.

# Story 📖
Part of [NT-654]
