### PR TITLE
[ℹ️] NT-805 BackingFragment reward card IA

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/NativeCheckoutRewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/NativeCheckoutRewardViewHolder.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.util.Pair
 import android.view.View
 import androidx.annotation.NonNull
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.jakewharton.rxbinding.view.RxView
 import com.kickstarter.R
@@ -41,7 +40,7 @@ class NativeCheckoutRewardViewHolder(private val view: View, val delegate: Deleg
         this.viewModel.outputs.background()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { if (!this.inset) this.view.reward_contents.setBackgroundResource(it) }
+                .subscribe { this.view.reward_contents.setBackgroundResource(it) }
 
         this.viewModel.outputs.conversionIsGone()
                 .compose(bindToLifecycle())
@@ -161,7 +160,7 @@ class NativeCheckoutRewardViewHolder(private val view: View, val delegate: Deleg
         this.viewModel.outputs.backersCountIsGone()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { ViewUtils.setGone(this.view.reward_backers_count, this.inset || it) }
+                .subscribe { ViewUtils.setGone(this.view.reward_backers_count, it) }
 
         this.viewModel.outputs.estimatedDelivery()
                 .compose(bindToLifecycle())
@@ -171,15 +170,11 @@ class NativeCheckoutRewardViewHolder(private val view: View, val delegate: Deleg
         this.viewModel.outputs.estimatedDeliveryIsGone()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { ViewUtils.setGone(this.view.reward_estimated_delivery_section, this.inset || it) }
+                .subscribe { ViewUtils.setGone(this.view.reward_estimated_delivery_section, it) }
 
         RxView.clicks(this.view.reward_pledge_button)
                 .compose(bindToLifecycle())
                 .subscribe { this.viewModel.inputs.rewardClicked(this.adapterPosition) }
-
-        when {
-            BooleanUtils.isTrue(this.inset) -> this.view.reward_card.setCardBackgroundColor(ContextCompat.getColor(context(), R.color.transparent))
-        }
     }
 
     override fun bindData(data: Any?) {

--- a/app/src/main/res/layout/fragment_backing.xml
+++ b/app/src/main/res/layout/fragment_backing.xml
@@ -26,14 +26,14 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        android:layout_marginStart="@dimen/grid_3"
+        android:layout_marginEnd="@dimen/grid_3"
         android:paddingBottom="@dimen/grid_4">
 
         <LinearLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginStart="@dimen/grid_3"
           android:layout_marginTop="@dimen/grid_4"
-          android:layout_marginEnd="@dimen/grid_3"
           android:orientation="vertical">
 
           <LinearLayout
@@ -163,8 +163,6 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_gravity="center_vertical"
-          android:layout_marginStart="@dimen/grid_3"
-          android:layout_marginEnd="@dimen/grid_3"
           android:orientation="vertical"
           android:paddingBottom="@dimen/grid_2">
 


### PR DESCRIPTION
# 📲 What
Reverting hiding reward IA in view/manage pledge screen. It will now display the backers count and estimated delivery.

# 🤔 Why
They were hidden in #613 but they're back now.

# 🛠 How
- Added start and end margin to `BackingFragment` root view.
- Removed special `inset` behavior for `NativeCheckoutRewardCardViewHolder` except for `Select` button

# 👀 See
| After 🦋 | Before 🐛 |
| --- | --- |
| ![Screenshot_1581524534](https://user-images.githubusercontent.com/1289295/74354905-0bfa4c80-4d8a-11ea-808d-3007d034b509.png) | ![Screenshot_20200212-112328](https://user-images.githubusercontent.com/1289295/74354987-2f24fc00-4d8a-11ea-9246-69bff2207949.png) |

# 📋 QA
View or manage your pledge.

# Story 📖
NT-805
