### PR TITLE
[␡] NT-1195 No longer tracking Project Page Pledge Button Clicked in Optimizely

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -703,10 +703,11 @@ public final class Koala {
     final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
     props.putAll(KoalaUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()));
 
-    final Map<String, Object> optimizelyProperties = optimizelyProperties(projectData);
-    props.putAll(optimizelyProperties);
     if (pledgeFlowContext != null) {
       props.put("context_pledge_flow", pledgeFlowContext.getTrackingString());
+      if (pledgeFlowContext == PledgeFlowContext.NEW_PLEDGE) {
+        props.putAll(optimizelyProperties(projectData));
+      }
     }
 
     this.client.track(LakeEvent.PROJECT_PAGE_PLEDGE_BUTTON_CLICKED, props);

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -771,17 +771,6 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe { this.lake.trackCampaignDetailsButtonClicked(it) }
 
-            val shouldTrackCTAClickedEvent = this.pledgeActionButtonText
-                    .map { isPledgeCTA(it) }
-                    .compose<Boolean>(takeWhen(this.nativeProjectActionButtonClicked))
-
-            fullProjectDataAndCurrentUser
-                    .map { ExperimentData(it.second, it.first.refTagFromIntent(), it.first.refTagFromCookie()) }
-                    .compose<Pair<ExperimentData, Boolean>>(combineLatestPair(shouldTrackCTAClickedEvent))
-                    .filter { it.second }
-                    .compose(bindToLifecycle())
-                    .subscribe { this.optimizely.track(PROJECT_PAGE_PLEDGE_BUTTON_CLICKED, it.first) }
-
             fullProjectDataAndCurrentUser
                     .map { Pair(ExperimentData(it.second, it.first.refTagFromIntent(), it.first.refTagFromCookie()), it.first.project()) }
                     .compose<Pair<ExperimentData, Project>>(takeWhen(creatorInfoClicked))
@@ -798,17 +787,6 @@ interface ProjectViewModel {
                 R.string.Manage -> KoalaEvent.MANAGE_PLEDGE_BUTTON_CLICKED
                 R.string.View_your_pledge -> KoalaEvent.VIEW_YOUR_PLEDGE_BUTTON_CLICKED
                 else -> KoalaEvent.VIEW_REWARDS_BUTTON_CLICKED
-            }
-        }
-
-        private fun isPledgeCTA(projectActionButtonStringRes: Int) : Boolean {
-            return when (projectActionButtonStringRes) {
-                R.string.Back_this_project -> true
-                R.string.View_the_rewards -> true
-                R.string.See_the_rewards -> true
-                R.string.Manage -> false
-                R.string.View_your_pledge -> false
-                else -> false
             }
         }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -775,7 +775,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.goBack.assertNoValues()
         this.koalaTest.assertValues("Project Page", "Back this Project Button Clicked")
         this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
-        this.experimentsTest.assertValues("Project Page Pledge Button Clicked")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -788,7 +788,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page", "Back this Project Button Clicked")
         this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
-        this.experimentsTest.assertValues("Project Page Pledge Button Clicked")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
No longer tracking `Project Page Pledge Button Clicked` in Optimizely

# 🤔 Why
We're sending the Optimizely properties in the Data Lake call. This is the clean-up PR I mentioned in #846 

# 🛠 How
- Removed optimizely tracking call in `ProjectViewModel` when the project CTA button is clicked
- Only adding optimizely properties in `Koala.trackProjectPagePledgeButtonClicked` when the `PledgeFlowContext` is `NEW_PLEDGE`

# 👀 See
Nothing 2 c.

# 📋 QA
Check the LogCat filtered for `Optly` to see no tracking happens when the project CTA buttton is clicked.

# Story 📖
[NT-1195]


[NT-1195]: https://kickstarter.atlassian.net/browse/NT-1195