### PR TITLE
[😅] Adds missing session_os property

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -60,6 +60,7 @@ public abstract class TrackingClientType {
         put("enabled_features", enabledFeatureFlags());
         put("is_voiceover_running", isTalkBackOn());
         put("mp_lib", "kickstarter_android");
+        put("os", "Android");
         put("os_version", String.format("Android %s", OSVersion()));
         put("user_agent", userAgent());
         put("user_logged_in", userIsLoggedIn);

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -329,6 +329,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals(JSONArray().put("android_example_feature"), expectedProperties["session_enabled_features"])
         assertEquals(false, expectedProperties["session_is_voiceover_running"])
         assertEquals("kickstarter_android", expectedProperties["session_mp_lib"])
+        assertEquals("Android", expectedProperties["session_os"])
         assertEquals("Android 9", expectedProperties["session_os_version"])
         assertEquals("agent", expectedProperties["session_user_agent"])
         assertEquals(user != null, expectedProperties["session_user_logged_in"])


### PR DESCRIPTION
# 📲 What
Adds missing `session_os` property

# 🤔 Why
It's a must have!

# 🛠 How
Added `os` to `sessionProperties`.

# 👀 See
Nothing 2 c

# 📋 QA
All Lake events should have the `session_os` prop.

# Story 📖
Part of NT-654
