### PR TITLE
[🛤] NT-923 Sign Up Submit Button Clicked event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -722,5 +722,9 @@ public final class Koala {
   public void trackLogInSignUpPageViewed() {
     this.client.track(LakeEvent.LOG_IN_OR_SIGN_UP_PAGE_VIEWED);
   }
+
+  public void trackSignUpSubmitButtonClicked() {
+    this.client.track(LakeEvent.SIGN_UP_SUBMIT_BUTTON_CLICKED);
+  }
   //endregion
 }

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -25,4 +25,5 @@ const val THANKS_PAGE_VIEWED = "Thanks Page Viewed"
 // region Log In or Signup
 const val LOG_IN_OR_SIGNUP_BUTTON_CLICKED = "Log In or Signup Button Clicked"
 const val LOG_IN_OR_SIGN_UP_PAGE_VIEWED = "Log In or Sign Up Page Viewed"
+const val SIGN_UP_SUBMIT_BUTTON_CLICKED = "Sign Up Submit Button Clicked"
 // endregion

--- a/app/src/main/java/com/kickstarter/viewmodels/SignupViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SignupViewModel.java
@@ -111,6 +111,10 @@ public interface SignupViewModel {
         });
 
       this.koala.trackRegisterFormView();
+
+      this.signupClick
+        .compose(bindToLifecycle())
+        .subscribe(__ -> this.lake.trackSignUpSubmitButtonClicked());
     }
 
     private Observable<AccessTokenEnvelope> submit(final @NonNull SignupData data) {

--- a/app/src/test/java/com/kickstarter/viewmodels/SignupViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SignupViewModelTest.java
@@ -60,6 +60,7 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
     formSubmittingTest.assertValues(true, false);
     signupSuccessTest.assertValueCount(1);
     koalaTest.assertValues("User Signup", "Signup Newsletter Toggle", "Login", "New User");
+    this.lakeTest.assertValues("Sign Up Submit Button Clicked");
   }
 
   @Test
@@ -98,6 +99,7 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
     signupSuccessTest.assertValueCount(0);
     signupErrorTest.assertValueCount(1);
     koalaTest.assertValues("User Signup", "Signup Newsletter Toggle", "Errored User Signup");
+    this.lakeTest.assertValues("Sign Up Submit Button Clicked");
   }
 
   @Test
@@ -134,5 +136,6 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
     signupSuccessTest.assertValueCount(0);
     signupErrorTest.assertValueCount(1);
     koalaTest.assertValues("User Signup", "Signup Newsletter Toggle", "Errored User Signup");
+    this.lakeTest.assertValues("Sign Up Submit Button Clicked");
   }
 }


### PR DESCRIPTION
# 📲 What
Adding `Sign Up Submit Button Clicked` event.

# 🤔 Why
We have new Log In or Signup events.

# 🛠 How
- Added `LakeEvent.SIGN_UP_SUBMIT_BUTTON_CLICKED` with value `"Sign Up Submit Button Clicked"`
- Added `Koala.trackLogInSubmitButtonClicked` to track when a user clicks the sign up button in the `SignupActivity`
- Tracking `SIGN_UP_SUBMIT_BUTTON_CLICKED` in `SignupViewModel` when user clicks the log in button
- Added test in `SignupViewModelTest`

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-923]

[NT-923]: https://kickstarter.atlassian.net/browse/NT-923