### PR TITLE
[ℹ️] NT-849 Adding id field to checkout model

### DIFF
--- a/app/src/main/graphql/checkout.graphql
+++ b/app/src/main/graphql/checkout.graphql
@@ -1,6 +1,7 @@
 mutation CreateBacking($projectId: ID!, $amount: String!, $paymentType: String!, $paymentSourceId: String!, $locationId: String, $rewardId: ID, $refParam: String) {
   createBacking(input: {projectId: $projectId, amount: $amount, paymentType: $paymentType, paymentSourceId: $paymentSourceId, locationId: $locationId, rewardId: $rewardId, refParam: $refParam}) {
     checkout {
+      id
       backing {
         clientSecret
         requiresAction
@@ -20,6 +21,7 @@ mutation CancelBacking($backingId: ID!, $note: String) {
 mutation UpdateBacking($backingId: ID!, $amount: String, $locationId: String, $rewardId: ID, $paymentSourceId: String)  {
   updateBacking(input: { id: $backingId, amount: $amount, locationId: $locationId, rewardId: $rewardId, paymentSourceId: $paymentSourceId}) {
     checkout {
+      id
       backing {
         clientSecret
         requiresAction

--- a/app/src/main/java/com/kickstarter/mock/factories/CheckoutFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CheckoutFactory.kt
@@ -1,0 +1,14 @@
+package com.kickstarter.mock.factories
+
+import com.kickstarter.models.Checkout
+
+class CheckoutFactory private constructor() {
+    companion object {
+        fun requiresAction(requiresAction: Boolean): Checkout {
+            return Checkout.builder()
+                    .id(IdFactory.id().toLong())
+                    .backing(CheckoutBackingFactory.requiresAction(requiresAction))
+                    .build()
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -7,7 +7,7 @@ import UpdateUserCurrencyMutation
 import UpdateUserEmailMutation
 import UpdateUserPasswordMutation
 import UserPrivacyQuery
-import com.kickstarter.mock.factories.CheckoutBackingFactory
+import com.kickstarter.mock.factories.CheckoutFactory
 import com.kickstarter.mock.factories.StoredCardFactory
 import com.kickstarter.models.*
 import com.kickstarter.services.ApolloClientType
@@ -24,8 +24,8 @@ open class MockApolloClient : ApolloClientType {
         return Observable.just(true)
     }
 
-    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout.Backing> {
-        return Observable.just(CheckoutBackingFactory.requiresAction(false))
+    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout> {
+        return Observable.just(CheckoutFactory.requiresAction(false))
     }
 
     override fun clearUnseenActivity(): Observable<Int> {
@@ -58,8 +58,8 @@ open class MockApolloClient : ApolloClientType {
                 "12345")))
     }
 
-    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing> {
-        return Observable.just(CheckoutBackingFactory.requiresAction(false))
+    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
+        return Observable.just(CheckoutFactory.requiresAction(false))
     }
 
     override fun updateUserCurrencyPreference(currency: CurrencyCode): Observable<UpdateUserCurrencyMutation.Data> {

--- a/app/src/main/java/com/kickstarter/models/Checkout.kt
+++ b/app/src/main/java/com/kickstarter/models/Checkout.kt
@@ -5,10 +5,12 @@ import auto.parcel.AutoParcel
 
 @AutoParcel
 abstract class Checkout : Parcelable {
+    abstract fun id(): Long?
     abstract fun backing(): Backing
 
     @AutoParcel.Builder
     abstract class Builder {
+        abstract fun id(id: Long?): Builder
         abstract fun backing(backing: Backing): Builder
         abstract fun build(): Checkout
     }

--- a/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
+++ b/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
@@ -17,7 +17,7 @@ import type.CurrencyCode
 interface ApolloClientType {
     fun cancelBacking(backing: Backing, note: String): Observable<Any>
 
-    fun createBacking(createBackingData: CreateBackingData): Observable<Checkout.Backing>
+    fun createBacking(createBackingData: CreateBackingData): Observable<Checkout>
 
     fun clearUnseenActivity(): Observable<Int>
 
@@ -33,7 +33,7 @@ interface ApolloClientType {
 
     fun sendVerificationEmail(): Observable<SendEmailVerificationMutation.Data>
 
-    fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing>
+    fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout>
 
     fun updateUserCurrencyPreference(currency: CurrencyCode): Observable<UpdateUserCurrencyMutation.Data>
 

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -61,7 +61,7 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
         }
     }
 
-    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout.Backing> {
+    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout> {
         return Observable.defer {
             val createBackingMutation = CreateBackingMutation.builder()
                     .projectId(encodeRelayId(createBackingData.project))
@@ -73,7 +73,7 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                     .refParam(createBackingData.refTag?.tag())
                     .build()
 
-            val ps = PublishSubject.create<Checkout.Backing>()
+            val ps = PublishSubject.create<Checkout>()
 
             this.service.mutate(createBackingMutation)
                     .enqueue(object : ApolloCall.Callback<CreateBackingMutation.Data>() {
@@ -92,7 +92,10 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                                     .requiresAction(checkoutPayload?.backing()?.requiresAction()?: false)
                                     .build()
 
-                            ps.onNext(backing)
+                            ps.onNext(Checkout.builder()
+                                    .id(decodeRelayId(checkoutPayload?.id()))
+                                    .backing(backing)
+                                    .build())
                             ps.onCompleted()
                         }
                     })
@@ -291,7 +294,7 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
         }
     }
 
-    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing> {
+    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
         return Observable.defer {
             val updateBackingMutation = UpdateBackingMutation.builder()
                     .backingId(encodeRelayId(updateBackingData.backing))
@@ -301,7 +304,7 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                     .paymentSourceId(updateBackingData.paymentSourceId)
                     .build()
 
-            val ps = PublishSubject.create<Checkout.Backing>()
+            val ps = PublishSubject.create<Checkout>()
             service.mutate(updateBackingMutation)
                     .enqueue(object : ApolloCall.Callback<UpdateBackingMutation.Data>() {
                         override fun onFailure(exception: ApolloException) {
@@ -319,7 +322,10 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                                     .requiresAction(checkoutPayload?.backing()?.requiresAction()?: false)
                                     .build()
 
-                            ps.onNext(backing)
+                            ps.onNext(Checkout.builder()
+                                    .id(decodeRelayId(checkoutPayload?.id()))
+                                    .backing(backing)
+                                    .build())
                             ps.onCompleted()
                         }
                     })

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -891,11 +891,12 @@ interface PledgeFragmentViewModel {
                     }
                     .share()
 
-            val createOrUpdateSuccess = Observable.merge(createBackingNotification, updateBackingNotification)
+            val successfulBacking = Observable.merge(createBackingNotification, updateBackingNotification)
                     .compose(values())
+                    .map { it.backing() }
                     .filter { BooleanUtils.isFalse(it.requiresAction()) }
 
-            val successAndPledgeReason = Observable.merge(createOrUpdateSuccess,
+            val successAndPledgeReason = Observable.merge(successfulBacking,
                     this.stripeSetupResultSuccessful.filter { it == StripeIntentResult.Outcome.SUCCEEDED })
                     .compose<Pair<Any, PledgeReason>>(combineLatestPair(pledgeReason))
 
@@ -919,6 +920,7 @@ interface PledgeFragmentViewModel {
 
             Observable.merge(createBackingNotification, updateBackingNotification)
                     .compose(values())
+                    .map { it.backing() }
                     .filter { BooleanUtils.isTrue(it.requiresAction()) }
                     .map { it.clientSecret() }
                     .compose(bindToLifecycle())

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -1357,7 +1357,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
                 .cookieManager(cookieManager)
                 .sharedPreferences(sharedPreferences)
                 .apolloClient(object : MockApolloClient() {
-                    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout.Backing> {
+                    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout> {
                         //Assert that stored cookie is passed in
                         TestCase.assertEquals(createBackingData.refTag, RefTag.discovery())
                         return super.createBacking(createBackingData)
@@ -1506,7 +1506,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environment()
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing> {
+                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
                         return Observable.error(Exception("womp"))
                     }
                 })
@@ -1542,8 +1542,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForLoggedInUser(UserFactory.user())
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing> {
-                        return Observable.just(CheckoutBackingFactory.requiresAction(true))
+                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
+                        return Observable.just(CheckoutFactory.requiresAction(true))
                     }
                 })
                 .build()
@@ -1572,8 +1572,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForLoggedInUser(UserFactory.user())
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing> {
-                        return Observable.just(CheckoutBackingFactory.requiresAction(true))
+                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
+                        return Observable.just(CheckoutFactory.requiresAction(true))
                     }
                 })
                 .build()
@@ -1602,8 +1602,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForLoggedInUser(UserFactory.user())
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing> {
-                        return Observable.just(CheckoutBackingFactory.requiresAction(true))
+                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
+                        return Observable.just(CheckoutFactory.requiresAction(true))
                     }
                 })
                 .build()
@@ -1665,7 +1665,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
                     }
                 })
                 .apolloClient(object : MockApolloClient() {
-                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing> {
+                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
                         return Observable.error(Exception("womp"))
                     }
                 })
@@ -1697,7 +1697,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         val environment = environment().toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing> {
+                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
                         return Observable.error(Exception("womp"))
                     }
                 })
@@ -1717,7 +1717,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.shippingRules())
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing> {
+                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
                         return Observable.error(Exception("womp"))
                     }
                 })
@@ -1736,7 +1736,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environment()
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing> {
+                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
                         return Observable.error(Exception("womp"))
                     }
                 })
@@ -1863,8 +1863,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForLoggedInUser(UserFactory.user())
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing> {
-                        return Observable.just(CheckoutBackingFactory.requiresAction(true))
+                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
+                        return Observable.just(CheckoutFactory.requiresAction(true))
                     }
                 })
                 .build()
@@ -1904,8 +1904,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForLoggedInUser(UserFactory.user())
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing> {
-                        return Observable.just(CheckoutBackingFactory.requiresAction(true))
+                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
+                        return Observable.just(CheckoutFactory.requiresAction(true))
                     }
                 })
                 .build()
@@ -1945,8 +1945,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForLoggedInUser(UserFactory.user())
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout.Backing> {
-                        return Observable.just(CheckoutBackingFactory.requiresAction(true))
+                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
+                        return Observable.just(CheckoutFactory.requiresAction(true))
                     }
                 })
                 .build()
@@ -2105,7 +2105,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForLoggedInUser(UserFactory.user())
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout.Backing> {
+                    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout> {
                         return Observable.error(Throwable("error"))
                     }
                 })
@@ -2131,8 +2131,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForLoggedInUser(UserFactory.user())
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout.Backing> {
-                        return Observable.just(CheckoutBackingFactory.requiresAction(true))
+                    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout> {
+                        return Observable.just(CheckoutFactory.requiresAction(true))
                     }
                 })
                 .build()
@@ -2162,8 +2162,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForLoggedInUser(UserFactory.user())
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout.Backing> {
-                        return Observable.just(CheckoutBackingFactory.requiresAction(true))
+                    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout> {
+                        return Observable.just(CheckoutFactory.requiresAction(true))
                     }
                 })
                 .build()
@@ -2194,8 +2194,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environmentForLoggedInUser(UserFactory.user())
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout.Backing> {
-                        return Observable.just(CheckoutBackingFactory.requiresAction(true))
+                    override fun createBacking(createBackingData: CreateBackingData): Observable<Checkout> {
+                        return Observable.just(CheckoutFactory.requiresAction(true))
                     }
                 })
                 .build()


### PR DESCRIPTION
# 📲 What
Adding `id` field to `Checkout` model

# 🤔 Why
It will be used in the `Back a project` tracking events.

# 🛠 How
- Added `checkout.id` field to `CreateBacking` and `UpdateBacking` mutations.
- Added `id` field to `Checkout` model.
- `ApolloClientType.createBacking` and `updateBacking` now return a `Checkout`.
- Created `CheckoutFactory` to easily return mock `Checkout` objects for tests.
- Updated `PledgeFragmentViewModel` and `PledgeFragmentViewModelTest`.

# 👀 See
Under the hood changes only.

# 📋 QA
Backing or updating a pledge should behave the same.

# Story 📖
[NT-849]


[NT-849]: https://kickstarter.atlassian.net/browse/NT-849