### PR TITLE
[0️⃣] NT-949 Disabling updates row when there are no updates 

### DIFF
--- a/app/src/main/java/com/kickstarter/models/Project.java
+++ b/app/src/main/java/com/kickstarter/models/Project.java
@@ -3,10 +3,6 @@ package com.kickstarter.models;
 import android.net.Uri;
 import android.os.Parcelable;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringDef;
-
 import com.kickstarter.libs.Permission;
 import com.kickstarter.libs.qualifiers.AutoGson;
 import com.kickstarter.libs.utils.DateTimeUtils;
@@ -20,6 +16,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.Collections;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringDef;
 import auto.parcel.AutoParcel;
 
 @AutoGson
@@ -235,6 +234,10 @@ public abstract class Project implements Parcelable, Relay {
 
   public boolean hasRewards() {
     return rewards() != null;
+  }
+
+  public boolean hasUpdates() {
+    return !IntegerUtils.isNullOrZero(updatesCount());
   }
 
   public boolean hasVideo() {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.java
@@ -98,6 +98,7 @@ public final class ProjectViewHolder extends KSViewHolder {
   protected @Bind(R.id.project_state_subhead_text_view) TextView projectStateSubheadTextView;
   protected @Bind(R.id.project_state_view_group) ViewGroup projectStateViewGroup;
   protected @Bind(R.id.view_pledge_button) @Nullable MaterialButton viewPledgeButton;
+  protected @Bind(R.id.updates) ViewGroup updatesContainer;
   protected @Bind(R.id.updates_count) TextView updatesCountTextView;
 
   protected @BindColor(R.color.green_alpha_20) int greenAlpha50Color;
@@ -381,6 +382,11 @@ public final class ProjectViewHolder extends KSViewHolder {
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(this::startProjectSocialActivity);
+
+    this.viewModel.outputs.updatesContainerIsEnabled()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(this.updatesContainer::setEnabled);
 
     this.viewModel.outputs.updatesCountTextViewText()
       .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectHolderViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectHolderViewModel.java
@@ -2,8 +2,6 @@ package com.kickstarter.viewmodels;
 
 import android.util.Pair;
 
-import androidx.annotation.NonNull;
-
 import com.kickstarter.R;
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.Build;
@@ -35,6 +33,7 @@ import org.joda.time.DateTime;
 
 import java.util.List;
 
+import androidx.annotation.NonNull;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
@@ -188,6 +187,9 @@ public interface ProjectHolderViewModel {
 
     /** Emits when we should start the {@link com.kickstarter.ui.activities.ProjectSocialActivity}. */
     Observable<Project> startProjectSocialActivity();
+
+    /** Emits a boolean determining if the updates container should be enabled. */
+    Observable<Boolean> updatesContainerIsEnabled();
 
     /** Emits the updates count for display. */
     Observable<String> updatesCountTextViewText();
@@ -376,6 +378,12 @@ public interface ProjectHolderViewModel {
 
       this.startProjectSocialActivity = project.compose(takeWhen(this.projectSocialViewGroupClicked));
 
+      project
+        .map(Project::hasUpdates)
+        .distinctUntilChanged()
+        .compose(bindToLifecycle())
+        .subscribe(this.updatesContainerIsClickable);
+
       this.updatesCountTextViewText = project
         .map(Project::updatesCount)
         .filter(ObjectUtils::isNotNull)
@@ -430,6 +438,7 @@ public interface ProjectHolderViewModel {
     private final Observable<DateTime> setUnsuccessfulProjectStateView;
     private final Observable<Project> startProjectSocialActivity;
     private final Observable<Boolean> shouldSetDefaultStatsMargins;
+    private final BehaviorSubject<Boolean> updatesContainerIsClickable = BehaviorSubject.create();
     private final Observable<String> updatesCountTextViewText;
 
     public final Inputs inputs = this;
@@ -576,6 +585,9 @@ public interface ProjectHolderViewModel {
     }
     @Override public @NonNull Observable<Boolean> shouldSetDefaultStatsMargins() {
       return this.shouldSetDefaultStatsMargins;
+    }
+    @Override public @NonNull Observable<Boolean> updatesContainerIsEnabled() {
+      return this.updatesContainerIsClickable;
     }
     @Override public @NonNull Observable<String> updatesCountTextViewText() {
       return this.updatesCountTextViewText;

--- a/app/src/main/res/layout/project_creator_info.xml
+++ b/app/src/main/res/layout/project_creator_info.xml
@@ -19,8 +19,8 @@
       android:id="@+id/campaign"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:background="@drawable/click_indicator_light_masked"
       android:focusable="true"
+      android:foreground="@drawable/click_indicator_light_masked"
       android:paddingTop="@dimen/grid_2"
       android:paddingBottom="@dimen/grid_2">
 
@@ -50,6 +50,7 @@
       android:id="@+id/updates"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:focusable="true"
       android:foreground="?android:attr/selectableItemBackground"
       android:paddingTop="@dimen/grid_2"
       android:paddingBottom="@dimen/grid_2">
@@ -81,8 +82,8 @@
       android:id="@+id/comments"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:background="@drawable/click_indicator_light_masked"
       android:focusable="true"
+      android:foreground="?android:attr/selectableItemBackground"
       android:paddingTop="@dimen/grid_2"
       android:paddingBottom="@dimen/grid_2">
 

--- a/app/src/main/res/layout/project_creator_info.xml
+++ b/app/src/main/res/layout/project_creator_info.xml
@@ -1,123 +1,111 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical">
 
   <LinearLayout
-    android:paddingStart="@dimen/project_padding_x"
-    android:paddingEnd="@dimen/project_padding_x"
-    android:orientation="vertical"
     android:id="@+id/creator_links"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:divider="@color/ksr_grey_500"
-    android:dividerHeight="1dp" >
+    android:divider="@drawable/divider_grey_500_horizontal"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/project_padding_x"
+    android:paddingEnd="@dimen/project_padding_x"
+    android:showDividers="middle">
 
     <RelativeLayout
       android:id="@+id/campaign"
-      android:focusable="true"
-      android:background="@drawable/click_indicator_light_masked"
       android:layout_width="match_parent"
-      android:layout_height="@dimen/grid_7" >
+      android:layout_height="wrap_content"
+      android:background="@drawable/click_indicator_light_masked"
+      android:focusable="true"
+      android:paddingTop="@dimen/grid_2"
+      android:paddingBottom="@dimen/grid_2">
 
       <TextView
-        android:layout_toStartOf="@+id/campaign_button"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
-        android:gravity="center_vertical"
+        android:layout_centerVertical="true"
+        android:layout_toStartOf="@+id/campaign_button"
+        android:text="@string/project_menu_buttons_campaign"
         android:textColor="@color/ksr_soft_black"
-        android:textSize="@dimen/body"
-        android:text="@string/project_menu_buttons_campaign" />
+        android:textSize="@dimen/body" />
 
-      <com.kickstarter.ui.views.IconButton
+      <ImageView
         android:id="@+id/campaign_button"
-        android:textSize="@dimen/chevron_right_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/chevron_right_icon"
-        android:textColor="@color/ksr_soft_black"
         android:layout_alignParentEnd="true"
-        android:layout_centerVertical="true" />
+        android:layout_centerVertical="true"
+        android:importantForAccessibility="no"
+        android:src="@drawable/chevron_right"
+        android:tint="@color/ksr_soft_black" />
 
     </RelativeLayout>
-
-    <include
-      layout="@layout/horizontal_line_1dp_view"
-      android:layout_height="wrap_content"
-      android:layout_width="wrap_content"
-      android:layout_marginTop="@dimen/grid_1"
-      android:layout_marginBottom="@dimen/grid_1"/>
 
     <RelativeLayout
       android:id="@+id/updates"
-      android:background="@drawable/click_indicator_light_masked"
-      android:focusable="true"
       android:layout_width="match_parent"
-      android:layout_height="@dimen/grid_7" >
+      android:layout_height="wrap_content"
+      android:foreground="?android:attr/selectableItemBackground"
+      android:paddingTop="@dimen/grid_2"
+      android:paddingBottom="@dimen/grid_2">
 
       <TextView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_toStartOf="@+id/updates_count"
-        android:gravity="center_vertical"
+        android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:layout_toStartOf="@+id/updates_count"
+        android:text="@string/project_menu_buttons_updates"
         android:textColor="@color/ksr_soft_black"
-        android:textSize="@dimen/body"
-        android:text="@string/project_menu_buttons_updates" />
+        android:textSize="@dimen/body" />
 
       <TextView
         android:id="@+id/updates_count"
-        android:background="@drawable/text_view_rect_background"
-        android:gravity="center"
-        android:layout_centerVertical="true"
-        android:textSize="@dimen/body"
-        android:textColor="@color/ksr_soft_black"
-        android:layout_alignParentEnd="true"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        tools:text="45"/>
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:background="@drawable/text_view_rect_background"
+        android:textColor="@color/ksr_soft_black"
+        android:textSize="@dimen/body"
+        tools:text="45" />
 
     </RelativeLayout>
 
-    <include
-      layout="@layout/horizontal_line_1dp_view"
-      android:layout_height="wrap_content"
-      android:layout_width="wrap_content"
-      android:layout_marginTop="@dimen/grid_1_half"
-      android:layout_marginBottom="@dimen/grid_1_half"/>
-
     <RelativeLayout
       android:id="@+id/comments"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
       android:background="@drawable/click_indicator_light_masked"
       android:focusable="true"
-      android:layout_width="match_parent"
-      android:layout_height="@dimen/grid_7" >
+      android:paddingTop="@dimen/grid_2"
+      android:paddingBottom="@dimen/grid_2">
 
       <TextView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_toStartOf="@+id/comments_count"
+        android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
-        android:gravity="center_vertical"
+        android:layout_centerVertical="true"
+        android:layout_toStartOf="@+id/comments_count"
+        android:text="@string/project_menu_buttons_comments"
         android:textColor="@color/ksr_soft_black"
-        android:textSize="@dimen/body"
-        android:text="@string/project_menu_buttons_comments" />
+        android:textSize="@dimen/body" />
 
       <TextView
         android:id="@+id/comments_count"
-        android:background="@drawable/text_view_rect_background"
-        android:gravity="center"
-        android:layout_centerVertical="true"
-        android:textSize="@dimen/body"
-        android:textColor="@color/ksr_soft_black"
-        android:layout_alignParentEnd="true"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        tools:text="1,000"/>
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:background="@drawable/text_view_rect_background"
+        android:textColor="@color/ksr_soft_black"
+        android:textSize="@dimen/body"
+        tools:text="1,000" />
 
     </RelativeLayout>
 
@@ -126,19 +114,19 @@
   <TextView
     android:id="@+id/project_disclaimer_text_view"
     style="@style/Caption1Secondary"
-    android:textColor="@color/ksr_dark_grey_500"
-    android:paddingStart="@dimen/project_padding_x"
-    android:paddingEnd="@dimen/project_padding_x"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:focusable="true"
-    android:paddingTop="@dimen/grid_4" />
+    android:paddingStart="@dimen/project_padding_x"
+    android:paddingTop="@dimen/grid_4"
+    android:paddingEnd="@dimen/project_padding_x"
+    android:textColor="@color/ksr_dark_grey_500" />
 
   <View
     android:layout_width="match_parent"
     android:layout_height="1dp"
-    android:layout_marginBottom="@dimen/grid_4"
     android:layout_marginTop="@dimen/grid_5"
+    android:layout_marginBottom="@dimen/grid_4"
     android:background="@color/ksr_dark_grey_500" />
 
 </LinearLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectHolderViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectHolderViewModelTest.java
@@ -2,8 +2,6 @@ package com.kickstarter.viewmodels;
 
 import android.util.Pair;
 
-import androidx.annotation.NonNull;
-
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.R;
 import com.kickstarter.libs.Config;
@@ -38,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import androidx.annotation.NonNull;
 import rx.observers.TestSubscriber;
 
 public final class ProjectHolderViewModelTest extends KSRobolectricTestCase {
@@ -87,6 +86,7 @@ public final class ProjectHolderViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Void> setSuspendedProjectStateView = new TestSubscriber<>();
   private final TestSubscriber<DateTime> setUnsuccessfulProjectStateView = new TestSubscriber<>();
   private final TestSubscriber<Project> startProjectSocialActivity = new TestSubscriber<>();
+  private final TestSubscriber<Boolean> updatesContainerIsEnabled = new TestSubscriber<>();
   private final TestSubscriber<String> updatesCountTextViewText = new TestSubscriber<>();
 
   private void setUpEnvironment(final @NonNull Environment environment) {
@@ -136,6 +136,7 @@ public final class ProjectHolderViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.setSuspendedProjectStateView().subscribe(this.setSuspendedProjectStateView);
     this.vm.outputs.setUnsuccessfulProjectStateView().subscribe(this.setUnsuccessfulProjectStateView);
     this.vm.outputs.startProjectSocialActivity().subscribe(this.startProjectSocialActivity);
+    this.vm.outputs.updatesContainerIsEnabled().subscribe(this.updatesContainerIsEnabled);
     this.vm.outputs.updatesCountTextViewText().subscribe(this.updatesCountTextViewText);
   }
 
@@ -737,5 +738,39 @@ public final class ProjectHolderViewModelTest extends KSRobolectricTestCase {
 
     // USD conversion not shown for US project.
     this.conversionTextViewIsGone.assertValue(true);
+  }
+
+  @Test
+  public void testUpdatesContainerIsEnabled_whenUpdatesCountIsNull() {
+    setUpEnvironment(environment());
+    this.vm.inputs.configureWith(ProjectDataFactory.Companion.project(ProjectFactory.project()));
+
+    this.updatesContainerIsEnabled.assertValue(false);
+  }
+
+  @Test
+  public void testUpdatesContainerIsEnabled_whenUpdatesCountIsZero() {
+    setUpEnvironment(environment());
+
+    final Project project = ProjectFactory.project()
+      .toBuilder()
+      .updatesCount(0)
+      .build();
+    this.vm.inputs.configureWith(ProjectDataFactory.Companion.project(project));
+
+    this.updatesContainerIsEnabled.assertValue(false);
+  }
+
+  @Test
+  public void testUpdatesContainerIsEnabled_whenUpdatesCountIsNonZero() {
+    setUpEnvironment(environment());
+
+    final Project project = ProjectFactory.project()
+      .toBuilder()
+      .updatesCount(3)
+      .build();
+    this.vm.inputs.configureWith(ProjectDataFactory.Companion.project(project));
+
+    this.updatesContainerIsEnabled.assertValue(true);
   }
 }


### PR DESCRIPTION
# 📲 What
Disabling project updates container in Project page when there are no updates.

# 🤔 Why
If there are no updates, there's nothing 2 c.

# 🛠 How
- Disabling updates row in ProjectViewHolder when a project doesn't have any updates.
- Added helper method `hasUpdates` to `Project` model.
- Added output `updatesContainerIsEnabled` to `ProjectHolderViewModel` that emits a `Boolean` determining if the updates row should be enabled
- Cleaned up unnecessary dividers and strange padding in `project_creator_info`
- Tests for `updatesContainerIsEnabled`

# 👀 See
| After 🦋 | Before 🐛 |
| --- | --- |
| ![screenshot-2020-03-02_113711](https://user-images.githubusercontent.com/1289295/75696921-5597d200-5c7a-11ea-83c5-6073d3f7c346.png) | ![screenshot-2020-03-02_113415](https://user-images.githubusercontent.com/1289295/75696919-54ff3b80-5c7a-11ea-958e-47dedbc0ac4d.png) |

# 📋 QA
Click on the updates row.

# Story 📖
[NT-949]


[NT-949]: https://kickstarter.atlassian.net/browse/NT-949