### PR TITLE
[🎨] NT-1049 Added header layout for errored backings in Activity feed

### DIFF
--- a/app/src/main/res/layout/item_header_errored_backings.xml
+++ b/app/src/main/res/layout/item_header_errored_backings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:background="@color/ksr_grey_300"
+  android:orientation="vertical"
+  android:paddingStart="@dimen/grid_3"
+  android:paddingTop="@dimen/grid_4"
+  android:paddingEnd="@dimen/grid_3">
+
+  <TextView
+    style="@style/Title3Medium"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/grid_1_half"
+    android:text="@string/Payment_failure" />
+
+  <TextView
+    style="@style/BodyPrimary"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/We_cant_process_your_pledge_for" />
+
+</LinearLayout>


### PR DESCRIPTION
# 📲 What
Added layout for errored backings header.

# 🤔 Why
[We need it](https://www.figma.com/file/6GrAfzXmwgqdCaRGe1Ubyt/Checkout?node-id=1%3A13040)

# 🛠 How
- Added `item_header_errored_backings.xml`

# 👀 See
<img width="653" alt="Screen Shot 2020-03-27 at 3 06 22 PM" src="https://user-images.githubusercontent.com/1289295/77791306-bf6a8800-703c-11ea-9ab4-a20bd1c8653f.png">

# 📋 QA
Does it look legit? 🕵 

# Story 📖
[NT-1049]


[NT-1049]: https://kickstarter.atlassian.net/browse/NT-1049