### PR TITLE
[💦] NT-725 Cleaning up some context leaks

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/CheckoutActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/CheckoutActivity.java
@@ -80,6 +80,12 @@ public final class CheckoutActivity extends BaseActivity<CheckoutViewModel.ViewM
       .subscribe(this.webView::loadUrl);
   }
 
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    this.webView.setDelegate(null);
+  }
+
   private void popActivity() {
     super.back();
   }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectUpdatesActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectUpdatesActivity.java
@@ -77,6 +77,12 @@ public class ProjectUpdatesActivity extends BaseActivity<ProjectUpdatesViewModel
       .subscribe(this.ksWebView::loadUrl);
   }
 
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    this.ksWebView.setDelegate(null);
+  }
+
   private boolean handleProjectUpdateCommentsUriRequest(final @NonNull Request request, final @NonNull WebView webView) {
     this.viewModel.inputs.goToCommentsRequest(request);
     return true;

--- a/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.java
@@ -100,6 +100,12 @@ public class UpdateActivity extends BaseActivity<UpdateViewModel.ViewModel> impl
       .subscribe(this.ksWebView::loadUrl);
   }
 
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    this.ksWebView.setDelegate(null);
+  }
+
   private boolean handleProjectUpdateCommentsUriRequest(final @NonNull Request request, final @NonNull WebView webView) {
     this.viewModel.inputs.goToCommentsRequest(request);
     return true;

--- a/app/src/main/java/com/kickstarter/ui/views/KSWebView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/KSWebView.kt
@@ -88,6 +88,11 @@ class KSWebView : FrameLayout, KSWebViewClient.Delegate {
         internal_web_view.loadUrl("about:blank")
     }
 
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        this.client.setDelegate(null)
+    }
+
     fun canGoBack(): Boolean {
         return internal_web_view.canGoBack()
     }


### PR DESCRIPTION
# 📲 What
Trying to catch some errors in the [`ProjectUpdatesActivity`](https://console.firebase.google.com/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/f7165a53c873de79256d56f51d77232e?time=last-ninety-days&sessionId=5E1C919D03D100011C2C293B8ED36190_DNE_0_v2) and [`UpdateActivity`](https://console.firebase.google.com/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/996998e6f710ab9964d1faaf2bde6daf?time=last-ninety-days&sessionId=5E1C92F500E10001199439C4FF808AF6_DNE_0_v2) in my pokeball.

# 🤔 Why
we h8 bugz

# 🛠 How
Get in losers, we're fixing bugs. [mean girls reference](https://knowyourmeme.com/memes/get-in-loser-were-going-shopping)


## what is even happening
OKAY SO, if you Read The Error Message™: 
```Attempt to read from field 'com.kickstarter.viewmodels.ProjectUpdatesViewModel$Inputs com.kickstarter.viewmodels.ProjectUpdatesViewModel$ViewModel.inputs' on a null object reference```

which is saying the `ViewModel` is `null`... Now why would someone be trying to access a `null` VM? 👀 Because they played themselves. A VM will be `null` when a `BaseActivity` reaches the [`onDestroy`](https://github.com/kickstarter/android-oss/blob/master/app/src/main/java/com/kickstarter/libs/BaseActivity.java#L178) of its lifecycle. But someone (soon to be revealed) is still holding a reference to this `Activity` and trying to make updates.

## whodunit
We have these godforsaken `WebView`s littered through the app wreaking havoc and causing general discontent. I still don't know what Chrome broke on December 11, 2019 but this bug revealed itself on that day. I [dumped a couple memory profiles](https://developer.android.com/studio/profile/memory-profiler) of the app after viewing updates and bopping around. And I noticed, even after leaving the `UdpateActivity` I had 2 references to it 🔍 . `KSWebView` has a delegate for activities who want to do custom things while the `WebView` is webviewing. But it wasn't getting removed when the activity was destroyed.

## the solution ⚗️
I'm now setting the delegate to `null` in `onDestroy` of any `Activity` that sets a delegate:
- `CheckoutActivity`
- `ProjectUpdatesActivity`
- `UpdateActivity`

I also set the delegate of the `KSWebViewClient` to `null` which may be overkill but I want all the bugs to die.

# 👀 See
Not sure how helpful a memory dump is but you can ask me about it I guess 😛 

# 📋 QA
View some updatez.

# Story 📖
[NT-725]


[NT-725]: https://kickstarter.atlassian.net/browse/NT-725