### PR TITLE
[💳] NT-1079  Enabling reselecting failed payment method

### DIFF
--- a/app/src/test/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardCardViewHolderViewModelTest.kt
@@ -8,6 +8,7 @@ import com.kickstarter.mock.factories.BackingFactory
 import com.kickstarter.mock.factories.PaymentSourceFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.StoredCardFactory
+import com.kickstarter.models.Backing
 import com.stripe.android.model.Card
 import org.junit.Test
 import rx.observers.TestSubscriber
@@ -62,9 +63,32 @@ class RewardCardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.buttonCTA.assertValue(R.string.Not_available)
     }
 
+    @Test
+    fun testButtonCTA_whenCardIsBackingPaymentSource_andBackingIsErrored() {
+        setUpEnvironment(environment())
+        val visa = StoredCardFactory.visa()
+
+        val paymentSource = PaymentSourceFactory.visa()
+                .toBuilder()
+                .id(visa.id())
+                .build()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .paymentSource(paymentSource)
+                .status(Backing.STATUS_ERRORED)
+                .build()
+        val project = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        this.vm.inputs.configureWith(Pair(visa, project))
+
+        this.buttonCTA.assertValue(R.string.Select)
+    }
 
     @Test
-    fun testButtonCTA_whenCardIsBackingPaymentSource() {
+    fun testButtonCTA_whenCardIsBackingPaymentSource_andBackingIsNotErrored() {
         setUpEnvironment(environment())
         val visa = StoredCardFactory.visa()
 
@@ -127,7 +151,31 @@ class RewardCardViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testButtonEnabled_whenCardIsBackingPaymentSource() {
+    fun testButtonEnabled_whenCardIsBackingPaymentSource_andBackingIsErrored() {
+        setUpEnvironment(environment())
+        val visa = StoredCardFactory.visa()
+
+        val paymentSource = PaymentSourceFactory.visa()
+                .toBuilder()
+                .id(visa.id())
+                .build()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .paymentSource(paymentSource)
+                .status(Backing.STATUS_ERRORED)
+                .build()
+        val project = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        this.vm.inputs.configureWith(Pair(visa, project))
+
+        this.buttonEnabled.assertValue(true)
+    }
+
+    @Test
+    fun testButtonEnabled_whenCardIsBackingPaymentSource_andBackingIsNotErrored() {
         setUpEnvironment(environment())
         val visa = StoredCardFactory.visa()
 


### PR DESCRIPTION
# 📲 What
Enabling reselecting failed payment method

# 🤔 Why
So users can retry their problematic card.

# 🛠 How
## `RewardCardViewHolderViewModel`
- Enabling reselecting failed payment method.
  - Added helper methods for `buttonEnabled` and `buttonCTA` since the logic is more complex with the support of retrying errored payment methods.
- Tests

# 👀 See
The problematic 0341 card can be reselected.
<img width="288" alt="Screen Shot 2020-03-31 at 5 48 01 PM" src="https://user-images.githubusercontent.com/1289295/78078235-c9abbf80-7377-11ea-90e2-4209085e842a.png">

# 📋 QA
The tests are most helpful here.

# Story 📖
NT-1079
