### PR TITLE
[⛔️] NT-1116 Errored backings deadline warning copy

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/ErroredBackingViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ErroredBackingViewHolder.kt
@@ -2,6 +2,7 @@ package com.kickstarter.ui.viewholders
 
 import android.view.View
 import com.jakewharton.rxbinding.view.RxView
+import com.kickstarter.R
 import com.kickstarter.libs.RelativeDateTimeOptions
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.DateTimeUtils
@@ -49,7 +50,10 @@ class ErroredBackingViewHolder(private val view: View, val delegate: Delegate?) 
                 .relativeToDateTime(DateTime.now())
                 .build()
 
-        this.view.errored_backing_project_collection_date.text = DateTimeUtils.relative(context(), this.ksString, finalCollectionDate, options)
+        val timeRemaining = DateTimeUtils.relative(context(), this.ksString, finalCollectionDate, options)
+        val fixWithinTemplate = context().getString(R.string.Fix_within)
+        this.view.errored_backing_project_collection_date.text = this.ksString.format(fixWithinTemplate,
+                "time_remaining", timeRemaining)
     }
 
     override fun bindData(data: Any?) {

--- a/app/src/main/res/values-de/strings_i18n.xml
+++ b/app/src/main/res/values-de/strings_i18n.xml
@@ -205,6 +205,7 @@ Bitte antippen und erneut versuchen.</string>
   <string name="First_created" formatted="false">Erstes Projekt</string>
   <string name="Fix" formatted="false">Korrigieren</string>
   <string name="Fix_payment_method" formatted="false">Zahlungsmethode ändern</string>
+  <string name="Fix_within" formatted="false">Fix within %{time_remaining}</string>
   <string name="Fix_your_payment_method" formatted="false">Zahlungsmethode ändern</string>
   <string name="Follow_friend_name" formatted="false">%{friend_name} folgen.</string>
   <string name="Follow_friends" formatted="false">Freunden folgen</string>

--- a/app/src/main/res/values-es/strings_i18n.xml
+++ b/app/src/main/res/values-es/strings_i18n.xml
@@ -205,6 +205,7 @@ Haz clic para volver a intentarlo.</string>
   <string name="First_created" formatted="false">Primer proyecto creado</string>
   <string name="Fix" formatted="false">Corregir</string>
   <string name="Fix_payment_method" formatted="false">Corregir el método de pago</string>
+  <string name="Fix_within" formatted="false">Fix within %{time_remaining}</string>
   <string name="Fix_your_payment_method" formatted="false">Corrige tu método de pago</string>
   <string name="Follow_friend_name" formatted="false">Seguir a %{friend_name}.</string>
   <string name="Follow_friends" formatted="false">Seguir amigos</string>

--- a/app/src/main/res/values-fr/strings_i18n.xml
+++ b/app/src/main/res/values-fr/strings_i18n.xml
@@ -205,6 +205,7 @@ contributeurs</string>
   <string name="First_created" formatted="false">Premier projet créé</string>
   <string name="Fix" formatted="false">Corriger</string>
   <string name="Fix_payment_method" formatted="false">Correction du moyen de paiement</string>
+  <string name="Fix_within" formatted="false">Fix within %{time_remaining}</string>
   <string name="Fix_your_payment_method" formatted="false">Corriger votre moyen de paiement</string>
   <string name="Follow_friend_name" formatted="false">Suivre %{friend_name}</string>
   <string name="Follow_friends" formatted="false">Suivre vos amis</string>

--- a/app/src/main/res/values-ja/strings_i18n.xml
+++ b/app/src/main/res/values-ja/strings_i18n.xml
@@ -203,6 +203,7 @@
   <string name="First_created" formatted="false">1つめのプロジェクト</string>
   <string name="Fix" formatted="false">修正する</string>
   <string name="Fix_payment_method" formatted="false">お支払い方法を修正</string>
+  <string name="Fix_within" formatted="false">Fix within %{time_remaining}</string>
   <string name="Fix_your_payment_method" formatted="false">お支払い方法を修正</string>
   <string name="Follow_friend_name" formatted="false">%{friend_name} をフォロー</string>
   <string name="Follow_friends" formatted="false">友達をフォロー</string>

--- a/app/src/main/res/values/strings_i18n.xml
+++ b/app/src/main/res/values/strings_i18n.xml
@@ -205,6 +205,7 @@ Please tap to retry.</string>
   <string name="First_created" formatted="false">First created</string>
   <string name="Fix" formatted="false">Fix</string>
   <string name="Fix_payment_method" formatted="false">Fix payment method</string>
+  <string name="Fix_within" formatted="false">Fix within %{time_remaining}</string>
   <string name="Fix_your_payment_method" formatted="false">Fix your payment method</string>
   <string name="Follow_friend_name" formatted="false">Follow %{friend_name}</string>
   <string name="Follow_friends" formatted="false">Follow friends</string>


### PR DESCRIPTION
# 📲 What
Added new copy for errored backings' final collection date.

# 🤔 Why
This copy is better!

# 🛠 How
- Added (untranslated) `Fix_within_time_remaining` string resource
- Using `Fix_within_time_remaining` in `ErroredBackingViewHolder.kt`

# 👀 See
| After 🦋 | Before 🐛 |
| --- | --- |
| ![screenshot-2020-04-03_113203](https://user-images.githubusercontent.com/1289295/78379563-8da77300-75a0-11ea-9453-9b69193e999f.png) | ![screenshot-2020-03-30_120246](https://user-images.githubusercontent.com/1289295/78379519-7cf6fd00-75a0-11ea-8e8e-e70c1c9f9c15.png) |

# 📋 QA
^

# Story 📖
[NT-1116]


[NT-1116]: https://kickstarter.atlassian.net/browse/NT-1116