### PR TITLE
[🔄] NT-1190 Moving Campaign Details Pledge Button Clicked event from Optimizely to Data 💧

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -763,6 +763,17 @@ public final class Koala {
   }
   //endregion
 
+  //region Experiments
+  public void trackCampaignDetailsPledgeButtonClicked(final @NonNull ProjectData projectData) {
+    final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
+    props.putAll(KoalaUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()));
+    props.putAll(optimizelyProperties(projectData));
+    props.put("context_pledge_flow", PledgeFlowContext.NEW_PLEDGE.getTrackingString());
+
+    this.client.track(LakeEvent.CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED, props);
+  }
+  //endregion
+
   private @NonNull Map<String, Object> optimizelyProperties(final @NonNull ProjectData projectData) {
     final ExperimentData experimentData = new ExperimentData(this.client.loggedInUser(), projectData.refTagFromIntent(), projectData.refTagFromCookie());
     return this.client.optimizely().optimizelyProperties(experimentData);

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -33,3 +33,7 @@ const val SIGN_UP_BUTTON_CLICKED = "Sign Up Button Clicked"
 const val SIGN_UP_SUBMIT_BUTTON_CLICKED = "Sign Up Submit Button Clicked"
 const val TWO_FACTOR_CONFIRMATION_VIEWED = "Two-Factor Confirmation Viewed"
 // endregion
+
+// region native_project_page_campaign_details experiment
+const val CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED = "Campaign Details Pledge Button Clicked"
+// endregion

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
@@ -6,7 +6,6 @@ const val APP_COMPLETED_CHECKOUT = "App Completed Checkout"
 
 // region native_project_page_campaign_details
 const val CAMPAIGN_DETAILS_BUTTON_CLICKED = "Campaign Details Button Clicked"
-const val CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED = "Campaign Details Pledge Button Clicked"
 // endregion
 
 // region native_project_page_conversion_creator_details

--- a/app/src/main/java/com/kickstarter/viewmodels/CampaignDetailsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CampaignDetailsViewModel.kt
@@ -2,7 +2,6 @@ package com.kickstarter.viewmodels
 
 import android.util.Pair
 import com.kickstarter.libs.ActivityViewModel
-import com.kickstarter.libs.CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
@@ -78,11 +77,9 @@ interface CampaignDetailsViewModel {
                     .subscribe(this.goBackToProject)
 
             projectData
-                    .compose<Pair<ProjectData, User?>>(combineLatestPair(this.currentUser.observable()))
-                    .map { ExperimentData(it.second, it.first.refTagFromIntent(), it.first.refTagFromCookie()) }
-                    .compose<ExperimentData>(takeWhen(this.pledgeButtonClicked))
+                    .compose<ProjectData>(takeWhen(this.pledgeButtonClicked))
                     .compose(bindToLifecycle())
-                    .subscribe { this.optimizely.track(CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED, it) }
+                    .subscribe { this.lake.trackCampaignDetailsPledgeButtonClicked(it) }
         }
 
         override fun pledgeActionButtonClicked() = this.pledgeButtonClicked.onNext(null)

--- a/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
@@ -37,7 +37,7 @@ class CampaignDetailsViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.pledgeActionButtonClicked()
         this.goBackToProject.assertValueCount(1)
-        this.experimentsTest.assertValue("Campaign Details Pledge Button Clicked")
+        this.lakeTest.assertValue("Campaign Details Pledge Button Clicked")
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Moving `Campaign Details Pledge Button Clicked` from Optimizely to the Data Lake

# 🤔 Why
We're moving Optimizely tracking events into the Data Lake.

# 🛠 How
## `Koala`
- Added `trackCampaignDetailsPledgeButtonClicked` that tracks `Campaign Details Pledge Button Clicked` with Optimizely properties
## `LakeEvent`
- Added region for `native_project_page_campaign_details` experiment
- Added `CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED` const with value `Campaign Details Pledge Button Clicked`
## `OptimizelyEvent`
- Removed `CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED`
## `CampaignDetailsViewModel`
- Tracking `pledgeButtonClicked` event with `lake` instead of `optimizely`
- Updated test

# 👀 See
No visual changes.

# 📋 QA
- Get into `variant-2` of the `native_project_page_campaign_details` experiment.
- Click the pledge button in the Campaign screen
- Check your local logcat

# Story 📖
[NT-1190]


[NT-1190]: https://kickstarter.atlassian.net/browse/NT-1190