### PR TITLE
[🎩] NT-825 Changing home sort to magic but for real this time

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/DiscoveryUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/DiscoveryUtils.java
@@ -21,7 +21,7 @@ public final class DiscoveryUtils {
       return 0;
     }
     switch (sort) {
-      case HOME:
+      case MAGIC:
         return 0;
       case POPULAR:
         return 1;

--- a/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
+++ b/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
@@ -47,12 +47,12 @@ public abstract class DiscoveryParams implements Parcelable {
   public abstract @Nullable String term();
 
   public enum Sort {
-    HOME, POPULAR, NEWEST, ENDING_SOON;
+    MAGIC, POPULAR, NEWEST, ENDING_SOON;
     @Override
     public @NonNull String toString() {
       switch (this) {
-        case HOME:
-          return "home";
+        case MAGIC:
+          return "magic";
         case POPULAR:
           return "popularity";
         case NEWEST:
@@ -65,8 +65,8 @@ public abstract class DiscoveryParams implements Parcelable {
 
     public static @Nullable Sort fromString(final @NonNull String string) {
       switch (string) {
-        case "home":
-          return HOME;
+        case "magic":
+          return MAGIC;
         case "popularity":
           return POPULAR;
         case "newest":
@@ -74,12 +74,12 @@ public abstract class DiscoveryParams implements Parcelable {
         case "end_date":
           return ENDING_SOON;
       }
-      return HOME;
+      return MAGIC;
     }
 
     public @NonNull String refTagSuffix() {
       switch (this) {
-        case HOME:
+        case MAGIC:
           return "";
         case POPULAR:
           return "_popular";
@@ -417,7 +417,7 @@ public abstract class DiscoveryParams implements Parcelable {
    * featured project for the category comes back.
    */
   public boolean shouldIncludeFeatured() {
-    return category() != null && category().parent() == null && page() != null && page() == 1 && (sort() == null || sort() == Sort.HOME);
+    return category() != null && category().parent() == null && page() != null && page() == 1 && (sort() == null || sort() == Sort.MAGIC);
   }
 
   @Override
@@ -468,7 +468,7 @@ public abstract class DiscoveryParams implements Parcelable {
       builder.recommended(true).backed(-1);
     }
     return builder
-      .sort(Sort.HOME)
+      .sort(Sort.MAGIC)
       .build();
   }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -315,7 +315,7 @@ public interface DiscoveryFragmentViewModel {
 
     private boolean isOnboardingVisible(final @NonNull DiscoveryParams params, final boolean isLoggedIn) {
       final DiscoveryParams.Sort sort = params.sort();
-      final boolean isSortHome = DiscoveryParams.Sort.HOME.equals(sort);
+      final boolean isSortHome = DiscoveryParams.Sort.MAGIC.equals(sort);
       return isTrue(params.isAllProjects()) && isSortHome && !isLoggedIn;
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/EditorialViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/EditorialViewModel.kt
@@ -83,7 +83,7 @@ interface EditorialViewModel {
 
             editorial
                     .map { it.tagId }
-                    .map { DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).tagId(it).build() }
+                    .map { DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).tagId(it).build() }
                     .compose(bindToLifecycle())
                     .subscribe(this.discoveryParams)
 

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -82,7 +82,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals("discovery", expectedProperties["discover_ref_tag"])
         assertEquals(null, expectedProperties["discover_search_term"])
         assertEquals(false, expectedProperties["discover_social"])
-        assertEquals("home", expectedProperties["discover_sort"])
+        assertEquals("magic", expectedProperties["discover_sort"])
         assertNull(expectedProperties["discover_subcategory_id"])
         assertNull(expectedProperties["discover_subcategory_name"])
         assertEquals(null, expectedProperties["discover_tag"])

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -65,7 +65,7 @@ class LakeTest : KSRobolectricTestCase() {
 
         val params = DiscoveryParams
                 .builder()
-                .sort(DiscoveryParams.Sort.HOME)
+                .sort(DiscoveryParams.Sort.MAGIC)
                 .build()
 
         lake.trackExplorePageViewed(params)

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -71,7 +71,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
   }
 
   private void setUpInitialHomeAllProjectsParams() {
-    this.vm.inputs.paramsFromActivity(DiscoveryParams.getDefaultParams(null).toBuilder().sort(DiscoveryParams.Sort.HOME).build());
+    this.vm.inputs.paramsFromActivity(DiscoveryParams.getDefaultParams(null).toBuilder().sort(DiscoveryParams.Sort.MAGIC).build());
     this.vm.inputs.rootCategories(CategoryFactory.rootCategories());
   }
 
@@ -110,7 +110,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.paramsFromActivity(
       DiscoveryParams.builder()
         .category(CategoryFactory.artCategory())
-        .sort(DiscoveryParams.Sort.HOME)
+        .sort(DiscoveryParams.Sort.MAGIC)
         .build()
     );
 
@@ -184,7 +184,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.paramsFromActivity(
       DiscoveryParams.builder()
         .category(CategoryFactory.artCategory())
-        .sort(DiscoveryParams.Sort.HOME)
+        .sort(DiscoveryParams.Sort.MAGIC)
         .build()
     );
 
@@ -213,7 +213,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.paramsFromActivity(
       DiscoveryParams.builder()
         .category(CategoryFactory.artCategory())
-        .sort(DiscoveryParams.Sort.HOME)
+        .sort(DiscoveryParams.Sort.MAGIC)
         .build()
     );
 
@@ -362,7 +362,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     // Load editorial params and root categories from activity.
     final DiscoveryParams editorialParams = DiscoveryParams.builder()
       .tagId(Editorial.GO_REWARDLESS.getTagId())
-      .sort(DiscoveryParams.Sort.HOME)
+      .sort(DiscoveryParams.Sort.MAGIC)
       .build();
     this.vm.inputs.paramsFromActivity(editorialParams);
     this.vm.inputs.rootCategories(CategoryFactory.rootCategories());

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -87,7 +87,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     final Intent intent = new Intent(Intent.ACTION_MAIN);
     this.vm.intent(intent);
 
-    // Initial HOME page selected.
+    // Initial MAGIC page selected.
     this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 0);
 
     // Drawer data should emit. Drawer should be closed.
@@ -141,14 +141,14 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     final Intent intent = new Intent(Intent.ACTION_MAIN);
     this.vm.intent(intent);
 
-    // Initial HOME page selected.
+    // Initial MAGIC page selected.
     this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 0);
 
     // Sort tab should be expanded.
     this.expandSortTabLayout.assertValues(true);
 
     // Toolbar params should be loaded with initial params.
-    this.updateToolbarWithParams.assertValues(DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build());
+    this.updateToolbarWithParams.assertValues(DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).build());
 
     // Select POPULAR sort.
     this.vm.inputs.sortClicked(1);
@@ -160,7 +160,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     this.expandSortTabLayout.assertValues(true, true);
 
     // Unchanged toolbar params should not emit.
-    this.updateToolbarWithParams.assertValues(DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build());
+    this.updateToolbarWithParams.assertValues(DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).build());
 
     // Select ALL PROJECTS filter from drawer.
     this.vm.inputs.topFilterViewHolderRowClick(null,
@@ -251,12 +251,12 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     final Intent intent = new Intent(Intent.ACTION_MAIN);
     this.vm.intent(intent);
 
-    // Initial HOME page selected.
+    // Initial MAGIC page selected.
     this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 0);
 
     // Initial params should emit. Page should not be updated yet.
     this.updateParams.assertValues(
-      DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build()
+      DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).build()
     );
     this.updatePage.assertValues(0);
 
@@ -265,7 +265,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
 
     // Params and page should update with new POPULAR sort values.
     this.updateParams.assertValues(
-      DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build(),
+      DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).build(),
       DiscoveryParams.builder().sort(DiscoveryParams.Sort.POPULAR).build()
     );
     this.updatePage.assertValues(0, 1);
@@ -279,22 +279,22 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
 
     // Params should update with new category; page should remain the same.
     this.updateParams.assertValues(
-      DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build(),
+      DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).build(),
       DiscoveryParams.builder().sort(DiscoveryParams.Sort.POPULAR).build(),
       DiscoveryParams.builder().sort(DiscoveryParams.Sort.POPULAR).category(CategoryFactory.artCategory()).build()
     );
     this.updatePage.assertValues(0, 1, 1);
     this.koalaTest.assertValues("Discover Modal Selected Filter");
 
-    // Select HOME sort position.
+    // Select MAGIC sort position.
     this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 0);
 
-    // Params and page should update with new HOME sort value.
+    // Params and page should update with new MAGIC sort value.
     this.updateParams.assertValues(
-      DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build(),
+      DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).build(),
       DiscoveryParams.builder().sort(DiscoveryParams.Sort.POPULAR).build(),
       DiscoveryParams.builder().sort(DiscoveryParams.Sort.POPULAR).category(CategoryFactory.artCategory()).build(),
-      DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).category(CategoryFactory.artCategory()).build()
+      DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).category(CategoryFactory.artCategory()).build()
     );
     this.updatePage.assertValues(0, 1, 1, 0);
 
@@ -304,7 +304,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
 
     // Should emit again with same params.
     this.rotatedUpdateParams.assertValues(
-      DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).category(CategoryFactory.artCategory()).build()
+      DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).category(CategoryFactory.artCategory()).build()
     );
     this.rotatedUpdatePage.assertValues(0);
   }
@@ -314,7 +314,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     setUpDefaultParamsTest(null);
 
     this.updateParams.assertValues(
-      DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build()
+      DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).build()
     );
   }
 
@@ -323,7 +323,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     setUpDefaultParamsTest(UserFactory.user());
 
     this.updateParams.assertValues(
-      DiscoveryParams.builder().recommended(true).backed(-1).sort(DiscoveryParams.Sort.HOME).build()
+      DiscoveryParams.builder().recommended(true).backed(-1).sort(DiscoveryParams.Sort.MAGIC).build()
     );
   }
 
@@ -332,7 +332,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     setUpDefaultParamsTest(UserFactory.noRecommendations());
 
     this.updateParams.assertValues(
-      DiscoveryParams.builder().sort(DiscoveryParams.Sort.HOME).build()
+      DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).build()
     );
   }
 
@@ -459,10 +459,10 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     // Start initial activity.
     this.vm.intent(new Intent(Intent.ACTION_MAIN));
 
-    // Initial HOME page selected.
+    // Initial MAGIC page selected.
     this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 0);
 
-    // Root categories should emit for the initial HOME sort this.position.
+    // Root categories should emit for the initial MAGIC sort this.position.
     this.rootCategories.assertValueCount(1);
     this.position.assertValues(0);
 
@@ -663,7 +663,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
     final Intent intent = new Intent(Intent.ACTION_MAIN);
     this.vm.intent(intent);
 
-    // Initial HOME page selected.
+    // Initial MAGIC page selected.
     this.vm.inputs.discoveryPagerAdapterSetPrimaryPage(null, 0);
   }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/EditorialViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/EditorialViewModelTest.kt
@@ -53,7 +53,7 @@ class EditorialViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment(), Editorial.GO_REWARDLESS)
 
         val expectedParams = DiscoveryParams.builder()
-                .sort(DiscoveryParams.Sort.HOME)
+                .sort(DiscoveryParams.Sort.MAGIC)
                 .tagId(Editorial.GO_REWARDLESS.tagId)
                 .build()
         this.discoveryParams.assertValue(expectedParams)


### PR DESCRIPTION
# 📲 What
Actually using magic sort as the default in Discovery

# 🤔 Why
In https://github.com/kickstarter/android-oss/pull/240 I thought I was just making a copy change but I think we actually wanted to start sorting by `"magic"` 🙂 

I'm considering this both a bug and a feature!

# 🛠 How
- Renamed `DiscoveryParams.Sort.HOME` to `DiscoveryParams.Sort.MAGIC`
- `DiscoveryParams.Sort.toString` returns `"magic"` for `MAGIC`
- `DiscoveryParams.Sort.fromString` returns `MAGIC` for `"magic"`

# 👀 See
![Screen Shot 2020-01-24 at 7 02 30 PM](https://user-images.githubusercontent.com/1289295/73112372-256f4d80-3edc-11ea-92c5-1a895135810e.png)

# 📋 QA
Check your friendly LogCat.
`ktk` your user. `discover_sort` should now be `magic`

# Story 📖
[NT-825]

[NT-825]: https://kickstarter.atlassian.net/browse/NT-825