### PR TITLE
[🛤] NT-924 Forgot Password Page Viewed event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -715,6 +715,10 @@ public final class Koala {
   //endregion
 
   //region Log In or Signup
+  public void trackForgotPasswordPageViewed() {
+    this.client.track(LakeEvent.FORGOT_PASSWORD_PAGE_VIEWED);
+  }
+
   public void trackLogInSignUpButtonClicked() {
     this.client.track(LakeEvent.LOG_IN_OR_SIGNUP_BUTTON_CLICKED);
   }

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -23,6 +23,7 @@ const val THANKS_PAGE_VIEWED = "Thanks Page Viewed"
 // endregion
 
 // region Log In or Signup
+const val FORGOT_PASSWORD_PAGE_VIEWED = "Forgot Password Page Viewed"
 const val LOG_IN_OR_SIGNUP_BUTTON_CLICKED = "Log In or Signup Button Clicked"
 const val LOG_IN_OR_SIGN_UP_PAGE_VIEWED = "Log In or Sign Up Page Viewed"
 // endregion

--- a/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
@@ -84,6 +84,7 @@ interface ResetPasswordViewModel {
                     .subscribe { this.koala.trackResetPasswordSuccess() }
 
             this.koala.trackResetPasswordFormView()
+            this.lake.trackForgotPasswordPageViewed()
         }
 
         private fun success() {

--- a/app/src/test/java/com/kickstarter/viewmodels/ResetPasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ResetPasswordViewModelTest.kt
@@ -26,6 +26,7 @@ class ResetPasswordViewModelTest : KSRobolectricTestCase() {
         test.assertValues(false, true)
 
         koalaTest.assertValueCount(1)
+        this.lakeTest.assertValue("Forgot Password Page Viewed")
     }
 
     @Test
@@ -47,6 +48,7 @@ class ResetPasswordViewModelTest : KSRobolectricTestCase() {
         test.assertValueCount(1)
 
         koalaTest.assertValues("Forgot Password View", "Forgot Password Requested")
+        this.lakeTest.assertValue("Forgot Password Page Viewed")
     }
 
     @Test
@@ -74,5 +76,6 @@ class ResetPasswordViewModelTest : KSRobolectricTestCase() {
         errorTest.assertValue("bad request")
 
         koalaTest.assertValues("Forgot Password View", "Forgot Password Errored")
+        this.lakeTest.assertValue("Forgot Password Page Viewed")
     }
 }


### PR DESCRIPTION
# 📲 What
Adding `Forgot Password Page Viewed` event.

# 🤔 Why
We have new Log In or Signup events.

# 🛠 How
- Added `LakeEvent.FORGOT_PASSWORD_PAGE_VIEWED` with value `"Forgot Password Page Viewed"`
- Added `Koala.trackForgotPasswordPageViewed` to track when a user views the `ResetPasswordActivity`
- Tracking `FORGOT_PASSWORD_PAGE_VIEWED` in `SignupViewModel` when user clicks the reset password button
- Added test in `ResetPasswordViewModelTest`

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-924]

[NT-924]: https://kickstarter.atlassian.net/browse/NT-924