### PR TITLE
[⛔️] NT-1057 Automatically expanding pledge sheet when fixing pledge

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/IntentKey.java
+++ b/app/src/main/java/com/kickstarter/ui/IntentKey.java
@@ -13,6 +13,7 @@ public final class IntentKey {
   public static final String DISCOVERY_PARAMS = "com.kickstarter.kickstarter.intent_discovery_params";
   public static final String EDITORIAL = "com.kickstarter.kickstarter.intent_editorial";
   public static final String EMAIL = "com.kickstarter.kickstarter.intent_email";
+  public static final String EXPAND_PLEDGE_SHEET = "com.kickstarter.kickstarter.intent_expand_pledge_sheet";
   public static final String FACEBOOK_LOGIN = "com.kickstarter.kickstarter.intent_facebook_login";
   public static final String FACEBOOK_TOKEN = "com.kickstarter.kickstarter.intent_facebook_token";
   public static final String FACEBOOK_USER = "com.kickstarter.kickstarter.intent_facebook_user";

--- a/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
@@ -156,6 +156,7 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
   private void startFixPledge(final @NonNull String projectSlug) {
     final Intent intent = new Intent(this, ProjectActivity.class)
       .putExtra(IntentKey.PROJECT_PARAM, projectSlug)
+      .putExtra(IntentKey.EXPAND_PLEDGE_SHEET, true)
       .putExtra(IntentKey.REF_TAG, RefTag.activity());
     startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -15,6 +15,7 @@ import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.User
 import com.kickstarter.services.ApiClientType
+import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.BackingActivity
 import com.kickstarter.ui.activities.ProjectActivity
 import com.kickstarter.ui.adapters.ProjectAdapter
@@ -378,6 +379,12 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe { this.expandPledgeSheet.onNext(Pair(true, true)) }
 
+            intent()
+                    .take(1)
+                    .filter { it.getBooleanExtra(IntentKey.EXPAND_PLEDGE_SHEET, false) }
+                    .compose(bindToLifecycle())
+                    .subscribe { this.expandPledgeSheet.onNext(Pair(true, true)) }
+
             val pledgeSheetExpanded = this.expandPledgeSheet
                     .map { it.first }
                     .startWith(false)
@@ -385,9 +392,6 @@ interface ProjectViewModel {
             progressBarIsGone
                     .compose<Pair<Boolean, Boolean>>(combineLatestPair(nativeCheckoutEnabled))
                     .filter { BooleanUtils.isTrue(it.second) }
-                    .map { it.first }
-                    .compose<Pair<Boolean, Boolean>>(combineLatestPair(pledgeSheetExpanded))
-                    .filter { BooleanUtils.isFalse(it.second) }
                     .map { it.first }
                     .compose(bindToLifecycle())
                     .subscribe(this.retryProgressBarIsGone)

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -1098,6 +1098,47 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testExpandPledgeSheet_whenIntentExpandPledgeSheet_isTrue() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        val intent = Intent()
+                .putExtra(IntentKey.PROJECT, ProjectFactory.project())
+                .putExtra(IntentKey.EXPAND_PLEDGE_SHEET, true)
+        this.vm.intent(intent)
+
+        this.expandPledgeSheet.assertValues(Pair(true, true))
+        this.koalaTest.assertValue("Project Page")
+        this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
+    }
+
+    @Test
+    fun testExpandPledgeSheet_whenIntentExpandPledgeSheet_isFalse() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        val intent = Intent()
+                .putExtra(IntentKey.PROJECT, ProjectFactory.project())
+                .putExtra(IntentKey.EXPAND_PLEDGE_SHEET, false)
+        this.vm.intent(intent)
+
+        this.expandPledgeSheet.assertNoValues()
+        this.koalaTest.assertValue("Project Page")
+        this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
+    }
+
+    @Test
+    fun testExpandPledgeSheet_whenIntentExpandPledgeSheet_isNull() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        val intent = Intent()
+                .putExtra(IntentKey.PROJECT, ProjectFactory.project())
+        this.vm.intent(intent)
+
+        this.expandPledgeSheet.assertNoValues()
+        this.koalaTest.assertValue("Project Page")
+        this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
+    }
+
+    @Test
     fun testGoBack_whenFragmentBackStackIsEmpty() {
         setUpEnvironment(environmentWithNativeCheckoutEnabled())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))


### PR DESCRIPTION
# 📲 What
Displaying View pledge when clicking `Manage` of an errored backing in the Activity feed

# 🤔 Why
Save a click

# 🛠 How
- Added `IntentKey.EXPAND_PLEDGE_SHEET` that is called when we want t…o show the pledge sheet expanded as soon as the `ProjectActivity` is started.
  - Adding to `ProjectActivity` `Intent` in `ActivityFeedActivity.startFixPledge`
## `ProjectViewModel`
- `ProjectViewModel.expandPledgeSheet` emits when the `Intent` contains a `true` value for the `Extra` `EXPAND_PLEDGE_SHEET`
- Added tests for when `EXPAND_PLEDGE_SHEET` is `true`, `false`, or `null`

# 👀 See

Trello, screenshots, external resources?

| After 🦋 | Before 🐛 |
| --- | --- |
| ![device-2020-03-31-144931 2020-03-31 14_57_35](https://user-images.githubusercontent.com/1289295/78064750-33b86a80-7360-11ea-95fa-24f5ca05b0d7.gif) | ![device-2020-03-30-151745 2020-03-30 15_21_02](https://user-images.githubusercontent.com/1289295/78064754-35822e00-7360-11ea-8e94-703f731c77a0.gif) |

# 📋 QA
Smash that `Manage` button.

# Story 📖
[NT-1057]


[NT-1057]: https://kickstarter.atlassian.net/browse/NT-1057