### PR TITLE
[🔄] NT-1191 Moving Campaign Details Button Clicked event from Optimizely to Data 💧

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -764,6 +764,15 @@ public final class Koala {
   //endregion
 
   //region Experiments
+  public void trackCampaignDetailsButtonClicked(final @NonNull ProjectData projectData) {
+    final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
+    props.putAll(KoalaUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()));
+    props.putAll(optimizelyProperties(projectData));
+    props.put("context_pledge_flow", PledgeFlowContext.NEW_PLEDGE.getTrackingString());
+
+    this.client.track(LakeEvent.CAMPAIGN_DETAILS_BUTTON_CLICKED, props);
+  }
+
   public void trackCampaignDetailsPledgeButtonClicked(final @NonNull ProjectData projectData) {
     final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
     props.putAll(KoalaUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()));

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -35,5 +35,6 @@ const val TWO_FACTOR_CONFIRMATION_VIEWED = "Two-Factor Confirmation Viewed"
 // endregion
 
 // region native_project_page_campaign_details experiment
+const val CAMPAIGN_DETAILS_BUTTON_CLICKED = "Campaign Details Button Clicked"
 const val CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED = "Campaign Details Pledge Button Clicked"
 // endregion

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
@@ -4,10 +4,6 @@ package com.kickstarter.libs
 
 const val APP_COMPLETED_CHECKOUT = "App Completed Checkout"
 
-// region native_project_page_campaign_details
-const val CAMPAIGN_DETAILS_BUTTON_CLICKED = "Campaign Details Button Clicked"
-// endregion
-
 // region native_project_page_conversion_creator_details
 const val CREATOR_DETAILS_CLICKED = "Creator Details Clicked"
 // endregion

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -735,12 +735,12 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe { this.koala.trackOpenedAppBanner() }
 
-            fullProjectDataAndCurrentUser
-                    .map { Pair(ExperimentData(it.second, it.first.refTagFromIntent(), it.first.refTagFromCookie()), it.first.project()) }
-                    .compose<Pair<ExperimentData, Project>>(takeWhen(blurbClicked))
-                    .filter { it.second.isLive && !it.second.isBacking }
+            fullProjectDataAndPledgeFlowContext
+                    .map { it.first }
+                    .compose<ProjectData>(takeWhen(blurbClicked))
+                    .filter { it.project().isLive && !it.project().isBacking }
                     .compose(bindToLifecycle())
-                    .subscribe { this.optimizely.track(CAMPAIGN_DETAILS_BUTTON_CLICKED, it.first) }
+                    .subscribe { this.lake.trackCampaignDetailsButtonClicked(it) }
 
             val shouldTrackCTAClickedEvent = this.pledgeActionButtonText
                     .map { isPledgeCTA(it) }

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -6,7 +6,10 @@ import android.net.Uri
 import android.util.Pair
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
-import com.kickstarter.libs.*
+import com.kickstarter.libs.ActivityRequestCodes
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.KoalaEvent
+import com.kickstarter.libs.MockCurrentUser
 import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.*
@@ -398,7 +401,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
-        this.experimentsTest.assertValue("Campaign Details Button Clicked")
+        this.lakeTest.assertValues("Project Page Viewed", "Campaign Details Button Clicked")
     }
 
     @Test
@@ -411,7 +414,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
-        this.experimentsTest.assertNoValues()
+        this.lakeTest.assertValue("Project Page Viewed")
     }
 
     @Test
@@ -424,7 +427,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
-        this.experimentsTest.assertNoValues()
+        this.lakeTest.assertValue("Project Page Viewed")
     }
 
     @Test
@@ -437,7 +440,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbVariantClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
-        this.experimentsTest.assertValue("Campaign Details Button Clicked")
+        this.lakeTest.assertValues("Project Page Viewed", "Campaign Details Button Clicked")
     }
 
     @Test
@@ -450,7 +453,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbVariantClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
-        this.experimentsTest.assertNoValues()
+        this.lakeTest.assertValue("Project Page Viewed")
     }
 
     @Test
@@ -463,7 +466,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbVariantClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
-        this.experimentsTest.assertNoValues()
+        this.lakeTest.assertValue("Project Page Viewed")
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Moving `Campaign Details Button Clicked` from Optimizely to the Data Lake

# 🤔 Why
We're moving Optimizely tracking events into the Data Lake.

# 🛠 How
## `Koala`
- Added `trackCampaignDetailsButtonClicked` that tracks `Campaign Details Button Clicked` with Optimizely properties
## `LakeEvent`
- Added `CAMPAIGN_DETAILS_BUTTON_CLICKED` const with value `Campaign Details Button Clicked`
## `OptimizelyEvent`
- Removed `CAMPAIGN_DETAILS_BUTTON_CLICKED` and `native_project_page_campaign_details` region
## `ProjectViewModel`
- Tracking `blurbClicked` event with `lake` instead of `optimizely`
- Updated tests

# 👀 See
No visual changes.

# 📋 QA
- Click the project blurb
- Check your local logcat

# Story 📖
[NT-1191]

[NT-1191]: https://kickstarter.atlassian.net/browse/NT-1191