### PR TITLE
[⛔️] NT-598 Fix your pledge

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,7 +176,8 @@ buildscript {
 apollo {
     customTypeMapping = [
             "Date" : "java.util.Date",
-            "Email": "java.lang.String"
+            "Email": "java.lang.String",
+            "ISO8601DateTime" : "org.joda.time.DateTime"
     ]
 }
 

--- a/app/src/main/graphql/activity.graphql
+++ b/app/src/main/graphql/activity.graphql
@@ -3,3 +3,17 @@ mutation ClearUserUnseenActivity {
   activityIndicatorCount
  }
 }
+
+query ErroredBackings {
+  me {
+    backings(status:errored) {
+      nodes {
+        project {
+          finalCollectionDate
+          name
+          slug
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/graphql/schema.json
+++ b/app/src/main/graphql/schema.json
@@ -130,6 +130,22 @@
               "deprecationReason": null
             },
             {
+              "name": "currentCurrency",
+              "description": "The visitor's chosen currency",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyCode",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "dripCreatorInvitation",
               "description": "Fetches a drip creator invitation given its token.",
               "args": [
@@ -395,6 +411,197 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "EditorialConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "editorialPage",
+              "description": "",
+              "args": [
+                {
+                  "name": "slug",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EditorialPage",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "editorialPageForAdmin",
+              "description": "",
+              "args": [
+                {
+                  "name": "slug",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EditorialPageForAdmin",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "editorialPages",
+              "description": "",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "search",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sortDirection",
+                  "description": "",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "EditorialPageSortDirection",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sortField",
+                  "description": "",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "EditorialPageSortField",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EditorialPageForAdminConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "editorialRevision",
+              "description": "",
+              "args": [
+                {
+                  "name": "uuid",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EditorialRevision",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "editorialRevisionForAdmin",
+              "description": "",
+              "args": [
+                {
+                  "name": "uuid",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EditorialRevisionForAdmin",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -825,12 +1032,20 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "recommendationsModel",
-                  "description": "The recommendations model to use",
+                  "name": "recommendationsModels",
+                  "description": "The recommendations models to use",
                   "type": {
-                    "kind": "ENUM",
-                    "name": "RecommendationsModel",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "RecommendationsModel",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null
                 },
@@ -1291,6 +1506,18 @@
               "deprecationReason": null
             },
             {
+              "name": "usdType",
+              "description": "How USD currencies should be rendered, based on user's location",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "UsdType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "visibleCountries",
               "description": "Countries that are visible to the current user. This may include countries that cannot launch projects.",
               "args": [],
@@ -1607,6 +1834,26 @@
             },
             {
               "kind": "OBJECT",
+              "name": "Reward",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "RewardItem",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ShippingRule",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Location",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Category",
               "ofType": null
             },
@@ -1627,11 +1874,6 @@
             },
             {
               "kind": "OBJECT",
-              "name": "RewardItem",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
               "name": "Video",
               "ofType": null
             },
@@ -1647,22 +1889,17 @@
             },
             {
               "kind": "OBJECT",
-              "name": "Location",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "Reward",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "ShippingRule",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
               "name": "ProjectProfile",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AttachedAudio",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AttachedVideo",
               "ofType": null
             },
             {
@@ -1693,6 +1930,11 @@
             {
               "kind": "OBJECT",
               "name": "FreeformPost",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Address",
               "ofType": null
             },
             {
@@ -1728,16 +1970,6 @@
             {
               "kind": "OBJECT",
               "name": "DripComment",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "AttachedAudio",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "AttachedVideo",
               "ofType": null
             },
             {
@@ -1778,6 +2010,11 @@
             {
               "kind": "OBJECT",
               "name": "Checkout",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Survey",
               "ofType": null
             }
           ]
@@ -1993,6 +2230,59 @@
               "deprecationReason": null
             },
             {
+              "name": "addresses",
+              "description": "This user's saved shipping addresses",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AddressConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "allowsFollows",
               "description": "Indicates whether or not the user allows other Kickstarter users to follow them",
               "args": [],
@@ -2181,8 +2471,44 @@
               "deprecationReason": null
             },
             {
+              "name": "canSeeConfirmSignalModal",
+              "description": "Whether user can see the confirmation modal that appears after the user likes or dislike a project for the first time",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "canSeeConfirmWatchModal",
-              "description": "Whether user can see the confirmation modal that appears after the user watches a project",
+              "description": "Whether user can see the confirmation modal that appears after the user watches a project for the first time",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canSeePylToast",
+              "description": "Whether user can see PYL toast notification",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canSeeTasteProfileToast",
+              "description": "Whether user can see the taste profile toast notification that appears on the thanks page",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -3643,18 +3969,6 @@
               "deprecationReason": null
             },
             {
-              "name": "vizNotification",
-              "description": "Is the user opted in to receive a notification about visualizations",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "websites",
               "description": "A user's websites",
               "args": [],
@@ -3840,6 +4154,59 @@
               "deprecationReason": null
             },
             {
+              "name": "addOns",
+              "description": "Backing Add-ons",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectRewardConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "availableCardTypes",
               "description": "Available card types.",
               "args": [],
@@ -3957,6 +4324,54 @@
             {
               "name": "canComment",
               "description": "True if the current user can comment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canUserEditProjectStatus",
+              "description": "Whether user is allowed to edit project status",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canUserRequestUpdate",
+              "description": "Whether a user can request an update about this project from the Creator",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canUserViewProjectStatusFeedback",
+              "description": "Whether user is a backer of the project or not",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -4381,6 +4796,18 @@
               "deprecationReason": null
             },
             {
+              "name": "finalCollectionDate",
+              "description": "The date at which pledge collections will end",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "flagging",
               "description": "A report by the current user for the project.",
               "args": [],
@@ -4681,6 +5108,38 @@
             {
               "name": "isProjectWeLove",
               "description": "Whether or not this is a Kickstarter-featured project.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isRisky",
+              "description": "Whether or not this project is considered risky.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isSharingProjectBudget",
+              "description": "Whether the project is sharing it's budgeting information with the everyone",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5010,6 +5469,22 @@
               "deprecationReason": null
             },
             {
+              "name": "projectRelayId",
+              "description": "The root project id under which the comment is nested",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "projectShortLink",
               "description": "The project's bitly short URL",
               "args": [
@@ -5028,6 +5503,34 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectStatus",
+              "description": "Project's now and next status",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectStatus",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectSummary",
+              "description": "A list of responses that summarize the project.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectSummary",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -5084,6 +5587,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": "Sort the rewards by availability and cost",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -5168,11 +5681,11 @@
             },
             {
               "name": "spreadsheet",
-              "description": "The URL of the Google Sheet associated to this project",
+              "description": "The Google Sheet associated to this project",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "OBJECT",
+                "name": "Spreadsheet",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -5253,6 +5766,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "HTML",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "storyRichText",
+              "description": "Return an itemized version of the story. This feature is in BETA: types can change anytime!",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RichText",
                   "ofType": null
                 }
               },
@@ -5410,7 +5939,34 @@
               "deprecationReason": null
             },
             {
-              "name": "verifiedIdentity",
+              "name": "userFeedback",
+              "description": "The feedback the current user has left for the project",
+              "args": [
+                {
+                  "name": "questionName",
+                  "description": "Which question to fetch",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectFeedback",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "verifiedCreatorName",
               "description": "Name of user on verified account",
               "args": [],
               "type": {
@@ -5420,6 +5976,18 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "verifiedIdentity",
+              "description": "Name of user on verified account",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use verified_creator_name instead"
             },
             {
               "name": "video",
@@ -5470,6 +6038,22 @@
             {
               "name": "canComment",
               "description": "True if the current user can comment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canUserRequestUpdate",
+              "description": "Whether a user can request an update about this project from the Creator",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5557,6 +6141,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectRelayId",
+              "description": "The root project id under which the comment is nested",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
                   "ofType": null
                 }
               },
@@ -6163,6 +6763,22 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentsOnboarding",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PaymentsOnboarding",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "usesAccountHolderName",
               "description": "True if the project accepts an account holder name.",
               "args": [],
@@ -6310,7 +6926,7 @@
         {
           "kind": "SCALAR",
           "name": "Date",
-          "description": "ISO Date.",
+          "description": "ISO Date: YYYY-MM-DD",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -6685,66 +7301,6 @@
           "fields": [
             {
               "name": "country",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "locality",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "postalCode",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "region",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "street1",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "street2",
               "description": "",
               "args": [],
               "type": {
@@ -7226,34 +7782,6 @@
               "deprecationReason": null
             },
             {
-              "name": "redirectUrl",
-              "description": "Jumio URL to load in an iframe that will be shown to the creator",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "token",
-              "description": "The identity document's token.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "verificationState",
               "description": "",
               "args": [],
@@ -7400,9 +7928,81 @@
         },
         {
           "kind": "OBJECT",
+          "name": "PaymentsOnboarding",
+          "description": "A representation of the creator's progress through the payments & identity parts\nof Project Build onboarding. Currently just their overall 'status'",
+          "fields": [
+            {
+              "name": "status",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "PaymentsOnboardingStatus",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "PaymentsOnboardingStatus",
+          "description": "The overall status of the payments & identity onboarding flow of project build.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "complete",
+              "description": "The creator successfully completed payments & identity onboarding",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "in_progress",
+              "description": "The creator has started onboarding but has not yet finished",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "requires_hosted_onboarding",
+              "description": "The creator must proceed to Stripe Hosted Onboarding to finish onboarding",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "ProjectActions",
           "description": "List actions current user can perform on a project",
           "fields": [
+            {
+              "name": "displayConvertAmount",
+              "description": "Whether or not the user is in a state to see currency conversions",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "shareDraft",
               "description": "",
@@ -7415,6 +8015,1150 @@
                   "name": "Boolean",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectRewardConnection",
+          "description": "The connection type for Reward.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RewardEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Reward",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RewardEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Reward",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Reward",
+          "description": "A project reward.",
+          "fields": [
+            {
+              "name": "amount",
+              "description": "Amount for claiming this reward.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "available",
+              "description": "Whether or not the reward is available for new pledges",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "backersCount",
+              "description": "count of backers for this reward",
+              "args": [
+                {
+                  "name": "excludeInactive",
+                  "description": "Filters out backings in an inactive state",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "A reward description.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "displayName",
+              "description": "A reward's title plus the amount, or a default title (the reward amount) if it doesn't have a title.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "endsAt",
+              "description": "When the reward is scheduled to end",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "estimatedDeliveryOn",
+              "description": "Estimated delivery day.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Date",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isMaxPledge",
+              "description": "Does reward amount meet or exceed maximum pledge for the project",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "items",
+              "description": "Items in the reward.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RewardItemsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "limit",
+              "description": "A reward limit.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "A reward title.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "project",
+              "description": "The project",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Project",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "remainingQuantity",
+              "description": "Remaining reward quantity.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rewardType",
+              "description": "The type of the reward - base or addon.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "RewardType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingPreference",
+              "description": "Shipping preference for this reward",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "ShippingPreference",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingRules",
+              "description": "Shipping rules defined by the creator for this reward",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ShippingRule",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingRulesExpanded",
+              "description": "Shipping rules for all shippable countries.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RewardShippingRulesConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingSummary",
+              "description": "A shipping summary",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startsAt",
+              "description": "When the reward is scheduled to start",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RewardItemsConnection",
+          "description": "The connection type for RewardItem.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RewardItemEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RewardItem",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RewardItemEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RewardItem",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "position",
+              "description": "The position that an item has been ordered on a reward",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quantity",
+              "description": "The quantity of an item associated with a reward",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RewardItem",
+          "description": "A reward item.",
+          "fields": [
+            {
+              "name": "hasBackers",
+              "description": "Whether backers have backed rewards this item belongs to",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "An item name.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "project",
+              "description": "The project",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Project",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rewardsCount",
+              "description": "The number of rewards that the item is included in.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "RewardType",
+          "description": "Describes the purpose of the reward",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "addon",
+              "description": "A reward that can only be added to a backing for another reward",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "base",
+              "description": "A reward that cannot be combined with others",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ShippingPreference",
+          "description": "A preference for shipping a reward",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "none",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "restricted",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unrestricted",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ShippingRule",
+          "description": "A project reward's shipping rule.",
+          "fields": [
+            {
+              "name": "cost",
+              "description": "The shipping cost for this location.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasBackers",
+              "description": "Shipping rule has backers",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "location",
+              "description": "The shipping location to which the rule pertains.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Location",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Location",
+          "description": "A location.",
+          "fields": [
+            {
+              "name": "country",
+              "description": "The country code.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countryName",
+              "description": "The localized country name.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "county",
+              "description": "The county name or code. Can be null.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "discoverUrl",
+              "description": "A URL to a discover page filtered by location",
+              "args": [
+                {
+                  "name": "ref_tag",
+                  "description": "The ref tag",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "displayableName",
+              "description": "The displayable name. It includes the state code for US cities. ex: 'Seattle, WA'",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "latitude",
+              "description": "The latitude of the location.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "longitude",
+              "description": "The longitude of the location.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "The localized name",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state",
+              "description": "The state name or code. Can be null.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RewardShippingRulesConnection",
+          "description": "The connection type for ShippingRule.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ShippingRuleEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ShippingRule",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ShippingRuleEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ShippingRule",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -10291,6 +12035,16 @@
           "possibleTypes": null
         },
         {
+          "kind": "SCALAR",
+          "name": "ISO8601DateTime",
+          "description": "An ISO 8601-encoded datetime",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "Flagging",
           "description": "A report by a user.",
@@ -10870,16 +12624,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "SCALAR",
-          "name": "Float",
-          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "Photo",
           "description": "A photo",
@@ -11010,91 +12754,6 @@
               "deprecationReason": null
             }
           ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "RewardItem",
-          "description": "A reward item.",
-          "fields": [
-            {
-              "name": "hasBackers",
-              "description": "Whether backers have backed rewards this item belongs to",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": "An item name.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "project",
-              "description": "The project",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Project",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "rewardsCount",
-              "description": "The number of rewards that the item is included in.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
           "possibleTypes": null
         },
         {
@@ -12097,174 +13756,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "Location",
-          "description": "A location.",
-          "fields": [
-            {
-              "name": "country",
-              "description": "The country code.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "countryName",
-              "description": "The localized country name.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "county",
-              "description": "The county name or code. Can be null.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "discoverUrl",
-              "description": "A URL to a discover page filtered by location",
-              "args": [
-                {
-                  "name": "ref_tag",
-                  "description": "The ref tag",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "displayableName",
-              "description": "The displayable name. It includes the state code for US cities. ex: 'Seattle, WA'",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "latitude",
-              "description": "The latitude of the location.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "longitude",
-              "description": "The longitude of the location.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": "The localized name",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "state",
-              "description": "The state name or code. Can be null.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "ENUM",
           "name": "PostFormat",
           "description": "The possible post types.",
@@ -13089,757 +14580,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "RewardEdge",
-          "description": "An edge in a connection.",
-          "fields": [
-            {
-              "name": "cursor",
-              "description": "A cursor for use in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": "The item at the end of the edge.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Reward",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Reward",
-          "description": "A project reward.",
-          "fields": [
-            {
-              "name": "amount",
-              "description": "Amount for claiming this reward.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Money",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "backersCount",
-              "description": "count of backers for this reward",
-              "args": [
-                {
-                  "name": "excludeInactive",
-                  "description": "Filters out backings in an inactive state",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": "A reward description.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "displayName",
-              "description": "A reward's title plus the amount, or a default title (the reward amount) if it doesn't have a title.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "endsAt",
-              "description": "When the reward is scheduled to end",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "estimatedDeliveryOn",
-              "description": "Estimated delivery day.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Date",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isMaxPledge",
-              "description": "Does reward amount meet or exceed maximum pledge for the project",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "items",
-              "description": "Items in the reward.",
-              "args": [
-                {
-                  "name": "after",
-                  "description": "Returns the elements in the list that come after the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": "Returns the elements in the list that come before the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "first",
-                  "description": "Returns the first _n_ elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": "Returns the last _n_ elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "RewardItemsConnection",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "limit",
-              "description": "A reward limit.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": "A reward title.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "project",
-              "description": "The project",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Project",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "remainingQuantity",
-              "description": "Remaining reward quantity.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "shippingPreference",
-              "description": "Shipping preference for this reward",
-              "args": [],
-              "type": {
-                "kind": "ENUM",
-                "name": "ShippingPreference",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "shippingRules",
-              "description": "Shipping rules defined by the creator for this reward",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "ShippingRule",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "shippingRulesExpanded",
-              "description": "Shipping rules for all shippable countries.",
-              "args": [
-                {
-                  "name": "after",
-                  "description": "Returns the elements in the list that come after the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": "Returns the elements in the list that come before the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "first",
-                  "description": "Returns the first _n_ elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": "Returns the last _n_ elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "RewardShippingRulesConnection",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "shippingSummary",
-              "description": "A shipping summary",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "startsAt",
-              "description": "When the reward is scheduled to start",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "RewardItemsConnection",
-          "description": "The connection type for RewardItem.",
-          "fields": [
-            {
-              "name": "edges",
-              "description": "A list of edges.",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "RewardItemEdge",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "nodes",
-              "description": "A list of nodes.",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "RewardItem",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": "Information to aid in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "totalCount",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "RewardItemEdge",
-          "description": "An edge in a connection.",
-          "fields": [
-            {
-              "name": "cursor",
-              "description": "A cursor for use in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": "The item at the end of the edge.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "RewardItem",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "position",
-              "description": "The position that an item has been ordered on a reward",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "quantity",
-              "description": "The quantity of an item associated with a reward",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "ShippingPreference",
-          "description": "A preference for shipping a reward",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "none",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "restricted",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "unrestricted",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ShippingRule",
-          "description": "A project reward's shipping rule.",
-          "fields": [
-            {
-              "name": "cost",
-              "description": "The shipping cost for this location.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Money",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "hasBackers",
-              "description": "Shipping rule has backers",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "location",
-              "description": "The shipping location to which the rule pertains.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Location",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "RewardShippingRulesConnection",
-          "description": "The connection type for ShippingRule.",
-          "fields": [
-            {
-              "name": "edges",
-              "description": "A list of edges.",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ShippingRuleEdge",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "nodes",
-              "description": "A list of nodes.",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ShippingRule",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": "Information to aid in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "totalCount",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ShippingRuleEdge",
-          "description": "An edge in a connection.",
-          "fields": [
-            {
-              "name": "cursor",
-              "description": "A cursor for use in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": "The item at the end of the edge.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "ShippingRule",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "ENUM",
           "name": "Post",
           "description": "Post types",
@@ -14022,6 +14762,169 @@
         },
         {
           "kind": "OBJECT",
+          "name": "ProjectStatus",
+          "description": "Project status set by user",
+          "fields": [
+            {
+              "name": "id",
+              "description": "Id of a project status",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nextDueDate",
+              "description": "The estimated due date for the next_status of the project",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nextStatus",
+              "description": "The next_status of the project",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nowStatus",
+              "description": "The now_status of the project",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "When project status is updated",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectSummary",
+          "description": "",
+          "fields": [
+            {
+              "name": "question",
+              "description": "A question prompt for the creator to summarize their project",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProjectSummaryQuestion",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "response",
+              "description": "Response to a question prompt that summarizes the project",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ProjectSummaryQuestion",
+          "description": "Question prompts for the creator to summarize their project",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "WHAT_IS_THE_PROJECT",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "WHAT_WILL_YOU_DO_WITH_THE_MONEY",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "WHO_ARE_YOU",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "Recommendations",
           "description": "Score and model from recommendations engine if a project was fetched via recommendations.",
           "fields": [
@@ -14069,19 +14972,19 @@
         },
         {
           "kind": "OBJECT",
-          "name": "ProjectRewardConnection",
-          "description": "The connection type for Reward.",
+          "name": "Spreadsheet",
+          "description": "A project spreadsheet, including a url and row data",
           "fields": [
             {
-              "name": "edges",
-              "description": "A list of edges.",
+              "name": "data",
+              "description": "The data of the Google Sheet associated to this project",
               "args": [],
               "type": {
                 "kind": "LIST",
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "RewardEdge",
+                  "name": "SpreadsheetDatum",
                   "ofType": null
                 }
               },
@@ -14089,31 +14992,27 @@
               "deprecationReason": null
             },
             {
-              "name": "nodes",
-              "description": "A list of nodes.",
+              "name": "dataLastUpdatedAt",
+              "description": "When the data for the sheet was last fetched successfully",
               "args": [],
               "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Reward",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "pageInfo",
-              "description": "Information to aid in pagination.",
+              "name": "displayMode",
+              "description": "Can be `amount` or `percent` based on the creator's choice",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -14121,8 +15020,99 @@
               "deprecationReason": null
             },
             {
-              "name": "totalCount",
-              "description": "",
+              "name": "hasDisplayableData",
+              "description": "Whether a spreadsheet contains the minimum information to render a graphic budget",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "public",
+              "description": "Whether the sheet is shareable with the public",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "The URL of the Google Sheet associated to this project",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SpreadsheetDatum",
+          "description": "A row of datum for a funding spreadsheet",
+          "fields": [
+            {
+              "name": "description",
+              "description": "Expanded description of the purpose of that row",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "The name of the row",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "phase",
+              "description": "The funding category of the row",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rowNum",
+              "description": "The spreadsheet row number",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -14132,6 +15122,18 @@
                   "name": "Int",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "value",
+              "description": "The dollar value of the row",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -14208,6 +15210,1079 @@
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RichText",
+          "description": "Itemized rich text",
+          "fields": [
+            {
+              "name": "items",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "UNION",
+                    "name": "RichTextItem",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "UNION",
+          "name": "RichTextItem",
+          "description": "Rich text items: Paragraph, Headers, List, Quote, Photo, Audio, Video or Oembed",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "RichTextAudio",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "RichTextHeader1",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "RichTextHeader2",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "RichTextHeader3",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "RichTextList",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "RichTextOembed",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "RichTextParagraph",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "RichTextPhoto",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "RichTextQuote",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "RichTextVideo",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RichTextAudio",
+          "description": "An Audio asset",
+          "fields": [
+            {
+              "name": "altText",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "asset",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AttachedAudio",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "caption",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AttachedAudio",
+          "description": "",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": "Upload status of the audio",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AssetEncodingState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "AssetEncodingState",
+          "description": "All available asset upload states",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "ENCODED",
+              "description": "Processing the asset successfully completed",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENCODING",
+              "description": "Initial, incomplete status of an asset upload",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FAILED",
+              "description": "Processing the asset failed",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RichTextHeader1",
+          "description": "A Header 1. <h1>",
+          "fields": [
+            {
+              "name": "html",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RichTextHeader2",
+          "description": "A Header 2. <h2>",
+          "fields": [
+            {
+              "name": "html",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RichTextHeader3",
+          "description": "A Header 3. <h3>",
+          "fields": [
+            {
+              "name": "html",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RichTextList",
+          "description": "A list. <ul>",
+          "fields": [
+            {
+              "name": "items",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "RichTextListItem",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RichTextListItem",
+          "description": "A list item. <li>",
+          "fields": [
+            {
+              "name": "html",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RichTextOembed",
+          "description": "An Oembed item",
+          "fields": [
+            {
+              "name": "authorName",
+              "description": "ex: Bryson Lovett",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "authorUrl",
+              "description": "ex: https://www.youtube.com/user/brysonlovett",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "height",
+              "description": "ex: 270",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "html",
+              "description": "ex: <iframe width=\"560\" height=\"315\"\nsrc=\"https://www.youtube.com/embed/ijeaVn8znJ8?feature=oembed\" frameborder=\"0\"\nallow=\"autoplay; encrypted-media\" allowfullscreen></iframe>",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iframeUrl",
+              "description": "ex: https://www.youtube.com/embed/ijeaVn8znJ8?feature=oembed",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "originalUrl",
+              "description": "ex: https://youtu.be/ijeaVn8znJ8",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "photoUrl",
+              "description": "only for photo",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "providerName",
+              "description": "Ex: Embedly, Flickr, Kickstarter, Kickstarter Live, Scribd, SoundCloud, Spotify, Sketchfab, Twitter, Vimeo, YouTube",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "providerUrl",
+              "description": "ex: https://www.youtube.com/",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "thumbnailHeight",
+              "description": "ex: 360",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "thumbnailUrl",
+              "description": "ex: https://i.ytimg.com/vi/ijeaVn8znJ8/hqdefault.jpg",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "thumbnailWidth",
+              "description": "ex: 480",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "ex: Bird Photo Booth bird feeder kickstarter preview 2",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": "one of: photo, video, link, rich",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "version",
+              "description": "always \"1.0\"",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "width",
+              "description": "ex: 480",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RichTextParagraph",
+          "description": "A Paragraph. <p>",
+          "fields": [
+            {
+              "name": "html",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RichTextPhoto",
+          "description": "A Photo asset",
+          "fields": [
+            {
+              "name": "altText",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "asset",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Photo",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "caption",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "",
+              "args": [
+                {
+                  "name": "width",
+                  "description": "The width of the image in pixels.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RichTextQuote",
+          "description": "A quote. <blockquote>",
+          "fields": [
+            {
+              "name": "html",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RichTextVideo",
+          "description": "A Video asset",
+          "fields": [
+            {
+              "name": "altText",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "asset",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AttachedVideo",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "caption",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AttachedVideo",
+          "description": "",
+          "fields": [
+            {
+              "name": "formats",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AttachedVideoFormat",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "poster",
+              "description": "Image preview url",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "renderedHtml",
+              "description": "The rendered HTML player for a video asset",
+              "args": [
+                {
+                  "name": "assetWidth",
+                  "description": "The width of the video asset in pixels.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": "Upload status of the video",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AssetEncodingState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "Original video url",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AttachedVideoFormat",
+          "description": "",
+          "fields": [
+            {
+              "name": "encoding",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "height",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "profile",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "width",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -14614,16 +16689,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "SCALAR",
-          "name": "ISO8601DateTime",
-          "description": "An ISO 8601-encoded datetime",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "ProjectTimelineConnection",
           "description": "The connection type for ProjectTimelineEvent.",
@@ -14951,6 +17016,22 @@
             {
               "name": "canComment",
               "description": "True if the current user can comment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canUserRequestUpdate",
+              "description": "Whether a user can request an update about this project from the Creator",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -15389,6 +17470,22 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "Project",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectRelayId",
+              "description": "The root project id under which the comment is nested",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
                   "ofType": null
                 }
               },
@@ -16137,6 +18234,22 @@
               "deprecationReason": null
             },
             {
+              "name": "canUserRequestUpdate",
+              "description": "Whether a user can request an update about this project from the Creator",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "comments",
               "description": "List of comments on the commentable",
               "args": [
@@ -16572,6 +18685,22 @@
               "deprecationReason": null
             },
             {
+              "name": "projectRelayId",
+              "description": "The root project id under which the comment is nested",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "publishedAt",
               "description": "The date the project update was published.",
               "args": [],
@@ -16704,6 +18833,360 @@
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProjectFeedback",
+          "description": "Structured feedback left by a user on a project",
+          "fields": [
+            {
+              "name": "createdAt",
+              "description": "When the answer was provided",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "questionAnswer",
+              "description": "The answer the user provided",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "questionName",
+              "description": "The name of the question the user answered",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AddressConnection",
+          "description": "The connection type for Address.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AddressEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Address",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AddressEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Address",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Address",
+          "description": "A user's shipping address",
+          "fields": [
+            {
+              "name": "addressLine1",
+              "description": "Address line 1 (Street address/PO Box/Company name)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "addressLine2",
+              "description": "Address line 2 (Apartment/Suite/Unit/Building)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "city",
+              "description": "City",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countryCode",
+              "description": "2-letter country code",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "CountryCode",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nonUpdatableSurveyResponsesCount",
+              "description": "The number of non updatable survey responses to this address",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "phoneNumber",
+              "description": "Recipient's phone number",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postalCode",
+              "description": "ZIP or postal code",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "recipientName",
+              "description": "Address recipient name",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "referenceName",
+              "description": "Address reference or nickname",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "region",
+              "description": "State/County/Province/Region.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatableSurveyResponsesCount",
+              "description": "The number of current updatable survey responses to this address",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "user",
+              "description": "The user associated with the shipping address",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -21355,825 +23838,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "RichText",
-          "description": "Itemized rich text",
-          "fields": [
-            {
-              "name": "items",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "UNION",
-                    "name": "RichTextItem",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "UNION",
-          "name": "RichTextItem",
-          "description": "Rich text items: html, photo, audio, video or oembed",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": [
-            {
-              "kind": "OBJECT",
-              "name": "RichTextAudioItem",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "RichTextHtmlItem",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "RichTextOembedItem",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "RichTextPhotoItem",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "RichTextVideoItem",
-              "ofType": null
-            }
-          ]
-        },
-        {
-          "kind": "OBJECT",
-          "name": "RichTextAudioItem",
-          "description": "Audio item",
-          "fields": [
-            {
-              "name": "asset",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "AttachedAudio",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "caption",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "url",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "AttachedAudio",
-          "description": "",
-          "fields": [
-            {
-              "name": "id",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "status",
-              "description": "Upload status of the audio",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AssetEncodingState",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "url",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "AssetEncodingState",
-          "description": "All available asset upload states",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "ENCODED",
-              "description": "Processing the asset successfully completed",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ENCODING",
-              "description": "Initial, incomplete status of an asset upload",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FAILED",
-              "description": "Processing the asset failed",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "RichTextHtmlItem",
-          "description": "Html item",
-          "fields": [
-            {
-              "name": "html",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "RichTextOembedItem",
-          "description": "Oembed item",
-          "fields": [
-            {
-              "name": "authorName",
-              "description": "ex: Bryson Lovett",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "authorUrl",
-              "description": "ex: https://www.youtube.com/user/brysonlovett",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "height",
-              "description": "ex: 270",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "html",
-              "description": "ex: <iframe width=\"560\" height=\"315\"\nsrc=\"https://www.youtube.com/embed/ijeaVn8znJ8?feature=oembed\" frameborder=\"0\"\nallow=\"autoplay; encrypted-media\" allowfullscreen></iframe>",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "iframeUrl",
-              "description": "ex: https://www.youtube.com/embed/ijeaVn8znJ8?feature=oembed",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "originalUrl",
-              "description": "ex: https://youtu.be/ijeaVn8znJ8",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "photoUrl",
-              "description": "only for photo",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "providerName",
-              "description": "Ex: Embedly, Flickr, Kickstarter, Kickstarter Live, Scribd, SoundCloud, Spotify, Sketchfab, Twitter, Vimeo, YouTube",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "providerUrl",
-              "description": "ex: https://www.youtube.com/",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "thumbnailHeight",
-              "description": "ex: 360",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "thumbnailUrl",
-              "description": "ex: https://i.ytimg.com/vi/ijeaVn8znJ8/hqdefault.jpg",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "thumbnailWidth",
-              "description": "ex: 480",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "title",
-              "description": "ex: Bird Photo Booth bird feeder kickstarter preview 2",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "type",
-              "description": "one of: photo, video, link, rich",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "version",
-              "description": "always \"1.0\"",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "width",
-              "description": "ex: 480",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "RichTextPhotoItem",
-          "description": "Photo item",
-          "fields": [
-            {
-              "name": "asset",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Photo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "caption",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "url",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "RichTextVideoItem",
-          "description": "Video item",
-          "fields": [
-            {
-              "name": "asset",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "AttachedVideo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "caption",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "url",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "AttachedVideo",
-          "description": "",
-          "fields": [
-            {
-              "name": "formats",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AttachedVideoFormat",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "poster",
-              "description": "Image preview url",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "renderedHtml",
-              "description": "The rendered HTML player for a video asset",
-              "args": [
-                {
-                  "name": "assetWidth",
-                  "description": "The width of the video asset in pixels.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "status",
-              "description": "Upload status of the video",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AssetEncodingState",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "url",
-              "description": "Original video url",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "AttachedVideoFormat",
-          "description": "",
-          "fields": [
-            {
-              "name": "encoding",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "height",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "profile",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "url",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "width",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "UNION",
           "name": "AttachedMedia",
           "description": "Attached Media",
@@ -24732,6 +26396,12 @@
               "deprecationReason": null
             },
             {
+              "name": "addons_in_build",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "admin_checkout_debugger",
               "description": "",
               "isDeprecated": false,
@@ -24739,6 +26409,12 @@
             },
             {
               "name": "android_creator_view",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "android_go_rewardless_2",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -24756,13 +26432,19 @@
               "deprecationReason": null
             },
             {
-              "name": "break_ksr_footer",
+              "name": "budget_module",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "claim_popover",
+              "name": "budget_viz_arts",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "budget_viz_fashion",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -24780,31 +26462,7 @@
               "deprecationReason": null
             },
             {
-              "name": "drip_change_tier",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "drip_fire_hose_feed",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "drip_identity_document_upload",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "drip_iterate",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "drip_manage_push_notifications",
+              "name": "disable_manual_create_stripe_elements_postal_code",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -24822,12 +26480,6 @@
               "deprecationReason": null
             },
             {
-              "name": "fulfillment_dashboard_beta_message",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "funding_build",
               "description": "",
               "isDeprecated": false,
@@ -24835,6 +26487,18 @@
             },
             {
               "name": "funding_sheet",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "go_rewardless",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "how_it_works",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -24865,6 +26529,12 @@
             },
             {
               "name": "ios_favorite_categories",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ios_go_rewardless",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -24930,6 +26600,12 @@
               "deprecationReason": null
             },
             {
+              "name": "ios_qualtrics",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "ios_scroll_output_observe_for_ui",
               "description": "",
               "isDeprecated": false,
@@ -24948,12 +26624,6 @@
               "deprecationReason": null
             },
             {
-              "name": "jumio_v4",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "ksr10_build_overview",
               "description": "",
               "isDeprecated": false,
@@ -24961,6 +26631,30 @@
             },
             {
               "name": "ksr10_footer",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lazysizes",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "make_100_2020",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "make_100_banner",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "make_100_footer",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -24984,6 +26678,18 @@
               "deprecationReason": null
             },
             {
+              "name": "multiple_rewards_add_ons",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "multiple_rewards_quantification",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "native_creator_breakdown_chart",
               "description": "",
               "isDeprecated": false,
@@ -24996,31 +26702,19 @@
               "deprecationReason": null
             },
             {
-              "name": "new_payments_ui_checkout",
+              "name": "new_campaign_nav_desktop",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "new_payments_ui_refunds",
+              "name": "new_campaign_nav_mobile",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "new_payments_ui_render_on_native",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "new_payments_ui_retry",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "new_payments_ui_user_settings",
+              "name": "new_make100_link",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -25050,18 +26744,6 @@
               "deprecationReason": null
             },
             {
-              "name": "positive_negative_signal",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "prelaunch_page",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "profile_projects_react",
               "description": "",
               "isDeprecated": false,
@@ -25086,19 +26768,31 @@
               "deprecationReason": null
             },
             {
-              "name": "remind_me_bookmark",
+              "name": "project_header_media_carousel_hero",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "project_summary",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "project_update_requests",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qualtrics",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "rich_text_embedifier",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "rich_text_survey_intro_editor",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -25116,31 +26810,19 @@
               "deprecationReason": null
             },
             {
-              "name": "stripe_document_upload",
+              "name": "sysint_risky_toast",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "target_launch_date",
+              "name": "track_define_namespace",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "vanity_profile_url",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "view_more_project_collections",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "view_more_recommended_projects",
+              "name": "user_menu_draft_project",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -25626,6 +27308,22 @@
             {
               "name": "artsCultureNewsletter",
               "description": "The subscription to the ArtsCultureNewsletter newsletter",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "creatorNewsletter",
+              "description": "The subscription to the CreatorNewsletter newsletter",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -27236,6 +28934,34 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentUrl",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pledgeTotal",
+              "description": "Desired amount backer wishes to pledge to the project, excluding the shipping amount",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "redirectUrl",
               "description": "The URL to redirect to on a successful checkout",
               "args": [],
@@ -27839,7 +29565,17 @@
           "possibleTypes": [
             {
               "kind": "OBJECT",
+              "name": "Article",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "BespokeComponent",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ExploreSubcategories",
               "ofType": null
             },
             {
@@ -27876,8 +29612,164 @@
               "kind": "OBJECT",
               "name": "PromoCollection",
               "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ShortText",
+              "ofType": null
             }
           ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Article",
+          "description": "An article block for Editorial pages",
+          "fields": [
+            {
+              "name": "attachableAssoc",
+              "description": "AdminUI: Rich Text Editor property for attachableAssoc.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "attachableId",
+              "description": "AdminUI: Rich Text Editor property for attachableId.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "body",
+              "description": "The html body of the article.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "byline",
+              "description": "The author of the article. Can be an empty string.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "displayTopByline",
+              "description": "Determines if the byline should be displayed at the top of the article",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publicationDate",
+              "description": "The date this article is published on. This date is only informative and won't affect module visibility.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subtitle",
+              "description": "The subtitle of the article. Can be an empty string.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "The title of the article. Can be an empty string.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
         },
         {
           "kind": "OBJECT",
@@ -27949,6 +29841,178 @@
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ExploreSubcategories",
+          "description": "Top subcategories",
+          "fields": [
+            {
+              "name": "category",
+              "description": "The root category",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Category",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "categoryId",
+              "description": "The root category database id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subcategories",
+              "description": "Top subcategories ordered by number of live projects descending",
+              "args": [
+                {
+                  "name": "count",
+                  "description": "The maximum number of subcategories to return",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "10"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ExploreSubcategory",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ExploreSubcategory",
+          "description": "A subcategory for ExploreSubcategories",
+          "fields": [
+            {
+              "name": "categoryId",
+              "description": "The category database id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "The subcategory name for the current language",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projects",
+              "description": "The projects to display in this collection",
+              "args": [
+                {
+                  "name": "count",
+                  "description": "The number of projects needed for this collection",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "10"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Project",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -28874,6 +30938,22 @@
               "deprecationReason": null
             },
             {
+              "name": "layout",
+              "description": "Layout for this promo collection",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "EditorialPromoCollectionLayout",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "maxFeaturedItems",
               "description": "Maximum number of items to display",
               "args": [],
@@ -28935,11 +31015,62 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "theme",
+              "description": "Visual theme for this promo collection",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "EditorialPromoCollectionTheme",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "Title for this collection. Can be blank.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "EditorialPromoCollectionLayout",
+          "description": "Layouts for Editorial Promo Collections",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "THREE_COLUMNS",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TWO_COLUMNS",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -29048,18 +31179,6 @@
               "deprecationReason": null
             },
             {
-              "name": "textColor",
-              "description": "The color the text within the promo module.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "title",
               "description": "The localized title of this promo module.",
               "args": [],
@@ -29090,6 +31209,1380 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "EditorialPromoCollectionTheme",
+          "description": "Visual themes for Editorial Promo Collections",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "FLEX",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROMO",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ShortText",
+          "description": "An Short Text block for Editorial pages",
+          "fields": [
+            {
+              "name": "backgroundColor",
+              "description": "Hex value of the background color.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "body",
+              "description": "The html body of the Short Text.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ctaText",
+              "description": "The text of the CTA. Can be an empty string.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ctaUrl",
+              "description": "The url the CTA points to. Can be an empty string.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ruleColor",
+              "description": "Hex value of the rule color.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subtitle",
+              "description": "The subtitle of the Short Text. Can be an empty string.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "The title of the Short Text. Can be an empty string.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EditorialPage",
+          "description": "An Editorial Page",
+          "fields": [
+            {
+              "name": "createdAt",
+              "description": "When this page was created",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "The page name.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageType",
+              "description": "The page type.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "EditorialPageType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publishedRevision",
+              "description": "The currently published revision. Can be null.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EditorialRevision",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "slug",
+              "description": "The slug of this page. Can include `/'.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "When this page was last updated",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "EditorialPageType",
+          "description": "Editorial page types.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "article",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "category",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "international",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "prompt",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "resource",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EditorialRevision",
+          "description": "An Editorial Page Revision",
+          "fields": [
+            {
+              "name": "metadata",
+              "description": "The page metadata",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EditorialRevisionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "modules",
+              "description": "The modules for the editorial revision",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "UNION",
+                      "name": "Editorial",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "page",
+              "description": "The page that this revision belongs to",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EditorialPage",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uuid",
+              "description": "The revision uuid",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EditorialRevisionMetadata",
+          "description": "",
+          "fields": [
+            {
+              "name": "description",
+              "description": "The revision description",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ogImage",
+              "description": "The revision og_image",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "The revision title",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EditorialPageForAdmin",
+          "description": "An Editorial Page fully loaded with admin only fields",
+          "fields": [
+            {
+              "name": "attachableAssoc",
+              "description": "Rich Text Editor property for attachableAssoc.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "attachableId",
+              "description": "Rich Text Editor property for attachableId.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": "When this page was created",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "editor",
+              "description": "This page's editor.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "User",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastPublishedOrDraftRevision",
+              "description": "Last published or draft revision",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EditorialRevisionForAdmin",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "The page name.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageType",
+              "description": "The page type.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "EditorialPageType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publishedRevision",
+              "description": "Published revision",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EditorialRevisionForAdmin",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "revisions",
+              "description": "The revisions in reverse chronological order.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EditorialRevisionForAdminConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "slug",
+              "description": "The slug of this page. Can include `/'.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stats",
+              "description": "Stats for the past 30 days",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EditorialPageStats",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "When this page was last updated",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EditorialRevisionForAdmin",
+          "description": "An Editorial Page Revision fully loaded with admin attributes",
+          "fields": [
+            {
+              "name": "author",
+              "description": "The person who created this revision",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "User",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": "When this editorial layout was created",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "metadata",
+              "description": "The page metadata",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EditorialRevisionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "modules",
+              "description": "The modules for the editorial revision",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "UNION",
+                      "name": "Editorial",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "page",
+              "description": "The page that this revision belongs to",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EditorialPage",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "published",
+              "description": "Is the editorial revision published?",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publishedAt",
+              "description": "When the editorial revision was published.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publisher",
+              "description": "The person who published this revision",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sequence",
+              "description": "The sequence number for this revision",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "translationStatus",
+              "description": "Counts of translated / total strings for each locale",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "EditorialTranslationStatus",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "When this editorial layout was created",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uuid",
+              "description": "The revision uuid",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EditorialTranslationStatus",
+          "description": "",
+          "fields": [
+            {
+              "name": "locale",
+              "description": "The language",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "EditorialTranslationStatusLocale",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "total",
+              "description": "Total number of strings",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "translated",
+              "description": "Number of strings translated",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "EditorialTranslationStatusLocale",
+          "description": "Editorial locale",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "de",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "es",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fr",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "it",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ja",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zh",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EditorialRevisionForAdminConnection",
+          "description": "The connection type for EditorialRevisionForAdmin.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EditorialRevisionForAdminEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EditorialRevisionForAdmin",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EditorialRevisionForAdminEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EditorialRevisionForAdmin",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EditorialPageStats",
+          "description": "",
+          "fields": [
+            {
+              "name": "backingsCount",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "backingsUsd",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageViews",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectClicks",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "EditorialPageSortDirection",
+          "description": "Direction to sort Editorial Pages",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "ASC",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DESC",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "EditorialPageSortField",
+          "description": "Field you can sort Editorial Pages by",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "CREATED_AT",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NAME",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SLUG",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UPDATED_AT",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EditorialPageForAdminConnection",
+          "description": "The connection type for EditorialPageForAdmin.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EditorialPageForAdminEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EditorialPageForAdmin",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EditorialPageForAdminEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EditorialPageForAdmin",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -29612,13 +33105,13 @@
           "interfaces": null,
           "enumValues": [
             {
-              "name": "BLEND",
+              "name": "CF",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "CF",
+              "name": "LDA",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -29642,6 +33135,18 @@
           "enumValues": [
             {
               "name": "BACKINGS",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "PROJECT",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TASTE_PROFILE_DISLIKES",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -30337,6 +33842,29 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "UsdType",
+          "description": "Informs how USD currencies should be rendered, based on user's location",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "domestic",
+              "description": "The user has chosen USD as their currency and they are in the US",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "international",
+              "description": "The user has chosen USD as their currency but they are not in the US",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "Mutation",
           "description": "The mutation root of the Kickstarter GraphQL interface",
@@ -30369,6 +33897,33 @@
               "deprecationReason": null
             },
             {
+              "name": "acceptOrRejectAddressSuggestion",
+              "description": "Updates an address if the user rejects or accepts a suggestion",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "AcceptOrRejectAddressSuggestionInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AcceptOrRejectAddressSuggestionPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "activatePrelaunch",
               "description": "Activates the prelaunch page for a project",
               "args": [
@@ -30390,6 +33945,33 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "ActivateProjectPrelaunchPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "answerProjectFeedbackQuestion",
+              "description": "Updates the toggle-able options of the spreadsheet graph",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "AnswerProjectFeedbackQuestionInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AnswerProjectFeedbackQuestionPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -30444,6 +34026,33 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "AttachThankYouMediaPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "batchUpdateSurveyResponseAddresses",
+              "description": "Batch updates addresses for users's active survey responses",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "BatchUpdateSurveyResponseAddressesInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "BatchUpdateSurveyResponseAddressesPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -30666,6 +34275,33 @@
               "deprecationReason": null
             },
             {
+              "name": "createAddress",
+              "description": "Save a new shipping address.",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreateAddressInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CreateAddressPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "createApplePayBacking",
               "description": "[DEPRECATED in favor of CreateBackingType] Create a checkout with Apple Pay.",
               "args": [
@@ -30741,6 +34377,33 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "CreateBackingPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createBackingWithoutSync",
+              "description": "Create a backing and checkout without syncing to Rosie",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreateBackingWithoutSyncInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CreateBackingWithoutSyncPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -31098,6 +34761,33 @@
               "deprecationReason": null
             },
             {
+              "name": "createJapanAdditionalOwner",
+              "description": "Registers an AdditionalOwner in Japan with a given DepositAccount",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreateJapanAdditionalOwnerInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CreateJapanAdditionalOwnerPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "createNewsletterSignup",
               "description": "Create a newsletter signup.",
               "args": [
@@ -31260,6 +34950,33 @@
               "deprecationReason": null
             },
             {
+              "name": "createProjectUpdateRequest",
+              "description": "",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreateProjectUpdateRequestInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CreateProjectUpdateRequestPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "createProjectVideo",
               "description": "Create a project video.",
               "args": [
@@ -31362,6 +35079,60 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "CreateSheetForProjectPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createTrackEvent",
+              "description": "Creates a track event",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreateTrackEventInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CreateTrackEventPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createUser",
+              "description": "Creates a new registered user",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreateUserInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CreateUserPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -31524,6 +35295,33 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "DeleteAdditionalOwnersPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deleteAddress",
+              "description": "Deletes an address",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "DeleteAddressInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "DeleteAddressPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -32448,6 +36246,33 @@
               "deprecationReason": null
             },
             {
+              "name": "refreshSpreadsheetData",
+              "description": "Refreshes the spreadsheet data from the sheet",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "RefreshSpreadsheetDataInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RefreshSpreadsheetDataPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "registerDripDevice",
               "description": "Register a mobile device on Drip. Requires the user to be authenticated. Idempotent.",
               "args": [
@@ -32712,6 +36537,33 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "SetProjectSlugPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setProjectStatus",
+              "description": "Updates the project status",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "SetProjectStatusInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SetProjectStatusPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -33771,6 +37623,33 @@
               "deprecationReason": null
             },
             {
+              "name": "updateProjectVerifiedCreatorName",
+              "description": "",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdateProjectVerifiedCreatorNameInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UpdateProjectVerifiedCreatorNamePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "updateReward",
               "description": "Update a reward on a Kickstarter project.",
               "args": [
@@ -33819,6 +37698,33 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "UpdateRewardItemPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updateSpreadsheetToggles",
+              "description": "Updates the toggle-able options of the spreadsheet graph",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdateSpreadsheetTogglesInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UpdateSpreadsheetTogglesPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -33934,7 +37840,7 @@
             },
             {
               "name": "updateUserSetting",
-              "description": "Create confirmed_watch_notice user setting",
+              "description": "Creates a valid user setting",
               "args": [
                 {
                   "name": "input",
@@ -33954,33 +37860,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "UpdateUserSettingPayload",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "updateVizNotificationUserSetting",
-              "description": "Update user's viz_notification usersetting",
-              "args": [
-                {
-                  "name": "input",
-                  "description": "",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "UpdateVizNotificationUserSettingInput",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "UpdateVizNotificationUserSettingPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -34118,6 +37997,94 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "AcceptOrRejectAddressSuggestionInput",
+          "description": "Autogenerated input type of AcceptOrRejectAddressSuggestion",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "fulfillmentAddressId",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "suggestionAccepted",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AcceptOrRejectAddressSuggestionPayload",
+          "description": "Autogenerated return type of AcceptOrRejectAddressSuggestion",
+          "fields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "success",
+              "description": "True if address was successfully updated",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "ActivateProjectPrelaunchInput",
           "description": "Autogenerated input type of ActivateProjectPrelaunch",
           "fields": null,
@@ -34175,6 +38142,141 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Project",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AnswerProjectFeedbackQuestionInput",
+          "description": "Autogenerated input type of AnswerProjectFeedbackQuestion",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "location",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProjectFeedbackLocation",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "questionAnswer",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "questionName",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ProjectFeedbackLocation",
+          "description": "",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "backed_projects",
+              "description": "Project Feedback from the Backed Projects user profile page",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "project_header",
+              "description": "Project Feedback from the backer bar in the project header",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AnswerProjectFeedbackQuestionPayload",
+          "description": "Autogenerated return type of AnswerProjectFeedbackQuestion",
+          "fields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feedback",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectFeedback",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -34348,6 +38450,88 @@
                 "kind": "UNION",
                 "name": "AttachedMedia",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "BatchUpdateSurveyResponseAddressesInput",
+          "description": "Autogenerated input type of BatchUpdateSurveyResponseAddresses",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "fulfillmentAddressId",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "BatchUpdateSurveyResponseAddressesPayload",
+          "description": "Autogenerated return type of BatchUpdateSurveyResponseAddresses",
+          "fields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedSurveyResponses",
+              "description": "List of SurveyResponses that were successfully updated",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "SurveyResponse",
+                      "ofType": null
+                    }
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -34911,22 +39095,67 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "address",
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "identity",
               "description": "",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "AddressInput",
+                  "name": "IdentityInput",
                   "ofType": null
                 }
               },
               "defaultValue": null
             },
             {
-              "name": "birthdate",
+              "name": "projectId",
               "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "role",
+              "description": "",
+              "type": {
+                "kind": "ENUM",
+                "name": "DepositAccountRole",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "IdentityInput",
+          "description": "An identity's information.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "birthdate",
+              "description": "The birthdate for this identity",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -34939,38 +39168,8 @@
               "defaultValue": null
             },
             {
-              "name": "clientMutationId",
-              "description": "A unique identifier for the client performing the mutation.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "document",
-              "description": "",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "documentBack",
-              "description": "",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
               "name": "firstName",
-              "description": "",
+              "description": "The first name for this identity",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -34984,7 +39183,7 @@
             },
             {
               "name": "lastName",
-              "description": "",
+              "description": "The last name for this identity",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -34997,8 +39196,8 @@
               "defaultValue": null
             },
             {
-              "name": "personalIdNumber",
-              "description": "",
+              "name": "nationalId",
+              "description": "The number of a personal identity document",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -35007,14 +39206,77 @@
               "defaultValue": null
             },
             {
-              "name": "projectId",
-              "description": "",
+              "name": "secondLastName",
+              "description": "The second last name for this identity - Mexico",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "streetAddress",
+              "description": "The address for this identity",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AddressInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "BirthdateInput",
+          "description": "A representation of a birthdate.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "day",
+              "description": "The birthdate's day",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "ID",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "month",
+              "description": "The birthdate's month",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "year",
+              "description": "The birthdate's year",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
                   "ofType": null
                 }
               },
@@ -35105,56 +39367,32 @@
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "BirthdateInput",
-          "description": "A representation of a birthdate.",
+          "kind": "ENUM",
+          "name": "DepositAccountRole",
+          "description": "The role that the account opener plays in a legal entity that has created a project",
           "fields": null,
-          "inputFields": [
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
             {
-              "name": "day",
-              "description": "The birthdate's day",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
+              "name": "director",
+              "description": "A member of the governing board of the company or responsible for ensuring the company meets its regulatory obligations.",
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "name": "month",
-              "description": "The birthdate's month",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
+              "name": "executive",
+              "description": "An executive, senior manager or someone who otherwise has significant\nresponsibility for the control and management of the business.",
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "name": "year",
-              "description": "The birthdate's year",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
+              "name": "owner",
+              "description": "An individual who owns 25% or more of the company.",
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
           "possibleTypes": null
         },
         {
@@ -35190,6 +39428,251 @@
           "inputFields": null,
           "interfaces": [],
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CreateAddressInput",
+          "description": "Autogenerated input type of CreateAddress",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "addressLine1",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressLine2",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "city",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "countryCode",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CountryCode",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "phoneNumber",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "postalCode",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "recipientName",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "referenceName",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "region",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CreateAddressPayload",
+          "description": "Autogenerated return type of CreateAddress",
+          "fields": [
+            {
+              "name": "address",
+              "description": "Address that was created",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Address",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "suggestedAddress",
+              "description": "Address suggestion",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Address",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "validationStatus",
+              "description": "Validation status for created address",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ValidationStatus",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ValidationStatus",
+          "description": "Status returned from an address validation",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "error",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "exact",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "not_found",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "suggestion",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -35704,13 +40187,9 @@
               "name": "googleTransactionId",
               "description": "",
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null
             },
@@ -35765,6 +40244,106 @@
           "kind": "OBJECT",
           "name": "CreateBackingPayload",
           "description": "Autogenerated return type of CreateBacking",
+          "fields": [
+            {
+              "name": "checkout",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Checkout",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CreateBackingWithoutSyncInput",
+          "description": "Autogenerated input type of CreateBackingWithoutSync",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "amount",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "locationId",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectId",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "rewardId",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CreateBackingWithoutSyncPayload",
+          "description": "Autogenerated return type of CreateBackingWithoutSync",
           "fields": [
             {
               "name": "checkout",
@@ -36735,8 +41314,20 @@
           "interfaces": null,
           "enumValues": [
             {
+              "name": "Article",
+              "description": "Article",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "BespokeComponent",
               "description": "BespokeComponent",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ExploreSubcategories",
+              "description": "ExploreSubcategories",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -36779,6 +41370,12 @@
             {
               "name": "PromoCollection",
               "description": "PromoCollection",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ShortText",
+              "description": "ShortText",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -37186,13 +41783,9 @@
               "name": "googleTransactionId",
               "description": "",
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null
             },
@@ -37342,9 +41935,13 @@
               "name": "foreignKey",
               "description": "",
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "defaultValue": null
             },
@@ -37369,16 +41966,6 @@
                   "name": "ID",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "v4Enabled",
-              "description": "",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
               },
               "defaultValue": null
             }
@@ -37428,6 +42015,431 @@
                   "name": "Boolean",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CreateJapanAdditionalOwnerInput",
+          "description": "Autogenerated input type of CreateJapanAdditionalOwner",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "identity",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "JapanIdentityInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectId",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "role",
+              "description": "",
+              "type": {
+                "kind": "ENUM",
+                "name": "DepositAccountRole",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "JapanIdentityInput",
+          "description": "An identity's information for Japan.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "birthdate",
+              "description": "The birthdate for this identity",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BirthdateInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "firstName",
+              "description": "The first name for this identity",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "firstNameKana",
+              "description": "The first name for this identity in Kana",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "firstNameKanji",
+              "description": "The first name for this identity in Kanji",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "gender",
+              "description": "The gender for this identity",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "JapanIdentityGender",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lastName",
+              "description": "The last name for this identity",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lastNameKana",
+              "description": "The last name for this identity in Kana",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lastNameKanji",
+              "description": "The last name for this identity in Kanji",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "streetAddress",
+              "description": "The address for this identity",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "JapanAddressInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "JapanIdentityGender",
+          "description": "The gender in which an individual has identified as",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "female",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "male",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "JapanAddressInput",
+          "description": "A physical address for Japan.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "addressKanaCity",
+              "description": "City/Ward of the address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressKanaLine1",
+              "description": "First line of the street address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressKanaLine2",
+              "description": "Second line of the street address",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressKanaPostalCode",
+              "description": "Postal code of the address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressKanaState",
+              "description": "Prefecture of the address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressKanaTown",
+              "description": "Town of the address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressKanjiCity",
+              "description": "City/Ward of the address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressKanjiLine1",
+              "description": "First line of the street address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressKanjiLine2",
+              "description": "Second line of the street address",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressKanjiPostalCode",
+              "description": "Postal code of the address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressKanjiState",
+              "description": "Prefecture of the address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressKanjiTown",
+              "description": "Town of the address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CreateJapanAdditionalOwnerPayload",
+          "description": "Autogenerated return type of CreateJapanAdditionalOwner",
+          "fields": [
+            {
+              "name": "additionalOwner",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AdditionalOwner",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -38131,6 +43143,123 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "CreateProjectUpdateRequestInput",
+          "description": "Autogenerated input type of CreateProjectUpdateRequest",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "location",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProjectUpdateRequestLocation",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectId",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ProjectUpdateRequestLocation",
+          "description": "",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "backer_bar",
+              "description": "Project Update Request from the Backer Bar flow",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "comment",
+              "description": "Project Update Request from the inline prompt on a comment",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updates",
+              "description": "Project Update Request from the prompt at the top of Project Updates",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CreateProjectUpdateRequestPayload",
+          "description": "Autogenerated return type of CreateProjectUpdateRequest",
+          "fields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "project",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Project",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "CreateProjectVideoInput",
           "description": "Autogenerated input type of CreateProjectVideo",
           "fields": null,
@@ -38382,6 +43511,16 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "rewardType",
+              "description": "",
+              "type": {
+                "kind": "ENUM",
+                "name": "RewardType",
+                "ofType": null
               },
               "defaultValue": null
             },
@@ -38724,6 +43863,292 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "spreadsheetData",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SpreadsheetDatum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CreateTrackEventInput",
+          "description": "Autogenerated input type of CreateTrackEvent",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "eventName",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "eventProperties",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CreateTrackEventPayload",
+          "description": "Autogenerated return type of CreateTrackEvent",
+          "fields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "successful",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CreateUserInput",
+          "description": "Autogenerated input type of CreateUser",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "checkoutId",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "email",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "emailConfirmation",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "n",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "optIntoNewsletters",
+              "description": "If the user agrees to opt into weekly newsletters",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "optIntoUserResearch",
+              "description": "If the user agrees to opt into receiving surveys for user research",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "password",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectPid",
+              "description": "Supply if creating an account via backing flow -- used for tracking purposes",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "recaptchaV2Token",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "recaptchaV3Token",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CreateUserPayload",
+          "description": "Autogenerated return type of CreateUser",
+          "fields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "user",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -39193,6 +44618,80 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "DeleteAddressInput",
+          "description": "Autogenerated input type of DeleteAddress",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "fulfillmentAddressId",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DeleteAddressPayload",
+          "description": "Autogenerated return type of DeleteAddress",
+          "fields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "success",
+              "description": "Success if address was deleted successfully",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "DeleteAssetInput",
           "description": "Autogenerated input type of DeleteAsset",
           "fields": null,
@@ -39312,8 +44811,46 @@
               "kind": "OBJECT",
               "name": "Project",
               "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Survey",
+              "ofType": null
             }
           ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Survey",
+          "description": "A survey",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -40294,6 +45831,16 @@
                 }
               },
               "defaultValue": null
+            },
+            {
+              "name": "trackingContext",
+              "description": "The context or page that the user disliked this project from. Used for tracking",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
@@ -40918,6 +46465,16 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "trackingContext",
+              "description": "The context or page that the user liked this project from. Used for tracking",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null
             }
@@ -41812,6 +47369,76 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "DropPost",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "RefreshSpreadsheetDataInput",
+          "description": "Autogenerated input type of RefreshSpreadsheetData",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RefreshSpreadsheetDataPayload",
+          "description": "Autogenerated return type of RefreshSpreadsheetData",
+          "fields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "spreadsheet",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Spreadsheet",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -42825,6 +48452,118 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "SetProjectStatusInput",
+          "description": "Autogenerated input type of SetProjectStatus",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "nextDueDate",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "nextStatus",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "nowStatus",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectId",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SetProjectStatusPayload",
+          "description": "Autogenerated return type of SetProjectStatus",
+          "fields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectStatus",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectStatus",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "StartDropPostInput",
           "description": "Autogenerated input type of StartDropPost",
           "fields": null,
@@ -43081,93 +48820,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "IdentityInput",
-          "description": "An identity's information.",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "birthdate",
-              "description": "The birthdate for this identity",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "BirthdateInput",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "firstName",
-              "description": "The first name for this identity",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lastName",
-              "description": "The last name for this identity",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "nationalId",
-              "description": "The number of a personal identity document",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "secondLastName",
-              "description": "The second last name for this identity - Mexico",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "streetAddress",
-              "description": "The address for this identity",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "AddressInput",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "SubmitDripIdentityPayload",
           "description": "Autogenerated return type of SubmitDripIdentity",
@@ -43351,10 +49003,43 @@
                 }
               },
               "defaultValue": null
+            },
+            {
+              "name": "role",
+              "description": "",
+              "type": {
+                "kind": "ENUM",
+                "name": "DepositAccountOpenerRole",
+                "ofType": null
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "DepositAccountOpenerRole",
+          "description": "The role that the account opener plays in a legal entity that has created a project",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "executive",
+              "description": "An executive, senior manager or someone who otherwise has significant\nresponsibility for the control and management of the business.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "owner",
+              "description": "An individual who owns 25% or more of the company.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -43512,337 +49197,6 @@
             {
               "name": "taxId",
               "description": "The legal entity's tax ID",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "JapanIdentityInput",
-          "description": "An identity's information for Japan.",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "birthdate",
-              "description": "The birthdate for this identity",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "BirthdateInput",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "firstName",
-              "description": "The first name for this identity",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "firstNameKana",
-              "description": "The first name for this identity in Kana",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "firstNameKanji",
-              "description": "The first name for this identity in Kanji",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "gender",
-              "description": "The gender for this identity",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "JapanIdentityGender",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lastName",
-              "description": "The last name for this identity",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lastNameKana",
-              "description": "The last name for this identity in Kana",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lastNameKanji",
-              "description": "The last name for this identity in Kanji",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "streetAddress",
-              "description": "The address for this identity",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "JapanAddressInput",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "JapanIdentityGender",
-          "description": "The gender in which an individual has identified as",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "female",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "male",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "JapanAddressInput",
-          "description": "A physical address for Japan.",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "addressKanaCity",
-              "description": "City/Ward of the address",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "addressKanaLine1",
-              "description": "First line of the street address",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "addressKanaLine2",
-              "description": "Second line of the street address",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "addressKanaPostalCode",
-              "description": "Postal code of the address",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "addressKanaState",
-              "description": "Prefecture of the address",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "addressKanaTown",
-              "description": "Town of the address",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "addressKanjiCity",
-              "description": "City/Ward of the address",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "addressKanjiLine1",
-              "description": "First line of the street address",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "addressKanjiLine2",
-              "description": "Second line of the street address",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "addressKanjiPostalCode",
-              "description": "Postal code of the address",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "addressKanjiState",
-              "description": "Prefecture of the address",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "addressKanjiTown",
-              "description": "Town of the address",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -44469,6 +49823,16 @@
                 }
               },
               "defaultValue": null
+            },
+            {
+              "name": "trackingContext",
+              "description": "The context or page that the user undisliked this project from. Used for tracking",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
@@ -44759,6 +50123,16 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "trackingContext",
+              "description": "The context or page that the user unliked this project from. Used for tracking",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null
             }
@@ -45227,7 +50601,7 @@
               "description": "",
               "type": {
                 "kind": "SCALAR",
-                "name": "ID",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null
@@ -45305,26 +50679,6 @@
               "defaultValue": null
             },
             {
-              "name": "address",
-              "description": "",
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "AddressInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "birthdate",
-              "description": "",
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "BirthdateInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
               "type": {
@@ -45346,36 +50700,6 @@
             },
             {
               "name": "documentBack",
-              "description": "",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "firstName",
-              "description": "",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lastName",
-              "description": "",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "personalIdNumber",
               "description": "",
               "type": {
                 "kind": "SCALAR",
@@ -47181,6 +52505,24 @@
               "defaultValue": null
             },
             {
+              "name": "projectSummary",
+              "description": "",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectSummaryInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
               "name": "risks",
               "description": "",
               "type": {
@@ -47258,6 +52600,45 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ProjectSummaryInput",
+          "description": "A summary for a project.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "question",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProjectSummaryQuestion",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "response",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -47513,6 +52894,94 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "UpdateProjectVerifiedCreatorNameInput",
+          "description": "Autogenerated input type of UpdateProjectVerifiedCreatorName",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UpdateProjectVerifiedCreatorNamePayload",
+          "description": "Autogenerated return type of UpdateProjectVerifiedCreatorName",
+          "fields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "project",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Project",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "UpdateRewardInput",
           "description": "Autogenerated input type of UpdateReward",
           "fields": null,
@@ -47611,6 +53080,16 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "rewardType",
+              "description": "",
+              "type": {
+                "kind": "ENUM",
+                "name": "RewardType",
                 "ofType": null
               },
               "defaultValue": null
@@ -47768,6 +53247,96 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "RewardItem",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdateSpreadsheetTogglesInput",
+          "description": "Autogenerated input type of UpdateSpreadsheetToggles",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "displayMode",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "public",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UpdateSpreadsheetTogglesPayload",
+          "description": "Autogenerated return type of UpdateSpreadsheetToggles",
+          "fields": [
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "spreadsheet",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Spreadsheet",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -48191,10 +53760,95 @@
                 "ofType": null
               },
               "defaultValue": null
+            },
+            {
+              "name": "setting",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "UserSetting",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "UserSetting",
+          "description": "Possible user settings",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "confirmed_signal_notice",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "confirmed_watch_notice",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dismissed_pyl_toast",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dismissed_taste_profile_toast",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "manual_play_videos",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "opt_in_ksr_research",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "opted_out_of_recommendations",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "show_public_profile",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "superbacker_not_visible",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "viz_notification",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -48221,72 +53875,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "User",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "UpdateVizNotificationUserSettingInput",
-          "description": "Autogenerated input type of UpdateVizNotificationUserSetting",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "clientMutationId",
-              "description": "A unique identifier for the client performing the mutation.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "value",
-              "description": "",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "UpdateVizNotificationUserSettingPayload",
-          "description": "Autogenerated return type of UpdateVizNotificationUserSetting",
-          "fields": [
-            {
-              "name": "clientMutationId",
-              "description": "A unique identifier for the client performing the mutation.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "vizNotification",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -38,6 +38,7 @@ import com.kickstarter.libs.Logout;
 import com.kickstarter.libs.OptimizelyExperimentsClient;
 import com.kickstarter.libs.PushNotifications;
 import com.kickstarter.libs.graphql.DateAdapter;
+import com.kickstarter.libs.graphql.DateTimeAdapter;
 import com.kickstarter.libs.graphql.EmailAdapter;
 import com.kickstarter.libs.preferences.BooleanPreference;
 import com.kickstarter.libs.preferences.BooleanPreferenceType;
@@ -188,6 +189,7 @@ public final class ApplicationModule {
     return ApolloClient.builder()
       .addCustomTypeAdapter(CustomType.DATE, new DateAdapter())
       .addCustomTypeAdapter(CustomType.EMAIL, new EmailAdapter())
+      .addCustomTypeAdapter(CustomType.ISO8601DATETIME, new DateTimeAdapter())
       .serverUrl(webEndpoint + "/graph")
       .okHttpClient(okHttpClient)
       .build();

--- a/app/src/main/java/com/kickstarter/libs/graphql/DateTimeAdapter.kt
+++ b/app/src/main/java/com/kickstarter/libs/graphql/DateTimeAdapter.kt
@@ -1,0 +1,21 @@
+package com.kickstarter.libs.graphql
+
+import com.apollographql.apollo.response.CustomTypeAdapter
+import com.apollographql.apollo.response.CustomTypeValue
+import org.joda.time.DateTime
+import java.text.ParseException
+
+class DateTimeAdapter: CustomTypeAdapter<DateTime> {
+
+    override fun encode(value: DateTime): CustomTypeValue<*> {
+        return CustomTypeValue.GraphQLString(value.toString())
+    }
+
+    override fun decode(value: CustomTypeValue<*>): DateTime {
+        try {
+            return DateTime.parse(value.value.toString())
+        } catch (exception: ParseException) {
+            throw RuntimeException(exception)
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/libs/utils/BackingUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/BackingUtils.java
@@ -24,6 +24,13 @@ public final class BackingUtils {
     return rewardId == reward.id();
   }
 
+  public static boolean isErrored(final @Nullable Backing backing) {
+    if (backing == null) {
+      return false;
+    }
+    return backing.status().equals(Backing.STATUS_ERRORED);
+  }
+
   public static boolean isShippable(final @NonNull Backing backing) {
     final Reward reward = backing.reward();
     if (reward == null) {

--- a/app/src/main/java/com/kickstarter/libs/utils/ProjectViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/ProjectViewUtils.kt
@@ -28,7 +28,10 @@ object ProjectViewUtils {
         return if (project.isBacking && project.isLive) {
             R.color.button_pledge_manage
         } else if (!project.isLive || project.creator().id() == currentUser?.id()) {
-            R.color.button_pledge_ended
+            when {
+                BackingUtils.isErrored(project.backing()) -> R.color.button_pledge_error
+                else -> R.color.button_pledge_ended
+            }
         } else {
             R.color.button_pledge_live
         }
@@ -50,7 +53,10 @@ object ProjectViewUtils {
         } else if (project.isBacking && project.isLive) {
             R.string.Manage
         } else if (project.isBacking && !project.isLive) {
-            R.string.View_your_pledge
+            when {
+                BackingUtils.isErrored(project.backing()) -> R.string.Manage
+                else -> R.string.View_your_pledge
+            }
         } else {
             R.string.View_rewards
         }

--- a/app/src/main/java/com/kickstarter/mock/factories/ErroredBackingFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/ErroredBackingFactory.kt
@@ -1,0 +1,18 @@
+package com.kickstarter.mock.factories
+
+import com.kickstarter.models.ErroredBacking
+import org.joda.time.DateTime
+
+class ErroredBackingFactory private constructor() {
+    companion object {
+        fun erroredBacking(): ErroredBacking {
+            return ErroredBacking.builder()
+                    .project(ErroredBacking.Project.builder()
+                            .finalCollectionDate(DateTime.parse("2020-04-02T18:08:32Z"))
+                            .name("Some Project Name")
+                            .slug("slug")
+                            .build())
+                    .build()
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -46,6 +46,10 @@ open class MockApolloClient : ApolloClientType {
         return Observable.just(DeletePaymentSourceMutation.Data(DeletePaymentSourceMutation.PaymentSourceDelete("", "")))
     }
 
+    override fun erroredBackings(): Observable<List<ErroredBacking>> {
+        return Observable.empty()
+    }
+
     override fun getStoredCards(): Observable<List<StoredCard>> {
         return Observable.just(Collections.singletonList(StoredCardFactory.discoverCard()))
     }

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -9,6 +9,7 @@ import UpdateUserPasswordMutation
 import UserPrivacyQuery
 import com.kickstarter.mock.factories.CheckoutFactory
 import com.kickstarter.mock.factories.CreatorDetailsFactory
+import com.kickstarter.mock.factories.ErroredBackingFactory
 import com.kickstarter.mock.factories.StoredCardFactory
 import com.kickstarter.models.*
 import com.kickstarter.services.ApolloClientType
@@ -47,7 +48,7 @@ open class MockApolloClient : ApolloClientType {
     }
 
     override fun erroredBackings(): Observable<List<ErroredBacking>> {
-        return Observable.empty()
+        return Observable.just(Collections.singletonList(ErroredBackingFactory.erroredBacking()))
     }
 
     override fun getStoredCards(): Observable<List<StoredCard>> {

--- a/app/src/main/java/com/kickstarter/models/ErroredBacking.kt
+++ b/app/src/main/java/com/kickstarter/models/ErroredBacking.kt
@@ -1,0 +1,52 @@
+package com.kickstarter.models
+
+import android.os.Parcelable
+import auto.parcel.AutoParcel
+import org.joda.time.DateTime
+
+@AutoParcel
+abstract class ErroredBacking : Parcelable {
+    abstract fun project(): Project
+
+    @AutoParcel.Builder
+    abstract class Builder {
+        abstract fun project(project: Project): Builder
+        abstract fun build(): ErroredBacking
+    }
+
+    abstract fun toBuilder(): Builder
+
+    companion object {
+
+        fun builder(): Builder {
+            return AutoParcel_ErroredBacking.Builder()
+        }
+    }
+
+    @AutoParcel
+    abstract class Project : Parcelable {
+
+        abstract fun finalCollectionDate(): DateTime
+        abstract fun name(): String
+        abstract fun slug(): String
+
+        @AutoParcel.Builder
+        abstract class Builder {
+            abstract fun finalCollectionDate(finalCollectionDate: DateTime?): Builder
+            abstract fun name(name: String?): Builder
+            abstract fun slug(slug: String?): Builder
+            abstract fun build(): Project
+        }
+
+        abstract fun toBuilder(): Builder
+
+        companion object {
+
+            fun builder(): Builder {
+                return AutoParcel_ErroredBacking_Project.Builder()
+            }
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
+++ b/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
@@ -27,6 +27,8 @@ interface ApolloClientType {
 
     fun deletePaymentSource(paymentSourceId: String): Observable<DeletePaymentSourceMutation.Data>
 
+    fun erroredBackings(): Observable<List<ErroredBacking>>
+
     fun getStoredCards(): Observable<List<StoredCard>>
 
     fun savePaymentMethod(savePaymentMethodData: SavePaymentMethodData): Observable<StoredCard>

--- a/app/src/main/java/com/kickstarter/ui/IntentKey.java
+++ b/app/src/main/java/com/kickstarter/ui/IntentKey.java
@@ -13,6 +13,7 @@ public final class IntentKey {
   public static final String DISCOVERY_PARAMS = "com.kickstarter.kickstarter.intent_discovery_params";
   public static final String EDITORIAL = "com.kickstarter.kickstarter.intent_editorial";
   public static final String EMAIL = "com.kickstarter.kickstarter.intent_email";
+  public static final String EXPAND_PLEDGE_SHEET = "com.kickstarter.kickstarter.intent_expand_pledge_sheet";
   public static final String FACEBOOK_LOGIN = "com.kickstarter.kickstarter.intent_facebook_login";
   public static final String FACEBOOK_TOKEN = "com.kickstarter.kickstarter.intent_facebook_token";
   public static final String FACEBOOK_USER = "com.kickstarter.kickstarter.intent_facebook_user";

--- a/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
@@ -156,6 +156,7 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
   private void startFixPledge(final @NonNull String projectSlug) {
     final Intent intent = new Intent(this, ProjectActivity.class)
       .putExtra(IntentKey.PROJECT_PARAM, projectSlug)
+      .putExtra(IntentKey.EXPAND_PLEDGE_SHEET, true)
       .putExtra(IntentKey.REF_TAG, RefTag.activity());
     startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }

--- a/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.java
@@ -14,6 +14,7 @@ import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
 import com.kickstarter.libs.utils.ApplicationUtils;
 import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.models.Activity;
+import com.kickstarter.models.ErroredBacking;
 import com.kickstarter.models.Project;
 import com.kickstarter.models.SurveyResponse;
 import com.kickstarter.ui.IntentKey;
@@ -71,6 +72,11 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
       .compose(observeForUI())
       .subscribe(this::showActivities);
 
+    this.viewModel.outputs.erroredBackings()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(this::showErroredBackings);
+
     this.viewModel.outputs.goToDiscovery()
       .compose(bindToLifecycle())
       .compose(observeForUI())
@@ -85,6 +91,11 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(this::startProjectActivity);
+
+    this.viewModel.outputs.startFixPledge()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(this::startFixPledge);
 
     this.viewModel.outputs.startUpdateActivity()
       .compose(bindToLifecycle())
@@ -124,6 +135,10 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
     this.adapter.takeActivities(activities);
   }
 
+  private void showErroredBackings(final @NonNull List<ErroredBacking> erroredBackings) {
+    this.adapter.takeErroredBackings(erroredBackings);
+  }
+
   private void showSurveys(final @NonNull List<SurveyResponse> surveyResponses) {
     this.adapter.takeSurveys(surveyResponses);
   }
@@ -136,6 +151,13 @@ public final class ActivityFeedActivity extends BaseActivity<ActivityFeedViewMod
     final Intent intent = new Intent(this, LoginToutActivity.class)
       .putExtra(IntentKey.LOGIN_REASON, LoginReason.ACTIVITY_FEED);
     startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW);
+  }
+
+  private void startFixPledge(final @NonNull String projectSlug) {
+    final Intent intent = new Intent(this, ProjectActivity.class)
+      .putExtra(IntentKey.PROJECT_PARAM, projectSlug)
+      .putExtra(IntentKey.REF_TAG, RefTag.activity());
+    startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left);
   }
 
   private void startProjectActivity(final @NonNull Project project) {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -320,6 +320,10 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         this.viewModel.inputs.refreshProject()
     }
 
+    override fun showFixPaymentMethod() {
+        this.viewModel.inputs.fixPaymentMethodButtonClicked()
+    }
+
     override fun onNetworkConnectionChanged(isConnected: Boolean) {}
 
     override fun exitTransition(): Pair<Int, Int>? {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -14,6 +14,7 @@ import android.view.ViewTreeObserver
 import android.widget.EditText
 import android.widget.LinearLayout
 import androidx.annotation.MenuRes
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentManager
@@ -22,10 +23,7 @@ import com.crashlytics.android.Crashlytics
 import com.kickstarter.R
 import com.kickstarter.extensions.hideKeyboard
 import com.kickstarter.extensions.showSnackbar
-import com.kickstarter.libs.ActivityRequestCodes
-import com.kickstarter.libs.BaseActivity
-import com.kickstarter.libs.KSString
-import com.kickstarter.libs.KoalaContext
+import com.kickstarter.libs.*
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ApplicationUtils
@@ -88,10 +86,15 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         project_recycler_view.adapter = this.adapter
         project_recycler_view.layoutManager = LinearLayoutManager(this)
 
-        this.viewModel.outputs.backingDetails()
+        this.viewModel.outputs.backingDetailsSubtitle()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { reward_infos.text = it }
+                .subscribe { setBackingDetailsSubtitle(it) }
+
+        this.viewModel.outputs.backingDetailsTitle()
+                .compose(bindToLifecycle())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe { backing_details_title.setText(it) }
 
         this.viewModel.outputs.backingDetailsIsVisible()
                 .compose(bindToLifecycle())
@@ -459,6 +462,14 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
     private fun rewardsFragment() = supportFragmentManager.findFragmentById(R.id.fragment_rewards) as RewardsFragment?
 
     private fun rewardsSheetGuideline(): Int = resources.getDimensionPixelSize(R.dimen.reward_fragment_guideline_constraint_end)
+
+    private fun setBackingDetailsSubtitle(stringResOrTitle: Either<String, Int>?) {
+        stringResOrTitle?.let { either ->
+            @StringRes val stringRes = either.right()
+            val title = either.left()
+            backing_details_subtitle.text = stringRes?.let { getString(it) }?: title
+        }
+    }
 
     private fun setClickListeners() {
         pledge_action_button.setOnClickListener {

--- a/app/src/main/java/com/kickstarter/ui/adapters/ActivityFeedAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/ActivityFeedAdapter.java
@@ -5,9 +5,11 @@ import android.view.View;
 import com.kickstarter.R;
 import com.kickstarter.libs.utils.ListUtils;
 import com.kickstarter.models.Activity;
+import com.kickstarter.models.ErroredBacking;
 import com.kickstarter.models.SurveyResponse;
 import com.kickstarter.ui.viewholders.EmptyActivityFeedViewHolder;
 import com.kickstarter.ui.viewholders.EmptyViewHolder;
+import com.kickstarter.ui.viewholders.ErroredBackingViewHolder;
 import com.kickstarter.ui.viewholders.FriendBackingViewHolder;
 import com.kickstarter.ui.viewholders.FriendFollowViewHolder;
 import com.kickstarter.ui.viewholders.KSViewHolder;
@@ -27,20 +29,29 @@ import androidx.annotation.Nullable;
 public final class ActivityFeedAdapter extends KSAdapter {
   private static final int SECTION_LOGGED_IN_EMPTY_VIEW = 0;
   private static final int SECTION_LOGGED_OUT_EMPTY_VIEW = 1;
-  private static final int SECTION_SURVEYS_HEADER_VIEW = 2;
-  private static final int SECTION_SURVEYS_VIEW = 3;
-  private static final int SECTION_ACTIVITIES_VIEW = 4;
+  private static final int SECTION_ERRORED_BACKINGS_HEADER_VIEW = 2;
+  private static final int SECTION_ERRORED_BACKINGS_VIEW = 3;
+  private static final int SECTION_SURVEYS_HEADER_VIEW = 4;
+  private static final int SECTION_SURVEYS_VIEW = 5;
+  private static final int SECTION_ACTIVITIES_VIEW = 6;
 
   private final @Nullable Delegate delegate;
 
-  public interface Delegate extends FriendBackingViewHolder.Delegate, ProjectStateChangedPositiveViewHolder.Delegate,
-    ProjectStateChangedViewHolder.Delegate, ProjectUpdateViewHolder.Delegate, EmptyActivityFeedViewHolder.Delegate {}
+  public interface Delegate extends
+    ErroredBackingViewHolder.Delegate,
+    FriendBackingViewHolder.Delegate,
+    ProjectStateChangedPositiveViewHolder.Delegate,
+    ProjectStateChangedViewHolder.Delegate,
+    ProjectUpdateViewHolder.Delegate,
+    EmptyActivityFeedViewHolder.Delegate {}
 
   public ActivityFeedAdapter(final @Nullable Delegate delegate) {
     this.delegate = delegate;
 
     insertSection(SECTION_LOGGED_IN_EMPTY_VIEW, Collections.emptyList());
     insertSection(SECTION_LOGGED_OUT_EMPTY_VIEW, Collections.emptyList());
+    insertSection(SECTION_ERRORED_BACKINGS_HEADER_VIEW, Collections.emptyList());
+    insertSection(SECTION_ERRORED_BACKINGS_VIEW, Collections.emptyList());
     insertSection(SECTION_SURVEYS_HEADER_VIEW, Collections.emptyList());
     insertSection(SECTION_SURVEYS_VIEW, Collections.emptyList());
     insertSection(SECTION_ACTIVITIES_VIEW, Collections.emptyList());
@@ -48,6 +59,17 @@ public final class ActivityFeedAdapter extends KSAdapter {
 
   public void takeActivities(final @NonNull List<Activity> activities) {
     setSection(SECTION_ACTIVITIES_VIEW, activities);
+    notifyDataSetChanged();
+  }
+
+  public void takeErroredBackings(final @NonNull List<ErroredBacking> erroredBackings) {
+    if (erroredBackings.isEmpty()) {
+      setSection(SECTION_ERRORED_BACKINGS_HEADER_VIEW, Collections.emptyList());
+      setSection(SECTION_ERRORED_BACKINGS_VIEW, Collections.emptyList());
+    } else {
+      setSection(SECTION_ERRORED_BACKINGS_HEADER_VIEW, Collections.singletonList(erroredBackings.size()));
+      setSection(SECTION_ERRORED_BACKINGS_VIEW, erroredBackings);
+    }
     notifyDataSetChanged();
   }
 
@@ -79,6 +101,10 @@ public final class ActivityFeedAdapter extends KSAdapter {
         return R.layout.empty_activity_feed_view;
       case SECTION_LOGGED_OUT_EMPTY_VIEW:
         return R.layout.empty_activity_feed_view;
+      case SECTION_ERRORED_BACKINGS_HEADER_VIEW:
+        return R.layout.item_header_errored_backings;
+      case SECTION_ERRORED_BACKINGS_VIEW:
+        return R.layout.item_errored_backing;
       case SECTION_SURVEYS_HEADER_VIEW:
         return R.layout.activity_survey_header_view;
       case SECTION_SURVEYS_VIEW:
@@ -130,6 +156,8 @@ public final class ActivityFeedAdapter extends KSAdapter {
         return new ProjectUpdateViewHolder(view, this.delegate);
       case R.layout.empty_activity_feed_view:
         return new EmptyActivityFeedViewHolder(view, this.delegate);
+      case R.layout.item_errored_backing:
+        return new ErroredBackingViewHolder(view, this.delegate);
       default:
         return new EmptyViewHolder(view);
     }

--- a/app/src/main/java/com/kickstarter/ui/data/PledgeReason.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/PledgeReason.kt
@@ -1,5 +1,5 @@
 package com.kickstarter.ui.data
 
 enum class PledgeReason {
-    PLEDGE, UPDATE_PAYMENT, UPDATE_PLEDGE, UPDATE_REWARD
+    FIX_PLEDGE, PLEDGE, UPDATE_PAYMENT, UPDATE_PLEDGE, UPDATE_REWARD
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -34,6 +34,7 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
 
     interface BackingDelegate {
         fun refreshProject()
+        fun showFixPaymentMethod()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -93,6 +94,11 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .subscribe { (activity as BackingDelegate?)?.refreshProject() }
+
+        this.viewModel.outputs.notifyDelegateToShowFixPledge()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe { (activity as BackingDelegate?)?.showFixPaymentMethod() }
 
         this.viewModel.outputs.paymentMethodIsGone()
                 .compose(bindToLifecycle())
@@ -162,6 +168,10 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
         SwipeRefresher(
                 this, backing_swipe_refresh_layout, { this.viewModel.inputs.refreshProject() }, { this.viewModel.outputs.swipeRefresherProgressIsVisible() }
         )
+
+        RxView.clicks(fix_payment_method_button)
+                .compose(bindToLifecycle())
+                .subscribe { this.viewModel.inputs.fixPaymentMethodButtonClicked() }
 
         RxView.clicks(mark_as_received_checkbox)
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -79,6 +79,16 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
                 .compose(Transformers.observeForUI())
                 .subscribe { setCardLastFourText(it) }
 
+        this.viewModel.outputs.fixPaymentMethodButtonIsGone()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe { ViewUtils.setGone(fix_payment_method_button, it) }
+
+        this.viewModel.outputs.fixPaymentMethodButtonIsGone()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe { ViewUtils.setGone(fix_payment_method_message, it) }
+
         this.viewModel.outputs.notifyDelegateToRefreshProject()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ErroredBackingViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ErroredBackingViewHolder.kt
@@ -1,0 +1,62 @@
+package com.kickstarter.ui.viewholders
+
+import android.view.View
+import com.jakewharton.rxbinding.view.RxView
+import com.kickstarter.libs.RelativeDateTimeOptions
+import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
+import com.kickstarter.libs.utils.DateTimeUtils
+import com.kickstarter.libs.utils.ObjectUtils.requireNonNull
+import com.kickstarter.models.ErroredBacking
+import com.kickstarter.viewmodels.ErroredBackingViewHolderViewModel
+import kotlinx.android.synthetic.main.item_errored_backing.view.*
+import org.joda.time.DateTime
+
+class ErroredBackingViewHolder(private val view: View, val delegate: Delegate?) : KSViewHolder(view) {
+
+    interface Delegate {
+        fun managePledgeClicked(projectSlug: String)
+    }
+
+    private val ksString = environment().ksString()
+    private var viewModel = ErroredBackingViewHolderViewModel.ViewModel(environment())
+
+    init {
+
+        this.viewModel.outputs.notifyDelegateToStartFixPaymentMethod()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { delegate?.managePledgeClicked(it) }
+
+        this.viewModel.outputs.projectFinalCollectionDate()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { setProjectFinaCollectionDateText(it) }
+
+        this.viewModel.outputs.projectName()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.errored_backing_project_title.text = it }
+
+        RxView.clicks(this.view.errored_backing_manage_button)
+                .compose(bindToLifecycle())
+                .subscribe { this.viewModel.inputs.manageButtonClicked() }
+
+    }
+
+    private fun setProjectFinaCollectionDateText(finalCollectionDate: DateTime) {
+        val options = RelativeDateTimeOptions.builder()
+                .absolute(true)
+                .relativeToDateTime(DateTime.now())
+                .build()
+
+        this.view.errored_backing_project_collection_date.text = DateTimeUtils.relative(context(), this.ksString, finalCollectionDate, options)
+    }
+
+    override fun bindData(data: Any?) {
+        @Suppress("UNCHECKED_CAST")
+        val erroredBacking = requireNonNull(data as ErroredBacking)
+
+        this.viewModel.inputs.configureWith(erroredBacking)
+    }
+
+}

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ErroredBackingViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ErroredBackingViewHolder.kt
@@ -51,7 +51,7 @@ class ErroredBackingViewHolder(private val view: View, val delegate: Delegate?) 
                 .build()
 
         val timeRemaining = DateTimeUtils.relative(context(), this.ksString, finalCollectionDate, options)
-        val fixWithinTemplate = context().getString(R.string.Fix_within)
+        val fixWithinTemplate = context().getString(R.string.Fix_within_time_remaining)
         this.view.errored_backing_project_collection_date.text = this.ksString.format(fixWithinTemplate,
                 "time_remaining", timeRemaining)
     }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ErroredBackingViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ErroredBackingViewHolder.kt
@@ -2,6 +2,7 @@ package com.kickstarter.ui.viewholders
 
 import android.view.View
 import com.jakewharton.rxbinding.view.RxView
+import com.kickstarter.R
 import com.kickstarter.libs.RelativeDateTimeOptions
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.DateTimeUtils
@@ -49,7 +50,10 @@ class ErroredBackingViewHolder(private val view: View, val delegate: Delegate?) 
                 .relativeToDateTime(DateTime.now())
                 .build()
 
-        this.view.errored_backing_project_collection_date.text = DateTimeUtils.relative(context(), this.ksString, finalCollectionDate, options)
+        val timeRemaining = DateTimeUtils.relative(context(), this.ksString, finalCollectionDate, options)
+        val fixWithinTemplate = context().getString(R.string.Fix_within)
+        this.view.errored_backing_project_collection_date.text = this.ksString.format(fixWithinTemplate,
+                "time_remaining", timeRemaining)
     }
 
     override fun bindData(data: Any?) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardCardSelectedViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardCardSelectedViewHolder.kt
@@ -5,9 +5,11 @@ import android.view.View
 import com.kickstarter.R
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
+import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Project
 import com.kickstarter.models.StoredCard
 import com.kickstarter.viewmodels.RewardCardSelectedViewHolderViewModel
+import kotlinx.android.synthetic.main.retry_card_warning.view.*
 import kotlinx.android.synthetic.main.reward_card_details.view.*
 
 class RewardCardSelectedViewHolder(val view : View) : KSViewHolder(view) {
@@ -39,6 +41,11 @@ class RewardCardSelectedViewHolder(val view : View) : KSViewHolder(view) {
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
                 .subscribe { setLastFourTextView(it) }
+
+        this.viewModel.outputs.retryCopyIsVisible()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { ViewUtils.setGone(this.view.retry_card_warning, !it) }
     }
 
     override fun bindData(data: Any?) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardCardUnselectedViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardCardUnselectedViewHolder.kt
@@ -11,6 +11,7 @@ import com.kickstarter.models.Project
 import com.kickstarter.models.StoredCard
 import com.kickstarter.viewmodels.RewardCardUnselectedViewHolderViewModel
 import kotlinx.android.synthetic.main.item_reward_unselected_card.view.*
+import kotlinx.android.synthetic.main.retry_card_warning.view.*
 import kotlinx.android.synthetic.main.reward_card_details.view.*
 
 class RewardCardUnselectedViewHolder(val view : View, val delegate : Delegate) : KSViewHolder(view) {
@@ -71,6 +72,11 @@ class RewardCardUnselectedViewHolder(val view : View, val delegate : Delegate) :
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
                 .subscribe { this.delegate.cardSelected(it.first, it.second) }
+
+        this.viewModel.outputs.retryCopyIsVisible()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { ViewUtils.setGone(this.view.retry_card_warning, !it) }
 
         this.viewModel.outputs.selectImageIsVisible()
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -63,6 +63,12 @@ interface BackingFragmentViewModel {
         /** Emits the card brand drawable to display. */
         fun cardLogo(): Observable<Int>
 
+        /** Emits a boolean determining if the fix payment method button should be visible. */
+        fun fixPaymentMethodButtonIsGone(): Observable<Boolean>
+
+        /** Emits a boolean determining if the fix payment method message should be visible. */
+        fun fixPaymentMethodMessageIsGone(): Observable<Boolean>
+
         /** Emits when we should notify the [BackingFragment.BackingDelegate] to refresh the project. */
         fun notifyDelegateToRefreshProject(): Observable<Void>
 
@@ -123,6 +129,8 @@ interface BackingFragmentViewModel {
         private val cardIssuer = BehaviorSubject.create<Either<String, Int>>()
         private val cardLastFour = BehaviorSubject.create<String>()
         private val cardLogo = BehaviorSubject.create<Int>()
+        private val fixPaymentMethodButtonIsGone = BehaviorSubject.create<Boolean>()
+        private val fixPaymentMethodMessageIsGone = BehaviorSubject.create<Boolean>()
         private val notifyDelegateToRefreshProject = PublishSubject.create<Void>()
         private val paymentMethodIsGone = BehaviorSubject.create<Boolean>()
         private val pledgeAmount = BehaviorSubject.create<CharSequence>()
@@ -276,6 +284,19 @@ interface BackingFragmentViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.cardLogo)
 
+            val backingIsNotErrored = backing
+                    .map { BackingUtils.isErrored(it) }
+                    .distinctUntilChanged()
+                    .map { BooleanUtils.negate(it) }
+
+            backingIsNotErrored
+                    .compose(bindToLifecycle())
+                    .subscribe { this.fixPaymentMethodButtonIsGone.onNext(it) }
+
+            backingIsNotErrored
+                    .compose(bindToLifecycle())
+                    .subscribe { this.fixPaymentMethodMessageIsGone.onNext(it) }
+
             backing
                     .map { it.backerCompletedAt() }
                     .map { ObjectUtils.isNotNull(it) }
@@ -390,6 +411,10 @@ interface BackingFragmentViewModel {
         override fun cardLastFour(): Observable<String> = this.cardLastFour
 
         override fun cardLogo(): Observable<Int> = this.cardLogo
+
+        override fun fixPaymentMethodButtonIsGone(): Observable<Boolean> = this.fixPaymentMethodButtonIsGone
+
+        override fun fixPaymentMethodMessageIsGone(): Observable<Boolean> = this.fixPaymentMethodMessageIsGone
 
         override fun notifyDelegateToRefreshProject(): Observable<Void> = this.notifyDelegateToRefreshProject
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -31,6 +31,9 @@ interface BackingFragmentViewModel {
         /** Configure with current [ProjectData]. */
         fun configureWith(projectData: ProjectData)
 
+        /** Call when the fix payment method button is clicked. */
+        fun fixPaymentMethodButtonClicked()
+
         /** Call when the pledge has been successfully updated. */
         fun pledgeSuccessfullyUpdated()
 
@@ -71,6 +74,9 @@ interface BackingFragmentViewModel {
 
         /** Emits when we should notify the [BackingFragment.BackingDelegate] to refresh the project. */
         fun notifyDelegateToRefreshProject(): Observable<Void>
+
+        /** Call when the [BackingFragment.BackingDelegate] should be notified to show the fix pledge flow. */
+        fun notifyDelegateToShowFixPledge(): Observable<Void>
 
         /** Emits a boolean determining if the payment method section should be visible. */
         fun paymentMethodIsGone(): Observable<Boolean>
@@ -117,6 +123,7 @@ interface BackingFragmentViewModel {
 
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<BackingFragment>(environment), Inputs, Outputs {
 
+        private val fixPaymentMethodButtonClicked = PublishSubject.create<Void>()
         private val pledgeSuccessfullyCancelled = PublishSubject.create<Void>()
         private val projectDataInput = PublishSubject.create<ProjectData>()
         private val receivedCheckboxToggled = PublishSubject.create<Boolean>()
@@ -132,6 +139,7 @@ interface BackingFragmentViewModel {
         private val fixPaymentMethodButtonIsGone = BehaviorSubject.create<Boolean>()
         private val fixPaymentMethodMessageIsGone = BehaviorSubject.create<Boolean>()
         private val notifyDelegateToRefreshProject = PublishSubject.create<Void>()
+        private val notifyDelegateToShowFixPledge = PublishSubject.create<Void>()
         private val paymentMethodIsGone = BehaviorSubject.create<Boolean>()
         private val pledgeAmount = BehaviorSubject.create<CharSequence>()
         private val pledgeDate = BehaviorSubject.create<String>()
@@ -297,6 +305,10 @@ interface BackingFragmentViewModel {
                     .compose(bindToLifecycle())
                     .subscribe { this.fixPaymentMethodMessageIsGone.onNext(it) }
 
+            this.fixPaymentMethodButtonClicked
+                    .compose(bindToLifecycle())
+                    .subscribe { this.notifyDelegateToShowFixPledge.onNext(null) }
+
             backing
                     .map { it.backerCompletedAt() }
                     .map { ObjectUtils.isNotNull(it) }
@@ -386,6 +398,10 @@ interface BackingFragmentViewModel {
             this.projectDataInput.onNext(projectData)
         }
 
+        override fun fixPaymentMethodButtonClicked() {
+            this.fixPaymentMethodButtonClicked.onNext(null)
+        }
+
         override fun pledgeSuccessfullyUpdated() {
             this.showUpdatePledgeSuccess.onNext(null)
         }
@@ -417,6 +433,8 @@ interface BackingFragmentViewModel {
         override fun fixPaymentMethodMessageIsGone(): Observable<Boolean> = this.fixPaymentMethodMessageIsGone
 
         override fun notifyDelegateToRefreshProject(): Observable<Void> = this.notifyDelegateToRefreshProject
+
+        override fun notifyDelegateToShowFixPledge(): Observable<Void> = this.notifyDelegateToShowFixPledge
 
         override fun paymentMethodIsGone(): Observable<Boolean> = this.paymentMethodIsGone
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ErroredBackingViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ErroredBackingViewHolderViewModel.kt
@@ -1,0 +1,83 @@
+package com.kickstarter.viewmodels
+
+import androidx.annotation.NonNull
+import com.kickstarter.libs.ActivityViewModel
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
+import com.kickstarter.models.ErroredBacking
+import com.kickstarter.ui.viewholders.ErroredBackingViewHolder
+import org.joda.time.DateTime
+import rx.Observable
+import rx.subjects.BehaviorSubject
+import rx.subjects.PublishSubject
+
+interface ErroredBackingViewHolderViewModel {
+    interface Inputs {
+        /** Configure with the current [ErroredBacking]. */
+        fun configureWith(erroredBacking: ErroredBacking)
+
+        /** Call when the manage button is clicked. */
+        fun manageButtonClicked()
+    }
+
+    interface Outputs {
+        /** Emits the final collection date of the [ErroredBacking.Project]. */
+        fun projectFinalCollectionDate(): Observable<DateTime>
+
+        /** Emits the name of the [ErroredBacking.Project]. */
+        fun projectName(): Observable<String>
+
+        /** Emits the [ErroredBacking.Project] slug when the [ErroredBackingViewHolder.Delegate] should be notified to show the fix pledge flow. */
+        fun notifyDelegateToStartFixPaymentMethod(): Observable<String>
+    }
+
+    class ViewModel(@NonNull environment: Environment) : ActivityViewModel<ErroredBackingViewHolder>(environment), Inputs, Outputs {
+
+        private val erroredBacking = PublishSubject.create<ErroredBacking>()
+        private val manageButtonClicked = PublishSubject.create<Void>()
+
+        private val notifyDelegateToStartFixPaymentMethod = PublishSubject.create<String>()
+        private val projectFinalCollectionDate = BehaviorSubject.create<DateTime>()
+        private val projectName = BehaviorSubject.create<String>()
+
+        val inputs: Inputs = this
+        val outputs: Outputs = this
+
+        init {
+
+            val project = this.erroredBacking
+                    .map { it.project() }
+
+            project
+                    .map { it.name() }
+                    .compose(bindToLifecycle())
+                    .subscribe { this.projectName.onNext(it) }
+
+            project
+                    .map { it.finalCollectionDate() }
+                    .compose(bindToLifecycle())
+                    .subscribe { this.projectFinalCollectionDate.onNext(it) }
+
+            project
+                    .map { it.slug() }
+                    .compose<String>(takeWhen(this.manageButtonClicked))
+                    .compose(bindToLifecycle())
+                    .subscribe { this.notifyDelegateToStartFixPaymentMethod.onNext(it) }
+        }
+
+        override fun configureWith(erroredBacking: ErroredBacking) {
+            this.erroredBacking.onNext(erroredBacking)
+        }
+
+        override fun manageButtonClicked() {
+            this.manageButtonClicked.onNext(null)
+        }
+
+        override fun notifyDelegateToStartFixPaymentMethod(): Observable<String> = this.notifyDelegateToStartFixPaymentMethod
+
+        override fun projectFinalCollectionDate(): Observable<DateTime> = this.projectFinalCollectionDate
+
+        override fun projectName(): Observable<String> = this.projectName
+
+    }
+}

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -333,11 +333,11 @@ interface PledgeFragmentViewModel {
                     .map { it.getSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON) as PledgeReason }
 
             val updatingPayment = pledgeReason
-                    .map { it == PledgeReason.UPDATE_PAYMENT }
+                    .map { it == PledgeReason.UPDATE_PAYMENT || it == PledgeReason.FIX_PLEDGE }
                     .distinctUntilChanged()
 
             val updatingPaymentOrUpdatingPledge = pledgeReason
-                    .map { it == PledgeReason.UPDATE_PAYMENT || it == PledgeReason.UPDATE_PLEDGE }
+                    .map { it == PledgeReason.UPDATE_PAYMENT || it == PledgeReason.UPDATE_PLEDGE || it == PledgeReason.FIX_PLEDGE  }
                     .distinctUntilChanged()
 
             val projectAndReward = project
@@ -830,7 +830,7 @@ interface PledgeFragmentViewModel {
 
             val updatePaymentClick = pledgeReason
                     .compose<PledgeReason>(takeWhen(this.pledgeButtonClicked))
-                    .filter { it == PledgeReason.UPDATE_PAYMENT }
+                    .filter { it == PledgeReason.UPDATE_PAYMENT || it.first == PledgeReason.FIX_PLEDGE }
                     .compose(ignoreValues())
 
             val updatePledgeClick = pledgeReason
@@ -888,7 +888,7 @@ interface PledgeFragmentViewModel {
                     .subscribe(this.showUpdatePledgeSuccess)
 
             successAndPledgeReason
-                    .filter { it.second == PledgeReason.UPDATE_PAYMENT }
+                    .filter { it.second == PledgeReason.UPDATE_PAYMENT || it.second == PledgeReason.FIX_PLEDGE }
                     .compose(ignoreValues())
                     .compose(bindToLifecycle())
                     .subscribe(this.showUpdatePaymentSuccess)
@@ -932,7 +932,7 @@ interface PledgeFragmentViewModel {
                     }
 
             errorAndPledgeReason
-                    .filter { it.second == PledgeReason.UPDATE_PAYMENT }
+                    .filter { it.second == PledgeReason.UPDATE_PAYMENT || it.second == PledgeReason.FIX_PLEDGE }
                     .compose(ignoreValues())
                     .compose(bindToLifecycle())
                     .subscribe {
@@ -984,8 +984,10 @@ interface PledgeFragmentViewModel {
 
             project
                     .compose<Project>(takeWhen(updatePaymentClick))
+                    .compose<Pair<Project, PledgeReason>>(combineLatestPair(pledgeReason))
+                    .filter { it.second == PledgeReason.UPDATE_PAYMENT }
                     .compose(bindToLifecycle())
-                    .subscribe { this.koala.trackUpdatePaymentMethodButtonClicked(it) }
+                    .subscribe { this.koala.trackUpdatePaymentMethodButtonClicked(it.first) }
 
             pledgeData
                     .take(1)

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -724,7 +724,7 @@ interface PledgeFragmentViewModel {
             userIsLoggedIn
                     .filter { BooleanUtils.isTrue(it) }
                     .compose<Pair<Boolean, PledgeReason>>(combineLatestPair(pledgeReason))
-                    .filter { it.second == PledgeReason.PLEDGE || it.second == PledgeReason.UPDATE_PAYMENT}
+                    .filter { it.second == PledgeReason.PLEDGE || it.second == PledgeReason.UPDATE_PAYMENT || it.second == PledgeReason.FIX_PLEDGE }
                     .take(1)
                     .switchMap { storedCards() }
                     .compose(bindToLifecycle())
@@ -830,7 +830,12 @@ interface PledgeFragmentViewModel {
 
             val updatePaymentClick = pledgeReason
                     .compose<PledgeReason>(takeWhen(this.pledgeButtonClicked))
-                    .filter { it == PledgeReason.UPDATE_PAYMENT || it.first == PledgeReason.FIX_PLEDGE }
+                    .filter { it == PledgeReason.UPDATE_PAYMENT }
+                    .compose(ignoreValues())
+
+            val fixPaymentClick = pledgeReason
+                    .compose<PledgeReason>(takeWhen(this.pledgeButtonClicked))
+                    .filter { it == PledgeReason.FIX_PLEDGE }
                     .compose(ignoreValues())
 
             val updatePledgeClick = pledgeReason
@@ -847,7 +852,7 @@ interface PledgeFragmentViewModel {
                     reward,
                     optionalPaymentMethodId)
             { b, a, l, r, p -> UpdateBackingData(b, a, l, r, p) }
-                    .compose<UpdateBackingData>(takeWhen(Observable.merge(updatePledgeClick, updatePaymentClick)))
+                    .compose<UpdateBackingData>(takeWhen(Observable.merge(updatePledgeClick, updatePaymentClick, fixPaymentClick)))
                     .switchMap {
                         this.apolloClient.updateBacking(it)
                                 .doOnSubscribe {

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -105,11 +105,14 @@ interface ProjectViewModel {
     }
 
     interface Outputs {
-        /** Emits a string with the backing details to be displayed in the manage pledge view. */
-        fun backingDetails(): Observable<String>
-
         /** Emits a boolean that determines if the backing details should be visible. */
         fun backingDetailsIsVisible(): Observable<Boolean>
+
+        /** Emits a string or string resource ID of the backing details subtitle. */
+        fun backingDetailsSubtitle(): Observable<Either<String, Int>?>
+
+        /** Emits the string resource ID of the backing details title. */
+        fun backingDetailsTitle(): Observable<Int>
 
         /** Emits when rewards sheet should expand and if it should animate. */
         fun expandPledgeSheet(): Observable<Pair<Boolean, Boolean>>
@@ -246,8 +249,9 @@ interface ProjectViewModel {
         private val updatesTextViewClicked = PublishSubject.create<Void>()
         private val viewRewardsClicked = PublishSubject.create<Void>()
 
-        private val backingDetails = BehaviorSubject.create<String>()
         private val backingDetailsIsVisible = BehaviorSubject.create<Boolean>()
+        private val backingDetailsSubtitle = BehaviorSubject.create<Either<String, Int>?>()
+        private val backingDetailsTitle = BehaviorSubject.create<Int>()
         private val expandPledgeSheet = BehaviorSubject.create<Pair<Boolean, Boolean>>()
         private val goBack = PublishSubject.create<Void>()
         private val heartDrawableId = BehaviorSubject.create<Int>()
@@ -566,17 +570,25 @@ interface ProjectViewModel {
                     .subscribe(this.revealRewardsFragment)
 
             currentProject
-                    .map { it.isBacking && it.isLive }
+                    .map { it.isBacking && it.isLive || BackingUtils.isErrored(it.backing()) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.backingDetailsIsVisible)
 
             currentProject
-                    .filter { it.isBacking && it.isLive }
-                    .map { backingDetails(it) }
+                    .filter { it.isBacking }
+                    .map { it.backing() }
+                    .map { if (BackingUtils.isErrored(it)) R.string.Payment_failure else R.string.Youre_a_backer }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
-                    .subscribe(this.backingDetails)
+                    .subscribe(this.backingDetailsTitle)
+
+            currentProject
+                    .filter { it.isBacking }
+                    .map { backingDetailsSubtitle(it) }
+                    .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.backingDetailsSubtitle)
 
             val currentProjectAndUser = currentProject
                     .compose<Pair<Project, User>>(combineLatestPair(this.currentUser.observable()))
@@ -957,7 +969,10 @@ interface ProjectViewModel {
         }
 
         @NonNull
-        override fun backingDetails(): Observable<String> = this.backingDetails
+        override fun backingDetailsSubtitle(): Observable<Either<String, Int>?> = this.backingDetailsSubtitle
+
+        @NonNull
+        override fun backingDetailsTitle(): Observable<Int> = this.backingDetailsTitle
 
         @NonNull
         override fun backingDetailsIsVisible(): Observable<Boolean> = this.backingDetailsIsVisible
@@ -1061,17 +1076,21 @@ interface ProjectViewModel {
         @NonNull
         override fun updateFragments(): Observable<ProjectData> = this.updateFragments
 
-        private fun backingDetails(project: Project): String {
+        private fun backingDetailsSubtitle(project: Project): Either<String, Int>? {
             return project.backing()?.let { backing ->
-                val reward = project.rewards()?.firstOrNull { it.id() == backing.rewardId() }
-                val title = reward?.let { "• ${it.title()}" } ?: ""
+                return if(backing.status() == Backing.STATUS_ERRORED) {
+                    Either.Right(R.string.We_cant_process_your_pledge)
+                } else {
+                    val reward = project.rewards()?.firstOrNull { it.id() == backing.rewardId() }
+                    val title = reward?.let { "• ${it.title()}" } ?: ""
 
-                val backingAmount = backing.amount()
+                    val backingAmount = backing.amount()
 
-                val formattedAmount = this.ksCurrency.format(backingAmount, project, RoundingMode.HALF_UP)
+                    val formattedAmount = this.ksCurrency.format(backingAmount, project, RoundingMode.HALF_UP)
 
-                return "$formattedAmount $title".trim()
-            } ?: ""
+                    Either.Left("$formattedAmount $title".trim())
+                }
+            }
         }
 
         private fun saveProject(project: Project): Observable<Project> {

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -14,6 +14,7 @@ import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.User
 import com.kickstarter.services.ApiClientType
+import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.ProjectActivity
 import com.kickstarter.ui.adapters.ProjectAdapter
 import com.kickstarter.ui.data.*
@@ -317,13 +318,19 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe { this.expandPledgeSheet.onNext(Pair(true, true)) }
 
+            intent()
+                    .take(1)
+                    .filter { it.getBooleanExtra(IntentKey.EXPAND_PLEDGE_SHEET, false) }
+                    .compose(bindToLifecycle())
+                    .subscribe { this.expandPledgeSheet.onNext(Pair(true, true)) }
+
             val pledgeSheetExpanded = this.expandPledgeSheet
                     .map { it.first }
                     .startWith(false)
 
             progressBarIsGone
                     .compose<Pair<Boolean, Boolean>>(combineLatestPair(pledgeSheetExpanded))
-                    .filter { BooleanUtils.isFalse(it.second) }
+                    .filter { BooleanUtils.isTrue(it.second) }
                     .map { it.first }
                     .compose(bindToLifecycle())
                     .subscribe(this.retryProgressBarIsGone)

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -330,7 +330,7 @@ interface ProjectViewModel {
 
             progressBarIsGone
                     .compose<Pair<Boolean, Boolean>>(combineLatestPair(pledgeSheetExpanded))
-                    .filter { BooleanUtils.isTrue(it.second) }
+                    .filter { BooleanUtils.isFalse(it.second) }
                     .map { it.first }
                     .compose(bindToLifecycle())
                     .subscribe(this.retryProgressBarIsGone)

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -52,6 +52,9 @@ interface ProjectViewModel {
         /** Call when the creator name is clicked.  */
         fun creatorNameTextViewClicked()
 
+        /** Call when the fix payment method is clicked.  */
+        fun fixPaymentMethodButtonClicked()
+
         /** Call when the count of fragments on the back stack changes.  */
         fun fragmentStackCount(count: Int)
 
@@ -231,6 +234,7 @@ interface ProjectViewModel {
         private val creatorDashboardButtonClicked = PublishSubject.create<Void>()
         private val creatorInfoVariantClicked = PublishSubject.create<Void>()
         private val creatorNameTextViewClicked = PublishSubject.create<Void>()
+        private val fixPaymentMethodButtonClicked = PublishSubject.create<Void>()
         private val fragmentStackCount = PublishSubject.create<Int>()
         private val heartButtonClicked = PublishSubject.create<Void>()
         private val nativeProjectActionButtonClicked = PublishSubject.create<Void>()
@@ -554,6 +558,12 @@ interface ProjectViewModel {
                     .map { pD -> BackingUtils.backedReward(pD.project())?.let { Pair(pD, it) } }
 
             projectDataAndBackedReward
+                    .compose(takeWhen<Pair<ProjectData, Reward>, Void>(this.fixPaymentMethodButtonClicked))
+                    .map { Pair(pledgeData(it.second, it.first, PledgeFlowContext.MANAGE_REWARD), PledgeReason.FIX_PLEDGE) }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.showUpdatePledge)
+
+            projectDataAndBackedReward
                     .compose(takeWhen<Pair<ProjectData, Reward>, Void>(this.updatePaymentClicked))
                     .map { Pair(pledgeData(it.second, it.first, PledgeFlowContext.MANAGE_REWARD), PledgeReason.UPDATE_PAYMENT) }
                     .compose(bindToLifecycle())
@@ -868,6 +878,10 @@ interface ProjectViewModel {
             this.creatorNameTextViewClicked.onNext(null)
         }
 
+        override fun fixPaymentMethodButtonClicked() {
+            this.fixPaymentMethodButtonClicked.onNext(null)
+        }
+
         override fun fragmentStackCount(count: Int) {
             this.fragmentStackCount.onNext(count)
         }
@@ -1030,7 +1044,6 @@ interface ProjectViewModel {
 
         @NonNull
         override fun showCancelPledgeSuccess(): Observable<Void> = this.showCancelPledgeSuccess
-
         @NonNull
         override fun showPledgeNotCancelableDialog(): Observable<Void> = this.showPledgeNotCancelableDialog
 

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardCardUnselectedViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardCardUnselectedViewHolderViewModel.kt
@@ -52,9 +52,6 @@ interface RewardCardUnselectedViewHolderViewModel : BaseRewardCardViewHolderView
 
         init {
 
-            val project = this.cardAndProject
-                    .map { it.second }
-
             val allowedCardType = this.cardAndProject
                     .map { ProjectUtils.acceptedCardType(it.first.type(), it.second) }
 

--- a/app/src/main/res/color/button_pledge_error.xml
+++ b/app/src/main/res/color/button_pledge_error.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:color="@color/ksr_grey_500" android:state_enabled="false" />
+  <item android:color="@color/ksr_red_400"/>
+</selector>

--- a/app/src/main/res/layout/fragment_backing.xml
+++ b/app/src/main/res/layout/fragment_backing.xml
@@ -121,6 +121,7 @@
             android:id="@+id/payment_method"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/grid_1"
             android:focusable="true"
             android:orientation="vertical">
 
@@ -136,7 +137,27 @@
               layout="@layout/reward_card_details"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              android:layout_marginBottom="@dimen/grid_4" />
+              android:layout_marginBottom="@dimen/grid_3" />
+
+            <TextView
+              android:id="@+id/fix_payment_method_message"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_marginBottom="@dimen/grid_2"
+              android:text="@string/We_cant_process_your_pledge_Please_update_your_payment_method"
+              android:textColor="@color/ksr_red_400"
+              android:visibility="gone"
+              tools:visibility="visible" />
+
+            <com.google.android.material.button.MaterialButton
+              android:id="@+id/fix_payment_method_button"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_marginBottom="@dimen/grid_3"
+              android:backgroundTint="@color/button_pledge_error"
+              android:text="@string/Fix"
+              android:visibility="gone"
+              tools:visibility="visible" />
 
             <include layout="@layout/horizontal_line_1dp_view" />
 

--- a/app/src/main/res/layout/item_errored_backing.xml
+++ b/app/src/main/res/layout/item_errored_backing.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:background="@color/ksr_grey_300"
+  android:clipChildren="false"
+  android:orientation="horizontal"
+  android:padding="@dimen/grid_3">
+
+  <LinearLayout
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="@dimen/grid_4"
+    android:layout_weight="1"
+    android:orientation="vertical"
+    android:paddingTop="@dimen/grid_1">
+
+    <TextView
+      android:id="@+id/errored_backing_project_title"
+      style="@style/BodyPrimaryMedium"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="start"
+      android:layout_marginBottom="@dimen/grid_1_half"
+      android:gravity="top"
+      tools:text="zoe | juniper's FORM/S and Foundations" />
+
+    <LinearLayout
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:gravity="center_vertical"
+      android:orientation="horizontal">
+
+      <!-- TODO: this needs a11y copy -->
+      <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/grid_1"
+        android:importantForAccessibility="no"
+        android:src="@drawable/ic_icon_alert"
+        android:tint="@color/ksr_red_400" />
+
+      <TextView
+        android:id="@+id/errored_backing_project_collection_date"
+        style="@style/BodyPrimary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:includeFontPadding="false"
+        android:textColor="@color/ksr_red_400"
+        tools:text="6 days" />
+
+    </LinearLayout>
+  </LinearLayout>
+
+
+  <com.google.android.material.button.MaterialButton
+    android:id="@+id/errored_backing_manage_button"
+    style="@style/SmallButton"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:backgroundTint="@color/button_pledge_error"
+    android:text="@string/Manage" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_errored_backing.xml
+++ b/app/src/main/res/layout/item_errored_backing.xml
@@ -32,12 +32,11 @@
       android:gravity="center_vertical"
       android:orientation="horizontal">
 
-      <!-- TODO: this needs a11y copy -->
       <ImageView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/grid_1"
-        android:importantForAccessibility="no"
+        android:contentDescription="@string/Alert"
         android:src="@drawable/ic_icon_alert"
         android:tint="@color/ksr_red_400" />
 
@@ -52,7 +51,6 @@
 
     </LinearLayout>
   </LinearLayout>
-
 
   <com.google.android.material.button.MaterialButton
     android:id="@+id/errored_backing_manage_button"

--- a/app/src/main/res/layout/item_header_errored_backings.xml
+++ b/app/src/main/res/layout/item_header_errored_backings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:background="@color/ksr_grey_300"
+  android:orientation="vertical"
+  android:paddingStart="@dimen/grid_3"
+  android:paddingTop="@dimen/grid_4"
+  android:paddingEnd="@dimen/grid_3">
+
+  <TextView
+    style="@style/Title3Medium"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/grid_1_half"
+    android:text="@string/Payment_failure" />
+
+  <TextView
+    style="@style/BodyPrimary"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/We_cant_process_your_pledge_for" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_reward_selected_card.xml
+++ b/app/src/main/res/layout/item_reward_selected_card.xml
@@ -7,20 +7,29 @@
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:animateLayoutChanges="true"
-    android:orientation="horizontal"
-    android:padding="@dimen/grid_2">
+    android:orientation="vertical">
 
-    <ImageView
-      android:layout_width="@dimen/grid_3"
-      android:layout_height="@dimen/grid_3"
-      android:layout_gravity="center_vertical"
-      android:layout_marginEnd="@dimen/grid_3"
-      android:background="@drawable/circle_accent"
-      android:contentDescription="@string/Selected_card"
-      android:src="@drawable/icon__check"
-      android:tint="@color/white" />
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:animateLayoutChanges="true"
+      android:orientation="horizontal"
+      android:padding="@dimen/grid_2">
 
-    <include layout="@layout/reward_card_details" />
+      <ImageView
+        android:layout_width="@dimen/grid_3"
+        android:layout_height="@dimen/grid_3"
+        android:layout_gravity="center_vertical"
+        android:layout_marginEnd="@dimen/grid_3"
+        android:background="@drawable/circle_accent"
+        android:contentDescription="@string/Selected_card"
+        android:src="@drawable/icon__check"
+        android:tint="@color/white" />
+
+      <include layout="@layout/reward_card_details" />
+    </LinearLayout>
+
+    <include layout="@layout/retry_card_warning" />
+
   </LinearLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/item_reward_unselected_card.xml
+++ b/app/src/main/res/layout/item_reward_unselected_card.xml
@@ -43,5 +43,7 @@
       android:textColor="@color/ksr_red_400"
       android:visibility="gone"
       tools:visibility="visible" />
+
+    <include layout="@layout/retry_card_warning" />
   </LinearLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/pledge_container.xml
+++ b/app/src/main/res/layout/pledge_container.xml
@@ -87,14 +87,14 @@
       android:visibility="gone">
 
       <TextView
-        android:id="@+id/you_backer_text"
+        android:id="@+id/backing_details_title"
         style="@style/SubheadlineMedium"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:text="@string/Youre_a_backer" />
 
       <TextView
-        android:id="@+id/reward_infos"
+        android:id="@+id/backing_details_subtitle"
         style="@style/Caption1Secondary"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/retry_card_warning.xml
+++ b/app/src/main/res/layout/retry_card_warning.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/retry_card_warning"
+  style="@style/Caption1SecondaryMedium"
+  android:layout_width="wrap_content"
+  android:layout_height="wrap_content"
+  android:layout_marginStart="@dimen/grid_8"
+  android:layout_marginEnd="@dimen/grid_2"
+  android:layout_marginBottom="@dimen/grid_2"
+  android:text="@string/Retry_or_select_another_method"
+  android:textColor="@color/ksr_red_400"
+  android:visibility="gone"
+  tools:showIn="@layout/item_reward_unselected_card"
+  tools:visibility="visible" />

--- a/app/src/main/res/layout/reward_card_details.xml
+++ b/app/src/main/res/layout/reward_card_details.xml
@@ -38,15 +38,4 @@
       tools:text="Expires in 03/2020" />
   </LinearLayout>
 
-  <!--  TODO: I need some a11y copy-->
-  <ImageView
-    android:id="@+id/failed_indicator_icon"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginTop="@dimen/grid_1_half"
-    android:importantForAccessibility="no"
-    android:src="@drawable/ic_icon_alert"
-    android:tint="@color/ksr_red_400"
-    android:visibility="gone" />
-
 </LinearLayout>

--- a/app/src/main/res/layout/reward_card_details.xml
+++ b/app/src/main/res/layout/reward_card_details.xml
@@ -17,8 +17,9 @@
     tools:src="@drawable/mastercard_md" />
 
   <LinearLayout
-    android:layout_width="wrap_content"
+    android:layout_width="0dp"
     android:layout_height="wrap_content"
+    android:layout_weight="1"
     android:layout_marginStart="@dimen/grid_2"
     android:orientation="vertical">
 
@@ -36,5 +37,16 @@
       android:layout_height="wrap_content"
       tools:text="Expires in 03/2020" />
   </LinearLayout>
+
+  <!--  TODO: I need some a11y copy-->
+  <ImageView
+    android:id="@+id/failed_indicator_icon"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/grid_1_half"
+    android:importantForAccessibility="no"
+    android:src="@drawable/ic_icon_alert"
+    android:tint="@color/ksr_red_400"
+    android:visibility="gone" />
 
 </LinearLayout>

--- a/app/src/test/java/com/kickstarter/libs/utils/BackingUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/BackingUtilsTest.java
@@ -25,6 +25,16 @@ public final class BackingUtilsTest extends KSRobolectricTestCase {
   }
 
   @Test
+  public void testIsErrored() {
+    assertFalse(BackingUtils.isErrored(BackingFactory.backing(Backing.STATUS_CANCELED)));
+    assertFalse(BackingUtils.isErrored(BackingFactory.backing(Backing.STATUS_COLLECTED)));
+    assertFalse(BackingUtils.isErrored(BackingFactory.backing(Backing.STATUS_DROPPED)));
+    assertTrue(BackingUtils.isErrored(BackingFactory.backing(Backing.STATUS_ERRORED)));
+    assertFalse(BackingUtils.isErrored(BackingFactory.backing(Backing.STATUS_PLEDGED)));
+    assertFalse(BackingUtils.isErrored(BackingFactory.backing(Backing.STATUS_PREAUTH)));
+  }
+
+  @Test
   public void testIsShippable() {
     final Backing backingWithShipping = BackingFactory.backing().toBuilder()
       .reward(RewardFactory.rewardWithShipping())

--- a/app/src/test/java/com/kickstarter/ui/adapters/ActivityFeedAdapterTest.java
+++ b/app/src/test/java/com/kickstarter/ui/adapters/ActivityFeedAdapterTest.java
@@ -2,8 +2,10 @@ package com.kickstarter.ui.adapters;
 
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.mock.factories.ActivityFactory;
+import com.kickstarter.mock.factories.ErroredBackingFactory;
 import com.kickstarter.mock.factories.SurveyResponseFactory;
 import com.kickstarter.models.Activity;
+import com.kickstarter.models.ErroredBacking;
 import com.kickstarter.models.SurveyResponse;
 
 import org.junit.Assert;
@@ -17,7 +19,7 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
   private ActivityFeedAdapter adapter = new ActivityFeedAdapter(null);
 
   @Test
-  public void justActivities() throws Exception {
+  public void justActivities() {
     final Activity activity0 = ActivityFactory.projectStateChangedPositiveActivity();
     final Activity activity1 = ActivityFactory.friendBackingActivity();
     final Activity activity2 = ActivityFactory.projectStateChangedActivity();
@@ -25,6 +27,8 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
     this.adapter.takeActivities(Arrays.asList(activity0, activity1, activity2));
 
     final List<List<Activity>> data = Arrays.asList(
+      Collections.emptyList(),
+      Collections.emptyList(),
       Collections.emptyList(),
       Collections.emptyList(),
       Collections.emptyList(),
@@ -40,7 +44,7 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void loggedInWithActivities() throws Exception {
+  public void loggedInWithActivities() {
     final Activity activity0 = ActivityFactory.projectStateChangedPositiveActivity();
     final Activity activity1 = ActivityFactory.friendBackingActivity();
     final Activity activity2 = ActivityFactory.projectStateChangedActivity();
@@ -53,6 +57,8 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
       Collections.emptyList(),
       Collections.emptyList(),
       Collections.emptyList(),
+      Collections.emptyList(),
+      Collections.emptyList(),
       Arrays.asList(
         activity0,
         activity1,
@@ -64,7 +70,7 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void loggedOutWithActivities() throws Exception {
+  public void loggedOutWithActivities() {
     final Activity activity0 = ActivityFactory.projectStateChangedPositiveActivity();
     final Activity activity1 = ActivityFactory.friendBackingActivity();
     final Activity activity2 = ActivityFactory.projectStateChangedActivity();
@@ -77,6 +83,8 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
       Collections.singletonList(false),
       Collections.emptyList(),
       Collections.emptyList(),
+      Collections.emptyList(),
+      Collections.emptyList(),
       Arrays.asList(
         activity0,
         activity1,
@@ -88,20 +96,64 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void loggedInWithActivitiesAndSurveys() throws Exception {
+  public void loggedInWithErroredBackings() {
+    final ErroredBacking erroredBacking = ErroredBackingFactory.Companion.erroredBacking();
+
+    this.adapter.takeErroredBackings(Collections.singletonList(erroredBacking));
+    this.adapter.showLoggedInEmptyState(true);
+
+    final List<List<Object>> data = Arrays.asList(
+      Collections.singletonList(true),
+      Collections.emptyList(),
+      Collections.singletonList(1),
+      Collections.singletonList(erroredBacking),
+      Collections.emptyList(),
+      Collections.emptyList(),
+      Collections.emptyList()
+    );
+
+    Assert.assertEquals(data, this.adapter.sections());
+  }
+
+  @Test
+  public void loggedOutWithErroredBackings() {
+    final ErroredBacking erroredBacking = ErroredBackingFactory.Companion.erroredBacking();
+
+    this.adapter.takeErroredBackings(Collections.singletonList(erroredBacking));
+    this.adapter.showLoggedOutEmptyState(true);
+
+    final List<List<Object>> data = Arrays.asList(
+      Collections.emptyList(),
+      Collections.singletonList(false),
+      Collections.singletonList(1),
+      Collections.singletonList(erroredBacking),
+      Collections.emptyList(),
+      Collections.emptyList(),
+      Collections.emptyList()
+    );
+
+    Assert.assertEquals(data, this.adapter.sections());
+  }
+
+  @Test
+  public void loggedInWithActivitiesAndErroredBackingsAndSurveys() {
     final Activity activity0 = ActivityFactory.projectStateChangedPositiveActivity();
     final Activity activity1 = ActivityFactory.friendBackingActivity();
     final Activity activity2 = ActivityFactory.projectStateChangedActivity();
+    final ErroredBacking erroredBacking = ErroredBackingFactory.Companion.erroredBacking();
     final SurveyResponse surveyResponse0 = SurveyResponseFactory.surveyResponse();
     final SurveyResponse surveyResponse1 = SurveyResponseFactory.surveyResponse();
 
     this.adapter.takeActivities(Arrays.asList(activity0, activity1, activity2));
+    this.adapter.takeErroredBackings(Collections.singletonList(erroredBacking));
     this.adapter.takeSurveys(Arrays.asList(surveyResponse0, surveyResponse1));
     this.adapter.showLoggedInEmptyState(true);
 
     final List<List<Object>> data = Arrays.asList(
       Collections.singletonList(true),
       Collections.emptyList(),
+      Collections.singletonList(1),
+      Collections.singletonList(erroredBacking),
       Collections.singletonList(2),
       Arrays.asList(
         surveyResponse0,

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -28,6 +28,8 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     private val cardIssuer = TestSubscriber.create<Either<String, Int>>()
     private val cardLastFour = TestSubscriber.create<String>()
     private val cardLogo = TestSubscriber.create<Int>()
+    private val fixPaymentMethodButtonIsGone = TestSubscriber.create<Boolean>()
+    private val fixPaymentMethodMessageIsGone = TestSubscriber.create<Boolean>()
     private val notifyDelegateToRefreshProject = TestSubscriber.create<Void>()
     private val paymentMethodIsGone = TestSubscriber.create<Boolean>()
     private val pledgeAmount = TestSubscriber.create<CharSequence>()
@@ -53,6 +55,8 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
         this.vm.outputs.cardIssuer().subscribe(this.cardIssuer)
         this.vm.outputs.cardLastFour().subscribe(this.cardLastFour)
         this.vm.outputs.cardLogo().subscribe(this.cardLogo)
+        this.vm.outputs.fixPaymentMethodButtonIsGone().subscribe(this.fixPaymentMethodButtonIsGone)
+        this.vm.outputs.fixPaymentMethodMessageIsGone().subscribe(this.fixPaymentMethodMessageIsGone)
         this.vm.outputs.notifyDelegateToRefreshProject().subscribe(this.notifyDelegateToRefreshProject)
         this.vm.outputs.paymentMethodIsGone().subscribe(this.paymentMethodIsGone)
         this.vm.outputs.pledgeAmount().map { it.toString() }.subscribe(this.pledgeAmount)
@@ -339,6 +343,62 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     }
 
     @Test
+    fun testFixPaymentMethodButtonIsGone_whenBackingIsErrored() {
+        val backedProject = backedProjectWithBackingStatus(Backing.STATUS_ERRORED)
+                .toBuilder()
+                .deadline(DateTime.parse("2019-11-11T17:10:04+00:00"))
+                .state(Project.STATE_SUCCESSFUL)
+                .build()
+
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
+        this.fixPaymentMethodButtonIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testFixPaymentMethodButtonIsGone_whenBackingIsNotErrored() {
+        val backedProject = backedProjectWithBackingStatus(Backing.STATUS_COLLECTED)
+                .toBuilder()
+                .deadline(DateTime.parse("2019-11-11T17:10:04+00:00"))
+                .state(Project.STATE_SUCCESSFUL)
+                .build()
+
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
+        this.fixPaymentMethodButtonIsGone.assertValue(true)
+    }
+
+    @Test
+    fun testFixPaymentMethodMessageIsGone_whenBackingIsErrored() {
+        val backedProject = backedProjectWithBackingStatus(Backing.STATUS_ERRORED)
+                .toBuilder()
+                .deadline(DateTime.parse("2019-11-11T17:10:04+00:00"))
+                .state(Project.STATE_SUCCESSFUL)
+                .build()
+
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
+        this.fixPaymentMethodMessageIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testFixPaymentMethodMessageIsGone_whenBackingIsNotErrored() {
+        val backedProject = backedProjectWithBackingStatus(Backing.STATUS_COLLECTED)
+                .toBuilder()
+                .deadline(DateTime.parse("2019-11-11T17:10:04+00:00"))
+                .state(Project.STATE_SUCCESSFUL)
+                .build()
+
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
+        this.fixPaymentMethodMessageIsGone.assertValue(true)
+    }
+
+    @Test
     fun testNotifyDelegateToRefreshProject() {
         setUpEnvironment(environment())
 
@@ -453,6 +513,21 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
         this.pledgeStatusData.assertValue(PledgeStatusData(R.string.Your_pledge_was_dropped_because_of_payment_errors,
+                "$20", "November 11, 2019"))
+    }
+
+    @Test
+    fun testPledgeStatusData_whenBackingIsErrored() {
+        val backedProject = backedProjectWithBackingStatus(Backing.STATUS_ERRORED)
+                .toBuilder()
+                .deadline(DateTime.parse("2019-11-11T17:10:04+00:00"))
+                .state(Project.STATE_SUCCESSFUL)
+                .build()
+
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
+        this.pledgeStatusData.assertValue(PledgeStatusData(R.string.We_cant_process_your_pledge_Please_update_your_payment_method,
                 "$20", "November 11, 2019"))
     }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -31,6 +31,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     private val fixPaymentMethodButtonIsGone = TestSubscriber.create<Boolean>()
     private val fixPaymentMethodMessageIsGone = TestSubscriber.create<Boolean>()
     private val notifyDelegateToRefreshProject = TestSubscriber.create<Void>()
+    private val notifyDelegateToShowFixPledge = TestSubscriber.create<Void>()
     private val paymentMethodIsGone = TestSubscriber.create<Boolean>()
     private val pledgeAmount = TestSubscriber.create<CharSequence>()
     private val pledgeDate = TestSubscriber.create<String>()
@@ -58,6 +59,7 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
         this.vm.outputs.fixPaymentMethodButtonIsGone().subscribe(this.fixPaymentMethodButtonIsGone)
         this.vm.outputs.fixPaymentMethodMessageIsGone().subscribe(this.fixPaymentMethodMessageIsGone)
         this.vm.outputs.notifyDelegateToRefreshProject().subscribe(this.notifyDelegateToRefreshProject)
+        this.vm.outputs.notifyDelegateToShowFixPledge().subscribe(this.notifyDelegateToShowFixPledge)
         this.vm.outputs.paymentMethodIsGone().subscribe(this.paymentMethodIsGone)
         this.vm.outputs.pledgeAmount().map { it.toString() }.subscribe(this.pledgeAmount)
         this.vm.outputs.pledgeDate().subscribe(this.pledgeDate)
@@ -404,6 +406,14 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
 
         this.vm.inputs.refreshProject()
         this.notifyDelegateToRefreshProject.assertValueCount(1)
+    }
+
+    @Test
+    fun testNotifyDelegateToShowFixPledge() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.fixPaymentMethodButtonClicked()
+        this.notifyDelegateToShowFixPledge.assertValueCount(1)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ErroredBackingViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ErroredBackingViewHolderViewModelTest.kt
@@ -1,0 +1,54 @@
+package com.kickstarter.viewmodels
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Environment
+import com.kickstarter.mock.factories.ErroredBackingFactory
+import org.joda.time.DateTime
+import org.junit.Test
+import rx.observers.TestSubscriber
+
+class ErroredBackingViewHolderViewModelTest : KSRobolectricTestCase() {
+
+    private lateinit var vm: ErroredBackingViewHolderViewModel.ViewModel
+
+    private val projectFinalCollectionDate = TestSubscriber.create<DateTime>()
+    private val projectName = TestSubscriber.create<String>()
+    private val notifyDelegateToStartFixPaymentMethod = TestSubscriber.create<String>()
+
+    private fun setUpEnvironment(environment: Environment) {
+        this.vm = ErroredBackingViewHolderViewModel.ViewModel(environment)
+
+        this.vm.outputs.projectFinalCollectionDate().subscribe(this.projectFinalCollectionDate)
+        this.vm.outputs.projectName().subscribe(this.projectName)
+        this.vm.outputs.notifyDelegateToStartFixPaymentMethod().subscribe(this.notifyDelegateToStartFixPaymentMethod)
+    }
+
+    @Test
+    fun testProjectFinalCollectionDate() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(ErroredBackingFactory.erroredBacking())
+
+        this.projectFinalCollectionDate.assertValue(DateTime.parse("2020-04-02T18:08:32Z"))
+    }
+
+    @Test
+    fun testProjectName() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(ErroredBackingFactory.erroredBacking())
+
+        this.projectName.assertValue("Some Project Name")
+    }
+
+    @Test
+    fun testNotifyDelegateToStartFixPaymentMethod() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(ErroredBackingFactory.erroredBacking())
+
+        this.vm.inputs.manageButtonClicked()
+        this.notifyDelegateToStartFixPaymentMethod.assertValue("slug")
+    }
+
+}

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -588,6 +588,92 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testPledgeScreenConfiguration_whenFixingPaymentOfShippableReward() {
+        val shippableReward = RewardFactory.rewardWithShipping()
+        val unitedStates = LocationFactory.unitedStates()
+        val shippingRule = ShippingRuleFactory.usShippingRule().toBuilder().location(unitedStates).build()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(50.0)
+                .location(unitedStates)
+                .locationId(unitedStates.id())
+                .reward(shippableReward)
+                .rewardId(shippableReward.id())
+                .shippingAmount(shippingRule.cost().toFloat())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        val shippingRulesEnvelope = ShippingRulesEnvelopeFactory.shippingRules()
+                .toBuilder()
+                .shippingRules(listOf(ShippingRuleFactory.germanyShippingRule(), shippingRule))
+                .build()
+
+        val environment = environmentForShippingRules(shippingRulesEnvelope)
+                .toBuilder()
+                .currentUser(MockCurrentUser(UserFactory.user()))
+                .build()
+
+        setUpEnvironment(environment, shippableReward, backedProject, PledgeReason.FIX_PLEDGE)
+
+        this.continueButtonIsEnabled.assertNoValues()
+        this.continueButtonIsGone.assertValue(true)
+        this.deliveryDividerIsGone.assertValue(true)
+        this.deliverySectionIsGone.assertValue(true)
+        this.paymentContainerIsGone.assertValue(false)
+        this.pledgeButtonIsEnabled.assertValue(true)
+        this.pledgeMaximumIsGone.assertNoValues()
+        this.pledgeSectionIsGone.assertValue(true)
+        this.pledgeSummaryIsGone.assertValue(false)
+        this.shippingRulesSectionIsGone.assertValue(true)
+        this.shippingSummaryIsGone.assertValue(false)
+        this.totalDividerIsGone.assertValue(true)
+        this.updatePledgeButtonIsEnabled.assertNoValues()
+        this.updatePledgeButtonIsGone.assertValue(true)
+        this.updatePledgeProgressIsGone.assertNoValues()
+
+        this.koalaTest.assertNoValues()
+        this.lakeTest.assertNoValues()
+    }
+
+    @Test
+    fun testPledgeScreenConfiguration_whenFixingPaymentOfDigitalReward() {
+        val noReward = RewardFactory.noReward()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .reward(noReward)
+                .rewardId(noReward.id())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        setUpEnvironment(environmentForLoggedInUser(UserFactory.user()), noReward, backedProject, PledgeReason.FIX_PLEDGE)
+
+        this.continueButtonIsEnabled.assertNoValues()
+        this.continueButtonIsGone.assertValue(true)
+        this.deliveryDividerIsGone.assertValue(true)
+        this.deliverySectionIsGone.assertValue(true)
+        this.paymentContainerIsGone.assertValue(false)
+        this.pledgeButtonIsEnabled.assertValue(true)
+        this.pledgeMaximumIsGone.assertNoValues()
+        this.pledgeSectionIsGone.assertValue(true)
+        this.pledgeSummaryIsGone.assertValue(true)
+        this.shippingRulesSectionIsGone.assertValue(true)
+        this.shippingSummaryIsGone.assertValue(true)
+        this.totalDividerIsGone.assertValue(true)
+        this.updatePledgeButtonIsEnabled.assertNoValues()
+        this.updatePledgeButtonIsGone.assertValue(true)
+        this.updatePledgeProgressIsGone.assertNoValues()
+
+        this.koalaTest.assertNoValues()
+        this.lakeTest.assertNoValues()
+    }
+
+    @Test
     fun testPledgeScreenConfiguration_whenUpdatingRewardToShippableReward() {
         val shippableReward = RewardFactory.rewardWithShipping()
 
@@ -642,12 +728,23 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeSummaryAmount() {
+    fun testPledgeSummaryAmount_whenUpatingPaymentMethod() {
         val testData = setUpBackedNoRewardTestData()
         val backedProject = testData.project
         val noReward = testData.reward
 
         setUpEnvironment(environment(), noReward, backedProject, PledgeReason.UPDATE_PAYMENT)
+
+        this.pledgeSummaryAmount.assertValue("$10")
+    }
+
+    @Test
+    fun testPledgeSummaryAmount_whenFixingPaymentMethod() {
+        val testData = setUpBackedNoRewardTestData()
+        val backedProject = testData.project
+        val noReward = testData.reward
+
+        setUpEnvironment(environment(), noReward, backedProject, PledgeReason.FIX_PLEDGE)
 
         this.pledgeSummaryAmount.assertValue("$10")
     }
@@ -690,6 +787,27 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
                 })
                 .build()
         setUpEnvironment(environment, shippableReward, backedProject, PledgeReason.UPDATE_PAYMENT)
+
+        this.totalAmount.assertValue("$50")
+    }
+
+    @Test
+    fun testTotalAmount_whenFixingPaymentMethod() {
+        val testData = setUpBackedShippableRewardTestData()
+        val backedProject = testData.project
+        val shippableReward = testData.reward
+        val shippingRulesEnvelope = testData.shippingRulesEnvelope as ShippingRulesEnvelope
+
+        val environment = environmentForShippingRules(shippingRulesEnvelope)
+                .toBuilder()
+                .currentUser(MockCurrentUser(UserFactory.user()))
+                .apiClient(object : MockApiClient() {
+                    override fun fetchShippingRules(project: Project, reward: Reward): Observable<ShippingRulesEnvelope> {
+                        return Observable.just(shippingRulesEnvelope)
+                    }
+                })
+                .build()
+        setUpEnvironment(environment, shippableReward, backedProject, PledgeReason.FIX_PLEDGE)
 
         this.totalAmount.assertValue("$50")
     }
@@ -1441,7 +1559,27 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShippingSummaryAmount() {
+    fun testShippingSummaryAmount_whenFixingPaymentMethod() {
+        val reward = RewardFactory.rewardWithShipping()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .amount(30.0)
+                .shippingAmount(10f)
+                .reward(reward)
+                .rewardId(reward.id())
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        setUpEnvironment(environment(), reward, backedProject, PledgeReason.FIX_PLEDGE)
+
+        this.shippingSummaryAmount.assertValue("$10")
+    }
+
+    @Test
+    fun testShippingSummaryAmount_whenUpdatingPaymentMethod() {
         val reward = RewardFactory.rewardWithShipping()
         val backing = BackingFactory.backing()
                 .toBuilder()
@@ -1461,7 +1599,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShippingSummaryLocation() {
+    fun testShippingSummaryLocation_whenUpdatingPaymentMethod() {
         val testData = setUpBackedShippableRewardTestData()
         val backedProject = testData.project
         val shippableReward = testData.reward
@@ -1477,6 +1615,27 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
                 })
                 .build()
         setUpEnvironment(environment, shippableReward, backedProject, PledgeReason.UPDATE_PAYMENT)
+
+        this.shippingSummaryLocation.assertValue("Brooklyn, NY")
+    }
+
+    @Test
+    fun testShippingSummaryLocation_whenFixingPaymentMethod() {
+        val testData = setUpBackedShippableRewardTestData()
+        val backedProject = testData.project
+        val shippableReward = testData.reward
+        val shippingRulesEnvelope = testData.shippingRulesEnvelope as ShippingRulesEnvelope
+
+        val environment = environmentForShippingRules(shippingRulesEnvelope)
+                .toBuilder()
+                .currentUser(MockCurrentUser(UserFactory.user()))
+                .apiClient(object : MockApiClient() {
+                    override fun fetchShippingRules(project: Project, reward: Reward): Observable<ShippingRulesEnvelope> {
+                        return Observable.just(shippingRulesEnvelope)
+                    }
+                })
+                .build()
+        setUpEnvironment(environment, shippableReward, backedProject, PledgeReason.FIX_PLEDGE)
 
         this.shippingSummaryLocation.assertValue("Brooklyn, NY")
     }
@@ -1533,6 +1692,17 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testShowNewCardFragment_whenFixingPaymentMethod() {
+        val backedProject = ProjectFactory.backedProject()
+        setUpEnvironment(environmentForLoggedInUser(UserFactory.user()), RewardFactory.noReward(), backedProject, PledgeReason.FIX_PLEDGE)
+
+        this.vm.inputs.newCardButtonClicked()
+        this.showNewCardFragment.assertValue(backedProject)
+        this.koalaTest.assertNoValues()
+        this.lakeTest.assertNoValues()
+    }
+
+    @Test
     fun testShowNewCardFragment_whenUpdatingPaymentMethod() {
         val backedProject = ProjectFactory.backedProject()
         setUpEnvironment(environmentForLoggedInUser(UserFactory.user()), RewardFactory.noReward(), backedProject, PledgeReason.UPDATE_PAYMENT)
@@ -1544,7 +1714,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShowUpdatePaymentError() {
+    fun testShowUpdatePaymentError_whenUpdatingPaymentMethod() {
         val testData = setUpBackedNoRewardTestData()
         val backedProject = testData.project
         val noReward = testData.reward
@@ -1580,7 +1750,43 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShowUpdatePaymentSuccess() {
+    fun testShowUpdatePaymentError_whenFixingPaymentMethod() {
+        val testData = setUpBackedNoRewardTestData()
+        val backedProject = testData.project
+        val noReward = testData.reward
+        val storedCards = testData.storedCards
+
+        val environment = environment()
+                .toBuilder()
+                .currentUser(MockCurrentUser(UserFactory.user()))
+                .apolloClient(object : MockApolloClient() {
+                    override fun getStoredCards(): Observable<List<StoredCard>> {
+                        return Observable.just(storedCards)
+                    }
+
+                    override fun updateBacking(updateBackingData: UpdateBackingData): Observable<Checkout> {
+                        return Observable.error(Exception("womp"))
+                    }
+                }).build()
+
+        setUpEnvironment(environment, noReward, backedProject, PledgeReason.FIX_PLEDGE)
+
+        this.showSelectedCard.assertValue(Pair(1, CardState.SELECTED))
+
+        this.vm.inputs.cardSelected(storedCards[0], 0)
+
+        this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
+
+        this.vm.inputs.pledgeButtonClicked()
+
+        this.pledgeButtonIsEnabled.assertValues(true, false, true)
+        this.pledgeProgressIsGone.assertValues(false, true)
+        this.showUpdatePaymentError.assertValueCount(1)
+        this.koalaTest.assertNoValues()
+    }
+
+    @Test
+    fun testShowUpdatePaymentSuccess_whenUpdatingPaymentMethod() {
         val testData = setUpBackedNoRewardTestData()
         val backedProject = testData.project
         val noReward = testData.reward
@@ -1606,6 +1812,35 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeProgressIsGone.assertValues(false)
         this.showUpdatePaymentSuccess.assertValueCount(1)
         this.koalaTest.assertValues("Update Payment Method Button Clicked")
+    }
+
+    @Test
+    fun testShowUpdatePaymentSuccess_whenFixingPaymentMethod() {
+        val testData = setUpBackedNoRewardTestData()
+        val backedProject = testData.project
+        val noReward = testData.reward
+        val storedCards = testData.storedCards
+
+        val environment = environment()
+                .toBuilder()
+                .currentUser(MockCurrentUser(UserFactory.user()))
+                .apolloClient(apolloClientWithStoredCards(storedCards))
+                .build()
+
+        setUpEnvironment(environment, noReward, backedProject, PledgeReason.FIX_PLEDGE)
+
+        this.showSelectedCard.assertValue(Pair(1, CardState.SELECTED))
+
+        this.vm.inputs.cardSelected(storedCards[0], 0)
+
+        this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
+
+        this.vm.inputs.pledgeButtonClicked()
+
+        this.pledgeButtonIsEnabled.assertValues(true, false)
+        this.pledgeProgressIsGone.assertValues(false)
+        this.showUpdatePaymentSuccess.assertValueCount(1)
+        this.koalaTest.assertNoValues()
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -620,8 +620,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.continueButtonIsEnabled.assertNoValues()
         this.continueButtonIsGone.assertValue(true)
-        this.deliveryDividerIsGone.assertValue(true)
-        this.deliverySectionIsGone.assertValue(true)
         this.paymentContainerIsGone.assertValue(false)
         this.pledgeButtonIsEnabled.assertValue(true)
         this.pledgeMaximumIsGone.assertNoValues()
@@ -630,9 +628,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingRulesSectionIsGone.assertValue(true)
         this.shippingSummaryIsGone.assertValue(false)
         this.totalDividerIsGone.assertValue(true)
-        this.updatePledgeButtonIsEnabled.assertNoValues()
-        this.updatePledgeButtonIsGone.assertValue(true)
-        this.updatePledgeProgressIsGone.assertNoValues()
 
         this.koalaTest.assertNoValues()
         this.lakeTest.assertNoValues()
@@ -655,8 +650,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.continueButtonIsEnabled.assertNoValues()
         this.continueButtonIsGone.assertValue(true)
-        this.deliveryDividerIsGone.assertValue(true)
-        this.deliverySectionIsGone.assertValue(true)
         this.paymentContainerIsGone.assertValue(false)
         this.pledgeButtonIsEnabled.assertValue(true)
         this.pledgeMaximumIsGone.assertNoValues()
@@ -665,9 +658,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingRulesSectionIsGone.assertValue(true)
         this.shippingSummaryIsGone.assertValue(true)
         this.totalDividerIsGone.assertValue(true)
-        this.updatePledgeButtonIsEnabled.assertNoValues()
-        this.updatePledgeButtonIsGone.assertValue(true)
-        this.updatePledgeProgressIsGone.assertNoValues()
 
         this.koalaTest.assertNoValues()
         this.lakeTest.assertNoValues()

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -1213,6 +1213,34 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testShowUpdatePledge_whenFixingPaymentMethod() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+
+        // Start the view model with a backed project
+        val reward = RewardFactory.reward()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(BackingFactory.backing()
+                        .toBuilder()
+                        .rewardId(reward.id())
+                        .build())
+                .rewards(listOf(RewardFactory.noReward(), reward))
+                .build()
+
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, backedProject))
+
+        this.vm.inputs.fixPaymentMethodButtonClicked()
+
+        this.showUpdatePledge.assertValuesAndClear(Pair(PledgeData.builder()
+                .pledgeFlowContext(PledgeFlowContext.MANAGE_REWARD)
+                .reward(reward)
+                .projectData(ProjectDataFactory.project(backedProject))
+                .build(), PledgeReason.FIX_PLEDGE))
+        this.koalaTest.assertValue("Project Page")
+        this.lakeTest.assertValue("Project Page Viewed")
+    }
+
+    @Test
     fun testShowUpdatePledge_whenUpdatingPledge() {
         setUpEnvironment(environment())
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -692,8 +692,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeActionButtonUIOutputs_whenNativeCheckoutEnabled_whenBackingIsErrored() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+    fun testPledgeActionButtonUIOutputs_whenBackingIsErrored() {
+        setUpEnvironment(environment())
         val backedSuccessfulProject = ProjectFactory.backedProject()
                 .toBuilder()
                 .backing(BackingFactory.backing(Backing.STATUS_ERRORED))
@@ -706,7 +706,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeToolbarNavigationIcon_whenNativeCheckoutEnabled() {
+    fun testPledgeToolbarNavigationIcon() {
         setUpEnvironment(environment())
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
@@ -858,7 +858,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testExpandPledgeSheet_whenIntentExpandPledgeSheet_isTrue() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         val intent = Intent()
                 .putExtra(IntentKey.PROJECT, ProjectFactory.project())
                 .putExtra(IntentKey.EXPAND_PLEDGE_SHEET, true)
@@ -872,7 +872,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testExpandPledgeSheet_whenIntentExpandPledgeSheet_isFalse() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         val intent = Intent()
                 .putExtra(IntentKey.PROJECT, ProjectFactory.project())
                 .putExtra(IntentKey.EXPAND_PLEDGE_SHEET, false)
@@ -886,7 +886,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testExpandPledgeSheet_whenIntentExpandPledgeSheet_isNull() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
         val intent = Intent()
                 .putExtra(IntentKey.PROJECT, ProjectFactory.project())
         this.vm.intent(intent)
@@ -986,7 +986,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testBackingDetails_whenBackingIsErrored() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         val backedSuccessfulProject = ProjectFactory.backedProject()
                 .toBuilder()
@@ -1255,7 +1255,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowUpdatePledge_whenFixingPaymentMethod() {
-        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        setUpEnvironment(environment())
 
         // Start the view model with a backed project
         val reward = RewardFactory.reward()

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -857,6 +857,47 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testExpandPledgeSheet_whenIntentExpandPledgeSheet_isTrue() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        val intent = Intent()
+                .putExtra(IntentKey.PROJECT, ProjectFactory.project())
+                .putExtra(IntentKey.EXPAND_PLEDGE_SHEET, true)
+        this.vm.intent(intent)
+
+        this.expandPledgeSheet.assertValues(Pair(true, true))
+        this.koalaTest.assertValue("Project Page")
+        this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
+    }
+
+    @Test
+    fun testExpandPledgeSheet_whenIntentExpandPledgeSheet_isFalse() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        val intent = Intent()
+                .putExtra(IntentKey.PROJECT, ProjectFactory.project())
+                .putExtra(IntentKey.EXPAND_PLEDGE_SHEET, false)
+        this.vm.intent(intent)
+
+        this.expandPledgeSheet.assertNoValues()
+        this.koalaTest.assertValue("Project Page")
+        this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
+    }
+
+    @Test
+    fun testExpandPledgeSheet_whenIntentExpandPledgeSheet_isNull() {
+        setUpEnvironment(environmentWithNativeCheckoutEnabled())
+        val intent = Intent()
+                .putExtra(IntentKey.PROJECT, ProjectFactory.project())
+        this.vm.intent(intent)
+
+        this.expandPledgeSheet.assertNoValues()
+        this.koalaTest.assertValue("Project Page")
+        this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
+    }
+
+    @Test
     fun testGoBack_whenFragmentBackStackIsEmpty() {
         setUpEnvironment(environment())
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardCardUnselectedViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardCardUnselectedViewHolderViewModelTest.kt
@@ -6,6 +6,7 @@ import com.kickstarter.R
 import com.kickstarter.libs.Environment
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.StoredCardFactory
+import com.kickstarter.models.Backing
 import com.kickstarter.models.StoredCard
 import com.stripe.android.model.Card
 import org.junit.Test

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardCardUnselectedViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardCardUnselectedViewHolderViewModelTest.kt
@@ -4,6 +4,8 @@ import android.util.Pair
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.libs.Environment
+import com.kickstarter.mock.factories.BackingFactory
+import com.kickstarter.mock.factories.PaymentSourceFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.StoredCardFactory
 import com.kickstarter.models.Backing
@@ -18,7 +20,6 @@ class RewardCardUnselectedViewHolderViewModelTest : KSRobolectricTestCase() {
     private lateinit var vm: RewardCardUnselectedViewHolderViewModel.ViewModel
 
     private val expirationDate = TestSubscriber.create<String>()
-    private val id = TestSubscriber.create<String>()
     private val isClickable = TestSubscriber.create<Boolean>()
     private val issuer = TestSubscriber.create<String>()
     private val issuerImage = TestSubscriber.create<Int>()
@@ -27,6 +28,7 @@ class RewardCardUnselectedViewHolderViewModelTest : KSRobolectricTestCase() {
     private val lastFour = TestSubscriber.create<String>()
     private val notAvailableCopyIsVisible = TestSubscriber.create<Boolean>()
     private val notifyDelegateCardSelected = TestSubscriber.create<Pair<StoredCard, Int>>()
+    private val retryCopyIsVisible = TestSubscriber.create<Boolean>()
     private val selectImageIsVisible = TestSubscriber.create<Boolean>()
 
     private fun setUpEnvironment(environment: Environment) {
@@ -41,6 +43,7 @@ class RewardCardUnselectedViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.lastFour().subscribe(this.lastFour)
         this.vm.outputs.notAvailableCopyIsVisible().subscribe(this.notAvailableCopyIsVisible)
         this.vm.outputs.notifyDelegateCardSelected().subscribe(this.notifyDelegateCardSelected)
+        this.vm.outputs.retryCopyIsVisible().subscribe(this.retryCopyIsVisible)
         this.vm.outputs.selectImageIsVisible().subscribe(this.selectImageIsVisible)
     }
 
@@ -182,6 +185,92 @@ class RewardCardUnselectedViewHolderViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.cardSelected(2)
         this.notifyDelegateCardSelected.assertValue(Pair(creditCard, 2))
+    }
+
+    @Test
+    fun testRetryCopyIsVisible_whenCardIsBackingPaymentSource_backingIsErrored() {
+        setUpEnvironment(environment())
+        val visa = StoredCardFactory.visa()
+
+        val paymentSource = PaymentSourceFactory.visa()
+                .toBuilder()
+                .id(visa.id())
+                .build()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .paymentSource(paymentSource)
+                .status(Backing.STATUS_ERRORED)
+                .build()
+        val project = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        this.vm.inputs.configureWith(Pair(visa, project))
+
+        this.retryCopyIsVisible.assertValue(true)
+    }
+
+    @Test
+    fun testRetryCopyIsVisible_whenCardIsBackingPaymentSource_backingIsNotErrored() {
+        setUpEnvironment(environment())
+        val visa = StoredCardFactory.visa()
+
+        val paymentSource = PaymentSourceFactory.visa()
+                .toBuilder()
+                .id(visa.id())
+                .build()
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .paymentSource(paymentSource)
+                .build()
+        val project = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        this.vm.inputs.configureWith(Pair(visa, project))
+
+        this.retryCopyIsVisible.assertValue(false)
+    }
+
+    @Test
+    fun testRetryCopyIsVisible_whenCardIsNotBackingPaymentSource_backingIsErrored() {
+        setUpEnvironment(environment())
+        val discover = StoredCardFactory.discoverCard()
+
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .paymentSource(PaymentSourceFactory.visa())
+                .status(Backing.STATUS_ERRORED)
+                .build()
+        val project = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        this.vm.inputs.configureWith(Pair(discover, project))
+
+        this.retryCopyIsVisible.assertValue(false)
+    }
+
+    @Test
+    fun testRetryCopyIsVisible_whenCardIsNotBackingPaymentSource_backingIsNotErrored() {
+        setUpEnvironment(environment())
+        val discover = StoredCardFactory.discoverCard()
+
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .paymentSource(PaymentSourceFactory.visa())
+                .build()
+        val project = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(backing)
+                .build()
+
+        this.vm.inputs.configureWith(Pair(discover, project))
+
+        this.retryCopyIsVisible.assertValue(false)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Merging in the fix your pledge feature branch.

# 🤔 Why
It'll be in the 2.7.0 release.

# 🛠 How
I successfully rebased!!!
[⛔️] NT-660 Displaying errored backing status in pledge container sum
[⛔️] NT-1031 Displaying fix pledge CTAs in BackingFragment (#801) 
[⛔️] NT-1048 Added graphQL call to get errored backings (#802)
[🎨] NT-1049 Added header layout for errored backings in Activity feed (…
[⛔️] NT-1031 Navigating to pledge screen when users click "Fix" (#804)
[⛔️] NT-1050 Adding ErroredBackingViewHolder (#805)
[⛔️] NT-1051 Displaying errored backings in Activity feed (#809)
[⛔️] NT-1057 Automatically expanding pledge sheet when fixing pledge (#…
[⛔️] NT-1080 Pledge screen UI when fixing an errored backing's payment (
[💳] NT-1079 Enabling reselecting failed payment method (#812)
[💳] NT-1078 Showing failed indicator icon on failed payment method (#811
[⛔️] NT-1116 Errored backings deadline warning copy (#819)
[🗣] NT-1117 Errored backings icon a11y (#820)
[🤕] Merging master into NT-598 (#845)

# Story 📖
[NT-598]


[NT-598]: https://kickstarter.atlassian.net/browse/NT-598