### PR TITLE
[🚮] NT-1082 Deleting Android Pay references

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/Secrets.java.example
+++ b/app/src/main/java/com/kickstarter/libs/utils/Secrets.java.example
@@ -48,8 +48,6 @@ public final class Secrets {
   public static final class RegExpPattern {
     public static final Pattern API = Pattern.compile("\\Aapi\\z");
     public static final Pattern HIVEQUEEN = Pattern.compile("\\Adev\\z");
-    public static final Pattern ANDROID_PAY_1 = Pattern.compile("\\Apay\\z");
-    public static final Pattern ANDROID_PAY_2 = Pattern.compile("\\Apay\\z");
     public static final Pattern STAGING = Pattern.compile("\\Astaging\\z");
   }
 

--- a/app/src/main/java/com/kickstarter/services/KSUri.java
+++ b/app/src/main/java/com/kickstarter/services/KSUri.java
@@ -14,12 +14,6 @@ import androidx.annotation.NonNull;
 public final class KSUri {
   private KSUri() {}
 
-  public static boolean isAndroidPayUri(@NonNull final Uri uri, @NonNull final String webEndpoint) {
-    return isKickstarterUri(uri, webEndpoint)
-      && (Secrets.RegExpPattern.ANDROID_PAY_1.matcher(UriUtilsKt.path(uri)).matches()
-        || Secrets.RegExpPattern.ANDROID_PAY_2.matcher(UriUtilsKt.path(uri)).matches());
-  }
-
   public static boolean isApiUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
     return isKickstarterUri(uri, webEndpoint) && Secrets.RegExpPattern.API.matcher(UriUtilsKt.host(uri)).matches();
   }


### PR DESCRIPTION
**Please note:** This PR depends on the updated secrets https://github.com/kickstarter/native-secrets/pull/68

# 📲 What
Deleting Android Pay references.

# 🤔 Why
Android Pay isn't supported in this app

# 🛠 How
- Removing placeholder `Secrets.RegExpPattern.ANDROID_PAY_1` and `Secrets.RegExpPattern.ANDROID_PAY_2`
- Removing `KSUri.isAndroidPayUri` since it's no longer used.

# 👀 See
No visuals

# 📋 QA
Circle CI

# Story 📖
[NT-1082]

[NT-1082]: https://kickstarter.atlassian.net/browse/NT-1082