### PR TITLE
[🚮] NT-831 Removing volatile user tracking properties

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -97,12 +97,7 @@ public final class KoalaUtils {
   public static @NonNull Map<String, Object> userProperties(final @NonNull User user, final @NonNull String prefix) {
     final Map<String, Object> properties = new HashMap<String, Object>() {
       {
-        put("backed_projects_count", user.backedProjectsCount());
-        put("facebook_account", BooleanUtils.isTrue(user.facebookConnected()));
-        put("is_admin", BooleanUtils.isTrue(user.isAdmin()));
-        put("launched_projects_count", user.createdProjectsCount());
         put("uid", user.id());
-        put("watched_projects_count", user.starredProjectsCount());
       }
     };
 

--- a/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
@@ -44,11 +44,6 @@ class KoalaTest : KSRobolectricTestCase() {
         assertDefaultProperties(user)
         val expectedProperties = propertiesTest.value
         assertEquals(15L, expectedProperties["user_uid"])
-        assertEquals(3, expectedProperties["user_backed_projects_count"])
-        assertEquals(false, expectedProperties["user_facebook_account"])
-        assertEquals(false, expectedProperties["user_is_admin"])
-        assertEquals(2, expectedProperties["user_launched_projects_count"])
-        assertEquals(10, expectedProperties["user_watched_projects_count"])
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -47,12 +47,7 @@ class LakeTest : KSRobolectricTestCase() {
 
         val expectedProperties = propertiesTest.value
         assertEquals(15L, expectedProperties["user_uid"])
-        assertEquals(3, expectedProperties["user_backed_projects_count"])
         assertEquals("NG", expectedProperties["user_country"])
-        assertEquals(false, expectedProperties["user_facebook_account"])
-        assertEquals(false, expectedProperties["user_is_admin"])
-        assertEquals(2, expectedProperties["user_launched_projects_count"])
-        assertEquals(10, expectedProperties["user_watched_projects_count"])
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Removing volatile user tracking properties

# 🤔 Why
The values Can Change™ 

# 🛠 How
- Removing volatile user attributes:
`backed_projects_count`
`facebook_account`
`is_admin`
`launched_projects_count`
`watched_projects_count`
- Updated `KoalaTest` and `LakeTest`.

# 👀 See
Nothing visual

# 📋 QA
So many ways 2 QA:
- ktk the staging lake
- check the Logcat in Android Studio
- Look at the dev project in Amplitude

# Story 📖
[NT-831]


[NT-831]: https://kickstarter.atlassian.net/browse/NT-831