### PR TITLE
[🔍] NT-817 Filter Clicked event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -705,6 +705,12 @@ public final class Koala {
     this.client.track(LakeEvent.EXPLORE_SORT_CLICKED, props);
   }
 
+  public void trackFilterClicked(final @NonNull DiscoveryParams discoveryParams) {
+    final Map<String, Object> props = KoalaUtils.discoveryParamsProperties(discoveryParams);
+
+    this.client.track(LakeEvent.FILTER_CLICKED, props);
+  }
+
   public void trackHamburgerMenuClicked(final @NonNull DiscoveryParams discoveryParams) {
     final Map<String, Object> props = KoalaUtils.discoveryParamsProperties(discoveryParams);
 

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -4,4 +4,5 @@ package com.kickstarter.libs
 
 const val EXPLORE_PAGE_VIEWED = "Explore Page Viewed"
 const val EXPLORE_SORT_CLICKED = "Explore Sort Clicked"
+const val FILTER_CLICKED = "Filter Clicked"
 const val HAMBURGER_MENU_CLICKED = "Hamburger Menu Clicked"

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -208,13 +208,13 @@ public interface DiscoveryViewModel {
       final Observable<Integer> pagerSelectedPage = this.pagerSetPrimaryPage.distinctUntilChanged();
 
       // Combine params with the selected sort position.
-      final Observable<DiscoveryParams> paramsWithLatestSort = Observable.combineLatest(
+      final Observable<DiscoveryParams> paramsWithSort = Observable.combineLatest(
         params,
         pagerSelectedPage.map(DiscoveryUtils::sortFromPosition),
         (p, s) -> p.toBuilder().sort(s).build()
       );
 
-      paramsWithLatestSort
+      paramsWithSort
         .compose(bindToLifecycle())
         .subscribe(this.updateParamsForPage);
 
@@ -224,7 +224,7 @@ public interface DiscoveryViewModel {
         .compose(bindToLifecycle())
         .subscribe(this.lake::trackExploreSortClicked);
 
-      paramsWithLatestSort
+      paramsWithSort
         .compose(takeWhen(drawerParamsClicked))
         .compose(bindToLifecycle())
         .subscribe(this.lake::trackFilterClicked);
@@ -325,7 +325,7 @@ public interface DiscoveryViewModel {
         .compose(bindToLifecycle())
         .subscribe(__ -> this.koala.trackDiscoveryFilters());
 
-      paramsWithLatestSort
+      paramsWithSort
         .compose(takeWhen(drawerOpened))
         .compose(bindToLifecycle())
         .subscribe(this.lake::trackHamburgerMenuClicked);

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -87,10 +87,14 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     final Intent intent = new Intent(Intent.ACTION_MAIN);
     this.vm.intent(intent);
 
+    // Initial HOME page selected.
+    this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 0);
+
     // Drawer data should emit. Drawer should be closed.
     this.navigationDrawerDataEmitted.assertValueCount(1);
     this.drawerIsOpen.assertNoValues();
     this.koalaTest.assertNoValues();
+    this.lakeTest.assertNoValues();
 
     // Open drawer and click the top PWL filter.
     this.vm.inputs.openDrawer(true);
@@ -104,7 +108,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.navigationDrawerDataEmitted.assertValueCount(2);
     this.drawerIsOpen.assertValues(true, false);
     this.koalaTest.assertValues("Discover Switch Modal", "Discover Modal Selected Filter");
-    this.lakeTest.assertValues("Hamburger Menu Clicked");
+    this.lakeTest.assertValues("Hamburger Menu Clicked", "Filter Clicked");
 
     // Open drawer and click a child filter.
     this.vm.inputs.openDrawer(true);
@@ -123,7 +127,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.drawerIsOpen.assertValues(true, false, true, false);
     this.koalaTest.assertValues("Discover Switch Modal", "Discover Modal Selected Filter", "Discover Switch Modal",
       "Discover Modal Selected Filter");
-    this.lakeTest.assertValues("Hamburger Menu Clicked", "Hamburger Menu Clicked");
+    this.lakeTest.assertValues("Hamburger Menu Clicked", "Filter Clicked", "Hamburger Menu Clicked", "Filter Clicked");
   }
 
   @Test
@@ -150,6 +154,8 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.sortClicked(1);
     this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 1);
 
+    this.lakeTest.assertValue("Explore Sort Clicked");
+
     // Sort tab should be expanded.
     this.expandSortTabLayout.assertValues(true, true);
 
@@ -164,7 +170,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     // Sort tab should be expanded.
     this.expandSortTabLayout.assertValues(true, true, true);
     this.koalaTest.assertValues("Discover Modal Selected Filter");
-    this.lakeTest.assertValue("Explore Sort Clicked");
+    this.lakeTest.assertValues("Explore Sort Clicked", "Filter Clicked");
 
     // Select ART category from drawer.
     this.vm.inputs.childFilterViewHolderRowClick(null,
@@ -176,6 +182,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     // Sort tab should be expanded.
     this.expandSortTabLayout.assertValues(true, true, true, true);
     this.koalaTest.assertValues("Discover Modal Selected Filter", "Discover Modal Selected Filter");
+    this.lakeTest.assertValues("Explore Sort Clicked", "Filter Clicked", "Filter Clicked");
 
     // Simulate rotating the device and hitting initial inputs again.
     this.vm.outputs.updateToolbarWithParams().subscribe(this.rotatedUpdateToolbarWithParams);


### PR DESCRIPTION
# 📲 What
Adding `Filter Clicked` event.

# 🤔 Why
We have new Discovery events.

# 🛠 How
- Added `LakeEvent.FILTER_CLICKED ` `const`
- Calling `lake.trackFilterClicked ` when user clicks a Discovery filter in the drawer
- Updated Lake tests in `DiscoveryViewModelTest.testDrawerData` and `DiscoveryViewModelTest.testUpdateInterfaceElementsWithParams `
- Fixed bug with `Explore Sort Clicked` being called with previous sort value

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-817]

[NT-817]: https://kickstarter.atlassian.net/browse/NT-817