### PR TITLE
[🔴] NT-1197 Red drawer activity count text color when there are errored backings

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/discoverydrawer/LoggedInViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/discoverydrawer/LoggedInViewHolder.kt
@@ -2,6 +2,7 @@ package com.kickstarter.ui.viewholders.discoverydrawer
 
 import android.view.View
 import androidx.annotation.NonNull
+import androidx.core.content.ContextCompat
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.transformations.CircleTransformation
 import com.kickstarter.libs.utils.IntegerUtils
@@ -61,6 +62,11 @@ class LoggedInViewHolder(@NonNull view: View, @NonNull private val delegate: Del
                         else -> NumberUtils.format(it)
                     }
                 }
+
+        this.viewModel.outputs.activityCountTextColor()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { view.unseen_activity_count.setTextColor(ContextCompat.getColor(context(), it)) }
 
         this.viewModel.outputs.dashboardRowIsGone()
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/LoggedInViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoggedInViewHolderViewModel.kt
@@ -1,8 +1,10 @@
 package com.kickstarter.viewmodels
 
 import androidx.annotation.NonNull
+import com.kickstarter.R
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.BooleanUtils
 import com.kickstarter.libs.utils.IntegerUtils
 import com.kickstarter.models.User
 import com.kickstarter.ui.viewholders.discoverydrawer.LoggedInViewHolder
@@ -20,6 +22,9 @@ interface LoggedInViewHolderViewModel {
     interface Outputs {
         /** Emits the user's unseen activity and errored backings count. */
         fun activityCount(): Observable<Int>
+
+        /** Emits the color resource ID of the activity count text color. */
+        fun activityCountTextColor(): Observable<Int>
 
         /** Emits the user's medium avatar URL. */
         fun avatarUrl(): Observable<String>
@@ -42,6 +47,7 @@ interface LoggedInViewHolderViewModel {
         private val user = PublishSubject.create<User>()
 
         private val activityCount = BehaviorSubject.create<Int>()
+        private val activityCountTextColor = BehaviorSubject.create<Int>()
         private val avatarUrl = BehaviorSubject.create<String>()
         private val dashboardRowIsGone = BehaviorSubject.create<Boolean>()
         private val name = BehaviorSubject.create<String>()
@@ -78,6 +84,12 @@ interface LoggedInViewHolderViewModel {
                     .subscribe(this.activityCount)
 
             this.user
+                    .map { IntegerUtils.isZero(IntegerUtils.intValueOrZero(it.erroredBackingsCount())) }
+                    .map { if (BooleanUtils.isTrue(it)) R.color.text_primary else R.color.ksr_red_400 }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.activityCountTextColor)
+
+            this.user
                     .map { IntegerUtils.isZero(IntegerUtils.intValueOrZero(it.memberProjectsCount())) }
                     .compose(bindToLifecycle())
                     .subscribe(this.dashboardRowIsGone)
@@ -90,6 +102,9 @@ interface LoggedInViewHolderViewModel {
 
         @NonNull
         override fun activityCount(): Observable<Int> = this.activityCount
+
+        @NonNull
+        override fun activityCountTextColor(): Observable<Int> = this.activityCountTextColor
 
         @NonNull
         override fun avatarUrl(): Observable<String> = this.avatarUrl

--- a/app/src/test/java/com/kickstarter/viewmodels/LoggedInViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoggedInViewHolderViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.viewmodels
 
 import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.R
 import com.kickstarter.libs.Environment
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.User
@@ -10,6 +11,7 @@ import rx.observers.TestSubscriber
 class LoggedInViewHolderViewModelTest : KSRobolectricTestCase() {
     private lateinit var vm: LoggedInViewHolderViewModel.ViewModel
     private val activityCount = TestSubscriber<Int>()
+    private val activityCountTextColor = TestSubscriber<Int>()
     private val avatarUrl = TestSubscriber<String>()
     private val dashboardRowIsGone = TestSubscriber<Boolean>()
     private val name = TestSubscriber<String>()
@@ -19,6 +21,7 @@ class LoggedInViewHolderViewModelTest : KSRobolectricTestCase() {
     fun setUpEnvironment(environment: Environment) {
         this.vm = LoggedInViewHolderViewModel.ViewModel(environment)
         this.vm.outputs.activityCount().subscribe(this.activityCount)
+        this.vm.outputs.activityCountTextColor().subscribe(this.activityCountTextColor)
         this.vm.outputs.avatarUrl().subscribe(this.avatarUrl)
         this.vm.outputs.dashboardRowIsGone().subscribe(this.dashboardRowIsGone)
         this.vm.outputs.name().subscribe(this.name)
@@ -66,7 +69,6 @@ class LoggedInViewHolderViewModelTest : KSRobolectricTestCase() {
         this.activityCount.assertValue(3)
     }
 
-
     @Test
     fun testActivityCount_whenUserHasNoUnseenActivityAndNoErroredBackings() {
         setUpEnvironment(environment())
@@ -74,6 +76,28 @@ class LoggedInViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(UserFactory.user())
 
         this.activityCount.assertValue(0)
+    }
+
+    @Test
+    fun testActivityCountTextColor_whenUserHasErroredBackings() {
+        setUpEnvironment(environment())
+
+        val user = UserFactory.user()
+                .toBuilder()
+                .erroredBackingsCount(3)
+                .build()
+        this.vm.inputs.configureWith(user)
+
+        this.activityCountTextColor.assertValue(R.color.ksr_red_400)
+    }
+
+    @Test
+    fun testActivityCountTextColor_whenUserNoErroredBackings() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(UserFactory.user())
+
+        this.activityCountTextColor.assertValue(R.color.text_primary)
     }
 
     @Test


### PR DESCRIPTION


# 📲 What
The drawer Activity count is red when a user has errrored backings.

# 🤔 Why
Calling more attention to the Activity row when there's an errored backing.

# 🛠 How
## `LoggedInViewHolderViewModel`
- Added output `activityCountTextColor` that emits the text color of the activity count. It's `ksr_red_400` when a user has errored backings and `text_primary` when they don't
- Added a test for both cases

# 👀 See
| After 🦋 | Before 🐛 | 
| --- | --- |
| ![screenshot-2020-04-24_180921](https://user-images.githubusercontent.com/1289295/80260829-c47c2080-8656-11ea-8aaf-6519543501f4.png) | ![screenshot-2020-04-24_172756](https://user-images.githubusercontent.com/1289295/80260827-c3e38a00-8656-11ea-9198-b00e35b29cc2.png) |

# 📋 QA
Open your drawer with an errored backing!

# Story 📖
[NT-1197]


[NT-1197]: https://kickstarter.atlassian.net/browse/NT-1197