### PR TITLE
[🛁] Adding new tracking discover properties

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -28,35 +28,36 @@ public final class KoalaUtils {
     final Map<String, Object> properties = Collections.unmodifiableMap(new HashMap<String, Object>() {
       {
         put("everything", BooleanUtils.isTrue(params.isAllProjects()));
+        put("pwl", BooleanUtils.isTrue(params.staffPicks()));
         put("recommended", BooleanUtils.isTrue(params.recommended()));
+        put("ref_tag", DiscoveryParamsUtils.refTag(params).tag());
+        put("search_term", params.term());
         put("social", BooleanUtils.isIntTrue(params.social()));
-        put("staff_picks", BooleanUtils.isTrue(params.staffPicks()));
-        put("starred", BooleanUtils.isIntTrue(params.starred()));
-        put("term", params.term());
-        put("sort", params.sort() != null ? String.valueOf(params.sort()) : "");
+        put("sort", params.sort() != null ? String.valueOf(params.sort()) : null);
+        put("tag", params.tagId());
+        put("watched", BooleanUtils.isIntTrue(params.starred()));
 
         final Category category = params.category();
         if (category != null) {
-          putAll(categoryProperties(category));
-        }
-
-        final Location location = params.location();
-        if (location != null) {
-          putAll(locationProperties(location));
+          if (category.isRoot()) {
+            putAll(categoryProperties(category));
+          } else {
+            putAll(categoryProperties(category.root()));
+            putAll(subcategoryProperties(category));
+          }
         }
       }
     });
 
-    final Map<String, Object> prefixedProperties = MapUtils.prefixKeys(properties, prefix);
-
-    prefixedProperties.put("page", params.page());
-    prefixedProperties.put("per_page", params.perPage());
-
-    return prefixedProperties;
+    return MapUtils.prefixKeys(properties, prefix);
   }
 
   public static @NonNull Map<String, Object> categoryProperties(final @NonNull Category category) {
     return categoryProperties(category, "category_");
+  }
+
+  public static @NonNull Map<String, Object> subcategoryProperties(final @NonNull Category category) {
+    return categoryProperties(category, "subcategory_");
   }
 
   public static @NonNull Map<String, Object> categoryProperties(final @NonNull Category category, final @NonNull String prefix) {

--- a/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
@@ -56,21 +56,28 @@ class KoalaTest : KSRobolectricTestCase() {
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
 
-        val params = DiscoveryParams.builder().staffPicks(true).category(CategoryFactory.artCategory()).build()
+        val params = DiscoveryParams.builder()
+                .staffPicks(true)
+                .category(CategoryFactory.artCategory())
+                .build()
 
         koala.trackDiscovery(params, false)
 
         assertDefaultProperties(user)
         val expectedProperties = propertiesTest.value
         assertEquals(1L, expectedProperties["discover_category_id"])
-        assertEquals(false, expectedProperties["discover_recommended"])
-        assertEquals(false, expectedProperties["discover_social"])
-        assertEquals(true, expectedProperties["discover_staff_picks"])
-        assertEquals(false, expectedProperties["discover_starred"])
-        assertEquals(null, expectedProperties["discover_term"])
+        assertEquals("Art", expectedProperties["discover_category_name"])
         assertEquals(false, expectedProperties["discover_everything"])
-        assertEquals(1, expectedProperties["page"])
-        assertEquals(15, expectedProperties["per_page"])
+        assertEquals(true, expectedProperties["discover_pwl"])
+        assertEquals(false, expectedProperties["discover_recommended"])
+        assertEquals("category", expectedProperties["discover_ref_tag"])
+        assertEquals(null, expectedProperties["discover_search_term"])
+        assertEquals(false, expectedProperties["discover_social"])
+        assertEquals(null, expectedProperties["discover_sort"])
+        assertNull(expectedProperties["discover_subcategory_id"])
+        assertNull(expectedProperties["discover_subcategory_name"])
+        assertEquals(null, expectedProperties["discover_tag"])
+        assertEquals(false, expectedProperties["discover_watched"])
     }
 
     @Test
@@ -81,21 +88,27 @@ class KoalaTest : KSRobolectricTestCase() {
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
 
-        val params = DiscoveryParams.builder().build()
+        val params = DiscoveryParams
+                .builder()
+                .build()
 
         koala.trackDiscovery(params, false)
 
         assertDefaultProperties(user)
         val expectedProperties = propertiesTest.value
         assertNull(expectedProperties["discover_category_id"])
-        assertEquals(false, expectedProperties["discover_recommended"])
-        assertEquals(false, expectedProperties["discover_social"])
-        assertEquals(false, expectedProperties["discover_staff_picks"])
-        assertEquals(false, expectedProperties["discover_starred"])
-        assertEquals(null, expectedProperties["discover_term"])
+        assertNull(expectedProperties["discover_category_name"])
         assertEquals(true, expectedProperties["discover_everything"])
-        assertEquals(1, expectedProperties["page"])
-        assertEquals(15, expectedProperties["per_page"])
+        assertEquals(false, expectedProperties["discover_pwl"])
+        assertEquals(false, expectedProperties["discover_recommended"])
+        assertEquals("discovery", expectedProperties["discover_ref_tag"])
+        assertEquals(null, expectedProperties["discover_search_term"])
+        assertEquals(false, expectedProperties["discover_social"])
+        assertEquals(null, expectedProperties["discover_sort"])
+        assertNull(expectedProperties["discover_subcategory_id"])
+        assertNull(expectedProperties["discover_subcategory_name"])
+        assertEquals(null, expectedProperties["discover_tag"])
+        assertEquals(false, expectedProperties["discover_watched"])
     }
 
     @Test
@@ -106,21 +119,29 @@ class KoalaTest : KSRobolectricTestCase() {
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
 
-        val params = DiscoveryParams.builder().staffPicks(true).build()
+        val params = DiscoveryParams
+                .builder()
+                .sort(DiscoveryParams.Sort.POPULAR)
+                .staffPicks(true)
+                .build()
 
         koala.trackDiscovery(params, false)
 
         assertDefaultProperties(user)
         val expectedProperties = propertiesTest.value
         assertNull(expectedProperties["discover_category_id"])
-        assertEquals(false, expectedProperties["discover_recommended"])
-        assertEquals(false, expectedProperties["discover_social"])
-        assertEquals(true, expectedProperties["discover_staff_picks"])
-        assertEquals(false, expectedProperties["discover_starred"])
-        assertEquals(null, expectedProperties["discover_term"])
+        assertNull(expectedProperties["discover_category_name"])
         assertEquals(false, expectedProperties["discover_everything"])
-        assertEquals(1, expectedProperties["page"])
-        assertEquals(15, expectedProperties["per_page"])
+        assertEquals(true, expectedProperties["discover_pwl"])
+        assertEquals(false, expectedProperties["discover_recommended"])
+        assertEquals("recommended_popular", expectedProperties["discover_ref_tag"])
+        assertEquals(null, expectedProperties["discover_search_term"])
+        assertEquals(false, expectedProperties["discover_social"])
+        assertEquals("popularity", expectedProperties["discover_sort"])
+        assertNull(expectedProperties["discover_subcategory_id"])
+        assertNull(expectedProperties["discover_subcategory_name"])
+        assertEquals(null, expectedProperties["discover_tag"])
+        assertEquals(false, expectedProperties["discover_watched"])
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -2,9 +2,11 @@ package com.kickstarter.libs
 
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.mock.MockCurrentConfig
+import com.kickstarter.mock.factories.CategoryFactory
 import com.kickstarter.mock.factories.ConfigFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.User
+import com.kickstarter.services.DiscoveryParams
 import org.json.JSONArray
 import org.junit.Test
 import rx.subjects.BehaviorSubject
@@ -40,6 +42,104 @@ class LakeTest : KSRobolectricTestCase() {
         this.lakeTest.assertValue("App Open")
 
         assertSessionProperties(user)
+    }
+
+    @Test
+    fun testDiscoveryProperties_AllProjects() {
+        val user = user()
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), true)
+        client.eventNames.subscribe(this.koalaTest)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val koala = Koala(client)
+
+        val params = DiscoveryParams
+                .builder()
+                .sort(DiscoveryParams.Sort.HOME)
+                .build()
+
+        koala.trackDiscovery(params, false)
+
+        assertSessionProperties(user)
+        val expectedProperties = propertiesTest.value
+        assertNull(expectedProperties["discover_category_id"])
+        assertNull(expectedProperties["discover_category_name"])
+        assertEquals(true, expectedProperties["discover_everything"])
+        assertEquals(false, expectedProperties["discover_pwl"])
+        assertEquals(false, expectedProperties["discover_recommended"])
+        assertEquals("discovery", expectedProperties["discover_ref_tag"])
+        assertEquals(null, expectedProperties["discover_search_term"])
+        assertEquals(false, expectedProperties["discover_social"])
+        assertEquals("home", expectedProperties["discover_sort"])
+        assertNull(expectedProperties["discover_subcategory_id"])
+        assertNull(expectedProperties["discover_subcategory_name"])
+        assertEquals(null, expectedProperties["discover_tag"])
+        assertEquals(false, expectedProperties["discover_watched"])
+    }
+
+    @Test
+    fun testDiscoveryProperties_NoCategory() {
+        val user = user()
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), true)
+        client.eventNames.subscribe(this.koalaTest)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val koala = Koala(client)
+
+        val params = DiscoveryParams
+                .builder()
+                .sort(DiscoveryParams.Sort.POPULAR)
+                .staffPicks(true)
+                .build()
+
+        koala.trackDiscovery(params, false)
+
+        assertSessionProperties(user)
+        val expectedProperties = propertiesTest.value
+        assertNull(expectedProperties["discover_category_id"])
+        assertNull(expectedProperties["discover_category_name"])
+        assertEquals(false, expectedProperties["discover_everything"])
+        assertEquals(true, expectedProperties["discover_pwl"])
+        assertEquals(false, expectedProperties["discover_recommended"])
+        assertEquals("recommended_popular", expectedProperties["discover_ref_tag"])
+        assertEquals(null, expectedProperties["discover_search_term"])
+        assertEquals(false, expectedProperties["discover_social"])
+        assertEquals("popularity", expectedProperties["discover_sort"])
+        assertNull(expectedProperties["discover_subcategory_id"])
+        assertNull(expectedProperties["discover_subcategory_name"])
+        assertEquals(null, expectedProperties["discover_tag"])
+        assertEquals(false, expectedProperties["discover_watched"])
+    }
+
+    @Test
+    fun testDiscoveryProperties_Category() {
+        val user = user()
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), true)
+        client.eventNames.subscribe(this.koalaTest)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val koala = Koala(client)
+
+        val params = DiscoveryParams
+                .builder()
+                .category(CategoryFactory.ceramicsCategory())
+                .sort(DiscoveryParams.Sort.NEWEST)
+                .build()
+
+        koala.trackDiscovery(params, false)
+
+        assertSessionProperties(user)
+        val expectedProperties = propertiesTest.value
+        assertEquals(1L, expectedProperties["discover_category_id"])
+        assertEquals("Art", expectedProperties["discover_category_name"])
+        assertEquals(false, expectedProperties["discover_everything"])
+        assertEquals(false, expectedProperties["discover_pwl"])
+        assertEquals(false, expectedProperties["discover_recommended"])
+        assertEquals("category_newest", expectedProperties["discover_ref_tag"])
+        assertEquals(null, expectedProperties["discover_search_term"])
+        assertEquals(false, expectedProperties["discover_social"])
+        assertEquals("newest", expectedProperties["discover_sort"])
+        assertEquals(287L, expectedProperties["discover_subcategory_id"])
+        assertEquals("Ceramics", expectedProperties["discover_subcategory_name"])
+        assertEquals(null, expectedProperties["discover_tag"])
+        assertEquals(false, expectedProperties["discover_watched"])
     }
 
     private fun assertSessionProperties(user: User?) {


### PR DESCRIPTION
# 📲 What
Adding "Discover Properties" tracking group.

# 🤔 Why
The next next step of many for new tracking events 😛

# 🛠 How
- Added new discover properties to TrackingClientType.
- Implemented new discover property values in TrackingClient.
- Testz

# 👀 See
nothing 2 c

# 📋 QA
All discovery events sent to the Lake 💧 should have these properties. This is a WIP so I'm only hitting staging.

# Story 📖
Part of [NT-654]
