### PR TITLE
[💥] Fixes crash when clicking a project update

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -122,7 +122,8 @@ public final class KoalaUtils {
           if (category.isRoot()) {
             put("category", category.name());
           } else {
-            put("category", category.parent().name());
+            final Category parent = category.parent();
+            put("category", parent != null ? parent.name() : null);
             put("subcategory", category.name());
           }
         }


### PR DESCRIPTION
# 📲 What
Fixes crash when clicking a project update.

# 🤔 Why
Crashes are bad.

# 🛠 How
When a project update is clicked in the Activity feed is clicked, `Koala.trackViewedUpdate` is called with `activity.project` which is a minified `Project` so `project.category.parent` can return `null` despite being a subcategory.

# 👀 See
| Before 🐛 | After 🦋 |
| --- | --- |
| 💥 | ![device-2020-01-10-173403 2020-01-10 17_34_51](https://user-images.githubusercontent.com/1289295/72191224-8de40800-33cf-11ea-8b58-f6da82a73fa9.gif) |

# 📋 QA
Click a project update.

# Story 📖
Bug fix for #705 
