### PR TITLE
[🛤] NT-851 Add session_client_platform to session properties

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.java
@@ -49,6 +49,7 @@ public abstract class TrackingClientType {
       {
         put("app_build_number", buildNumber());
         put("app_release_version", versionName());
+        put("client_platform", "android");
         put("client_type", "native");
         put("current_variants", currentVariants());
         put("device_distinct_id", deviceDistinctId());

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -313,6 +313,7 @@ class LakeTest : KSRobolectricTestCase() {
         val expectedProperties = propertiesTest.value
         assertEquals(9999, expectedProperties["session_app_build_number"])
         assertEquals("9.9.9", expectedProperties["session_app_release_version"])
+        assertEquals("android", expectedProperties["session_client_platform"])
         assertEquals("native", expectedProperties["session_client_type"])
         assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_current_variants"])
         assertEquals("uuid", expectedProperties["session_device_distinct_id"])


### PR DESCRIPTION
# 📲 What
Adds `session_client_platform` to session properties.

# 🤔 Why
It's needed.

# 🛠 How
Added `session_client_platform` to session properties and updated test

# 👀 See
no visual changes

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-851]

[NT-851]: https://kickstarter.atlassian.net/browse/NT-851