### PR TITLE
[🛤] NT-925 Two-Factor Confirmation Viewed event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -722,5 +722,9 @@ public final class Koala {
   public void trackLogInSignUpPageViewed() {
     this.client.track(LakeEvent.LOG_IN_OR_SIGN_UP_PAGE_VIEWED);
   }
+
+  public void trackTwoFactorConfirmationViewed() {
+    this.client.track(LakeEvent.TWO_FACTOR_CONFIRMATION_VIEWED);
+  }
   //endregion
 }

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -25,4 +25,5 @@ const val THANKS_PAGE_VIEWED = "Thanks Page Viewed"
 // region Log In or Signup
 const val LOG_IN_OR_SIGNUP_BUTTON_CLICKED = "Log In or Signup Button Clicked"
 const val LOG_IN_OR_SIGN_UP_PAGE_VIEWED = "Log In or Sign Up Page Viewed"
+const val TWO_FACTOR_CONFIRMATION_VIEWED = "Two-Factor Confirmation Viewed"
 // endregion

--- a/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.java
@@ -118,6 +118,7 @@ public interface TwoFactorViewModel {
         .subscribe(__ -> this.koala.trackLoginError());
 
       this.koala.trackTwoFactorAuthView();
+      this.lake.trackTwoFactorConfirmationViewed();
     }
 
     private void success(final @NonNull AccessTokenEnvelope envelope) {

--- a/app/src/test/java/com/kickstarter/viewmodels/TwoFactorViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/TwoFactorViewModelTest.java
@@ -49,6 +49,7 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
     this.formIsValid.assertValues(true, false);
 
     this.koalaTest.assertValue(KoalaEvent.TWO_FACTOR_AUTH_CONFIRM_VIEW);
+    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
   }
 
   @Test
@@ -72,6 +73,7 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
     this.tfaSuccess.assertValueCount(1);
 
     this.koalaTest.assertValues(KoalaEvent.TWO_FACTOR_AUTH_CONFIRM_VIEW, KoalaEvent.LOGIN);
+    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
   }
 
   @Test
@@ -95,6 +97,7 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
     this.tfaSuccess.assertValueCount(1);
 
     this.koalaTest.assertValues(KoalaEvent.TWO_FACTOR_AUTH_CONFIRM_VIEW, KoalaEvent.LOGIN);
+    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
   }
 
   @Test
@@ -114,6 +117,7 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
 
     this.showResendCodeConfirmation.assertValueCount(1);
     this.koalaTest.assertValues(KoalaEvent.TWO_FACTOR_AUTH_CONFIRM_VIEW, KoalaEvent.TWO_FACTOR_AUTH_RESEND_CODE);
+    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
   }
 
   @Test
@@ -133,6 +137,7 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
 
     this.showResendCodeConfirmation.assertValueCount(1);
     this.koalaTest.assertValues(KoalaEvent.TWO_FACTOR_AUTH_CONFIRM_VIEW, KoalaEvent.TWO_FACTOR_AUTH_RESEND_CODE);
+    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
   }
 
   @Test
@@ -170,6 +175,7 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
     this.tfaSuccess.assertNoValues();
     this.genericTfaError.assertValueCount(1);
     this.koalaTest.assertValues(KoalaEvent.TWO_FACTOR_AUTH_CONFIRM_VIEW, KoalaEvent.ERRORED_USER_LOGIN);
+    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
   }
 
   @Test
@@ -205,5 +211,6 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
     this.tfaSuccess.assertNoValues();
     this.tfaCodeMismatchError.assertValueCount(1);
     this.koalaTest.assertValues(KoalaEvent.TWO_FACTOR_AUTH_CONFIRM_VIEW, KoalaEvent.ERRORED_USER_LOGIN);
+    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
   }
 }


### PR DESCRIPTION
# 📲 What
Adding `Two-Factor Confirmation Viewed` event.

# 🤔 Why
We have new Log In or Signup events.

# 🛠 How
- Added `LakeEvent.TWO_FACTOR_CONFIRMATION_VIEWED` with value `"Two-Factor Confirmation Viewed"`
- Added `Koala.trackTwoFactorConfirmationViewed` to track when a user views the `TwoFactorActivity`
- Tracking `TWO_FACTOR_CONFIRMATION_VIEWED` in `TwoFactorViewModel` when user views the 2FA screen
- Added tests in `TwoFactorViewModelTest`

# 👀 See
No visual changes.

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-925]

[NT-925]: https://kickstarter.atlassian.net/browse/NT-925