### PR TITLE
[🔒] NT-693 Adding client_id param to Lake requests

### DIFF
--- a/app/src/main/java/com/kickstarter/services/LakeBackgroundService.kt
+++ b/app/src/main/java/com/kickstarter/services/LakeBackgroundService.kt
@@ -19,6 +19,8 @@ class LakeBackgroundService : JobService() {
     lateinit var lakeService: LakeService
     @Inject
     lateinit var build: Build
+    @Inject
+    lateinit var clientId: String
 
     override fun onCreate() {
         super.onCreate()
@@ -28,7 +30,8 @@ class LakeBackgroundService : JobService() {
     override fun onStartJob(job: JobParameters?): Boolean {
         val extras = job?.extras
         val eventName = extras?.get(IntentKey.LAKE_EVENT_NAME) as String
-        lakeService.track(RequestBody.create(MediaType.parse("application/json"), extras.get(IntentKey.LAKE_EVENT) as String))
+        val body = RequestBody.create(MediaType.parse("application/json"), extras.get(IntentKey.LAKE_EVENT) as String)
+        lakeService.track(body, this.clientId)
                 .subscribeOn(Schedulers.io())
                 .subscribe({
                     logResponse(it, eventName)

--- a/app/src/main/java/com/kickstarter/services/LakeService.kt
+++ b/app/src/main/java/com/kickstarter/services/LakeService.kt
@@ -6,11 +6,12 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.PUT
+import retrofit2.http.Query
 import rx.Observable
 
 interface LakeService {
 
     @Headers("Content-Type: application/json")
     @PUT("record")
-    fun track(@Body body: RequestBody) : Observable<Response<ResponseBody>>
+    fun track(@Body body: RequestBody, @Query("client_id") clientId: String) : Observable<Response<ResponseBody>>
 }


### PR DESCRIPTION
# 📲 What
Sending the client ID as a query param of requests to the Lake endpoint.

# 🤔 Why
SECURITY

# 🛠 How
- Injected the `clientId` into `LakeBackgroundService` and passed it into `LakeService.track` that's annotated as a `Query` named `"client_id"`

# 👀 See
An extremely redacted request log:
<img width="949" alt="Screen Shot 2020-01-22 at 4 39 35 PM" src="https://user-images.githubusercontent.com/1289295/72936800-f0c19180-3d35-11ea-88c6-b684d0419c40.png">

# 📋 QA
We don't currently test our network clients but I believe there is a ticket in the backlog.
Please check your friendly Logcat 🐱 on a debug build of the app for the Lake requests. The URL should contain a `client_id` query param. 

# Story 📖
[NT-693]


[NT-693]: https://kickstarter.atlassian.net/browse/NT-693