### PR TITLE
[⏱] NT-951 Adding context_pledge_flow to Project Page Viewed and Project Page Pledge Button Clicked events

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -1,8 +1,5 @@
 package com.kickstarter.libs;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import com.kickstarter.libs.utils.KoalaUtils;
 import com.kickstarter.models.Activity;
 import com.kickstarter.models.Project;
@@ -15,9 +12,14 @@ import com.kickstarter.ui.data.Editorial;
 import com.kickstarter.ui.data.LoginReason;
 import com.kickstarter.ui.data.Mailbox;
 import com.kickstarter.ui.data.PledgeData;
+import com.kickstarter.ui.data.PledgeFlowContext;
+import com.kickstarter.ui.data.ProjectData;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public final class Koala {
   private final @NonNull TrackingClientType client;
@@ -90,13 +92,12 @@ public final class Koala {
   /**
    * Tracks a project show event.
    *
-   * @param intentRefTag (nullable) The ref tag present in the activity upon displaying the project.
-   * @param cookieRefTag (nullable) The ref tag extracted from the cookie store upon viewing the project.
+   * @param projectData The Intent RefTag is the (nullable) RefTag present in the activity upon displaying the project.
+   * The Cookie RefTag is the (nullable) RefTag extracted from the cookie store upon viewing the project.
    */
-  public void trackProjectShow(final @NonNull Project project, final @Nullable RefTag intentRefTag, final @Nullable RefTag cookieRefTag) {
-    final Map<String, Object> properties = KoalaUtils.projectProperties(project, this.client.loggedInUser());
-
-    properties.putAll(KoalaUtils.refTagProperties(intentRefTag, cookieRefTag));
+  public void trackProjectShow(final @NonNull ProjectData projectData) {
+    final Map<String, Object> properties = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
+    properties.putAll(KoalaUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()));
 
     this.client.track(KoalaEvent.PROJECT_PAGE, properties);
   }
@@ -657,9 +658,12 @@ public final class Koala {
     this.client.track(LakeEvent.HAMBURGER_MENU_CLICKED, props);
   }
 
-  public void trackProjectPageViewed(final @NonNull Project project, final @Nullable RefTag intentRefTag, final @Nullable RefTag cookieRefTag) {
-    final Map<String, Object> props = KoalaUtils.projectProperties(project, this.client.loggedInUser());
-    props.putAll(KoalaUtils.refTagProperties(intentRefTag, cookieRefTag));
+  public void trackProjectPageViewed(final @NonNull ProjectData projectData, final @Nullable PledgeFlowContext pledgeFlowContext) {
+    final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
+    props.putAll(KoalaUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()));
+    if (pledgeFlowContext != null) {
+      props.put("context_pledge_flow", pledgeFlowContext.getTrackingString());
+    }
 
     this.client.track(LakeEvent.PROJECT_PAGE_VIEWED, props);
   }
@@ -694,9 +698,12 @@ public final class Koala {
     this.client.track(LakeEvent.PLEDGE_SUBMIT_BUTTON_CLICKED, props);
   }
 
-  public void trackProjectPagePledgeButtonClicked(final @NonNull Project project, final @Nullable RefTag intentRefTag, final @Nullable RefTag cookieRefTag) {
-    final Map<String, Object> props = KoalaUtils.projectProperties(project, this.client.loggedInUser());
-    props.putAll(KoalaUtils.refTagProperties(intentRefTag, cookieRefTag));
+  public void trackProjectPagePledgeButtonClicked(final @NonNull ProjectData projectData, final @Nullable PledgeFlowContext pledgeFlowContext) {
+    final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
+    props.putAll(KoalaUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()));
+    if (pledgeFlowContext != null) {
+      props.put("context_pledge_flow", pledgeFlowContext.getTrackingString());
+    }
 
     this.client.track(LakeEvent.PROJECT_PAGE_PLEDGE_BUTTON_CLICKED, props);
   }

--- a/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
@@ -6,6 +6,7 @@ import com.kickstarter.models.Reward;
 import com.kickstarter.models.User;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 import java.util.Arrays;
 
@@ -39,7 +40,7 @@ public final class ProjectFactory {
       .category(CategoryFactory.category())
       .creator(UserFactory.creator())
       .country("US")
-      .createdAt(DateTime.now())
+      .createdAt(DateTime.now(DateTimeZone.UTC))
       .currency("USD")
       .currencySymbol("$")
       .currentCurrency("USD")
@@ -59,8 +60,8 @@ public final class ProjectFactory {
       .updatedAt(DateTime.now())
       .urls(Project.Urls.builder().web(web).build())
       .video(VideoFactory.video())
-      .launchedAt(new DateTime().minusDays(10))
-      .deadline(new DateTime().plusDays(10))
+      .launchedAt(new DateTime(DateTimeZone.UTC).minusDays(10))
+      .deadline(new DateTime(DateTimeZone.UTC).plusDays(10))
       .build();
   }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -755,11 +755,10 @@ interface ProjectViewModel {
                     }
 
             fullProjectDataAndPledgeFlowContext
+                    .compose<Pair<ProjectData, PledgeFlowContext?>>(takeWhen(this.nativeProjectActionButtonClicked))
+                    .filter { it.first.project().isLive && !it.first.project().isBacking }
                     .compose(bindToLifecycle())
-                    .subscribe {
-                        val dataWithStoredCookieRefTag = storeCurrentCookieRefTag(it.first)
-                        this.lake.trackProjectPagePledgeButtonClicked(dataWithStoredCookieRefTag, it.second)
-                    }
+                    .subscribe { this.lake.trackProjectPagePledgeButtonClicked(storeCurrentCookieRefTag(it.first), it.second) }
 
             this.pledgeActionButtonText
                     .map { eventName(it) }

--- a/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/KoalaTest.kt
@@ -151,7 +151,7 @@ class KoalaTest : KSRobolectricTestCase() {
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
 
-        koala.trackProjectShow(project, RefTag.discovery(), RefTag.recommended())
+        koala.trackProjectShow(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()))
 
         assertDefaultProperties(null)
         assertProjectProperties(project)
@@ -167,7 +167,7 @@ class KoalaTest : KSRobolectricTestCase() {
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
 
-        koala.trackProjectShow(project, RefTag.discovery(), RefTag.recommended())
+        koala.trackProjectShow(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()))
 
         assertDefaultProperties(user)
         assertProjectProperties(project)
@@ -196,7 +196,7 @@ class KoalaTest : KSRobolectricTestCase() {
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
 
-        koala.trackProjectShow(project, RefTag.discovery(), RefTag.recommended())
+        koala.trackProjectShow(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()))
 
         assertDefaultProperties(user)
         assertProjectProperties(project)
@@ -217,7 +217,7 @@ class KoalaTest : KSRobolectricTestCase() {
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
 
-        koala.trackProjectShow(project, RefTag.discovery(), RefTag.recommended())
+        koala.trackProjectShow(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()))
 
         assertDefaultProperties(creator)
         assertProjectProperties(project)
@@ -238,7 +238,7 @@ class KoalaTest : KSRobolectricTestCase() {
         client.eventProperties.subscribe(this.propertiesTest)
         val koala = Koala(client)
 
-        koala.trackProjectShow(project, RefTag.discovery(), RefTag.recommended())
+        koala.trackProjectShow(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()))
 
         assertDefaultProperties(user)
         assertProjectProperties(project)

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -8,7 +8,6 @@ import com.kickstarter.models.User
 import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeFlowContext
-import junit.framework.TestCase
 import org.joda.time.DateTime
 import org.json.JSONArray
 import org.junit.Test
@@ -158,7 +157,7 @@ class LakeTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testProjectProperties() {
+    fun testProjectProperties_loggedOutUser() {
         val project = project()
 
         val client = MockTrackingClient(MockCurrentUser(), mockCurrentConfig(), true)
@@ -171,6 +170,12 @@ class LakeTest : KSRobolectricTestCase() {
         assertSessionProperties(null)
         assertContextProperties()
         assertProjectProperties(project)
+
+        val expectedProperties = propertiesTest.value
+        assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
+        assertEquals(false, expectedProperties["project_user_has_watched"])
+        assertEquals(false, expectedProperties["project_user_is_backer"])
+        assertEquals(false, expectedProperties["project_user_is_project_creator"])
 
         this.lakeTest.assertValues("Project Page Viewed")
     }
@@ -191,6 +196,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertContextProperties()
 
         val expectedProperties = propertiesTest.value
+        assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
         assertEquals(false, expectedProperties["project_user_has_watched"])
         assertEquals(false, expectedProperties["project_user_is_backer"])
         assertEquals(false, expectedProperties["project_user_is_project_creator"])
@@ -222,6 +228,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertContextProperties()
 
         val expectedProperties = propertiesTest.value
+        assertNull(expectedProperties["context_pledge_flow"])
         assertEquals(false, expectedProperties["project_user_has_watched"])
         assertEquals(true, expectedProperties["project_user_is_backer"])
         assertEquals(false, expectedProperties["project_user_is_project_creator"])
@@ -245,7 +252,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertContextProperties()
 
         val expectedProperties = this.propertiesTest.value
-        TestCase.assertNull(expectedProperties["project_user_has_watched"])
+        assertNull(expectedProperties["context_pledge_flow"])
         assertEquals(false, expectedProperties["project_user_has_watched"])
         assertEquals(false, expectedProperties["project_user_is_backer"])
         assertEquals(true, expectedProperties["project_user_is_project_creator"])
@@ -269,6 +276,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertContextProperties()
 
         val expectedProperties = this.propertiesTest.value
+        assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
         assertEquals(true, expectedProperties["project_user_has_watched"])
         assertEquals(false, expectedProperties["project_user_is_backer"])
         assertEquals(false, expectedProperties["project_user_is_project_creator"])

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -8,6 +8,7 @@ import com.kickstarter.models.User
 import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeFlowContext
+import junit.framework.TestCase
 import org.joda.time.DateTime
 import org.json.JSONArray
 import org.junit.Test
@@ -165,7 +166,7 @@ class LakeTest : KSRobolectricTestCase() {
         client.eventProperties.subscribe(this.propertiesTest)
         val lake = Koala(client)
 
-        lake.trackProjectPageViewed(project, RefTag.discovery(), RefTag.recommended())
+        lake.trackProjectPageViewed(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()), PledgeFlowContext.NEW_PLEDGE)
 
         assertSessionProperties(null)
         assertContextProperties()
@@ -183,7 +184,7 @@ class LakeTest : KSRobolectricTestCase() {
         client.eventProperties.subscribe(this.propertiesTest)
         val lake = Koala(client)
 
-        lake.trackProjectPageViewed(project, RefTag.discovery(), RefTag.recommended())
+        lake.trackProjectPageViewed(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()), PledgeFlowContext.NEW_PLEDGE)
 
         assertSessionProperties(user)
         assertProjectProperties(project)
@@ -214,7 +215,7 @@ class LakeTest : KSRobolectricTestCase() {
         client.eventProperties.subscribe(this.propertiesTest)
         val lake = Koala(client)
 
-        lake.trackProjectPageViewed(project, RefTag.discovery(), RefTag.recommended())
+        lake.trackProjectPageViewed(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()), null)
 
         assertSessionProperties(user)
         assertProjectProperties(project)
@@ -237,13 +238,14 @@ class LakeTest : KSRobolectricTestCase() {
         client.eventProperties.subscribe(this.propertiesTest)
         val lake = Koala(client)
 
-        lake.trackProjectPageViewed(project, RefTag.discovery(), RefTag.recommended())
+        lake.trackProjectPageViewed(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()), null)
 
         assertSessionProperties(creator)
         assertProjectProperties(project)
         assertContextProperties()
 
-        val expectedProperties = propertiesTest.value
+        val expectedProperties = this.propertiesTest.value
+        TestCase.assertNull(expectedProperties["project_user_has_watched"])
         assertEquals(false, expectedProperties["project_user_has_watched"])
         assertEquals(false, expectedProperties["project_user_is_backer"])
         assertEquals(true, expectedProperties["project_user_is_project_creator"])
@@ -260,18 +262,43 @@ class LakeTest : KSRobolectricTestCase() {
         client.eventProperties.subscribe(this.propertiesTest)
         val lake = Koala(client)
 
-        lake.trackProjectPageViewed(project, RefTag.discovery(), RefTag.recommended())
+        lake.trackProjectPageViewed(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()), PledgeFlowContext.NEW_PLEDGE)
+
+        assertSessionProperties(user)
+        assertProjectProperties(project)
+        assertContextProperties()
+
+        val expectedProperties = this.propertiesTest.value
+        assertEquals(true, expectedProperties["project_user_has_watched"])
+        assertEquals(false, expectedProperties["project_user_is_backer"])
+        assertEquals(false, expectedProperties["project_user_is_project_creator"])
+
+        this.lakeTest.assertValues("Project Page Viewed")
+    }
+
+    @Test
+    fun testProjectProperties_LoggedInUser_NotBacked() {
+        val project = project()
+        val user = user()
+        val client = MockTrackingClient(MockCurrentUser(user), mockCurrentConfig(), true)
+        client.eventNames.subscribe(this.lakeTest)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val lake = Koala(client)
+
+        val projectData = ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended())
+        lake.trackProjectPagePledgeButtonClicked(projectData, PledgeFlowContext.NEW_PLEDGE)
 
         assertSessionProperties(user)
         assertProjectProperties(project)
         assertContextProperties()
 
         val expectedProperties = propertiesTest.value
-        assertEquals(true, expectedProperties["project_user_has_watched"])
+        assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
+        assertEquals(false, expectedProperties["project_user_has_watched"])
         assertEquals(false, expectedProperties["project_user_is_backer"])
         assertEquals(false, expectedProperties["project_user_is_project_creator"])
 
-        this.lakeTest.assertValues("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Pledge Button Clicked")
     }
 
     @Test
@@ -321,7 +348,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertPledgeProperties()
         assertCheckoutProperties()
 
-        val expectedProperties = propertiesTest.value
+        val expectedProperties = this.propertiesTest.value
         assertNull(expectedProperties["checkout_id"])
         assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
         assertEquals(false, expectedProperties["project_user_has_watched"])
@@ -351,7 +378,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertPledgeProperties()
         assertCheckoutProperties()
 
-        val expectedProperties = propertiesTest.value
+        val expectedProperties = this.propertiesTest.value
         assertEquals(3L, expectedProperties["checkout_id"])
         assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
         assertEquals(false, expectedProperties["project_user_has_watched"])
@@ -362,7 +389,7 @@ class LakeTest : KSRobolectricTestCase() {
     }
 
     private fun assertCheckoutProperties() {
-        val expectedProperties = propertiesTest.value
+        val expectedProperties = this.propertiesTest.value
         assertEquals(30.0, expectedProperties["checkout_amount"])
         assertEquals("CREDIT_CARD", expectedProperties["checkout_payment_type"])
         assertEquals(3000L, expectedProperties["checkout_revenue_in_usd_cents"])
@@ -370,12 +397,12 @@ class LakeTest : KSRobolectricTestCase() {
     }
 
     private fun assertContextProperties() {
-        val expectedProperties = propertiesTest.value
+        val expectedProperties = this.propertiesTest.value
         assertEquals(DateTime.parse("2018-11-02T18:42:05Z").millis / 1000, expectedProperties["context_timestamp"])
     }
 
     private fun assertPledgeProperties() {
-        val expectedProperties = propertiesTest.value
+        val expectedProperties = this.propertiesTest.value
         assertEquals(DateTime.parse("2019-03-26T19:26:09Z").millis / 1000, expectedProperties["pledge_backer_reward_estimated_delivery_on"])
         assertEquals(false, expectedProperties["pledge_backer_reward_has_items"])
         assertEquals(2L, expectedProperties["pledge_backer_reward_id"])
@@ -388,7 +415,7 @@ class LakeTest : KSRobolectricTestCase() {
     }
 
     private fun assertProjectProperties(project: Project) {
-        val expectedProperties = propertiesTest.value
+        val expectedProperties = this.propertiesTest.value
         assertEquals(100, expectedProperties["project_backers_count"])
         assertEquals("Ceramics", expectedProperties["project_subcategory"])
         assertEquals("Art", expectedProperties["project_category"])
@@ -420,7 +447,7 @@ class LakeTest : KSRobolectricTestCase() {
     }
 
     private fun assertSessionProperties(user: User?) {
-        val expectedProperties = propertiesTest.value
+        val expectedProperties = this.propertiesTest.value
         assertEquals(9999, expectedProperties["session_app_build_number"])
         assertEquals("9.9.9", expectedProperties["session_app_release_version"])
         assertEquals("android", expectedProperties["session_client_platform"])


### PR DESCRIPTION
# 📲 What
Adding `context_pledge_flow` to `Project Page Viewed` and `Project Page Pledge Button Clicked` events

# 🤔 Why
This value is expected for Back a Project events despite its potential to be `null`.

# 🛠 How
- `Koala. trackProjectShow` now takes in a `ProjectData` object instead of a separate `Project` and `RefTag`s
- `Koala. trackProjectPageViewed` and `trackProjectPagePledgeButtonClicked` now takes in `ProjectData` and `PledgeFlowContext instead of a separate `Project` and `RefTag`s
- Added helper method `ProjectViewModel.pledgeFlowContext` to derive the `PledgeFlowContext` from a `Project` and `User`
- Added helper method `ProjectViewModel.storeCurrentCookieRefTag` to ensure the `ProjectData` has the correct `cookieRefTag`.

## bug
The tests for `Project` properties broke because of DST. The `ProjectFactory` now uses `DateTimeZone.UTC` so the tests are not off by one hour.

# 👀 See
Nothing 2 c

# 📋 QA
So many ways 2 QA:
- `ktk` the staging lake
- check the `Logcat` in Android Studio
- Look at the `dev` project in Amplitude

# Story 📖
[NT-951]


[NT-951]: https://kickstarter.atlassian.net/browse/NT-951