### PR TITLE
[🙏🏾] NT-848 Thanks Page Viewed event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -1,5 +1,8 @@
 package com.kickstarter.libs;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.kickstarter.libs.utils.KoalaUtils;
 import com.kickstarter.models.Activity;
 import com.kickstarter.models.Project;
@@ -15,9 +18,6 @@ import com.kickstarter.ui.data.PledgeData;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 public final class Koala {
   private final @NonNull TrackingClientType client;
@@ -785,6 +785,12 @@ public final class Koala {
     final Map<String, Object> props = KoalaUtils.pledgeDataProperties(pledgeData, this.client.loggedInUser());
 
     this.client.track(LakeEvent.SELECT_REWARD_BUTTON_CLICKED, props);
+  }
+
+  public void trackThanksPageViewed(final @NonNull CheckoutData checkoutData, final @NonNull PledgeData pledgeData) {
+    final Map<String, Object> props = KoalaUtils.checkoutDataProperties(checkoutData, pledgeData, this.client.loggedInUser());
+
+    this.client.track(LakeEvent.THANKS_PAGE_VIEWED, props);
   }
   //endregion
 }

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -19,4 +19,5 @@ const val CHECKOUT_PAYMENT_PAGE_VIEWED = "Checkout Payment Page Viewed"
 const val PLEDGE_SUBMIT_BUTTON_CLICKED = "Pledge Submit Button Clicked"
 const val PROJECT_PAGE_PLEDGE_BUTTON_CLICKED = "Project Page Pledge Button Clicked"
 const val SELECT_REWARD_BUTTON_CLICKED = "Select Reward Button Clicked"
+const val THANKS_PAGE_VIEWED = "Thanks Page Viewed"
 // endregion

--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -28,7 +28,6 @@ public final class KoalaUtils {
   }
 
   public static @NonNull Map<String, Object> checkoutProperties(final @NonNull CheckoutData checkoutData, final @NonNull PledgeData pledgeData, final @NonNull String prefix) {
-    final Reward reward = pledgeData.reward();
     final Project project = pledgeData.projectData().project();
     final Map<String, Object> properties = Collections.unmodifiableMap(new HashMap<String, Object>() {
       {

--- a/app/src/main/java/com/kickstarter/mock/factories/CheckoutDataFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CheckoutDataFactory.kt
@@ -12,5 +12,12 @@ class CheckoutDataFactory private constructor() {
                     .shippingAmount(shippingAmount)
                     .build()
         }
+
+        fun checkoutData(id: Long, shippingAmount: Double, totalAmount: Double): CheckoutData {
+            return checkoutData(shippingAmount, totalAmount)
+                    .toBuilder()
+                    .id(id)
+                    .build()
+        }
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/IntentKey.java
+++ b/app/src/main/java/com/kickstarter/ui/IntentKey.java
@@ -9,6 +9,7 @@ public final class IntentKey {
    */
   public static final String BACKER = "com.kickstarter.kickstarter.intent_backer";
   public static final String BACKING = "com.kickstarter.kickstarter.intent_backing";
+  public static final String CHECKOUT_DATA = "com.kickstarter.kickstarter.intent_checkout_data";
   public static final String DISCOVERY_PARAMS = "com.kickstarter.kickstarter.intent_discovery_params";
   public static final String EDITORIAL = "com.kickstarter.kickstarter.intent_editorial";
   public static final String EMAIL = "com.kickstarter.kickstarter.intent_email";
@@ -26,6 +27,7 @@ public final class IntentKey {
   public static final String MESSAGE_THREAD = "com.kickstarter.kickstarter.intent_message_thread";
   public static final String NATIVE_CHECKOUT_ENABLED = "com.kickstarter.kickstarter.intent_native_checkout_enabled";
   public static final String PASSWORD = "com.kickstarter.kickstarter.intent_password";
+  public static final String PLEDGE_DATA = "com.kickstarter.kickstarter.intent_pledge_data";
   public static final String PROJECT = "com.kickstarter.kickstarter.intent_project";
   public static final String PROJECT_PARAM = "com.kickstarter.kickstarter.intent_project_param";
   public static final String REF_TAG = "com.kickstarter.kickstarter.ref_tag";

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -37,10 +37,7 @@ import com.kickstarter.models.User
 import com.kickstarter.ui.ArgumentsKey
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.adapters.ProjectAdapter
-import com.kickstarter.ui.data.LoginReason
-import com.kickstarter.ui.data.PledgeData
-import com.kickstarter.ui.data.PledgeReason
-import com.kickstarter.ui.data.ProjectData
+import com.kickstarter.ui.data.*
 import com.kickstarter.ui.fragments.*
 import com.kickstarter.viewmodels.ProjectViewModel
 import com.stripe.android.view.CardInputWidget
@@ -339,8 +336,8 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         this.viewModel.inputs.pledgeSuccessfullyCancelled()
     }
 
-    override fun pledgeSuccessfullyCreated() {
-        this.viewModel.inputs.pledgeSuccessfullyCreated()
+    override fun pledgeSuccessfullyCreated(checkoutDataAndPledgeData: Pair<CheckoutData, PledgeData>) {
+        this.viewModel.inputs.pledgeSuccessfullyCreated(checkoutDataAndPledgeData)
     }
 
     override fun pledgeSuccessfullyUpdated() {
@@ -602,11 +599,16 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         showSnackbar(snackbar_anchor, getString(R.string.Youve_canceled_your_pledge))
     }
 
-    private fun showCreatePledgeSuccess(projectData: ProjectData) {
+    private fun showCreatePledgeSuccess(checkoutDatandProjectData: Pair<CheckoutData, PledgeData>) {
+        val checkoutData = checkoutDatandProjectData.first
+        val pledgeData = checkoutDatandProjectData.second
+        val projectData = pledgeData.projectData()
         if (clearFragmentBackStack()) {
             updateFragments(projectData)
             startActivity(Intent(this, ThanksActivity::class.java)
                     .putExtra(IntentKey.PROJECT, projectData.project())
+                    .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
+                    .putExtra(IntentKey.PLEDGE_DATA, pledgeData)
                     .putExtra(IntentKey.NATIVE_CHECKOUT_ENABLED, true))
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -70,7 +70,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
 
     interface PledgeDelegate {
         fun pledgePaymentSuccessfullyUpdated()
-        fun pledgeSuccessfullyCreated()
+        fun pledgeSuccessfullyCreated(checkoutDataAndPledgeData: Pair<CheckoutData, PledgeData>)
         fun pledgeSuccessfullyUpdated()
     }
 
@@ -335,7 +335,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.outputs.showPledgeSuccess()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { (activity as PledgeDelegate?)?.pledgeSuccessfullyCreated() }
+                .subscribe { (activity as PledgeDelegate?)?.pledgeSuccessfullyCreated(it) }
 
         this.viewModel.outputs.showSCAFlow()
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.java
@@ -2,6 +2,8 @@ package com.kickstarter.viewmodels;
 
 import android.util.Pair;
 
+import androidx.annotation.NonNull;
+
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
@@ -21,12 +23,13 @@ import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.activities.ThanksActivity;
 import com.kickstarter.ui.adapters.ThanksAdapter;
 import com.kickstarter.ui.adapters.data.ThanksData;
+import com.kickstarter.ui.data.CheckoutData;
+import com.kickstarter.ui.data.PledgeData;
 import com.kickstarter.ui.viewholders.ProjectCardViewHolder;
 import com.kickstarter.ui.viewholders.ThanksCategoryViewHolder;
 
 import java.util.List;
 
-import androidx.annotation.NonNull;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
@@ -189,6 +192,20 @@ public interface ThanksViewModel {
       this.signedUpToGamesNewsletter
         .compose(bindToLifecycle())
         .subscribe(__ -> this.koala.trackNewsletterToggle(true));
+
+      final Observable<CheckoutData> checkoutData = intent()
+              .map(i -> i.getParcelableExtra(IntentKey.CHECKOUT_DATA))
+              .ofType(CheckoutData.class)
+              .take(1);
+
+      final Observable<PledgeData> pledgeData = intent()
+              .map(i -> i.getParcelableExtra(IntentKey.PLEDGE_DATA))
+              .ofType(PledgeData.class)
+              .take(1);
+
+      Observable.combineLatest(checkoutData, pledgeData, Pair::create)
+              .compose(bindToLifecycle())
+              .subscribe(checkoutDataPledgeData -> this.lake.trackThanksPageViewed(checkoutDataPledgeData.first, checkoutDataPledgeData.second));
     }
 
     /**

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -342,7 +342,7 @@ class LakeTest : KSRobolectricTestCase() {
 
         val projectData = ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended())
 
-        lake.trackPledgeSubmitButtonClicked(CheckoutDataFactory.checkoutData(3L, 20.0, 30.0),
+        lake.trackThanksPageViewed(CheckoutDataFactory.checkoutData(3L, 20.0, 30.0),
                 PledgeData.with(PledgeFlowContext.NEW_PLEDGE, projectData, reward()))
 
         assertSessionProperties(user)

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -358,7 +358,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals(false, expectedProperties["project_user_is_backer"])
         assertEquals(false, expectedProperties["project_user_is_project_creator"])
 
-        this.lakeTest.assertValues("Pledge Submit Button Clicked")
+        this.lakeTest.assertValues("Thanks Page Viewed")
     }
 
     private fun assertCheckoutProperties() {

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -72,7 +72,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val showNewCardFragment = TestSubscriber<Project>()
     private val showPledgeCard = TestSubscriber<Pair<Int, CardState>>()
     private val showPledgeError = TestSubscriber<Void>()
-    private val showPledgeSuccess = TestSubscriber<Void>()
+    private val showPledgeSuccess = TestSubscriber<Pair<CheckoutData, PledgeData>>()
     private val showSCAFlow = TestSubscriber<String>()
     private val showUpdatePaymentError = TestSubscriber<Void>()
     private val showUpdatePaymentSuccess = TestSubscriber<Void>()

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -16,10 +16,7 @@ import com.kickstarter.models.Backing
 import com.kickstarter.models.Project
 import com.kickstarter.models.User
 import com.kickstarter.ui.IntentKey
-import com.kickstarter.ui.data.PledgeData
-import com.kickstarter.ui.data.PledgeFlowContext
-import com.kickstarter.ui.data.PledgeReason
-import com.kickstarter.ui.data.ProjectData
+import com.kickstarter.ui.data.*
 import org.junit.Test
 import rx.Observable
 import rx.observers.TestSubscriber
@@ -64,7 +61,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     private val startManagePledgeActivity = TestSubscriber<Project>()
     private val startMessagesActivity = TestSubscriber<Project>()
     private val startProjectUpdatesActivity = TestSubscriber<Project>()
-    private val startThanksActivity = TestSubscriber<ProjectData>()
+    private val startThanksActivity = TestSubscriber<Pair<CheckoutData, PledgeData>>()
     private val startVideoActivity = TestSubscriber<Project>()
     private val updateFragments = TestSubscriber<ProjectData>()
 
@@ -1382,13 +1379,16 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
 
         // Start the view model with a unbacked project
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
+        val project = ProjectFactory.project()
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
 
         this.projectAndNativeCheckoutEnabled.assertValueCount(2)
 
-        this.vm.inputs.pledgeSuccessfullyCreated()
+        val checkoutData = CheckoutDataFactory.checkoutData(3L, 20.0, 30.0)
+        val pledgeData = PledgeData.with(PledgeFlowContext.NEW_PLEDGE, ProjectDataFactory.project(project), RewardFactory.reward())
+        this.vm.inputs.pledgeSuccessfullyCreated(Pair(checkoutData, pledgeData))
         this.expandPledgeSheet.assertValue(Pair(false, false))
-        this.startThanksActivity.assertValueCount(1)
+        this.startThanksActivity.assertValue(Pair(checkoutData, pledgeData))
         this.projectAndNativeCheckoutEnabled.assertValueCount(3)
     }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
@@ -3,6 +3,8 @@ package com.kickstarter.viewmodels;
 import android.content.Intent;
 import android.util.Pair;
 
+import androidx.annotation.NonNull;
+
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
@@ -10,8 +12,11 @@ import com.kickstarter.libs.MockCurrentUser;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.preferences.MockBooleanPreference;
 import com.kickstarter.mock.factories.CategoryFactory;
+import com.kickstarter.mock.factories.CheckoutDataFactory;
 import com.kickstarter.mock.factories.LocationFactory;
+import com.kickstarter.mock.factories.ProjectDataFactory;
 import com.kickstarter.mock.factories.ProjectFactory;
+import com.kickstarter.mock.factories.RewardFactory;
 import com.kickstarter.mock.factories.UserFactory;
 import com.kickstarter.mock.services.MockApiClient;
 import com.kickstarter.models.Category;
@@ -20,12 +25,14 @@ import com.kickstarter.models.User;
 import com.kickstarter.services.DiscoveryParams;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.adapters.data.ThanksData;
+import com.kickstarter.ui.data.CheckoutData;
+import com.kickstarter.ui.data.PledgeData;
+import com.kickstarter.ui.data.PledgeFlowContext;
 
 import org.junit.Test;
 
 import java.util.Arrays;
 
-import androidx.annotation.NonNull;
 import rx.observers.TestSubscriber;
 
 public final class ThanksViewModelTest extends KSRobolectricTestCase {
@@ -325,5 +332,35 @@ public final class ThanksViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.projectCardViewHolderClicked(project);
     this.startProjectTest.assertValues(Pair.create(project, RefTag.thanks()));
     this.koalaTest.assertValue("Checkout Finished Discover Open Project");
+  }
+
+  @Test
+  public void testTracking_whenCheckoutDataAndPledgeDataExtrasNull() {
+    setUpEnvironment(environment());
+
+    final Project project = ProjectFactory.project();
+    final CheckoutData checkoutData = CheckoutDataFactory.Companion.checkoutData(3L,
+            20.0, 30.0);
+    final PledgeData pledgeData = PledgeData.Companion.with(PledgeFlowContext.NEW_PLEDGE,
+            ProjectDataFactory.Companion.project(project), RewardFactory.reward());
+    final Intent intent = new Intent()
+            .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
+            .putExtra(IntentKey.PLEDGE_DATA, pledgeData)
+            .putExtra(IntentKey.PROJECT, project)
+            .putExtra(IntentKey.NATIVE_CHECKOUT_ENABLED, true);
+    this.vm.intent(intent);
+
+    this.lakeTest.assertValue("Thanks Page Viewed");
+  }
+
+  @Test
+  public void testTracking_whenCheckoutDataAndPledgeDataExtrasPresent() {
+    setUpEnvironment(environment());
+
+    final Intent intent = new Intent()
+            .putExtra(IntentKey.PROJECT, ProjectFactory.project());
+    this.vm.intent(intent);
+
+    this.lakeTest.assertNoValues();
   }
 }


### PR DESCRIPTION
# 📲 What
Adding `Thanks Page Viewed` event.

# 🤔 Why
We have new Back a Project events.

# 🛠 How
- Added `Koala.trackThanksPageViewed`
- Added `LakeEvent.THANKS_PAGE_VIEWED` with value `"Thanks Page Viewed"`
- `PledgeFragmentViewModel.Output.showPledgeSuccess` now emits a pair of `CheckoutData` and `PledgeData`
- `PledgeFragment.PledgeDelegate.pledgeSuccessfullyCreated` now takes in a pair of `CheckoutData` and `PledgeData`
- Added `IntentKey.CHECKOUT_DATA` and `PLEDGE_DATA`
- `ThanksActivity` is now started with `CheckoutData` and `PledgeData` to pass through to event
- Tracking `THANKS_PAGE_VIEWED` in `ThanksViewModel`
- Updated tests.
- Added tests in `ThanksViewModelTest`.
- Added test in `LakeEvent` for a successful checkout

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-848]


[NT-848]: https://kickstarter.atlassian.net/browse/NT-848