### PR TITLE
[🕷] NT-786 Fixes bug with clicking project URLs from an update

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/ApplicationUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ApplicationUtils.java
@@ -55,7 +55,7 @@ public final class ApplicationUtils {
     context.startActivity(intent);
   }
 
-  private static List<Intent> targetIntents(@NonNull Context context, Uri uri) {
+  private static List<Intent> targetIntents(final @NonNull Context context, final @NonNull Uri uri) {
     final Uri fakeUri = Uri.parse("http://www.kickstarter.com");
     final Intent browserIntent = new Intent(Intent.ACTION_VIEW, fakeUri);
 

--- a/app/src/main/java/com/kickstarter/libs/utils/ApplicationUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ApplicationUtils.java
@@ -2,13 +2,33 @@ package com.kickstarter.libs.utils;
 
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
+import android.os.Parcelable;
 
+import com.kickstarter.R;
 import com.kickstarter.ui.activities.DiscoveryActivity;
 
+import java.util.List;
+
 import androidx.annotation.NonNull;
+import rx.Observable;
 
 public final class ApplicationUtils {
   private ApplicationUtils() {}
+
+  public static void openUrlExternally(final @NonNull Context context, final @NonNull String url) {
+    final Uri uri = Uri.parse(url);
+    final List<Intent> targetIntents = targetIntents(context, uri);
+
+    if (!targetIntents.isEmpty()) {
+      /* We need to remove the first intent so it's not duplicated when we add the
+      EXTRA_INITIAL_INTENTS intents. */
+      final Intent chooserIntent = Intent.createChooser(targetIntents.remove(0), context.getString(R.string.View_project));
+      chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS,
+        targetIntents.toArray(new Parcelable[targetIntents.size()]));
+      context.startActivity(chooserIntent);
+    }
+  }
 
   /**
    *
@@ -33,5 +53,22 @@ public final class ApplicationUtils {
       .setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
     context.startActivity(intent);
+  }
+
+  private static List<Intent> targetIntents(@NonNull Context context, Uri uri) {
+    final Uri fakeUri = Uri.parse("http://www.kickstarter.com");
+    final Intent browserIntent = new Intent(Intent.ACTION_VIEW, fakeUri);
+
+    return Observable.from(context.getPackageManager().queryIntentActivities(browserIntent, 0))
+      .filter(resolveInfo -> !resolveInfo.activityInfo.packageName.contains("com.kickstarter"))
+      .map(resolveInfo -> {
+        final Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        intent.setPackage(resolveInfo.activityInfo.packageName);
+        intent.setData(uri);
+        return intent;
+      })
+      .toList()
+      .toBlocking()
+      .single();
   }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.java
@@ -3,7 +3,6 @@ package com.kickstarter.ui.activities;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.Parcelable;
 
 import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.RefTag;
@@ -12,8 +11,6 @@ import com.kickstarter.libs.utils.ApplicationUtils;
 import com.kickstarter.libs.utils.UrlUtils;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.viewmodels.DeepLinkViewModel;
-
-import java.util.List;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -25,11 +22,6 @@ public final class DeepLinkActivity extends BaseActivity<DeepLinkViewModel.ViewM
   @Override
   protected void onCreate(final @Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    
-    this.viewModel.outputs.requestPackageManager()
-      .compose(bindToLifecycle())
-      .compose(observeForUI())
-      .subscribe(__ -> inputPackageManager());
 
     this.viewModel.outputs.startBrowser()
       .compose(bindToLifecycle())
@@ -63,19 +55,8 @@ public final class DeepLinkActivity extends BaseActivity<DeepLinkViewModel.ViewM
     finish();
   }
 
-  private void startBrowser(final @NonNull List<Intent> targetIntents) {
-    if (!targetIntents.isEmpty()) {
-      /* We need to remove the first intent so it's not duplicated
-      when we add the EXTRA_INITIAL_INTENTS intents. */
-      final Intent chooserIntent = Intent.createChooser(targetIntents.remove(0), "");
-      chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS,
-        targetIntents.toArray(new Parcelable[targetIntents.size()]));
-      startActivity(chooserIntent);
-    }
+  private void startBrowser(final @NonNull String url) {
+    ApplicationUtils.openUrlExternally(this, url);
     finish();
-  }
-
-  private void inputPackageManager() {
-    this.viewModel.inputs.packageManager(getPackageManager());
   }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -6,7 +6,6 @@ import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
 import android.content.Intent
 import android.graphics.Rect
-import android.net.Uri
 import android.os.Bundle
 import android.util.Pair
 import android.view.MotionEvent
@@ -29,6 +28,7 @@ import com.kickstarter.libs.KSString
 import com.kickstarter.libs.KoalaContext
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
+import com.kickstarter.libs.utils.ApplicationUtils
 import com.kickstarter.libs.utils.ProjectViewUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Project
@@ -467,28 +467,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     }
 
     private fun openProjectAndFinish(url: String) {
-        val uri = Uri.parse(url)
-
-        val fakeUri = Uri.parse("http://www.kickstarter.com")
-        val browserIntent = Intent(Intent.ACTION_VIEW, fakeUri)
-        val queryIntentActivities = packageManager.queryIntentActivities(browserIntent, 0)
-        val targetIntents = queryIntentActivities
-                .filter { !it.activityInfo.packageName.contains("com.kickstarter") }
-                .map { resolveInfo ->
-                    val intent = Intent(Intent.ACTION_VIEW, uri)
-                    intent.setPackage(resolveInfo.activityInfo.packageName)
-                    intent
-                }
-                .toMutableList()
-
-        if (targetIntents.isNotEmpty()) {
-            /* We need to remove the first intent so it's not duplicated
-            when we add the EXTRA_INITIAL_INTENTS intents. */
-            val chooserIntent = Intent.createChooser(targetIntents.removeAt(0), "")
-            chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, targetIntents.toTypedArray())
-            startActivity(chooserIntent)
-        }
-
+        ApplicationUtils.openUrlExternally(this, url)
         finish()
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.java
@@ -1,6 +1,7 @@
 package com.kickstarter.ui.activities;
 
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.util.Pair;
 import android.webkit.WebView;
@@ -10,8 +11,8 @@ import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.KSString;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
+import com.kickstarter.libs.utils.ApplicationUtils;
 import com.kickstarter.libs.utils.NumberUtils;
-import com.kickstarter.models.Project;
 import com.kickstarter.models.Update;
 import com.kickstarter.services.KSUri;
 import com.kickstarter.services.RequestHandler;
@@ -62,6 +63,11 @@ public class UpdateActivity extends BaseActivity<UpdateViewModel.ViewModel> impl
       )
     );
 
+    this.viewModel.outputs.openProjectExternally()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(this::openProjectExternally);
+
     this.viewModel.outputs.startCommentsActivity()
       .compose(bindToLifecycle())
       .compose(observeForUI())
@@ -70,7 +76,7 @@ public class UpdateActivity extends BaseActivity<UpdateViewModel.ViewModel> impl
     this.viewModel.outputs.startProjectActivity()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(projectAndRefTag -> this.startProjectActivity(projectAndRefTag.first, projectAndRefTag.second));
+      .subscribe(uriAndRefTag -> this.startProjectActivity(uriAndRefTag.first, uriAndRefTag.second));
 
     this.viewModel.outputs.startShareIntent()
       .compose(bindToLifecycle())
@@ -109,6 +115,10 @@ public class UpdateActivity extends BaseActivity<UpdateViewModel.ViewModel> impl
     return true;
   }
 
+  private void openProjectExternally(final @NonNull String projectUrl) {
+    ApplicationUtils.openUrlExternally(this, projectUrl);
+  }
+
   private void setToolbarTitle(final @NonNull String updateSequence) {
     this.toolbar.setTitle(this.ksString.format(this.updateNumberString, "update_number", updateSequence));
   }
@@ -119,9 +129,9 @@ public class UpdateActivity extends BaseActivity<UpdateViewModel.ViewModel> impl
     startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }
 
-  private void startProjectActivity(final @NonNull Project project, final @NonNull RefTag refTag) {
+  private void startProjectActivity(final @NonNull Uri uri, final @NonNull RefTag refTag) {
     final Intent intent = new Intent(this, ProjectActivity.class)
-      .putExtra(IntentKey.PROJECT, project)
+      .setData(uri)
       .putExtra(IntentKey.REF_TAG, refTag);
     startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }

--- a/app/src/main/java/com/kickstarter/viewmodels/DeepLinkViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DeepLinkViewModel.java
@@ -1,10 +1,8 @@
 package com.kickstarter.viewmodels;
 
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.text.TextUtils;
-import android.util.Pair;
 
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.Environment;
@@ -15,34 +13,19 @@ import com.kickstarter.libs.utils.UrlUtils;
 import com.kickstarter.services.KSUri;
 import com.kickstarter.ui.activities.DeepLinkActivity;
 
-import java.util.List;
-
 import androidx.annotation.NonNull;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
-import rx.subjects.PublishSubject;
 
 import static com.kickstarter.libs.rx.transformers.Transformers.ignoreValues;
 
 public interface DeepLinkViewModel {
 
-  interface Inputs {
-    /**
-     * Call when user clicks link that can't be deep linked.
-     */
-    void packageManager(PackageManager packageManager);
-  }
-
   interface Outputs {
-    /**
-     * Emits when we need to get {@link PackageManager} to query for activities that can open a link.
-     */
-    Observable<Void> requestPackageManager();
-
     /**
      * Emits when we should start an external browser because we don't want to deep link.
      */
-    Observable<List<Intent>> startBrowser();
+    Observable<String> startBrowser();
 
     /**
      * Emits when we should start the {@link com.kickstarter.ui.activities.DiscoveryActivity}.
@@ -55,7 +38,7 @@ public interface DeepLinkViewModel {
     Observable<Uri> startProjectActivity();
   }
 
-  final class ViewModel extends ActivityViewModel<DeepLinkActivity> implements Outputs, Inputs {
+  final class ViewModel extends ActivityViewModel<DeepLinkActivity> implements Outputs {
     public ViewModel(final @NonNull Environment environment) {
       super(environment);
 
@@ -82,30 +65,6 @@ public interface DeepLinkViewModel {
       this.startProjectActivity
         .subscribe(__ -> koala.trackContinueUserActivityAndOpenedDeepLink());
 
-      final Observable<Pair<PackageManager, Uri>> packageManagerAndUri =
-        Observable.combineLatest(this.packageManager, uriFromIntent, Pair::create);
-
-      final Observable<List<Intent>> targetIntents = packageManagerAndUri
-        .flatMap(pair -> {
-          /* We use a fake Uri because in Android 6.0 and above,
-          if a link is domain verified, only that app is returned. */
-          final Uri fakeUri = Uri.parse("http://www.kickstarter.com");
-          final Intent browserIntent = new Intent(Intent.ACTION_VIEW, fakeUri);
-          return Observable.from(pair.first.queryIntentActivities(browserIntent, 0))
-            .filter(resolveInfo -> !resolveInfo.activityInfo.packageName.contains("com.kickstarter"))
-            .map(resolveInfo -> {
-              final Intent intent = new Intent(Intent.ACTION_VIEW, pair.second);
-              intent.setPackage(resolveInfo.activityInfo.packageName);
-              intent.setData(pair.second);
-              return intent;
-            })
-            .toList();
-        });
-
-      targetIntents
-        .compose(bindToLifecycle())
-        .subscribe(this.startBrowser::onNext);
-
       final Observable<Uri> projectPreview = uriFromIntent
         .filter(uri -> KSUri.isProjectPreviewUri(uri, Secrets.WebEndpoint.PRODUCTION));
 
@@ -116,9 +75,8 @@ public interface DeepLinkViewModel {
       Observable.merge(projectPreview, unsupportedDeepLink)
         .map(Uri::toString)
         .filter(url -> !TextUtils.isEmpty(url))
-        .compose(ignoreValues())
         .compose(bindToLifecycle())
-        .subscribe(this.requestPackageManager::onNext);
+        .subscribe(this.startBrowser::onNext);
     }
 
     private Uri appendRefTagIfNone(final @NonNull Uri uri) {
@@ -135,24 +93,13 @@ public interface DeepLinkViewModel {
       return uri.getLastPathSegment().equals("projects");
     }
 
-    private final PublishSubject<PackageManager> packageManager = PublishSubject.create();
-
-    private final BehaviorSubject<Void> requestPackageManager = BehaviorSubject.create();
-    private final BehaviorSubject<List<Intent>> startBrowser = BehaviorSubject.create();
+    private final BehaviorSubject<String> startBrowser = BehaviorSubject.create();
     private final BehaviorSubject<Void> startDiscoveryActivity = BehaviorSubject.create();
     private final BehaviorSubject<Uri> startProjectActivity = BehaviorSubject.create();
 
-    public final Inputs inputs = this;
     public final Outputs outputs = this;
 
-    @Override public void packageManager(final PackageManager packageManager) {
-      this.packageManager.onNext(packageManager);
-    }
-
-    @Override public @NonNull Observable<Void> requestPackageManager() {
-      return this.requestPackageManager;
-    }
-    @Override public @NonNull Observable<List<Intent>> startBrowser() {
+    @Override public @NonNull Observable<String> startBrowser() {
       return this.startBrowser;
     }
     @Override public @NonNull Observable<Void> startDiscoveryActivity() {

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -283,7 +283,7 @@ interface ProjectViewModel {
         private val pledgeContainerIsGone = BehaviorSubject.create<Boolean>()
         private val pledgeToolbarNavigationIcon = BehaviorSubject.create<Int>()
         private val pledgeToolbarTitle = BehaviorSubject.create<Int>()
-        private val prelaunchUrl = PublishSubject.create<String>()
+        private val prelaunchUrl = BehaviorSubject.create<String>()
         private val projectActionButtonContainerIsGone = BehaviorSubject.create<Boolean>()
         private val horizontalProgressBarIsGone = BehaviorSubject.create<Boolean>()
         private val projectAndNativeCheckoutEnabled = BehaviorSubject.create<Pair<Project, Boolean>>()

--- a/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.java
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels;
 
+import android.net.Uri;
 import android.util.Pair;
 
 import com.kickstarter.libs.ActivityViewModel;
@@ -7,10 +8,12 @@ import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.KoalaContext;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.utils.NumberUtils;
+import com.kickstarter.libs.utils.Secrets;
 import com.kickstarter.libs.utils.UrlUtils;
 import com.kickstarter.models.Project;
 import com.kickstarter.models.Update;
 import com.kickstarter.services.ApiClientType;
+import com.kickstarter.services.KSUri;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.activities.UpdateActivity;
 import com.kickstarter.ui.intentmappers.ProjectIntentMapper;
@@ -44,14 +47,17 @@ public interface UpdateViewModel {
   }
 
   interface Outputs {
+    /** Emits a project url to open externally. */
+    Observable<String> openProjectExternally();
+
     /** Emits when we should start the share intent to show the share sheet. */
     Observable<Pair<Update, String>> startShareIntent();
 
     /** Emits an update to start the comments activity with. */
     Observable<Update> startCommentsActivity();
 
-    /** Emits a project and a ref tag to start the project activity with. */
-    Observable<Pair<Project, RefTag>> startProjectActivity();
+    /** Emits a Uri and a ref tag to start the project activity with. */
+    Observable<Pair<Uri, RefTag>> startProjectActivity();
 
     /** Emits a string to display in the toolbar title. */
     Observable<String> updateSequence();
@@ -111,10 +117,23 @@ public interface UpdateViewModel {
         .compose(bindToLifecycle())
         .subscribe(this.updateSequence::onNext);
 
-      project
-        .compose(takeWhen(this.goToProjectRequest))
+      this.goToProjectRequest
+        .map(request -> Uri.parse(request.url().uri().toString()))
+        .filter(uri -> KSUri.isProjectUri(uri, Secrets.WebEndpoint.PRODUCTION))
+        .filter(uri -> !KSUri.isProjectPreviewUri(uri, Secrets.WebEndpoint.PRODUCTION))
         .compose(bindToLifecycle())
-        .subscribe(p -> this.startProjectActivity.onNext(Pair.create(p, RefTag.update())));
+        .subscribe(uri -> this.startProjectActivity.onNext(Pair.create(uri, RefTag.update())));
+
+      this.goToProjectRequest
+        .map(request -> Uri.parse(request.url().uri().toString()))
+        .filter(uri -> KSUri.isProjectUri(uri, Secrets.WebEndpoint.PRODUCTION))
+        .filter(uri -> KSUri.isProjectPreviewUri(uri, Secrets.WebEndpoint.PRODUCTION))
+        .map(Uri::toString)
+        .map(uriString -> UrlUtils.INSTANCE.refTag(uriString) == null
+          ? UrlUtils.INSTANCE.appendRefTag(uriString, RefTag.update().tag())
+          : uriString)
+        .compose(bindToLifecycle())
+        .subscribe(this.openProjectExternally::onNext);
 
       project
         .compose(takeWhen(this.externalLinkActivated))
@@ -141,9 +160,10 @@ public interface UpdateViewModel {
     private final PublishSubject<Request> goToUpdateRequest = PublishSubject.create();
     private final PublishSubject<Void> shareButtonClicked = PublishSubject.create();
 
+    private final PublishSubject<String> openProjectExternally = PublishSubject.create();
     private final PublishSubject<Pair<Update, String>> startShareIntent = PublishSubject.create();
     private final PublishSubject<Update> startCommentsActivity = PublishSubject.create();
-    private final PublishSubject<Pair<Project, RefTag>> startProjectActivity = PublishSubject.create();
+    private final PublishSubject<Pair<Uri, RefTag>> startProjectActivity = PublishSubject.create();
     private final BehaviorSubject<String> updateSequence = BehaviorSubject.create();
     private final BehaviorSubject<String> webViewUrl = BehaviorSubject.create();
 
@@ -166,13 +186,16 @@ public interface UpdateViewModel {
       this.shareButtonClicked.onNext(null);
     }
 
+    @Override public @NonNull Observable<String> openProjectExternally() {
+      return this.openProjectExternally;
+    }
     @Override public Observable<Pair<Update, String>> startShareIntent() {
       return this.startShareIntent;
     }
     @Override public @NonNull Observable<Update> startCommentsActivity() {
       return this.startCommentsActivity;
     }
-    @Override public @NonNull Observable<Pair<Project, RefTag>> startProjectActivity() {
+    @Override public @NonNull Observable<Pair<Uri, RefTag>> startProjectActivity() {
       return this.startProjectActivity;
     }
     @Override public @NonNull Observable<String> updateSequence() {

--- a/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.java
@@ -8,20 +8,16 @@ import com.kickstarter.libs.KoalaEvent;
 
 import org.junit.Test;
 
-import java.util.List;
-
 import rx.observers.TestSubscriber;
 
 public class DeepLinkViewModelTest extends KSRobolectricTestCase {
   private DeepLinkViewModel.ViewModel vm;
-  private final TestSubscriber<Void> requestPackageManager = new TestSubscriber<>();
-  private final TestSubscriber<List<Intent>> startBrowser = new TestSubscriber<>();
+  private final TestSubscriber<String> startBrowser = new TestSubscriber<>();
   private final TestSubscriber<Void> startDiscoveryActivity = new TestSubscriber<>();
   private final TestSubscriber<Uri> startProjectActivity = new TestSubscriber<>();
 
   protected void setUpEnvironment() {
     this.vm = new DeepLinkViewModel.ViewModel(environment());
-    this.vm.outputs.requestPackageManager().subscribe(this.requestPackageManager);
     this.vm.outputs.startBrowser().subscribe(this.startBrowser);
     this.vm.outputs.startDiscoveryActivity().subscribe(this.startDiscoveryActivity);
     this.vm.outputs.startProjectActivity().subscribe(this.startProjectActivity);
@@ -33,10 +29,8 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
 
     final String url = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap/comments";
     this.vm.intent(intentWithData(url));
-    this.vm.packageManager(application().getPackageManager());
 
-    this.requestPackageManager.assertValueCount(1);
-    this.startBrowser.assertValueCount(1);
+    this.startBrowser.assertValue(url);
     this.startDiscoveryActivity.assertNoValues();
     this.startProjectActivity.assertNoValues();
     this.koalaTest.assertNoValues();
@@ -48,10 +42,8 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
 
     final String url = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap?token=beepboop";
     this.vm.intent(intentWithData(url));
-    this.vm.packageManager(application().getPackageManager());
 
-    this.requestPackageManager.assertValueCount(1);
-    this.startBrowser.assertValueCount(1);
+    this.startBrowser.assertValue(url);
     this.startDiscoveryActivity.assertNoValues();
     this.startProjectActivity.assertNoValues();
     this.koalaTest.assertNoValues();
@@ -66,7 +58,6 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
 
     this.startProjectActivity.assertValue(Uri.parse(url));
     this.startBrowser.assertNoValues();
-    this.requestPackageManager.assertNoValues();
     this.startDiscoveryActivity.assertNoValues();
     this.koalaTest.assertValues(KoalaEvent.CONTINUE_USER_ACTIVITY, KoalaEvent.OPENED_DEEP_LINK);
   }
@@ -81,7 +72,6 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
     final String expectedUrl = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap?ref=android_deep_link";
     this.startProjectActivity.assertValue(Uri.parse(expectedUrl));
     this.startBrowser.assertNoValues();
-    this.requestPackageManager.assertNoValues();
     this.startDiscoveryActivity.assertNoValues();
     this.koalaTest.assertValues(KoalaEvent.CONTINUE_USER_ACTIVITY, KoalaEvent.OPENED_DEEP_LINK);
   }
@@ -95,7 +85,6 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
 
     this.startDiscoveryActivity.assertValueCount(1);
     this.startBrowser.assertNoValues();
-    this.requestPackageManager.assertNoValues();
     this.startProjectActivity.assertNoValues();
     this.koalaTest.assertValues(KoalaEvent.CONTINUE_USER_ACTIVITY, KoalaEvent.OPENED_DEEP_LINK);
   }


### PR DESCRIPTION
# 📲 What
Fixes bug where clicking a project URL in an update takes users to the current project instead of the one they clicked.

# 🤔 Why
issa bug

# 🛠 How
- Added `ApplicationUtils.openUrlExternally` because we do this behavior in 3 places: 
  1. `DeepLinkActivity`
  2. `ProjectActivity`
  3. `UpdateActivity`
- `DeepLinkViewModel` output `startBrowser` now emits a `String` instead of a list of `Intent`s.
- `UpdateViewModel` now supports clicking project links.
  - If the project is live, it'll open natively.
  - If the project is a preview or in  prelaunch, it'll open in the browser.
- I also a noticed a bug with prelaunch projects not opening sometimes. I fixed it by making the `ProjectViewModel.prelaunchUrl` output a `BehaviorSubject`.
- Updated `DeepLinkViewModelTest` and `UpdateViewModelTest`

# 👀 See
| Pre launch project After 🦋 | Before 🐛|
| --- | --- |
| ![device-2020-01-11-005121 2020-01-11 00_58_45](https://user-images.githubusercontent.com/1289295/72199700-91967f80-340d-11ea-81cb-412ed1ff2709.gif) | ![device-2020-01-10-134016 2020-01-11 00_55_00](https://user-images.githubusercontent.com/1289295/72199662-0d43fc80-340d-11ea-90eb-829705f4474b.gif) |
| Live project After 🦋 | Before 🐛|
| ![device-2020-01-11-005146 2020-01-11 00_56_20](https://user-images.githubusercontent.com/1289295/72199684-5300c500-340d-11ea-991d-a3b91962478e.gif) | ![device-2020-01-11-005304 2020-01-11 00_55_12](https://user-images.githubusercontent.com/1289295/72199663-0d43fc80-340d-11ea-9af5-c06985ae49bb.gif) |

# 📋 QA
Smash those project links in updates.

# Story 📖
[NT-786]


[NT-786]: https://kickstarter.atlassian.net/browse/NT-786