### PR TITLE
[⛔️] NT-660 Displaying errored backing status in pledge container summary

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/BackingUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/BackingUtils.java
@@ -24,6 +24,14 @@ public final class BackingUtils {
     return rewardId == reward.id();
   }
 
+  public static boolean isErrored(final @Nullable Backing backing) {
+    if (backing == null) {
+      return false;
+    }
+    return backing.status().equals(Backing.STATUS_ERRORED);
+  }
+
+
   public static boolean isShippable(final @NonNull Backing backing) {
     final Reward reward = backing.reward();
     if (reward == null) {

--- a/app/src/main/java/com/kickstarter/libs/utils/BackingUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/BackingUtils.java
@@ -31,7 +31,6 @@ public final class BackingUtils {
     return backing.status().equals(Backing.STATUS_ERRORED);
   }
 
-
   public static boolean isShippable(final @NonNull Backing backing) {
     final Reward reward = backing.reward();
     if (reward == null) {

--- a/app/src/main/java/com/kickstarter/libs/utils/ProjectViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/ProjectViewUtils.kt
@@ -30,7 +30,10 @@ object ProjectViewUtils {
         return if (project.isBacking && project.isLive) {
             R.color.button_pledge_manage
         } else if (!project.isLive || project.creator().id() == currentUser?.id()) {
-            R.color.button_pledge_ended
+            when {
+                BackingUtils.isErrored(project.backing()) -> R.color.button_pledge_error
+                else -> R.color.button_pledge_ended
+            }
         } else {
             R.color.button_pledge_live
         }
@@ -52,7 +55,10 @@ object ProjectViewUtils {
         } else if (project.isBacking && project.isLive) {
             R.string.Manage
         } else if (project.isBacking && !project.isLive) {
-            R.string.View_your_pledge
+            when {
+                BackingUtils.isErrored(project.backing()) -> R.string.Manage
+                else -> R.string.View_your_pledge
+            }
         } else {
             R.string.View_rewards
         }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -14,6 +14,7 @@ import android.view.ViewTreeObserver
 import android.widget.EditText
 import android.widget.LinearLayout
 import androidx.annotation.MenuRes
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentManager
@@ -22,10 +23,7 @@ import com.crashlytics.android.Crashlytics
 import com.kickstarter.R
 import com.kickstarter.extensions.hideKeyboard
 import com.kickstarter.extensions.showSnackbar
-import com.kickstarter.libs.ActivityRequestCodes
-import com.kickstarter.libs.BaseActivity
-import com.kickstarter.libs.KSString
-import com.kickstarter.libs.KoalaContext
+import com.kickstarter.libs.*
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ApplicationUtils
@@ -92,10 +90,15 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         project_recycler_view.adapter = this.adapter
         project_recycler_view.layoutManager = LinearLayoutManager(this)
 
-        this.viewModel.outputs.backingDetails()
+        this.viewModel.outputs.backingDetailsSubtitle()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { reward_infos.text = it }
+                .subscribe { setBackingDetailsSubtitle(it) }
+
+        this.viewModel.outputs.backingDetailsTitle()
+                .compose(bindToLifecycle())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe { backing_details_title.setText(it) }
 
         this.viewModel.outputs.backingDetailsIsVisible()
                 .compose(bindToLifecycle())
@@ -496,6 +499,14 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     private fun rewardsFragment() = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment?
 
     private fun rewardsSheetGuideline(): Int = resources.getDimensionPixelSize(R.dimen.reward_fragment_guideline_constraint_end)
+
+    private fun setBackingDetailsSubtitle(stringResOrTitle: Either<String, Int>?) {
+        stringResOrTitle?.let {
+            @StringRes val stringRes = it.right()
+            val title = it.left()
+            backing_details_subtitle.text = stringRes?.let { stringRes -> getString(stringRes) }?: title
+        }
+    }
 
     private fun setClickListeners() {
         pledge_action_button.setOnClickListener {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -501,10 +501,10 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     private fun rewardsSheetGuideline(): Int = resources.getDimensionPixelSize(R.dimen.reward_fragment_guideline_constraint_end)
 
     private fun setBackingDetailsSubtitle(stringResOrTitle: Either<String, Int>?) {
-        stringResOrTitle?.let {
-            @StringRes val stringRes = it.right()
-            val title = it.left()
-            backing_details_subtitle.text = stringRes?.let { stringRes -> getString(stringRes) }?: title
+        stringResOrTitle?.let { either ->
+            @StringRes val stringRes = either.right()
+            val title = either.left()
+            backing_details_subtitle.text = stringRes?.let { getString(it) }?: title
         }
     }
 

--- a/app/src/main/res/color/button_pledge_error.xml
+++ b/app/src/main/res/color/button_pledge_error.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:color="@color/ksr_grey_500" android:state_enabled="false" />
+  <item android:color="@color/ksr_red_400"/>
+</selector>

--- a/app/src/main/res/layout/pledge_container.xml
+++ b/app/src/main/res/layout/pledge_container.xml
@@ -87,14 +87,14 @@
       android:visibility="gone">
 
       <TextView
-        android:id="@+id/you_backer_text"
+        android:id="@+id/backing_details_title"
         style="@style/SubheadlineMedium"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:text="@string/Youre_a_backer" />
 
       <TextView
-        android:id="@+id/reward_infos"
+        android:id="@+id/backing_details_subtitle"
         style="@style/Caption1Secondary"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"

--- a/app/src/test/java/com/kickstarter/libs/utils/BackingUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/BackingUtilsTest.java
@@ -25,6 +25,16 @@ public final class BackingUtilsTest extends KSRobolectricTestCase {
   }
 
   @Test
+  public void testIsErrored() {
+    assertFalse(BackingUtils.isErrored(BackingFactory.backing(Backing.STATUS_CANCELED)));
+    assertFalse(BackingUtils.isErrored(BackingFactory.backing(Backing.STATUS_COLLECTED)));
+    assertFalse(BackingUtils.isErrored(BackingFactory.backing(Backing.STATUS_DROPPED)));
+    assertTrue(BackingUtils.isErrored(BackingFactory.backing(Backing.STATUS_ERRORED)));
+    assertFalse(BackingUtils.isErrored(BackingFactory.backing(Backing.STATUS_PLEDGED)));
+    assertFalse(BackingUtils.isErrored(BackingFactory.backing(Backing.STATUS_PREAUTH)));
+  }
+
+  @Test
   public void testIsShippable() {
     final Backing backingWithShipping = BackingFactory.backing().toBuilder()
       .reward(RewardFactory.rewardWithShipping())

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -919,7 +919,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
         val backedSuccessfulProject = ProjectFactory.backedProject()
                 .toBuilder()
-                .backing(BackingFactory.backing())
+                .backing(BackingFactory.backing(Backing.STATUS_ERRORED))
                 .state(Project.STATE_SUCCESSFUL)
                 .build()
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedSuccessfulProject))
@@ -1190,7 +1190,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         val backedSuccessfulProject = ProjectFactory.backedProject()
                 .toBuilder()
-                .backing(BackingFactory.backing())
+                .backing(BackingFactory.backing(Backing.STATUS_ERRORED))
                 .state(Project.STATE_SUCCESSFUL)
                 .build()
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -24,8 +24,9 @@ import rx.observers.TestSubscriber
 
 class ProjectViewModelTest : KSRobolectricTestCase() {
     private lateinit var vm: ProjectViewModel.ViewModel
-    private val backingDetails = TestSubscriber<String>()
     private val backingDetailsIsVisible = TestSubscriber<Boolean>()
+    private val backingDetailsSubtitle = TestSubscriber<Either<String, Int>?>()
+    private val backingDetailsTitle = TestSubscriber<Int>()
     private val expandPledgeSheet = TestSubscriber<Pair<Boolean, Boolean>>()
     private val goBack = TestSubscriber<Void>()
     private val heartDrawableId = TestSubscriber<Int>()
@@ -68,8 +69,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     private fun setUpEnvironment(environment: Environment) {
         this.vm = ProjectViewModel.ViewModel(environment)
-        this.vm.outputs.backingDetails().subscribe(this.backingDetails)
         this.vm.outputs.backingDetailsIsVisible().subscribe(this.backingDetailsIsVisible)
+        this.vm.outputs.backingDetailsSubtitle().subscribe(this.backingDetailsSubtitle)
+        this.vm.outputs.backingDetailsTitle().subscribe(this.backingDetailsTitle)
         this.vm.outputs.expandPledgeSheet().subscribe(this.expandPledgeSheet)
         this.vm.outputs.goBack().subscribe(this.goBack)
         this.vm.outputs.heartDrawableId().subscribe(this.heartDrawableId)
@@ -913,6 +915,20 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testPledgeActionButtonUIOutputs_whenNativeCheckoutEnabled_whenBackingIsErrored() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        val backedSuccessfulProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(BackingFactory.backing())
+                .state(Project.STATE_SUCCESSFUL)
+                .build()
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedSuccessfulProject))
+
+        this.pledgeActionButtonColor.assertValue(R.color.button_pledge_error)
+        this.pledgeActionButtonText.assertValue(R.string.Manage)
+    }
+
+    @Test
     fun testPledgeToolbarNavigationIcon_whenNativeCheckoutDisabled() {
         setUpEnvironment(environment())
 
@@ -1117,7 +1133,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
         this.backingDetailsIsVisible.assertValue(false)
-        this.backingDetails.assertNoValues()
+        this.backingDetailsSubtitle.assertNoValues()
+        this.backingDetailsTitle.assertNoValues()
     }
 
     @Test
@@ -1142,8 +1159,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
                 .build()
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedProject))
-        this.backingDetails.assertValuesAndClear("$34 • Digital Bundle")
         this.backingDetailsIsVisible.assertValue(true)
+        this.backingDetailsSubtitle.assertValue(Either.Left("$34 • Digital Bundle"))
+        this.backingDetailsTitle.assertValue(R.string.Youre_a_backer)
     }
 
     @Test
@@ -1161,8 +1179,25 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
                 .build()
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedProject))
-        this.backingDetails.assertValuesAndClear("$13.50")
         this.backingDetailsIsVisible.assertValue(true)
+        this.backingDetailsSubtitle.assertValue(Either.Left("$13.50"))
+        this.backingDetailsTitle.assertValue(R.string.Youre_a_backer)
+    }
+
+    @Test
+    fun testBackingDetails_whenBackingIsErrored() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        val backedSuccessfulProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(BackingFactory.backing())
+                .state(Project.STATE_SUCCESSFUL)
+                .build()
+
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedSuccessfulProject))
+        this.backingDetailsIsVisible.assertValue(true)
+        this.backingDetailsSubtitle.assertValue(Either.Right(R.string.We_cant_process_your_pledge))
+        this.backingDetailsTitle.assertValue(R.string.Payment_failure)
     }
 
     @Test


### PR DESCRIPTION
**Please note:** I am aware _errored_ is not a word but that's the word we're using in the app!

# 📲 What
Displaying errored backing status in pledge container summary.

# 🤔 Why
So users can know if their pledge was unsuccessfully collected when they're on the project page.

# 🛠 How
## `BackingUtils`
- Added helper `isErrored` that returns true when a backing's status is `"errored"`
- Added tests in `BackingUtilsTest`
## `ProjectViewUtils`
- Added support for returning `R.color.button_pledge_error` in `pledgeActionButtonColor` when the Backing is errored.
- Added support for returning `R.string.Manage` in `pledgeActionButtonText` when the Backing is errored.
## `ProjectViewModel`
- Renamed output `backingDetails` to `backingDetailsSubtitle`.
- Added output `backingDetailsTitle` that returns a String resource ID for the title `TextView`.
- Added tests for errored backings in `ProjectViewModelTest`
## Resources
- Added new color state list `button_pledge_error`
- `pledge_container.xml`
  - Renamed `you_backer_text` to `backing_details_title`
  - Renamed `reward_infos` to `backing_details_subtitle`

# 👀 See
<img src=https://user-images.githubusercontent.com/1289295/77690385-9634f380-6f79-11ea-8b7b-41abf1c6e74a.png width=330/>

# 📋 QA
View one of your errored pledges or ask me for some test creds on the native HQ

# Story 📖
[NT-660]



[NT-660]: https://kickstarter.atlassian.net/browse/NT-660