### PR TITLE
[␡] NT-965 Removing native checkout feature flag support from internal tools

### DIFF
--- a/app/src/internal/java/com/kickstarter/ui/activities/FeatureFlagsActivity.kt
+++ b/app/src/internal/java/com/kickstarter/ui/activities/FeatureFlagsActivity.kt
@@ -30,8 +30,6 @@ class FeatureFlagsActivity : BaseActivity<FeatureFlagsViewModel.ViewModel>() {
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
                 .subscribe { featureFlagAdapter.takeFlags(it) }
-
-        displayPreference(R.string.Native_Checkout, environment().nativeCheckoutPreference(), native_checkout)
     }
 
     private fun displayPreference(@StringRes labelRes: Int, booleanPreferenceType: BooleanPreferenceType, overrideContainer: View) {

--- a/app/src/internal/res/layout/activity_feature_flags.xml
+++ b/app/src/internal/res/layout/activity_feature_flags.xml
@@ -44,10 +44,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/Overrides"/>
-
-      <include
-        android:id="@+id/native_checkout"
-        layout="@layout/item_feature_flag_override"/>
     </LinearLayout>
 
   </ScrollView>

--- a/app/src/internal/res/layout/item_feature_flag_override.xml
+++ b/app/src/internal/res/layout/item_feature_flag_override.xml
@@ -15,7 +15,7 @@
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:layout_weight="1"
-    tools:text="@string/Native_Checkout" />
+    tools:text="Native Checkout" />
 
   <androidx.appcompat.widget.SwitchCompat
     android:id="@+id/override_switch"

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -59,7 +59,6 @@ import com.kickstarter.libs.qualifiers.KoalaTracker;
 import com.kickstarter.libs.qualifiers.LakeEndpoint;
 import com.kickstarter.libs.qualifiers.LakeRetrofit;
 import com.kickstarter.libs.qualifiers.LakeTracker;
-import com.kickstarter.libs.qualifiers.NativeCheckoutPreference;
 import com.kickstarter.libs.qualifiers.PackageNameString;
 import com.kickstarter.libs.qualifiers.UserPreference;
 import com.kickstarter.libs.qualifiers.WebEndpoint;
@@ -132,7 +131,6 @@ public final class ApplicationModule {
     final @NonNull KSString ksString,
     final @NonNull @LakeTracker Koala lake,
     final @NonNull Logout logout,
-    final @NonNull @NativeCheckoutPreference BooleanPreferenceType nativeCheckoutPreference,
     final @NonNull ExperimentsClientType optimizely,
     final @NonNull PlayServicesCapability playServicesCapability,
     final @NonNull Scheduler scheduler,
@@ -160,7 +158,6 @@ public final class ApplicationModule {
       .ksString(ksString)
       .lake(lake)
       .logout(logout)
-      .nativeCheckoutPreference(nativeCheckoutPreference)
       .optimizely(optimizely)
       .playServicesCapability(playServicesCapability)
       .scheduler(scheduler)
@@ -395,14 +392,6 @@ public final class ApplicationModule {
   @NonNull
   static BooleanPreferenceType provideFirstSessionPreference(final @NonNull SharedPreferences sharedPreferences) {
     return new BooleanPreference(sharedPreferences, SharedPreferenceKey.FIRST_SESSION);
-  }
-
-  @Provides
-  @Singleton
-  @NativeCheckoutPreference
-  @NonNull
-  static BooleanPreferenceType provideNativeCheckoutPreference(final @NonNull SharedPreferences sharedPreferences) {
-    return new BooleanPreference(sharedPreferences, SharedPreferenceKey.NATIVE_CHECKOUT);
   }
 
   @Provides

--- a/app/src/main/java/com/kickstarter/libs/Environment.java
+++ b/app/src/main/java/com/kickstarter/libs/Environment.java
@@ -37,7 +37,6 @@ public abstract class Environment implements Parcelable {
   public abstract KSString ksString();
   public abstract Koala lake();
   public abstract Logout logout();
-  public abstract BooleanPreferenceType nativeCheckoutPreference();
   public abstract ExperimentsClientType optimizely();
   public abstract PlayServicesCapability playServicesCapability();
   public abstract Scheduler scheduler();
@@ -66,7 +65,6 @@ public abstract class Environment implements Parcelable {
     public abstract Builder ksString(KSString __);
     public abstract Builder lake(Koala __);
     public abstract Builder logout(Logout __);
-    public abstract Builder nativeCheckoutPreference(BooleanPreferenceType __);
     public abstract Builder optimizely(ExperimentsClientType __);
     public abstract Builder playServicesCapability(PlayServicesCapability __);
     public abstract Builder scheduler(Scheduler __);

--- a/app/src/main/java/com/kickstarter/libs/qualifiers/NativeCheckoutPreference.kt
+++ b/app/src/main/java/com/kickstarter/libs/qualifiers/NativeCheckoutPreference.kt
@@ -1,6 +1,0 @@
-package com.kickstarter.libs.qualifiers
-
-import javax.inject.Qualifier
-
-@Qualifier
-annotation class NativeCheckoutPreference

--- a/app/src/main/java/com/kickstarter/ui/SharedPreferenceKey.java
+++ b/app/src/main/java/com/kickstarter/ui/SharedPreferenceKey.java
@@ -10,6 +10,5 @@ public final class SharedPreferenceKey {
   public static final String HAS_SEEN_GAMES_NEWSLETTER = "has_seen_games_newsletter";
   public static final String LAST_SEEN_ACTIVITY_ID = "last_seen_activity_id";
   public static final String MESSAGE_THREAD_HAS_UNREAD_MESSAGES = "message_thread_has_unread_messages";
-  public static final String NATIVE_CHECKOUT = "native_checkout";
   public static final String USER = "user";
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectHolderViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectHolderViewModel.java
@@ -4,13 +4,11 @@ import android.util.Pair;
 
 import com.kickstarter.R;
 import com.kickstarter.libs.ActivityViewModel;
-import com.kickstarter.libs.CurrentConfigType;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.ExperimentsClientType;
 import com.kickstarter.libs.KSCurrency;
 import com.kickstarter.libs.models.OptimizelyExperiment;
-import com.kickstarter.libs.preferences.BooleanPreferenceType;
 import com.kickstarter.libs.utils.BooleanUtils;
 import com.kickstarter.libs.utils.DateTimeUtils;
 import com.kickstarter.libs.utils.ListUtils;
@@ -207,17 +205,14 @@ public interface ProjectHolderViewModel {
     private final ApolloClientType apolloClient;
     private final CurrentUserType currentUser;
     private final KSCurrency ksCurrency;
-    private final BooleanPreferenceType nativeCheckoutPreference;
     private final ExperimentsClientType optimizely;
 
     public ViewModel(final @NonNull Environment environment) {
       super(environment);
 
-      final CurrentConfigType currentConfig = environment.currentConfig();
       this.apolloClient = environment.apolloClient();
       this.currentUser = environment.currentUser();
       this.ksCurrency = environment.ksCurrency();
-      this.nativeCheckoutPreference = environment.nativeCheckoutPreference();
       this.optimizely = environment.optimizely();
 
       final Observable<Project> project = this.projectData

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,6 @@
   <string name="internal_tools_push_notifications">Push notifications</string>
   <string name="Logged_Out">Logged Out</string>
   <string name="mailto">mailto:</string>
-  <string name="Native_Checkout">Native Checkout</string>
   <string name="Network">Network</string>
   <string name="Not_implemented_yet">Not implemented yet, coming soon!</string>
   <string name="Open_downloads_folder">Open Downloads folder</string>


### PR DESCRIPTION
# 📲 What
Removing native checkout feature flag support from internal tools

# 🤔 Why
Maintaining.

# 🛠 How
## `FeatureFlagActivity`
- Removed native checkout feature flag override
## `activity_feature_flags.xml`
- Removed override container
## `strings.xml`
- Removed `Native_Checkout`
- Deleted `NativeCheckoutPreference`
## Environment
- Removed `nativeCheckoutPreference`
## `SharedPreferenceKey`
- Removed `NATIVE_CHECKOUT`
## `ProjectHolderViewModel`
- Removed unused `nativeCheckoutPreference`
## `ApplicationModule`
- Removed `NativeCheckoutPreference` dependency injection

# 👀 See
| Before 🐛 | After 🦋 |
| --- | --- |
| ![screenshot-2020-03-16_165145](https://user-images.githubusercontent.com/1289295/76799538-1902c500-67a8-11ea-9a5d-4eabf59c6243.png) | ![screenshot-2020-03-16_165733](https://user-images.githubusercontent.com/1289295/76799539-1902c500-67a8-11ea-91f2-d07b33e639c6.png) |

# 📋 QA
^

# Story 📖
[NT-965]


[NT-965]: https://kickstarter.atlassian.net/browse/NT-965