### PR TITLE
[🧪] NT-913 Campaign Details Button Clicked event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
@@ -1,0 +1,7 @@
+@file:JvmName("OptimizelyEvent")
+
+package com.kickstarter.libs
+
+// region native_project_page_campaign_details
+const val CAMPAIGN_DETAILS_BUTTON_CLICKED = "Campaign Details Button Clicked"
+// endregion

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.java
@@ -535,7 +535,7 @@ public final class ProjectViewHolder extends KSViewHolder {
     this.delegate.projectViewHolderBlurbClicked(this);
   }
 
-  @OnClick({R.id.read_more})
+  @OnClick(R.id.read_more)
   public void blurbVariantOnClick() {
     this.delegate.projectViewHolderBlurbVariantClicked(this);
   }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.java
@@ -15,10 +15,6 @@ import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
-
 import com.google.android.material.button.MaterialButton;
 import com.kickstarter.R;
 import com.kickstarter.libs.BaseActivity;
@@ -38,6 +34,9 @@ import com.squareup.picasso.Picasso;
 
 import org.joda.time.DateTime;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import butterknife.Bind;
 import butterknife.BindColor;
 import butterknife.BindDimen;
@@ -134,6 +133,7 @@ public final class ProjectViewHolder extends KSViewHolder {
   public interface Delegate {
     void projectViewHolderBackProjectClicked(ProjectViewHolder viewHolder);
     void projectViewHolderBlurbClicked(ProjectViewHolder viewHolder);
+    void projectViewHolderBlurbVariantClicked(ProjectViewHolder viewHolder);
     void projectViewHolderCommentsClicked(ProjectViewHolder viewHolder);
     void projectViewHolderCreatorClicked(ProjectViewHolder viewHolder);
     void projectViewHolderDashboardClicked(ProjectViewHolder viewHolder);
@@ -533,6 +533,11 @@ public final class ProjectViewHolder extends KSViewHolder {
   @OnClick({R.id.blurb_view, R.id.campaign, R.id.read_more})
   public void blurbOnClick() {
     this.delegate.projectViewHolderBlurbClicked(this);
+  }
+
+  @OnClick({R.id.read_more})
+  public void blurbVariantOnClick() {
+    this.delegate.projectViewHolderBlurbVariantClicked(this);
   }
 
   @OnClick(R.id.comments)

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -609,7 +609,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
 
         this.vm.inputs.blurbVariantClicked()
-        this.startCampaignWebViewActivity.assertValues(project)
+        this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.experimentsTest.assertValue("Campaign Details Button Clicked")
     }
 
@@ -622,7 +622,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
 
         this.vm.inputs.blurbVariantClicked()
-        this.startCampaignWebViewActivity.assertValues(project)
+        this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.experimentsTest.assertNoValues()
     }
 
@@ -635,7 +635,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
 
         this.vm.inputs.blurbVariantClicked()
-        this.startCampaignWebViewActivity.assertValues(project)
+        this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.experimentsTest.assertNoValues()
     }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -588,7 +588,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testStartCampaignWebViewActivity() {
+    fun testStartCampaignWebViewActivity_whenBlurbClicked() {
         val project = ProjectFactory.project()
         setUpEnvironment(environment())
 
@@ -597,6 +597,45 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(project)
+    }
+
+    @Test
+    fun testStartCampaignWebViewActivity_whenBlurbVariantClicked_liveNotBackedProject() {
+        val project = ProjectFactory.project()
+        setUpEnvironment(environment())
+
+        // Start the view model with a project.
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
+
+        this.vm.inputs.blurbVariantClicked()
+        this.startCampaignWebViewActivity.assertValues(project)
+        this.experimentsTest.assertValue("Campaign Details Button Clicked")
+    }
+
+    @Test
+    fun testStartCampaignWebViewActivity_whenBlurbVariantClicked_backedProject() {
+        val project = ProjectFactory.backedProject()
+        setUpEnvironment(environment())
+
+        // Start the view model with a project.
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
+
+        this.vm.inputs.blurbVariantClicked()
+        this.startCampaignWebViewActivity.assertValues(project)
+        this.experimentsTest.assertNoValues()
+    }
+
+    @Test
+    fun testStartCampaignWebViewActivity_whenBlurbVariantClicked_endedProject() {
+        val project = ProjectFactory.successfulProject()
+        setUpEnvironment(environment())
+
+        // Start the view model with a project.
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
+
+        this.vm.inputs.blurbVariantClicked()
+        this.startCampaignWebViewActivity.assertValues(project)
+        this.experimentsTest.assertNoValues()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Added Campaign Details Button Clicked Optimizely tracking event

# 🤔 Why
So we can get those sweet funnel numbers.

# 🛠 How
- Created `OptimizelyEvent` file to hold event name constants.
- Added `OptimizelyEvent.CAMPAIGN_DETAILS_BUTTON_CLICKED` with value `"Campaign Details Button Clicked"`
- Added separate `ProjectViewHolder.Delegate` method `projectViewHolderBlurbVariantClicked` that is called when a user clicks the `Read more about the campaign` button.
- Tracking `CAMPAIGN_DETAILS_BUTTON_CLICKED` when `blurbVariantClicked` emits with a live, not backed project.
- Added tests to assert the webview is shown when `blurbVariantClicked` emits and `CAMPAIGN_DETAILS_BUTTON_CLICKED` is tracked for only live, not backed projects.

# 👀 See
Nothing to see.

# 📋 QA
Take a look at the Android experiment results! I'm in `variant-2` and clicked the button.
<img width="1057" alt="Screen Shot 2020-02-21 at 1 14 18 PM" src="https://user-images.githubusercontent.com/1289295/75060059-262fdb00-54ac-11ea-8ce8-41ff11214bc2.png">

# Story 📖
[NT-913]


[NT-913]: https://kickstarter.atlassian.net/browse/NT-913