### PR TITLE
[🧪] NT-915 Adding Project Page Pledge Button Clicked event to Optimizely

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -826,6 +826,17 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe { this.optimizely.track(CAMPAIGN_DETAILS_BUTTON_CLICKED, it.second, it.first.refTagFromIntent()) }
 
+            val isBackThisProjectCTA = this.pledgeActionButtonText
+                    .map { isPledgeCTA(it) }
+                    .compose<Boolean>(takeWhen(this.nativeProjectActionButtonClicked))
+
+            currentFullProjectData
+                    .compose<Pair<ProjectData, User?>>(combineLatestPair(this.currentUser.observable()))
+                    .compose<Pair<Pair<ProjectData, User?>, Boolean>>(combineLatestPair(isBackThisProjectCTA))
+                    .filter { it.second }
+                    .map { it.first }
+                    .compose(bindToLifecycle())
+                    .subscribe { this.optimizely.track(PROJECT_PAGE_PLEDGE_BUTTON_CLICKED, it.second, it.first.refTagFromIntent()) }
         }
 
         private fun eventName(projectActionButtonStringRes: Int) : String {
@@ -836,6 +847,17 @@ interface ProjectViewModel {
                 R.string.Manage -> KoalaEvent.MANAGE_PLEDGE_BUTTON_CLICKED
                 R.string.View_your_pledge -> KoalaEvent.VIEW_YOUR_PLEDGE_BUTTON_CLICKED
                 else -> KoalaEvent.VIEW_REWARDS_BUTTON_CLICKED
+            }
+        }
+
+        private fun isPledgeCTA(projectActionButtonStringRes: Int) : Boolean {
+            return when (projectActionButtonStringRes) {
+                R.string.Back_this_project -> true
+                R.string.View_the_rewards -> true
+                R.string.See_the_rewards -> true
+                R.string.Manage -> false
+                R.string.View_your_pledge -> false
+                else -> false
             }
         }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -826,13 +826,13 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe { this.optimizely.track(CAMPAIGN_DETAILS_BUTTON_CLICKED, it.second, it.first.refTagFromIntent()) }
 
-            val isBackThisProjectCTA = this.pledgeActionButtonText
+            val shouldTrackCTAClickedEvent = this.pledgeActionButtonText
                     .map { isPledgeCTA(it) }
                     .compose<Boolean>(takeWhen(this.nativeProjectActionButtonClicked))
 
             currentFullProjectData
                     .compose<Pair<ProjectData, User?>>(combineLatestPair(this.currentUser.observable()))
-                    .compose<Pair<Pair<ProjectData, User?>, Boolean>>(combineLatestPair(isBackThisProjectCTA))
+                    .compose<Pair<Pair<ProjectData, User?>, Boolean>>(combineLatestPair(shouldTrackCTAClickedEvent))
                     .filter { it.second }
                     .map { it.first }
                     .compose(bindToLifecycle())

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -915,6 +915,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.goBack.assertNoValues()
         this.koalaTest.assertValues("Project Page", "Back this Project Button Clicked")
         this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
+        this.experimentsTest.assertValues("Project Page Pledge Button Clicked")
     }
 
     @Test
@@ -927,6 +928,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page", "Back this Project Button Clicked")
         this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
+        this.experimentsTest.assertValues("Project Page Pledge Button Clicked")
     }
 
     @Test
@@ -938,6 +940,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page", "Manage Pledge Button Clicked")
+        this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -950,6 +954,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page", "View Rewards Button Clicked")
         this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -962,6 +967,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page", "View Your Pledge Button Clicked")
         this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -974,6 +980,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page")
         this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -986,6 +993,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertNoValues()
         this.koalaTest.assertValue("Project Page")
         this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Added Project Page Pledge Button Clicked tracking event to Optimizely

# 🤔 Why
So we can get those sweet funnel numbers.

# 🛠 How
- Tracking `PROJECT_PAGE_PLEDGE_BUTTON_CLICKED` when user clicks on the `Back this project` button and its variants (`View the reward`, `See the rewards`).
- Added tests in `ProjectViewModel` to ensure it's being tracked on for live, not backed projects 

# 👀 See
Nothing to see.

# 📋 QA
Check those sweet logs.

# Story 📖
[NT-915]

[NT-915]: https://kickstarter.atlassian.net/browse/NT-915