### PR TITLE
[💧] NT-815 Hitting prod data Lake in prod

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -528,7 +528,7 @@ public final class ApplicationModule {
   static String provideLakeEndpoint(final @NonNull ApiEndpoint apiEndpoint) {
     /* Only sending events to the staging endpoint until the properties have been finalized. */
     return (apiEndpoint == ApiEndpoint.PRODUCTION) ?
-      Secrets.LakeEndpoint.STAGING :
+      Secrets.LakeEndpoint.PRODUCTION :
       Secrets.LakeEndpoint.STAGING;
   }
 

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -526,7 +526,6 @@ public final class ApplicationModule {
   @LakeEndpoint
   @NonNull
   static String provideLakeEndpoint(final @NonNull ApiEndpoint apiEndpoint) {
-    /* Only sending events to the staging endpoint until the properties have been finalized. */
     return (apiEndpoint == ApiEndpoint.PRODUCTION) ?
       Secrets.LakeEndpoint.PRODUCTION :
       Secrets.LakeEndpoint.STAGING;


### PR DESCRIPTION
# 📲 What
Hitting prod data Lake when hitting prod API.

# 🤔 Why
We're prepping for 2.2.0 release and need to start hitting prod Data Lake so events get sent to the right Amplitude project.

# 🛠 How
- Removed comment and now return `Secrets.LakeEndpoint.PRODUCTION` if the API endpoint is production in `ApplicationModule.provideLakeEndpoint`

# 👀 See
Nothing 2 c

# 📋 QA
Tail the prod data lake!

# Story 📖
[NT-815]


[NT-815]: https://kickstarter.atlassian.net/browse/NT-815