### PR TITLE
[📄] NT-802 Updating no reward copy in Pledge screen

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -17,7 +17,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.NonNull
-import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.jakewharton.rxbinding.view.RxView
@@ -27,7 +26,6 @@ import com.kickstarter.extensions.hideKeyboard
 import com.kickstarter.extensions.onChange
 import com.kickstarter.extensions.snackbar
 import com.kickstarter.libs.BaseFragment
-import com.kickstarter.libs.Either
 import com.kickstarter.libs.FreezeLinearLayoutManager
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
@@ -43,7 +41,10 @@ import com.kickstarter.ui.activities.HelpActivity
 import com.kickstarter.ui.activities.LoginToutActivity
 import com.kickstarter.ui.adapters.RewardCardAdapter
 import com.kickstarter.ui.adapters.ShippingRulesAdapter
-import com.kickstarter.ui.data.*
+import com.kickstarter.ui.data.CardState
+import com.kickstarter.ui.data.CheckoutData
+import com.kickstarter.ui.data.PledgeData
+import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.itemdecorations.RewardCardItemDecoration
 import com.kickstarter.viewmodels.PledgeFragmentViewModel
 import com.stripe.android.ApiResultCallback
@@ -192,7 +193,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.outputs.rewardTitle()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { setRewardTitle(it) }
+                .subscribe { reward_title.text = it }
 
         this.viewModel.outputs.cardsAndProject()
                 .compose(bindToLifecycle())
@@ -509,12 +510,6 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         val ksString = this.viewModel.environment.ksString()
         textView.contentDescription = ksString.format(getString(R.string.plus_shipping_cost), "shipping_cost", localizedAmount.toString())
         textView.text = localizedAmount
-    }
-
-    private fun setRewardTitle(stringResOrTitle: Either<Int, String>) {
-        @StringRes val stringRes = stringResOrTitle.left()
-        val title = stringResOrTitle.right()
-        reward_title.text = stringRes?.let { getString(it) }?: title
     }
 
     private fun setTextColor(colorResId: Int, vararg textViews: TextView) {

--- a/app/src/main/res/layout/fragment_pledge_section_reward_summary.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_reward_summary.xml
@@ -58,6 +58,8 @@
         style="@style/Headline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="2"
         tools:text="Attend the Wrap Party in Sandusky, Ohio" />
 
     </LinearLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -59,7 +59,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val pledgeSummaryIsGone = TestSubscriber<Boolean>()
     private val pledgeTextColor = TestSubscriber<Int>()
     private val projectCurrencySymbol = TestSubscriber<String>()
-    private val rewardTitle = TestSubscriber<Either<Int, String>>()
+    private val rewardTitle = TestSubscriber<String>()
     private val selectedShippingRule = TestSubscriber<ShippingRule>()
     private val shippingAmount = TestSubscriber<CharSequence>()
     private val shippingRuleAndProject = TestSubscriber<Pair<List<ShippingRule>, Project>>()
@@ -1382,7 +1382,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         setUpEnvironment(environment(), reward, backedProject, PledgeReason.PLEDGE)
 
-        this.rewardTitle.assertValue(Either.Right("Coolest reward"))
+        this.rewardTitle.assertValue("Coolest reward")
     }
 
     @Test
@@ -1401,11 +1401,12 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val backedProject = ProjectFactory.backedProject()
                 .toBuilder()
                 .backing(backing)
+                .name("Restart Your Computer")
                 .build()
 
         setUpEnvironment(environment(), reward, backedProject, PledgeReason.PLEDGE)
 
-        this.rewardTitle.assertValue(Either.Left(R.string.Back_it_because_you_believe_in_it))
+        this.rewardTitle.assertValue("Restart Your Computer")
     }
 
     @Test
@@ -1421,11 +1422,12 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val backedProject = ProjectFactory.backedProject()
                 .toBuilder()
                 .backing(backing)
+                .name("Restart Your Computer")
                 .build()
 
         setUpEnvironment(environment(), reward, backedProject, PledgeReason.PLEDGE)
 
-        this.rewardTitle.assertValue(Either.Left(R.string.Back_it_because_you_believe_in_it))
+        this.rewardTitle.assertValue("Restart Your Computer")
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Updating no reward copy in Pledge screen

# 🤔 Why
3rd time's the charm 😛 

# 🛠 How
## `PledgeFragmentViewModel`
- `rewardTitle` output now emits a `String` that is the reward's title if available or else the project name
  - Added helper method `rewardTitle`
- Removed `setRewardTitle` method since it's no longer needed
- Updated tests
## `fragment_pledge_section_reward_summary`
- `reward_title` shows max `2` lines and ellipses at the `end` of the text

# 👀 See
| After 🦋| After (but bigger) 🦋 | Before 🐛 |
| --- | --- | --- |
| ![screenshot-2020-04-01_190928](https://user-images.githubusercontent.com/1289295/78194937-6dff3600-744c-11ea-8247-82e2f0c60132.png) | ![screenshot-2020-04-01_190918](https://user-images.githubusercontent.com/1289295/78194933-6cce0900-744c-11ea-9282-c40f4ef55685.png) | ![screenshot-2020-04-01_190209](https://user-images.githubusercontent.com/1289295/78194559-80c53b00-744b-11ea-84e5-2c283ecaea8d.png) |

# 📋 QA
Take a l:eye::eye:k

# Story 📖
[NT-802]


[NT-802]: https://kickstarter.atlassian.net/browse/NT-802