### PR TITLE
[🦟] NT-916 Campaign Details Pledge Button Clicked event 

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
@@ -4,4 +4,5 @@ package com.kickstarter.libs
 
 // region native_project_page_campaign_details
 const val CAMPAIGN_DETAILS_BUTTON_CLICKED = "Campaign Details Button Clicked"
+const val CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED = "Campaign Details Pledge Button Clicked"
 // endregion

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.java
@@ -530,7 +530,7 @@ public final class ProjectViewHolder extends KSViewHolder {
     this.delegate.projectViewHolderBackProjectClicked(this);
   }
 
-  @OnClick({R.id.blurb_view, R.id.campaign, R.id.read_more})
+  @OnClick({R.id.blurb_view, R.id.campaign})
   public void blurbOnClick() {
     this.delegate.projectViewHolderBlurbClicked(this);
   }

--- a/app/src/main/java/com/kickstarter/viewmodels/CampaignDetailsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CampaignDetailsViewModel.kt
@@ -2,9 +2,11 @@ package com.kickstarter.viewmodels
 
 import android.util.Pair
 import com.kickstarter.libs.ActivityViewModel
+import com.kickstarter.libs.CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
+import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
 import com.kickstarter.models.User
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.CampaignDetailsActivity
@@ -72,6 +74,12 @@ interface CampaignDetailsViewModel {
             this.pledgeButtonClicked
                     .compose(bindToLifecycle())
                     .subscribe(this.goBackToProject)
+
+            projectData
+                    .compose<Pair<ProjectData, User?>>(combineLatestPair(this.currentUser.observable()))
+                    .compose<Pair<ProjectData, User?>>(takeWhen(this.pledgeButtonClicked))
+                    .compose(bindToLifecycle())
+                    .subscribe { this.optimizely.track(CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED, it.second, it.first.refTagFromIntent()) }
         }
 
         override fun pledgeActionButtonClicked() = this.pledgeButtonClicked.onNext(null)

--- a/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
@@ -39,6 +39,7 @@ class CampaignDetailsViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.pledgeActionButtonClicked()
         this.goBackToProject.assertValueCount(1)
+        this.experimentsTest.assertValue("Campaign Details Pledge Button Clicked")
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Added `Campaign Details Pledge Button Clicked` event for Optimizely and fixed bug with campaign details opening twice.

# 🤔 Why
So we can get those sweet funnel numbers.

# 🛠 How
- Added `OptimizelyEvent.CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED` with value `"Campaign Details Pledge Button Clicked"`
- Tracking `CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED` when `Back this project` button is clicked in `CampaignDetailsActivity`.
- Added tests to assert `CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED` is tracked when the button is clicked.

## bug
- Forgot to remove click listener from `read_more` in #755 when I gave the blurb variant its own click listener

# 👀 See
Nothing to see.

# 📋 QA
Check your local logs!

# Story 📖
[NT-916]

[NT-916]: https://kickstarter.atlassian.net/browse/NT-916