### PR TITLE
[🗣] NT-1117 Errored backings icon a11y

### DIFF
--- a/app/src/main/res/layout/item_errored_backing.xml
+++ b/app/src/main/res/layout/item_errored_backing.xml
@@ -32,12 +32,11 @@
       android:gravity="center_vertical"
       android:orientation="horizontal">
 
-      <!-- TODO: this needs a11y copy -->
       <ImageView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/grid_1"
-        android:importantForAccessibility="no"
+        android:contentDescription="@string/Alert"
         android:src="@drawable/ic_icon_alert"
         android:tint="@color/ksr_red_400" />
 
@@ -52,7 +51,6 @@
 
     </LinearLayout>
   </LinearLayout>
-
 
   <com.google.android.material.button.MaterialButton
     android:id="@+id/errored_backing_manage_button"

--- a/app/src/main/res/values-de/strings_i18n.xml
+++ b/app/src/main/res/values-de/strings_i18n.xml
@@ -9,6 +9,7 @@
   <string name="Add" formatted="false">Hinzufügen</string>
   <string name="Add_attachments" formatted="false">Anhänge hinzufügen ...</string>
   <string name="Add_new_card" formatted="false">Kreditkarte hinzufügen</string>
+  <string name="Alert" formatted="false">Alert</string>
   <string name="All_Art_Projects" formatted="false">Alle Projekte der Kategorie Kunst</string>
   <string name="All_Comics_Projects" formatted="false">Alle Projekte der Kategorie Comics</string>
   <string name="All_Crafts_Projects" formatted="false">Alle Projekte der Kategorie Kunsthandwerk</string>

--- a/app/src/main/res/values-es/strings_i18n.xml
+++ b/app/src/main/res/values-es/strings_i18n.xml
@@ -9,6 +9,7 @@
   <string name="Add" formatted="false">Añadir</string>
   <string name="Add_attachments" formatted="false">Agregar anexos …</string>
   <string name="Add_new_card" formatted="false">Añadir una nueva tarjeta</string>
+  <string name="Alert" formatted="false">Alert</string>
   <string name="All_Art_Projects" formatted="false">Todos los proyectos</string>
   <string name="All_Comics_Projects" formatted="false">Todos los proyectos</string>
   <string name="All_Crafts_Projects" formatted="false">Todos los proyectos</string>

--- a/app/src/main/res/values-fr/strings_i18n.xml
+++ b/app/src/main/res/values-fr/strings_i18n.xml
@@ -9,6 +9,7 @@
   <string name="Add" formatted="false">Ajouter</string>
   <string name="Add_attachments" formatted="false">Ajouter des pièces jointes...</string>
   <string name="Add_new_card" formatted="false">Ajouter une autre carte</string>
+  <string name="Alert" formatted="false">Alert</string>
   <string name="All_Art_Projects" formatted="false">Tous les projets de la catégorie Art</string>
   <string name="All_Comics_Projects" formatted="false">Tous les projets de la catégorie Bande dessinée</string>
   <string name="All_Crafts_Projects" formatted="false">Tous les projets de la catégorie Artisanat</string>

--- a/app/src/main/res/values-ja/strings_i18n.xml
+++ b/app/src/main/res/values-ja/strings_i18n.xml
@@ -9,6 +9,7 @@
   <string name="Add" formatted="false">追加</string>
   <string name="Add_attachments" formatted="false">添付ファイルを追加...</string>
   <string name="Add_new_card" formatted="false">新しいカードを追加</string>
+  <string name="Alert" formatted="false">Alert</string>
   <string name="All_Art_Projects" formatted="false">全てのアートプロジェクト</string>
   <string name="All_Comics_Projects" formatted="false">全てのコミックプロジェクト</string>
   <string name="All_Crafts_Projects" formatted="false">全ての工芸プロジェクト</string>

--- a/app/src/main/res/values/strings_i18n.xml
+++ b/app/src/main/res/values/strings_i18n.xml
@@ -9,6 +9,7 @@
   <string name="Add" formatted="false">Add</string>
   <string name="Add_attachments" formatted="false">Add attachments…</string>
   <string name="Add_new_card" formatted="false">Add new card</string>
+  <string name="Alert" formatted="false">Alert</string>
   <string name="All_Art_Projects" formatted="false">All Art Projects</string>
   <string name="All_Comics_Projects" formatted="false">All Comics Projects</string>
   <string name="All_Crafts_Projects" formatted="false">All Crafts Projects</string>


### PR DESCRIPTION
# 📲 What
Added new a11y copy for errored backings icon.

# 🤔 Why
So that icon has some context for users who use TalkBack™.

# 🛠 How
- Added (untranslated) `Alert` string resource
- Using `Alert` for `contentDescription` of `ic_icon_alert`

# 👀 See
<img src=https://user-images.githubusercontent.com/1289295/78380670-3904f780-75a2-11ea-828e-c079c63d04d2.png width=330/>

# 📋 QA
Turn on TalkBack and navigate to the Activity feed with an errored backing.

# Story 📖
[NT-1117]


[NT-1117]: https://kickstarter.atlassian.net/browse/NT-1117