### PR TITLE
[🍔] NT-811 Added Hamburger Menu Clicked event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -698,5 +698,11 @@ public final class Koala {
 
     this.client.track(LakeEvent.EXPLORE_PAGE_VIEWED, props);
   }
+
+  public void trackHamburgerMenuClicked(final @NonNull DiscoveryParams discoveryParams) {
+    final Map<String, Object> props = KoalaUtils.discoveryParamsProperties(discoveryParams);
+
+    this.client.track(LakeEvent.HAMBURGER_MENU_CLICKED, props);
+  }
   //endregion
 }

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -3,3 +3,4 @@
 package com.kickstarter.libs
 
 const val EXPLORE_PAGE_VIEWED = "Explore Page Viewed"
+const val HAMBURGER_MENU_CLICKED = "Hamburger Menu Clicked"

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -298,12 +298,17 @@ public interface DiscoveryViewModel {
         .compose(bindToLifecycle())
         .subscribe(this.drawerIsOpen);
 
-      this.openDrawer
-        .filter(BooleanUtils::isTrue)
+      final Observable<Boolean> drawerOpened = this.openDrawer
+        .filter(BooleanUtils::isTrue);
+
+      drawerOpened
         .compose(bindToLifecycle())
-        .subscribe(__ -> {
-          this.koala.trackDiscoveryFilters();
-        });
+        .subscribe(__ -> this.koala.trackDiscoveryFilters());
+
+      params
+        .compose(takeWhen(drawerOpened))
+        .compose(bindToLifecycle())
+        .subscribe(this.lake::trackHamburgerMenuClicked);
 
       intent()
         .filter(IntentMapper::appBannerIsSet)

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -147,6 +147,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.navigationDrawerDataEmitted.assertValueCount(2);
     this.drawerIsOpen.assertValues(true, false);
     this.koalaTest.assertValues("Discover Switch Modal", "Discover Modal Selected Filter");
+    this.lakeTest.assertValues("Hamburger Menu Clicked");
 
     // Open drawer and click a child filter.
     this.vm.inputs.openDrawer(true);
@@ -165,6 +166,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.drawerIsOpen.assertValues(true, false, true, false);
     this.koalaTest.assertValues("Discover Switch Modal", "Discover Modal Selected Filter", "Discover Switch Modal",
       "Discover Modal Selected Filter");
+    this.lakeTest.assertValues("Hamburger Menu Clicked", "Hamburger Menu Clicked");
   }
 
   @Test


### PR DESCRIPTION
# 📲 What
Adding `Hamburger Menu Clicked` event.

# 🤔 Why
We have new Discovery events.

# 🛠 How
- Added `LakeEvent.HAMBURGER_MENU_CLICKED` `const`
- Calling `lake.trackHamburgerMenuClicked ` when user clicks the menu icon or slides the drawer open
- Added Lake tests in `DiscoveryFragmentViewModelTest.testDrawerData`

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-811]

[NT-811]: https://kickstarter.atlassian.net/browse/NT-811