### PR TITLE
[␡] NT-1189 Removed App Completed Checkout Optimizely event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
@@ -1,5 +1,0 @@
-@file:JvmName("OptimizelyEvent")
-
-package com.kickstarter.libs
-
-const val APP_COMPLETED_CHECKOUT = "App Completed Checkout"

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.java
@@ -6,11 +6,8 @@ import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.ExperimentsClientType;
-import com.kickstarter.libs.OptimizelyEvent;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.preferences.BooleanPreferenceType;
-import com.kickstarter.libs.utils.ExperimentData;
-import com.kickstarter.libs.utils.ExperimentRevenueData;
 import com.kickstarter.libs.utils.ListUtils;
 import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.libs.utils.UserUtils;
@@ -196,23 +193,6 @@ public interface ThanksViewModel {
       checkoutAndPledgeData
         .compose(bindToLifecycle())
         .subscribe(checkoutDataPledgeData -> this.lake.trackThanksPageViewed(checkoutDataPledgeData.first, checkoutDataPledgeData.second));
-
-      checkoutAndPledgeData
-        .compose(combineLatestPair(this.currentUser.observable()))
-        .map(this::experimentRevenueData)
-        .take(1)
-        .compose(bindToLifecycle())
-        .subscribe(data -> this.optimizely.trackRevenue(OptimizelyEvent.APP_COMPLETED_CHECKOUT, data));
-    }
-
-    private ExperimentRevenueData experimentRevenueData(final @NonNull Pair<Pair<CheckoutData, PledgeData>, User> dataAndUser) {
-      final User currentUser = dataAndUser.second;
-      final PledgeData pledgeData = dataAndUser.first.second;
-      final RefTag intentRefTag = pledgeData.projectData().refTagFromIntent();
-      final RefTag cookieRefTag = pledgeData.projectData().refTagFromCookie();
-      final ExperimentData experimentData = new ExperimentData(currentUser, intentRefTag, cookieRefTag);
-      final CheckoutData checkoutData = dataAndUser.first.first;
-      return new ExperimentRevenueData(experimentData, checkoutData, pledgeData);
     }
 
     /**

--- a/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
@@ -320,7 +320,7 @@ public final class ThanksViewModelTest extends KSRobolectricTestCase {
     this.vm.intent(intent);
 
     this.lakeTest.assertValue("Thanks Page Viewed");
-    this.experimentsTest.assertValue("App Completed Checkout");
+    this.experimentsTest.assertNoValues();
   }
 
   @Test


### PR DESCRIPTION
# 📲 What
Removed App Completed Checkout Optimizely event

# 🤔 Why
The backend will be sending `Completed Checkout` events :pray: https://kickstarter.atlassian.net/wiki/spaces/NT/pages/126713858/Cut+Over+Strategy+for+Optimizely+Events

# 🛠 How
## `OptimizelyEvent`
- Deleted this file since there are no more Optimizely events
## `ThanksViewModel`
- Removed Optimizely tracking call
- Updated test

# 👀 See
N/A

# 📋 QA
Check the LogCat filtered for `Optly` to see no tracking happens when the thanks page is viewed.

# Story 📖
[NT-1189]


[NT-1189]: https://kickstarter.atlassian.net/browse/NT-1189