### PR TITLE
[🧫] NT-959 Adding `distinct_id` user attribute to Optimizely in non prod environments

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -9,9 +9,6 @@ import android.content.res.AssetManager;
 import android.content.res.Resources;
 import android.util.Log;
 
-import androidx.annotation.NonNull;
-import androidx.preference.PreferenceManager;
-
 import com.apollographql.apollo.ApolloClient;
 import com.crashlytics.android.Crashlytics;
 import com.google.gson.FieldNamingPolicy;
@@ -93,6 +90,8 @@ import java.net.CookieManager;
 
 import javax.inject.Singleton;
 
+import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
 import dagger.Module;
 import dagger.Provides;
 import okhttp3.CookieJar;
@@ -663,6 +662,6 @@ public final class ApplicationModule {
         }
       }
     });
-    return new OptimizelyExperimentsClient(optimizelyManager);
+    return new OptimizelyExperimentsClient(optimizelyManager, apiEndpoint);
   }
 }

--- a/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
@@ -6,8 +6,8 @@ import com.kickstarter.models.User
 
 interface ExperimentsClientType {
 
-    fun ExperimentsClientType.attributes(user: User?, refTag: RefTag?): MutableMap<String, *> {
-        return ExperimentUtils.attributes(user, refTag, androidBuildVersion())
+    fun ExperimentsClientType.attributes(user: User?, refTag: RefTag?, apiEndpoint: ApiEndpoint): MutableMap<String, *> {
+        return ExperimentUtils.attributes(user, refTag, androidBuildVersion(), apiEndpoint)
     }
 
     fun androidBuildVersion(): String

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
@@ -6,20 +6,20 @@ import com.kickstarter.models.User
 import com.optimizely.ab.android.sdk.OptimizelyClient
 import com.optimizely.ab.android.sdk.OptimizelyManager
 
-class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManager) : ExperimentsClientType {
+class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManager, private val apiEndpoint: ApiEndpoint) : ExperimentsClientType {
     override fun androidBuildVersion(): String {
         return android.os.Build.VERSION.RELEASE
     }
 
     override fun track(eventKey: String, user: User?, refTag: RefTag?) {
-        optimizelyClient().track(eventKey, userId(), attributes(user, refTag))
+        optimizelyClient().track(eventKey, userId(), attributes(user, refTag, this.apiEndpoint))
     }
 
     override fun variant(experiment: OptimizelyExperiment.Key, user: User?, refTag: RefTag?): OptimizelyExperiment.Variant {
         val variationString: String? = if (user?.isAdmin == true) {
-            optimizelyClient().getVariation(experiment.key, user.id().toString(), attributes(user, refTag))
+            optimizelyClient().getVariation(experiment.key, user.id().toString(), attributes(user, refTag, this.apiEndpoint))
         } else {
-            optimizelyClient().activate(experiment.key, userId(), attributes(user, refTag))
+            optimizelyClient().activate(experiment.key, userId(), attributes(user, refTag, this.apiEndpoint))
         }?.key
 
         return OptimizelyExperiment.Variant.safeValueOf(variationString)

--- a/app/src/main/java/com/kickstarter/libs/utils/ExperimentUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/ExperimentUtils.kt
@@ -1,18 +1,21 @@
 package com.kickstarter.libs.utils
 
+import com.google.firebase.iid.FirebaseInstanceId
+import com.kickstarter.libs.ApiEndpoint
 import com.kickstarter.libs.RefTag
 import com.kickstarter.models.User
 import java.util.*
 
 object ExperimentUtils {
 
-    fun attributes(user: User?, refTag: RefTag?, buildVersion: String): MutableMap<String, Any?> {
+    fun attributes(user: User?, refTag: RefTag?, buildVersion: String, apiEndpoint: ApiEndpoint): MutableMap<String, Any?> {
         return mutableMapOf(
                 Pair("user_backed_projects_count", user?.backedProjectsCount() ?: 0),
                 Pair("user_country", user?.location()?.country() ?: Locale.getDefault().country),
                 Pair("session_os_version", String.format("Android %s", buildVersion)),
                 Pair("session_ref_tag", refTag?.tag()),
-                Pair("session_user_is_logged_in", user != null)
+                Pair("session_user_is_logged_in", user != null),
+                Pair("distinct_id", if (apiEndpoint != ApiEndpoint.PRODUCTION) FirebaseInstanceId.getInstance().id else null)
         )
     }
 }

--- a/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.mock
 
+import com.kickstarter.libs.ApiEndpoint
 import com.kickstarter.libs.ExperimentsClientType
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.models.OptimizelyExperiment
@@ -7,14 +8,17 @@ import com.kickstarter.models.User
 import rx.Observable
 import rx.subjects.PublishSubject
 
-open class MockExperimentsClientType(private val variant: OptimizelyExperiment.Variant = OptimizelyExperiment.Variant.CONTROL) : ExperimentsClientType {
+open class MockExperimentsClientType(private val variant: OptimizelyExperiment.Variant, private val apiEndpoint: ApiEndpoint) : ExperimentsClientType {
+    constructor(variant: OptimizelyExperiment.Variant) : this(variant, ApiEndpoint.STAGING)
+    constructor() : this(OptimizelyExperiment.Variant.CONTROL, ApiEndpoint.STAGING)
+
     class ExperimentsEvent internal constructor(internal val eventKey: String, internal val attributes: MutableMap<String, *>)
 
     private val experimentEvents : PublishSubject<ExperimentsEvent> = PublishSubject.create()
     val eventKeys: Observable<String> = this.experimentEvents.map { e -> e.eventKey }
 
     override fun track(eventKey: String, user: User?, refTag: RefTag?) {
-        this.experimentEvents.onNext(ExperimentsEvent(eventKey, attributes(user, refTag)))
+        this.experimentEvents.onNext(ExperimentsEvent(eventKey, attributes(user, refTag, this.apiEndpoint)))
     }
 
     override fun userId(): String = "device-id"

--- a/app/src/test/java/com/kickstarter/libs/utils/ExperimentUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/ExperimentUtilsTest.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.libs.utils
 
 import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.ApiEndpoint
 import com.kickstarter.libs.RefTag
 import com.kickstarter.mock.factories.UserFactory
 import org.junit.Test
@@ -8,26 +9,54 @@ import org.junit.Test
 class ExperimentUtilsTest : KSRobolectricTestCase() {
 
     @Test
-    fun attributes_loggedInUser() {
+    fun attributes_loggedInUser_notProd() {
         val user = UserFactory.user()
                 .toBuilder()
                 .backedProjectsCount(10)
                 .build()
-        val attributes = ExperimentUtils.attributes(user, RefTag.discovery(), "10")
+        val attributes = ExperimentUtils.attributes(user, RefTag.discovery(), "10", ApiEndpoint.STAGING)
         assertEquals(10, attributes["user_backed_projects_count"])
         assertEquals("US", attributes["user_country"])
         assertEquals("Android 10", attributes["session_os_version"])
         assertEquals("discovery", attributes["session_ref_tag"])
         assertEquals(true, attributes["session_user_is_logged_in"])
+        assertNotNull(attributes["distinct_id"])
     }
 
     @Test
-    fun attributes_loggedOutUser() {
-        val attributes = ExperimentUtils.attributes(null, null, "9")
+    fun attributes_loggedInUser_prod() {
+        val user = UserFactory.user()
+                .toBuilder()
+                .backedProjectsCount(10)
+                .build()
+        val attributes = ExperimentUtils.attributes(user, RefTag.discovery(), "10", ApiEndpoint.PRODUCTION)
+        assertEquals(10, attributes["user_backed_projects_count"])
+        assertEquals("US", attributes["user_country"])
+        assertEquals("Android 10", attributes["session_os_version"])
+        assertEquals("discovery", attributes["session_ref_tag"])
+        assertEquals(true, attributes["session_user_is_logged_in"])
+        assertNull(attributes["distinct_id"])
+    }
+
+    @Test
+    fun attributes_loggedOutUser_notProd() {
+        val attributes = ExperimentUtils.attributes(null, null, "9", ApiEndpoint.STAGING)
         assertEquals(0, attributes["user_backed_projects_count"])
         assertEquals("US", attributes["user_country"])
         assertEquals("Android 9", attributes["session_os_version"])
         assertNull(attributes["session_ref_tag"])
         assertEquals(false, attributes["session_user_is_logged_in"])
+        assertNotNull(attributes["distinct_id"])
+    }
+
+    @Test
+    fun attributes_loggedOutUser_prod() {
+        val attributes = ExperimentUtils.attributes(null, null, "9", ApiEndpoint.PRODUCTION)
+        assertEquals(0, attributes["user_backed_projects_count"])
+        assertEquals("US", attributes["user_country"])
+        assertEquals("Android 9", attributes["session_os_version"])
+        assertNull(attributes["session_ref_tag"])
+        assertEquals(false, attributes["session_user_is_logged_in"])
+        assertNull(attributes["distinct_id"])
     }
 }


### PR DESCRIPTION
# 📲 What
Adding `distinct_id` user attribute to Optimizely in non production environments.

# 🤔 Why
So we can filter events by distinct ID for non production environments for testing purposes.

# 🛠 How
Adding `distinct_id` user attribute to Optimizely:
- `ExperimentUtils.attributes` now also takes in an `ApiEndpoint`. When we're not on `PRODUCTION`, we send the `distinct_id` property.
- `ExperimentsClientType.attributes` now takes in an `ApiEndpoint`.
- `OptimizelyExperimentsClient` constructor now takes in an `ApiEndpoint`.
- `MockExperimentsClientType` constructor now takes in an `ApiEndpoint`.
- Added secondary helper constructors for `MockExperimentsClientType`.
- Added tests in `ExperimentUtilsTest` for production and non production environments.

# 👀 See
No visuals~

# 📋 QA
Activate™ an experiment in a non production environment.

# Story 📖
[NT-959]


[NT-959]: https://kickstarter.atlassian.net/browse/NT-959