### PR TITLE
[🧪] NT-888 Campaign details experiment on Campaign details page

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/ActivityRequestCodes.java
+++ b/app/src/main/java/com/kickstarter/libs/ActivityRequestCodes.java
@@ -8,4 +8,5 @@ public final class ActivityRequestCodes {
   public final static int CHECKOUT_ACTIVITY_WALLET_CHANGE_REQUEST = 592_11;
   public final static int CHECKOUT_ACTIVITY_WALLET_OBTAINED_FULL = 592_12;
   public final static int SAVE_NEW_PAYMENT_METHOD = 592_13;
+  public final static int SHOW_REWARDS = 592_14;
 }

--- a/app/src/main/java/com/kickstarter/ui/IntentKey.java
+++ b/app/src/main/java/com/kickstarter/ui/IntentKey.java
@@ -29,6 +29,7 @@ public final class IntentKey {
   public static final String PASSWORD = "com.kickstarter.kickstarter.intent_password";
   public static final String PLEDGE_DATA = "com.kickstarter.kickstarter.intent_pledge_data";
   public static final String PROJECT = "com.kickstarter.kickstarter.intent_project";
+  public static final String PROJECT_DATA = "com.kickstarter.kickstarter.intent_project_data";
   public static final String PROJECT_PARAM = "com.kickstarter.kickstarter.intent_project_param";
   public static final String REF_TAG = "com.kickstarter.kickstarter.ref_tag";
   public static final String SURVEY_RESPONSE = "com.kickstarter.kickstarter.survey_response";

--- a/app/src/main/java/com/kickstarter/ui/activities/CampaignDetailsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CampaignDetailsActivity.kt
@@ -1,13 +1,16 @@
 package com.kickstarter.ui.activities
 
+import android.app.Activity
 import android.os.Bundle
 import android.util.Pair
 import androidx.annotation.NonNull
 import androidx.annotation.Nullable
+import com.jakewharton.rxbinding.view.RxView
 import com.kickstarter.R
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft
+import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.viewmodels.CampaignDetailsViewModel
 import kotlinx.android.synthetic.main.activity_campaign_details.*
 import rx.android.schedulers.AndroidSchedulers
@@ -19,14 +22,33 @@ class CampaignDetailsActivity : BaseActivity<CampaignDetailsViewModel.ViewModel>
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_campaign_details)
 
+        this.viewModel.outputs.goBackToProject()
+                .observeOn(AndroidSchedulers.mainThread())
+                .compose(bindToLifecycle())
+                .subscribe { goBackToProject() }
+
+        this.viewModel.outputs.pledgeContainerIsVisible()
+                .observeOn(AndroidSchedulers.mainThread())
+                .compose(bindToLifecycle())
+                .subscribe { ViewUtils.setGone(campaign_details_pledge_container, !it) }
+
         this.viewModel.outputs.url()
                 .observeOn(AndroidSchedulers.mainThread())
                 .compose(bindToLifecycle())
                 .subscribe { web_view.loadUrl(it) }
+
+        RxView.clicks(campaign_details_pledge_action_button)
+                .compose(bindToLifecycle())
+                .subscribe { this.viewModel.inputs.pledgeActionButtonClicked() }
     }
 
     @NonNull
     override fun exitTransition(): Pair<Int, Int>? {
         return slideInFromLeft()
+    }
+
+    private fun goBackToProject() {
+        setResult(Activity.RESULT_OK)
+        finish()
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -647,10 +647,11 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         backingFragment()?.pledgeSuccessfullyUpdated()
     }
 
-    private fun startCampaignWebViewActivity(project: Project) {
+    private fun startCampaignWebViewActivity(projectData: ProjectData) {
         val intent = Intent(this, CampaignDetailsActivity::class.java)
-                .putExtra(IntentKey.PROJECT, project)
-        startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
+                .putExtra(IntentKey.PROJECT_DATA, projectData)
+        startActivityForResult(intent, ActivityRequestCodes.SHOW_REWARDS)
+        overridePendingTransition(R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 
     private fun startCreatorBioWebViewActivity(project: Project) {

--- a/app/src/main/java/com/kickstarter/viewmodels/CampaignDetailsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CampaignDetailsViewModel.kt
@@ -1,42 +1,79 @@
 package com.kickstarter.viewmodels
 
-import androidx.annotation.NonNull
+import android.util.Pair
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
-import com.kickstarter.models.Project
+import com.kickstarter.libs.models.OptimizelyExperiment
+import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
+import com.kickstarter.models.User
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.CampaignDetailsActivity
+import com.kickstarter.ui.data.ProjectData
 import rx.Observable
 import rx.subjects.BehaviorSubject
+import rx.subjects.PublishSubject
 
 interface CampaignDetailsViewModel {
 
-    interface Inputs
+    interface Inputs {
+        /** Call when the user clicks the pledge action button. */
+        fun pledgeActionButtonClicked()
+    }
 
     interface Outputs {
+        /** Emits when we should return to the [com.kickstarter.ui.activities.ProjectActivity] with the rewards visible. */
+        fun goBackToProject(): Observable<Void>
+
+        /** Emits a boolean determining if the faux pledge container is visible. */
+        fun pledgeContainerIsVisible(): Observable<Boolean>
+
         /** Emits the URL of the campaign to load in the web view. */
         fun url(): Observable<String>
     }
 
     class ViewModel(environment: Environment) : ActivityViewModel<CampaignDetailsActivity>(environment), Inputs, Outputs {
+        private val currentUser = environment.currentUser()
+        private val optimizely = environment.optimizely()
 
+        private val pledgeButtonClicked = PublishSubject.create<Void>()
+
+        private val goBackToProject = PublishSubject.create<Void>()
+        private val pledgeContainerIsVisible = BehaviorSubject.create<Boolean>()
         private val url = BehaviorSubject.create<String>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
 
         init {
-            val project = intent()
-                    .map { it.getParcelableExtra(IntentKey.PROJECT) as Project? }
-                    .ofType(Project::class.java)
+            val projectData = intent()
+                    .map { it.getParcelableExtra(IntentKey.PROJECT_DATA) as ProjectData? }
+                    .ofType(ProjectData::class.java)
 
-            project
+            projectData
+                    .filter { it.project().isLive && !it.project().isBacking }
+                    .compose<Pair<ProjectData, User?>>(combineLatestPair(this.currentUser.observable()))
+                    .map { projectDataAndUser -> this.optimizely.variant(OptimizelyExperiment.Key.CAMPAIGN_DETAILS, projectDataAndUser.second, projectDataAndUser.first.refTagFromIntent()) }
+                    .map { it == OptimizelyExperiment.Variant.VARIANT_2 }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.pledgeContainerIsVisible)
+
+            projectData
+                    .map { it.project() }
                     .map { it.descriptionUrl() }
                     .compose(bindToLifecycle())
                     .subscribe(this.url)
+
+            this.pledgeButtonClicked
+                    .compose(bindToLifecycle())
+                    .subscribe(this.goBackToProject)
         }
 
-        @NonNull
+        override fun pledgeActionButtonClicked() = this.pledgeButtonClicked.onNext(null)
+
+        override fun goBackToProject(): Observable<Void> = this.goBackToProject
+
+        override fun pledgeContainerIsVisible(): Observable<Boolean> = this.pledgeContainerIsVisible
+
         override fun url(): Observable<String> = this.url
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/CampaignDetailsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CampaignDetailsViewModel.kt
@@ -58,6 +58,12 @@ interface CampaignDetailsViewModel {
                     .subscribe(this.pledgeContainerIsVisible)
 
             projectData
+                    .filter { !it.project().isLive || it.project().isBacking }
+                    .map { false }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.pledgeContainerIsVisible)
+
+            projectData
                     .map { it.project() }
                     .map { it.descriptionUrl() }
                     .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -199,7 +199,7 @@ interface ProjectViewModel {
         fun startBackingActivity(): Observable<Pair<Project, User>>
 
         /** Emits when we should start the campaign [com.kickstarter.ui.activities.CampaignDetailsActivity].  */
-        fun startCampaignWebViewActivity(): Observable<Project>
+        fun startCampaignWebViewActivity(): Observable<ProjectData>
 
         /** Emits when we should start the [com.kickstarter.ui.activities.CheckoutActivity].  */
         fun startCheckoutActivity(): Observable<Project>
@@ -300,7 +300,7 @@ interface ProjectViewModel {
         private val showSavedPrompt = PublishSubject.create<Void>()
         private val showUpdatePledge = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
         private val showUpdatePledgeSuccess = PublishSubject.create<Void>()
-        private val startCampaignWebViewActivity = PublishSubject.create<Project>()
+        private val startCampaignWebViewActivity = PublishSubject.create<ProjectData>()
         private val startCheckoutActivity = PublishSubject.create<Project>()
         private val startCommentsActivity = PublishSubject.create<Project>()
         private val startCreatorBioWebViewActivity = PublishSubject.create<Project>()
@@ -355,6 +355,12 @@ interface ProjectViewModel {
                     .map { it.first }
                     .compose(bindToLifecycle())
                     .subscribe(this.horizontalProgressBarIsGone)
+
+            activityResult()
+                    .filter { it.isOk }
+                    .filter { it.isRequestCode(ActivityRequestCodes.SHOW_REWARDS) }
+                    .compose(bindToLifecycle())
+                    .subscribe { this.expandPledgeSheet.onNext(Pair(true, true)) }
 
             val pledgeSheetExpanded = this.expandPledgeSheet
                     .map { it.first }
@@ -469,8 +475,11 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.showShareSheet)
 
-            currentProject
-                    .compose<Project>(takeWhen(this.blurbTextViewClicked))
+            val currentProjectData = Observable.combineLatest<RefTag, RefTag, Project, ProjectData>(refTag, cookieRefTag, currentProject)
+            { refTagFromIntent, refTagFromCookie, project -> projectData(refTagFromIntent, refTagFromCookie, project) }
+
+            currentProjectData
+                    .compose<ProjectData>(takeWhen(this.blurbTextViewClicked))
                     .compose(bindToLifecycle())
                     .subscribe(this.startCampaignWebViewActivity)
 
@@ -715,11 +724,8 @@ interface ProjectViewModel {
                     .subscribe(this.heartDrawableId)
 
             //Tracking
-            val currentProjectData = Observable.combineLatest<RefTag, RefTag, Project, ProjectData>(refTag, cookieRefTag, currentProject)
-            { refTagFromIntent, refTagFromCookie, project -> projectData(refTagFromIntent, refTagFromCookie, project) }
-                    .filter { it.project().hasRewards() }
-
             currentProjectData
+                    .filter { it.project().hasRewards() }
                     .take(1)
                     .compose(bindToLifecycle())
                     .subscribe { data ->
@@ -1072,7 +1078,7 @@ interface ProjectViewModel {
         override fun startBackingActivity(): Observable<Pair<Project, User>> = this.startBackingActivity
 
         @NonNull
-        override fun startCampaignWebViewActivity(): Observable<Project> = this.startCampaignWebViewActivity
+        override fun startCampaignWebViewActivity(): Observable<ProjectData> = this.startCampaignWebViewActivity
 
         @NonNull
         override fun startCheckoutActivity(): Observable<Project> = this.startCheckoutActivity

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -478,9 +478,6 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.showShareSheet)
 
-            val currentProjectData = Observable.combineLatest<RefTag, RefTag, Project, ProjectData>(refTag, cookieRefTag, currentProject)
-            { refTagFromIntent, refTagFromCookie, project -> projectData(refTagFromIntent, refTagFromCookie, project) }
-
             currentProjectData
                     .compose<ProjectData>(takeWhen(this.blurbTextViewClicked))
                     .compose(bindToLifecycle())

--- a/app/src/main/res/layout/activity_campaign_details.xml
+++ b/app/src/main/res/layout/activity_campaign_details.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
@@ -42,5 +41,29 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+  <androidx.cardview.widget.CardView
+    android:id="@+id/campaign_details_pledge_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom"
+    android:layout_marginBottom="-30dp"
+    android:minHeight="130dp"
+    android:visibility="gone"
+    app:cardBackgroundColor="@color/white"
+    app:cardCornerRadius="@dimen/card_container_radius"
+    app:cardElevation="@dimen/grid_2"
+    tools:showIn="@layout/activity_project"
+    tools:visibility="visible">
+
+    <com.google.android.material.button.MaterialButton
+      android:id="@+id/campaign_details_pledge_action_button"
+      style="@style/PledgeActionButton"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/activity_horizontal_margin"
+      android:layout_marginEnd="@dimen/activity_horizontal_margin"
+      android:text="@string/project_back_button" />
+  </androidx.cardview.widget.CardView>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
@@ -3,24 +3,98 @@ package com.kickstarter.viewmodels
 import android.content.Intent
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.RefTag
+import com.kickstarter.libs.models.OptimizelyExperiment
+import com.kickstarter.mock.MockExperimentsClientType
+import com.kickstarter.mock.factories.ProjectDataFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.models.Project
+import com.kickstarter.models.User
 import com.kickstarter.ui.IntentKey
+import com.kickstarter.ui.data.ProjectData
 import org.junit.Test
 import rx.observers.TestSubscriber
 
 class CampaignDetailsViewModelTest : KSRobolectricTestCase() {
     private lateinit var vm: CampaignDetailsViewModel.ViewModel
 
+    private val goBackToProject = TestSubscriber<Void>()
+    private val pledgeContainerIsVisible = TestSubscriber<Boolean>()
     private val url = TestSubscriber<String>()
 
-    private fun setUpEnvironment(environment: Environment, project: Project) {
+    private fun setUpEnvironment(environment: Environment, projectData: ProjectData) {
         this.vm = CampaignDetailsViewModel.ViewModel(environment)
 
+        this.vm.outputs.goBackToProject().subscribe(this.goBackToProject)
+        this.vm.outputs.pledgeContainerIsVisible().subscribe(this.pledgeContainerIsVisible)
         this.vm.outputs.url().subscribe(this.url)
 
-        // Configure the view model with a project.
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
+        // Configure the view model with ProjectData.
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, projectData))
+    }
+
+    @Test
+    fun testGoBackToProject() {
+        setUpEnvironment(environment(), ProjectDataFactory.project(ProjectFactory.project()))
+
+        this.vm.inputs.pledgeActionButtonClicked()
+        this.goBackToProject.assertValueCount(1)
+    }
+
+    @Test
+    fun testPledgeContainerIsVisible_whenProjectIsLiveNotBacked_control() {
+        setUpEnvironment(environment(), ProjectDataFactory.project(ProjectFactory.project()))
+
+        this.vm.inputs.pledgeActionButtonClicked()
+        this.pledgeContainerIsVisible.assertValue(false)
+    }
+
+    @Test
+    fun testPledgeContainerIsVisible_whenProjectIsLiveNotBacked_variant1() {
+        val environment = environment()
+                .toBuilder()
+                .optimizely(object : MockExperimentsClientType(){
+                    override fun variant(experiment: OptimizelyExperiment.Key, user: User?, refTag: RefTag?): OptimizelyExperiment.Variant {
+                        return OptimizelyExperiment.Variant.VARIANT_1
+                    }
+                })
+                .build()
+        setUpEnvironment(environment, ProjectDataFactory.project(ProjectFactory.project()))
+
+        this.vm.inputs.pledgeActionButtonClicked()
+        this.pledgeContainerIsVisible.assertValue(false)
+    }
+
+    @Test
+    fun testPledgeContainerIsVisible_whenProjectIsLiveNotBacked_variant2() {
+        val environment = environment()
+                .toBuilder()
+                .optimizely(object : MockExperimentsClientType(){
+                    override fun variant(experiment: OptimizelyExperiment.Key, user: User?, refTag: RefTag?): OptimizelyExperiment.Variant {
+                        return OptimizelyExperiment.Variant.VARIANT_2
+                    }
+                })
+                .build()
+        setUpEnvironment(environment, ProjectDataFactory.project(ProjectFactory.project()))
+
+        this.vm.inputs.pledgeActionButtonClicked()
+        this.pledgeContainerIsVisible.assertValue(true)
+    }
+
+    @Test
+    fun testPledgeContainerIsVisible_whenProjectIsNotLive() {
+        setUpEnvironment(environment(), ProjectDataFactory.project(ProjectFactory.successfulProject()))
+
+        this.vm.inputs.pledgeActionButtonClicked()
+        this.pledgeContainerIsVisible.assertNoValues()
+    }
+
+    @Test
+    fun testPledgeContainerIsVisible_whenProjectIsBacked() {
+        setUpEnvironment(environment(), ProjectDataFactory.project(ProjectFactory.backedProject()))
+
+        this.vm.inputs.pledgeActionButtonClicked()
+        this.pledgeContainerIsVisible.assertNoValues()
     }
 
     @Test
@@ -36,7 +110,7 @@ class CampaignDetailsViewModelTest : KSRobolectricTestCase() {
                 .urls(Project.Urls.builder().web(web).build())
                 .build()
 
-        setUpEnvironment(environment(), project)
+        setUpEnvironment(environment(), ProjectDataFactory.project(project))
 
         this.url.assertValue("https://www.kickstarter.com/projects/creator/slug/description")
     }

--- a/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
@@ -34,7 +34,7 @@ class CampaignDetailsViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testGoBackToProject() {
+    fun testGoBackToProject_whenPledgeActionButtonClicked() {
         setUpEnvironment(environment(), ProjectDataFactory.project(ProjectFactory.project()))
 
         this.vm.inputs.pledgeActionButtonClicked()
@@ -45,7 +45,6 @@ class CampaignDetailsViewModelTest : KSRobolectricTestCase() {
     fun testPledgeContainerIsVisible_whenProjectIsLiveNotBacked_control() {
         setUpEnvironment(environment(), ProjectDataFactory.project(ProjectFactory.project()))
 
-        this.vm.inputs.pledgeActionButtonClicked()
         this.pledgeContainerIsVisible.assertValue(false)
     }
 
@@ -61,7 +60,6 @@ class CampaignDetailsViewModelTest : KSRobolectricTestCase() {
                 .build()
         setUpEnvironment(environment, ProjectDataFactory.project(ProjectFactory.project()))
 
-        this.vm.inputs.pledgeActionButtonClicked()
         this.pledgeContainerIsVisible.assertValue(false)
     }
 
@@ -77,7 +75,6 @@ class CampaignDetailsViewModelTest : KSRobolectricTestCase() {
                 .build()
         setUpEnvironment(environment, ProjectDataFactory.project(ProjectFactory.project()))
 
-        this.vm.inputs.pledgeActionButtonClicked()
         this.pledgeContainerIsVisible.assertValue(true)
     }
 
@@ -85,16 +82,14 @@ class CampaignDetailsViewModelTest : KSRobolectricTestCase() {
     fun testPledgeContainerIsVisible_whenProjectIsNotLive() {
         setUpEnvironment(environment(), ProjectDataFactory.project(ProjectFactory.successfulProject()))
 
-        this.vm.inputs.pledgeActionButtonClicked()
-        this.pledgeContainerIsVisible.assertNoValues()
+        this.pledgeContainerIsVisible.assertValue(false)
     }
 
     @Test
     fun testPledgeContainerIsVisible_whenProjectIsBacked() {
         setUpEnvironment(environment(), ProjectDataFactory.project(ProjectFactory.backedProject()))
 
-        this.vm.inputs.pledgeActionButtonClicked()
-        this.pledgeContainerIsVisible.assertNoValues()
+        this.pledgeContainerIsVisible.assertValue(false)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels
 
+import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.util.Pair
@@ -53,7 +54,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     private val showUpdatePledge = TestSubscriber<Pair<PledgeData, PledgeReason>>()
     private val showUpdatePledgeSuccess = TestSubscriber<Void>()
     private val startBackingActivity = TestSubscriber<Pair<Project, User>>()
-    private val startCampaignWebViewActivity = TestSubscriber<Project>()
+    private val startCampaignWebViewActivity = TestSubscriber<ProjectData>()
     private val startCommentsActivity = TestSubscriber<Project>()
     private val startCreatorBioWebViewActivity = TestSubscriber<Project>()
     private val startCreatorDashboardActivity = TestSubscriber<Project>()
@@ -598,7 +599,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
 
         this.vm.inputs.blurbTextViewClicked()
-        this.startCampaignWebViewActivity.assertValues(project)
+        this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
     }
 
     @Test
@@ -923,6 +924,30 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page", "View Your Pledge Button Clicked")
+        this.lakeTest.assertValue("Project Page Viewed")
+    }
+
+    @Test
+    fun testExpandPledgeSheet_whenComingBackFromProjectPage_OKResult() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
+
+        this.vm.activityResult(ActivityResult.create(ActivityRequestCodes.SHOW_REWARDS, Activity.RESULT_OK, null))
+
+        this.expandPledgeSheet.assertValue(Pair(true, true))
+        this.koalaTest.assertValues("Project Page")
+        this.lakeTest.assertValue("Project Page Viewed")
+    }
+
+    @Test
+    fun testExpandPledgeSheet_whenComingBackFromProjectPage_CanceledResult() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
+
+        this.vm.activityResult(ActivityResult.create(ActivityRequestCodes.SHOW_REWARDS, Activity.RESULT_CANCELED, null))
+
+        this.expandPledgeSheet.assertNoValues()
+        this.koalaTest.assertValue("Project Page")
         this.lakeTest.assertValue("Project Page Viewed")
     }
 


### PR DESCRIPTION
# 📲 What
Displaying native_project_page_campaign_details variants on live and not backed Campaign details screen.

# 🤔 Why
🧬

# 🛠 How
- Added `ActivityRequestCodes.SHOW_REWARDS` when starting `CampaignDetailsActivity`
- Added `IntentKey.PROJECT_DATA` for passing `ProjectData` to started Activity
- `CampaignDetails`
  - `CampaignDetailsActivity` is now started with `ProjectData`
  - Added faux pledge container `campaign_details_pledge_container`
  - `CampaignDetailsViewModel`
    - Added `pledgeActionButtonClicked` input that is called when the user clicks the pledge action button.
    - Added `goBackToProject` output that emits when we should dismiss this screen and show the rewards.
    - Added `pledgeContainerIsVisible` output that emits a `Boolean` determining if the faux pledge container should be visible.
    - Tests
- `Project`
  - `ProjectActivity.startCampaignWebViewActivity` now takes in a `[ProjectData]` and starts `CampaignDetailsActivity` for a result of `SHOW_REWARDS`
  - `ProjectViewModel`
    - `startCampaignWebViewActivity` output now emits `ProjectData`
    - `expandPledgeSheet` emits when an `OK` `SHOW_REWARDS` result is received.
    - Tests

# 👀 See
| Variant 2 🐛 | Variant 1 🐛 | Control 🐛 |
| --- | --- | --- |
| ![screenshot-2020-02-20_152913](https://user-images.githubusercontent.com/1289295/74975952-de4e7c80-53f5-11ea-9e83-0191a81b96bc.png) | ![screenshot-2020-02-20_152903](https://user-images.githubusercontent.com/1289295/74975948-ddb5e600-53f5-11ea-8945-3ba5c015d811.png) | ![screenshot-2020-02-20_152903](https://user-images.githubusercontent.com/1289295/74975948-ddb5e600-53f5-11ea-8945-3ba5c015d811.png) |
| ![device-2020-02-20-134307 2020-02-20 13_46_55](https://user-images.githubusercontent.com/1289295/74976276-6f255800-53f6-11ea-9b8a-abb0c41d33cb.gif) |

# 📋 QA
Get yourself into variant-2 of `native_project_page_campaign_details` and check out the campaign details!
The faux pledge container should only be visible on live and unbacked projects.

# Story 📖
[NT-888]


[NT-888]: https://kickstarter.atlassian.net/browse/NT-888