### PR TITLE
[🔄] NT-1192 Moving Creator Details Button Clicked event from Optimizely to Data 💧

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -777,7 +777,7 @@ public final class Koala {
   }
   //endregion
 
-  private @NonNull Map<String, Object> experimentProperties(@NonNull ProjectData projectData) {
+  private @NonNull Map<String, Object> experimentProperties(final @NonNull ProjectData projectData) {
     final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
     props.putAll(KoalaUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()));
     props.putAll(optimizelyProperties(projectData));

--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -16,6 +16,8 @@ import com.kickstarter.ui.data.PledgeData;
 import com.kickstarter.ui.data.PledgeFlowContext;
 import com.kickstarter.ui.data.ProjectData;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -765,23 +767,25 @@ public final class Koala {
 
   //region Experiments
   public void trackCampaignDetailsButtonClicked(final @NonNull ProjectData projectData) {
-    final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
-    props.putAll(KoalaUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()));
-    props.putAll(optimizelyProperties(projectData));
-    props.put("context_pledge_flow", PledgeFlowContext.NEW_PLEDGE.getTrackingString());
-
-    this.client.track(LakeEvent.CAMPAIGN_DETAILS_BUTTON_CLICKED, props);
+    this.client.track(LakeEvent.CAMPAIGN_DETAILS_BUTTON_CLICKED, experimentProperties(projectData));
   }
 
   public void trackCampaignDetailsPledgeButtonClicked(final @NonNull ProjectData projectData) {
+    this.client.track(LakeEvent.CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED, experimentProperties(projectData));
+  }
+
+  public void trackCreatorDetailsClicked(final @NonNull ProjectData projectData) {
+    this.client.track(LakeEvent.CREATOR_DETAILS_CLICKED, experimentProperties(projectData));
+  }
+  //endregion
+
+  private @NonNull Map<String, Object> experimentProperties(@NonNull ProjectData projectData) {
     final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
     props.putAll(KoalaUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()));
     props.putAll(optimizelyProperties(projectData));
     props.put("context_pledge_flow", PledgeFlowContext.NEW_PLEDGE.getTrackingString());
-
-    this.client.track(LakeEvent.CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED, props);
+    return props;
   }
-  //endregion
 
   private @NonNull Map<String, Object> optimizelyProperties(final @NonNull ProjectData projectData) {
     final ExperimentData experimentData = new ExperimentData(this.client.loggedInUser(), projectData.refTagFromIntent(), projectData.refTagFromCookie());

--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -16,8 +16,6 @@ import com.kickstarter.ui.data.PledgeData;
 import com.kickstarter.ui.data.PledgeFlowContext;
 import com.kickstarter.ui.data.ProjectData;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.util.HashMap;
 import java.util.Map;
 

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -38,3 +38,8 @@ const val TWO_FACTOR_CONFIRMATION_VIEWED = "Two-Factor Confirmation Viewed"
 const val CAMPAIGN_DETAILS_BUTTON_CLICKED = "Campaign Details Button Clicked"
 const val CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED = "Campaign Details Pledge Button Clicked"
 // endregion
+
+// region native_project_page_conversion_creator_details
+const val CREATOR_DETAILS_CLICKED = "Creator Details Clicked"
+// endregion
+

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
@@ -3,7 +3,3 @@
 package com.kickstarter.libs
 
 const val APP_COMPLETED_CHECKOUT = "App Completed Checkout"
-
-// region native_project_page_conversion_creator_details
-const val CREATOR_DETAILS_CLICKED = "Creator Details Clicked"
-// endregion

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -754,11 +754,11 @@ interface ProjectViewModel {
                     .subscribe { this.optimizely.track(PROJECT_PAGE_PLEDGE_BUTTON_CLICKED, it.first) }
 
             fullProjectDataAndCurrentUser
-                    .map { Pair(ExperimentData(it.second, it.first.refTagFromIntent(), it.first.refTagFromCookie()), it.first.project()) }
-                    .compose<Pair<ExperimentData, Project>>(takeWhen(creatorInfoClicked))
-                    .filter { it.second.isLive && !it.second.isBacking }
+                    .map { it.first }
+                    .compose<ProjectData>(takeWhen(creatorInfoClicked))
+                    .filter { it.project().isLive && !it.project().isBacking }
                     .compose(bindToLifecycle())
-                    .subscribe { this.optimizely.track(CREATOR_DETAILS_CLICKED, it.first) }
+                    .subscribe { this.lake.trackCreatorDetailsClicked(it) }
         }
 
         private fun eventName(projectActionButtonStringRes: Int) : String {

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -479,7 +479,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.creatorNameTextViewClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
-        this.experimentsTest.assertValue("Creator Details Clicked")
+        this.lakeTest.assertValues("Project Page Viewed", "Creator Details Clicked")
     }
 
     @Test
@@ -492,7 +492,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.creatorNameTextViewClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
-        this.experimentsTest.assertNoValues()
+        this.lakeTest.assertValue("Project Page Viewed")
     }
 
     @Test
@@ -505,7 +505,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.creatorNameTextViewClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
-        this.experimentsTest.assertNoValues()
+        this.lakeTest.assertValue("Project Page Viewed")
     }
 
     @Test
@@ -518,7 +518,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.creatorInfoVariantClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
-        this.experimentsTest.assertValue("Creator Details Clicked")
+        this.lakeTest.assertValues("Project Page Viewed", "Creator Details Clicked")
     }
 
     @Test
@@ -531,7 +531,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.creatorInfoVariantClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
-        this.experimentsTest.assertNoValues()
+        this.lakeTest.assertValue("Project Page Viewed")
     }
 
     @Test
@@ -544,7 +544,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.creatorInfoVariantClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
-        this.experimentsTest.assertNoValues()
+        this.lakeTest.assertValue("Project Page Viewed")
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Moving `Creator Details Button Clicked` from Optimizely to the Data Lake

# 🤔 Why
We're moving Optimizely tracking events into the Data Lake.

# 🛠 How
## `Koala`
- Added `trackCreatorDetailsClicked` that tracks `Creator Details Button Clicked` with Optimizely properties
- Added `experimentProperties` helper method since the 3 experiment tracking methods did the same thing
## `LakeEvent`
- Added `CREATOR_DETAILS_CLICKED` const with value `Campaign Details Button Clicked` in `native_project_page_conversion_creator_details` region
## `OptimizelyEvent`
- Removed `CREATOR_DETAILS_CLICKED` and `native_project_page_conversion_creator_details` region
## `ProjectViewModel`
- Tracking `creatorInfoClicked` event with `lake` instead of `optimizely`
- Updated tests

# 👀 See
No visual changes.

# 📋 QA
- Click the creator details
- Check your local logcat

# Story 📖
[NT-1192]

[NT-1192]: https://kickstarter.atlassian.net/browse/NT-1192