### PR TITLE
[🔍] NT-812 Added Explore Sort Clicked event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -699,6 +699,12 @@ public final class Koala {
     this.client.track(LakeEvent.EXPLORE_PAGE_VIEWED, props);
   }
 
+  public void trackExploreSortClicked(final @NonNull DiscoveryParams discoveryParams) {
+    final Map<String, Object> props = KoalaUtils.discoveryParamsProperties(discoveryParams);
+
+    this.client.track(LakeEvent.EXPLORE_SORT_CLICKED, props);
+  }
+
   public void trackHamburgerMenuClicked(final @NonNull DiscoveryParams discoveryParams) {
     final Map<String, Object> props = KoalaUtils.discoveryParamsProperties(discoveryParams);
 

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -3,4 +3,5 @@
 package com.kickstarter.libs
 
 const val EXPLORE_PAGE_VIEWED = "Explore Page Viewed"
+const val EXPLORE_SORT_CLICKED = "Explore Sort Clicked"
 const val HAMBURGER_MENU_CLICKED = "Hamburger Menu Clicked"

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
@@ -244,7 +244,7 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel.Vie
     this.sortTabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
       @Override
       public void onTabSelected(final TabLayout.Tab tab) {
-
+        DiscoveryActivity.this.viewModel.sortClicked(tab.getPosition());
       }
       @Override
       public void onTabUnselected(final TabLayout.Tab tab) {
@@ -253,6 +253,7 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel.Vie
       @Override
       public void onTabReselected(final TabLayout.Tab tab) {
         DiscoveryActivity.this.pagerAdapter.scrollToTop(tab.getPosition());
+        DiscoveryActivity.this.viewModel.sortClicked(tab.getPosition());
       }
     });
   }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -384,8 +384,8 @@ public interface DiscoveryViewModel {
     private final PublishSubject<Void> qualtricsConfirmClicked = PublishSubject.create();
     private final PublishSubject<Void> qualtricsDismissClicked = PublishSubject.create();
     private final PublishSubject<QualtricsResult> qualtricsResult = PublishSubject.create();
-    private final PublishSubject<Integer> sortClicked = PublishSubject.create();
     private final PublishSubject<Void> settingsClick = PublishSubject.create();
+    private final PublishSubject<Integer> sortClicked = PublishSubject.create();
     private final PublishSubject<NavigationDrawerData.Section.Row> topFilterRowClick = PublishSubject.create();
 
     private final BehaviorSubject<User> currentUser = BehaviorSubject.create();

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -279,6 +279,10 @@ public interface DiscoveryViewModel {
         .compose(bindToLifecycle())
         .subscribe(this.koala::trackDiscoveryFilterSelected);
 
+      drawerParamsClicked
+        .compose(bindToLifecycle())
+        .subscribe(this.lake::trackExploreSortClicked);
+
       final List<Observable<Boolean>> drawerOpenObservables = Arrays.asList(
         this.openDrawer,
         this.childFilterRowClick.map(__ -> false),

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -66,6 +66,9 @@ public interface DiscoveryViewModel {
 
     /** Call when you receive a {@link com.qualtrics.digital.TargetingResult} from Qualtrics. */
     void qualtricsResult(final QualtricsResult qualtricsResult);
+
+    /** Call when the user selects a sort tab. */
+    void sortClicked(final int sortPosition);
   }
 
   interface Outputs {
@@ -201,13 +204,20 @@ public interface DiscoveryViewModel {
       final Observable<Integer> pagerSelectedPage = this.pagerSetPrimaryPage.distinctUntilChanged();
 
       // Combine params with the selected sort position.
-      Observable.combineLatest(
+      final Observable<DiscoveryParams> paramsWithLatestSort = Observable.combineLatest(
         params,
         pagerSelectedPage.map(DiscoveryUtils::sortFromPosition),
         (p, s) -> p.toBuilder().sort(s).build()
-      )
+      );
+
+      paramsWithLatestSort
         .compose(bindToLifecycle())
         .subscribe(this.updateParamsForPage);
+
+      paramsWithLatestSort
+        .compose(takeWhen(this.sortClicked))
+        .compose(bindToLifecycle())
+        .subscribe(this.lake::trackExploreSortClicked);
 
       final Observable<List<Category>> categories = this.apiClient.fetchCategories()
         .compose(neverError())
@@ -278,10 +288,6 @@ public interface DiscoveryViewModel {
       drawerParamsClicked
         .compose(bindToLifecycle())
         .subscribe(this.koala::trackDiscoveryFilterSelected);
-
-      drawerParamsClicked
-        .compose(bindToLifecycle())
-        .subscribe(this.lake::trackExploreSortClicked);
 
       final List<Observable<Boolean>> drawerOpenObservables = Arrays.asList(
         this.openDrawer,
@@ -378,6 +384,7 @@ public interface DiscoveryViewModel {
     private final PublishSubject<Void> qualtricsConfirmClicked = PublishSubject.create();
     private final PublishSubject<Void> qualtricsDismissClicked = PublishSubject.create();
     private final PublishSubject<QualtricsResult> qualtricsResult = PublishSubject.create();
+    private final PublishSubject<Integer> sortClicked = PublishSubject.create();
     private final PublishSubject<Void> settingsClick = PublishSubject.create();
     private final PublishSubject<NavigationDrawerData.Section.Row> topFilterRowClick = PublishSubject.create();
 
@@ -458,6 +465,9 @@ public interface DiscoveryViewModel {
     }
     @Override public void qualtricsResult(final @NonNull QualtricsResult qualtricsResult) {
       this.qualtricsResult.onNext(qualtricsResult);
+    }
+    @Override public void sortClicked(final @NonNull int position) {
+      this.sortClicked.onNext(position);
     }
     @Override public void topFilterViewHolderRowClick(final @NonNull TopFilterViewHolder viewHolder, final @NonNull NavigationDrawerData.Section.Row row) {
       this.topFilterRowClick.onNext(row);

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -147,7 +147,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.navigationDrawerDataEmitted.assertValueCount(2);
     this.drawerIsOpen.assertValues(true, false);
     this.koalaTest.assertValues("Discover Switch Modal", "Discover Modal Selected Filter");
-    this.lakeTest.assertValues("Hamburger Menu Clicked");
+    this.lakeTest.assertValues("Hamburger Menu Clicked", "Explore Sort Clicked");
 
     // Open drawer and click a child filter.
     this.vm.inputs.openDrawer(true);
@@ -166,7 +166,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.drawerIsOpen.assertValues(true, false, true, false);
     this.koalaTest.assertValues("Discover Switch Modal", "Discover Modal Selected Filter", "Discover Switch Modal",
       "Discover Modal Selected Filter");
-    this.lakeTest.assertValues("Hamburger Menu Clicked", "Hamburger Menu Clicked");
+    this.lakeTest.assertValues("Hamburger Menu Clicked", "Explore Sort Clicked", "Hamburger Menu Clicked", "Explore Sort Clicked");
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -147,7 +147,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.navigationDrawerDataEmitted.assertValueCount(2);
     this.drawerIsOpen.assertValues(true, false);
     this.koalaTest.assertValues("Discover Switch Modal", "Discover Modal Selected Filter");
-    this.lakeTest.assertValues("Hamburger Menu Clicked", "Explore Sort Clicked");
+    this.lakeTest.assertValues("Hamburger Menu Clicked");
 
     // Open drawer and click a child filter.
     this.vm.inputs.openDrawer(true);
@@ -166,7 +166,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.drawerIsOpen.assertValues(true, false, true, false);
     this.koalaTest.assertValues("Discover Switch Modal", "Discover Modal Selected Filter", "Discover Switch Modal",
       "Discover Modal Selected Filter");
-    this.lakeTest.assertValues("Hamburger Menu Clicked", "Explore Sort Clicked", "Hamburger Menu Clicked", "Explore Sort Clicked");
+    this.lakeTest.assertValues("Hamburger Menu Clicked", "Hamburger Menu Clicked");
   }
 
   @Test
@@ -190,6 +190,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.updateToolbarWithParams.assertValues(DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build());
 
     // Select POPULAR sort.
+    this.vm.inputs.sortClicked(1);
     this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 1);
 
     // Sort tab should be expanded.
@@ -206,6 +207,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     // Sort tab should be expanded.
     this.expandSortTabLayout.assertValues(true, true, true);
     this.koalaTest.assertValues("Discover Modal Selected Filter");
+    this.lakeTest.assertValue("Explore Sort Clicked");
 
     // Select ART category from drawer.
     this.vm.inputs.childFilterViewHolderRowClick(null,


### PR DESCRIPTION
# 📲 What
Adding `Explore Sort Clicked` event.

# 🤔 Why
We have new Discovery events.

# 🛠 How
- Added `LakeEvent.EXPLORE_SORT_CLICKED` `const`
- Added input `sortClicked` that takes in the position of the selected sort to `DiscoveryViewModel`
- Calling `lake.trackExploreSortClicked ` when user clicks on a sort tab
- Updated Lake tests in `DiscoveryViewModelTest.testUpdateInterfaceElementsWithParams`

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-812]

[NT-812]: https://kickstarter.atlassian.net/browse/NT-812