### PR TITLE
[⚡️] NT-816 Activity Feed Viewed event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -693,6 +693,10 @@ public final class Koala {
   }
 
   //region Discover a Project
+  public void trackActivityFeedViewed() {
+    this.client.track(LakeEvent.ACTVITIY_FEED_VIEWED);
+  }
+
   public void trackExplorePageViewed(final @NonNull DiscoveryParams discoveryParams) {
     final Map<String, Object> props = KoalaUtils.discoveryParamsProperties(discoveryParams);
 

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -2,5 +2,6 @@
 
 package com.kickstarter.libs
 
+const val ACTVITIY_FEED_VIEWED = "Activity Feed Viewed"
 const val EXPLORE_PAGE_VIEWED = "Explore Page Viewed"
 const val HAMBURGER_MENU_CLICKED = "Hamburger Menu Clicked"

--- a/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.java
@@ -160,11 +160,18 @@ public interface ActivityFeedViewModel {
         .subscribe(this.loggedInEmptyStateIsVisible);
 
       // Track viewing and paginating activity.
-      this.nextPage
+      final Observable<Integer> feedViewed = this.nextPage
         .compose(incrementalCount())
-        .startWith(0)
+        .startWith(0);
+
+      feedViewed
         .compose(this.bindToLifecycle())
         .subscribe(this.koala::trackActivityView);
+
+      feedViewed
+        .take(1)
+        .compose(this.bindToLifecycle())
+        .subscribe(__ -> this.lake.trackActivityFeedViewed());
 
       // Track tapping on any of the activity items.
       Observable.merge(

--- a/app/src/test/java/com/kickstarter/viewmodels/ActivityFeedViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ActivityFeedViewModelTest.java
@@ -66,6 +66,7 @@ public class ActivityFeedViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.nextPage();
     this.activityList.assertValueCount(1);
     this.koalaTest.assertValues(KoalaEvent.ACTIVITY_VIEW, KoalaEvent.ACTIVITY_LOAD_MORE);
+    this.lakeTest.assertValue("Activity Feed Viewed");
   }
 
   @Test
@@ -103,6 +104,7 @@ public class ActivityFeedViewModelTest extends KSRobolectricTestCase {
       KoalaEvent.ACTIVITY_VIEW, KoalaEvent.ACTIVITY_VIEW_ITEM, KoalaEvent.ACTIVITY_VIEW_ITEM, KoalaEvent.ACTIVITY_VIEW_ITEM,
       KoalaEvent.ACTIVITY_VIEW_ITEM, KoalaEvent.VIEWED_UPDATE
     );
+    this.lakeTest.assertValue("Activity Feed Viewed");
   }
 
   @Test


### PR DESCRIPTION
# 📲 What
Adding `Activity Feed Viewed` event.

# 🤔 Why
We have new Discovery events.

# 🛠 How
- Added `LakeEvent.ACTVITIY_FEED_VIEWED ` `const`
- Calling `lake.trackActivityFeedViewed ` when user views the Activity feed 
- Added Lake tests in `ActivityFeedViewModelTest.testActivitiesEmit `

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-816]

[NT-816]: https://kickstarter.atlassian.net/browse/NT-816