### PR TITLE
[🐛] NT-1193 Pledge button disabled bug

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -775,10 +775,11 @@ interface PledgeFragmentViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.continueButtonIsEnabled)
 
-            initialCardSelection
+            selectedCardAndPosition
                     .compose(ignoreValues())
                     .compose<Pair<Void, Boolean>>(combineLatestPair(totalIsValid))
                     .map { it.second }
+                    .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.pledgeButtonIsEnabled)
 


### PR DESCRIPTION
# 📲 What
Fixes bug where pledge button was still disabled after user added their first payment method.

# 🤔 Why
So people can pledge after adding their first stored card!

# 🛠 How
- Instead of depending on `initialCardSelection` which won't emit if a user has no stored cards, using `selectedCardAndPosition` to determine if `pledgeButtonIsEnabled` should emit
- Added `distinctUntilChanged` to fix broken tests

# 👀 See
![device-2020-04-23-144353 2020-04-23 14_48_58](https://user-images.githubusercontent.com/1289295/80137648-97a20d80-8571-11ea-96ec-7ea5d02b5150.gif)

# 📋 QA
Steps to repro:
- Have 0 saved payment methods
- Navigate to the pledge screen
- The pledge button should be disabled
- Added a payment method
- The pledge button should be enabled

# Story 📖
[NT-1193]


[NT-1193]: https://kickstarter.atlassian.net/browse/NT-1193