### PR TITLE
[💳] NT-1078 Showing failed indicator icon on failed payment method

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardCardViewHolder.kt
@@ -32,6 +32,11 @@ class RewardCardViewHolder(val view : View, val delegate : Delegate) : KSViewHol
                 .compose(observeForUI())
                 .subscribe { setExpirationDateText(it) }
 
+        this.viewModel.outputs.failedIndicatorIconIsVisible()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { ViewUtils.setGone(this.view.failed_indicator_icon, !it) }
+
         this.viewModel.outputs.issuerImage()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Pair
 import com.kickstarter.R
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
+import com.kickstarter.libs.utils.BackingUtils
 import com.kickstarter.libs.utils.BooleanUtils
 import com.kickstarter.libs.utils.ProjectUtils
 import com.kickstarter.models.Backing
@@ -20,6 +21,9 @@ interface RewardCardViewHolderViewModel : BaseRewardCardViewHolderViewModel {
         /** Emits a boolean that determines if the pledge button should be enabled. */
         fun buttonEnabled() : Observable<Boolean>
 
+        /** Emits a boolean that determines if the failed indicator icon should be visible. */
+        fun failedIndicatorIconIsVisible(): Observable<Boolean>
+
         /** Emits a boolean that determines if the not available copy should be visible. */
         fun notAvailableCopyIsVisible(): Observable<Boolean>
 
@@ -33,6 +37,7 @@ interface RewardCardViewHolderViewModel : BaseRewardCardViewHolderViewModel {
 
         private val buttonCTA = BehaviorSubject.create<Int>()
         private val buttonEnabled = BehaviorSubject.create<Boolean>()
+        private val failedIndicatorIconIsVisible = BehaviorSubject.create<Boolean>()
         private val notAvailableCopyIsVisible = BehaviorSubject.create<Boolean>()
         private val projectCountry = BehaviorSubject.create<String>()
 
@@ -72,6 +77,12 @@ interface RewardCardViewHolderViewModel : BaseRewardCardViewHolderViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.buttonCTA)
 
+            isBackingPaymentSource
+                    .compose<Pair<Boolean, Backing?>>(combineLatestPair(backing))
+                    .map { it.first && BackingUtils.isErrored(it.second) }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.failedIndicatorIconIsVisible)
+
             project
                     .map { it.location()?.expandedCountry()?: "" }
                     .compose(bindToLifecycle())
@@ -87,6 +98,8 @@ interface RewardCardViewHolderViewModel : BaseRewardCardViewHolderViewModel {
         override fun buttonCTA() : Observable<Int> = this.buttonCTA
 
         override fun buttonEnabled() : Observable<Boolean> = this.buttonEnabled
+
+        override fun failedIndicatorIconIsVisible(): Observable<Boolean> = this.failedIndicatorIconIsVisible
 
         override fun notAvailableCopyIsVisible(): Observable<Boolean> = this.notAvailableCopyIsVisible
 

--- a/app/src/main/res/layout/reward_card_details.xml
+++ b/app/src/main/res/layout/reward_card_details.xml
@@ -18,8 +18,9 @@
     tools:src="@drawable/mastercard_md" />
 
   <LinearLayout
-    android:layout_width="wrap_content"
+    android:layout_width="0dp"
     android:layout_height="wrap_content"
+    android:layout_weight="1"
     android:layout_marginStart="@dimen/grid_2"
     android:orientation="vertical">
 
@@ -37,5 +38,16 @@
       android:layout_height="wrap_content"
       tools:text="Expires in 03/2020" />
   </LinearLayout>
+
+  <!--  TODO: I need some a11y copy-->
+  <ImageView
+    android:id="@+id/failed_indicator_icon"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/grid_1_half"
+    android:importantForAccessibility="no"
+    android:src="@drawable/ic_icon_alert"
+    android:tint="@color/ksr_red_400"
+    android:visibility="gone" />
 
 </LinearLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModelTest.kt
@@ -210,7 +210,6 @@ class RewardCardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.failedIndicatorIconIsVisible.assertValue(true)
     }
 
-
     @Test
     fun testFailedIndicatorIconIsVisible_whenCardIsBackingPaymentSource_backingIsNotErrored() {
         setUpEnvironment(environment())
@@ -272,7 +271,6 @@ class RewardCardViewHolderViewModelTest : KSRobolectricTestCase() {
 
         this.failedIndicatorIconIsVisible.assertValue(false)
     }
-
 
     @Test
     fun testId() {


### PR DESCRIPTION
# 📲 What
Showing failed indicator icon on failed payment method

# 🤔 Why
So users know what card was problematic.

# 🛠 How
## `RewardCardViewHolderViewModel`
- Added output `failedIndicatorIconIsVisible` that emits a `Boolean` that represents if the payment method was the errored payment method.
- Tests
## `reward_card_details.xml`
- Added `ImageView` `failed_indicator_icon`

# 👀 See
<img width="281" alt="Screen Shot 2020-03-31 at 5 00 27 PM" src="https://user-images.githubusercontent.com/1289295/78074691-2bb4f680-7371-11ea-8f06-330b6a6d1501.png">

# 📋 QA
Take a look at your failed payment method 👀 

# Story 📖
[NT-1078]


[NT-1078]: https://kickstarter.atlassian.net/browse/NT-1078