### PR TITLE
[ℹ️] NT-840 Adding device identifier to InternalToolsActivity

### DIFF
--- a/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.java
+++ b/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.java
@@ -10,6 +10,7 @@ import android.webkit.URLUtil;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import com.google.firebase.iid.FirebaseInstanceId;
 import com.jakewharton.processphoenix.ProcessPhoenix;
 import com.kickstarter.KSApplication;
 import com.kickstarter.R;
@@ -47,6 +48,7 @@ public final class InternalToolsActivity extends BaseActivity<InternalToolsViewM
   @Bind(R.id.api_endpoint) TextView apiEndpoint;
   @Bind(R.id.build_date) TextView buildDate;
   @Bind(R.id.commit_sha) TextView commitSha;
+  @Bind(R.id.device_id) TextView deviceID;
   @Bind(R.id.variant) TextView variant;
   @Bind(R.id.version_code) TextView versionCode;
   @Bind(R.id.version_name) TextView versionName;
@@ -155,6 +157,7 @@ public final class InternalToolsActivity extends BaseActivity<InternalToolsViewM
     this.apiEndpoint.setText(this.apiEndpointPreference.get());
     this.buildDate.setText(this.build.buildDate().toString(DateTimeFormat.forPattern("MMM dd, yyyy h:mm:ss aa zzz")));
     this.commitSha.setText(this.build.sha());
+    this.deviceID.setText(FirebaseInstanceId.getInstance().getId());
     this.variant.setText(this.build.variant());
     this.versionCode.setText(this.build.versionCode().toString());
     this.versionName.setText(this.build.versionName());

--- a/app/src/internal/res/layout/internal_tools_layout.xml
+++ b/app/src/internal/res/layout/internal_tools_layout.xml
@@ -24,7 +24,7 @@
       android:clipToPadding="false"
       android:orientation="vertical"
       android:paddingStart="@dimen/activity_horizontal_margin"
-      android:paddingTop="@dimen/activity_vertical_margin"
+      android:paddingTop="@dimen/grid_1"
       android:paddingEnd="@dimen/activity_horizontal_margin"
       android:paddingBottom="@dimen/activity_vertical_margin">
 
@@ -81,6 +81,18 @@
             android:id="@+id/commit_sha"
             style="@style/InternalToolsValue"
             tools:text="aaaaaaaa" />
+        </TableRow>
+
+        <TableRow style="@style/InternalToolsRow">
+
+          <TextView
+            style="@style/InternalToolsKey"
+            android:text="@string/Device_ID" />
+
+          <TextView
+            android:id="@+id/device_id"
+            style="@style/InternalToolsValue"
+            tools:text="abc123" />
         </TableRow>
 
         <TableRow style="@style/InternalToolsRow">

--- a/app/src/internal/res/values/styles.xml
+++ b/app/src/internal/res/values/styles.xml
@@ -15,8 +15,8 @@
   </style>
 
   <style name="InternalToolsRow">
-    <item name="android:layout_marginTop">@dimen/grid_3_half</item>
-    <item name="android:layout_marginBottom">@dimen/grid_3_half</item>
+    <item name="android:layout_marginTop">@dimen/grid_1</item>
+    <item name="android:layout_marginBottom">@dimen/grid_1</item>
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">wrap_content</item>
   </style>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
   <string name="Change_endpoint">Change API endpoint</string>
   <string name="Custom">Custom</string>
   <string name="Development_settings">Development Settings</string>
+  <string name="Device_ID">Device ID</string>
   <string name="debug_push_notifications_register_device">Register device</string>
   <string name="debug_push_notifications_device_registration">Device registration</string>
   <string name="debug_push_notifications_friend_backing">Friend backing</string>


### PR DESCRIPTION
# 📲 What
Adding device identifier to `InternalToolsActivity`

# 🤔 Why
When #731 is merged, it would be nice to know the device's distinct ID for Optimizely.

# 🛠 How
- Added a row to the `InternalToolsActivity` for the device identifier.
- Changed the row margins from `grid_3_half` to `grid_1` and the top padding from `activity_vertical_margin` to `grid_1` to condense the screen.

# 👀 See
| After 🦋 | Before 🐛 |
| --- | --- |
| ![screenshot-2020-02-12_104155](https://user-images.githubusercontent.com/1289295/74350949-74462f80-4d84-11ea-94a3-c244e6b5407e.png) | ![screenshot-2020-02-12_104206](https://user-images.githubusercontent.com/1289295/74350953-74462f80-4d84-11ea-9896-d9ababdc2e15.png) |

# 📋 QA
Take a peek at the Internal Tools.

# Story 📖
[NT-840]


[NT-840]: https://kickstarter.atlassian.net/browse/NT-840