### PR TITLE
[␠] NT-805 Missed bottom margin of reward in fragment_backing

### DIFF
--- a/app/src/main/res/layout/fragment_backing.xml
+++ b/app/src/main/res/layout/fragment_backing.xml
@@ -156,7 +156,7 @@
           layout="@layout/item_reward"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          tools:visibility="gone" />
+          android:layout_marginBottom="@dimen/grid_4"/>
 
         <LinearLayout
           android:id="@+id/received_section"


### PR DESCRIPTION
# 📲 What
Adding some bottom margin to the reward card of view/manage pledge screen.

# 🤔 Why
So the divider has room to breathe.

# 🛠 How
`item_reward` now has `grid_4` bottom margin

# 👀 See
| After 🦋 | Before 🐛 |
| --- | --- |
| ![screenshot-2020-02-13_135643](https://user-images.githubusercontent.com/1289295/74468332-ae88fd00-4e68-11ea-9a2b-bd7d88f78f76.png) | ![screenshot-2020-02-13_134548](https://user-images.githubusercontent.com/1289295/74468330-adf06680-4e68-11ea-8fa6-e95d6b6cd652.png) |

# 📋 QA
Look at all that space.

# Story 📖
[NT-805]

[NT-805]: https://kickstarter.atlassian.net/browse/NT-805