### PR TITLE
[🛤] NT-918 Log In or Sign Up Page Viewed events

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -793,4 +793,10 @@ public final class Koala {
     this.client.track(LakeEvent.THANKS_PAGE_VIEWED, props);
   }
   //endregion
+
+  //region Log In or Signup
+  public void trackLogInSignUpPageViewed() {
+    this.client.track(LakeEvent.LOG_IN_OR_SIGN_UP_PAGE_VIEWED);
+  }
+  //endregion
 }

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -21,3 +21,7 @@ const val PROJECT_PAGE_PLEDGE_BUTTON_CLICKED = "Project Page Pledge Button Click
 const val SELECT_REWARD_BUTTON_CLICKED = "Select Reward Button Clicked"
 const val THANKS_PAGE_VIEWED = "Thanks Page Viewed"
 // endregion
+
+// region Log In or Signup
+const val LOG_IN_OR_SIGN_UP_PAGE_VIEWED = "Log In or Sign Up Page Viewed"
+// endregion

--- a/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
@@ -140,6 +140,11 @@ public interface LoginToutViewModel {
         .compose(bindToLifecycle())
         .subscribe(this.koala::trackLoginRegisterTout);
 
+      this.loginReason
+        .take(1)
+        .compose(bindToLifecycle())
+        .subscribe(__ -> this.lake.trackLogInSignUpPageViewed());
+
       this.loginError
         .compose(bindToLifecycle())
         .subscribe(__ -> this.koala.trackLoginError());

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
@@ -1,5 +1,7 @@
 package com.kickstarter.viewmodels;
 
+import android.content.Intent;
+
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.MockCurrentUser;
@@ -7,6 +9,8 @@ import com.kickstarter.mock.services.MockApiClient;
 import com.kickstarter.models.User;
 import com.kickstarter.services.apiresponses.AccessTokenEnvelope;
 import com.kickstarter.services.apiresponses.ErrorEnvelope;
+import com.kickstarter.ui.IntentKey;
+import com.kickstarter.ui.data.LoginReason;
 
 import org.junit.Test;
 
@@ -22,7 +26,7 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Void> startSignupActivity = new TestSubscriber<>();
   private final TestSubscriber<User> currentUser = new TestSubscriber<>();
 
-  private void setUpEnvironment(final @NonNull Environment environment) {
+  private void setUpEnvironment(final @NonNull Environment environment, final @NonNull LoginReason loginReason) {
     this.vm = new LoginToutViewModel.ViewModel(environment);
 
     this.vm.outputs.finishWithSuccessfulResult().subscribe(this.finishWithSuccessfulResult);
@@ -30,26 +34,30 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.startSignupActivity().subscribe(this.startSignupActivity);
     this.vm.outputs.startLoginActivity().subscribe(this.startLoginActivity);
     environment.currentUser().observable().subscribe(this.currentUser);
+
+    this.vm.intent(new Intent().putExtra(IntentKey.LOGIN_REASON, loginReason));
   }
 
   @Test
   public void testLoginButtonClicked() {
-    setUpEnvironment(environment());
+    setUpEnvironment(environment(), LoginReason.DEFAULT);
 
     this.startLoginActivity.assertNoValues();
 
     this.vm.inputs.loginClick();
     this.startLoginActivity.assertValueCount(1);
+    this.lakeTest.assertValue("Log In or Sign Up Page Viewed");
   }
 
   @Test
   public void testSignupButtonClicked() {
-    setUpEnvironment(environment());
+    setUpEnvironment(environment(), LoginReason.DEFAULT);
 
     this.startSignupActivity.assertNoValues();
 
     this.vm.inputs.signupClick();
     this.startSignupActivity.assertValueCount(1);
+    this.lakeTest.assertValue("Log In or Sign Up Page Viewed");
   }
 
   @Test
@@ -59,12 +67,13 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
       .toBuilder()
       .currentUser(currentUser)
       .build();
-    setUpEnvironment(environment);
+    setUpEnvironment(environment, LoginReason.DEFAULT);
 
     this.currentUser.assertValuesAndClear(null);
     this.vm.facebookAccessToken.onNext("token");
     this.currentUser.assertValueCount(1);
     this.finishWithSuccessfulResult.assertValueCount(1);
+    this.lakeTest.assertValue("Log In or Sign Up Page Viewed");
   }
 
   @Test
@@ -81,11 +90,12 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
       })
       .build();
 
-    setUpEnvironment(environment);
+    setUpEnvironment(environment, LoginReason.DEFAULT);
 
     this.currentUser.assertValuesAndClear(null);
     this.vm.facebookAccessToken.onNext("token");
     this.currentUser.assertNoValues();
     this.finishWithSuccessfulResult.assertNoValues();
+    this.lakeTest.assertValue("Log In or Sign Up Page Viewed");
   }
 }


### PR DESCRIPTION
**Note:** This won't pass lint checks because `Koala.java` is too long. Please take a look at #759 first!

# 📲 What
Adding `Log In or Sign Up Page Viewed` event.

# 🤔 Why
We have new Log In or Signup events.

# 🛠 How
- Added `LakeEvent.LOG_IN_OR_SIGN_UP_PAGE_VIEWED` with value `"Log In or Sign Up Page Viewed"`
- Added `Koala.trackLogInSignUpPageViewed` to track when a user lands on the login tout screen.
- Tracking `LOG_IN_OR_SIGN_UP_PAGE_VIEWED` in `LoginToutViewModel`
- There were no tracking tests in `LoginToutViewModelTest` so I added tests for the Data Lake.

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-918]

[NT-918]: https://kickstarter.atlassian.net/browse/NT-918