### PR TITLE
[␡] NT-965 Removing native checkout feature flag support from the Thanks page

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/IntentKey.java
+++ b/app/src/main/java/com/kickstarter/ui/IntentKey.java
@@ -25,7 +25,6 @@ public final class IntentKey {
   public static final String LAKE_EVENT_NAME = "com.kickstarter.kickstarter.intent_koala_event_name";
   public static final String LOGIN_REASON = "com.kickstarter.kickstarter.intent_login_reason";
   public static final String MESSAGE_THREAD = "com.kickstarter.kickstarter.intent_message_thread";
-  public static final String NATIVE_CHECKOUT_ENABLED = "com.kickstarter.kickstarter.intent_native_checkout_enabled";
   public static final String PASSWORD = "com.kickstarter.kickstarter.intent_password";
   public static final String PLEDGE_DATA = "com.kickstarter.kickstarter.intent_pledge_data";
   public static final String PROJECT = "com.kickstarter.kickstarter.intent_project";

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -592,8 +592,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
             startActivity(Intent(this, ThanksActivity::class.java)
                     .putExtra(IntentKey.PROJECT, projectData.project())
                     .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
-                    .putExtra(IntentKey.PLEDGE_DATA, pledgeData)
-                    .putExtra(IntentKey.NATIVE_CHECKOUT_ENABLED, true))
+                    .putExtra(IntentKey.PLEDGE_DATA, pledgeData))
         }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ThanksActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ThanksActivity.java
@@ -9,7 +9,6 @@ import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.KSString;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
-import com.kickstarter.libs.utils.ApplicationUtils;
 import com.kickstarter.libs.utils.ViewUtils;
 import com.kickstarter.models.Project;
 import com.kickstarter.services.DiscoveryParams;
@@ -97,11 +96,6 @@ public final class ThanksActivity extends BaseActivity<ThanksViewModel.ViewModel
           showRatingDialog();
         }
       });
-
-    this.viewModel.outputs.resumeDiscoveryActivity()
-      .compose(bindToLifecycle())
-      .compose(observeForUI())
-      .subscribe(__ -> ApplicationUtils.resumeDiscoveryActivity(this));
 
     this.viewModel.outputs.startDiscoveryActivity()
       .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.java
@@ -2,14 +2,11 @@ package com.kickstarter.viewmodels;
 
 import android.util.Pair;
 
-import androidx.annotation.NonNull;
-
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.preferences.BooleanPreferenceType;
-import com.kickstarter.libs.utils.BooleanUtils;
 import com.kickstarter.libs.utils.ListUtils;
 import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.libs.utils.UserUtils;
@@ -30,6 +27,7 @@ import com.kickstarter.ui.viewholders.ThanksCategoryViewHolder;
 
 import java.util.List;
 
+import androidx.annotation.NonNull;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
@@ -57,9 +55,6 @@ public interface ThanksViewModel {
 
     /** Emits when we should finish the {@link com.kickstarter.ui.activities.ThanksActivity}. */
     Observable<Void> finish();
-
-    /** Emits when we should resume the {@link com.kickstarter.ui.activities.DiscoveryActivity}. */
-    Observable<Void> resumeDiscoveryActivity();
 
     /** Show a dialog confirming the user will be signed up to the games newsletter. Required for German users. */
     Observable<Void> showConfirmGamesNewsletterDialog();
@@ -118,23 +113,9 @@ public interface ThanksViewModel {
         .compose(bindToLifecycle())
         .subscribe(this.startDiscoveryActivity::onNext);
 
-      final Observable<Boolean> nativeCheckoutEnabled = intent()
-        .map(i -> i.getBooleanExtra(IntentKey.NATIVE_CHECKOUT_ENABLED, false))
-        .take(1);
-
-      nativeCheckoutEnabled
-        .compose(takeWhen(this.closeButtonClicked))
-        .filter(BooleanUtils::isTrue)
-        .compose(ignoreValues())
+      this.closeButtonClicked
         .compose(bindToLifecycle())
         .subscribe(this.finish);
-
-      nativeCheckoutEnabled
-        .compose(takeWhen(this.closeButtonClicked))
-        .filter(BooleanUtils::isFalse)
-        .compose(ignoreValues())
-        .compose(bindToLifecycle())
-        .subscribe(this.resumeDiscoveryActivity);
 
       this.projectCardViewHolderClicked
         .compose(bindToLifecycle())
@@ -288,7 +269,6 @@ public interface ThanksViewModel {
 
     private final BehaviorSubject<ThanksData> adapterData = BehaviorSubject.create();
     private final PublishSubject<Void> finish = PublishSubject.create();
-    private final PublishSubject<Void> resumeDiscoveryActivity = PublishSubject.create();
     private final PublishSubject<Void> showConfirmGamesNewsletterDialog = PublishSubject.create();
     private final PublishSubject<Void> showGamesNewsletterDialog = PublishSubject.create();
     private final PublishSubject<Void> showRatingDialog = PublishSubject.create();
@@ -317,9 +297,6 @@ public interface ThanksViewModel {
     }
     @Override public @NonNull Observable<Void> finish() {
       return this.finish;
-    }
-    @Override public @NonNull Observable<Void> resumeDiscoveryActivity() {
-      return this.resumeDiscoveryActivity;
     }
     @Override public @NonNull Observable<Void> showConfirmGamesNewsletterDialog() {
       return this.showConfirmGamesNewsletterDialog;

--- a/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
@@ -3,8 +3,6 @@ package com.kickstarter.viewmodels;
 import android.content.Intent;
 import android.util.Pair;
 
-import androidx.annotation.NonNull;
-
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
@@ -33,13 +31,13 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
+import androidx.annotation.NonNull;
 import rx.observers.TestSubscriber;
 
 public final class ThanksViewModelTest extends KSRobolectricTestCase {
   private ThanksViewModel.ViewModel vm;
   private final TestSubscriber<ThanksData> adapterData = new TestSubscriber<>();
   private final TestSubscriber<Void> finish = new TestSubscriber<>();
-  private final TestSubscriber<Void> resumeDiscoveryActivity = new TestSubscriber<>();
   private final TestSubscriber<Void> showGamesNewsletterDialogTest = new TestSubscriber<>();
   private final TestSubscriber<Void> showRatingDialogTest = new TestSubscriber<>();
   private final TestSubscriber<Void> showConfirmGamesNewsletterDialogTest = TestSubscriber.create();
@@ -50,7 +48,6 @@ public final class ThanksViewModelTest extends KSRobolectricTestCase {
     this.vm = new ThanksViewModel.ViewModel(environment);
     this.vm.outputs.adapterData().subscribe(this.adapterData);
     this.vm.outputs.finish().subscribe(this.finish);
-    this.vm.outputs.resumeDiscoveryActivity().subscribe(this.resumeDiscoveryActivity);
     this.vm.outputs.showGamesNewsletterDialog().subscribe(this.showGamesNewsletterDialogTest);
     this.vm.outputs.showRatingDialog().subscribe(this.showRatingDialogTest);
     this.vm.outputs.showConfirmGamesNewsletterDialog().subscribe(this.showConfirmGamesNewsletterDialogTest);
@@ -72,42 +69,15 @@ public final class ThanksViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testFinishEmits_whenNativeCheckoutExtra_isTrue() {
+  public void testFinishEmits() {
     setUpEnvironment(environment());
 
     final Intent intent = new Intent()
-      .putExtra(IntentKey.PROJECT, ProjectFactory.project())
-      .putExtra(IntentKey.NATIVE_CHECKOUT_ENABLED, true);
+      .putExtra(IntentKey.PROJECT, ProjectFactory.project());
     this.vm.intent(intent);
     this.vm.inputs.closeButtonClicked();
 
     this.finish.assertValueCount(1);
-    this.resumeDiscoveryActivity.assertNoValues();
-  }
-
-  @Test
-  public void testResumeDiscoveryActivityEmits_whenNativeCheckoutExtra_isNull() {
-    setUpEnvironment(environment());
-
-    this.vm.intent(new Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()));
-    this.vm.inputs.closeButtonClicked();
-
-    this.finish.assertNoValues();
-    this.resumeDiscoveryActivity.assertValueCount(1);
-  }
-
-  @Test
-  public void testResumeDiscoveryActivityEmits_whenNativeCheckoutExtra_isFalse() {
-    setUpEnvironment(environment());
-
-    final Intent intent = new Intent()
-      .putExtra(IntentKey.PROJECT, ProjectFactory.project())
-      .putExtra(IntentKey.NATIVE_CHECKOUT_ENABLED, false);
-    this.vm.intent(intent);
-    this.vm.inputs.closeButtonClicked();
-
-    this.finish.assertNoValues();
-    this.resumeDiscoveryActivity.assertValueCount(1);
   }
 
   @Test
@@ -335,7 +305,7 @@ public final class ThanksViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testTracking_whenCheckoutDataAndPledgeDataExtrasNull() {
+  public void testTracking_whenCheckoutDataAndPledgeDataExtrasExist() {
     setUpEnvironment(environment());
 
     final Project project = ProjectFactory.project();
@@ -346,8 +316,7 @@ public final class ThanksViewModelTest extends KSRobolectricTestCase {
     final Intent intent = new Intent()
             .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
             .putExtra(IntentKey.PLEDGE_DATA, pledgeData)
-            .putExtra(IntentKey.PROJECT, project)
-            .putExtra(IntentKey.NATIVE_CHECKOUT_ENABLED, true);
+            .putExtra(IntentKey.PROJECT, project);
     this.vm.intent(intent);
 
     this.lakeTest.assertValue("Thanks Page Viewed");


### PR DESCRIPTION
# 📲 What
Removing native checkout feature flag support from the Thanks page

# 🤔 Why
Tech debt.

# 🛠 How
## `ThanksViewModel`
- Removed `resumeDiscoveryActivity` output.
- Cleaned up tests.

- Removed `IntentKey.NATIVE_CHECKOUT_ENABLED` since it's no longer used.

# 👀 See
Native checkout only.

# 📋 QA
Dismissing the Thanks page always goes back to the last screen, no longer to Discovery when Native checkout is disabled.

# Story 📖
[NT-965]

[NT-965]: https://kickstarter.atlassian.net/browse/NT-965