### PR TITLE
[⛔️] NT-1031 Navigating to pledge screen when users click "Fix"

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -354,6 +354,10 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         this.viewModel.inputs.refreshProject()
     }
 
+    override fun showFixPaymentMethod() {
+        this.viewModel.inputs.fixPaymentMethodButtonClicked()
+    }
+
     override fun onNetworkConnectionChanged(isConnected: Boolean) {}
 
     override fun exitTransition(): Pair<Int, Int>? {

--- a/app/src/main/java/com/kickstarter/ui/data/PledgeReason.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/PledgeReason.kt
@@ -1,5 +1,5 @@
 package com.kickstarter.ui.data
 
 enum class PledgeReason {
-    PLEDGE, UPDATE_PAYMENT, UPDATE_PLEDGE, UPDATE_REWARD
+    FIX_PLEDGE, PLEDGE, UPDATE_PAYMENT, UPDATE_PLEDGE, UPDATE_REWARD
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -169,6 +169,10 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
                 this, backing_swipe_refresh_layout, { this.viewModel.inputs.refreshProject() }, { this.viewModel.outputs.swipeRefresherProgressIsVisible() }
         )
 
+        RxView.clicks(fix_payment_method_button)
+                .compose(bindToLifecycle())
+                .subscribe { this.viewModel.inputs.fixPaymentMethodButtonClicked() }
+
         RxView.clicks(mark_as_received_checkbox)
                 .compose(bindToLifecycle())
                 .subscribe { this.viewModel.inputs.receivedCheckboxToggled(mark_as_received_checkbox.isChecked) }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -34,6 +34,7 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
 
     interface BackingDelegate {
         fun refreshProject()
+        fun showFixPaymentMethod()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -93,6 +94,11 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .subscribe { (activity as BackingDelegate?)?.refreshProject() }
+
+        this.viewModel.outputs.notifyDelegateToShowFixPledge()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe { (activity as BackingDelegate?)?.showFixPaymentMethod() }
 
         this.viewModel.outputs.paymentMethodIsGone()
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -31,6 +31,9 @@ interface BackingFragmentViewModel {
         /** Configure with current [ProjectData]. */
         fun configureWith(projectData: ProjectData)
 
+        /** Call when the fix payment method button is clicked. */
+        fun fixPaymentMethodButtonClicked()
+
         /** Call when the pledge has been successfully updated. */
         fun pledgeSuccessfullyUpdated()
 
@@ -71,6 +74,9 @@ interface BackingFragmentViewModel {
 
         /** Emits when we should notify the [BackingFragment.BackingDelegate] to refresh the project. */
         fun notifyDelegateToRefreshProject(): Observable<Void>
+
+        /** Call when the [BackingFragment.BackingDelegate] should be notified to show the fix pledge flow. */
+        fun notifyDelegateToShowFixPledge(): Observable<Void>
 
         /** Emits a boolean determining if the payment method section should be visible. */
         fun paymentMethodIsGone(): Observable<Boolean>
@@ -117,6 +123,7 @@ interface BackingFragmentViewModel {
 
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<BackingFragment>(environment), Inputs, Outputs {
 
+        private val fixPaymentMethodButtonClicked = PublishSubject.create<Void>()
         private val pledgeSuccessfullyCancelled = PublishSubject.create<Void>()
         private val projectDataInput = PublishSubject.create<ProjectData>()
         private val receivedCheckboxToggled = PublishSubject.create<Boolean>()
@@ -132,6 +139,7 @@ interface BackingFragmentViewModel {
         private val fixPaymentMethodButtonIsGone = BehaviorSubject.create<Boolean>()
         private val fixPaymentMethodMessageIsGone = BehaviorSubject.create<Boolean>()
         private val notifyDelegateToRefreshProject = PublishSubject.create<Void>()
+        private val notifyDelegateToShowFixPledge = PublishSubject.create<Void>()
         private val paymentMethodIsGone = BehaviorSubject.create<Boolean>()
         private val pledgeAmount = BehaviorSubject.create<CharSequence>()
         private val pledgeDate = BehaviorSubject.create<String>()
@@ -297,6 +305,10 @@ interface BackingFragmentViewModel {
                     .compose(bindToLifecycle())
                     .subscribe { this.fixPaymentMethodMessageIsGone.onNext(it) }
 
+            this.fixPaymentMethodButtonClicked
+                    .compose(bindToLifecycle())
+                    .subscribe { this.notifyDelegateToShowFixPledge.onNext(null) }
+
             backing
                     .map { it.backerCompletedAt() }
                     .map { ObjectUtils.isNotNull(it) }
@@ -386,6 +398,10 @@ interface BackingFragmentViewModel {
             this.projectDataInput.onNext(projectData)
         }
 
+        override fun fixPaymentMethodButtonClicked() {
+            this.fixPaymentMethodButtonClicked.onNext(null)
+        }
+
         override fun pledgeSuccessfullyUpdated() {
             this.showUpdatePledgeSuccess.onNext(null)
         }
@@ -417,6 +433,8 @@ interface BackingFragmentViewModel {
         override fun fixPaymentMethodMessageIsGone(): Observable<Boolean> = this.fixPaymentMethodMessageIsGone
 
         override fun notifyDelegateToRefreshProject(): Observable<Void> = this.notifyDelegateToRefreshProject
+
+        override fun notifyDelegateToShowFixPledge(): Observable<Void> = this.notifyDelegateToShowFixPledge
 
         override fun paymentMethodIsGone(): Observable<Boolean> = this.paymentMethodIsGone
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -57,6 +57,9 @@ interface ProjectViewModel {
         /** Call when the creator name is clicked.  */
         fun creatorNameTextViewClicked()
 
+        /** Call when the fix payment method is clicked.  */
+        fun fixPaymentMethodButtonClicked()
+
         /** Call when the count of fragments on the back stack changes.  */
         fun fragmentStackCount(count: Int)
 
@@ -263,6 +266,7 @@ interface ProjectViewModel {
         private val creatorDashboardButtonClicked = PublishSubject.create<Void>()
         private val creatorInfoVariantClicked = PublishSubject.create<Void>()
         private val creatorNameTextViewClicked = PublishSubject.create<Void>()
+        private val fixPaymentMethodButtonClicked = PublishSubject.create<Void>()
         private val fragmentStackCount = PublishSubject.create<Int>()
         private val heartButtonClicked = PublishSubject.create<Void>()
         private val managePledgeButtonClicked = PublishSubject.create<Void>()
@@ -642,6 +646,12 @@ interface ProjectViewModel {
                     .map { pD -> BackingUtils.backedReward(pD.project())?.let { Pair(pD, it) } }
 
             projectDataAndBackedReward
+                    .compose(takeWhen<Pair<ProjectData, Reward>, Void>(this.fixPaymentMethodButtonClicked))
+                    .map { Pair(pledgeData(it.second, it.first, PledgeFlowContext.MANAGE_REWARD), PledgeReason.FIX_PLEDGE) }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.showUpdatePledge)
+
+            projectDataAndBackedReward
                     .compose(takeWhen<Pair<ProjectData, Reward>, Void>(this.updatePaymentClicked))
                     .map { Pair(pledgeData(it.second, it.first, PledgeFlowContext.MANAGE_REWARD), PledgeReason.UPDATE_PAYMENT) }
                     .compose(bindToLifecycle())
@@ -963,6 +973,10 @@ interface ProjectViewModel {
             this.creatorNameTextViewClicked.onNext(null)
         }
 
+        override fun fixPaymentMethodButtonClicked() {
+            this.fixPaymentMethodButtonClicked.onNext(null)
+        }
+
         override fun fragmentStackCount(count: Int) {
             this.fragmentStackCount.onNext(count)
         }
@@ -1154,7 +1168,6 @@ interface ProjectViewModel {
 
         @NonNull
         override fun showCancelPledgeSuccess(): Observable<Void> = this.showCancelPledgeSuccess
-
         @NonNull
         override fun showPledgeNotCancelableDialog(): Observable<Void> = this.showPledgeNotCancelableDialog
 

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -31,6 +31,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     private val fixPaymentMethodButtonIsGone = TestSubscriber.create<Boolean>()
     private val fixPaymentMethodMessageIsGone = TestSubscriber.create<Boolean>()
     private val notifyDelegateToRefreshProject = TestSubscriber.create<Void>()
+    private val notifyDelegateToShowFixPledge = TestSubscriber.create<Void>()
     private val paymentMethodIsGone = TestSubscriber.create<Boolean>()
     private val pledgeAmount = TestSubscriber.create<CharSequence>()
     private val pledgeDate = TestSubscriber.create<String>()
@@ -58,6 +59,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
         this.vm.outputs.fixPaymentMethodButtonIsGone().subscribe(this.fixPaymentMethodButtonIsGone)
         this.vm.outputs.fixPaymentMethodMessageIsGone().subscribe(this.fixPaymentMethodMessageIsGone)
         this.vm.outputs.notifyDelegateToRefreshProject().subscribe(this.notifyDelegateToRefreshProject)
+        this.vm.outputs.notifyDelegateToShowFixPledge().subscribe(this.notifyDelegateToShowFixPledge)
         this.vm.outputs.paymentMethodIsGone().subscribe(this.paymentMethodIsGone)
         this.vm.outputs.pledgeAmount().map { it.toString() }.subscribe(this.pledgeAmount)
         this.vm.outputs.pledgeDate().subscribe(this.pledgeDate)
@@ -404,6 +406,14 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
 
         this.vm.inputs.refreshProject()
         this.notifyDelegateToRefreshProject.assertValueCount(1)
+    }
+
+    @Test
+    fun testNotifyDelegateToShowFixPledge() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.fixPaymentMethodButtonClicked()
+        this.notifyDelegateToShowFixPledge.assertValueCount(1)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -1463,6 +1463,34 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testShowUpdatePledge_whenFixingPaymentMethod() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        // Start the view model with a backed project
+        val reward = RewardFactory.reward()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(BackingFactory.backing()
+                        .toBuilder()
+                        .rewardId(reward.id())
+                        .build())
+                .rewards(listOf(RewardFactory.noReward(), reward))
+                .build()
+
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedProject))
+
+        this.vm.inputs.fixPaymentMethodButtonClicked()
+
+        this.showUpdatePledge.assertValuesAndClear(Pair(PledgeData.builder()
+                .pledgeFlowContext(PledgeFlowContext.MANAGE_REWARD)
+                .reward(reward)
+                .projectData(ProjectDataFactory.project(backedProject))
+                .build(), PledgeReason.FIX_PLEDGE))
+        this.koalaTest.assertValue("Project Page")
+        this.lakeTest.assertValue("Project Page Viewed")
+    }
+
+    @Test
     fun testShowUpdatePledge_whenUpdatingPledge() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
 


### PR DESCRIPTION
# 📲 What
Showing the pledge screen when users click the `Fix` button in the Backing screen

# 🤔 Why
So users can fix their pledge 🔜 The actual fixin will be in NT-666 😈 

# 🛠 How
- Added new `PledgeReason` `FIX_PLEDGE`
## `BackingFragment`
- Added `BackingDelegate.showFixPaymentMethod`
- `BackingFragmentViewModel`
  - Added input `fixPaymentMethodButtonClicked` and matching output `notifyDelegateToShowFixPledge`
  - Tests
## `ProjectActivity`
- Implements new `BackingDelegate.showFixPaymentMethod`
- `ProjectViewModel`
  - Added input `fixPaymentMethodButtonClicked` that will cause `showUpdatePledge` to emit with `PledgeReason.FIX_PLEDGE`
  - Tests

# 👀 See
![device-2020-03-27-153130 2020-03-27 15_32_16](https://user-images.githubusercontent.com/1289295/77793279-2d647e80-7040-11ea-9ffe-16a2a07b97fa.gif)

# 📋 QA
Smash that `Fix` button

# Story 📖
[NT-1031]

[NT-1031]: https://kickstarter.atlassian.net/browse/NT-1031