### PR TITLE
[🛍] NT-847 Pledge Submit Button Clicked event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -7,6 +7,7 @@ import com.kickstarter.models.Update;
 import com.kickstarter.models.User;
 import com.kickstarter.services.DiscoveryParams;
 import com.kickstarter.services.apiresponses.PushNotificationEnvelope;
+import com.kickstarter.ui.data.CheckoutData;
 import com.kickstarter.ui.data.Editorial;
 import com.kickstarter.ui.data.LoginReason;
 import com.kickstarter.ui.data.Mailbox;
@@ -755,6 +756,12 @@ public final class Koala {
   //endregion
 
   //region Back a project
+  public void trackPledgeSubmitButtonClicked(final @NonNull CheckoutData checkoutData, final @NonNull PledgeData pledgeData) {
+    final Map<String, Object> props = KoalaUtils.checkoutDataProperties(checkoutData, pledgeData, this.client.loggedInUser());
+
+    this.client.track(LakeEvent.PLEDGE_SUBMIT_BUTTON_CLICKED, props);
+  }
+
   public void trackProjectPagePledgeButtonClicked(final @NonNull Project project, final @Nullable RefTag intentRefTag, final @Nullable RefTag cookieRefTag) {
     final Map<String, Object> props = KoalaUtils.projectProperties(project, this.client.loggedInUser());
 

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -16,5 +16,6 @@ const val SEARCH_RESULTS_LOADED = "Search Results Loaded"
 // endregion
 
 // region Back a Project
+const val PLEDGE_SUBMIT_BUTTON_CLICKED = "Pledge Submit Button Clicked"
 const val SELECT_REWARD_BUTTON_CLICKED = "Select Reward Button Clicked"
 // endregion

--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -1,5 +1,8 @@
 package com.kickstarter.libs.utils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.models.Activity;
 import com.kickstarter.models.Category;
@@ -17,22 +20,22 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 public final class KoalaUtils {
   private KoalaUtils() {}
 
-  public static @NonNull Map<String, Object> checkoutProperties(final @NonNull CheckoutData checkoutData, final @NonNull Reward reward) {
-    return checkoutProperties(checkoutData, reward, "checkout_");
+  public static @NonNull Map<String, Object> checkoutProperties(final @NonNull CheckoutData checkoutData, final @NonNull PledgeData pledgeData) {
+    return checkoutProperties(checkoutData, pledgeData, "checkout_");
   }
 
-  public static @NonNull Map<String, Object> checkoutProperties(final @NonNull CheckoutData checkoutData, final @NonNull Reward reward, final @NonNull String prefix) {
+  public static @NonNull Map<String, Object> checkoutProperties(final @NonNull CheckoutData checkoutData, final @NonNull PledgeData pledgeData, final @NonNull String prefix) {
+    final Reward reward = pledgeData.reward();
+    final Project project = pledgeData.projectData().project();
     final Map<String, Object> properties = Collections.unmodifiableMap(new HashMap<String, Object>() {
       {
+        put("amount", checkoutData.amount());
         put("id", checkoutData.id());
-        put("payment_type", checkoutData.paymentType());
-        put("revenue_in_usd_cents", checkoutData.revenueInUSDCents());
+        put("payment_type", checkoutData.paymentType().rawValue());
+        put("revenue_in_usd_cents", Math.round(checkoutData.amount() * project.staticUsdRate() * 100));
         put("reward_estimated_delivery_on", reward.estimatedDeliveryOn() != null ? reward.estimatedDeliveryOn().getMillis() / 1000 : null);
         put("reward_id", reward.id());
         put("reward_title", reward.title());
@@ -48,7 +51,7 @@ public final class KoalaUtils {
     final ProjectData projectData = pledgeData.projectData();
     final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), loggedInUser);
     props.putAll(KoalaUtils.pledgeProperties(pledgeData.reward()));
-    props.putAll(KoalaUtils.checkoutProperties(checkoutData, pledgeData.reward()));
+    props.putAll(KoalaUtils.checkoutProperties(checkoutData, pledgeData));
 
     final RefTag intentRefTag = projectData.refTagFromIntent();
     if (intentRefTag != null) {

--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -1,5 +1,8 @@
 package com.kickstarter.libs.utils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.models.Activity;
 import com.kickstarter.models.Category;
@@ -16,9 +19,6 @@ import com.kickstarter.ui.data.ProjectData;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public final class KoalaUtils {
   private KoalaUtils() {}
@@ -40,7 +40,6 @@ public final class KoalaUtils {
         put("reward_id", reward.id());
         put("reward_title", reward.title());
         put("shipping_amount", checkoutData.shippingAmount());
-
       }
     });
 

--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -36,9 +36,6 @@ public final class KoalaUtils {
         put("id", checkoutData.id());
         put("payment_type", checkoutData.paymentType().rawValue());
         put("revenue_in_usd_cents", Math.round(checkoutData.amount() * project.staticUsdRate() * 100));
-        put("reward_estimated_delivery_on", reward.estimatedDeliveryOn() != null ? reward.estimatedDeliveryOn().getMillis() / 1000 : null);
-        put("reward_id", reward.id());
-        put("reward_title", reward.title());
         put("shipping_amount", checkoutData.shippingAmount());
       }
     });
@@ -165,6 +162,7 @@ public final class KoalaUtils {
   public static @NonNull Map<String, Object> pledgeProperties(final @NonNull Reward reward, final @NonNull String prefix) {
     final Map<String, Object> properties = new HashMap<String, Object>() {
       {
+        put("estimated_delivery_on", reward.estimatedDeliveryOn() != null ? reward.estimatedDeliveryOn().getMillis() / 1000 : null);
         put("has_items", RewardUtils.isItemized(reward));
         put("id", reward.id());
         put("is_limited_time", RewardUtils.isTimeLimited(reward));
@@ -172,6 +170,7 @@ public final class KoalaUtils {
         put("minimum", reward.minimum());
         put("shipping_enabled", RewardUtils.isShippable(reward));
         put("shipping_preference", reward.shippingPreference());
+        put("title", reward.title());
       }
     };
 

--- a/app/src/main/java/com/kickstarter/mock/factories/CheckoutDataFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CheckoutDataFactory.kt
@@ -1,0 +1,16 @@
+package com.kickstarter.mock.factories
+
+import com.kickstarter.ui.data.CheckoutData
+import type.CreditCardPaymentType
+
+class CheckoutDataFactory private constructor() {
+    companion object {
+        fun checkoutData(shippingAmount: Double, totalAmount: Double): CheckoutData {
+            return CheckoutData.builder()
+                    .amount(totalAmount)
+                    .paymentType(CreditCardPaymentType.CREDIT_CARD)
+                    .shippingAmount(shippingAmount)
+                    .build()
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/ui/data/CheckoutData.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/CheckoutData.kt
@@ -7,17 +7,15 @@ import type.CreditCardPaymentType
 @AutoParcel
 abstract class CheckoutData : Parcelable {
     abstract fun amount(): Double
-    abstract fun id(): Long
-    abstract fun paymentType(): ProjectData
-    abstract fun revenueInUSDCents(): Int
-    abstract fun shippingAmount(): Double?
+    abstract fun id(): Long?
+    abstract fun paymentType(): CreditCardPaymentType
+    abstract fun shippingAmount(): Double
 
     @AutoParcel.Builder
     abstract class Builder {
         abstract fun amount(amount: Double): Builder
-        abstract fun id(id: Long): Builder
+        abstract fun id(id: Long?): Builder
         abstract fun paymentType(paymentType: CreditCardPaymentType): Builder
-        abstract fun revenueInUSDCents(revenueInCents: Int): Builder
         abstract fun shippingAmount(shippingAmount: Double): Builder
         abstract fun build(): CheckoutData
     }

--- a/app/src/main/java/com/kickstarter/ui/data/CheckoutData.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/CheckoutData.kt
@@ -1,0 +1,33 @@
+package com.kickstarter.ui.data
+
+import android.os.Parcelable
+import auto.parcel.AutoParcel
+import type.CreditCardPaymentType
+
+@AutoParcel
+abstract class CheckoutData : Parcelable {
+    abstract fun amount(): Double
+    abstract fun id(): Long
+    abstract fun paymentType(): ProjectData
+    abstract fun revenueInUSDCents(): Int
+    abstract fun shippingAmount(): Double?
+
+    @AutoParcel.Builder
+    abstract class Builder {
+        abstract fun amount(amount: Double): Builder
+        abstract fun id(id: Long): Builder
+        abstract fun paymentType(paymentType: CreditCardPaymentType): Builder
+        abstract fun revenueInUSDCents(revenueInCents: Int): Builder
+        abstract fun shippingAmount(shippingAmount: Double): Builder
+        abstract fun build(): CheckoutData
+    }
+
+    abstract fun toBuilder(): Builder
+
+    companion object {
+
+        fun builder(): Builder {
+            return AutoParcel_CheckoutData.Builder()
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -18,15 +18,13 @@ import com.kickstarter.services.apiresponses.ShippingRulesEnvelope
 import com.kickstarter.services.mutations.CreateBackingData
 import com.kickstarter.services.mutations.UpdateBackingData
 import com.kickstarter.ui.ArgumentsKey
-import com.kickstarter.ui.data.CardState
-import com.kickstarter.ui.data.PledgeData
-import com.kickstarter.ui.data.PledgeReason
-import com.kickstarter.ui.data.ScreenLocation
+import com.kickstarter.ui.data.*
 import com.kickstarter.ui.fragments.PledgeFragment
 import com.stripe.android.StripeIntentResult
 import rx.Observable
 import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
+import type.CreditCardPaymentType
 import java.math.RoundingMode
 import java.net.CookieManager
 import kotlin.math.max
@@ -1009,10 +1007,26 @@ interface PledgeFragmentViewModel {
                     .compose<Project>(takeWhen(updatePaymentClick))
                     .compose(bindToLifecycle())
                     .subscribe { this.koala.trackUpdatePaymentMethodButtonClicked(it) }
+
+            Observable.combineLatest<Double, Double, CheckoutData>(shippingAmount, total)
+            { s, t -> checkoutData(s, t) }
+                    .compose<Pair<CheckoutData, PledgeData>>(combineLatestPair(pledgeData))
+                    .filter { it.second.pledgeFlowContext() == PledgeFlowContext.NEW_PLEDGE }
+                    .compose<Pair<CheckoutData, PledgeData>>(takeWhen(this.pledgeButtonClicked))
+                    .compose(bindToLifecycle())
+                    .subscribe { this.lake.trackPledgeSubmitButtonClicked(it.first, it.second) }
         }
 
         private fun backingShippingRule(shippingRules: List<ShippingRule>, backing: Backing): Observable<ShippingRule> {
             return Observable.just(shippingRules.firstOrNull { it.location().id() == backing.locationId() })
+        }
+
+        private fun checkoutData(shippingAmount: Double, total: Double): CheckoutData {
+            return CheckoutData.builder()
+                    .amount(total)
+                    .paymentType(CreditCardPaymentType.CREDIT_CARD)
+                    .shippingAmount(shippingAmount)
+                    .build()
         }
 
         private fun defaultShippingRule(shippingRules: List<ShippingRule>): Observable<ShippingRule> {

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -722,9 +722,9 @@ interface ProjectViewModel {
             val currentProjectData = Observable.combineLatest<RefTag, RefTag, Project, ProjectData>(refTag, cookieRefTag, currentProject)
             { refTagFromIntent, refTagFromCookie, project -> projectData(refTagFromIntent, refTagFromCookie, project) }
                     .filter { it.project().hasRewards() }
-                    .take(1)
 
             currentProjectData
+                    .take(1)
                     .compose(bindToLifecycle())
                     .subscribe { data ->
                         // If a cookie hasn't been set for this ref+project then do so.

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -312,12 +312,14 @@ class LakeTest : KSRobolectricTestCase() {
 
         val projectData = ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended())
 
-        lake.trackSelectRewardButtonClicked(PledgeData.with(PledgeFlowContext.NEW_PLEDGE, projectData, reward()))
+        lake.trackPledgeSubmitButtonClicked(CheckoutDataFactory.checkoutData(20.0, 30.0),
+                PledgeData.with(PledgeFlowContext.NEW_PLEDGE, projectData, reward()))
 
         assertSessionProperties(user)
         assertProjectProperties(project)
         assertContextProperties()
         assertPledgeProperties()
+        assertCheckoutProperties()
 
         val expectedProperties = propertiesTest.value
         assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
@@ -325,7 +327,19 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals(false, expectedProperties["project_user_is_backer"])
         assertEquals(false, expectedProperties["project_user_is_project_creator"])
 
-        this.lakeTest.assertValues("Pledge Submit Button Clickedd")
+        this.lakeTest.assertValues("Pledge Submit Button Clicked")
+    }
+
+    private fun assertCheckoutProperties() {
+        val expectedProperties = propertiesTest.value
+        assertEquals(30.0, expectedProperties["checkout_amount"])
+        assertNull(expectedProperties["id"])
+        assertEquals("CREDIT_CARD", expectedProperties["checkout_payment_type"])
+        assertEquals(3000L, expectedProperties["checkout_revenue_in_usd_cents"])
+        assertEquals(DateTime.parse("2019-03-26T19:26:09Z").millis / 1000, expectedProperties["checkout_reward_estimated_delivery_on"])
+        assertEquals(2L, expectedProperties["checkout_reward_id"])
+        assertEquals("Digital Bundle", expectedProperties["checkout_reward_title"])
+        assertEquals(20.0, expectedProperties["checkout_shipping_amount"])
     }
 
     private fun assertContextProperties() {

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -336,9 +336,6 @@ class LakeTest : KSRobolectricTestCase() {
         assertNull(expectedProperties["id"])
         assertEquals("CREDIT_CARD", expectedProperties["checkout_payment_type"])
         assertEquals(3000L, expectedProperties["checkout_revenue_in_usd_cents"])
-        assertEquals(DateTime.parse("2019-03-26T19:26:09Z").millis / 1000, expectedProperties["checkout_reward_estimated_delivery_on"])
-        assertEquals(2L, expectedProperties["checkout_reward_id"])
-        assertEquals("Digital Bundle", expectedProperties["checkout_reward_title"])
         assertEquals(20.0, expectedProperties["checkout_shipping_amount"])
     }
 
@@ -349,6 +346,7 @@ class LakeTest : KSRobolectricTestCase() {
 
     private fun assertPledgeProperties() {
         val expectedProperties = propertiesTest.value
+        assertEquals(DateTime.parse("2019-03-26T19:26:09Z").millis / 1000, expectedProperties["pledge_backer_reward_estimated_delivery_on"])
         assertEquals(false, expectedProperties["pledge_backer_reward_has_items"])
         assertEquals(2L, expectedProperties["pledge_backer_reward_id"])
         assertEquals(false, expectedProperties["pledge_backer_reward_is_limited_time"])
@@ -356,6 +354,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals(10.0, expectedProperties["pledge_backer_reward_minimum"])
         assertEquals(true, expectedProperties["pledge_backer_reward_shipping_enabled"])
         assertEquals("unrestricted", expectedProperties["pledge_backer_reward_shipping_preference"])
+        assertEquals("Digital Bundle", expectedProperties["pledge_backer_reward_title"])
     }
 
     private fun assertProjectProperties(project: Project) {

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -301,6 +301,33 @@ class LakeTest : KSRobolectricTestCase() {
         this.lakeTest.assertValues("Select Reward Button Clicked")
     }
 
+    @Test
+    fun testCheckoutProperties() {
+        val project = project()
+        val user = user()
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), true)
+        client.eventNames.subscribe(this.lakeTest)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val lake = Koala(client)
+
+        val projectData = ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended())
+
+        lake.trackSelectRewardButtonClicked(PledgeData.with(PledgeFlowContext.NEW_PLEDGE, projectData, reward()))
+
+        assertSessionProperties(user)
+        assertProjectProperties(project)
+        assertContextProperties()
+        assertPledgeProperties()
+
+        val expectedProperties = propertiesTest.value
+        assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
+        assertEquals(false, expectedProperties["project_user_has_watched"])
+        assertEquals(false, expectedProperties["project_user_is_backer"])
+        assertEquals(false, expectedProperties["project_user_is_project_creator"])
+
+        this.lakeTest.assertValues("Pledge Submit Button Clickedd")
+    }
+
     private fun assertContextProperties() {
         val expectedProperties = propertiesTest.value
         assertEquals(DateTime.parse("2018-11-02T18:42:05Z").millis / 1000, expectedProperties["context_timestamp"])

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -1380,7 +1380,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.pledgeButtonClicked("t3st")
 
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
-        this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
     }
 
     @Test
@@ -2064,7 +2064,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
-        this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
     }
 
     @Test
@@ -2084,7 +2084,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
-        this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
     }
 
     @Test
@@ -2108,7 +2108,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
-        this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
     }
 
     @Test
@@ -2135,7 +2135,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeError.assertValueCount(1)
         this.showSCAFlow.assertNoValues()
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
-        this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
     }
 
     @Test
@@ -2162,7 +2162,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeError.assertNoValues()
         this.showSCAFlow.assertValueCount(1)
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
-        this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
 
         this.vm.inputs.stripeSetupResultSuccessful(StripeIntentResult.Outcome.SUCCEEDED)
 
@@ -2194,7 +2194,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeError.assertNoValues()
         this.showSCAFlow.assertValueCount(1)
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
-        this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
 
         this.vm.inputs.stripeSetupResultSuccessful(StripeIntentResult.Outcome.FAILED)
 
@@ -2227,7 +2227,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeError.assertNoValues()
         this.showSCAFlow.assertValueCount(1)
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
-        this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
 
         this.vm.inputs.stripeSetupResultUnsuccessful(Exception("yikes"))
 


### PR DESCRIPTION
# 📲 What
Adding `Pledge Submit Button Clicked` event.

# 🤔 Why
We have new Back a Project events.

# 🛠 How
- Added `LakeEvent. PLEDGE_SUBMIT_BUTTON_CLICKED ` with value `"Pledge Submit Button Clicked"`
- Added `Koala. trackPledgeSubmitButtonClicked `
- Added `CheckoutData` and `CheckoutDataFactory `model to hold data needed for Checkout properties group
- Tracking when a user clicks the `"Pledge"` button in `PledgeFragmentViewModel`
- Added tests in `PledgeFragmentViewModelTest`
- Added `LakeTest` for checkout properties

## bug
- Fixed bug where `Project Page Pledge Button Clicked` event fired after user backed project because `take(1)` was used.

## property update
- Moved `reward_estimated_delivery_on` and `reward_title` to pledge property group.

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-847]

[NT-847]: https://kickstarter.atlassian.net/browse/NT-847