### PR TITLE
[⛔️] NT-1051 Displaying errored backings in Activity feed

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -9,6 +9,7 @@ import UpdateUserPasswordMutation
 import UserPrivacyQuery
 import com.kickstarter.mock.factories.CheckoutFactory
 import com.kickstarter.mock.factories.CreatorDetailsFactory
+import com.kickstarter.mock.factories.ErroredBackingFactory
 import com.kickstarter.mock.factories.StoredCardFactory
 import com.kickstarter.models.*
 import com.kickstarter.services.ApolloClientType
@@ -47,7 +48,7 @@ open class MockApolloClient : ApolloClientType {
     }
 
     override fun erroredBackings(): Observable<List<ErroredBacking>> {
-        return Observable.empty()
+        return Observable.just(Collections.singletonList(ErroredBackingFactory.erroredBacking()))
     }
 
     override fun getStoredCards(): Observable<List<StoredCard>> {

--- a/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
@@ -14,6 +14,7 @@ import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
 import com.kickstarter.libs.utils.ApplicationUtils;
 import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.models.Activity;
+import com.kickstarter.models.ErroredBacking;
 import com.kickstarter.models.Project;
 import com.kickstarter.models.SurveyResponse;
 import com.kickstarter.ui.IntentKey;
@@ -71,6 +72,11 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
       .compose(observeForUI())
       .subscribe(this::showActivities);
 
+    this.viewModel.outputs.erroredBackings()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(this::showErroredBackings);
+
     this.viewModel.outputs.goToDiscovery()
       .compose(bindToLifecycle())
       .compose(observeForUI())
@@ -85,6 +91,11 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(this::startProjectActivity);
+
+    this.viewModel.outputs.startFixPledge()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(this::startFixPledge);
 
     this.viewModel.outputs.startUpdateActivity()
       .compose(bindToLifecycle())
@@ -124,6 +135,10 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
     this.adapter.takeActivities(activities);
   }
 
+  private void showErroredBackings(final @NonNull List<ErroredBacking> erroredBackings) {
+    this.adapter.takeErroredBackings(erroredBackings);
+  }
+
   private void showSurveys(final @NonNull List<SurveyResponse> surveyResponses) {
     this.adapter.takeSurveys(surveyResponses);
   }
@@ -136,6 +151,13 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
     final Intent intent = new Intent(this, LoginToutActivity.class)
       .putExtra(IntentKey.LOGIN_REASON, LoginReason.ACTIVITY_FEED);
     startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW);
+  }
+
+  private void startFixPledge(final @NonNull String projectSlug) {
+    final Intent intent = new Intent(this, ProjectActivity.class)
+      .putExtra(IntentKey.PROJECT_PARAM, projectSlug)
+      .putExtra(IntentKey.REF_TAG, RefTag.activity());
+    startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }
 
   private void startProjectActivity(final @NonNull Project project) {

--- a/app/src/main/java/com/kickstarter/ui/adapters/ActivityFeedAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/ActivityFeedAdapter.java
@@ -5,9 +5,11 @@ import android.view.View;
 import com.kickstarter.R;
 import com.kickstarter.libs.utils.ListUtils;
 import com.kickstarter.models.Activity;
+import com.kickstarter.models.ErroredBacking;
 import com.kickstarter.models.SurveyResponse;
 import com.kickstarter.ui.viewholders.EmptyActivityFeedViewHolder;
 import com.kickstarter.ui.viewholders.EmptyViewHolder;
+import com.kickstarter.ui.viewholders.ErroredBackingViewHolder;
 import com.kickstarter.ui.viewholders.FriendBackingViewHolder;
 import com.kickstarter.ui.viewholders.FriendFollowViewHolder;
 import com.kickstarter.ui.viewholders.KSViewHolder;
@@ -27,20 +29,29 @@ import androidx.annotation.Nullable;
 public final class ActivityFeedAdapter extends KSAdapter {
   private static final int SECTION_LOGGED_IN_EMPTY_VIEW = 0;
   private static final int SECTION_LOGGED_OUT_EMPTY_VIEW = 1;
-  private static final int SECTION_SURVEYS_HEADER_VIEW = 2;
-  private static final int SECTION_SURVEYS_VIEW = 3;
-  private static final int SECTION_ACTIVITIES_VIEW = 4;
+  private static final int SECTION_ERRORED_BACKINGS_HEADER_VIEW = 2;
+  private static final int SECTION_ERRORED_BACKINGS_VIEW = 3;
+  private static final int SECTION_SURVEYS_HEADER_VIEW = 4;
+  private static final int SECTION_SURVEYS_VIEW = 5;
+  private static final int SECTION_ACTIVITIES_VIEW = 6;
 
   private final @Nullable Delegate delegate;
 
-  public interface Delegate extends FriendBackingViewHolder.Delegate, ProjectStateChangedPositiveViewHolder.Delegate,
-    ProjectStateChangedViewHolder.Delegate, ProjectUpdateViewHolder.Delegate, EmptyActivityFeedViewHolder.Delegate {}
+  public interface Delegate extends
+    ErroredBackingViewHolder.Delegate,
+    FriendBackingViewHolder.Delegate,
+    ProjectStateChangedPositiveViewHolder.Delegate,
+    ProjectStateChangedViewHolder.Delegate,
+    ProjectUpdateViewHolder.Delegate,
+    EmptyActivityFeedViewHolder.Delegate {}
 
   public ActivityFeedAdapter(final @Nullable Delegate delegate) {
     this.delegate = delegate;
 
     insertSection(SECTION_LOGGED_IN_EMPTY_VIEW, Collections.emptyList());
     insertSection(SECTION_LOGGED_OUT_EMPTY_VIEW, Collections.emptyList());
+    insertSection(SECTION_ERRORED_BACKINGS_HEADER_VIEW, Collections.emptyList());
+    insertSection(SECTION_ERRORED_BACKINGS_VIEW, Collections.emptyList());
     insertSection(SECTION_SURVEYS_HEADER_VIEW, Collections.emptyList());
     insertSection(SECTION_SURVEYS_VIEW, Collections.emptyList());
     insertSection(SECTION_ACTIVITIES_VIEW, Collections.emptyList());
@@ -48,6 +59,17 @@ public final class ActivityFeedAdapter extends KSAdapter {
 
   public void takeActivities(final @NonNull List<Activity> activities) {
     setSection(SECTION_ACTIVITIES_VIEW, activities);
+    notifyDataSetChanged();
+  }
+
+  public void takeErroredBackings(final @NonNull List<ErroredBacking> erroredBackings) {
+    if (erroredBackings.isEmpty()) {
+      setSection(SECTION_ERRORED_BACKINGS_HEADER_VIEW, Collections.emptyList());
+      setSection(SECTION_ERRORED_BACKINGS_VIEW, Collections.emptyList());
+    } else {
+      setSection(SECTION_ERRORED_BACKINGS_HEADER_VIEW, Collections.singletonList(erroredBackings.size()));
+      setSection(SECTION_ERRORED_BACKINGS_VIEW, erroredBackings);
+    }
     notifyDataSetChanged();
   }
 
@@ -79,6 +101,10 @@ public final class ActivityFeedAdapter extends KSAdapter {
         return R.layout.empty_activity_feed_view;
       case SECTION_LOGGED_OUT_EMPTY_VIEW:
         return R.layout.empty_activity_feed_view;
+      case SECTION_ERRORED_BACKINGS_HEADER_VIEW:
+        return R.layout.item_header_errored_backings;
+      case SECTION_ERRORED_BACKINGS_VIEW:
+        return R.layout.item_errored_backing;
       case SECTION_SURVEYS_HEADER_VIEW:
         return R.layout.activity_survey_header_view;
       case SECTION_SURVEYS_VIEW:
@@ -130,6 +156,8 @@ public final class ActivityFeedAdapter extends KSAdapter {
         return new ProjectUpdateViewHolder(view, this.delegate);
       case R.layout.empty_activity_feed_view:
         return new EmptyActivityFeedViewHolder(view, this.delegate);
+      case R.layout.item_errored_backing:
+        return new ErroredBackingViewHolder(view, this.delegate);
       default:
         return new EmptyViewHolder(view);
     }

--- a/app/src/test/java/com/kickstarter/ui/adapters/ActivityFeedAdapterTest.java
+++ b/app/src/test/java/com/kickstarter/ui/adapters/ActivityFeedAdapterTest.java
@@ -2,8 +2,10 @@ package com.kickstarter.ui.adapters;
 
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.mock.factories.ActivityFactory;
+import com.kickstarter.mock.factories.ErroredBackingFactory;
 import com.kickstarter.mock.factories.SurveyResponseFactory;
 import com.kickstarter.models.Activity;
+import com.kickstarter.models.ErroredBacking;
 import com.kickstarter.models.SurveyResponse;
 
 import org.junit.Assert;
@@ -17,7 +19,7 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
   private ActivityFeedAdapter adapter = new ActivityFeedAdapter(null);
 
   @Test
-  public void justActivities() throws Exception {
+  public void justActivities() {
     final Activity activity0 = ActivityFactory.projectStateChangedPositiveActivity();
     final Activity activity1 = ActivityFactory.friendBackingActivity();
     final Activity activity2 = ActivityFactory.projectStateChangedActivity();
@@ -25,6 +27,8 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
     this.adapter.takeActivities(Arrays.asList(activity0, activity1, activity2));
 
     final List<List<Activity>> data = Arrays.asList(
+      Collections.emptyList(),
+      Collections.emptyList(),
       Collections.emptyList(),
       Collections.emptyList(),
       Collections.emptyList(),
@@ -40,7 +44,7 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void loggedInWithActivities() throws Exception {
+  public void loggedInWithActivities() {
     final Activity activity0 = ActivityFactory.projectStateChangedPositiveActivity();
     final Activity activity1 = ActivityFactory.friendBackingActivity();
     final Activity activity2 = ActivityFactory.projectStateChangedActivity();
@@ -53,6 +57,8 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
       Collections.emptyList(),
       Collections.emptyList(),
       Collections.emptyList(),
+      Collections.emptyList(),
+      Collections.emptyList(),
       Arrays.asList(
         activity0,
         activity1,
@@ -64,7 +70,7 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void loggedOutWithActivities() throws Exception {
+  public void loggedOutWithActivities() {
     final Activity activity0 = ActivityFactory.projectStateChangedPositiveActivity();
     final Activity activity1 = ActivityFactory.friendBackingActivity();
     final Activity activity2 = ActivityFactory.projectStateChangedActivity();
@@ -77,6 +83,8 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
       Collections.singletonList(false),
       Collections.emptyList(),
       Collections.emptyList(),
+      Collections.emptyList(),
+      Collections.emptyList(),
       Arrays.asList(
         activity0,
         activity1,
@@ -88,20 +96,64 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void loggedInWithActivitiesAndSurveys() throws Exception {
+  public void loggedInWithErroredBackings() {
+    final ErroredBacking erroredBacking = ErroredBackingFactory.Companion.erroredBacking();
+
+    this.adapter.takeErroredBackings(Collections.singletonList(erroredBacking));
+    this.adapter.showLoggedInEmptyState(true);
+
+    final List<List<Object>> data = Arrays.asList(
+      Collections.singletonList(true),
+      Collections.emptyList(),
+      Collections.singletonList(1),
+      Collections.singletonList(erroredBacking),
+      Collections.emptyList(),
+      Collections.emptyList(),
+      Collections.emptyList()
+    );
+
+    Assert.assertEquals(data, this.adapter.sections());
+  }
+
+  @Test
+  public void loggedOutWithErroredBackings() {
+    final ErroredBacking erroredBacking = ErroredBackingFactory.Companion.erroredBacking();
+
+    this.adapter.takeErroredBackings(Collections.singletonList(erroredBacking));
+    this.adapter.showLoggedOutEmptyState(true);
+
+    final List<List<Object>> data = Arrays.asList(
+      Collections.emptyList(),
+      Collections.singletonList(false),
+      Collections.singletonList(1),
+      Collections.singletonList(erroredBacking),
+      Collections.emptyList(),
+      Collections.emptyList(),
+      Collections.emptyList()
+    );
+
+    Assert.assertEquals(data, this.adapter.sections());
+  }
+
+  @Test
+  public void loggedInWithActivitiesAndErroredBackingsAndSurveys() {
     final Activity activity0 = ActivityFactory.projectStateChangedPositiveActivity();
     final Activity activity1 = ActivityFactory.friendBackingActivity();
     final Activity activity2 = ActivityFactory.projectStateChangedActivity();
+    final ErroredBacking erroredBacking = ErroredBackingFactory.Companion.erroredBacking();
     final SurveyResponse surveyResponse0 = SurveyResponseFactory.surveyResponse();
     final SurveyResponse surveyResponse1 = SurveyResponseFactory.surveyResponse();
 
     this.adapter.takeActivities(Arrays.asList(activity0, activity1, activity2));
+    this.adapter.takeErroredBackings(Collections.singletonList(erroredBacking));
     this.adapter.takeSurveys(Arrays.asList(surveyResponse0, surveyResponse1));
     this.adapter.showLoggedInEmptyState(true);
 
     final List<List<Object>> data = Arrays.asList(
       Collections.singletonList(true),
       Collections.emptyList(),
+      Collections.singletonList(1),
+      Collections.singletonList(erroredBacking),
       Collections.singletonList(2),
       Arrays.asList(
         surveyResponse0,


### PR DESCRIPTION
# 📲 What
Displaying errored backings in Activity feed. 
**Plz note:** I will automatically open the view pledge screen in a separate PR.

# 🤔 Why
So users know they have pledges that have failed.

# 🛠 How
## `ActivityFeedViewModel` 
- Added `errorBackings` output that emits list of logged in user's errored backings
- Added `startFixPledge` output that emits when the `ProjectActivity` should be started.
- Tests

# 👀 See
| Activity feed | Navigating to project page |
| --- | --- |
| <img src=https://user-images.githubusercontent.com/1289295/77952625-f7bad200-7299-11ea-920b-b43b531bee67.png width=330/> | ![device-2020-03-30-151745 2020-03-30 15_21_02](https://user-images.githubusercontent.com/1289295/77952713-14efa080-729a-11ea-83b7-ed7373bb6d4d.gif) |

# 📋 QA
View the Activity feed if you have an errored backing!

# Story 📖
[NT-1051]


[NT-1051]: https://kickstarter.atlassian.net/browse/NT-1051