### PR TITLE
[⬇] NT-1120 Vertical payment methods in Pledge screen

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -522,7 +522,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     }
 
     private fun setUpCardsAdapter() {
-        cards_recycler.layoutManager = FreezeLinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
+        cards_recycler.layoutManager = FreezeLinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
         cards_recycler.adapter = RewardCardAdapter(this)
         cards_recycler.addItemDecoration(RewardCardItemDecoration(resources.getDimensionPixelSize(R.dimen.grid_3_half)))
     }

--- a/app/src/main/java/com/kickstarter/ui/itemdecorations/RewardCardItemDecoration.kt
+++ b/app/src/main/java/com/kickstarter/ui/itemdecorations/RewardCardItemDecoration.kt
@@ -8,18 +8,9 @@ class RewardCardItemDecoration(private val margin: Int) : RecyclerView.ItemDecor
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
         super.getItemOffsets(outRect, view, parent, state)
         outRect.apply {
-            left = if (parent.getChildAdapterPosition(view) == 0) {
-                margin
-            } else {
-                0
-            }
+            left = margin
+            right = margin
             top = margin
-            bottom = margin
-            right = if (parent.getChildAdapterPosition(view) == state.itemCount - 1) {
-                margin
-            } else {
-                0
-            }
         }
     }
 }

--- a/app/src/main/res/layout/item_reward_add_card.xml
+++ b/app/src/main/res/layout/item_reward_add_card.xml
@@ -3,7 +3,7 @@
   android:id="@+id/card_container"
   style="@style/PledgeStoredCard"
   xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="@dimen/stored_card_width"
+  android:layout_width="match_parent"
   android:layout_height="wrap_content">
 
   <LinearLayout

--- a/app/src/main/res/layout/item_reward_credit_card.xml
+++ b/app/src/main/res/layout/item_reward_credit_card.xml
@@ -2,8 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/card_container"
-  android:layout_width="@dimen/stored_card_width"
-  android:layout_height="match_parent"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
   android:orientation="vertical">
 
   <androidx.cardview.widget.CardView

--- a/app/src/main/res/layout/item_reward_placeholder_card.xml
+++ b/app/src/main/res/layout/item_reward_placeholder_card.xml
@@ -3,7 +3,7 @@
   style="@style/PledgeStoredCard"
   android:id="@+id/card_container"
   xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="@dimen/stored_card_width"
+  android:layout_width="match_parent"
   android:layout_height="wrap_content">
 
   <LinearLayout

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -183,7 +183,6 @@
   <dimen name="fragment_rewards_parent_min_height">@dimen/grid_20</dimen>
   <dimen name="stored_card_radius">16dp</dimen>
   <dimen name="mini_reward_height">@dimen/grid_20</dimen>
-  <dimen name="stored_card_width">260dp</dimen>
   <dimen name="mini_reward_elevation">8dp</dimen>
   <dimen name="plus_sign_height">20dp</dimen>
   <dimen name="plus_sign_width">9dp</dimen>


### PR DESCRIPTION
# 📲 What
Payment methods in the Pledge screen are now displayed vertically

# 🤔 Why
This is the first step in the payment methods redesign.

# 🛠 How
- `cards_recycler` orientation is now `VERTICAL`
- Removed `stored_card_width`. All cards are now full width.
## `RewardCardItemDecoration`
- Removed special logic for stored cards margins

# 👀 See
|  After 🦋 | Before 🐛 |
| --- | --- |
| ![screenshot-2020-04-03_142224](https://user-images.githubusercontent.com/1289295/78393008-1f21df80-75b7-11ea-9c49-7992e5da3508.png) | ![screenshot-2020-04-03_141451](https://user-images.githubusercontent.com/1289295/78393006-1e894900-75b7-11ea-8b1e-c5463fb15d1e.png) 
# 📋 QA
N/A

# Story 📖
[NT-1120]


[NT-1120]: https://kickstarter.atlassian.net/browse/NT-1120