### PR TITLE
[🕸] NT-875 Campaign details webview

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,10 @@
       android:theme="@style/ActivityFeedActivity">
     </activity>
     <activity
+      android:name=".ui.activities.CampaignDetailsActivity"
+      android:parentActivityName=".ui.activities.ProjectActivity">
+    </activity>
+    <activity
       android:name=".ui.activities.ChangeEmailActivity"
       android:theme="@style/SettingsActivity" />
     <activity

--- a/app/src/main/java/com/kickstarter/models/Project.java
+++ b/app/src/main/java/com/kickstarter/models/Project.java
@@ -3,10 +3,15 @@ package com.kickstarter.models;
 import android.net.Uri;
 import android.os.Parcelable;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringDef;
+
 import com.kickstarter.libs.Permission;
 import com.kickstarter.libs.qualifiers.AutoGson;
 import com.kickstarter.libs.utils.DateTimeUtils;
 import com.kickstarter.libs.utils.IntegerUtils;
+import com.kickstarter.libs.utils.UrlUtils;
 
 import org.joda.time.DateTime;
 
@@ -15,9 +20,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.Collections;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringDef;
 import auto.parcel.AutoParcel;
 
 @AutoGson
@@ -196,17 +198,11 @@ public abstract class Project implements Parcelable, Relay {
       public abstract Builder toBuilder();
 
       public @NonNull String creatorBio() {
-        return Uri.parse(project())
-          .buildUpon()
-          .appendEncodedPath("/creator_bio")
-          .toString();
+        return UrlUtils.INSTANCE.appendPath(project(), "creator_bio");
       }
 
       public @NonNull String description() {
-        return Uri.parse(project())
-          .buildUpon()
-          .appendEncodedPath("/description")
-          .toString();
+        return UrlUtils.INSTANCE.appendPath(project(), "description");
       }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/CampaignDetailsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CampaignDetailsActivity.kt
@@ -1,0 +1,32 @@
+package com.kickstarter.ui.activities
+
+import android.os.Bundle
+import android.util.Pair
+import androidx.annotation.NonNull
+import androidx.annotation.Nullable
+import com.kickstarter.R
+import com.kickstarter.libs.BaseActivity
+import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
+import com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft
+import com.kickstarter.viewmodels.CampaignDetailsViewModel
+import kotlinx.android.synthetic.main.activity_campaign_details.*
+import rx.android.schedulers.AndroidSchedulers
+
+@RequiresActivityViewModel(CampaignDetailsViewModel.ViewModel::class)
+class CampaignDetailsActivity : BaseActivity<CampaignDetailsViewModel.ViewModel>(){
+
+    override fun onCreate(@Nullable savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_campaign_details)
+
+        this.viewModel.outputs.url()
+                .observeOn(AndroidSchedulers.mainThread())
+                .compose(bindToLifecycle())
+                .subscribe { web_view.loadUrl(it) }
+    }
+
+    @NonNull
+    override fun exitTransition(): Pair<Int, Int>? {
+        return slideInFromLeft()
+    }
+}

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -61,7 +61,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     private val projectShareLabelString = R.string.project_accessibility_button_share_label
     private val projectShareCopyString = R.string.project_share_twitter_message
     private val projectStarConfirmationString = R.string.project_star_confirmation
-    private val campaignString = R.string.project_subpages_menu_buttons_campaign
 
     private val animDuration = 200L
 
@@ -647,7 +646,9 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     }
 
     private fun startCampaignWebViewActivity(project: Project) {
-        startWebViewActivity(getString(this.campaignString), project.descriptionUrl())
+        val intent = Intent(this, CampaignDetailsActivity::class.java)
+                .putExtra(IntentKey.PROJECT, project)
+        startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 
     private fun startCreatorBioWebViewActivity(project: Project) {
@@ -700,13 +701,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 .setType("text/plain")
                 .putExtra(Intent.EXTRA_TEXT, "$shareMessage $url")
         startActivity(Intent.createChooser(intent, getString(this.projectShareLabelString)))
-    }
-
-    private fun startWebViewActivity(toolbarTitle: String, url: String) {
-        val intent = Intent(this, WebViewActivity::class.java)
-                .putExtra(IntentKey.TOOLBAR_TITLE, toolbarTitle)
-                .putExtra(IntentKey.URL, url)
-        startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 
     private fun startLoginToutActivity() {

--- a/app/src/main/java/com/kickstarter/viewmodels/CampaignDetailsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CampaignDetailsViewModel.kt
@@ -1,0 +1,42 @@
+package com.kickstarter.viewmodels
+
+import androidx.annotation.NonNull
+import com.kickstarter.libs.ActivityViewModel
+import com.kickstarter.libs.Environment
+import com.kickstarter.models.Project
+import com.kickstarter.ui.IntentKey
+import com.kickstarter.ui.activities.CampaignDetailsActivity
+import rx.Observable
+import rx.subjects.BehaviorSubject
+
+interface CampaignDetailsViewModel {
+
+    interface Inputs
+
+    interface Outputs {
+        /** Emits the URL of the campaign to load in the web view. */
+        fun url(): Observable<String>
+    }
+
+    class ViewModel(environment: Environment) : ActivityViewModel<CampaignDetailsActivity>(environment), Inputs, Outputs {
+
+        private val url = BehaviorSubject.create<String>()
+
+        val inputs: Inputs = this
+        val outputs: Outputs = this
+
+        init {
+            val project = intent()
+                    .map { it.getParcelableExtra(IntentKey.PROJECT) as Project? }
+                    .ofType(Project::class.java)
+
+            project
+                    .map { it.descriptionUrl() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.url)
+        }
+
+        @NonNull
+        override fun url(): Observable<String> = this.url
+    }
+}

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -201,7 +201,7 @@ interface ProjectViewModel {
         /** Emits when we should start the [BackingActivity].  */
         fun startBackingActivity(): Observable<Pair<Project, User>>
 
-        /** Emits when we should start the campaign [com.kickstarter.ui.activities.WebViewActivity].  */
+        /** Emits when we should start the campaign [com.kickstarter.ui.activities.CampaignDetailsActivity].  */
         fun startCampaignWebViewActivity(): Observable<Project>
 
         /** Emits when we should start the [com.kickstarter.ui.activities.CheckoutActivity].  */

--- a/app/src/main/res/layout/activity_campaign_details.xml
+++ b/app/src/main/res/layout/activity_campaign_details.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+
+  <com.google.android.material.appbar.AppBarLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.kickstarter.ui.toolbars.KSToolbar
+      android:id="@+id/web_view_toolbar"
+      style="@style/Toolbar"
+      app:contentInsetLeft="0dp"
+      app:contentInsetStart="0dp">
+
+      <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <com.kickstarter.ui.views.IconButton
+          android:id="@+id/back_button"
+          style="@style/ToolbarIconBackButton" />
+
+        <TextView
+          android:id="@+id/title_text_view"
+          style="@style/ToolbarTitle"
+          android:text="@string/project_menu_buttons_campaign" />
+
+      </RelativeLayout>
+
+    </com.kickstarter.ui.toolbars.KSToolbar>
+
+  </com.google.android.material.appbar.AppBarLayout>
+
+  <com.kickstarter.ui.views.KSWebView
+    android:id="@+id/web_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
@@ -1,0 +1,44 @@
+package com.kickstarter.viewmodels
+
+import android.content.Intent
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Environment
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.models.Project
+import com.kickstarter.ui.IntentKey
+import org.junit.Test
+import rx.observers.TestSubscriber
+
+class CampaignDetailsViewModelTest : KSRobolectricTestCase() {
+    private lateinit var vm: CampaignDetailsViewModel.ViewModel
+
+    private val url = TestSubscriber<String>()
+
+    private fun setUpEnvironment(environment: Environment, project: Project) {
+        this.vm = CampaignDetailsViewModel.ViewModel(environment)
+
+        this.vm.outputs.url().subscribe(this.url)
+
+        // Configure the view model with a project.
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
+    }
+
+    @Test
+    fun testUrl() {
+        val projectUrl = "https://www.kickstarter.com/projects/creator/slug"
+        val web = Project.Urls.Web.builder()
+                .project(projectUrl)
+                .rewards("$projectUrl/rewards")
+                .updates("$projectUrl/posts")
+                .build()
+        val project = ProjectFactory.project()
+                .toBuilder()
+                .urls(Project.Urls.builder().web(web).build())
+                .build()
+
+        setUpEnvironment(environment(), project)
+
+        this.url.assertValue("https://www.kickstarter.com/projects/creator/slug/description")
+    }
+
+}


### PR DESCRIPTION
# 📲 What
Added a new screen explicitly for the campaign details.

# 🤔 Why
Prep for an experiment ⚗️

# 🛠 How
- Created new `CampaignDetailsActivity` to open campaign in webview. It has one output `url` that's the URL of the project's campaign.
- Now using `UrlUtils.appendPath` in Project url helper methods.
Tests.

# 👀 See
Looks EYE dentical
| Before 🐛 | After 🦋 |
| --- | --- |
| ![device-2020-02-14-180421 2020-02-14 18_06_38](https://user-images.githubusercontent.com/1289295/74575437-eff6d680-4f54-11ea-80dc-ad76ab4cfd10.gif) | ![device-2020-02-14-180421 2020-02-14 18_06_38](https://user-images.githubusercontent.com/1289295/74575437-eff6d680-4f54-11ea-80dc-ad76ab4cfd10.gif) |

# 📋 QA
Smash that read more button

# Story 📖
[NT-875]

[NT-875]: https://kickstarter.atlassian.net/browse/NT-875