### PR TITLE
[␡] NT-965 Removing native checkout feature flag support from the Project page

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/ProjectViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/ProjectViewUtils.kt
@@ -6,8 +6,6 @@ import android.text.Spanned
 import android.text.TextUtils
 import android.text.style.RelativeSizeSpan
 import android.util.Pair
-import android.view.View
-import android.widget.Button
 import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
 import com.kickstarter.R
@@ -70,34 +68,6 @@ object ProjectViewUtils {
             R.string.View_your_pledge
         } else {
             R.string.View_rewards
-        }
-    }
-
-    /**
-     * Set correct button view based on project and backing status.
-     */
-    @JvmStatic
-    fun setActionButton(project: Project, backProjectButton: Button,
-                        managePledgeButton: Button, viewPledgeButton: Button) {
-
-        if (project.hasRewards()) {
-            if (!project.isBacking && project.isLive) {
-                backProjectButton.visibility = View.VISIBLE
-            } else {
-                backProjectButton.visibility = View.GONE
-            }
-
-            if (project.isBacking && project.isLive) {
-                managePledgeButton.visibility = View.VISIBLE
-            } else {
-                managePledgeButton.visibility = View.GONE
-            }
-
-            if (project.isBacking && !project.isLive) {
-                viewPledgeButton.visibility = View.VISIBLE
-            } else {
-                viewPledgeButton.visibility = View.GONE
-            }
         }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -29,11 +29,9 @@ import com.kickstarter.libs.KoalaContext
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ApplicationUtils
-import com.kickstarter.libs.utils.ProjectViewUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Project
 import com.kickstarter.models.StoredCard
-import com.kickstarter.models.User
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.adapters.ProjectAdapter
 import com.kickstarter.ui.data.*
@@ -52,8 +50,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     private lateinit var adapter: ProjectAdapter
     private lateinit var ksString: KSString
 
-    private val projectBackButtonString = R.string.project_back_button
-    private val managePledgeString = R.string.project_checkout_manage_navbar_title
     private val projectShareLabelString = R.string.project_accessibility_button_share_label
     private val projectShareCopyString = R.string.project_share_twitter_message
     private val projectStarConfirmationString = R.string.project_star_confirmation
@@ -117,11 +113,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 .compose(Transformers.observeForUI())
                 .subscribe { heart_icon.setImageDrawable(ContextCompat.getDrawable(this, it)) }
 
-        this.viewModel.outputs.horizontalProgressBarIsGone()
-                .compose(bindToLifecycle())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { ViewUtils.setGone(project_progress_bar, it) }
-
         this.viewModel.outputs.managePledgeMenu()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
@@ -142,11 +133,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { setPledgeActionButtonCTA(it) }
 
-        this.viewModel.outputs.pledgeContainerIsGone()
-                .compose(bindToLifecycle())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { ViewUtils.setGone(pledge_container_root, it) }
-
         this.viewModel.outputs.pledgeToolbarNavigationIcon()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
@@ -162,12 +148,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { openProjectAndFinish(it) }
 
-        this.viewModel.outputs.projectActionButtonContainerIsGone()
-                .compose(bindToLifecycle())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { ViewUtils.setGone(project_action_buttons, if (ViewUtils.isLandscape(this)) true else it) }
-
-        this.viewModel.outputs.projectDataAndNativeCheckoutEnabled()
+        this.viewModel.outputs.projectData()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { renderProject(it) }
@@ -232,20 +213,10 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { showPledgeFragment(it) }
 
-        this.viewModel.outputs.startBackingActivity()
-                .compose(bindToLifecycle())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { this.startBackingActivity(it) }
-
         this.viewModel.outputs.startCampaignWebViewActivity()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { this.startCampaignWebViewActivity(it) }
-
-        this.viewModel.outputs.startCheckoutActivity()
-                .compose(bindToLifecycle())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { this.startCheckoutActivity(it) }
 
         this.viewModel.outputs.startCommentsActivity()
                 .compose(bindToLifecycle())
@@ -261,11 +232,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { this.startCreatorDashboardActivity(it) }
-
-        this.viewModel.outputs.startManagePledgeActivity()
-                .compose(bindToLifecycle())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { this.startManagePledge(it) }
 
         this.viewModel.outputs.startProjectUpdatesActivity()
                 .compose(bindToLifecycle())
@@ -469,12 +435,9 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     private fun pledgeFragment() = supportFragmentManager
             .findFragmentByTag(PledgeFragment::class.java.simpleName) as PledgeFragment?
 
-    private fun renderProject(projectDataAndNativeCheckoutEnabled: Pair<ProjectData, Boolean>) {
-        val projectData = projectDataAndNativeCheckoutEnabled.first
-        val nativeCheckoutEnabled = projectDataAndNativeCheckoutEnabled.second
-        this.adapter.takeProject(projectData, nativeCheckoutEnabled)
-        ProjectViewUtils.setActionButton(projectData.project(), this.back_project_button, this.manage_pledge_button, this.view_pledge_button)
-        project_recycler_view.setPadding(0, 0, 0, if (nativeCheckoutEnabled) rewardsSheetGuideline() else 0)
+    private fun renderProject(projectData: ProjectData) {
+        this.adapter.takeProject(projectData, true)
+        project_recycler_view.setPadding(0, 0, 0, rewardsSheetGuideline())
     }
 
     private fun renderProject(backingFragment: BackingFragment, rewardsFragment: RewardsFragment, projectData: ProjectData) {
@@ -534,23 +497,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
 
         pledge_sheet_retry_container.setOnClickListener {
             this.viewModel.inputs.reloadProjectContainerClicked()
-        }
-
-        project_action_buttons.visibility = when {
-            ViewUtils.isLandscape(this) -> View.GONE
-            else -> View.VISIBLE
-        }
-
-        back_project_button.setOnClickListener {
-            this.viewModel.inputs.backProjectButtonClicked()
-        }
-
-        manage_pledge_button.setOnClickListener {
-            this.viewModel.inputs.managePledgeButtonClicked()
-        }
-
-        view_pledge_button.setOnClickListener {
-            this.viewModel.inputs.viewPledgeButtonClicked()
         }
 
         heart_icon.setOnClickListener {
@@ -658,22 +604,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 
-    private fun startCheckoutActivity(project: Project) {
-        val intent = Intent(this, CheckoutActivity::class.java)
-                .putExtra(IntentKey.PROJECT, project)
-                .putExtra(IntentKey.URL, project.newPledgeUrl())
-                .putExtra(IntentKey.TOOLBAR_TITLE, this.projectBackButtonString)
-        startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
-    }
-
-    private fun startManagePledge(project: Project) {
-        val intent = Intent(this, CheckoutActivity::class.java)
-                .putExtra(IntentKey.PROJECT, project)
-                .putExtra(IntentKey.URL, project.editPledgeUrl())
-                .putExtra(IntentKey.TOOLBAR_TITLE, this.managePledgeString)
-        startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
-    }
-
     private fun startCommentsActivity(project: Project) {
         val intent = Intent(this, CommentsActivity::class.java)
                 .putExtra(IntentKey.PROJECT, project)
@@ -695,13 +625,6 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         val intent = Intent(this, LoginToutActivity::class.java)
                 .putExtra(IntentKey.LOGIN_REASON, LoginReason.STAR_PROJECT)
         startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW)
-    }
-
-    private fun startBackingActivity(projectAndBacker: Pair<Project, User>) {
-        val intent = Intent(this, BackingActivity::class.java)
-                .putExtra(IntentKey.PROJECT, projectAndBacker.first)
-                .putExtra(IntentKey.BACKER, projectAndBacker.second)
-        startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 
     private fun startMessagesActivity(project: Project) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.java
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.java
@@ -15,14 +15,12 @@ import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import com.google.android.material.button.MaterialButton;
 import com.kickstarter.R;
 import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.KSString;
 import com.kickstarter.libs.transformations.CircleTransformation;
 import com.kickstarter.libs.utils.NumberUtils;
 import com.kickstarter.libs.utils.ProjectUtils;
-import com.kickstarter.libs.utils.ProjectViewUtils;
 import com.kickstarter.libs.utils.SocialUtils;
 import com.kickstarter.libs.utils.ViewUtils;
 import com.kickstarter.models.Photo;
@@ -63,7 +61,6 @@ public final class ProjectViewHolder extends KSViewHolder {
   protected @Bind(R.id.avatar_variant) ImageView avatarVariantImageView;
   protected @Bind(R.id.backers_count) TextView backersCountTextView;
   protected @Bind(R.id.backing_group) ViewGroup backingViewGroup;
-  protected @Bind(R.id.back_project_button) @Nullable MaterialButton backProjectButton;
   protected @Bind(R.id.blurb_view) ViewGroup blurbViewGroup;
   protected @Bind(R.id.blurb_view_variant) ViewGroup blurbVariantViewGroup;
   protected @Bind(R.id.blurb) TextView blurbTextView;
@@ -85,13 +82,11 @@ public final class ProjectViewHolder extends KSViewHolder {
   protected @Bind(R.id.goal) TextView goalTextView;
   protected @Bind(R.id.land_overlay_text) @Nullable ViewGroup landOverlayTextViewGroup;
   protected @Bind(R.id.location) TextView locationTextView;
-  protected @Bind(R.id.manage_pledge_button) @Nullable MaterialButton managePledgeButton;
   protected @Bind(R.id.name_creator_view) @Nullable ViewGroup nameCreatorViewGroup;
   protected @Bind(R.id.percentage_funded) ProgressBar percentageFundedProgressBar;
   protected @Bind(R.id.project_photo) ImageView photoImageView;
   protected @Bind(R.id.play_button_overlay) ImageButton playButton;
   protected @Bind(R.id.pledged) TextView pledgedTextView;
-  protected @Bind(R.id.project_action_buttons) @Nullable ViewGroup projectActionButtonsContainer;
   protected @Bind(R.id.project_dashboard_button) Button projectDashboardButton;
   protected @Bind(R.id.project_dashboard_container) ViewGroup projectDashboardContainer;
   protected @Bind(R.id.project_launch_date) TextView projectLaunchDateTextView;
@@ -104,7 +99,6 @@ public final class ProjectViewHolder extends KSViewHolder {
   protected @Bind(R.id.project_state_header_text_view) TextView projectStateHeaderTextView;
   protected @Bind(R.id.project_state_subhead_text_view) TextView projectStateSubheadTextView;
   protected @Bind(R.id.project_state_view_group) ViewGroup projectStateViewGroup;
-  protected @Bind(R.id.view_pledge_button) @Nullable MaterialButton viewPledgeButton;
   protected @Bind(R.id.updates) ViewGroup updatesContainer;
   protected @Bind(R.id.updates_count) TextView updatesCountTextView;
 
@@ -140,17 +134,14 @@ public final class ProjectViewHolder extends KSViewHolder {
   protected @BindString(R.string.discovery_baseball_card_stats_backers) String backersString;
 
   public interface Delegate {
-    void projectViewHolderBackProjectClicked(ProjectViewHolder viewHolder);
     void projectViewHolderBlurbClicked(ProjectViewHolder viewHolder);
     void projectViewHolderBlurbVariantClicked(ProjectViewHolder viewHolder);
     void projectViewHolderCommentsClicked(ProjectViewHolder viewHolder);
     void projectViewHolderCreatorClicked(ProjectViewHolder viewHolder);
     void projectViewHolderCreatorInfoVariantClicked(ProjectViewHolder viewHolder);
     void projectViewHolderDashboardClicked(ProjectViewHolder viewHolder);
-    void projectViewHolderManagePledgeClicked(ProjectViewHolder viewHolder);
     void projectViewHolderUpdatesClicked(ProjectViewHolder viewHolder);
     void projectViewHolderVideoStarted(ProjectViewHolder viewHolder);
-    void projectViewHolderViewPledgeClicked(ProjectViewHolder viewHolder);
   }
 
   public ProjectViewHolder(final @NonNull View view, final @NonNull Delegate delegate) {
@@ -252,7 +243,6 @@ public final class ProjectViewHolder extends KSViewHolder {
       .subscribe(p -> {
         // todo: break down these helpers
         setLandscapeOverlayText(p);
-        setLandscapeActionButton(p);
         this.deadlineCountdownUnitTextView.setText(ProjectUtils.deadlineCountdownDetail(p, context(), this.ksString));
       });
 
@@ -275,11 +265,6 @@ public final class ProjectViewHolder extends KSViewHolder {
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(this.pledgedTextView::setText);
-
-    this.viewModel.outputs.projectActionButtonContainerIsGone()
-      .compose(bindToLifecycle())
-      .compose(observeForUI())
-      .subscribe(this::setProjectActionButtonsContainerVisibility);
 
     this.viewModel.outputs.projectDashboardButtonText()
       .compose(bindToLifecycle())
@@ -492,12 +477,6 @@ public final class ProjectViewHolder extends KSViewHolder {
     this.projectStateSubheadTextView.setText(this.fundingCanceledByCreatorString);
   }
 
-  private void setProjectActionButtonsContainerVisibility(final boolean gone) {
-    if (this.projectActionButtonsContainer != null) {
-      ViewUtils.setGone(this.projectActionButtonsContainer, gone);
-    }
-  }
-
   private void setBlurbTextViews(final String blurb) {
     final Spanned blurbHtml = Html.fromHtml(TextUtils.htmlEncode(blurb));
     this.blurbTextView.setText(blurbHtml);
@@ -578,11 +557,6 @@ public final class ProjectViewHolder extends KSViewHolder {
     activity.overridePendingTransition(R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }
 
-  @Nullable @OnClick(R.id.back_project_button)
-  public void backProjectButtonOnClick() {
-    this.delegate.projectViewHolderBackProjectClicked(this);
-  }
-
   @OnClick({R.id.blurb_view, R.id.campaign})
   public void blurbOnClick() {
     this.delegate.projectViewHolderBlurbClicked(this);
@@ -613,33 +587,14 @@ public final class ProjectViewHolder extends KSViewHolder {
     this.delegate.projectViewHolderDashboardClicked(this);
   }
 
-  @Nullable @OnClick(R.id.manage_pledge_button)
-  public void managePledgeOnClick() {
-    this.delegate.projectViewHolderManagePledgeClicked(this);
-  }
-
   @OnClick(R.id.play_button_overlay)
   public void playButtonOnClick() {
     this.delegate.projectViewHolderVideoStarted(this);
   }
 
-  @Nullable @OnClick(R.id.view_pledge_button)
-  public void viewPledgeOnClick() {
-    this.delegate.projectViewHolderViewPledgeClicked(this);
-  }
-
   @OnClick(R.id.updates)
   public void updatesOnClick() {
     this.delegate.projectViewHolderUpdatesClicked(this);
-  }
-
-  /**
-   * Set landscape project action buttons in the ViewHolder rather than Activity.
-   */
-  private void setLandscapeActionButton(final @NonNull Project project) {
-    if (this.backProjectButton != null && this.managePledgeButton != null && this.viewPledgeButton != null) {
-      ProjectViewUtils.setActionButton(project, this.backProjectButton, this.managePledgeButton, this.viewPledgeButton);
-    }
   }
 
   /**

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectHolderViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectHolderViewModel.java
@@ -4,13 +4,10 @@ import android.util.Pair;
 
 import com.kickstarter.R;
 import com.kickstarter.libs.ActivityViewModel;
-import com.kickstarter.libs.Build;
-import com.kickstarter.libs.Config;
 import com.kickstarter.libs.CurrentConfigType;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.ExperimentsClientType;
-import com.kickstarter.libs.FeatureKey;
 import com.kickstarter.libs.KSCurrency;
 import com.kickstarter.libs.models.OptimizelyExperiment;
 import com.kickstarter.libs.preferences.BooleanPreferenceType;
@@ -123,9 +120,6 @@ public interface ProjectHolderViewModel {
 
     /** Emits the pledged amount for display. */
     Observable<String> pledgedTextViewText();
-
-    /** Emits a boolean determining if the project action buttons should be visible. */
-    Observable<Boolean> projectActionButtonContainerIsGone();
 
     /** Emits the string resource ID of the project dashboard button. */
     Observable<Integer> projectDashboardButtonText();
@@ -336,13 +330,6 @@ public interface ProjectHolderViewModel {
       this.pledgedTextViewText = project
         .map(p -> this.ksCurrency.formatWithUserPreference(p.pledged(), p));
 
-      this.projectActionButtonContainerIsGone = currentConfig.observable()
-        .map(Config::features)
-        .map(features -> ObjectUtils.isNotNull(features) ? ObjectUtils.coalesce(features.get(FeatureKey.ANDROID_NATIVE_CHECKOUT), false) : false)
-        .map(enabled -> Pair.create(enabled, this.nativeCheckoutPreference.get()))
-        .map(enabledAndOverride -> Build.isExternal() ? enabledAndOverride.first : enabledAndOverride.second)
-        .distinctUntilChanged();
-
       final Observable<Boolean> userIsCreatorOfProject = project
         .map(Project::creator)
         .compose(combineLatestPair(this.currentUser.observable()))
@@ -467,7 +454,6 @@ public interface ProjectHolderViewModel {
     private final Observable<Boolean> percentageFundedProgressBarIsGone;
     private final Observable<Boolean> playButtonIsGone;
     private final Observable<String> pledgedTextViewText;
-    private final Observable<Boolean> projectActionButtonContainerIsGone;
     private final Observable<Integer> projectDashboardButtonText;
     private final Observable<Boolean> projectDashboardContainerIsGone;
     private final Observable<DateTime> projectDisclaimerGoalReachedDateTime;
@@ -570,9 +556,6 @@ public interface ProjectHolderViewModel {
     }
     @Override public @NonNull Observable<String> pledgedTextViewText() {
       return this.pledgedTextViewText;
-    }
-    @Override public @NonNull Observable<Boolean> projectActionButtonContainerIsGone() {
-      return this.projectActionButtonContainerIsGone;
     }
     @Override public @NonNull Observable<Integer> projectDashboardButtonText() {
       return this.projectDashboardButtonText;

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -7,7 +7,6 @@ import androidx.annotation.NonNull
 import com.kickstarter.R
 import com.kickstarter.libs.*
 import com.kickstarter.libs.models.OptimizelyExperiment
-import com.kickstarter.libs.preferences.BooleanPreferenceType
 import com.kickstarter.libs.rx.transformers.Transformers.*
 import com.kickstarter.libs.utils.*
 import com.kickstarter.models.Backing
@@ -15,7 +14,6 @@ import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.User
 import com.kickstarter.services.ApiClientType
-import com.kickstarter.ui.activities.BackingActivity
 import com.kickstarter.ui.activities.ProjectActivity
 import com.kickstarter.ui.adapters.ProjectAdapter
 import com.kickstarter.ui.data.*
@@ -30,9 +28,6 @@ import java.net.CookieManager
 
 interface ProjectViewModel {
     interface Inputs {
-        /** Call when the back project button is clicked.  */
-        fun backProjectButtonClicked()
-
         /** Call when the blurb view is clicked.  */
         fun blurbTextViewClicked()
 
@@ -62,9 +57,6 @@ interface ProjectViewModel {
 
         /** Call when the heart button is clicked.  */
         fun heartButtonClicked()
-
-        /** Call when the manage pledge button is clicked.  */
-        fun managePledgeButtonClicked()
 
         /** Call when the native_project_action_button is clicked.  */
         fun nativeProjectActionButtonClicked()
@@ -108,9 +100,6 @@ interface ProjectViewModel {
         /** Call when the updates button is clicked.  */
         fun updatesTextViewClicked()
 
-        /** Call when the view pledge button is clicked.  */
-        fun viewPledgeButtonClicked()
-
         /** Call when the view rewards option is clicked.  */
         fun viewRewardsClicked()
     }
@@ -131,9 +120,6 @@ interface ProjectViewModel {
         /** Emits a drawable id that corresponds to whether the project is saved. */
         fun heartDrawableId(): Observable<Int>
 
-        /** Emits a boolean that determines if the horizontal progress bar should be visible. */
-        fun horizontalProgressBarIsGone(): Observable<Boolean>
-
         /** Emits a menu for managing your pledge or null if there's no menu. */
         fun managePledgeMenu(): Observable<Int?>
 
@@ -146,9 +132,6 @@ interface ProjectViewModel {
         /** Emits the string resource ID for the pledge action button. */
         fun pledgeActionButtonText(): Observable<Int>
 
-        /** Emits a boolean that determines if the pledge container should be visible. */
-        fun pledgeContainerIsGone(): Observable<Boolean>
-
         /** Emits the proper string resource ID for the pledge toolbar navigation icon. */
         fun pledgeToolbarNavigationIcon(): Observable<Int>
 
@@ -158,12 +141,9 @@ interface ProjectViewModel {
         /** Emits the url of a prelaunch activated project to open in the browser. */
         fun prelaunchUrl(): Observable<String>
 
-        /** Emits a boolean that determines if the project action button container should be visible. */
-        fun projectActionButtonContainerIsGone(): Observable<Boolean>
-
-        /** Emits a project and whether the native checkout feature is enabled. If the view model is created with a full project
+        /** Emits [ProjectData]. If the view model is created with a full project
          * model, this observable will emit that project immediately, and then again when it has updated from the api. */
-        fun projectDataAndNativeCheckoutEnabled(): Observable<Pair<ProjectData, Boolean>>
+        fun projectData(): Observable<ProjectData>
 
         /** Emits a boolean that determines if the reload project container should be visible. */
         fun reloadProjectContainerIsGone(): Observable<Boolean>
@@ -201,14 +181,8 @@ interface ProjectViewModel {
         /** Emits when the backing has successfully been updated. */
         fun showUpdatePledgeSuccess(): Observable<Void>
 
-        /** Emits when we should start the [BackingActivity].  */
-        fun startBackingActivity(): Observable<Pair<Project, User>>
-
         /** Emits when we should start the campaign [com.kickstarter.ui.activities.CampaignDetailsActivity].  */
         fun startCampaignWebViewActivity(): Observable<ProjectData>
-
-        /** Emits when we should start the [com.kickstarter.ui.activities.CheckoutActivity].  */
-        fun startCheckoutActivity(): Observable<Project>
 
         /** Emits when we should start [com.kickstarter.ui.activities.CommentsActivity].  */
         fun startCommentsActivity(): Observable<Project>
@@ -221,9 +195,6 @@ interface ProjectViewModel {
 
         /** Emits when we should start [com.kickstarter.ui.activities.LoginToutActivity].  */
         fun startLoginToutActivity(): Observable<Void>
-
-        /** Emits when we should start the [com.kickstarter.ui.activities.CheckoutActivity] to manage the pledge.  */
-        fun startManagePledgeActivity(): Observable<Project>
 
         /** Emits when we should show the [com.kickstarter.ui.activities.MessagesActivity]. */
         fun startMessagesActivity(): Observable<Project>
@@ -244,14 +215,11 @@ interface ProjectViewModel {
     class ViewModel(@NonNull val environment: Environment) : ActivityViewModel<ProjectActivity>(environment), ProjectAdapter.Delegate, Inputs, Outputs {
         private val client: ApiClientType = environment.apiClient()
         private val cookieManager: CookieManager = environment.cookieManager()
-        private val currentConfig: CurrentConfigType = environment.currentConfig()
         private val currentUser: CurrentUserType = environment.currentUser()
         private val ksCurrency: KSCurrency = environment.ksCurrency()
-        private val nativeCheckoutPreference: BooleanPreferenceType = environment.nativeCheckoutPreference()
         private val optimizely: ExperimentsClientType = environment.optimizely()
         private val sharedPreferences: SharedPreferences = environment.sharedPreferences()
 
-        private val backProjectButtonClicked = PublishSubject.create<Void>()
         private val blurbTextViewClicked = PublishSubject.create<Void>()
         private val blurbVariantClicked = PublishSubject.create<Void>()
         private val cancelPledgeClicked = PublishSubject.create<Void>()
@@ -262,7 +230,6 @@ interface ProjectViewModel {
         private val creatorNameTextViewClicked = PublishSubject.create<Void>()
         private val fragmentStackCount = PublishSubject.create<Int>()
         private val heartButtonClicked = PublishSubject.create<Void>()
-        private val managePledgeButtonClicked = PublishSubject.create<Void>()
         private val nativeProjectActionButtonClicked = PublishSubject.create<Void>()
         private val onGlobalLayout = PublishSubject.create<Void>()
         private val playVideoButtonClicked = PublishSubject.create<Void>()
@@ -278,7 +245,6 @@ interface ProjectViewModel {
         private val updatePledgeClicked = PublishSubject.create<Void>()
         private val updatesTextViewClicked = PublishSubject.create<Void>()
         private val viewRewardsClicked = PublishSubject.create<Void>()
-        private val viewPledgeButtonClicked = PublishSubject.create<Void>()
 
         private val backingDetails = BehaviorSubject.create<String>()
         private val backingDetailsIsVisible = BehaviorSubject.create<Boolean>()
@@ -289,13 +255,10 @@ interface ProjectViewModel {
         private val pledgeActionButtonColor = BehaviorSubject.create<Int>()
         private val pledgeActionButtonContainerIsGone = BehaviorSubject.create<Boolean>()
         private val pledgeActionButtonText = BehaviorSubject.create<Int>()
-        private val pledgeContainerIsGone = BehaviorSubject.create<Boolean>()
         private val pledgeToolbarNavigationIcon = BehaviorSubject.create<Int>()
         private val pledgeToolbarTitle = BehaviorSubject.create<Int>()
         private val prelaunchUrl = BehaviorSubject.create<String>()
-        private val projectActionButtonContainerIsGone = BehaviorSubject.create<Boolean>()
-        private val horizontalProgressBarIsGone = BehaviorSubject.create<Boolean>()
-        private val projectDataAndNativeCheckoutEnabled = BehaviorSubject.create<Pair<ProjectData, Boolean>>()
+        private val projectData = BehaviorSubject.create<ProjectData>()
         private val retryProgressBarIsGone = BehaviorSubject.create<Boolean>()
         private val reloadProjectContainerIsGone = BehaviorSubject.create<Boolean>()
         private val revealRewardsFragment = PublishSubject.create<Void>()
@@ -309,37 +272,20 @@ interface ProjectViewModel {
         private val showUpdatePledge = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
         private val showUpdatePledgeSuccess = PublishSubject.create<Void>()
         private val startCampaignWebViewActivity = PublishSubject.create<ProjectData>()
-        private val startCheckoutActivity = PublishSubject.create<Project>()
         private val startCommentsActivity = PublishSubject.create<Project>()
         private val startCreatorBioWebViewActivity = PublishSubject.create<Project>()
         private val startCreatorDashboardActivity = PublishSubject.create<Project>()
         private val startLoginToutActivity = PublishSubject.create<Void>()
-        private val startManagePledgeActivity = PublishSubject.create<Project>()
         private val startMessagesActivity = PublishSubject.create<Project>()
         private val startProjectUpdatesActivity = PublishSubject.create<Project>()
         private val startThanksActivity = PublishSubject.create<Pair<CheckoutData, PledgeData>>()
         private val startVideoActivity = PublishSubject.create<Project>()
-        private val startBackingActivity = PublishSubject.create<Pair<Project, User>>()
         private val updateFragments = BehaviorSubject.create<ProjectData>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
 
         init {
-            val nativeCheckoutEnabled = this.currentConfig.observable()
-                    .map { it.features()?.get(FeatureKey.ANDROID_NATIVE_CHECKOUT)?: false }
-                    .map { Pair(it, this.nativeCheckoutPreference.get()) }
-                    .map { if (Build.isExternal()) it.first else it.second }
-                    .distinctUntilChanged()
-
-            nativeCheckoutEnabled
-                    .compose(bindToLifecycle())
-                    .subscribe(this.projectActionButtonContainerIsGone)
-
-            nativeCheckoutEnabled
-                    .map { BooleanUtils.negate(it) }
-                    .compose(bindToLifecycle())
-                    .subscribe(this.pledgeContainerIsGone)
 
             val progressBarIsGone = PublishSubject.create<Boolean>()
 
@@ -357,13 +303,6 @@ interface ProjectViewModel {
                     }
                     .share()
 
-            progressBarIsGone
-                    .compose<Pair<Boolean, Boolean>>(combineLatestPair(nativeCheckoutEnabled))
-                    .filter { BooleanUtils.isFalse(it.second) }
-                    .map { it.first }
-                    .compose(bindToLifecycle())
-                    .subscribe(this.horizontalProgressBarIsGone)
-
             activityResult()
                     .filter { it.isOk }
                     .filter { it.isRequestCode(ActivityRequestCodes.SHOW_REWARDS) }
@@ -375,9 +314,6 @@ interface ProjectViewModel {
                     .startWith(false)
 
             progressBarIsGone
-                    .compose<Pair<Boolean, Boolean>>(combineLatestPair(nativeCheckoutEnabled))
-                    .filter { BooleanUtils.isTrue(it.second) }
-                    .map { it.first }
                     .compose<Pair<Boolean, Boolean>>(combineLatestPair(pledgeSheetExpanded))
                     .filter { BooleanUtils.isFalse(it.second) }
                     .map { it.first }
@@ -389,8 +325,6 @@ interface ProjectViewModel {
 
             val mappedProjectErrors = mappedProjectNotification
                     .compose(errors())
-                    .compose<Pair<Throwable, Boolean>>(combineLatestPair(nativeCheckoutEnabled))
-                    .filter { BooleanUtils.isTrue(it.second) }
 
             mappedProjectValues
                     .filter { BooleanUtils.isTrue(it.prelaunchActivated()) }
@@ -476,9 +410,8 @@ interface ProjectViewModel {
             { refTagFromIntent, refTagFromCookie, project -> projectData(refTagFromIntent, refTagFromCookie, project) }
 
             currentProjectData
-                    .compose<Pair<ProjectData, Boolean>>(combineLatestPair(nativeCheckoutEnabled))
                     .compose(bindToLifecycle())
-                    .subscribe(this.projectDataAndNativeCheckoutEnabled)
+                    .subscribe(this.projectData)
 
             currentProject
                     .compose<Project>(takeWhen(this.shareButtonClicked))
@@ -492,11 +425,6 @@ interface ProjectViewModel {
                     .compose<ProjectData>(takeWhen(blurbClicked))
                     .compose(bindToLifecycle())
                     .subscribe(this.startCampaignWebViewActivity)
-
-            currentProject
-                    .compose<Project>(takeWhen(this.backProjectButtonClicked))
-                    .compose(bindToLifecycle())
-                    .subscribe(this.startCheckoutActivity)
 
             currentProject
                     .compose<Project>(takeWhen(this.creatorInfoVariantClicked))
@@ -519,11 +447,6 @@ interface ProjectViewModel {
                     .subscribe(this.startCreatorDashboardActivity)
 
             currentProject
-                    .compose<Project>(takeWhen(this.managePledgeButtonClicked))
-                    .compose(bindToLifecycle())
-                    .subscribe(this.startManagePledgeActivity)
-
-            currentProject
                     .compose<Project>(takeWhen(this.updatesTextViewClicked))
                     .compose(bindToLifecycle())
                     .subscribe(this.startProjectUpdatesActivity)
@@ -532,12 +455,6 @@ interface ProjectViewModel {
                     .compose<Project>(takeWhen(this.playVideoButtonClicked))
                     .compose(bindToLifecycle())
                     .subscribe(this.startVideoActivity)
-
-            Observable.combineLatest<Project, User, Pair<Project, User>>(currentProject, this.currentUser.observable())
-            { project, user -> Pair.create(project, user) }
-                    .compose<Pair<Project, User>>(takeWhen(this.viewPledgeButtonClicked))
-                    .compose(bindToLifecycle())
-                    .subscribe(this.startBackingActivity)
 
             this.onGlobalLayout
                     .compose(bindToLifecycle())
@@ -569,12 +486,7 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.expandPledgeSheet)
 
-            val currentProjectWhenFeatureEnabled = currentProject
-                    .compose<Pair<Project, Boolean>>(combineLatestPair(nativeCheckoutEnabled))
-                    .filter { BooleanUtils.isTrue(it.second) }
-                    .map { it.first }
-
-            val projectHasRewardsAndSheetCollapsed = currentProjectWhenFeatureEnabled
+            val projectHasRewardsAndSheetCollapsed = currentProject
                     .map { it.hasRewards() }
                     .distinctUntilChanged()
                     .compose<Pair<Boolean, Boolean>>(combineLatestPair(pledgeSheetExpanded))
@@ -601,7 +513,7 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.pledgeActionButtonContainerIsGone)
 
-            val projectData = Observable.combineLatest<RefTag, RefTag, Project, ProjectData>(refTag, cookieRefTag, currentProjectWhenFeatureEnabled)
+            val projectData = Observable.combineLatest<RefTag, RefTag, Project, ProjectData>(refTag, cookieRefTag, currentProject)
             { refTagFromIntent, refTagFromCookie, project -> projectData(refTagFromIntent, refTagFromCookie, project) }
 
             projectData
@@ -609,14 +521,14 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.updateFragments)
 
-            currentProjectWhenFeatureEnabled
+            currentProject
                     .compose<Pair<Project, Int>>(combineLatestPair(fragmentStackCount))
                     .map { managePledgeMenu(it) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.managePledgeMenu)
 
-            val backedProject = currentProjectWhenFeatureEnabled
+            val backedProject = currentProject
                     .filter { it.isBacking }
 
             backedProject
@@ -632,7 +544,7 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.showPledgeNotCancelableDialog)
 
-            currentProjectWhenFeatureEnabled
+            currentProject
                     .compose<Project>(takeWhen(this.contactCreatorClicked))
                     .compose(bindToLifecycle())
                     .subscribe(this.startMessagesActivity)
@@ -656,20 +568,20 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.revealRewardsFragment)
 
-            currentProjectWhenFeatureEnabled
+            currentProject
                     .map { it.isBacking && it.isLive }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.backingDetailsIsVisible)
 
-            currentProjectWhenFeatureEnabled
+            currentProject
                     .filter { it.isBacking && it.isLive }
                     .map { backingDetails(it) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.backingDetails)
 
-            val currentProjectAndUser = currentProjectWhenFeatureEnabled
+            val currentProjectAndUser = currentProject
                     .compose<Pair<Project, User>>(combineLatestPair(this.currentUser.observable()))
 
             Observable.combineLatest(currentProjectAndUser, refTag)
@@ -683,7 +595,7 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.pledgeActionButtonText)
 
-            currentProjectWhenFeatureEnabled
+            currentProject
                     .compose<Pair<Project, Int>>(combineLatestPair(fragmentStackCount))
                     .map { if (it.second <= 0) R.drawable.ic_arrow_down else R.drawable.ic_arrow_back }
                     .distinctUntilChanged()
@@ -719,7 +631,7 @@ interface ProjectViewModel {
                     .subscribe(this.showUpdatePledgeSuccess)
 
             this.fragmentStackCount
-                    .compose<Pair<Int, Project>>(combineLatestPair(currentProjectWhenFeatureEnabled))
+                    .compose<Pair<Int, Project>>(combineLatestPair(currentProject))
                     .map { if (it.second.isBacking) it.first > 2 else it.first > 1}
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
@@ -771,39 +683,39 @@ interface ProjectViewModel {
 
             this.pledgeActionButtonText
                     .map { eventName(it) }
-                    .compose<Pair<String, Project>>(combineLatestPair(currentProjectWhenFeatureEnabled))
+                    .compose<Pair<String, Project>>(combineLatestPair(currentProject))
                     .compose<Pair<String, Project>>(takeWhen(this.nativeProjectActionButtonClicked))
                     .compose(bindToLifecycle())
                     .subscribe { this.koala.trackProjectActionButtonClicked(it.first, it.second) }
 
-            currentProjectWhenFeatureEnabled
+            currentProject
                     .compose<Project>(takeWhen(this.updatePledgeClicked))
                     .compose(bindToLifecycle())
                     .subscribe { this.koala.trackManagePledgeOptionClicked(it, "update_pledge") }
 
-            currentProjectWhenFeatureEnabled
+            currentProject
                     .compose<Project>(takeWhen(this.updatePaymentClicked))
                     .compose(bindToLifecycle())
                     .subscribe { this.koala.trackManagePledgeOptionClicked(it, "change_payment_method") }
 
-            currentProjectWhenFeatureEnabled
+            currentProject
                     .filter { it.isLive }
                     .compose<Project>(takeWhen(this.viewRewardsClicked))
                     .compose(bindToLifecycle())
                     .subscribe { this.koala.trackManagePledgeOptionClicked(it, "choose_another_reward") }
 
-            currentProjectWhenFeatureEnabled
+            currentProject
                     .filter { !it.isLive }
                     .compose<Project>(takeWhen(this.viewRewardsClicked))
                     .compose(bindToLifecycle())
                     .subscribe { this.koala.trackManagePledgeOptionClicked(it, "view_rewards") }
 
-            currentProjectWhenFeatureEnabled
+            currentProject
                     .compose<Project>(takeWhen(this.cancelPledgeClicked))
                     .compose(bindToLifecycle())
                     .subscribe { this.koala.trackManagePledgeOptionClicked(it, "cancel_pledge") }
 
-            currentProjectWhenFeatureEnabled
+            currentProject
                     .compose<Project>(takeWhen(this.contactCreatorClicked))
                     .compose(bindToLifecycle())
                     .subscribe { this.koala.trackManagePledgeOptionClicked(it, "contact_creator") }
@@ -906,10 +818,6 @@ interface ProjectViewModel {
                     .build()
         }
 
-        override fun backProjectButtonClicked() {
-            this.backProjectButtonClicked.onNext(null)
-        }
-
         override fun blurbTextViewClicked() {
             this.blurbTextViewClicked.onNext(null)
         }
@@ -950,10 +858,6 @@ interface ProjectViewModel {
             this.heartButtonClicked.onNext(null)
         }
 
-        override fun managePledgeButtonClicked() {
-            this.managePledgeButtonClicked.onNext(null)
-        }
-
         override fun nativeProjectActionButtonClicked() {
             this.nativeProjectActionButtonClicked.onNext(null)
         }
@@ -986,10 +890,6 @@ interface ProjectViewModel {
             this.pledgeToolbarNavigationClicked.onNext(null)
         }
 
-        override fun projectViewHolderBackProjectClicked(viewHolder: ProjectViewHolder) {
-            this.backProjectButtonClicked()
-        }
-
         override fun projectViewHolderBlurbClicked(viewHolder: ProjectViewHolder) {
             this.blurbTextViewClicked()
         }
@@ -1014,16 +914,8 @@ interface ProjectViewModel {
             this.creatorDashboardButtonClicked()
         }
 
-        override fun projectViewHolderManagePledgeClicked(viewHolder: ProjectViewHolder) {
-            this.managePledgeButtonClicked()
-        }
-
         override fun projectViewHolderVideoStarted(viewHolder: ProjectViewHolder) {
             this.playVideoButtonClicked()
-        }
-
-        override fun projectViewHolderViewPledgeClicked(viewHolder: ProjectViewHolder) {
-            this.viewPledgeButtonClicked()
         }
 
         override fun projectViewHolderUpdatesClicked(viewHolder: ProjectViewHolder) {
@@ -1054,10 +946,6 @@ interface ProjectViewModel {
             this.updatesTextViewClicked.onNext(null)
         }
 
-        override fun viewPledgeButtonClicked() {
-            this.viewPledgeButtonClicked.onNext(null)
-        }
-
         override fun viewRewardsClicked() {
             this.viewRewardsClicked.onNext(null)
         }
@@ -1078,9 +966,6 @@ interface ProjectViewModel {
         override fun heartDrawableId(): Observable<Int> = this.heartDrawableId
 
         @NonNull
-        override fun horizontalProgressBarIsGone(): Observable<Boolean> = this.horizontalProgressBarIsGone
-
-        @NonNull
         override fun managePledgeMenu(): Observable<Int?> = this.managePledgeMenu
 
         @NonNull
@@ -1093,9 +978,6 @@ interface ProjectViewModel {
         override fun pledgeActionButtonText(): Observable<Int> = this.pledgeActionButtonText
 
         @NonNull
-        override fun pledgeContainerIsGone(): Observable<Boolean> = this.pledgeContainerIsGone
-
-        @NonNull
         override fun pledgeToolbarNavigationIcon(): Observable<Int> = this.pledgeToolbarNavigationIcon
 
         @NonNull
@@ -1105,10 +987,7 @@ interface ProjectViewModel {
         override fun prelaunchUrl(): Observable<String> = this.prelaunchUrl
 
         @NonNull
-        override fun projectActionButtonContainerIsGone(): Observable<Boolean> = this.projectActionButtonContainerIsGone
-
-        @NonNull
-        override fun projectDataAndNativeCheckoutEnabled(): Observable<Pair<ProjectData, Boolean>> = this.projectDataAndNativeCheckoutEnabled
+        override fun projectData(): Observable<ProjectData> = this.projectData
 
         @NonNull
         override fun reloadProjectContainerIsGone(): Observable<Boolean> = this.reloadProjectContainerIsGone
@@ -1147,13 +1026,7 @@ interface ProjectViewModel {
         override fun showUpdatePledgeSuccess(): Observable<Void> = this.showUpdatePledgeSuccess
 
         @NonNull
-        override fun startBackingActivity(): Observable<Pair<Project, User>> = this.startBackingActivity
-
-        @NonNull
         override fun startCampaignWebViewActivity(): Observable<ProjectData> = this.startCampaignWebViewActivity
-
-        @NonNull
-        override fun startCheckoutActivity(): Observable<Project> = this.startCheckoutActivity
 
         @NonNull
         override fun startCommentsActivity(): Observable<Project> = this.startCommentsActivity
@@ -1166,9 +1039,6 @@ interface ProjectViewModel {
 
         @NonNull
         override fun startLoginToutActivity(): Observable<Void> = this.startLoginToutActivity
-
-        @NonNull
-        override fun startManagePledgeActivity(): Observable<Project> = this.startManagePledgeActivity
 
         @NonNull
         override fun startMessagesActivity(): Observable<Project> = this.startMessagesActivity

--- a/app/src/main/res/layout-land/project_main_layout.xml
+++ b/app/src/main/res/layout-land/project_main_layout.xml
@@ -74,40 +74,6 @@
         android:id="@+id/stats_view"
         layout="@layout/project_stats_view" />
 
-      <RelativeLayout
-        android:id="@+id/project_action_buttons"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_alignTop="@id/stats_view"
-        android:animateLayoutChanges="true"
-        android:focusable="true"
-        tools:ignore="InconsistentLayout">
-
-        <com.google.android.material.button.MaterialButton
-          android:id="@+id/back_project_button"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:text="@string/project_back_button"
-          android:visibility="gone"
-          tools:ignore="InconsistentLayout" />
-
-        <com.google.android.material.button.MaterialButton
-          android:id="@+id/manage_pledge_button"
-          style="@style/SecondaryButton"
-          android:text="@string/project_manage_button"
-          android:visibility="gone"
-          tools:ignore="InconsistentLayout" />
-
-        <com.google.android.material.button.MaterialButton
-          android:id="@+id/view_pledge_button"
-          style="@style/SecondaryButton"
-          android:text="@string/project_view_button"
-          android:visibility="gone"
-          tools:ignore="InconsistentLayout" />
-
-      </RelativeLayout>
-
       <TextView
         android:id="@+id/usd_conversion_text_view"
         style="@style/BodySecondary"

--- a/app/src/main/res/layout/activity_project.xml
+++ b/app/src/main/res/layout/activity_project.xml
@@ -47,37 +47,4 @@
     android:layout_height="match_parent"
     android:layout_marginBottom="@dimen/reward_fragment_guideline_constraint_end" />
 
-  <RelativeLayout
-    android:id="@+id/project_action_buttons"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_alignParentBottom="true"
-    android:layout_gravity="bottom"
-    android:animateLayoutChanges="true"
-    android:focusable="true"
-    android:visibility="gone"
-    tools:visibility="visible">
-
-    <Button
-      android:id="@+id/back_project_button"
-      style="@style/ProjectActionButton"
-      android:text="@string/project_back_button"
-      android:visibility="gone"
-      tools:visibility="visible" />
-
-    <Button
-      android:id="@+id/manage_pledge_button"
-      style="@style/ProjectActionButton"
-      android:text="@string/project_manage_button"
-      android:visibility="gone"
-      app:backgroundTint="@color/button_secondary" />
-
-    <Button
-      android:id="@+id/view_pledge_button"
-      style="@style/ProjectActionButton"
-      android:text="@string/project_view_button"
-      android:visibility="gone"
-      app:backgroundTint="@color/button_secondary" />
-  </RelativeLayout>
-
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectHolderViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectHolderViewModelTest.java
@@ -6,11 +6,9 @@ import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.R;
 import com.kickstarter.libs.Config;
 import com.kickstarter.libs.Environment;
-import com.kickstarter.libs.FeatureKey;
 import com.kickstarter.libs.KSCurrency;
 import com.kickstarter.libs.MockCurrentUser;
 import com.kickstarter.libs.models.OptimizelyExperiment;
-import com.kickstarter.libs.preferences.MockBooleanPreference;
 import com.kickstarter.libs.utils.NumberUtils;
 import com.kickstarter.libs.utils.ProgressBarUtils;
 import com.kickstarter.libs.utils.ProjectUtils;
@@ -67,7 +65,6 @@ public final class ProjectHolderViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Boolean> percentageFundedProgressBarIsGone = new TestSubscriber<>();
   private final TestSubscriber<Boolean> playButtonIsGone = new TestSubscriber<>();
   private final TestSubscriber<String> pledgedTextViewText = new TestSubscriber<>();
-  private final TestSubscriber<Boolean> projectActionButtonContainerIsGone = new TestSubscriber<>();
   private final TestSubscriber<Integer> projectDashboardButtonText = new TestSubscriber<>();
   private final TestSubscriber<Boolean> projectDashboardContainerIsGone = new TestSubscriber<>();
   private final TestSubscriber<DateTime> projectDisclaimerGoalReachedDateTime = new TestSubscriber<>();
@@ -120,7 +117,6 @@ public final class ProjectHolderViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.percentageFundedProgressBarIsGone().subscribe(this.percentageFundedProgressBarIsGone);
     this.vm.outputs.playButtonIsGone().subscribe(this.playButtonIsGone);
     this.vm.outputs.pledgedTextViewText().subscribe(this.pledgedTextViewText);
-    this.vm.outputs.projectActionButtonContainerIsGone().subscribe(this.projectActionButtonContainerIsGone);
     this.vm.outputs.projectDashboardButtonText().subscribe(this.projectDashboardButtonText);
     this.vm.outputs.projectDashboardContainerIsGone().subscribe(this.projectDashboardContainerIsGone);
     this.vm.outputs.projectDisclaimerGoalReachedDateTime().subscribe(this.projectDisclaimerGoalReachedDateTime);
@@ -326,33 +322,6 @@ public final class ProjectHolderViewModelTest extends KSRobolectricTestCase {
     setUpEnvironment(environment(), ProjectDataFactory.Companion.project(ProjectFactory.successfulProject()));
 
     this.percentageFundedProgressBarIsGone.assertValues(true);
-  }
-
-  @Test
-  public void testProjectActionButtonContainerIsGone_whenNativeCheckoutDisabled() {
-    final MockCurrentConfig currentConfig = new MockCurrentConfig();
-    currentConfig.config(ConfigFactory.config());
-    final Environment environment = environment()
-      .toBuilder()
-      .currentConfig(currentConfig)
-      .build();
-    setUpEnvironment(environment, ProjectDataFactory.Companion.project(ProjectFactory.project()));
-
-    this.projectActionButtonContainerIsGone.assertValue(false);
-  }
-
-  @Test
-  public void testProjectActionButtonContainerIsGone_whenNativeCheckoutEnabled() {
-    final MockCurrentConfig currentConfig = new MockCurrentConfig();
-    currentConfig.config(ConfigFactory.configWithFeatureEnabled(FeatureKey.ANDROID_NATIVE_CHECKOUT));
-    final Environment environment = environment()
-      .toBuilder()
-      .currentConfig(currentConfig)
-      .nativeCheckoutPreference(new MockBooleanPreference(true))
-      .build();
-    setUpEnvironment(environment, ProjectDataFactory.Companion.project(ProjectFactory.project()));
-
-    this.projectActionButtonContainerIsGone.assertValue(true);
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -8,8 +8,6 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.libs.*
 import com.kickstarter.libs.models.OptimizelyExperiment
-import com.kickstarter.libs.preferences.MockBooleanPreference
-import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.*
 import com.kickstarter.mock.services.MockApiClient
@@ -29,17 +27,14 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     private val expandPledgeSheet = TestSubscriber<Pair<Boolean, Boolean>>()
     private val goBack = TestSubscriber<Void>()
     private val heartDrawableId = TestSubscriber<Int>()
-    private val horizontalProgressBarIsGone = TestSubscriber<Boolean>()
     private val managePledgeMenu = TestSubscriber<Int?>()
     private val pledgeActionButtonColor = TestSubscriber<Int>()
     private val pledgeActionButtonContainerIsGone = TestSubscriber<Boolean>()
     private val pledgeActionButtonText = TestSubscriber<Int>()
-    private val pledgeContainerIsGone = TestSubscriber<Boolean>()
     private val pledgeToolbarNavigationIcon = TestSubscriber<Int>()
     private val pledgeToolbarTitle = TestSubscriber<Int>()
     private val prelaunchUrl = TestSubscriber<String>()
-    private val projectActionButtonContainerIsGone = TestSubscriber<Boolean>()
-    private val projectDataAndNativeCheckoutEnabled = TestSubscriber<Pair<ProjectData, Boolean>>()
+    private val projectData = TestSubscriber<ProjectData>()
     private val reloadProjectContainerIsGone = TestSubscriber<Boolean>()
     private val reloadProgressBarIsGone = TestSubscriber<Boolean>()
     private val revealRewardsFragment = TestSubscriber<Void>()
@@ -53,13 +48,11 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     private val showShareSheet = TestSubscriber<Pair<String, String>>()
     private val showUpdatePledge = TestSubscriber<Pair<PledgeData, PledgeReason>>()
     private val showUpdatePledgeSuccess = TestSubscriber<Void>()
-    private val startBackingActivity = TestSubscriber<Pair<Project, User>>()
     private val startCampaignWebViewActivity = TestSubscriber<ProjectData>()
     private val startCommentsActivity = TestSubscriber<Project>()
     private val startCreatorBioWebViewActivity = TestSubscriber<Project>()
     private val startCreatorDashboardActivity = TestSubscriber<Project>()
     private val startLoginToutActivity = TestSubscriber<Void>()
-    private val startManagePledgeActivity = TestSubscriber<Project>()
     private val startMessagesActivity = TestSubscriber<Project>()
     private val startProjectUpdatesActivity = TestSubscriber<Project>()
     private val startThanksActivity = TestSubscriber<Pair<CheckoutData, PledgeData>>()
@@ -73,17 +66,14 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.expandPledgeSheet().subscribe(this.expandPledgeSheet)
         this.vm.outputs.goBack().subscribe(this.goBack)
         this.vm.outputs.heartDrawableId().subscribe(this.heartDrawableId)
-        this.vm.outputs.horizontalProgressBarIsGone().subscribe(this.horizontalProgressBarIsGone)
         this.vm.outputs.managePledgeMenu().subscribe(this.managePledgeMenu)
         this.vm.outputs.pledgeActionButtonColor().subscribe(this.pledgeActionButtonColor)
         this.vm.outputs.pledgeActionButtonContainerIsGone().subscribe(this.pledgeActionButtonContainerIsGone)
         this.vm.outputs.pledgeActionButtonText().subscribe(this.pledgeActionButtonText)
-        this.vm.outputs.pledgeContainerIsGone().subscribe(this.pledgeContainerIsGone)
         this.vm.outputs.pledgeToolbarNavigationIcon().subscribe(this.pledgeToolbarNavigationIcon)
         this.vm.outputs.pledgeToolbarTitle().subscribe(this.pledgeToolbarTitle)
         this.vm.outputs.prelaunchUrl().subscribe(this.prelaunchUrl)
-        this.vm.outputs.projectActionButtonContainerIsGone().subscribe(this.projectActionButtonContainerIsGone)
-        this.vm.outputs.projectDataAndNativeCheckoutEnabled().subscribe(this.projectDataAndNativeCheckoutEnabled)
+        this.vm.outputs.projectData().subscribe(this.projectData)
         this.vm.outputs.reloadProgressBarIsGone().subscribe(this.reloadProgressBarIsGone)
         this.vm.outputs.reloadProjectContainerIsGone().subscribe(this.reloadProjectContainerIsGone)
         this.vm.outputs.revealRewardsFragment().subscribe(this.revealRewardsFragment)
@@ -97,13 +87,11 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.showUpdatePledge().subscribe(this.showUpdatePledge)
         this.vm.outputs.showUpdatePledgeSuccess().subscribe(this.showUpdatePledgeSuccess)
         this.vm.outputs.startLoginToutActivity().subscribe(this.startLoginToutActivity)
-        this.vm.outputs.projectDataAndNativeCheckoutEnabled().map { pc -> pc.first.project().isStarred }.subscribe(this.savedTest)
-        this.vm.outputs.startBackingActivity().subscribe(this.startBackingActivity)
+        this.vm.outputs.projectData().map { pD -> pD.project().isStarred }.subscribe(this.savedTest)
         this.vm.outputs.startCampaignWebViewActivity().subscribe(this.startCampaignWebViewActivity)
         this.vm.outputs.startCommentsActivity().subscribe(this.startCommentsActivity)
         this.vm.outputs.startCreatorBioWebViewActivity().subscribe(this.startCreatorBioWebViewActivity)
         this.vm.outputs.startCreatorDashboardActivity().subscribe(this.startCreatorDashboardActivity)
-        this.vm.outputs.startManagePledgeActivity().subscribe(this.startManagePledgeActivity)
         this.vm.outputs.startMessagesActivity().subscribe(this.startMessagesActivity)
         this.vm.outputs.startProjectUpdatesActivity().subscribe(this.startProjectUpdatesActivity)
         this.vm.outputs.startThanksActivity().subscribe(this.startThanksActivity)
@@ -112,71 +100,10 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testUIOutputs_whenNativeCheckoutDisabled_andFetchProjectFromIntent_isSuccessful() {
-        val currentConfig = MockCurrentConfig()
-        currentConfig.config(ConfigFactory.config())
-
+    fun testUIOutputs_whenFetchProjectFromIntent_isSuccessful() {
         val initialProject = ProjectFactory.initialProject()
         val refreshedProject = ProjectFactory.project()
         val environment = environment()
-                .toBuilder()
-                .apiClient(apiClientWithSuccessFetchingProject(refreshedProject))
-                .currentConfig(currentConfig)
-                .build()
-
-        setUpEnvironment(environment)
-
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, initialProject))
-
-        this.horizontalProgressBarIsGone.assertValues(false, true)
-        this.pledgeActionButtonContainerIsGone.assertNoValues()
-        this.pledgeContainerIsGone.assertValue(true)
-        this.prelaunchUrl.assertNoValues()
-        this.projectActionButtonContainerIsGone.assertValues(false)
-        this.projectDataAndNativeCheckoutEnabled.assertValues(Pair(ProjectDataFactory.project(refreshedProject), false))
-        this.reloadProjectContainerIsGone.assertNoValues()
-        this.reloadProgressBarIsGone.assertNoValues()
-        this.updateFragments.assertNoValues()
-        this.koalaTest.assertValue(KoalaEvent.PROJECT_PAGE)
-        this.lakeTest.assertValue("Project Page Viewed")
-    }
-
-    @Test
-    fun testUIOutputs_whenNativeCheckoutDisabled_andFetchProjectFromIntent_isUnsuccessful() {
-        val currentConfig = MockCurrentConfig()
-        currentConfig.config(ConfigFactory.config())
-
-        val environment = environment()
-                .toBuilder()
-                .apiClient(apiClientWithErrorFetchingProject())
-                .currentConfig(currentConfig)
-                .build()
-        setUpEnvironment(environment)
-
-        val projectWithNullRewards = ProjectFactory.project()
-                .toBuilder()
-                .rewards(null)
-                .build()
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, projectWithNullRewards))
-
-        this.horizontalProgressBarIsGone.assertValues(false, true)
-        this.pledgeActionButtonContainerIsGone.assertNoValues()
-        this.pledgeContainerIsGone.assertValue(true)
-        this.prelaunchUrl.assertNoValues()
-        this.projectActionButtonContainerIsGone.assertValues(false)
-        this.projectDataAndNativeCheckoutEnabled.assertValues(Pair(ProjectDataFactory.project(projectWithNullRewards), false))
-        this.reloadProjectContainerIsGone.assertNoValues()
-        this.reloadProgressBarIsGone.assertNoValues()
-        this.updateFragments.assertNoValues()
-        this.koalaTest.assertNoValues()
-        this.lakeTest.assertNoValues()
-    }
-
-    @Test
-    fun testUIOutputs_whenNativeCheckoutEnabled_andFetchProjectFromIntent_isSuccessful() {
-        val initialProject = ProjectFactory.initialProject()
-        val refreshedProject = ProjectFactory.project()
-        val environment = environmentWithNativeCheckoutEnabled()
                 .toBuilder()
                 .apiClient(apiClientWithSuccessFetchingProject(refreshedProject))
                 .build()
@@ -185,12 +112,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, initialProject))
 
-        this.horizontalProgressBarIsGone.assertNoValues()
         this.pledgeActionButtonContainerIsGone.assertValues(true, false)
-        this.pledgeContainerIsGone.assertValue(false)
         this.prelaunchUrl.assertNoValues()
-        this.projectActionButtonContainerIsGone.assertValue(true)
-        this.projectDataAndNativeCheckoutEnabled.assertValues(Pair(ProjectDataFactory.project(refreshedProject), true))
+        this.projectData.assertValues(ProjectDataFactory.project(refreshedProject))
         this.reloadProjectContainerIsGone.assertValue(true)
         this.reloadProgressBarIsGone.assertValues(false, true)
         this.updateFragments.assertValue(ProjectDataFactory.project(refreshedProject))
@@ -199,12 +123,12 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testUIOutputs_whenNativeCheckoutEnabled_andFetchProjectFromIntent_isUnsuccessful() {
+    fun testUIOutputs_whenFetchProjectFromIntent_isUnsuccessful() {
         var error = true
         val initialProject = ProjectFactory.initialProject()
         val refreshedProject = ProjectFactory.project()
 
-        val environment = environmentWithNativeCheckoutEnabled()
+        val environment = environment()
                 .toBuilder()
                 .apiClient(object : MockApiClient() {
                     override fun fetchProject(project: Project): Observable<Project> {
@@ -222,12 +146,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, initialProject))
 
-        this.horizontalProgressBarIsGone.assertNoValues()
         this.pledgeActionButtonContainerIsGone.assertValues(true)
-        this.pledgeContainerIsGone.assertValue(false)
         this.prelaunchUrl.assertNoValues()
-        this.projectActionButtonContainerIsGone.assertValue(true)
-        this.projectDataAndNativeCheckoutEnabled.assertValues(Pair(ProjectDataFactory.project(initialProject), true))
+        this.projectData.assertValues(ProjectDataFactory.project(initialProject))
         this.reloadProjectContainerIsGone.assertValue(false)
         this.reloadProgressBarIsGone.assertValues(false, true)
         this.updateFragments.assertNoValues()
@@ -235,14 +156,11 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         error = false
         this.vm.inputs.reloadProjectContainerClicked()
 
-        this.horizontalProgressBarIsGone.assertNoValues()
         this.pledgeActionButtonContainerIsGone.assertValues(true, false)
-        this.pledgeContainerIsGone.assertValue(false)
         this.prelaunchUrl.assertNoValues()
-        this.projectActionButtonContainerIsGone.assertValue(true)
-        this.projectDataAndNativeCheckoutEnabled.assertValues(Pair(ProjectDataFactory.project(initialProject), true),
-                Pair(ProjectDataFactory.project(initialProject), true),
-                Pair(ProjectDataFactory.project(refreshedProject), true))
+        this.projectData.assertValues(ProjectDataFactory.project(initialProject),
+                ProjectDataFactory.project(initialProject),
+                ProjectDataFactory.project(refreshedProject))
         this.reloadProjectContainerIsGone.assertValues(false, true, true)
         this.reloadProgressBarIsGone.assertValues(false, true, false, true)
         this.updateFragments.assertValue(ProjectDataFactory.project(refreshedProject))
@@ -251,71 +169,11 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testUIOutputs_whenNativeCheckoutDisabled_andFetchProjectFromDeepLink_isSuccessful() {
+    fun testUIOutputs_whenFetchProjectFromDeepLink_isSuccessful() {
         val project = ProjectFactory.project()
-        val currentConfig = MockCurrentConfig()
-        currentConfig.config(ConfigFactory.config())
-
-        val environment = environment().toBuilder()
-                .currentConfig(currentConfig)
-                .apiClient(object : MockApiClient(){
-                    override fun fetchProject(param: String): Observable<Project> {
-                        return Observable.just(project)
-                    }
-                })
-                .build()
-
-        setUpEnvironment(environment)
-        val intent = deepLinkIntent()
-        this.vm.intent(intent)
-
-        this.horizontalProgressBarIsGone.assertValues(false, true)
-        this.pledgeActionButtonContainerIsGone.assertNoValues()
-        this.pledgeContainerIsGone.assertValue(true)
-        this.prelaunchUrl.assertNoValues()
-        this.projectActionButtonContainerIsGone.assertValues(false)
-        this.projectDataAndNativeCheckoutEnabled.assertValues(Pair(ProjectDataFactory.project(project), false))
-        this.reloadProjectContainerIsGone.assertNoValues()
-        this.reloadProgressBarIsGone.assertNoValues()
-        this.updateFragments.assertNoValues()
-        this.koalaTest.assertValue(KoalaEvent.PROJECT_PAGE)
-        this.lakeTest.assertValue("Project Page Viewed")
-    }
-
-    @Test
-    fun testUIOutputs_whenNativeCheckoutDisabled_andFetchProjectFromDeepLink_isUnsuccessful() {
-        val currentConfig = MockCurrentConfig()
-        currentConfig.config(ConfigFactory.config())
 
         val environment = environment()
                 .toBuilder()
-                .apiClient(apiClientWithErrorFetchingProjectFromParam())
-                .currentConfig(currentConfig)
-                .build()
-
-        setUpEnvironment(environment)
-
-        this.vm.intent(deepLinkIntent())
-
-        this.horizontalProgressBarIsGone.assertValues(false, true)
-        this.pledgeActionButtonContainerIsGone.assertNoValues()
-        this.pledgeContainerIsGone.assertValue(true)
-        this.prelaunchUrl.assertNoValues()
-        this.projectActionButtonContainerIsGone.assertValues(false)
-        this.projectDataAndNativeCheckoutEnabled.assertNoValues()
-        this.reloadProjectContainerIsGone.assertNoValues()
-        this.reloadProgressBarIsGone.assertNoValues()
-        this.updateFragments.assertNoValues()
-        this.koalaTest.assertNoValues()
-        this.lakeTest.assertNoValues()
-    }
-
-    @Test
-    fun testUIOutputs_whenNativeCheckoutEnabled_andFetchProjectFromDeepLink_isSuccessful() {
-        val project = ProjectFactory.project()
-
-        val environment = environmentWithNativeCheckoutEnabled()
-                .toBuilder()
                 .apiClient(object : MockApiClient(){
                     override fun fetchProject(param: String): Observable<Project> {
                         return Observable.just(project)
@@ -327,12 +185,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         val intent = deepLinkIntent()
         this.vm.intent(intent)
 
-        this.horizontalProgressBarIsGone.assertNoValues()
         this.pledgeActionButtonContainerIsGone.assertValues(true, false)
-        this.pledgeContainerIsGone.assertValue(false)
         this.prelaunchUrl.assertNoValues()
-        this.projectActionButtonContainerIsGone.assertValue(true)
-        this.projectDataAndNativeCheckoutEnabled.assertValue(Pair(ProjectDataFactory.project(project), true))
+        this.projectData.assertValue(ProjectDataFactory.project(project))
         this.reloadProgressBarIsGone.assertValues(false, true)
         this.updateFragments.assertValue(ProjectDataFactory.project(project))
         this.koalaTest.assertValue(KoalaEvent.PROJECT_PAGE)
@@ -340,11 +195,11 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testUIOutputs_whenNativeCheckoutEnabled_andFetchProjectFromDeepLink_isUnsuccessful() {
+    fun testUIOutputs_whenFetchProjectFromDeepLink_isUnsuccessful() {
         var error = true
         val refreshedProject = ProjectFactory.project()
 
-        val environment = environmentWithNativeCheckoutEnabled()
+        val environment = environment()
                 .toBuilder()
                 .apiClient(object : MockApiClient() {
                     override fun fetchProject(param: String): Observable<Project> {
@@ -360,12 +215,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.intent(deepLinkIntent())
 
-        this.horizontalProgressBarIsGone.assertNoValues()
         this.pledgeActionButtonContainerIsGone.assertNoValues()
-        this.pledgeContainerIsGone.assertValue(false)
         this.prelaunchUrl.assertNoValues()
-        this.projectActionButtonContainerIsGone.assertValue(true)
-        this.projectDataAndNativeCheckoutEnabled.assertNoValues()
+        this.projectData.assertNoValues()
         this.reloadProgressBarIsGone.assertValues(false, true)
         this.reloadProjectContainerIsGone.assertValue(false)
         this.updateFragments.assertNoValues()
@@ -373,12 +225,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         error = false
         this.vm.inputs.reloadProjectContainerClicked()
 
-        this.horizontalProgressBarIsGone.assertNoValues()
         this.pledgeActionButtonContainerIsGone.assertValues(true, false)
-        this.pledgeContainerIsGone.assertValue(false)
         this.prelaunchUrl.assertNoValues()
-        this.projectActionButtonContainerIsGone.assertValue(true)
-        this.projectDataAndNativeCheckoutEnabled.assertValue(Pair(ProjectDataFactory.project(refreshedProject), true))
+        this.projectData.assertValue(ProjectDataFactory.project(refreshedProject))
         this.reloadProgressBarIsGone.assertValues(false, true, false, true)
         this.reloadProjectContainerIsGone.assertValues(false, true, true)
         this.updateFragments.assertValue(ProjectDataFactory.project(refreshedProject))
@@ -387,44 +236,11 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testUIOutputs_whenNativeCheckoutDisabled_andFetchProjectReturnsPrelaunchActivatedProject() {
-        val url = "https://www.kickstarter.com/projects/1186238668/skull-graphic-tee"
-        val project = ProjectFactory.prelaunchProject(url)
-        val currentConfig = MockCurrentConfig()
-        currentConfig.config(ConfigFactory.config())
-
-        val environment = environment().toBuilder()
-                .currentConfig(currentConfig)
-                .apiClient(object : MockApiClient(){
-                    override fun fetchProject(param: String): Observable<Project> {
-                        return Observable.just(project)
-                    }
-                })
-                .build()
-
-        setUpEnvironment(environment)
-        val uri = Uri.parse(url)
-        this.vm.intent(Intent(Intent.ACTION_VIEW, uri))
-
-        this.horizontalProgressBarIsGone.assertValues(false, true)
-        this.pledgeActionButtonContainerIsGone.assertNoValues()
-        this.pledgeContainerIsGone.assertValue(true)
-        this.prelaunchUrl.assertValue(url)
-        this.projectActionButtonContainerIsGone.assertValues(false)
-        this.projectDataAndNativeCheckoutEnabled.assertNoValues()
-        this.reloadProgressBarIsGone.assertNoValues()
-        this.reloadProjectContainerIsGone.assertNoValues()
-        this.updateFragments.assertNoValues()
-        this.koalaTest.assertNoValues()
-        this.lakeTest.assertNoValues()
-    }
-
-    @Test
-    fun testUIOutputs_whenNativeCheckoutEnabled_andFetchProjectReturnsPrelaunchActivatedProject() {
+    fun testUIOutputs_whenFetchProjectReturnsPrelaunchActivatedProject() {
         val url = "https://www.kickstarter.com/projects/1186238668/skull-graphic-tee"
         val project = ProjectFactory.prelaunchProject(url)
 
-        val environment = environmentWithNativeCheckoutEnabled()
+        val environment = environment()
                 .toBuilder()
                 .apiClient(object : MockApiClient(){
                     override fun fetchProject(param: String): Observable<Project> {
@@ -437,12 +253,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         val uri = Uri.parse(url)
         this.vm.intent(Intent(Intent.ACTION_VIEW, uri))
 
-        this.horizontalProgressBarIsGone.assertNoValues()
         this.pledgeActionButtonContainerIsGone.assertNoValues()
-        this.pledgeContainerIsGone.assertValue(false)
         this.prelaunchUrl.assertValue(url)
-        this.projectActionButtonContainerIsGone.assertValue(true)
-        this.projectDataAndNativeCheckoutEnabled.assertNoValues()
+        this.projectData.assertNoValues()
         this.reloadProgressBarIsGone.assertValues(false, true)
         this.reloadProjectContainerIsGone.assertNoValues()
         this.updateFragments.assertNoValues()
@@ -577,18 +390,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testStartBackingActivity() {
-        val project = ProjectFactory.project()
-        val user = UserFactory.user()
-
-        setUpEnvironment(environment().toBuilder().currentUser(MockCurrentUser(user)).build())
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
-
-        this.vm.inputs.viewPledgeButtonClicked()
-        this.startBackingActivity.assertValues(Pair.create(project, user))
-    }
-
-    @Test
     fun testStartCampaignWebViewActivity_whenBlurbClicked() {
         val project = ProjectFactory.project()
         setUpEnvironment(environment())
@@ -688,19 +489,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testStartManagePledgeActivity() {
-        val project = ProjectFactory.project()
-        setUpEnvironment(environment())
-
-        // Start the view model with a project.
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
-
-        // Click on Manage pledge button.
-        this.vm.inputs.managePledgeButtonClicked()
-        this.startManagePledgeActivity.assertValues(project)
-    }
-
-    @Test
     fun testStartProjectUpdatesActivity() {
         val project = ProjectFactory.project()
         setUpEnvironment(environment())
@@ -726,18 +514,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeActionButtonUIOutputs_whenNativeCheckoutDisabled() {
+    fun testPledgeActionButtonUIOutputs_whenProjectIsLiveAndBacked() {
         setUpEnvironment(environment())
-
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
-
-        this.pledgeActionButtonColor.assertNoValues()
-        this.pledgeActionButtonText.assertNoValues()
-    }
-
-    @Test
-    fun testPledgeActionButtonUIOutputs_whenNativeCheckoutEnabled_whenProjectIsLiveAndBacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
 
@@ -746,8 +524,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeActionButtonUIOutputs_whenNativeCheckoutEnabled_projectIsLiveAndNotBacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+    fun testPledgeActionButtonUIOutputs_projectIsLiveAndNotBacked() {
+        setUpEnvironment(environment())
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
@@ -756,8 +534,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeActionButtonUIOutputs_whenNativeCheckoutEnabled_projectIsLiveAndNotBacked_control() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+    fun testPledgeActionButtonUIOutputs_projectIsLiveAndNotBacked_control() {
+        setUpEnvironment(environment())
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
@@ -766,8 +544,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeActionButtonUIOutputs_whenNativeCheckoutEnabled_projectIsLiveAndNotBacked_variant1() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled().toBuilder()
+    fun testPledgeActionButtonUIOutputs_projectIsLiveAndNotBacked_variant1() {
+        setUpEnvironment(environment().toBuilder()
                 .optimizely(object: MockExperimentsClientType() {
                     override fun variant(experiment: OptimizelyExperiment.Key, user: User?, refTag: RefTag?): OptimizelyExperiment.Variant {
                         return OptimizelyExperiment.Variant.VARIANT_1
@@ -782,8 +560,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeActionButtonUIOutputs_whenNativeCheckoutEnabled_projectIsLiveAndNotBacked_variant2() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled().toBuilder()
+    fun testPledgeActionButtonUIOutputs_projectIsLiveAndNotBacked_variant2() {
+        setUpEnvironment(environment().toBuilder()
                 .optimizely(object: MockExperimentsClientType() {
                     override fun variant(experiment: OptimizelyExperiment.Key, user: User?, refTag: RefTag?): OptimizelyExperiment.Variant {
                         return OptimizelyExperiment.Variant.VARIANT_2
@@ -798,8 +576,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeActionButtonUIOutputs_whenNativeCheckoutEnabled_whenProjectIsEndedAndBacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+    fun testPledgeActionButtonUIOutputs_whenProjectIsEndedAndBacked() {
+        setUpEnvironment(environment())
         val backedSuccessfulProject = ProjectFactory.backedProject()
                 .toBuilder()
                 .state(Project.STATE_SUCCESSFUL)
@@ -811,8 +589,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeActionButtonUIOutputs_whenNativeCheckoutEnabled_whenProjectIsEndedAndNotBacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+    fun testPledgeActionButtonUIOutputs_whenProjectIsEndedAndNotBacked() {
+        setUpEnvironment(environment())
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.successfulProject()))
 
@@ -821,13 +599,13 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeActionButtonUIOutputs_whenNativeCheckoutEnabled_whenCurrentUserIsProjectCreator() {
+    fun testPledgeActionButtonUIOutputs_whenCurrentUserIsProjectCreator() {
         val creator = UserFactory.creator()
         val creatorProject = ProjectFactory.project()
                 .toBuilder()
                 .creator(creator)
                 .build()
-        val environment = environmentWithNativeCheckoutEnabled()
+        val environment = environment()
                 .toBuilder()
                 .currentUser(MockCurrentUser(creator))
                 .build()
@@ -840,17 +618,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeToolbarNavigationIcon_whenNativeCheckoutDisabled() {
-        setUpEnvironment(environment())
-
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
-
-        this.pledgeToolbarNavigationIcon.assertNoValues()
-    }
-
-    @Test
     fun testPledgeToolbarNavigationIcon_whenNativeCheckoutEnabled() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
@@ -866,17 +635,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeToolbarTitle_whenNativeCheckoutDisabled() {
+    fun testPledgeToolbarTitle_whenProjectIsLiveAndUnbacked() {
         setUpEnvironment(environment())
-
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
-
-        this.pledgeToolbarTitle.assertNoValues()
-    }
-
-    @Test
-    fun testPledgeToolbarTitle_whenNativeCheckoutEnabled_projectIsLiveAndUnbacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
@@ -884,8 +644,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeToolbarTitle_whenNativeCheckoutEnabled_projectIsLiveAndBacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+    fun testPledgeToolbarTitle_whenProjectIsLiveAndBacked() {
+        setUpEnvironment(environment())
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
 
@@ -893,8 +653,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeToolbarTitle_whenNativeCheckoutEnabled_projectIsEndedAndUnbacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+    fun testPledgeToolbarTitle_whenProjectIsEndedAndUnbacked() {
+        setUpEnvironment(environment())
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.successfulProject()))
 
@@ -902,8 +662,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeToolbarTitle_whenNativeCheckoutEnabled_projectIsEndedAndBacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+    fun testPledgeToolbarTitle_whenProjectIsEndedAndBacked() {
+        setUpEnvironment(environment())
 
         val backedSuccessfulProject = ProjectFactory.backedProject()
                 .toBuilder()
@@ -916,7 +676,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testExpandPledgeSheet_whenCollapsingSheet() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
         this.vm.inputs.nativeProjectActionButtonClicked()
@@ -932,7 +692,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testExpandPledgeSheet_whenProjectLiveAndNotBacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
         this.vm.inputs.nativeProjectActionButtonClicked()
@@ -945,7 +705,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testExpandPledgeSheet_whenProjectLiveAndBacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
 
         this.vm.inputs.nativeProjectActionButtonClicked()
@@ -958,7 +718,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testExpandPledgeSheet_whenProjectEndedAndNotBacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.successfulProject()))
 
         this.vm.inputs.nativeProjectActionButtonClicked()
@@ -971,7 +731,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testExpandPledgeSheet_whenProjectEndedAndBacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedSuccessfulProject()))
 
         this.vm.inputs.nativeProjectActionButtonClicked()
@@ -984,7 +744,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testExpandPledgeSheet_whenComingBackFromProjectPage_OKResult() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
         this.vm.activityResult(ActivityResult.create(ActivityRequestCodes.SHOW_REWARDS, Activity.RESULT_OK, null))
@@ -997,7 +757,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testExpandPledgeSheet_whenComingBackFromProjectPage_CanceledResult() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
         this.vm.activityResult(ActivityResult.create(ActivityRequestCodes.SHOW_REWARDS, Activity.RESULT_CANCELED, null))
@@ -1010,7 +770,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testGoBack_whenFragmentBackStackIsEmpty() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
         this.vm.inputs.pledgeToolbarNavigationClicked()
@@ -1019,7 +779,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testGoBack_whenFragmentBackStackIsNotEmpty() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
         this.vm.inputs.fragmentStackCount(3)
@@ -1041,7 +801,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testBackingDetails_whenProjectNotBacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
         this.backingDetailsIsVisible.assertValue(false)
         this.backingDetails.assertNoValues()
@@ -1049,7 +809,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testBackingDetails_whenShippableRewardBacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         val reward = RewardFactory.reward()
                 .toBuilder()
                 .id(4)
@@ -1075,7 +835,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testBackingDetails_whenDigitalReward() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         val noRewardBacking = BackingFactory.backing()
                 .toBuilder()
                 .amount(13.5)
@@ -1093,17 +853,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testScrimIsVisible_whenNativeCheckoutDisabled() {
-        setUpEnvironment(environment())
-        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
-
-        this.vm.inputs.fragmentStackCount(0)
-        this.scrimIsVisible.assertNoValues()
-    }
-
-    @Test
     fun testScrimIsVisible_whenNotBackedProject() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
         this.vm.inputs.fragmentStackCount(0)
@@ -1121,7 +872,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testScrimIsVisible_whenBackedProject() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
 
         this.vm.inputs.fragmentStackCount(0)
@@ -1142,22 +893,22 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testCancelPledgeSuccess() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         // Start the view model with a backed project
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
 
-        this.projectDataAndNativeCheckoutEnabled.assertValueCount(1)
+        this.projectData.assertValueCount(1)
 
         this.vm.inputs.pledgeSuccessfullyCancelled()
         this.expandPledgeSheet.assertValue(Pair(false, false))
         this.showCancelPledgeSuccess.assertValueCount(1)
-        this.projectDataAndNativeCheckoutEnabled.assertValueCount(2)
+        this.projectData.assertValueCount(2)
     }
 
     @Test
     fun testManagePledgeMenu_whenProjectBackedAndLive_backingIsPledged() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         // Start the view model with a backed project
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
@@ -1167,7 +918,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testManagePledgeMenu_whenProjectBackedAndLive_backingIsPreauth() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         // Start the view model with a backed project
         val backing = BackingFactory.backing()
@@ -1185,7 +936,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testManagePledgeMenu_whenProjectBackedAndNotLive() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         // Start the view model with a backed project
         val successfulBackedProject = ProjectFactory.backedProject()
@@ -1199,7 +950,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testManagePledgeMenu_whenProjectNotBacked() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         // Start the view model with a backed project
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
@@ -1209,7 +960,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testManagePledgeMenu_whenManaging() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         // Start the view model with a backed project
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
@@ -1226,7 +977,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowCancelPledgeFragment_whenBackingIsCancelable() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         val backing = BackingFactory.backing()
                 .toBuilder()
                 .cancelable(true)
@@ -1249,7 +1000,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowCancelPledgeFragment_whenBackingIsNotCancelable() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         val backing = BackingFactory.backing()
                 .toBuilder()
                 .cancelable(false)
@@ -1272,7 +1023,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowConversation() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         // Start the view model with a backed project
         val backedProject = ProjectFactory.backedProject()
@@ -1288,7 +1039,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowPledgeNotCancelableDialog_whenBackingIsCancelable() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         val backing = BackingFactory.backing()
                 .toBuilder()
                 .cancelable(true)
@@ -1307,7 +1058,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowPledgeNotCancelableDialog_whenBackingIsNotCancelable() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         val backing = BackingFactory.backing()
                 .toBuilder()
                 .cancelable(false)
@@ -1326,7 +1077,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testRevealRewardsFragment_whenBackedProjectLive() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         // Start the view model with a backed project
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
@@ -1341,7 +1092,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testRevealRewardsFragment_whenBackedProjectEnded() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         // Start the view model with a backed project
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedSuccessfulProject()))
@@ -1356,7 +1107,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowUpdatePledge_whenUpdatingPledge() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         // Start the view model with a backed project
         val reward = RewardFactory.reward()
@@ -1384,7 +1135,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowUpdatePledge_whenUpdatingPaymentMethod() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         // Start the view model with a backed project
         val reward = RewardFactory.reward()
@@ -1414,7 +1165,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     fun testShowUpdatePledgeSuccess_whenUpdatingPayment() {
         val initialBackedProject = ProjectFactory.backedProject()
         val refreshedProject = ProjectFactory.backedProject()
-        val environment = environmentWithNativeCheckoutEnabled()
+        val environment = environment()
                 .toBuilder()
                 .apiClient(apiClientWithSuccessFetchingProjectFromSlug(refreshedProject))
                 .build()
@@ -1423,13 +1174,13 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         // Start the view model with a backed project
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, initialBackedProject))
 
-        this.projectDataAndNativeCheckoutEnabled.assertValues(Pair(ProjectDataFactory.project(initialBackedProject), true))
+        this.projectData.assertValues(ProjectDataFactory.project(initialBackedProject))
         this.showUpdatePledgeSuccess.assertNoValues()
         this.updateFragments.assertValue(ProjectDataFactory.project(initialBackedProject))
 
         this.vm.inputs.pledgePaymentSuccessfullyUpdated()
-        this.projectDataAndNativeCheckoutEnabled.assertValues(Pair(ProjectDataFactory.project(initialBackedProject), true),
-                Pair(ProjectDataFactory.project(refreshedProject), true))
+        this.projectData.assertValues(ProjectDataFactory.project(initialBackedProject),
+                ProjectDataFactory.project(refreshedProject))
         this.showUpdatePledgeSuccess.assertValueCount(1)
         this.updateFragments.assertValues(ProjectDataFactory.project(initialBackedProject),
                 ProjectDataFactory.project(refreshedProject))
@@ -1439,7 +1190,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     fun testShowUpdatePledgeSuccess_whenUpdatingPledge() {
         val initialBackedProject = ProjectFactory.backedProject()
         val refreshedProject = ProjectFactory.backedProject()
-        val environment = environmentWithNativeCheckoutEnabled()
+        val environment = environment()
                 .toBuilder()
                 .apiClient(apiClientWithSuccessFetchingProjectFromSlug(refreshedProject))
                 .build()
@@ -1448,13 +1199,13 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         // Start the view model with a backed project
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, initialBackedProject))
 
-        this.projectDataAndNativeCheckoutEnabled.assertValues(Pair(ProjectDataFactory.project(initialBackedProject), true))
+        this.projectData.assertValues(ProjectDataFactory.project(initialBackedProject))
         this.showUpdatePledgeSuccess.assertNoValues()
         this.updateFragments.assertValue(ProjectDataFactory.project(initialBackedProject))
 
         this.vm.inputs.pledgeSuccessfullyUpdated()
-        this.projectDataAndNativeCheckoutEnabled.assertValues(Pair(ProjectDataFactory.project(initialBackedProject), true),
-                Pair(ProjectDataFactory.project(refreshedProject), true))
+        this.projectData.assertValues(ProjectDataFactory.project(initialBackedProject),
+                ProjectDataFactory.project(refreshedProject))
         this.showUpdatePledgeSuccess.assertValueCount(1)
         this.updateFragments.assertValues(ProjectDataFactory.project(initialBackedProject),
                 ProjectDataFactory.project(refreshedProject))
@@ -1462,41 +1213,33 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testStartThanksActivity() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         // Start the view model with a unbacked project
         val project = ProjectFactory.project()
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
 
-        this.projectDataAndNativeCheckoutEnabled.assertValueCount(1)
+        this.projectData.assertValueCount(1)
 
         val checkoutData = CheckoutDataFactory.checkoutData(3L, 20.0, 30.0)
         val pledgeData = PledgeData.with(PledgeFlowContext.NEW_PLEDGE, ProjectDataFactory.project(project), RewardFactory.reward())
         this.vm.inputs.pledgeSuccessfullyCreated(Pair(checkoutData, pledgeData))
         this.expandPledgeSheet.assertValue(Pair(false, false))
         this.startThanksActivity.assertValue(Pair(checkoutData, pledgeData))
-        this.projectDataAndNativeCheckoutEnabled.assertValueCount(2)
+        this.projectData.assertValueCount(2)
     }
 
     @Test
-    fun testProjectAndNativeCheckoutEnabled_whenRefreshProjectIsCalled() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+    fun testProjectData_whenRefreshProjectIsCalled() {
+        setUpEnvironment(environment())
 
         // Start the view model with a backed project
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
 
-        this.projectDataAndNativeCheckoutEnabled.assertValueCount(1)
+        this.projectData.assertValueCount(1)
 
         this.vm.inputs.refreshProject()
-        this.projectDataAndNativeCheckoutEnabled.assertValueCount(2)
-    }
-
-    private fun apiClientWithErrorFetchingProject(): MockApiClient {
-        return object : MockApiClient() {
-            override fun fetchProject(project: Project): Observable<Project> {
-                return Observable.error(Throwable("boop"))
-            }
-        }
+        this.projectData.assertValueCount(2)
     }
 
     private fun apiClientWithSuccessFetchingProject(refreshedProject: Project): MockApiClient {
@@ -1515,27 +1258,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         }
     }
 
-    private fun apiClientWithErrorFetchingProjectFromParam(): MockApiClient {
-        return object : MockApiClient() {
-            override fun fetchProject(param: String): Observable<Project> {
-                return Observable.error(Throwable("boop"))
-            }
-        }
-    }
-
     private fun deepLinkIntent(): Intent {
         val uri = Uri.parse("https://www.kickstarter.com/projects/1186238668/skull-graphic-tee")
         return Intent(Intent.ACTION_VIEW, uri)
-    }
-
-    private fun environmentWithNativeCheckoutEnabled() : Environment {
-        val currentConfig = MockCurrentConfig()
-        currentConfig.config(ConfigFactory.configWithFeatureEnabled(FeatureKey.ANDROID_NATIVE_CHECKOUT))
-
-        return environment()
-                .toBuilder()
-                .currentConfig(currentConfig)
-                .nativeCheckoutPreference(MockBooleanPreference(true))
-                .build()
     }
 }


### PR DESCRIPTION
# 📲 What
Removing native checkout feature flag support from the Project page

# 🤔 Why
Tech debt.

# 🛠 How
## `ProjectViewModel`
- Removed `backProjectButtonClicked`, `managePledgeButtonClicked`, `viewPledgeButtonClicked` inputs.
- Removed `horizontalProgressBarIsGone`, `pledgeContainerIsGone`, `projectActionButtonContainerIsGone`, `startBackingActivity`, `startCheckoutActivity`, `startManagePledgeActivity` and outputs.
- Cleaned up tests.
## `activity_project.xml`
- Removed `project_action_buttons` container.
## `project_main_layout.xml`
- Removed `project_action_buttons` container.
## `ProjectHolderViewModel`
- Removed `projectActionButtonContainerIsGone` output.
- Cleaned up tests.
## `ProjectViewUtils`
- Removed `setActionButton` since it's no longer used.

# 👀 See
Native checkout only.

# 📋 QA
Check out, natively.

# Story 📖
[NT-965]


[NT-965]: https://kickstarter.atlassian.net/browse/NT-965