### PR TITLE
[␡] NT-965 Removed `FeatureKey.ANDROID_NATIVE_CHECKOUT`

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/FeatureKey.java
+++ b/app/src/main/java/com/kickstarter/libs/FeatureKey.java
@@ -3,6 +3,4 @@ package com.kickstarter.libs;
 public final class FeatureKey {
   private FeatureKey() {}
 
-  public static final String ANDROID_NATIVE_CHECKOUT = "android_native_checkout";
-
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/ConfigUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/ConfigUtilsTest.kt
@@ -1,7 +1,6 @@
 package com.kickstarter.libs.utils
 
 import com.kickstarter.KSRobolectricTestCase
-import com.kickstarter.libs.FeatureKey
 import com.kickstarter.mock.factories.ConfigFactory
 import org.json.JSONArray
 import org.junit.Test
@@ -32,13 +31,13 @@ class ConfigUtilsTest : KSRobolectricTestCase() {
         assertEquals(JSONArray(), ConfigUtils.enabledFeatureFlags(ConfigFactory.configWithFeatureEnabled("ios_native_checkout")))
 
         assertEquals(JSONArray(),
-                ConfigUtils.enabledFeatureFlags(ConfigFactory.configWithFeaturesEnabled(mapOf(Pair(FeatureKey.ANDROID_NATIVE_CHECKOUT, false),
+                ConfigUtils.enabledFeatureFlags(ConfigFactory.configWithFeaturesEnabled(mapOf(Pair("android_native_checkout", false),
                         Pair("ios_go_rewardless", true),
                         Pair("ios_native_checkout", true)))))
 
         assertEquals(JSONArray().apply {
             put("android_native_checkout")
-        }, ConfigUtils.enabledFeatureFlags(ConfigFactory.configWithFeaturesEnabled(mapOf(Pair(FeatureKey.ANDROID_NATIVE_CHECKOUT, true),
+        }, ConfigUtils.enabledFeatureFlags(ConfigFactory.configWithFeaturesEnabled(mapOf(Pair("android_native_checkout", true),
                 Pair("ios_go_rewardless", true),
                 Pair("ios_native_checkout", true)))))
     }


### PR DESCRIPTION
# 📲 What
Removed `FeatureKey.ANDROID_NATIVE_CHECKOUT`

# 🤔 Why
Feature flag is over.

# 🛠 How
- Updated `ConfigUtilsTest` that used key.

# 👀 See
N/A

# 📋 QA
N/A

# Story 📖
[NT-965]


[NT-965]: https://kickstarter.atlassian.net/browse/NT-965