### PR TITLE
[🛤] NT-989 Tracking `Campaign Details Button Clicked` for control variant

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -828,7 +828,7 @@ interface ProjectViewModel {
 
             fullProjectDataAndCurrentUser
                     .map { Pair(ExperimentData(it.second, it.first.refTagFromIntent(), it.first.refTagFromCookie()), it.first.project()) }
-                    .compose<Pair<ExperimentData, Project>>(takeWhen(this.blurbVariantClicked))
+                    .compose<Pair<ExperimentData, Project>>(takeWhen(blurbClicked))
                     .filter { it.second.isLive && !it.second.isBacking }
                     .compose(bindToLifecycle())
                     .subscribe { this.optimizely.track(CAMPAIGN_DETAILS_BUTTON_CLICKED, it.first) }

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -589,7 +589,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testStartCampaignWebViewActivity_whenBlurbClicked() {
+    fun testStartCampaignWebViewActivity_whenBlurbClicked_liveNotBackedProject() {
         val project = ProjectFactory.project()
         setUpEnvironment(environment())
 
@@ -598,6 +598,33 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
+        this.experimentsTest.assertValue("Campaign Details Button Clicked")
+    }
+
+    @Test
+    fun testStartCampaignWebViewActivity_whenBlurbClicked_backedProject() {
+        val project = ProjectFactory.backedProject()
+        setUpEnvironment(environment())
+
+        // Start the view model with a project.
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
+
+        this.vm.inputs.blurbTextViewClicked()
+        this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
+        this.experimentsTest.assertNoValues()
+    }
+
+    @Test
+    fun testStartCampaignWebViewActivity_whenBlurbClicked_endedProject() {
+        val project = ProjectFactory.successfulProject()
+        setUpEnvironment(environment())
+
+        // Start the view model with a project.
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
+
+        this.vm.inputs.blurbTextViewClicked()
+        this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
+        this.experimentsTest.assertNoValues()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Tracking `Campaign Details Button Clicked` in Optimizely when control blurb is clicked.

# 🤔 Why
So we can get those sweet funnel numbers.

# 🛠 How
- Tracking `Campaign Details Button Clicked` in Optimizely when control blurb is clicked in `ProjectViewModel`.
- Added tests to assert `Campaign Details Button Clicked` is tracked when the button is clicked on live and not backed projects only.

# 👀 See
Nothing to see.

# 📋 QA
Check your local logs!
Check your data dog logs!

# Story 📖
[NT-989]

[NT-989]: https://kickstarter.atlassian.net/browse/NT-989