### PR TITLE
[🔢] NT-1196 Including erroredBackingsCount in drawer Activity count

### DIFF
--- a/app/src/main/java/com/kickstarter/models/User.java
+++ b/app/src/main/java/com/kickstarter/models/User.java
@@ -20,6 +20,7 @@ public abstract class User implements Parcelable, Relay {
   public abstract Avatar avatar();
   public abstract @Nullable Integer backedProjectsCount();
   public abstract @Nullable Integer createdProjectsCount();
+  public abstract @Nullable Integer erroredBackingsCount();
   public abstract @Nullable Boolean facebookConnected();
   public abstract @Nullable Boolean filmNewsletter();
   public abstract @Nullable Boolean gamesNewsletter();
@@ -65,6 +66,7 @@ public abstract class User implements Parcelable, Relay {
     public abstract Builder avatar(Avatar __);
     public abstract Builder backedProjectsCount(Integer __);
     public abstract Builder createdProjectsCount(Integer __);
+    public abstract Builder erroredBackingsCount(Integer __);
     public abstract Builder facebookConnected(Boolean __);
     public abstract Builder filmNewsletter(Boolean __);
     public abstract Builder gamesNewsletter(Boolean __);

--- a/app/src/main/java/com/kickstarter/ui/viewholders/discoverydrawer/LoggedInViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/discoverydrawer/LoggedInViewHolder.kt
@@ -52,7 +52,7 @@ class LoggedInViewHolder(@NonNull view: View, @NonNull private val delegate: Del
                     }
                 }
 
-        this.viewModel.outputs.unseenActivityCount()
+        this.viewModel.outputs.activityCount()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
                 .subscribe {

--- a/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.java
@@ -130,8 +130,7 @@ public interface ActivityFeedViewModel {
 
       loggedInUser
         .compose(takeWhen(refreshOrResume))
-        .map(User::unseenActivityCount)
-        .map(IntegerUtils::intValueOrZero)
+        .map(user -> IntegerUtils.intValueOrZero(user.unseenActivityCount()) + IntegerUtils.intValueOrZero(user.erroredBackingsCount()))
         .filter(IntegerUtils::isNonZero)
         .distinctUntilChanged()
         .switchMap(__ -> this.apolloClient.clearUnseenActivity().compose(neverError()))

--- a/app/src/main/java/com/kickstarter/viewmodels/LoggedInViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoggedInViewHolderViewModel.kt
@@ -18,6 +18,9 @@ interface LoggedInViewHolderViewModel {
     }
 
     interface Outputs {
+        /** Emits the user's unseen activity and errored backings count. */
+        fun activityCount(): Observable<Int>
+
         /** Emits the user's medium avatar URL. */
         fun avatarUrl(): Observable<String>
 
@@ -30,9 +33,6 @@ interface LoggedInViewHolderViewModel {
         /** Emits the user's unread messages count. */
         fun unreadMessagesCount(): Observable<Int>
 
-        /** Emits the user's unseen activity count. */
-        fun unseenActivityCount(): Observable<Int>
-
         /** Emits the user to pass to delegate. */
         fun user(): Observable<User>
     }
@@ -41,11 +41,11 @@ interface LoggedInViewHolderViewModel {
 
         private val user = PublishSubject.create<User>()
 
+        private val activityCount = BehaviorSubject.create<Int>()
         private val avatarUrl = BehaviorSubject.create<String>()
         private val dashboardRowIsGone = BehaviorSubject.create<Boolean>()
         private val name = BehaviorSubject.create<String>()
         private val unreadMessagesCount = BehaviorSubject.create<Int>()
-        private val unseenActivityCount = BehaviorSubject.create<Int>()
         private val userOutput = BehaviorSubject.create<User>()
 
         val inputs: Inputs = this
@@ -73,9 +73,9 @@ interface LoggedInViewHolderViewModel {
                     .subscribe(this.unreadMessagesCount)
 
             this.user
-                    .map { it.unseenActivityCount() }
+                    .map { IntegerUtils.intValueOrZero(it.unseenActivityCount()) + IntegerUtils.intValueOrZero(it.erroredBackingsCount()) }
                     .compose(bindToLifecycle())
-                    .subscribe(this.unseenActivityCount)
+                    .subscribe(this.activityCount)
 
             this.user
                     .map { IntegerUtils.isZero(IntegerUtils.intValueOrZero(it.memberProjectsCount())) }
@@ -89,6 +89,9 @@ interface LoggedInViewHolderViewModel {
         }
 
         @NonNull
+        override fun activityCount(): Observable<Int> = this.activityCount
+
+        @NonNull
         override fun avatarUrl(): Observable<String> = this.avatarUrl
 
         @NonNull
@@ -99,9 +102,6 @@ interface LoggedInViewHolderViewModel {
 
         @NonNull
         override fun unreadMessagesCount(): Observable<Int> = this.unreadMessagesCount
-
-        @NonNull
-        override fun unseenActivityCount(): Observable<Int> = this.unseenActivityCount
 
         @NonNull
         override fun user(): Observable<User> = this.userOutput

--- a/app/src/test/java/com/kickstarter/viewmodels/ActivityFeedViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ActivityFeedViewModelTest.java
@@ -268,4 +268,32 @@ public class ActivityFeedViewModelTest extends KSRobolectricTestCase {
     this.surveys.assertValueCount(2);
     this.user.assertValues(initialUser, updatedUser);
   }
+
+  @Test
+  public void testUser_whenLoggedInAndResumedWithErroredBackings() {
+    final CurrentUserType currentUser = new MockCurrentUser();
+    final User initialUser = UserFactory.user()
+      .toBuilder()
+      .erroredBackingsCount(3)
+      .build();
+    currentUser.login(initialUser, "token");
+
+    final User updatedUser = UserFactory.user();
+    final Environment environment = this.environment().toBuilder()
+      .apiClient(new MockApiClient() {
+        @Override public @NonNull Observable<User> fetchCurrentUser() {
+          return Observable.just(updatedUser);
+        }
+      })
+      .currentUser(currentUser)
+      .build();
+
+    environment.currentUser().loggedInUser().subscribe(this.user);
+
+    setUpEnvironment(environment);
+    this.user.assertValues(initialUser, updatedUser);
+
+    this.vm.inputs.resume();
+    this.user.assertValues(initialUser, updatedUser);
+  }
 }


### PR DESCRIPTION
# 📲 What
Including `user.erroredBackingsCount` in drawer Activity count

# 🤔 Why
So users know they should check their Activity feed if they have an errored backing

# 🛠 How
## `User`
- Added `erroredBackingsCount` field
## `ActivityFeedViewModel`
- Refreshing user on resumes/refreshes when `erroredBackingsCount` and `unseenActivityCount` is non zero
- Added a test
## `LoggedInViewHolderViewModel`
- Renamed `unseenActivityCount` to `activityCount` because it includes errored backings now
- Added tests for all the combinations of `erroredBackingsCount` and `unseenActivityCount`

# 👀 See
| Still 🐛 | GIF 🦋 |
| --- | --- |
| <img src=https://user-images.githubusercontent.com/1289295/80258470-4e28ef80-8651-11ea-8786-bacbdaffd253.png width=330/> | ![device-2020-04-24-170400 2020-04-24 17_28_01](https://user-images.githubusercontent.com/1289295/80258463-4b2dff00-8651-11ea-84f8-6ec8c89c2a88.gif) |

# 📋 QA
The activity count includes the errored backings count.

# Story 📖
[NT-1196]


[NT-1196]: https://kickstarter.atlassian.net/browse/NT-1196