### PR TITLE
[🛤] NT-919 Facebook Log In or Signup Button Clicked event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -1,8 +1,5 @@
 package com.kickstarter.libs;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import com.kickstarter.libs.utils.KoalaUtils;
 import com.kickstarter.models.Activity;
 import com.kickstarter.models.Project;
@@ -18,6 +15,9 @@ import com.kickstarter.ui.data.PledgeData;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public final class Koala {
   private final @NonNull TrackingClientType client;
@@ -791,6 +791,12 @@ public final class Koala {
     final Map<String, Object> props = KoalaUtils.checkoutDataProperties(checkoutData, pledgeData, this.client.loggedInUser());
 
     this.client.track(LakeEvent.THANKS_PAGE_VIEWED, props);
+  }
+  //endregion
+
+  //region Log In or Signup
+  public void trackFacebookLogInSignUpButtonClicked() {
+    this.client.track(LakeEvent.FACEBOOK_LOG_IN_OR_SIGNUP_BUTTON_CLICKED);
   }
   //endregion
 }

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -21,3 +21,7 @@ const val PROJECT_PAGE_PLEDGE_BUTTON_CLICKED = "Project Page Pledge Button Click
 const val SELECT_REWARD_BUTTON_CLICKED = "Select Reward Button Clicked"
 const val THANKS_PAGE_VIEWED = "Thanks Page Viewed"
 // endregion
+
+// region Log In or Signup
+const val FACEBOOK_LOG_IN_OR_SIGNUP_BUTTON_CLICKED = "Facebook Log In or Signup Button Clicked"
+// endregion

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
@@ -10,6 +10,8 @@ import com.kickstarter.services.apiresponses.ErrorEnvelope;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import androidx.annotation.NonNull;
 import rx.Observable;
 import rx.observers.TestSubscriber;
@@ -62,9 +64,11 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
     setUpEnvironment(environment);
 
     this.currentUser.assertValuesAndClear(null);
+    this.vm.inputs.facebookLoginClick(null, Arrays.asList("public_profile", "user_friends", "email"));
     this.vm.facebookAccessToken.onNext("token");
     this.currentUser.assertValueCount(1);
     this.finishWithSuccessfulResult.assertValueCount(1);
+    this.lakeTest.assertValue("Facebook Log In or Signup Button Clicked");
   }
 
   @Test
@@ -84,8 +88,10 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
     setUpEnvironment(environment);
 
     this.currentUser.assertValuesAndClear(null);
+    this.vm.inputs.facebookLoginClick(null, Arrays.asList("public_profile", "user_friends", "email"));
     this.vm.facebookAccessToken.onNext("token");
     this.currentUser.assertNoValues();
     this.finishWithSuccessfulResult.assertNoValues();
+    this.lakeTest.assertValue("Facebook Log In or Signup Button Clicked");
   }
 }


### PR DESCRIPTION
# 📲 What
Adding `Facebook Log In or Signup Button Clicked` event.

# 🤔 Why
We have new Log In or Signup events.

# 🛠 How
- Added `LakeEvent.FACEBOOK_LOG_IN_OR_SIGNUP_BUTTON_CLICKED ` with value `"Facebook Log In or Signup Button Clicked"`
- Added `Koala.trackFacebookLogInSignUpButtonClicked `
- Tracking when a not logged in user clicks the Facebook sign in button in `LoginToutViewModel`
- Updated tests `DiscoveryFragmentViewModelTest`

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-919]
