### PR TITLE
[🔢] NT-929 Adding ProjectCreatorDetails query

### DIFF
--- a/app/src/main/graphql/project.graphql
+++ b/app/src/main/graphql/project.graphql
@@ -1,0 +1,11 @@
+query ProjectCreatorDetails($slug: String!) {
+  project(slug: $slug) {
+    creator {
+      name
+      backingsCount
+      launchedProjects {
+        totalCount
+      }
+    }
+  }
+}

--- a/app/src/main/graphql/project.graphql
+++ b/app/src/main/graphql/project.graphql
@@ -1,7 +1,6 @@
 query ProjectCreatorDetails($slug: String!) {
   project(slug: $slug) {
     creator {
-      name
       backingsCount
       launchedProjects {
         totalCount

--- a/app/src/main/java/com/kickstarter/mock/factories/CreatorDetailsFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CreatorDetailsFactory.kt
@@ -8,7 +8,6 @@ class CreatorDetailsFactory private constructor() {
             return CreatorDetails.builder()
                     .backingsCount(3)
                     .launchedProjectsCount(2)
-                    .name("Creator Name")
                     .build()
         }
     }

--- a/app/src/main/java/com/kickstarter/mock/factories/CreatorDetailsFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CreatorDetailsFactory.kt
@@ -1,0 +1,15 @@
+package com.kickstarter.mock.factories
+
+import com.kickstarter.models.CreatorDetails
+
+class CreatorDetailsFactory private constructor() {
+    companion object {
+        fun creatorDetails(): CreatorDetails {
+            return CreatorDetails.builder()
+                    .backingsCount(3)
+                    .launchedProjectsCount(2)
+                    .name("Creator Name")
+                    .build()
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -8,6 +8,7 @@ import UpdateUserEmailMutation
 import UpdateUserPasswordMutation
 import UserPrivacyQuery
 import com.kickstarter.mock.factories.CheckoutFactory
+import com.kickstarter.mock.factories.CreatorDetailsFactory
 import com.kickstarter.mock.factories.StoredCardFactory
 import com.kickstarter.models.*
 import com.kickstarter.services.ApolloClientType
@@ -35,6 +36,10 @@ open class MockApolloClient : ApolloClientType {
     override fun createPassword(password: String, confirmPassword: String): Observable<CreatePasswordMutation.Data> {
         return Observable.just(CreatePasswordMutation.Data(CreatePasswordMutation.UpdateUserAccount("",
                 CreatePasswordMutation.User("", "sample@ksr.com", true))))
+    }
+
+    override fun creatorDetails(slug: String): Observable<CreatorDetails> {
+        return Observable.just(CreatorDetailsFactory.creatorDetails())
     }
 
     override fun deletePaymentSource(paymentSourceId: String): Observable<DeletePaymentSourceMutation.Data> {

--- a/app/src/main/java/com/kickstarter/models/CreatorDetails.kt
+++ b/app/src/main/java/com/kickstarter/models/CreatorDetails.kt
@@ -7,13 +7,11 @@ import auto.parcel.AutoParcel
 abstract class CreatorDetails : Parcelable {
     abstract fun backingsCount(): Int
     abstract fun launchedProjectsCount(): Int
-    abstract fun name(): String
 
     @AutoParcel.Builder
     abstract class Builder {
-        abstract fun backingsCount(id: Int): Builder
-        abstract fun launchedProjectsCount(id: Int): Builder
-        abstract fun name(name: String): Builder
+        abstract fun backingsCount(backingsCount: Int): Builder
+        abstract fun launchedProjectsCount(launchedProjectsCount: Int): Builder
         abstract fun build(): CreatorDetails
     }
 

--- a/app/src/main/java/com/kickstarter/models/CreatorDetails.kt
+++ b/app/src/main/java/com/kickstarter/models/CreatorDetails.kt
@@ -1,0 +1,29 @@
+package com.kickstarter.models
+
+import android.os.Parcelable
+import auto.parcel.AutoParcel
+
+@AutoParcel
+abstract class CreatorDetails : Parcelable {
+    abstract fun backingsCount(): Int
+    abstract fun launchedProjectsCount(): Int
+    abstract fun name(): String
+
+    @AutoParcel.Builder
+    abstract class Builder {
+        abstract fun backingsCount(id: Int): Builder
+        abstract fun launchedProjectsCount(id: Int): Builder
+        abstract fun name(name: String): Builder
+        abstract fun build(): CreatorDetails
+    }
+
+    abstract fun toBuilder(): Builder
+
+    companion object {
+
+        fun builder(): Builder {
+            return AutoParcel_CreatorDetails.Builder()
+        }
+    }
+
+}

--- a/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
+++ b/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
@@ -23,6 +23,8 @@ interface ApolloClientType {
 
     fun createPassword(password: String, confirmPassword: String): Observable<CreatePasswordMutation.Data>
 
+    fun creatorDetails(slug: String): Observable<CreatorDetails>
+
     fun deletePaymentSource(paymentSourceId: String): Observable<DeletePaymentSourceMutation.Data>
 
     fun getStoredCards(): Observable<List<StoredCard>>

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -171,7 +171,7 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                             response.data()?.project()?.creator()?.let {
                                 ps.onNext(CreatorDetails.builder()
                                         .backingsCount(it.backingsCount())
-                                        .launchedProjectsCount(it.launchedProjects()?.totalCount() ?: 0)
+                                        .launchedProjectsCount(it.launchedProjects()?.totalCount() ?: 1)
                                         .build())
                                 ps.onCompleted()
                             }

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -172,7 +172,6 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                                 ps.onNext(CreatorDetails.builder()
                                         .backingsCount(it.backingsCount())
                                         .launchedProjectsCount(it.launchedProjects()?.totalCount() ?: 0)
-                                        .name(it.name())
                                         .build())
                                 ps.onCompleted()
                             }

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -5,6 +5,7 @@ import ClearUserUnseenActivityMutation
 import CreateBackingMutation
 import CreatePasswordMutation
 import DeletePaymentSourceMutation
+import ProjectCreatorDetailsQuery
 import SavePaymentMethodMutation
 import SendEmailVerificationMutation
 import SendMessageMutation
@@ -151,6 +152,35 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
         }
     }
 
+    override fun creatorDetails(slug: String): Observable<CreatorDetails> {
+        return Observable.defer {
+            val ps = PublishSubject.create<CreatorDetails>()
+            service.query(ProjectCreatorDetailsQuery.builder()
+                    .slug(slug)
+                    .build())
+                    .enqueue(object : ApolloCall.Callback<ProjectCreatorDetailsQuery.Data>() {
+                        override fun onFailure(exception: ApolloException) {
+                            ps.onError(exception)
+                        }
+
+                        override fun onResponse(response: Response<ProjectCreatorDetailsQuery.Data>) {
+                            if (response.hasErrors()) {
+                                ps.onError(Exception(response.errors().first().message()))
+                            }
+
+                            response.data()?.project()?.creator()?.let {
+                                ps.onNext(CreatorDetails.builder()
+                                        .backingsCount(it.backingsCount())
+                                        .launchedProjectsCount(it.launchedProjects()?.totalCount() ?: 0)
+                                        .name(it.name())
+                                        .build())
+                                ps.onCompleted()
+                            }
+                        }
+                    })
+            return@defer ps
+        }
+    }
 
     override fun deletePaymentSource(paymentSourceId: String): Observable<DeletePaymentSourceMutation.Data> {
         return Observable.defer {

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectHolderViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectHolderViewModelTest.java
@@ -50,6 +50,8 @@ public final class ProjectHolderViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<String> commentsCountTextViewText = new TestSubscriber<>();
   private final TestSubscriber<Pair<String, String>> conversionPledgedAndGoalText = new TestSubscriber<>();
   private final TestSubscriber<Boolean> conversionTextViewIsGone = new TestSubscriber<>();
+  private final TestSubscriber<Integer> creatorBackedProjectsCount = new TestSubscriber<>();
+  private final TestSubscriber<Integer> creatorLaunchedProjectsCount = new TestSubscriber<>();
   private final TestSubscriber<String> creatorNameTextViewText = new TestSubscriber<>();
   private final TestSubscriber<String> deadlineCountdownTextViewText = new TestSubscriber<>();
   private final TestSubscriber<String> featuredTextViewRootCategory = new TestSubscriber<>();
@@ -100,6 +102,8 @@ public final class ProjectHolderViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.commentsCountTextViewText().subscribe(this.commentsCountTextViewText);
     this.vm.outputs.conversionPledgedAndGoalText().subscribe(this.conversionPledgedAndGoalText);
     this.vm.outputs.conversionTextViewIsGone().subscribe(this.conversionTextViewIsGone);
+    this.vm.outputs.creatorBackedProjectsCount().subscribe(this.creatorBackedProjectsCount);
+    this.vm.outputs.creatorLaunchedProjectsCount().subscribe(this.creatorLaunchedProjectsCount);
     this.vm.outputs.creatorNameTextViewText().subscribe(this.creatorNameTextViewText);
     this.vm.outputs.deadlineCountdownTextViewText().subscribe(this.deadlineCountdownTextViewText);
     this.vm.outputs.featuredTextViewRootCategory().subscribe(this.featuredTextViewRootCategory);
@@ -182,6 +186,8 @@ public final class ProjectHolderViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.configureWith(ProjectDataFactory.Companion.project(project));
 
     this.avatarPhotoUrl.assertValues(project.creator().avatar().medium());
+    this.creatorBackedProjectsCount.assertValue(3);
+    this.creatorLaunchedProjectsCount.assertValue(2);
     this.creatorNameTextViewText.assertValues(project.creator().name());
   }
 


### PR DESCRIPTION
# 📲 What
Adding `ProjectCreatorDetails` query and corresponding outputs in `ProjectHolderViewModel`.

# 🤔 Why
Laying the foundation for the `native_project_page_conversion_creator_details` experiment.

# 🛠 How
- Added `project.graphql` with `ProjectCreatorDetails` query.
- Added `creatorDetails` call to `ApolloClientType` interface and implemented in subtypes that returns a `CreatorDetails` object.
- And `creatorBackedProjectsCount` and `creatorLaunchedProjectsCount` outputs to `ProjectHolderViewModel`.
- Added `CreatorDetailsFactory` for tests.
- Added tests to `ProjectHolderViewModelTest`.

# 👀 See
Nothing 2 c

# 📋 QA
Does the code look legit?

# Story 📖
[NT-929]


[NT-929]: https://kickstarter.atlassian.net/browse/NT-929