### PR TITLE
[🔴] NT-1198 Red menu indicator for errored backings

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
@@ -183,10 +183,10 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel.Vie
       .compose(observeForUI())
       .subscribe(RxDrawerLayout.open(this.discoveryLayout, GravityCompat.START));
 
-    this.viewModel.outputs.showMenuIconWithIndicator()
+    this.viewModel.outputs.drawerMenuIcon()
       .compose(bindToLifecycle())
       .compose(observeForUI())
-      .subscribe(this::showMenuIconWithIndicator);
+      .subscribe(this::updateDrawerMenuIcon);
 
     //region Qualtrics
     this.viewModel.outputs.qualtricsPromptIsGone()
@@ -278,13 +278,11 @@ public final class DiscoveryActivity extends BaseActivity<DiscoveryViewModel.Vie
       });
   }
 
-  private void showMenuIconWithIndicator(final boolean withIndicator) {
-    if (withIndicator) {
-      this.menuImageButton.setImageResource(R.drawable.ic_menu_indicator);
+  private void updateDrawerMenuIcon(final @NonNull Integer drawerMenuIcon) {
+    this.menuImageButton.setImageResource(drawerMenuIcon);
+    if (this.menuImageButton.getDrawable() instanceof Animatable) {
       final Animatable menuDrawable = (Animatable) this.menuImageButton.getDrawable();
       menuDrawable.start();
-    } else {
-      this.menuImageButton.setImageResource(R.drawable.ic_menu);
     }
   }
 

--- a/app/src/main/res/drawable/ic_menu_error_indicator.xml
+++ b/app/src/main/res/drawable/ic_menu_error_indicator.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<animated-vector xmlns:aapt="http://schemas.android.com/aapt"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+  <aapt:attr name="android:drawable">
+    <vector
+      android:width="24dp"
+      android:height="24dp"
+      android:viewportHeight="24"
+      android:viewportWidth="24">
+      <path
+        android:fillColor="#282828"
+        android:fillType="nonZero"
+        android:pathData="M4,18L20,18C20.55,18 21,17.55 21,17C21,16.45 20.55,16 20,16L4,16C3.45,16 3,16.45 3,17C3,17.55 3.45,18 4,18Z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1" />
+      <path
+        android:fillColor="#282828"
+        android:fillType="nonZero"
+        android:pathData="M4,13L20,13C20.55,13 21,12.55 21,12C21,11.45 20.55,11 20,11L4,11C3.45,11 3,11.45 3,12C3,12.55 3.45,13 4,13Z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1" />
+      <path
+        android:fillColor="#282828"
+        android:fillType="nonZero"
+        android:pathData="M3,7C3,7.55 3.45,8 4,8L20,8C20.55,8 21,7.55 21,7C21,6.45 20.55,6 20,6L4,6C3.45,6 3,6.45 3,7Z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1" />
+
+      <group android:name="indicator"
+        android:pivotX="20"
+        android:pivotY="6">
+
+        <path
+          android:pathData="M20,4.7762m-3.5,0a3.5,3.5 0,1 1,7 0a3.5,3.5 0,1 1,-7 0"
+          android:strokeWidth="1"
+          android:fillColor="#FF5151"
+          android:strokeColor="#FFFFFF"
+          android:fillType="nonZero"/>
+      </group>
+    </vector>
+  </aapt:attr>
+
+  <target android:name="indicator">
+    <aapt:attr name="android:animation">
+      <set>
+        <objectAnimator
+          android:interpolator="@android:anim/accelerate_decelerate_interpolator"
+          android:duration="500"
+          android:repeatCount="4"
+          android:repeatMode="reverse">
+          <propertyValuesHolder android:propertyName="scaleX" >
+            <keyframe android:value=".8" />
+            <keyframe android:value="1.2" />
+          </propertyValuesHolder>
+          <propertyValuesHolder android:propertyName="scaleY" >
+            <keyframe android:value=".8" />
+            <keyframe android:value="1.2" />
+          </propertyValuesHolder>
+        </objectAnimator>
+      </set>
+    </aapt:attr>
+  </target>
+</animated-vector>

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -3,6 +3,7 @@ package com.kickstarter.viewmodels;
 import android.content.Intent;
 
 import com.kickstarter.KSRobolectricTestCase;
+import com.kickstarter.R;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.MockCurrentUser;
 import com.kickstarter.libs.preferences.MockBooleanPreference;
@@ -33,6 +34,7 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
   private DiscoveryViewModel.ViewModel vm;
   private final TestSubscriber<List<Integer>> clearPages = new TestSubscriber<>();
   private final TestSubscriber<Boolean> drawerIsOpen = new TestSubscriber<>();
+  private final TestSubscriber<Integer> drawerMenuIcon = new TestSubscriber<>();
   private final TestSubscriber<Boolean> expandSortTabLayout = new TestSubscriber<>();
   private final TestSubscriber<Void> navigationDrawerDataEmitted = new TestSubscriber<>();
   private final TestSubscriber<Integer> position = new TestSubscriber<>();
@@ -49,7 +51,6 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Void> showHelp = new TestSubscriber<>();
   private final TestSubscriber<Void> showInternalTools = new TestSubscriber<>();
   private final TestSubscriber<Void> showLoginTout = new TestSubscriber<>();
-  private final TestSubscriber<Boolean> showMenuIconWithIndicator = new TestSubscriber<>();
   private final TestSubscriber<Void> showMessages = new TestSubscriber<>();
   private final TestSubscriber<Void> showProfile = new TestSubscriber<>();
   private final TestSubscriber<String> showQualtricsSurvey = new TestSubscriber<>();
@@ -486,65 +487,48 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testShowMenuIconWithIndicator_whenLoggedOut() {
+  public void testDrawerMenuIcon_whenLoggedOut() {
     this.vm = new DiscoveryViewModel.ViewModel(environment());
 
-    this.vm.outputs.showMenuIconWithIndicator().subscribe(this.showMenuIconWithIndicator);
+    this.vm.outputs.drawerMenuIcon().subscribe(this.drawerMenuIcon);
 
-    this.showMenuIconWithIndicator.assertValue(false);
+    this.drawerMenuIcon.assertValue(R.drawable.ic_menu);
   }
 
   @Test
-  public void testShowMenuIconWithIndicator_afterLogIn() {
+  public void testDrawerMenuIcon_afterLogInRefreshAndLogOut() {
     final MockCurrentUser currentUser = new MockCurrentUser();
 
     this.vm = new DiscoveryViewModel.ViewModel(environment().toBuilder().currentUser(currentUser).build());
-    this.vm.outputs.showMenuIconWithIndicator().subscribe(this.showMenuIconWithIndicator);
+    this.vm.outputs.drawerMenuIcon().subscribe(this.drawerMenuIcon);
 
-    this.showMenuIconWithIndicator.assertValue(false);
+    this.drawerMenuIcon.assertValue(R.drawable.ic_menu);
 
     currentUser.refresh(UserFactory.user().toBuilder().unreadMessagesCount(4).build());
+    this.drawerMenuIcon.assertValues(R.drawable.ic_menu, R.drawable.ic_menu_indicator);
 
-    this.showMenuIconWithIndicator.assertValues(false, true);
+    currentUser.refresh(UserFactory.user().toBuilder().erroredBackingsCount(2).build());
+    this.drawerMenuIcon.assertValues(R.drawable.ic_menu, R.drawable.ic_menu_indicator, R.drawable.ic_menu_error_indicator);
+
+    currentUser.refresh(UserFactory.user().toBuilder().unreadMessagesCount(4).unseenActivityCount(3).erroredBackingsCount(2).build());
+    this.drawerMenuIcon.assertValues(R.drawable.ic_menu, R.drawable.ic_menu_indicator, R.drawable.ic_menu_error_indicator);
 
     currentUser.logout();
-
-    this.showMenuIconWithIndicator.assertValues(false, true, false);
-
-    currentUser.refresh(UserFactory.user().toBuilder().unseenActivityCount(2).build());
-
-    this.showMenuIconWithIndicator.assertValues(false, true, false, true);
+    this.drawerMenuIcon.assertValues(R.drawable.ic_menu, R.drawable.ic_menu_indicator, R.drawable.ic_menu_error_indicator,
+      R.drawable.ic_menu);
   }
 
   @Test
-  public void testShowMenuIconWithIndicator_whenUserHasNoMessagesOrUnseenActivity() {
+  public void testDrawerMenuIcon_whenUserHasNoUnreadMessagesOrUnseenActivityOrErroredBackings() {
     final MockCurrentUser currentUser = new MockCurrentUser(UserFactory.user());
     this.vm = new DiscoveryViewModel.ViewModel(environment()
       .toBuilder()
       .currentUser(currentUser)
       .build());
 
-    this.vm.outputs.showMenuIconWithIndicator().subscribe(this.showMenuIconWithIndicator);
+    this.vm.outputs.drawerMenuIcon().subscribe(this.drawerMenuIcon);
 
-    this.showMenuIconWithIndicator.assertValue(false);
-  }
-
-  @Test
-  public void testShowMenuIconWithIndicator_whenUserHasUnreadMessagesOrUnseenActivity() {
-    final User user = UserFactory.user().toBuilder().unreadMessagesCount(3).build();
-    final MockCurrentUser currentUser = new MockCurrentUser(user);
-    this.vm = new DiscoveryViewModel.ViewModel(environment()
-      .toBuilder()
-      .currentUser(currentUser)
-      .build());
-
-    this.vm.outputs.showMenuIconWithIndicator().subscribe(this.showMenuIconWithIndicator);
-
-    this.showMenuIconWithIndicator.assertValue(true);
-
-    currentUser.refresh(UserFactory.user().toBuilder().unreadMessagesCount(0).unseenActivityCount(2).build());
-
-    this.showMenuIconWithIndicator.assertValue(true);
+    this.drawerMenuIcon.assertValue(R.drawable.ic_menu);
   }
 
   @Test


### PR DESCRIPTION
# 📲 What
Showing red indicator on drawer menu icon when a user has errored backings.

# 🤔 Why
To let users know they have urgent matters in the drawer to attend to!

# 🛠 How
## `DiscoveryViewModel`
- Replaced output `showMenuIconWithIndicator` with `drawerMenuIcon` that emits the menu icon of the drawer with helper `currentDrawerMenuIcon` method. Emits
  - `ic_menu_error_indicator` when a user has errored backings
  - `ic_menu_indicator` when a user has unseen activity or unread messages
  - `ic_menu` when a user is logged out or has no activity, messages or errored backings
- Updated tests
 - Removed `testShowMenuIconWithIndicator_whenUserHasUnreadMessagesOrUnseenActivity` because I think `testDrawerMenuIcon_afterLogInRefreshAndLogOut` handles that case

# 👀 See
| Errored backings 🔴  | Unread message ✳️ |
| --- | --- |
| ![device-2020-04-24-183426 2020-04-24 18_37_21](https://user-images.githubusercontent.com/1289295/80263474-bf22d400-865e-11ea-91eb-dd373870e359.gif) | ![device-2020-04-24-190223 2020-04-24 19_03_32](https://user-images.githubusercontent.com/1289295/80263475-bfbb6a80-865e-11ea-9009-a9b06052f9c3.gif) | 
| Logged Out  | Nothing |
<img src=https://user-images.githubusercontent.com/1289295/80263476-bfbb6a80-865e-11ea-86f9-e4b3b696163b.png width=330/> | <img src=https://user-images.githubusercontent.com/1289295/80263477-bfbb6a80-865e-11ea-839f-ab38c060191b.png width=330/> |

# 📋 QA
Test an account with an errored backing!

# Story 📖
[NT-1198]


[NT-1198]: https://kickstarter.atlassian.net/browse/NT-1198