### PR TITLE
[🎨] NT-792 Updating Qualtrics prompt background color

### DIFF
--- a/app/src/main/res/layout/qualtrics_prompt.xml
+++ b/app/src/main/res/layout/qualtrics_prompt.xml
@@ -15,6 +15,7 @@
     android:layout_margin="@dimen/grid_2"
     android:visibility="invisible"
     app:cardCornerRadius="@dimen/grid_1"
+    app:cardBackgroundColor="@color/ksr_grey_300"
     tools:showIn="@layout/discovery_layout"
     tools:visibility="visible">
 


### PR DESCRIPTION
# 📲 What
Changing background color of Qualtrics prompt to `ksr_grey_300` #F0F0F0

# 🤔 Why
So it's more distinct in Disco.

# 🛠 How
- Added `cardbackgroundColor` attribute to prompt `CardView`

# 👀 See
| After 🦋 | Before 🐛 |
| --- | --- |
| <img src=https://user-images.githubusercontent.com/1289295/72851581-096c7180-3c7a-11ea-88af-e3591039358b.png width=330/> | ![screenshot-2020-01-10_120245](https://user-images.githubusercontent.com/1289295/72851611-14270680-3c7a-11ea-9175-cd3547a88ffa.png) |

# 📋 QA
👀 View the prompt! (If you've dismissed it more than 3 times already, clear your data to reset the count)

# Story 📖
[NT-792]


[NT-792]: https://kickstarter.atlassian.net/browse/NT-792