### PR TITLE
[🎨] NT-986 Adding XML only changes for creator details experiment

### DIFF
--- a/app/src/main/res/drawable/circle_blue_white_stroke.xml
+++ b/app/src/main/res/drawable/circle_blue_white_stroke.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+  android:shape="oval">
+  <solid android:color="@color/ksr_cobalt_500" />
+  <stroke
+    android:width="1dp"
+    android:color="@color/white" />
+  <padding
+    android:bottom="@dimen/grid_1_half"
+    android:left="@dimen/grid_1_half"
+    android:right="@dimen/grid_1_half"
+    android:top="@dimen/grid_1_half" />
+</shape>

--- a/app/src/main/res/drawable/circle_grey_500.xml
+++ b/app/src/main/res/drawable/circle_grey_500.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+  android:shape="oval">
+  <solid android:color="@color/ksr_grey_500" />
+  <padding
+    android:bottom="@dimen/grid_1"
+    android:left="@dimen/grid_1"
+    android:right="@dimen/grid_1"
+    android:top="@dimen/grid_1" />
+</shape>

--- a/app/src/main/res/drawable/rect_grey_500_loading.xml
+++ b/app/src/main/res/drawable/rect_grey_500_loading.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+  android:shape="rectangle">
+  <corners android:radius="@dimen/grid_1" />
+  <gradient
+    android:angle="0"
+    android:endColor="@color/ksr_grey_300"
+    android:startColor="@color/ksr_grey_500" />
+  <size android:height="@dimen/grid_3_half" />
+</shape>

--- a/app/src/main/res/layout-land/project_media_header.xml
+++ b/app/src/main/res/layout-land/project_media_header.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
@@ -68,59 +66,109 @@
 
     </LinearLayout>
 
-    <LinearLayout
-      android:id="@+id/creator_info"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
+    <FrameLayout
+      android:id="@+id/creator_info_container"
       android:layout_below="@id/name_creator_view"
-      android:background="@drawable/click_indicator_light_masked"
-      android:focusable="true"
-      android:gravity="center_vertical"
-      android:orientation="horizontal"
-      android:paddingBottom="@dimen/grid_2"
-      android:paddingTop="@dimen/grid_3"
-      tools:ignore="InconsistentLayout">
-
-      <ImageView
-        android:id="@+id/avatar"
-        android:layout_width="@dimen/project_avatar_width"
-        android:layout_height="@dimen/project_avatar_height"
-        android:layout_marginEnd="@dimen/grid_3_half"
-        android:scaleType="centerCrop"
-        tools:background="@color/ksr_green_700"
-        tools:ignore="ContentDescription" />
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content">
 
       <LinearLayout
-        android:layout_width="0dp"
+        android:id="@+id/creator_info"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:orientation="vertical">
+        android:background="@drawable/click_indicator_light_masked"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingTop="@dimen/grid_3"
+        android:paddingBottom="@dimen/grid_2"
+        android:visibility="gone"
+        tools:ignore="InconsistentLayout">
 
-        <TextView
-          style="@style/FootnotePrimary"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:text="@string/project_menu_created_by"
-          android:textColor="@color/white" />
+        <ImageView
+          android:id="@+id/avatar"
+          android:layout_width="@dimen/project_avatar_width"
+          android:layout_height="@dimen/project_avatar_height"
+          android:layout_marginEnd="@dimen/grid_3_half"
+          android:scaleType="centerCrop"
+          tools:ignore="ContentDescription"
+          tools:src="@drawable/avatar_stroke" />
 
-        <TextView
-          android:id="@+id/creator_name"
-          style="@style/SubheadlineMedium"
-          android:layout_width="wrap_content"
+        <LinearLayout
+          android:layout_width="0dp"
           android:layout_height="wrap_content"
-          android:ellipsize="end"
-          android:maxLines="1"
-          android:textColor="@color/white"
-          tools:text="Creator Name" />
+          android:layout_weight="1"
+          android:orientation="vertical">
+
+          <TextView
+            style="@style/FootnotePrimary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/project_menu_created_by"
+            android:textColor="@color/white" />
+
+          <TextView
+            android:id="@+id/creator_name"
+            style="@style/SubheadlineMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/white"
+            tools:text="Creator Name" />
+        </LinearLayout>
+
       </LinearLayout>
 
-    </LinearLayout>
+      <LinearLayout
+        android:id="@+id/creator_info_variant"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/click_indicator_light_masked"
+        android:baselineAligned="false"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingTop="@dimen/grid_3"
+        android:paddingBottom="@dimen/grid_2"
+        android:visibility="gone"
+        tools:ignore="InconsistentLayout">
+
+        <include layout="@layout/creator_avatar_verified" />
+
+        <LinearLayout
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_weight="1"
+          android:orientation="vertical">
+
+          <TextView
+            android:id="@+id/creator_name_variant"
+            style="@style/FootnoteWhiteMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            tools:text="Creator Name" />
+
+          <TextView
+            android:id="@+id/creator_details"
+            style="@style/FootnoteWhiteMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="3 created • 2 launched" />
+        </LinearLayout>
+
+      </LinearLayout>
+
+      <include layout="@layout/loading_placeholder_creator_info" />
+    </FrameLayout>
 
     <LinearLayout
       android:id="@+id/blurb_category_location_view"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_below="@id/creator_info"
+      android:layout_below="@id/creator_info_container"
       android:layout_marginTop="@dimen/grid_4"
       android:orientation="vertical">
 
@@ -151,8 +199,8 @@
         <LinearLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/grid_3"
           android:layout_marginTop="@dimen/grid_3"
+          android:layout_marginBottom="@dimen/grid_3"
           android:gravity="center_vertical"
           android:orientation="horizontal">
 
@@ -184,8 +232,8 @@
         android:background="@drawable/click_indicator_light_masked"
         android:orientation="vertical"
         android:visibility="gone"
-        tools:visibility="visible"
-        tools:ignore="InconsistentLayout">
+        tools:ignore="InconsistentLayout"
+        tools:visibility="visible">
 
         <TextView
           android:id="@+id/blurb_variant"
@@ -227,8 +275,8 @@
           style="@style/BodyWhite"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:paddingEnd="@dimen/grid_5"
           android:paddingStart="@dimen/grid_1"
+          android:paddingEnd="@dimen/grid_5"
           tools:ignore="InconsistentLayout"
           tools:text="Category name" />
 

--- a/app/src/main/res/layout/creator_avatar_verified.xml
+++ b/app/src/main/res/layout/creator_avatar_verified.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="wrap_content"
+  android:layout_height="wrap_content"
+  android:layout_marginEnd="@dimen/grid_3_half"
+  tools:ignore="MergeRootFrame"
+  tools:showIn="@layout/project_main_layout">
+
+  <ImageView
+    android:id="@+id/avatar_variant"
+    android:layout_width="@dimen/project_avatar_width"
+    android:layout_height="@dimen/project_avatar_height"
+    android:scaleType="centerCrop"
+    tools:ignore="ContentDescription"
+    tools:src="@drawable/avatar_stroke" />
+
+  <ImageView
+    android:layout_width="@dimen/project_avatar_check_width"
+    android:layout_height="@dimen/project_avatar_check_width"
+    android:layout_gravity="end|bottom"
+    android:background="@drawable/circle_blue_white_stroke"
+    android:importantForAccessibility="no"
+    android:src="@drawable/icon__check"
+    android:tint="@color/white" />
+</FrameLayout>

--- a/app/src/main/res/layout/loading_placeholder_creator_info.xml
+++ b/app/src/main/res/layout/loading_placeholder_creator_info.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/creator_info_loading_container"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:baselineAligned="false"
+  android:focusable="true"
+  android:gravity="center_vertical"
+  android:orientation="horizontal"
+  android:layout_marginTop="@dimen/grid_3"
+  android:layout_marginBottom="@dimen/grid_2"
+  tools:ignore="InconsistentLayout">
+
+  <ImageView
+    android:layout_width="@dimen/project_avatar_width"
+    android:layout_height="@dimen/project_avatar_height"
+    android:layout_marginEnd="@dimen/grid_3_half"
+    android:scaleType="centerCrop"
+    android:src="@drawable/circle_grey_500"
+    tools:ignore="ContentDescription" />
+
+  <LinearLayout
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_weight="1"
+    android:orientation="vertical">
+
+    <include
+      layout="@layout/loading_placeholder_footnote"
+      android:layout_width="@dimen/grid_27"
+      android:layout_height="wrap_content" />
+
+    <include
+      layout="@layout/loading_placeholder_footnote"
+      android:layout_width="@dimen/grid_35"
+      android:layout_height="wrap_content" />
+
+  </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/loading_placeholder_footnote.xml
+++ b/app/src/main/res/layout/loading_placeholder_footnote.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  tools:ignore="MergeRootFrame">
+
+  <TextView
+    style="@style/FootnotePrimary"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:maxLines="1" />
+
+  <ImageView
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_vertical"
+    android:importantForAccessibility="no"
+    android:src="@drawable/rect_grey_500_loading" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/project_main_layout.xml
+++ b/app/src/main/res/layout/project_main_layout.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
@@ -21,8 +20,7 @@
       android:layout_gravity="bottom"
       android:layout_marginStart="@dimen/grid_1">
 
-      <include
-        layout="@layout/project_metadata_view" />
+      <include layout="@layout/project_metadata_view" />
     </FrameLayout>
 
   </FrameLayout>
@@ -31,9 +29,9 @@
     android:id="@+id/project_info"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginEnd="@dimen/project_padding_x"
     android:layout_marginStart="@dimen/project_padding_x"
     android:layout_marginTop="@dimen/grid_2"
+    android:layout_marginEnd="@dimen/project_padding_x"
     android:background="@color/white"
     android:orientation="vertical">
 
@@ -42,63 +40,121 @@
       style="@style/Title2Medium"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:focusable="true"
       android:paddingBottom="@dimen/grid_1_half"
       tools:ignore="InconsistentLayout"
-      android:focusable="true"
       tools:text="Project name" />
 
-    <LinearLayout
-      android:id="@+id/creator_info"
+    <FrameLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:background="@drawable/click_indicator_light_masked"
-      android:focusable="true"
-      android:gravity="center_vertical"
-      android:orientation="horizontal"
-      android:paddingBottom="@dimen/grid_3"
-      android:paddingTop="@dimen/grid_2"
-      tools:ignore="InconsistentLayout">
-
-      <ImageView
-        android:id="@+id/avatar"
-        android:layout_width="@dimen/project_avatar_width"
-        android:layout_height="@dimen/project_avatar_height"
-        android:layout_marginEnd="@dimen/grid_3_half"
-        android:importantForAccessibility="no"
-        android:scaleType="centerCrop"
-        tools:background="@color/ksr_green_700" />
+      android:layout_height="wrap_content">
 
       <LinearLayout
-        android:layout_width="0dp"
+        android:id="@+id/creator_info"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:orientation="vertical">
+        android:background="@drawable/click_indicator_light_masked"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingTop="@dimen/grid_2"
+        android:paddingBottom="@dimen/grid_3"
+        android:visibility="gone"
+        tools:ignore="InconsistentLayout">
 
-        <TextView
-          style="@style/FootnotePrimary"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:text="@string/project_menu_created_by" />
+        <ImageView
+          android:id="@+id/avatar"
+          android:layout_width="@dimen/project_avatar_width"
+          android:layout_height="@dimen/project_avatar_height"
+          android:layout_marginEnd="@dimen/grid_3_half"
+          android:importantForAccessibility="no"
+          android:scaleType="centerCrop"
+          tools:src="@drawable/circle_grey_300" />
 
-        <TextView
-          android:id="@+id/creator_name"
-          style="@style/SubheadlineMedium"
-          android:layout_width="wrap_content"
+        <LinearLayout
+          android:layout_width="0dp"
           android:layout_height="wrap_content"
-          android:ellipsize="end"
-          android:maxLines="1"
-          tools:text="Creator Name" />
+          android:layout_weight="1"
+          android:orientation="vertical">
+
+          <TextView
+            style="@style/FootnotePrimary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/project_menu_created_by" />
+
+          <TextView
+            android:id="@+id/creator_name"
+            style="@style/SubheadlineMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            tools:text="Creator Name" />
+        </LinearLayout>
+
       </LinearLayout>
 
-    </LinearLayout>
+      <LinearLayout
+        android:id="@+id/creator_info_variant"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/click_indicator_light_masked"
+        android:baselineAligned="false"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingTop="@dimen/grid_2"
+        android:paddingBottom="@dimen/grid_3"
+        android:visibility="gone"
+        tools:ignore="InconsistentLayout"
+        tools:visibility="visible">
+
+        <include layout="@layout/creator_avatar_verified" />
+
+        <LinearLayout
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_weight="1"
+          android:orientation="vertical">
+
+          <TextView
+            android:id="@+id/creator_name_variant"
+            style="@style/FootnotePrimaryMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            tools:text="Creator Name" />
+
+          <TextView
+            android:id="@+id/creator_details"
+            style="@style/FootnotePrimaryMedium"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/ksr_cobalt_500"
+            tools:text="3 created • 2 launched" />
+        </LinearLayout>
+
+      </LinearLayout>
+
+      <include
+        layout="@layout/loading_placeholder_creator_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/grid_2"
+        android:layout_marginBottom="@dimen/grid_3"
+        tools:visibility="gone" />
+
+    </FrameLayout>
 
     <LinearLayout
       android:id="@+id/blurb_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:background="@drawable/click_indicator_light_masked"
-      android:orientation="vertical"
       android:focusable="true"
+      android:orientation="vertical"
       tools:ignore="InconsistentLayout">
 
       <TextView
@@ -113,8 +169,8 @@
       <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/grid_3"
         android:layout_marginTop="@dimen/grid_3"
+        android:layout_marginBottom="@dimen/grid_3"
         android:gravity="center_vertical"
         android:orientation="horizontal">
 
@@ -140,8 +196,8 @@
       android:layout_height="wrap_content"
       android:orientation="vertical"
       android:visibility="gone"
-      tools:visibility="visible"
-      tools:ignore="InconsistentLayout">
+      tools:ignore="InconsistentLayout"
+      tools:visibility="visible">
 
       <TextView
         android:id="@+id/blurb_variant"
@@ -166,8 +222,8 @@
     <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:gravity="center_vertical"
       android:focusable="true"
+      android:gravity="center_vertical"
       android:orientation="horizontal">
 
       <com.kickstarter.ui.views.IconTextView
@@ -184,8 +240,8 @@
         style="@style/Caption1Primary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingEnd="@dimen/grid_5"
         android:paddingStart="@dimen/grid_1"
+        android:paddingEnd="@dimen/grid_5"
         android:textColor="@color/ksr_dark_grey_500"
         tools:ignore="InconsistentLayout"
         tools:text="Category name" />
@@ -206,8 +262,8 @@
         android:layout_height="wrap_content"
         android:ellipsize="end"
         android:maxLines="1"
-        android:paddingEnd="@dimen/grid_1_half"
         android:paddingStart="@dimen/grid_1"
+        android:paddingEnd="@dimen/grid_1_half"
         android:textColor="@color/ksr_dark_grey_500"
         tools:ignore="InconsistentLayout"
         tools:text="Location" />
@@ -229,16 +285,16 @@
       android:id="@+id/project_state_view_group"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginBottom="@dimen/grid_2"
       android:layout_marginTop="@dimen/grid_4"
+      android:layout_marginBottom="@dimen/grid_2"
+      android:focusable="true"
       android:gravity="center_vertical"
       android:orientation="vertical"
-      android:paddingBottom="@dimen/grid_2"
-      android:paddingEnd="@dimen/grid_4"
       android:paddingStart="@dimen/grid_4"
       android:paddingTop="@dimen/grid_2"
+      android:paddingEnd="@dimen/grid_4"
+      android:paddingBottom="@dimen/grid_2"
       android:visibility="gone"
-      android:focusable="true"
       tools:visibility="visible">
 
       <TextView
@@ -261,8 +317,8 @@
       android:id="@+id/project_stats_view"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_marginBottom="@dimen/grid_5"
       android:layout_marginTop="@dimen/grid_3"
+      android:layout_marginBottom="@dimen/grid_5"
       android:orientation="vertical">
 
       <include layout="@layout/project_stats_view" />
@@ -284,19 +340,19 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginBottom="@dimen/grid_4"
+      android:focusable="true"
       android:gravity="center_vertical"
       android:orientation="horizontal"
-      android:paddingBottom="@dimen/grid_1"
       android:paddingTop="@dimen/grid_1"
-      android:focusable="true"
+      android:paddingBottom="@dimen/grid_1"
       android:visibility="gone">
 
       <ImageView
         android:id="@+id/project_social_image"
         android:layout_width="@dimen/project_social_photo_height"
         android:layout_height="@dimen/project_social_photo_height"
-        android:visibility="gone"
-        android:importantForAccessibility="no" />
+        android:importantForAccessibility="no"
+        android:visibility="gone" />
 
       <TextView
         android:id="@+id/project_social_text"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -118,6 +118,8 @@
   <dimen name="profile_card_photo_width">160dp</dimen>
   <dimen name="project_avatar_width">@dimen/grid_7</dimen>
   <dimen name="project_avatar_height">@dimen/grid_7</dimen>
+  <dimen name="project_avatar_check_width">13dp</dimen>
+  <dimen name="project_avatar_check_height">13dp</dimen>
   <dimen name="project_card_photo_landscape_height">135dp</dimen>
   <dimen name="project_card_photo_landscape_width">240dp</dimen>
   <dimen name="project_social_photo_height">@dimen/grid_5</dimen>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -456,6 +456,14 @@
     <item name="android:textStyle">bold</item>
   </style>
 
+  <style name="FootnoteWhite" parent="TextWhite">
+    <item name="android:textSize">@dimen/footnote</item>
+  </style>
+
+  <style name="FootnoteWhiteMedium" parent="FootnoteWhite">
+    <item name="android:fontFamily">@string/font_family_sans_serif_medium</item>
+  </style>
+
   <style name="ProjectCardFootnote" parent="FootnoteSecondaryMedium">
     <item name="android:fontFamily">@string/font_family_sans_serif_medium</item>
     <item name="android:maxLines">1</item>


### PR DESCRIPTION
# 📲 What
The UI changes for the `native_project_page_conversion_creator details` experiment.

# 🤔 Why
I'm splitting up NT-934 so the PR isn't so big!

# 🛠 How
- Added `circle_blue_white_stroke.xml` `Drawable` for the verified icon background.
- Added `circle_grey_500.xml` `Drawable` for the loading placeholder of the avatar.
- Added `rect_grey_500_loading.xml` `Drawable` for the loading placeholder of the creator details text.
- Added `creator_avatar_verified.xml` container for the verified creator avatar.
- Added `loading_placeholder_creator_info.xml` for the loading state of the creator details.
- Added variant and loading layout to `project_media_header.xml` in landscape and `project_main_layout.xml` in portrait.
- Added `project_avatar_check_width` and `project_avatar_check_height` with value of `13dp` for the verified icon size.
- Added `FootnoteWhite` and `FootnoteWhiteMedium` for styling the creator details in landscape.

# 👀 See
| Loading 🔜 | Loaded ✔️  |
| --- | --- |
| ![screenshot-2020-03-11_113902](https://user-images.githubusercontent.com/1289295/76436114-38f04e00-638e-11ea-9333-83eaa57d2fdb.png) | ![screenshot-2020-03-10_102932](https://user-images.githubusercontent.com/1289295/76436127-3beb3e80-638e-11ea-82c9-59c45688bc47.png) |
| ![screenshot-2020-03-11_115525](https://user-images.githubusercontent.com/1289295/76436960-3b9f7300-638f-11ea-8e80-115074daf215.png) | ![screenshot-2020-03-10_104221](https://user-images.githubusercontent.com/1289295/76436963-3b9f7300-638f-11ea-878c-5be5ea9624e7.png) |

# 📋 QA
👀 take a look

# Story 📖
[NT-986]


[NT-986]: https://kickstarter.atlassian.net/browse/NT-986