### PR TITLE
[🔢] NT-850 session_os_version tracking property should only contain numbers.

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -61,7 +61,7 @@ public abstract class TrackingClientType {
         put("is_voiceover_running", isTalkBackOn());
         put("mp_lib", "kickstarter_android");
         put("os", "Android");
-        put("os_version", String.format("Android %s", OSVersion()));
+        put("os_version", OSVersion());
         put("user_agent", userAgent());
         put("user_is_logged_in", userIsLoggedIn);
         put("wifi_connection", wifiConnection());

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -325,7 +325,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals(false, expectedProperties["session_is_voiceover_running"])
         assertEquals("kickstarter_android", expectedProperties["session_mp_lib"])
         assertEquals("Android", expectedProperties["session_os"])
-        assertEquals("Android 9", expectedProperties["session_os_version"])
+        assertEquals("9", expectedProperties["session_os_version"])
         assertEquals("agent", expectedProperties["session_user_agent"])
         assertEquals(user != null, expectedProperties["session_user_is_logged_in"])
         assertEquals(false, expectedProperties["session_wifi_connection"])


### PR DESCRIPTION
# 📲 What
Removing platform prepend from `session_os_version` tracking property.

# 🤔 Why
It's not needed.

# 🛠 How
Removed `"Android"` prepend

# 👀 See
no visual changes

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-850]


[NT-850]: https://kickstarter.atlassian.net/browse/NT-850