### PR TITLE
[🆕] NT-968 Removing NativeCheckout prefix

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/adapters/RewardsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/RewardsAdapter.kt
@@ -6,12 +6,12 @@ import com.kickstarter.R
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.ui.viewholders.EmptyViewHolder
 import com.kickstarter.ui.viewholders.KSViewHolder
-import com.kickstarter.ui.viewholders.NativeCheckoutRewardViewHolder
+import com.kickstarter.ui.viewholders.RewardViewHolder
 import rx.Observable
 
-class NativeCheckoutRewardsAdapter(private val delegate: Delegate) : KSAdapter() {
+class RewardsAdapter(private val delegate: Delegate) : KSAdapter() {
 
-    interface Delegate: NativeCheckoutRewardViewHolder.Delegate
+    interface Delegate: RewardViewHolder.Delegate
 
     override fun layout(sectionRow: SectionRow): Int {
         return R.layout.item_reward
@@ -19,7 +19,7 @@ class NativeCheckoutRewardsAdapter(private val delegate: Delegate) : KSAdapter()
 
     override fun viewHolder(layout: Int, view: View): KSViewHolder {
         return when(layout) {
-            R.layout.item_reward -> NativeCheckoutRewardViewHolder(view, this.delegate)
+            R.layout.item_reward -> RewardViewHolder(view, this.delegate)
             else -> EmptyViewHolder(view)
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -19,7 +19,7 @@ import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.data.PledgeStatusData
 import com.kickstarter.ui.data.ProjectData
-import com.kickstarter.ui.viewholders.NativeCheckoutRewardViewHolder
+import com.kickstarter.ui.viewholders.RewardViewHolder
 import com.kickstarter.viewmodels.BackingFragmentViewModel
 import com.squareup.picasso.Picasso
 import kotlinx.android.synthetic.main.fragment_backing.*
@@ -167,7 +167,7 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
     }
 
     private fun bindDataToRewardViewHolder(projectAndReward: Pair<ProjectData, Reward>) {
-        val rewardViewHolder = NativeCheckoutRewardViewHolder(reward_container, delegate = null, inset = true)
+        val rewardViewHolder = RewardViewHolder(reward_container, delegate = null, inset = true)
         val project = projectAndReward.first
         val reward = projectAndReward.second
         rewardViewHolder.bindData(Pair(project, reward))

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -13,7 +13,7 @@ import com.kickstarter.libs.utils.NumberUtils
 import com.kickstarter.libs.utils.RewardDecoration
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Reward
-import com.kickstarter.ui.adapters.NativeCheckoutRewardsAdapter
+import com.kickstarter.ui.adapters.RewardsAdapter
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ProjectData
@@ -21,9 +21,9 @@ import com.kickstarter.viewmodels.RewardsFragmentViewModel
 import kotlinx.android.synthetic.main.fragment_rewards.*
 
 @RequiresFragmentViewModel(RewardsFragmentViewModel.ViewModel::class)
-class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), NativeCheckoutRewardsAdapter.Delegate {
+class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), RewardsAdapter.Delegate {
 
-    private var rewardsAdapter = NativeCheckoutRewardsAdapter(this)
+    private var rewardsAdapter = RewardsAdapter(this)
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardViewHolder.kt
@@ -18,17 +18,17 @@ import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.BackingActivity
 import com.kickstarter.ui.adapters.RewardItemsAdapter
 import com.kickstarter.ui.data.ProjectData
-import com.kickstarter.viewmodels.NativeCheckoutRewardViewHolderViewModel
+import com.kickstarter.viewmodels.RewardViewHolderViewModel
 import kotlinx.android.synthetic.main.item_reward.view.*
 
-class NativeCheckoutRewardViewHolder(private val view: View, val delegate: Delegate?, private val inset: Boolean = false) : KSViewHolder(view) {
+class RewardViewHolder(private val view: View, val delegate: Delegate?, private val inset: Boolean = false) : KSViewHolder(view) {
 
     interface Delegate {
         fun rewardClicked(reward: Reward)
     }
 
     private val ksString = environment().ksString()
-    private var viewModel = NativeCheckoutRewardViewHolderViewModel.ViewModel(environment())
+    private var viewModel = RewardViewHolderViewModel.ViewModel(environment())
 
     private val currencyConversionString = context().getString(R.string.About_reward_amount)
     private val remainingRewardsString = context().getString(R.string.Left_count_left_few)

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -18,7 +18,7 @@ import com.kickstarter.models.User
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeFlowContext
 import com.kickstarter.ui.data.ProjectData
-import com.kickstarter.ui.viewholders.NativeCheckoutRewardViewHolder
+import com.kickstarter.ui.viewholders.RewardViewHolder
 import org.joda.time.DateTime
 import rx.Observable
 import rx.subjects.BehaviorSubject
@@ -26,7 +26,7 @@ import rx.subjects.PublishSubject
 import java.math.RoundingMode
 import kotlin.math.roundToInt
 
-interface NativeCheckoutRewardViewHolderViewModel {
+interface RewardViewHolderViewModel {
     interface Inputs {
         /** Configure with the current [ProjectData] and [Reward]. */
         fun configureWith(projectData: ProjectData, reward: Reward)
@@ -115,7 +115,7 @@ interface NativeCheckoutRewardViewHolderViewModel {
         fun titleForReward(): Observable<String?>
     }
 
-    class ViewModel(@NonNull environment: Environment) : ActivityViewModel<NativeCheckoutRewardViewHolder>(environment), Inputs, Outputs {
+    class ViewModel(@NonNull environment: Environment) : ActivityViewModel<RewardViewHolder>(environment), Inputs, Outputs {
         private val currentUser: CurrentUserType = environment.currentUser()
         private val ksCurrency: KSCurrency = environment.ksCurrency()
 

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -14,9 +14,9 @@ import org.joda.time.DateTime
 import org.junit.Test
 import rx.observers.TestSubscriber
 
-class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
+class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
-    private lateinit var vm: NativeCheckoutRewardViewHolderViewModel.ViewModel
+    private lateinit var vm: RewardViewHolderViewModel.ViewModel
     private val backersCount = TestSubscriber.create<Int>()
     private val backersCountIsGone = TestSubscriber.create<Boolean>()
     private val buttonCTA = TestSubscriber.create<Int>()
@@ -45,7 +45,7 @@ class NativeCheckoutRewardViewHolderViewModelTest : KSRobolectricTestCase() {
     private val titleIsGone = TestSubscriber<Boolean>()
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
-        this.vm = NativeCheckoutRewardViewHolderViewModel.ViewModel(environment)
+        this.vm = RewardViewHolderViewModel.ViewModel(environment)
         this.vm.outputs.backersCount().subscribe(this.backersCount)
         this.vm.outputs.backersCountIsGone().subscribe(this.backersCountIsGone)
         this.vm.outputs.buttonCTA().subscribe(this.buttonCTA)


### PR DESCRIPTION
# 📲 What
Renaming files that start with `NativeCheckoutReward` to just `Reward`.

# 🤔 Why
Prefixing files with NativeCheckout is no longer necessary since there's only one way to pledge.

# 🛠 How
- Renamed `NativeCheckoutRewardsAdapter` to `RewardsAdapter`
- Remamed `NativeCheckoutRewardViewHolder` to `RewardViewHolder`
- Renamed `NativeCheckoutRewardViewHolderViewModel` to `RewardViewHolderViewModel`
- Renamed `NativeCheckoutRewardViewHolderViewModelTest` to `RewardViewHolderViewModelTest`

# 👀 See
nothing 2 c

# 📋 QA
Do the tests pass?

# Story 📖
[NT-968]


[NT-968]: https://kickstarter.atlassian.net/browse/NT-968