### PR TITLE
[🕷] NT-826 Renaming session_user_logged_in property to session_user_is_logged_in

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -63,7 +63,7 @@ public abstract class TrackingClientType {
         put("os", "Android");
         put("os_version", String.format("Android %s", OSVersion()));
         put("user_agent", userAgent());
-        put("user_logged_in", userIsLoggedIn);
+        put("user_is_logged_in", userIsLoggedIn);
         put("wifi_connection", wifiConnection());
       }
     };

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -332,7 +332,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals("Android", expectedProperties["session_os"])
         assertEquals("Android 9", expectedProperties["session_os_version"])
         assertEquals("agent", expectedProperties["session_user_agent"])
-        assertEquals(user != null, expectedProperties["session_user_logged_in"])
+        assertEquals(user != null, expectedProperties["session_user_is_logged_in"])
         assertEquals(false, expectedProperties["session_wifi_connection"])
     }
 


### PR DESCRIPTION
# 📲 What
what it says on the tin

# 🤔 Why
issa bug

# 🛠 How
- `TrackingClientType.sessionProperties` now sends `session_user_is_logged_in` instead of `session_user_logged_in`
- Updated `LakeTest`

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-826]


[NT-826]: https://kickstarter.atlassian.net/browse/NT-826