### PR TITLE
[💳] NT-846 Checkout Payment Page Viewed event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -11,7 +11,6 @@ import com.kickstarter.ui.data.Editorial;
 import com.kickstarter.ui.data.LoginReason;
 import com.kickstarter.ui.data.Mailbox;
 import com.kickstarter.ui.data.PledgeData;
-import com.kickstarter.ui.data.ProjectData;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -756,21 +755,7 @@ public final class Koala {
 
   //region Back a project
   public void trackCheckoutPaymentPageViewed(final @NonNull PledgeData pledgeData) {
-    final ProjectData projectData = pledgeData.projectData();
-    final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
-    props.putAll(KoalaUtils.pledgeProperties(pledgeData.reward()));
-
-    final RefTag intentRefTag = projectData.refTagFromIntent();
-    if (intentRefTag != null) {
-      props.put("session_ref_tag", intentRefTag.tag());
-    }
-
-    final RefTag cookieRefTag = projectData.refTagFromCookie();
-    if (cookieRefTag != null) {
-      props.put("session_referrer_credit", cookieRefTag.tag());
-    }
-
-    props.put("context_pledge_flow", pledgeData.pledgeFlowContext().getTrackingString());
+    final Map<String, Object> props = KoalaUtils.pledgeDataProperties(pledgeData, this.client.loggedInUser());
 
     this.client.track(LakeEvent.CHECKOUT_PAYMENT_PAGE_VIEWED, props);
   }
@@ -790,21 +775,7 @@ public final class Koala {
   }
 
   public void trackSelectRewardButtonClicked(final @NonNull PledgeData pledgeData) {
-    final ProjectData projectData = pledgeData.projectData();
-    final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
-    props.putAll(KoalaUtils.pledgeProperties(pledgeData.reward()));
-
-    final RefTag intentRefTag = projectData.refTagFromIntent();
-    if (intentRefTag != null) {
-      props.put("session_ref_tag", intentRefTag.tag());
-    }
-
-    final RefTag cookieRefTag = projectData.refTagFromCookie();
-    if (cookieRefTag != null) {
-      props.put("session_referrer_credit", cookieRefTag.tag());
-    }
-
-    props.put("context_pledge_flow", pledgeData.pledgeFlowContext().getTrackingString());
+    final Map<String, Object> props = KoalaUtils.pledgeDataProperties(pledgeData, this.client.loggedInUser());
 
     this.client.track(LakeEvent.SELECT_REWARD_BUTTON_CLICKED, props);
   }

--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -755,6 +755,26 @@ public final class Koala {
   //endregion
 
   //region Back a project
+  public void trackCheckoutPaymentPageViewed(final @NonNull PledgeData pledgeData) {
+    final ProjectData projectData = pledgeData.projectData();
+    final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
+    props.putAll(KoalaUtils.pledgeProperties(pledgeData.reward()));
+
+    final RefTag intentRefTag = projectData.refTagFromIntent();
+    if (intentRefTag != null) {
+      props.put("session_ref_tag", intentRefTag.tag());
+    }
+
+    final RefTag cookieRefTag = projectData.refTagFromCookie();
+    if (cookieRefTag != null) {
+      props.put("session_referrer_credit", cookieRefTag.tag());
+    }
+
+    props.put("context_pledge_flow", pledgeData.pledgeFlowContext().getTrackingString());
+
+    this.client.track(LakeEvent.CHECKOUT_PAYMENT_PAGE_VIEWED, props);
+  }
+
   public void trackProjectPagePledgeButtonClicked(final @NonNull Project project, final @Nullable RefTag intentRefTag, final @Nullable RefTag cookieRefTag) {
     final Map<String, Object> props = KoalaUtils.projectProperties(project, this.client.loggedInUser());
 

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -8,7 +8,6 @@ const val EXPLORE_PAGE_VIEWED = "Explore Page Viewed"
 const val EXPLORE_SORT_CLICKED = "Explore Sort Clicked"
 const val FILTER_CLICKED = "Filter Clicked"
 const val HAMBURGER_MENU_CLICKED = "Hamburger Menu Clicked"
-const val PROJECT_PAGE_PLEDGE_BUTTON_CLICKED = "Project Page Pledge Button Clicked"
 const val PROJECT_PAGE_VIEWED = "Project Page Viewed"
 const val SEARCH_BUTTON_CLICKED = "Search Button Clicked"
 const val SEARCH_PAGE_VIEWED = "Search Page Viewed"
@@ -16,5 +15,7 @@ const val SEARCH_RESULTS_LOADED = "Search Results Loaded"
 // endregion
 
 // region Back a Project
+const val CHECKOUT_PAYMENT_PAGE_VIEWED = "Checkout Payment Page Viewed"
+const val PROJECT_PAGE_PLEDGE_BUTTON_CLICKED = "Project Page Pledge Button Clicked"
 const val SELECT_REWARD_BUTTON_CLICKED = "Select Reward Button Clicked"
 // endregion

--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -1,5 +1,6 @@
 package com.kickstarter.libs.utils;
 
+import com.kickstarter.libs.RefTag;
 import com.kickstarter.models.Activity;
 import com.kickstarter.models.Category;
 import com.kickstarter.models.Location;
@@ -8,6 +9,8 @@ import com.kickstarter.models.Reward;
 import com.kickstarter.models.Update;
 import com.kickstarter.models.User;
 import com.kickstarter.services.DiscoveryParams;
+import com.kickstarter.ui.data.PledgeData;
+import com.kickstarter.ui.data.ProjectData;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -103,6 +106,25 @@ public final class KoalaUtils {
     };
 
     return MapUtils.prefixKeys(properties, prefix);
+  }
+
+  public static @NonNull Map<String, Object> pledgeDataProperties(final @NonNull PledgeData pledgeData, final @Nullable User loggedInUser) {
+    final ProjectData projectData = pledgeData.projectData();
+    final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), loggedInUser);
+    props.putAll(KoalaUtils.pledgeProperties(pledgeData.reward()));
+
+    final RefTag intentRefTag = projectData.refTagFromIntent();
+    if (intentRefTag != null) {
+      props.put("session_ref_tag", intentRefTag.tag());
+    }
+
+    final RefTag cookieRefTag = projectData.refTagFromCookie();
+    if (cookieRefTag != null) {
+      props.put("session_referrer_credit", cookieRefTag.tag());
+    }
+
+    props.put("context_pledge_flow", pledgeData.pledgeFlowContext().getTrackingString());
+    return props;
   }
 
   public static @NonNull Map<String, Object> pledgeProperties(final @NonNull Reward reward) {

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -18,10 +18,7 @@ import com.kickstarter.services.apiresponses.ShippingRulesEnvelope
 import com.kickstarter.services.mutations.CreateBackingData
 import com.kickstarter.services.mutations.UpdateBackingData
 import com.kickstarter.ui.ArgumentsKey
-import com.kickstarter.ui.data.CardState
-import com.kickstarter.ui.data.PledgeData
-import com.kickstarter.ui.data.PledgeReason
-import com.kickstarter.ui.data.ScreenLocation
+import com.kickstarter.ui.data.*
 import com.kickstarter.ui.fragments.PledgeFragment
 import com.stripe.android.StripeIntentResult
 import rx.Observable
@@ -1009,6 +1006,12 @@ interface PledgeFragmentViewModel {
                     .compose<Project>(takeWhen(updatePaymentClick))
                     .compose(bindToLifecycle())
                     .subscribe { this.koala.trackUpdatePaymentMethodButtonClicked(it) }
+
+            pledgeData
+                    .take(1)
+                    .filter { it.pledgeFlowContext() == PledgeFlowContext.NEW_PLEDGE }
+                    .compose(bindToLifecycle())
+                    .subscribe { this.lake.trackCheckoutPaymentPageViewed(it) }
         }
 
         private fun backingShippingRule(shippingRules: List<ShippingRule>, backing: Backing): Observable<ShippingRule> {

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -289,6 +289,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.updatePledgeProgressIsGone.assertNoValues()
 
         this.koalaTest.assertValue("Pledge Screen Viewed")
+        this.lakeTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -313,6 +314,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.updatePledgeProgressIsGone.assertNoValues()
 
         this.koalaTest.assertValue("Pledge Screen Viewed")
+        this.lakeTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -341,6 +343,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.updatePledgeProgressIsGone.assertNoValues()
 
         this.koalaTest.assertValue("Pledge Screen Viewed")
+        this.lakeTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -365,6 +368,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.updatePledgeProgressIsGone.assertNoValues()
 
         this.koalaTest.assertValue("Pledge Screen Viewed")
+        this.lakeTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -416,6 +420,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.updatePledgeProgressIsGone.assertNoValues()
 
         this.koalaTest.assertNoValues()
+        this.lakeTest.assertNoValues()
     }
 
     @Test
@@ -451,6 +456,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.updatePledgeProgressIsGone.assertNoValues()
 
         this.koalaTest.assertNoValues()
+        this.lakeTest.assertNoValues()
     }
 
     @Test
@@ -502,6 +508,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.updatePledgeProgressIsGone.assertNoValues()
 
         this.koalaTest.assertNoValues()
+        this.lakeTest.assertNoValues()
     }
 
     @Test
@@ -537,6 +544,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.updatePledgeProgressIsGone.assertNoValues()
 
         this.koalaTest.assertNoValues()
+        this.lakeTest.assertNoValues()
     }
 
     @Test
@@ -567,6 +575,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.updatePledgeProgressIsGone.assertNoValues()
 
         this.koalaTest.assertNoValues()
+        this.lakeTest.assertNoValues()
     }
 
     @Test
@@ -593,6 +602,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.updatePledgeProgressIsGone.assertNoValues()
 
         this.koalaTest.assertNoValues()
+        this.lakeTest.assertNoValues()
     }
 
     @Test
@@ -1370,6 +1380,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.pledgeButtonClicked("t3st")
 
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
+        this.lakeTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -1485,6 +1496,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.newCardButtonClicked()
         this.showNewCardFragment.assertValue(project)
         this.koalaTest.assertValues("Pledge Screen Viewed", "Add New Card Button Clicked")
+        this.lakeTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -1495,6 +1507,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.newCardButtonClicked()
         this.showNewCardFragment.assertValue(backedProject)
         this.koalaTest.assertNoValues()
+        this.lakeTest.assertNoValues()
     }
 
     @Test
@@ -2051,6 +2064,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
+        this.lakeTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -2070,6 +2084,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
+        this.lakeTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -2093,6 +2108,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
+        this.lakeTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -2119,6 +2135,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeError.assertValueCount(1)
         this.showSCAFlow.assertNoValues()
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
+        this.lakeTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -2145,6 +2162,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeError.assertNoValues()
         this.showSCAFlow.assertValueCount(1)
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
+        this.lakeTest.assertValue("Checkout Payment Page Viewed")
 
         this.vm.inputs.stripeSetupResultSuccessful(StripeIntentResult.Outcome.SUCCEEDED)
 
@@ -2176,6 +2194,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeError.assertNoValues()
         this.showSCAFlow.assertValueCount(1)
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
+        this.lakeTest.assertValue("Checkout Payment Page Viewed")
 
         this.vm.inputs.stripeSetupResultSuccessful(StripeIntentResult.Outcome.FAILED)
 
@@ -2208,6 +2227,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeError.assertNoValues()
         this.showSCAFlow.assertValueCount(1)
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
+        this.lakeTest.assertValue("Checkout Payment Page Viewed")
 
         this.vm.inputs.stripeSetupResultUnsuccessful(Exception("yikes"))
 


### PR DESCRIPTION
# 📲 What
Adding `Checkout Payment Page Viewed` event.

# 🤔 Why
We have new Back a Project events.

# 🛠 How
- Added `LakeEvent.CHECKOUT_PAYMENT_PAGE_VIEWED` with value `"Project Page Pledge Button Clicked"`
- Added `KoalaUtils.pledgeDataProperties` since we also pass the same data for the `Select Reward Button Clicked` event
- Added `Koala.trackCheckoutPaymentPageViewed`
- Tracking when a user views the pledge screen of an unbacked project
- Updated tests in `PledgeFragmentViewModelTest`

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-846]

[NT-846]: https://kickstarter.atlassian.net/browse/NT-846