### PR TITLE
[ℹ️] NT-1143 Adding more info to TrackingWorker error logs

### DIFF
--- a/app/src/main/java/com/kickstarter/services/TrackingWorker.kt
+++ b/app/src/main/java/com/kickstarter/services/TrackingWorker.kt
@@ -27,7 +27,7 @@ abstract class TrackingWorker(@ApplicationContext applicationContext: Context, p
             Result.success()
         } else {
             val code = response.code()
-            logTrackingError(code)
+            logTrackingError(code, response.message())
             when (code) {
                 in 400..499 -> {
                     Result.failure()
@@ -44,8 +44,8 @@ abstract class TrackingWorker(@ApplicationContext applicationContext: Context, p
         Crashlytics.log(this.eventName)
     }
 
-    private fun logTrackingError(code: Int) {
-        val errorMessage = "$code Failed to track $tag event: $eventName"
+    private fun logTrackingError(code: Int, message: String) {
+        val errorMessage = "$code Failed to track $tag event $eventName (run attempt #$runAttemptCount) $message"
         if (this.build.isDebug) {
             Timber.e(errorMessage)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
+        maven { url = uri("https://dl.bintray.com/apollographql/android/") }
         jcenter()
         mavenCentral()
         maven {


### PR DESCRIPTION
# 📲 What
Adding more info to TrackingWorker error logs.

# 🤔 Why
Tracking failures are a big mystery! Hopefully with more info in the logs, we can get down to the bottom of it.

# 🛠 How
- Added the `response.message` and `runAttemptCount` to the error message that's logged when an event fails to track.

## build.gradle
I had to add another repo for Apollo because it was causing the build to fail. More ammo for justification to get rid of it.

# 👀 See
Logs only.

# 📋 QA
We will see these failures in the Firebase console 🚀 

# Story 📖
[NT-1143]


[NT-1143]: https://kickstarter.atlassian.net/browse/NT-1143