### PR TITLE
[🆕] NT-790 Additional Qualtrics properties

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -47,6 +47,7 @@ import com.kickstarter.libs.qualifiers.ApiRetrofit;
 import com.kickstarter.libs.qualifiers.AppRatingPreference;
 import com.kickstarter.libs.qualifiers.ApplicationContext;
 import com.kickstarter.libs.qualifiers.ConfigPreference;
+import com.kickstarter.libs.qualifiers.FirstSessionPreference;
 import com.kickstarter.libs.qualifiers.GamesNewsletterPreference;
 import com.kickstarter.libs.qualifiers.GoRewardlessPreference;
 import com.kickstarter.libs.qualifiers.KoalaEndpoint;
@@ -117,6 +118,7 @@ public final class ApplicationModule {
     final @NonNull CookieManager cookieManager,
     final @NonNull CurrentConfigType currentConfig,
     final @NonNull CurrentUserType currentUser,
+    final @NonNull @FirstSessionPreference BooleanPreferenceType firstSessionPreference,
     final @NonNull @GoRewardlessPreference BooleanPreferenceType goRewardlessPreference,
     final @NonNull Gson gson,
     final @NonNull @AppRatingPreference BooleanPreferenceType hasSeenAppRatingPreference,
@@ -144,6 +146,7 @@ public final class ApplicationModule {
       .cookieManager(cookieManager)
       .currentConfig(currentConfig)
       .currentUser(currentUser)
+      .firstSessionPreference(firstSessionPreference)
       .goRewardlessPreference(goRewardlessPreference)
       .gson(gson)
       .hasSeenAppRatingPreference(hasSeenAppRatingPreference)
@@ -380,6 +383,14 @@ public final class ApplicationModule {
   @NonNull
   static BooleanPreferenceType provideAppRatingPreference(final @NonNull SharedPreferences sharedPreferences) {
     return new BooleanPreference(sharedPreferences, SharedPreferenceKey.HAS_SEEN_APP_RATING);
+  }
+
+  @Provides
+  @Singleton
+  @FirstSessionPreference
+  @NonNull
+  static BooleanPreferenceType provideFirstSessionPreference(final @NonNull SharedPreferences sharedPreferences) {
+    return new BooleanPreference(sharedPreferences, SharedPreferenceKey.FIRST_SESSION);
   }
 
   @Provides

--- a/app/src/main/java/com/kickstarter/libs/Environment.java
+++ b/app/src/main/java/com/kickstarter/libs/Environment.java
@@ -27,6 +27,7 @@ public abstract class Environment implements Parcelable {
   public abstract CookieManager cookieManager();
   public abstract CurrentConfigType currentConfig();
   public abstract CurrentUserType currentUser();
+  public abstract BooleanPreferenceType firstSessionPreference();
   public abstract BooleanPreferenceType goRewardlessPreference();
   public abstract Gson gson();
   public abstract BooleanPreferenceType hasSeenAppRatingPreference();
@@ -55,6 +56,7 @@ public abstract class Environment implements Parcelable {
     public abstract Builder cookieManager(CookieManager __);
     public abstract Builder currentConfig(CurrentConfigType __);
     public abstract Builder currentUser(CurrentUserType __);
+    public abstract Builder firstSessionPreference(BooleanPreferenceType __);
     public abstract Builder goRewardlessPreference(BooleanPreferenceType __);
     public abstract Builder gson(Gson __);
     public abstract Builder hasSeenAppRatingPreference(BooleanPreferenceType __);

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/FirstSessionPreference.kt
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/FirstSessionPreference.kt
@@ -1,0 +1,6 @@
+package com.kickstarter.libs.qualifiers
+
+import javax.inject.Qualifier
+
+@Qualifier
+annotation class FirstSessionPreference

--- a/app/src/main/java/com/kickstarter/models/QualtricsIntercept.kt
+++ b/app/src/main/java/com/kickstarter/models/QualtricsIntercept.kt
@@ -9,4 +9,8 @@ enum class QualtricsIntercept(private val prodId: String, private val testId: St
             else -> testId
         }
     }
+
+    fun impressionCountKey(packageName: String): String {
+        return id(packageName) + "_impression_count"
+    }
 }

--- a/app/src/main/java/com/kickstarter/models/User.java
+++ b/app/src/main/java/com/kickstarter/models/User.java
@@ -7,6 +7,7 @@ import com.kickstarter.R;
 import com.kickstarter.libs.qualifiers.AutoGson;
 
 import org.jetbrains.annotations.NotNull;
+import org.joda.time.DateTime;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -27,6 +28,7 @@ public abstract class User implements Parcelable, Relay {
   public abstract long id();
   public abstract @Nullable Boolean inventNewsletter();
   public abstract @Nullable Boolean isAdmin();
+  public abstract @Nullable DateTime joinDate();
   public abstract @Nullable Location location();
   public abstract @Nullable Integer memberProjectsCount();
   public abstract @Nullable Boolean musicNewsletter();
@@ -72,6 +74,7 @@ public abstract class User implements Parcelable, Relay {
     public abstract Builder id(long __);
     public abstract Builder isAdmin(Boolean __);
     public abstract Builder inventNewsletter(Boolean __);
+    public abstract Builder joinDate(DateTime __);
     public abstract Builder location(Location __);
     public abstract Builder memberProjectsCount(Integer __);
     public abstract Builder musicNewsletter(Boolean __);

--- a/app/src/main/java/com/kickstarter/models/User.java
+++ b/app/src/main/java/com/kickstarter/models/User.java
@@ -7,7 +7,6 @@ import com.kickstarter.R;
 import com.kickstarter.libs.qualifiers.AutoGson;
 
 import org.jetbrains.annotations.NotNull;
-import org.joda.time.DateTime;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -28,7 +27,6 @@ public abstract class User implements Parcelable, Relay {
   public abstract long id();
   public abstract @Nullable Boolean inventNewsletter();
   public abstract @Nullable Boolean isAdmin();
-  public abstract @Nullable DateTime joinDate();
   public abstract @Nullable Location location();
   public abstract @Nullable Integer memberProjectsCount();
   public abstract @Nullable Boolean musicNewsletter();
@@ -74,7 +72,6 @@ public abstract class User implements Parcelable, Relay {
     public abstract Builder id(long __);
     public abstract Builder isAdmin(Boolean __);
     public abstract Builder inventNewsletter(Boolean __);
-    public abstract Builder joinDate(DateTime __);
     public abstract Builder location(Location __);
     public abstract Builder memberProjectsCount(Integer __);
     public abstract Builder musicNewsletter(Boolean __);

--- a/app/src/main/java/com/kickstarter/ui/SharedPreferenceKey.java
+++ b/app/src/main/java/com/kickstarter/ui/SharedPreferenceKey.java
@@ -5,6 +5,7 @@ public final class SharedPreferenceKey {
 
   public static final String ACCESS_TOKEN = "access_token";
   public static final String CONFIG = "config";
+  public static final String FIRST_SESSION = "first_session";
   public static final String GO_REWARDLESS = "go_rewardless";
   public static final String HAS_SEEN_APP_RATING = "has_seen_app_rating";
   public static final String HAS_SEEN_GAMES_NEWSLETTER = "has_seen_games_newsletter";

--- a/app/src/test/java/com/kickstarter/models/QualtricsInterceptTest.kt
+++ b/app/src/test/java/com/kickstarter/models/QualtricsInterceptTest.kt
@@ -13,4 +13,13 @@ class QualtricsInterceptTest : KSRobolectricTestCase() {
         TestCase.assertEquals("SI_6nSwomRDiWXeXEV", QualtricsIntercept.NATIVE_APP_FEEDBACK.id("com.kickstarter.kickstarter.internal.debug"))
         TestCase.assertEquals("SI_6nSwomRDiWXeXEV", QualtricsIntercept.NATIVE_APP_FEEDBACK.id("boop"))
     }
+
+    @Test
+    fun testImpressionCountKey() {
+        TestCase.assertEquals("SI_3VjP7wWiUZg2wBf_impression_count", QualtricsIntercept.NATIVE_APP_FEEDBACK.impressionCountKey("com.kickstarter.kickstarter"))
+        TestCase.assertEquals("SI_6nSwomRDiWXeXEV_impression_count", QualtricsIntercept.NATIVE_APP_FEEDBACK.impressionCountKey("com.kickstarter.kickstarter.debug"))
+        TestCase.assertEquals("SI_6nSwomRDiWXeXEV_impression_count", QualtricsIntercept.NATIVE_APP_FEEDBACK.impressionCountKey("com.kickstarter.kickstarter.internal"))
+        TestCase.assertEquals("SI_6nSwomRDiWXeXEV_impression_count", QualtricsIntercept.NATIVE_APP_FEEDBACK.impressionCountKey("com.kickstarter.kickstarter.internal.debug"))
+        TestCase.assertEquals("SI_6nSwomRDiWXeXEV_impression_count", QualtricsIntercept.NATIVE_APP_FEEDBACK.impressionCountKey("boop"))
+    }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -548,18 +548,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.showQualtricsSurvey().subscribe(this.showQualtricsSurvey);
     final String surveyUrl = "http://www.survey.cool";
 
-    this.vm.qualtricsResult(new QualtricsResult() {
-      @Override
-      public boolean resultPassed() {
-        return true;
-      }
-
-      @NotNull
-      @Override
-      public String surveyUrl() {
-        return surveyUrl;
-      }
-    });
+    this.vm.qualtricsResult(qualtricsResult(surveyUrl, true));
 
     this.vm.qualtricsConfirmClicked();
 
@@ -582,18 +571,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.showQualtricsSurvey().subscribe(this.showQualtricsSurvey);
     final String surveyUrl = "http://www.survey.cool";
 
-    this.vm.qualtricsResult(new QualtricsResult() {
-      @Override
-      public boolean resultPassed() {
-        return true;
-      }
-
-      @NotNull
-      @Override
-      public String surveyUrl() {
-        return surveyUrl;
-      }
-    });
+    this.vm.qualtricsResult(qualtricsResult(surveyUrl, true));
 
     this.vm.qualtricsConfirmClicked();
 
@@ -607,18 +585,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.showQualtricsSurvey().subscribe(this.showQualtricsSurvey);
     final String surveyUrl = "http://www.survey.cool";
 
-    this.vm.qualtricsResult(new QualtricsResult() {
-      @Override
-      public boolean resultPassed() {
-        return true;
-      }
-
-      @NotNull
-      @Override
-      public String surveyUrl() {
-        return surveyUrl;
-      }
-    });
+    this.vm.qualtricsResult(qualtricsResult(surveyUrl, true));
 
     this.vm.qualtricsDismissClicked();
 
@@ -632,18 +599,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.showQualtricsSurvey().subscribe(this.showQualtricsSurvey);
     final String surveyUrl = "http://www.survey.cool";
 
-    this.vm.qualtricsResult(new QualtricsResult() {
-      @Override
-      public boolean resultPassed() {
-        return true;
-      }
-
-      @NotNull
-      @Override
-      public String surveyUrl() {
-        return surveyUrl;
-      }
-    });
+    this.vm.qualtricsResult(qualtricsResult(surveyUrl, true));
 
     this.vm.qualtricsDismissClicked();
 


### PR DESCRIPTION
# 📲 What
Additional Qualtrics properties. 

# 🤔 Why
😢

# 🛠 How
- Added `first_session` `SharedPreference` that's passed through to Qualtrics as `first_app_session`.
- Added `{interceptID}_impression_count` property to Qualtrics.
- Added `logged_in` and `user_uid` as embedded data in the survey url.
- Added tests for survey url, impression count and first session. 

# 👀 See
Nothing 2 c

# 📋 QA
@jamielynnroth this can't be verified until we update the intercept logic 🙏 

# Story 📖
[NT-790]


[NT-790]: https://kickstarter.atlassian.net/browse/NT-790