### PR TITLE
[🛤] NT-917 Log In or Signup Button Clicked event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -1,8 +1,5 @@
 package com.kickstarter.libs;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import com.kickstarter.libs.utils.KoalaUtils;
 import com.kickstarter.models.Activity;
 import com.kickstarter.models.Project;
@@ -18,6 +15,9 @@ import com.kickstarter.ui.data.PledgeData;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public final class Koala {
   private final @NonNull TrackingClientType client;
@@ -791,6 +791,12 @@ public final class Koala {
     final Map<String, Object> props = KoalaUtils.checkoutDataProperties(checkoutData, pledgeData, this.client.loggedInUser());
 
     this.client.track(LakeEvent.THANKS_PAGE_VIEWED, props);
+  }
+  //endregion
+
+  //region Log In or Signup
+  public void trackLogInSignUpButtonClicked() {
+    this.client.track(LakeEvent.LOG_IN_OR_SIGNUP_BUTTON_CLICKED);
   }
   //endregion
 }

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -21,3 +21,7 @@ const val PROJECT_PAGE_PLEDGE_BUTTON_CLICKED = "Project Page Pledge Button Click
 const val SELECT_REWARD_BUTTON_CLICKED = "Select Reward Button Clicked"
 const val THANKS_PAGE_VIEWED = "Thanks Page Viewed"
 // endregion
+
+// region Log In or Signup
+const val LOG_IN_OR_SIGNUP_BUTTON_CLICKED = "Log In or Signup Button Clicked"
+// endregion

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -296,7 +296,7 @@ public interface DiscoveryFragmentViewModel {
 
       this.discoveryOnboardingLoginToutClick
         .compose(bindToLifecycle())
-        .subscribe(v -> this.lake.trackDiscoveryRefreshTriggered());
+        .subscribe(v -> this.lake.trackLogInSignUpButtonClicked());
     }
 
     private boolean activityHasNotBeenSeen(final @Nullable Activity activity) {

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -293,6 +293,10 @@ public interface DiscoveryFragmentViewModel {
       this.refresh
         .compose(bindToLifecycle())
         .subscribe(v -> this.koala.trackDiscoveryRefreshTriggered());
+
+      this.discoveryOnboardingLoginToutClick
+        .compose(bindToLifecycle())
+        .subscribe(v -> this.lake.trackDiscoveryRefreshTriggered());
     }
 
     private boolean activityHasNotBeenSeen(final @Nullable Activity activity) {

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -341,6 +341,17 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
+  public void testShowLoginTout() {
+    setUpEnvironment(environment());
+
+    // Clicking login on onboarding view should show login tout.
+    this.vm.inputs.discoveryOnboardingViewHolderLoginToutClick(null);
+
+    this.showLoginTout.assertValue(true);
+    this.lakeTest.assertValue("Log In or Signup Button Clicked");
+  }
+
+  @Test
   public void testStartEditorialActivity() {
     setUpEnvironment(environmentWithGoRewardlessEnabled());
 
@@ -410,11 +421,6 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.activitySampleProjectViewHolderUpdateClicked(null, ActivityFactory.updateActivity());
     this.startUpdateActivity.assertValueCount(1);
     this.koalaTest.assertValues(KoalaEvent.VIEWED_UPDATE);
-
-    // Clicking login on onboarding view should show login tout.
-    this.showLoginTout.assertNoValues();
-    this.vm.inputs.discoveryOnboardingViewHolderLoginToutClick(null);
-    this.showLoginTout.assertValue(true);
   }
 
   private Environment environmentWithGoRewardlessDisabled() {


### PR DESCRIPTION
**Note:** This won't pass lint checks because `Koala.java` is too long. Please take a look at #759 first!

# 📲 What
Adding `Log In or Signup Button Clicked` event.

# 🤔 Why
We have new Log In or Signup events.

# 🛠 How
- Added `LakeEvent.LOG_IN_OR_SIGNUP_BUTTON_CLICKED ` with value `"Log In or Signup Button Clicked"`
- Added `Koala.trackLogInSignUpButtonClicked`
- Tracking when a not logged in user clicks the tout button in `DiscoveryFragmentViewModel`
- Added separate test for `showLoginTest` in `DiscoveryFragmentViewModelTest`

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-917]

[NT-917]: https://kickstarter.atlassian.net/browse/NT-917