### PR TITLE
[🎨] NT-1111 Adding 2 buttons in the new pledge footer

### DIFF
--- a/app/src/main/res/layout/fragment_pledge_section_footer.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_footer.xml
@@ -19,12 +19,46 @@
     android:orientation="vertical"
     android:padding="@dimen/grid_3">
 
-    <Button
-      android:id="@+id/pledge_footer_pledge_button"
+    <FrameLayout
+      android:id="@+id/pledge_button_container"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:enabled="false"
-      android:text="@string/Pledge" />
+      android:layout_height="wrap_content">
+
+      <Button
+        android:id="@+id/pledge_footer_pledge_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:text="@string/Pledge" />
+
+      <Button
+        android:id="@+id/pledge_footer_continue_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:text="@string/Continue"
+        android:visibility="gone" />
+
+      <FrameLayout
+        android:id="@+id/pledge_footer_pledge_button_progress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone">
+
+        <Button
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:stateListAnimator="@null" />
+
+        <ProgressBar
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center"
+          android:indeterminate="true"
+          android:indeterminateTint="@color/white"
+          android:indeterminateTintMode="src_in" />
+      </FrameLayout>
+    </FrameLayout>
 
     <TextView
       android:id="@+id/pledge_footer_pledge_agreement"


### PR DESCRIPTION
# 📲 What
Adding `Continue` and `ProgressBar` button in pledge screen footer.

# 🤔 Why
So I can use them in future PRs and not have conflicts in this file.

# 🛠 How
## `fragment_pledge_section_footer.xml`
- Added `pledge_footer_continue_button` button
- Added fake `pledge_footer_pledge_button_progress` button

# 👀 See
Screenshots from XML previews in Android Studio
| Continue | Progress | Pledge |
| --- | --- | --- |
| ![Screen Shot 2020-04-09 at 11 16 50 AM](https://user-images.githubusercontent.com/1289295/78911527-6a733c80-7a54-11ea-9413-a0a736a675b2.png) | ![Screen Shot 2020-04-09 at 11 17 26 AM](https://user-images.githubusercontent.com/1289295/78911528-6b0bd300-7a54-11ea-8911-a6ca634fb584.png) | ![Screen Shot 2020-04-09 at 11 18 11 AM](https://user-images.githubusercontent.com/1289295/78911529-6b0bd300-7a54-11ea-9e74-a364e7018cba.png) |

# 📋 QA
These buttons are hidden, this PR is just so I can access them when I add functionality.

# Story 📖
[NT-1111]


[NT-1111]: https://kickstarter.atlassian.net/browse/NT-1111