### PR TITLE
[💳] NT-1123 Card not allowed copy

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardCardUnselectedViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardCardUnselectedViewHolder.kt
@@ -22,7 +22,6 @@ class RewardCardUnselectedViewHolder(val view : View, val delegate : Delegate) :
     private val viewModel: RewardCardUnselectedViewHolderViewModel.ViewModel = RewardCardUnselectedViewHolderViewModel.ViewModel(environment())
     private val ksString: KSString = environment().ksString()
 
-    private val cardNotAllowedString = this.context().getString(R.string.You_cant_use_this_credit_card_to_back_a_project_from_project_country)
     private val creditCardExpirationString = this.context().getString(R.string.Credit_card_expiration)
     private val endingInString = this.context().getString(R.string.Ending_in_last_four)
 
@@ -73,11 +72,6 @@ class RewardCardUnselectedViewHolder(val view : View, val delegate : Delegate) :
                 .compose(observeForUI())
                 .subscribe { this.delegate.cardSelected(it.first, it.second) }
 
-        this.viewModel.outputs.projectCountry()
-                .compose(bindToLifecycle())
-                .compose(observeForUI())
-                .subscribe { setCardNotAllowedWarningText(it) }
-
         this.viewModel.outputs.selectImageIsVisible()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
@@ -92,11 +86,6 @@ class RewardCardUnselectedViewHolder(val view : View, val delegate : Delegate) :
         @Suppress("UNCHECKED_CAST")
         val cardAndProject = requireNotNull(data) as Pair<StoredCard, Project>
         this.viewModel.inputs.configureWith(cardAndProject)
-    }
-
-    private fun setCardNotAllowedWarningText(country: String) {
-        this.view.card_not_allowed_warning.text = this.ksString.format(this.cardNotAllowedString,
-                "project_country", country)
     }
 
     private fun setExpirationDateText(date: String) {

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -1002,11 +1002,11 @@ interface PledgeFragmentViewModel {
         }
 
         private fun initialCardSelection(storedCards: List<StoredCard>, project: Project): Pair<StoredCard, Int>? {
-            val defaultIndex = 0
+            val defaultIndex = storedCards.indexOfFirst { ProjectUtils.acceptedCardType(it.type(), project) }
             val backingPaymentSourceIndex = storedCards.indexOfFirst { it.id() == project.backing()?.paymentSource()?.id() }
             return when {
                 backingPaymentSourceIndex != -1 -> Pair(storedCards[backingPaymentSourceIndex], backingPaymentSourceIndex)
-                storedCards.isNotEmpty() -> Pair(storedCards[defaultIndex], defaultIndex)
+                storedCards.isNotEmpty() && defaultIndex != -1 -> Pair(storedCards[defaultIndex], defaultIndex)
                 else -> null
             }
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardCardUnselectedViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardCardUnselectedViewHolderViewModel.kt
@@ -33,9 +33,6 @@ interface RewardCardUnselectedViewHolderViewModel : BaseRewardCardViewHolderView
         /** Emits when we should notify the delegate the card was selected. */
         fun notifyDelegateCardSelected(): Observable<Pair<StoredCard, Int>>
 
-        /** Emits a string representing the project's country when the card is not accepted. */
-        fun projectCountry(): Observable<String>
-
         /** Emits a boolean that determines if the select image should be visible. */
         fun selectImageIsVisible(): Observable<Boolean>
     }
@@ -51,7 +48,6 @@ interface RewardCardUnselectedViewHolderViewModel : BaseRewardCardViewHolderView
         private val lastFourTextColor = BehaviorSubject.create<Int>()
         private val notAvailableCopyIsVisible = BehaviorSubject.create<Boolean>()
         private val notifyDelegateCardSelected = BehaviorSubject.create<Pair<StoredCard, Int>>()
-        private val projectCountry = BehaviorSubject.create<String>()
         private val selectImageIsVisible = BehaviorSubject.create<Boolean>()
 
         init {
@@ -75,11 +71,6 @@ interface RewardCardUnselectedViewHolderViewModel : BaseRewardCardViewHolderView
                     .map { if (it) R.color.text_primary else R.color.text_secondary }
                     .compose(bindToLifecycle())
                     .subscribe(this.lastFourTextColor)
-
-            project
-                    .map { it.location()?.expandedCountry()?: "" }
-                    .compose(bindToLifecycle())
-                    .subscribe(this.projectCountry)
 
             allowedCardType
                     .map { BooleanUtils.negate(it) }
@@ -108,8 +99,6 @@ interface RewardCardUnselectedViewHolderViewModel : BaseRewardCardViewHolderView
         override fun notAvailableCopyIsVisible(): Observable<Boolean> = this.notAvailableCopyIsVisible
 
         override fun notifyDelegateCardSelected(): Observable<Pair<StoredCard, Int>> = this.notifyDelegateCardSelected
-
-        override fun projectCountry(): Observable<String> = this.projectCountry
 
         override fun selectImageIsVisible(): Observable<Boolean> = this.selectImageIsVisible
     }

--- a/app/src/main/res/layout/item_reward_unselected_card.xml
+++ b/app/src/main/res/layout/item_reward_unselected_card.xml
@@ -40,9 +40,9 @@
       android:layout_marginStart="@dimen/grid_8"
       android:layout_marginEnd="@dimen/grid_2"
       android:layout_marginBottom="@dimen/grid_2"
+      android:text="@string/This_project_has_a_set_currency_that_cant_process_this_option"
       android:textColor="@color/ksr_red_400"
       android:visibility="gone"
-      tools:text="@string/You_cant_use_this_credit_card_to_back_a_project_from_project_country"
       tools:visibility="visible" />
   </LinearLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/values-de/strings_i18n.xml
+++ b/app/src/main/res/values-de/strings_i18n.xml
@@ -551,6 +551,7 @@ Bitte antippen und erneut versuchen.</string>
   <string name="This_pledge_was_dropped_because_of_payment_errors" formatted="false">Dieser Finanzierungsbeitrag wurde aufgrund von Fehlern, die bei der Zahlung auftraten, nicht übernommen.</string>
   <string name="This_post_is_for_backers_only" formatted="false">Dieser Beitrag ist nur für Unterstützer</string>
   <string name="This_project_didnt_reach_its_funding_goal_so_your_payment_method_was_never_charged" formatted="false">Bei diesem Projekt wurde das Finanzierungsziel nicht erreicht. Daher wurde deine Zahlungsmethode nicht belastet.</string>
+  <string name="This_project_has_a_set_currency_that_cant_process_this_option" formatted="false">Diese Option ist für die Währung dieses Projekts nicht verfügbar.</string>
   <string name="This_project_will_only_be_funded_on_if_at_least_amount_is_pledged_by_date" formatted="false">Dieses Projekt wird nur finanziert, wenn bis am %{date} Unterstützungsbeiträge von mindestens %{amount} geleistet werden.</string>
   <string name="Time_left_left" formatted="false">%{time_left} übrig</string>
   <string name="To_access_all_your_favorite_categories_tap_the_explore_dropdown" formatted="false">Für schnellen Zugriff auf deine meist besuchten Kategorien, tippe auf das Dropdown-Menü oben.</string>

--- a/app/src/main/res/values-es/strings_i18n.xml
+++ b/app/src/main/res/values-es/strings_i18n.xml
@@ -552,6 +552,7 @@ Haz clic para volver a intentarlo.</string>
   <string name="This_pledge_was_dropped_because_of_payment_errors" formatted="false">Esta contribución no pudo ser cobrada por un error en el método de pago.</string>
   <string name="This_post_is_for_backers_only" formatted="false">Esta publicación es únicamente para patrocinadores</string>
   <string name="This_project_didnt_reach_its_funding_goal_so_your_payment_method_was_never_charged" formatted="false">Este proyecto no alcanzó su meta de financiamiento, así que no se realizó ningún cargo a tu método de pago.</string>
+  <string name="This_project_has_a_set_currency_that_cant_process_this_option" formatted="false">Dado que este proyecto tiene una moneda establecida, no se puede procesar esta opción.</string>
   <string name="This_project_will_only_be_funded_on_if_at_least_amount_is_pledged_by_date" formatted="false">Este proyecto sólo será financiado si se contribuye al menos un monto de %{amount} antes del %{date}.</string>
   <string name="Time_left_left" formatted="false">%{time_left} restantes</string>
   <string name="To_access_all_your_favorite_categories_tap_the_explore_dropdown" formatted="false">Accede a tus categorías favoritas en el menú en la parte superior de la app.</string>

--- a/app/src/main/res/values-fr/strings_i18n.xml
+++ b/app/src/main/res/values-fr/strings_i18n.xml
@@ -552,6 +552,7 @@ n\'ont rien soutenu.</string>
   <string name="This_pledge_was_dropped_because_of_payment_errors" formatted="false">Cet engagement a été annulé en raison d\'un échec de règlement.</string>
   <string name="This_post_is_for_backers_only" formatted="false">Cette publication est réservée aux contributeurs.</string>
   <string name="This_project_didnt_reach_its_funding_goal_so_your_payment_method_was_never_charged" formatted="false">L\'objectif de financement de ce projet n\'a pas été atteint, donc votre moyen de paiement n\'a pas été débité.</string>
+  <string name="This_project_has_a_set_currency_that_cant_process_this_option" formatted="false">This project has a set currency that can\'t process this option.</string>
   <string name="This_project_will_only_be_funded_on_if_at_least_amount_is_pledged_by_date" formatted="false">Ce projet ne sera financé que si au moins %{amount} sont engagés d\'ici le %{date}.</string>
   <string name="Time_left_left" formatted="false">Plus que %{time_left}</string>
   <string name="To_access_all_your_favorite_categories_tap_the_explore_dropdown" formatted="false">Pour retrouver toutes vos catégories préférées, cliquez sur le menu déroulant Découvrir dans l\'application.</string>

--- a/app/src/main/res/values-ja/strings_i18n.xml
+++ b/app/src/main/res/values-ja/strings_i18n.xml
@@ -550,6 +550,7 @@
   <string name="This_pledge_was_dropped_because_of_payment_errors" formatted="false">支払関連のエラーにより、このプレッジは取り消されました。</string>
   <string name="This_post_is_for_backers_only" formatted="false">この投稿はバッカー向けです</string>
   <string name="This_project_didnt_reach_its_funding_goal_so_your_payment_method_was_never_charged" formatted="false">このプロジェクトはファンディングゴールに到達しなかったため、お支払い方法への請求は行われませんでした。</string>
+  <string name="This_project_has_a_set_currency_that_cant_process_this_option" formatted="false">このプロジェクトには、このオプションを処理できない通貨が設定されています。</string>
   <string name="This_project_will_only_be_funded_on_if_at_least_amount_is_pledged_by_date" formatted="false">%{date} までに %{amount} 以上のプレッジが集まれば、このプロジェクトは資金を得ることができます。</string>
   <string name="Time_left_left" formatted="false">あと%{time_left}</string>
   <string name="To_access_all_your_favorite_categories_tap_the_explore_dropdown" formatted="false">上部の「さがす」をタップし、お気に入りカテゴリにアクセス。</string>

--- a/app/src/main/res/values/strings_i18n.xml
+++ b/app/src/main/res/values/strings_i18n.xml
@@ -555,6 +555,7 @@ catch your eye?</string>
   <string name="This_pledge_was_dropped_because_of_payment_errors" formatted="false">This pledge was dropped because of payment errors.</string>
   <string name="This_post_is_for_backers_only" formatted="false">This post is for backers only</string>
   <string name="This_project_didnt_reach_its_funding_goal_so_your_payment_method_was_never_charged" formatted="false">This project didn’t reach its funding goal, so your payment method was never charged.</string>
+  <string name="This_project_has_a_set_currency_that_cant_process_this_option" formatted="false">This project has a set currency that can\'t process this option.</string>
   <string name="This_project_will_only_be_funded_on_if_at_least_amount_is_pledged_by_date" formatted="false">This project will only be funded on if at least %{amount} is pledged by %{date}.</string>
   <string name="Time_left_left" formatted="false">%{time_left} left</string>
   <string name="To_access_all_your_favorite_categories_tap_the_explore_dropdown" formatted="false">To access all your favorite categories, tap the explore dropdown at the top of the app.</string>

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardCardUnselectedViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardCardUnselectedViewHolderViewModelTest.kt
@@ -26,7 +26,6 @@ class RewardCardUnselectedViewHolderViewModelTest : KSRobolectricTestCase() {
     private val lastFour = TestSubscriber.create<String>()
     private val notAvailableCopyIsVisible = TestSubscriber.create<Boolean>()
     private val notifyDelegateCardSelected = TestSubscriber.create<Pair<StoredCard, Int>>()
-    private val projectCountry = TestSubscriber.create<String>()
     private val selectImageIsVisible = TestSubscriber.create<Boolean>()
 
     private fun setUpEnvironment(environment: Environment) {
@@ -41,7 +40,6 @@ class RewardCardUnselectedViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.lastFour().subscribe(this.lastFour)
         this.vm.outputs.notAvailableCopyIsVisible().subscribe(this.notAvailableCopyIsVisible)
         this.vm.outputs.notifyDelegateCardSelected().subscribe(this.notifyDelegateCardSelected)
-        this.vm.outputs.projectCountry().subscribe(this.projectCountry)
         this.vm.outputs.selectImageIsVisible().subscribe(this.selectImageIsVisible)
     }
 
@@ -183,17 +181,6 @@ class RewardCardUnselectedViewHolderViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.cardSelected(2)
         this.notifyDelegateCardSelected.assertValue(Pair(creditCard, 2))
-    }
-
-    @Test
-    fun testProjectCountry() {
-        setUpEnvironment(environment())
-
-        val creditCard = StoredCardFactory.discoverCard()
-
-        this.vm.inputs.configureWith(Pair(creditCard, ProjectFactory.project()))
-
-        this.projectCountry.assertValue("United States")
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Updating the copy for when a card is not allowed.

# 🤔 Why
New copy party.

# 🛠 How
- Added `This_project_has_a_set_currency_that_cant_process_this_option` string and set it as the text for `card_not_allowed_warning`
## `RewardCardUnselectedViewHolderViewModel`
- Removed `projectCountry` output because it's no longer needed
## `PledgeFragmentViewModel` 🐛 
- Fixed bug where a card that is not allowed could be selected by default
- Added test for when the first card is not allowed
- Added test for when none of the cards are allowed

# 👀 See
| After 🦋 | Before 🐛|
| --- | --- |
| ![screenshot-2020-04-08_154955](https://user-images.githubusercontent.com/1289295/78828777-3a279180-79b3-11ea-8661-056e3a517e81.png) | ![screenshot-2020-04-03_200313](https://user-images.githubusercontent.com/1289295/78828823-4dd2f800-79b3-11ea-9382-2ad9b966c70b.png) |

# 📋 QA
Try to pledge to a project with a card that's not allowed. SIKE, you can't.

# Story 📖
[NT-1123]


[NT-1123]: https://kickstarter.atlassian.net/browse/NT-1123