### PR TITLE
[ℹ️] NT-813 Updating "partition-key" value in Data Lake events

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
@@ -9,7 +9,6 @@ import com.kickstarter.services.LakeBackgroundService
 import com.kickstarter.ui.IntentKey
 import org.json.JSONException
 import org.json.JSONObject
-import java.util.*
 
 class LakeTrackingClient(
         @param:ApplicationContext private val context: Context,
@@ -51,7 +50,7 @@ class LakeTrackingClient(
         data.put("properties", propertiesJSON)
 
         val record = JSONObject()
-        record.put("partition-key", UUID.randomUUID().toString())
+        record.put("partition-key", this.loggedInUser?.id() ?: deviceDistinctId())
         record.put("data", data)
         return record.toString()
     }

--- a/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
@@ -50,7 +50,7 @@ class LakeTrackingClient(
         data.put("properties", propertiesJSON)
 
         val record = JSONObject()
-        record.put("partition-key", this.loggedInUser?.id() ?: deviceDistinctId())
+        record.put("partition-key", this.loggedInUser?.id()?.toString() ?: deviceDistinctId())
         record.put("data", data)
         return record.toString()
     }


### PR DESCRIPTION
# 📲 What
Updating "partition-key" value in Data Lake events

# 🤔 Why
To help with session tracking.

# 🛠 How
- When user is logged **in** the value of `partition-key` is `user.id`.
- When user is logged **out** the value of `partition-key` is `deviceDistinctId` that returns a non-null `String`.

# 👀 See
No visuals~

# 📋 QA
tail your device's events in `ktk`

# Story 📖
[NT-813]


[NT-813]: https://kickstarter.atlassian.net/browse/NT-813