### PR TITLE
[⏳] NT-952 Project updates progress bar

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectUpdatesActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectUpdatesActivity.java
@@ -3,12 +3,14 @@ package com.kickstarter.ui.activities;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Pair;
+import android.widget.ProgressBar;
 
 import com.kickstarter.R;
 import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.RecyclerViewPaginator;
 import com.kickstarter.libs.SwipeRefresher;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
+import com.kickstarter.libs.utils.ViewUtils;
 import com.kickstarter.models.Project;
 import com.kickstarter.models.Update;
 import com.kickstarter.ui.IntentKey;
@@ -35,6 +37,7 @@ public class ProjectUpdatesActivity extends BaseActivity<ProjectUpdatesViewModel
   private RecyclerViewPaginator recyclerViewPaginator;
   private SwipeRefresher swipeRefresher;
 
+  protected @Bind(R.id.updates_progress_bar) ProgressBar updatesProgressBar;
   protected @Bind(R.id.updates_toolbar) KSToolbar updatesToolbar;
   protected @Bind(R.id.updates_swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayout;
   protected @Bind(R.id.updates_recycler_view) RecyclerView recyclerView;
@@ -56,6 +59,11 @@ public class ProjectUpdatesActivity extends BaseActivity<ProjectUpdatesViewModel
             this, this.swipeRefreshLayout, this.viewModel.inputs::refresh, this.viewModel.outputs::isFetchingUpdates
     );
     this.updatesToolbar.setTitle(this.updatesTitleString);
+
+    this.viewModel.outputs.horizontalProgressBarIsGone()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(ViewUtils.setGone(this.updatesProgressBar));
 
     this.viewModel.outputs.startUpdateActivity()
       .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectUpdatesViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectUpdatesViewModel.java
@@ -6,6 +6,7 @@ import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.ApiPaginator;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.KoalaContext;
+import com.kickstarter.libs.utils.BooleanUtils;
 import com.kickstarter.libs.utils.ListUtils;
 import com.kickstarter.models.Project;
 import com.kickstarter.models.Update;
@@ -39,6 +40,9 @@ public interface ProjectUpdatesViewModel {
   }
 
   interface Outputs {
+    /** Emits a boolean indicating whether the horizontal ProgressBar is visible. */
+    Observable<Boolean> horizontalProgressBarIsGone();
+
     /** Emits a boolean indicating whether updates are being fetched from the API. */
     Observable<Boolean> isFetchingUpdates();
 
@@ -86,6 +90,14 @@ public interface ProjectUpdatesViewModel {
 
       paginator
         .isFetching()
+        .distinctUntilChanged()
+        .take(2)
+        .map(BooleanUtils::negate)
+        .compose(bindToLifecycle())
+        .subscribe(this.horizontalProgressBarIsGone);
+
+      paginator
+        .isFetching()
         .compose(bindToLifecycle())
         .subscribe(this.isFetchingUpdates);
 
@@ -109,6 +121,7 @@ public interface ProjectUpdatesViewModel {
     private final PublishSubject<Void> refresh = PublishSubject.create();
     private final PublishSubject<Update> updateClicked = PublishSubject.create();
 
+    private final BehaviorSubject<Boolean> horizontalProgressBarIsGone = BehaviorSubject.create();
     private final BehaviorSubject<Boolean> isFetchingUpdates = BehaviorSubject.create();
     private final BehaviorSubject<Pair<Project, List<Update>>> projectAndUpdates = BehaviorSubject.create();
     private final PublishSubject<Pair<Project, Update>> startUpdateActivity = PublishSubject.create();
@@ -126,6 +139,9 @@ public interface ProjectUpdatesViewModel {
       this.updateClicked.onNext(update);
     }
 
+    @Override public @NonNull Observable<Boolean> horizontalProgressBarIsGone() {
+      return this.horizontalProgressBarIsGone;
+    }
     @Override public @NonNull Observable<Boolean> isFetchingUpdates() {
       return this.isFetchingUpdates;
     }

--- a/app/src/main/res/layout/activity_account.xml
+++ b/app/src/main/res/layout/activity_account.xml
@@ -150,7 +150,7 @@
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="-6dp"
+        android:layout_marginTop="@dimen/indeterminate_horizontal_progress_bar_margin_top"
         android:indeterminate="true"
         android:visibility="gone" />
 

--- a/app/src/main/res/layout/activity_change_email.xml
+++ b/app/src/main/res/layout/activity_change_email.xml
@@ -109,7 +109,7 @@
       style="@style/Widget.AppCompat.ProgressBar.Horizontal"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginTop="-6dp"
+      android:layout_marginTop="@dimen/indeterminate_horizontal_progress_bar_margin_top"
       android:indeterminate="true"
       android:visibility="gone" />
 

--- a/app/src/main/res/layout/activity_change_password.xml
+++ b/app/src/main/res/layout/activity_change_password.xml
@@ -97,7 +97,7 @@
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="-6dp"
+        android:layout_marginTop="@dimen/indeterminate_horizontal_progress_bar_margin_top"
         android:indeterminate="true"
         android:visibility="gone" />
 

--- a/app/src/main/res/layout/activity_create_password.xml
+++ b/app/src/main/res/layout/activity_create_password.xml
@@ -84,7 +84,7 @@
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="-6dp"
+        android:layout_marginTop="@dimen/indeterminate_horizontal_progress_bar_margin_top"
         android:indeterminate="true"
         android:visibility="gone" />
 

--- a/app/src/main/res/layout/activity_message_creator.xml
+++ b/app/src/main/res/layout/activity_message_creator.xml
@@ -79,7 +79,7 @@
     style="@style/Widget.AppCompat.ProgressBar.Horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="-6dp"
+    android:layout_marginTop="@dimen/indeterminate_horizontal_progress_bar_margin_top"
     android:indeterminate="true"
     android:visibility="gone"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"

--- a/app/src/main/res/layout/activity_project.xml
+++ b/app/src/main/res/layout/activity_project.xml
@@ -26,7 +26,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_below="@id/project_app_bar_layout"
-    android:layout_marginTop="-6dp"
+    android:layout_marginTop="@dimen/indeterminate_horizontal_progress_bar_margin_top"
     android:indeterminate="true"
     android:visibility="gone"
     app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />

--- a/app/src/main/res/layout/activity_settings_payment_methods.xml
+++ b/app/src/main/res/layout/activity_settings_payment_methods.xml
@@ -75,7 +75,7 @@
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="-6dp"
+        android:layout_marginTop="@dimen/indeterminate_horizontal_progress_bar_margin_top"
         android:indeterminate="true"
         android:visibility="gone" />
 

--- a/app/src/main/res/layout/activity_updates.xml
+++ b/app/src/main/res/layout/activity_updates.xml
@@ -3,6 +3,7 @@
   android:id="@+id/search_layout"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
+  android:background="@color/ksr_grey_300"
   android:orientation="vertical"
   tools:context=".ui.activities.ProjectUpdatesActivity">
 
@@ -16,6 +17,14 @@
 
   </com.google.android.material.appbar.AppBarLayout>
 
+  <ProgressBar
+    android:id="@+id/updates_progress_bar"
+    style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="-6dp"
+    android:indeterminate="true" />
+
   <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
     android:id="@+id/updates_swipe_refresh_layout"
     android:layout_width="match_parent"
@@ -25,7 +34,6 @@
       android:id="@+id/updates_recycler_view"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:background="@color/ksr_grey_300"
       android:clipToPadding="false"
       android:paddingTop="@dimen/grid_1"
       tools:listitem="@layout/item_update_card" />

--- a/app/src/main/res/layout/activity_updates.xml
+++ b/app/src/main/res/layout/activity_updates.xml
@@ -22,7 +22,7 @@
     style="@style/Widget.AppCompat.ProgressBar.Horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="-6dp"
+    android:layout_marginTop="@dimen/indeterminate_horizontal_progress_bar_margin_top"
     android:indeterminate="true" />
 
   <androidx.swiperefreshlayout.widget.SwipeRefreshLayout

--- a/app/src/main/res/layout/form_new_card.xml
+++ b/app/src/main/res/layout/form_new_card.xml
@@ -154,7 +154,7 @@
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="-6dp"
+        android:layout_marginTop="@dimen/indeterminate_horizontal_progress_bar_margin_top"
         android:indeterminate="true"
         android:visibility="gone" />
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -95,8 +95,6 @@
   <dimen name="settings_icon_fixed_width">@dimen/grid_8</dimen>
   <dimen name="button_corner_radius">@dimen/grid_1_half</dimen>
   <dimen name="button_stroke_width">1dp</dimen>
-  <dimen name="progress_bar_min_height">@dimen/grid_1_half</dimen>
-  <dimen name="progress_bar_height">@dimen/grid_1_half</dimen>
   <dimen name="project_action_button_height">@dimen/grid_8</dimen>
 
   <!-- Photos -->
@@ -193,5 +191,10 @@
 
   <!-- Native Checkout -->
   <dimen name="editorial_radius">8dp</dimen>
+
+<!--  Progress Bars -->
+  <dimen name="indeterminate_horizontal_progress_bar_margin_top">@dimen/indeterminate_horizontal_progress_bar_margin_top</dimen>
+  <dimen name="progress_bar_min_height">@dimen/grid_1_half</dimen>
+  <dimen name="progress_bar_height">@dimen/grid_1_half</dimen>
 
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -192,7 +192,7 @@
   <!-- Native Checkout -->
   <dimen name="editorial_radius">8dp</dimen>
 
-<!--  Progress Bars -->
+  <!--  Progress Bars -->
   <dimen name="indeterminate_horizontal_progress_bar_margin_top">-6dp</dimen>
   <dimen name="progress_bar_min_height">@dimen/grid_1_half</dimen>
   <dimen name="progress_bar_height">@dimen/grid_1_half</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -193,7 +193,7 @@
   <dimen name="editorial_radius">8dp</dimen>
 
 <!--  Progress Bars -->
-  <dimen name="indeterminate_horizontal_progress_bar_margin_top">@dimen/indeterminate_horizontal_progress_bar_margin_top</dimen>
+  <dimen name="indeterminate_horizontal_progress_bar_margin_top">-6dp</dimen>
   <dimen name="progress_bar_min_height">@dimen/grid_1_half</dimen>
   <dimen name="progress_bar_height">@dimen/grid_1_half</dimen>
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectUpdatesViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectUpdatesViewModelTest.java
@@ -25,18 +25,28 @@ import rx.observers.TestSubscriber;
 
 public class ProjectUpdatesViewModelTest extends KSRobolectricTestCase {
   private ProjectUpdatesViewModel.ViewModel vm;
+  private final TestSubscriber<Boolean> horizontalProgressBarIsGone = new TestSubscriber<>();
   private final TestSubscriber<Boolean> isFetchingUpdates = new TestSubscriber<>();
   private final TestSubscriber<Pair<Project, List<Update>>> projectAndUpdates = new TestSubscriber<>();
   private final TestSubscriber<Pair<Project, Update>> startUpdateActivity = new TestSubscriber<>();
 
   private void setUpEnvironment(final @NonNull Environment env, final @NonNull Project project) {
     this.vm = new ProjectUpdatesViewModel.ViewModel(env);
+    this.vm.outputs.horizontalProgressBarIsGone().subscribe(this.horizontalProgressBarIsGone);
     this.vm.outputs.isFetchingUpdates().subscribe(this.isFetchingUpdates);
     this.vm.outputs.projectAndUpdates().subscribe(this.projectAndUpdates);
     this.vm.outputs.startUpdateActivity().subscribe(this.startUpdateActivity);
 
     // Configure the view model with a project intent.
     this.vm.intent(new Intent().putExtra(IntentKey.PROJECT, project));
+  }
+
+  @Test
+  public void testHorizontalProgressBarIsGone() {
+    setUpEnvironment(environment(), ProjectFactory.project());
+
+    this.horizontalProgressBarIsGone.assertValues(false, true);
+    this.koalaTest.assertValue("Viewed Updates");
   }
 
   @Test


### PR DESCRIPTION
# 📲 What
Added a horizontal progress bar to the project updates list.

# 🤔 Why
So the user has some indication something is happening when they get to the updates screen.

# 🛠 How

- Added output `horizontalProgressBarIsGone` to `ProjectUpdatesViewModel`
- Added `updates_progress_bar` to `activity_project_updates`
- Tests for `horizontalProgressBarIsGone`

# 👀 See

| After 🦋 |
| --- |
| ![device-2020-03-02-123102 2020-03-02 12_31_40](https://user-images.githubusercontent.com/1289295/75701433-c7bfe500-5c81-11ea-84c7-5714168d5125.gif) |

# 📋 QA
View those sweet updates.

# Story 📖
[NT-952]


[NT-952]: https://kickstarter.atlassian.net/browse/NT-952