### PR TITLE
[👤] NT-914 Adding distinct ID header to v1 and graphQL requests 

### DIFF
--- a/app/src/main/java/com/kickstarter/services/interceptors/ApiRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/ApiRequestInterceptor.java
@@ -2,6 +2,7 @@ package com.kickstarter.services.interceptors;
 
 import android.net.Uri;
 
+import com.google.firebase.iid.FirebaseInstanceId;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.services.KSUri;
 
@@ -36,7 +37,8 @@ public final class ApiRequestInterceptor implements Interceptor {
     }
 
     return initialRequest.newBuilder()
-      .header("Accept", "application/json")
+      .addHeader("Accept", "application/json")
+      .addHeader("Kickstarter-Android-App-UUID", FirebaseInstanceId.getInstance().getId())
       .url(url(initialRequest.url()))
       .build();
   }

--- a/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
+++ b/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.services.interceptors
 
+import com.google.firebase.iid.FirebaseInstanceId
 import com.kickstarter.libs.Build
 import com.kickstarter.libs.CurrentUserType
 import com.kickstarter.libs.utils.WebUtils
@@ -17,6 +18,7 @@ class GraphQLInterceptor(private val clientId: String,
         }
         builder.addHeader("User-Agent", WebUtils.userAgent(this.build))
                 .addHeader("X-KICKSTARTER-CLIENT", this.clientId)
+                .addHeader("Kickstarter-Android-App-UUID", FirebaseInstanceId.getInstance().id)
         return chain.proceed(builder.build())
     }
 }


### PR DESCRIPTION
# 📲 What
Adds the device identifier to our prepared request headers for requests to v1 endpoints and GraphQL queries/mutations.

# 🤔 Why
In order to properly attribute our _Completed Checkout_ server-side events to Optimizely experimental variants, we need to send the `device_distinct_id` to the server so that Optimizely tracking calls can be made using the `device_distinct_id` instead of the user's ID.

# 🛠 How
Added a header, `Kickstarter-Android-App-UUID` which will be set using the [`FirebaseInstanceId`](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId) to `ApiRequestInterceptor` for all v1 requests and `GraphQLInterceptor` for all graphQL requests.

# ✅ Acceptance criteria
I learned~ that OkHttp (our networking library) doesn't print headers for intercepted GET requests. But it does for `POST` calls so here's a log:
![Screen Shot 2020-02-21 at 2 22 26 PM](https://user-images.githubusercontent.com/1289295/75066176-58473a00-54b8-11ea-84f5-fd148e2a0a2d.png)

**Note**: We don't currently test our Interceptors but we do have a ticket to do so in the backlog.