### PR TITLE
[🛤] NT-921 Sign Up Button Clicked event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -722,5 +722,9 @@ public final class Koala {
   public void trackLogInSignUpPageViewed() {
     this.client.track(LakeEvent.LOG_IN_OR_SIGN_UP_PAGE_VIEWED);
   }
+
+  public void trackSignUpButtonClicked() {
+    this.client.track(LakeEvent.SIGN_UP_BUTTON_CLICKED);
+  }
   //endregion
 }

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -25,4 +25,5 @@ const val THANKS_PAGE_VIEWED = "Thanks Page Viewed"
 // region Log In or Signup
 const val LOG_IN_OR_SIGNUP_BUTTON_CLICKED = "Log In or Signup Button Clicked"
 const val LOG_IN_OR_SIGN_UP_PAGE_VIEWED = "Log In or Sign Up Page Viewed"
+const val SIGN_UP_BUTTON_CLICKED = "Sign Up Button Clicked"
 // endregion

--- a/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
@@ -154,6 +154,10 @@ public interface LoginToutViewModel {
         .mergeWith(showFacebookAuthorizationErrorDialog())
         .compose(bindToLifecycle())
         .subscribe(__ -> this.koala.trackFacebookLoginError());
+
+      this.signupClick
+        .compose(bindToLifecycle())
+        .subscribe(__ -> this.lake.trackSignUpButtonClicked());
     }
 
     private void clearFacebookSession(final @NonNull FacebookException e) {

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
@@ -57,7 +57,7 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
 
     this.vm.inputs.signupClick();
     this.startSignupActivity.assertValueCount(1);
-    this.lakeTest.assertValue("Log In or Sign Up Page Viewed");
+    this.lakeTest.assertValues("Log In or Sign Up Page Viewed", "Sign Up Button Clicked");
   }
 
   @Test


### PR DESCRIPTION
# 📲 What
Adding `Sign Up Button Clicked` event.

# 🤔 Why
We have new Log In or Signup events.

# 🛠 How
- Added `LakeEvent.SIGN_UP_BUTTON_CLICKED` with value `"Sign Up Button Clicked"`
- Added `Koala.trackSignUpButtonClicked` to track when a user clicks on the sign up button in the `LoginToutActivity`.
- Tracking `SIGN_UP_BUTTON_CLICKED` in `LoginToutViewModel` when user clicks the sign up button
- Added test in `LoginToutViewModelTest`

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-921]

[NT-921]: https://kickstarter.atlassian.net/browse/NT-921