### PR TITLE
[🔮] NT-985 Decreasing Optimizely event dispatch interval

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -639,7 +639,7 @@ public final class ApplicationModule {
     final OptimizelyManager optimizelyManager = OptimizelyManager.builder()
       .withSDKKey(optimizelyKey)
       .withDatafileDownloadInterval(60L * 10L)
-      .withEventDispatchInterval(60L)
+      .withEventDispatchInterval(2L)
       .build(context);
 
     optimizelyManager.initialize(context, null, optimizely -> {


### PR DESCRIPTION
# 📲 What
Decreasing Optimizely event dispatch interval from 10 seconds to 2 seconds.

# 🤔 Why
We are playing telephone with Optimizely events coming from both the client and the backend and there is a race condition if a user completes a checkout on the backend before the client side events.

# 🛠 How
~`60L`~ `2L`

# 👀 See
There are no visual changes!

# 📋 QA
Smash that pledge button.

# Story 📖
[NT-985]


[NT-985]: https://kickstarter.atlassian.net/browse/NT-985