### PR TITLE
[🔍] NT-654 Adding Explore Page Viewed event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -691,4 +691,12 @@ public final class Koala {
 
     this.client.track(KoalaEvent.VIEWED_PROJECT_DASHBOARD, properties);
   }
+
+  //region Discover a Project
+  public void trackExplorePageViewed(final @NonNull DiscoveryParams discoveryParams) {
+    final Map<String, Object> props = KoalaUtils.discoveryParamsProperties(discoveryParams);
+
+    this.client.track(LakeEvent.EXPLORE_PAGE_VIEWED, props);
+  }
+  //endregion
 }

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -1,0 +1,5 @@
+@file:JvmName("LakeEvent")
+
+package com.kickstarter.libs
+
+const val EXPLORE_PAGE_VIEWED = "Explore Page Viewed"

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -282,6 +282,12 @@ public interface DiscoveryFragmentViewModel {
           );
         });
 
+      this.paramsFromActivity
+        .compose(combineLatestPair(paginator.loadingPage().distinctUntilChanged()))
+        .filter(paramsAndPage -> paramsAndPage.second == 1)
+        .compose(bindToLifecycle())
+        .subscribe(paramsAndLoggedIn -> this.lake.trackExplorePageViewed(paramsAndLoggedIn.first));
+
       this.startUpdateActivity
         .map(Activity::project)
         .filter(ObjectUtils::isNotNull)

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -64,7 +64,7 @@ class LakeTest : KSRobolectricTestCase() {
                 .sort(DiscoveryParams.Sort.HOME)
                 .build()
 
-        lake.trackDiscovery(params, false)
+        lake.trackExplorePageViewed(params)
 
         assertSessionProperties(user)
         val expectedProperties = propertiesTest.value
@@ -97,7 +97,7 @@ class LakeTest : KSRobolectricTestCase() {
                 .staffPicks(true)
                 .build()
 
-        lake.trackDiscovery(params, false)
+        lake.trackExplorePageViewed(params)
 
         assertSessionProperties(user)
         val expectedProperties = propertiesTest.value
@@ -130,7 +130,7 @@ class LakeTest : KSRobolectricTestCase() {
                 .sort(DiscoveryParams.Sort.NEWEST)
                 .build()
 
-        lake.trackDiscovery(params, false)
+        lake.trackExplorePageViewed(params)
 
         assertSessionProperties(user)
         val expectedProperties = propertiesTest.value

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -85,11 +85,13 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     // Should emit current fragment's projects.
     this.hasProjects.assertValues(true);
     this.koalaTest.assertValues("Discover List View");
+    this.lakeTest.assertValue("Explore Page Viewed");
 
     //Page is refreshed
     this.vm.inputs.refresh();
     this.hasProjects.assertValues(true, true);
     this.koalaTest.assertValues("Discover List View", "Triggered Refresh");
+    this.lakeTest.assertValue("Explore Page Viewed");
   }
 
   @Test
@@ -102,6 +104,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     // Should emit current fragment's projects.
     this.hasProjects.assertValues(true);
     this.koalaTest.assertValues("Discover List View");
+    this.lakeTest.assertValue("Explore Page Viewed");
 
     // Select a new category.
     this.vm.inputs.paramsFromActivity(
@@ -114,6 +117,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     // New projects load with new params.
     this.hasProjects.assertValues(true, true, true);
     this.koalaTest.assertValues("Discover List View", "Discover List View");
+    this.lakeTest.assertValues("Explore Page Viewed", "Explore Page Viewed");
 
     this.vm.inputs.clearPage();
     this.hasProjects.assertValues(true, true, true, false);
@@ -128,11 +132,13 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
 
     this.projects.assertValueCount(1);
     this.koalaTest.assertValues("Discover List View");
+    this.lakeTest.assertValue("Explore Page Viewed");
 
     // Popular tab clicked.
     this.vm.inputs.paramsFromActivity(DiscoveryParams.builder().sort(DiscoveryParams.Sort.POPULAR).build());
     this.projects.assertValueCount(3);
     this.koalaTest.assertValues("Discover List View", "Discover List View");
+    this.lakeTest.assertValues("Explore Page Viewed", "Explore Page Viewed");
   }
 
   @Test
@@ -346,6 +352,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
 
     this.startEditorialActivity.assertValue(Editorial.GO_REWARDLESS);
     this.koalaTest.assertValues("Discover List View", "Editorial Card Clicked");
+    this.lakeTest.assertValue("Explore Page Viewed");
   }
 
   @Test
@@ -366,6 +373,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
 
     this.startProjectActivity.assertValue(Pair.create(project, RefTag.collection(518)));
     this.koalaTest.assertValues("Discover List View");
+    this.lakeTest.assertValue("Explore Page Viewed");
   }
 
   @Test
@@ -381,6 +389,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
 
     this.startProjectActivity.assertValue(Pair.create(project, RefTag.discovery()));
     this.koalaTest.assertValues("Discover List View");
+    this.lakeTest.assertValue("Explore Page Viewed");
   }
 
   @Test


### PR DESCRIPTION
# 📲 What
Adding `Explore Page Viewed` event.

# 🤔 Why
We have new Discovery events.

# 🛠 How
- Added `Discover a Project` region to `Koala`
- Added `LakeEvent` file and `EXPLORE_PAGE_VIEWED` `const`
- Calling `koala.trackExplorePageViewed` when user views a Discovery page (but not for pagination)
- Updating `LakeTest` to test `koala.trackExplorePageViewed` instead of `koala.trackDiscovery`
- Added Lake tests in `DiscoveryFragmentViewModelTest`

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
Part of [NT-654]


[NT-654]: https://kickstarter.atlassian.net/browse/NT-654