### PR TITLE
[␡] NT-1199 Removing unused Optimizely tracking calls

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
@@ -3,7 +3,6 @@ package com.kickstarter.libs
 import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.utils.ExperimentData
-import com.kickstarter.libs.utils.ExperimentRevenueData
 import com.kickstarter.libs.utils.ExperimentUtils
 import org.json.JSONArray
 import org.json.JSONObject
@@ -12,10 +11,6 @@ interface ExperimentsClientType {
 
     fun ExperimentsClientType.attributes(experimentData: ExperimentData, optimizelyEnvironment: OptimizelyEnvironment): Map<String, *> {
         return ExperimentUtils.attributes(experimentData, appVersion(), OSVersion(), optimizelyEnvironment)
-    }
-
-    fun ExperimentsClientType.checkoutTags(experimentRevenueData: ExperimentRevenueData): Map<String, *> {
-        return ExperimentUtils.checkoutTags(experimentRevenueData)
     }
 
     fun optimizelyProperties(experimentData: ExperimentData): Map<String, Any> {
@@ -36,8 +31,6 @@ interface ExperimentsClientType {
     fun appVersion(): String
     fun optimizelyEnvironment(): OptimizelyEnvironment
     fun OSVersion(): String
-    fun track(eventKey: String, experimentData: ExperimentData)
-    fun trackRevenue(eventKey: String, experimentRevenueData: ExperimentRevenueData)
     fun trackingVariation(experimentKey: String, experimentData: ExperimentData): String?
     fun userId() : String
     fun variant(experiment: OptimizelyExperiment.Key, experimentData: ExperimentData): OptimizelyExperiment.Variant?

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
@@ -6,7 +6,6 @@ import com.kickstarter.BuildConfig
 import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.utils.ExperimentData
-import com.kickstarter.libs.utils.ExperimentRevenueData
 import com.optimizely.ab.android.sdk.OptimizelyClient
 import com.optimizely.ab.android.sdk.OptimizelyManager
 
@@ -14,14 +13,6 @@ class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManag
     override fun appVersion(): String = BuildConfig.VERSION_NAME
 
     override fun OSVersion(): String = Build.VERSION.RELEASE
-
-    override fun track(eventKey: String, experimentData: ExperimentData) {
-        optimizelyClient().track(eventKey, userId(), attributes(experimentData, this.optimizelyEnvironment))
-    }
-
-    override fun trackRevenue(eventKey: String, experimentRevenueData: ExperimentRevenueData) {
-        optimizelyClient().track(eventKey, userId(), attributes(experimentRevenueData.experimentData, this.optimizelyEnvironment), checkoutTags(experimentRevenueData))
-    }
 
     override fun userId(): String = FirebaseInstanceId.getInstance().id
 

--- a/app/src/main/java/com/kickstarter/libs/utils/ExperimentUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/ExperimentUtils.kt
@@ -4,10 +4,7 @@ import com.google.firebase.iid.FirebaseInstanceId
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.models.User
-import com.kickstarter.ui.data.CheckoutData
-import com.kickstarter.ui.data.PledgeData
 import java.util.*
-import kotlin.math.roundToInt
 
 object ExperimentUtils {
 
@@ -23,22 +20,6 @@ object ExperimentUtils {
                 Pair("user_country", experimentData.user?.location()?.country() ?: Locale.getDefault().country)
         )
     }
-
-    fun checkoutTags(experimentRevenueData: ExperimentRevenueData): Map<String, Any?> {
-        val amount = experimentRevenueData.checkoutData.amount()
-        val project = experimentRevenueData.pledgeData.projectData().project()
-        val fxRate = project.fxRate()
-        val paymentType = experimentRevenueData.checkoutData.paymentType()
-        val revenue = (amount * fxRate * 100).roundToInt()
-        return mapOf(
-                Pair("checkout_amount", amount),
-                Pair("checkout_payment_type", paymentType.rawValue()),
-                Pair("checkout_revenue_in_usd_cents", revenue),
-                Pair("revenue", revenue),
-                Pair("currency", project.currency())
-        )
-    }
 }
 
 data class ExperimentData(val user: User?, val intentRefTag: RefTag?, val cookieRefTag: RefTag?)
-data class ExperimentRevenueData(val experimentData: ExperimentData, val checkoutData: CheckoutData, val pledgeData: PledgeData)

--- a/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
@@ -6,17 +6,10 @@ import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.utils.ExperimentData
 import org.json.JSONArray
 import org.json.JSONObject
-import rx.Observable
-import rx.subjects.PublishSubject
 
 open class MockExperimentsClientType(private val variant: OptimizelyExperiment.Variant, private val optimizelyEnvironment: OptimizelyEnvironment) : ExperimentsClientType {
     constructor(variant: OptimizelyExperiment.Variant) : this(variant, OptimizelyEnvironment.STAGING)
     constructor() : this(OptimizelyExperiment.Variant.CONTROL, OptimizelyEnvironment.STAGING)
-
-    class ExperimentsEvent internal constructor(internal val eventKey: String, internal val attributes: Map<String, *>, internal val tags: Map<String, *>?)
-
-    private val experimentEvents : PublishSubject<ExperimentsEvent> = PublishSubject.create()
-    val eventKeys: Observable<String> = this.experimentEvents.map { e -> e.eventKey }
 
     override fun appVersion(): String = "9.9.9"
 

--- a/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
@@ -4,7 +4,6 @@ import com.kickstarter.libs.ExperimentsClientType
 import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.utils.ExperimentData
-import com.kickstarter.libs.utils.ExperimentRevenueData
 import org.json.JSONArray
 import org.json.JSONObject
 import rx.Observable
@@ -34,17 +33,9 @@ open class MockExperimentsClientType(private val variant: OptimizelyExperiment.V
                 "optimizely_experiments" to experiments)
     }
 
-    override fun trackingVariation(experimentKey: String, experimentData: ExperimentData): String? = this.variant.rawValue
-
     override fun OSVersion(): String = "9"
 
-    override fun track(eventKey: String, experimentData: ExperimentData) {
-        this.experimentEvents.onNext(ExperimentsEvent(eventKey, attributes(experimentData, this.optimizelyEnvironment), null))
-    }
-
-    override fun trackRevenue(eventKey: String, experimentRevenueData: ExperimentRevenueData) {
-        this.experimentEvents.onNext(ExperimentsEvent(eventKey, attributes(experimentRevenueData.experimentData, this.optimizelyEnvironment), checkoutTags(experimentRevenueData)))
-    }
+    override fun trackingVariation(experimentKey: String, experimentData: ExperimentData): String? = this.variant.rawValue
 
     override fun userId(): String = "device-id"
 

--- a/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
+++ b/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
@@ -44,7 +44,7 @@ public abstract class KSRobolectricTestCase extends TestCase {
     super.setUp();
     final MockCurrentConfig mockCurrentConfig = new MockCurrentConfig();
 
-    final MockExperimentsClientType experimentsClientType = experimentsClient();
+    final MockExperimentsClientType experimentsClientType = new MockExperimentsClientType();
     final MockTrackingClient koalaTrackingClient = koalaTrackingClient(mockCurrentConfig, experimentsClientType);
     final MockTrackingClient lakeTrackingClient = lakeTrackingClient(mockCurrentConfig, experimentsClientType);
 
@@ -88,13 +88,6 @@ public abstract class KSRobolectricTestCase extends TestCase {
 
   protected @NonNull KSString ksString() {
     return new KSString(application().getPackageName(), application().getResources());
-  }
-
-  private MockExperimentsClientType experimentsClient() {
-    this.experimentsTest = new TestSubscriber<>();
-    final MockExperimentsClientType experimentsClientType = new MockExperimentsClientType();
-    experimentsClientType.getEventKeys().subscribe(this.experimentsTest);
-    return experimentsClientType;
   }
 
   private MockTrackingClient koalaTrackingClient(final @NonNull MockCurrentConfig mockCurrentConfig,

--- a/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
+++ b/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
@@ -33,7 +33,6 @@ import rx.observers.TestSubscriber;
 @Config(shadows = ShadowAndroidXMultiDex.class, sdk = KSRobolectricGradleTestRunner.DEFAULT_SDK)
 public abstract class KSRobolectricTestCase extends TestCase {
   private TestKSApplication application;
-  public TestSubscriber<String> experimentsTest;
   public TestSubscriber<String> koalaTest;
   public TestSubscriber<String> lakeTest;
   private Environment environment;

--- a/app/src/test/java/com/kickstarter/libs/utils/ExperimentUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/ExperimentUtilsTest.kt
@@ -3,9 +3,7 @@ package com.kickstarter.libs.utils
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.models.OptimizelyEnvironment
-import com.kickstarter.mock.factories.*
-import com.kickstarter.ui.data.PledgeData
-import com.kickstarter.ui.data.PledgeFlowContext
+import com.kickstarter.mock.factories.UserFactory
 import org.junit.Test
 
 class ExperimentUtilsTest : KSRobolectricTestCase() {
@@ -72,33 +70,5 @@ class ExperimentUtilsTest : KSRobolectricTestCase() {
         assertEquals(false, attributes["session_user_is_logged_in"])
         assertEquals(0, attributes["user_backed_projects_count"])
         assertEquals("US", attributes["user_country"])
-    }
-
-    @Test
-    fun checkoutTags_USProject() {
-        val experimentData = ExperimentData(UserFactory.user(), RefTag.discovery(), RefTag.search())
-        val pledgeData = PledgeData.with(PledgeFlowContext.NEW_PLEDGE, ProjectDataFactory.project(ProjectFactory.project()), RewardFactory.reward())
-        val checkoutData = CheckoutDataFactory.checkoutData(10.0, 20.0)
-        val experimentRevenueData = ExperimentRevenueData(experimentData, checkoutData, pledgeData)
-        val checkoutTags = ExperimentUtils.checkoutTags(experimentRevenueData)
-        assertEquals(20.0, checkoutTags["checkout_amount"])
-        assertEquals("CREDIT_CARD", checkoutTags["checkout_payment_type"])
-        assertEquals(2000, checkoutTags["checkout_revenue_in_usd_cents"])
-        assertEquals("USD", checkoutTags["currency"])
-        assertEquals(2000, checkoutTags["revenue"])
-    }
-
-    @Test
-    fun checkoutTags_CAProject() {
-        val experimentData = ExperimentData(UserFactory.user(), RefTag.discovery(), RefTag.search())
-        val pledgeData = PledgeData.with(PledgeFlowContext.NEW_PLEDGE, ProjectDataFactory.project(ProjectFactory.caProject()), RewardFactory.reward())
-        val checkoutData = CheckoutDataFactory.checkoutData(10.0, 20.0)
-        val experimentRevenueData = ExperimentRevenueData(experimentData, checkoutData, pledgeData)
-        val checkoutTags = ExperimentUtils.checkoutTags(experimentRevenueData)
-        assertEquals(20.0, checkoutTags["checkout_amount"])
-        assertEquals("CREDIT_CARD", checkoutTags["checkout_payment_type"])
-        assertEquals(1500, checkoutTags["checkout_revenue_in_usd_cents"])
-        assertEquals("CAD", checkoutTags["currency"])
-        assertEquals(1500, checkoutTags["revenue"])
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -775,7 +775,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.goBack.assertNoValues()
         this.koalaTest.assertValues("Project Page", "Back this Project Button Clicked")
         this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
-        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -788,7 +787,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page", "Back this Project Button Clicked")
         this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
-        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -801,7 +799,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page", "Manage Pledge Button Clicked")
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -814,7 +811,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page", "View Rewards Button Clicked")
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -827,7 +823,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page", "View Your Pledge Button Clicked")
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -840,7 +835,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page")
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -853,7 +847,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertNoValues()
         this.koalaTest.assertValue("Project Page")
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -867,7 +860,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValues(Pair(true, true))
         this.koalaTest.assertValue("Project Page")
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -881,7 +873,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertNoValues()
         this.koalaTest.assertValue("Project Page")
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -894,7 +885,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertNoValues()
         this.koalaTest.assertValue("Project Page")
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
@@ -320,7 +320,6 @@ public final class ThanksViewModelTest extends KSRobolectricTestCase {
     this.vm.intent(intent);
 
     this.lakeTest.assertValue("Thanks Page Viewed");
-    this.experimentsTest.assertNoValues();
   }
 
   @Test
@@ -332,6 +331,5 @@ public final class ThanksViewModelTest extends KSRobolectricTestCase {
     this.vm.intent(intent);
 
     this.lakeTest.assertNoValues();
-    this.experimentsTest.assertNoValues();
   }
 }


### PR DESCRIPTION
# 📲 What
Removing unused Optimizely tracking calls

# 🤔 Why
They're now being tracked in the Data Lake:
#850 
#852 
#853 
#855 
#856 
#858 
so we no longer need this code.

# 🛠 How
## `ExperimentsClientType`
- Removed `checkoutTags`, `track` and `trackRevenue` methods since they're no longer used
  - Removed in subclasses: ``MockExperimentsClientType` and `OptimizelyExperimentsClient`
## `ExperimentUtils`
- Removed `checkoutTags` method and tests since it's no longer used
- Removed `ExperimentRevenueData` since it's no longer used
## `KSRobolectricTestCase`
- Removed `experimentsTest` field since we no longer track experiment events with the experiments client
  - Removed usages in `ProjectViewModelTest` and `ThanksViewModelTest`

# 👀 See
␡␡␡␡␡␡␡␡␡␡␡

# 📋 QA
N/A

# Story 📖
[NT-1199]


[NT-1199]: https://kickstarter.atlassian.net/browse/NT-1199