### PR TITLE
[⛔️] NT-1149 Tracking Pledge Submit Button Clicked event for errored pledges

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/data/PledgeFlowContext.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/PledgeFlowContext.kt
@@ -2,12 +2,14 @@ package com.kickstarter.ui.data
 
 enum class PledgeFlowContext(val trackingString: String) {
     CHANGE_REWARD("change_reward"),
+    FIX_ERRORED_PLEDGE("fix_errored_pledge"),
     MANAGE_REWARD("manage_reward"),
     NEW_PLEDGE("new_pledge");
 
     companion object {
         fun forPledgeReason(pledgeReason: PledgeReason) : PledgeFlowContext {
-           return  when (pledgeReason) {
+           return when (pledgeReason) {
+                PledgeReason.FIX_PLEDGE -> FIX_ERRORED_PLEDGE
                 PledgeReason.PLEDGE -> NEW_PLEDGE
                 PledgeReason.UPDATE_REWARD -> CHANGE_REWARD
                 else -> MANAGE_REWARD

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -1004,7 +1004,7 @@ interface PledgeFragmentViewModel {
             Observable.combineLatest<Double, Double, CheckoutData>(shippingAmount, total)
             { s, t -> checkoutData(s, t, null) }
                     .compose<Pair<CheckoutData, PledgeData>>(combineLatestPair(pledgeData))
-                    .filter { it.second.pledgeFlowContext() == PledgeFlowContext.NEW_PLEDGE }
+                    .filter { shouldTrackPledgeSubmitButtonClicked(it.second.pledgeFlowContext()) }
                     .compose<Pair<CheckoutData, PledgeData>>(takeWhen(this.pledgeButtonClicked))
                     .compose(bindToLifecycle())
                     .subscribe { this.lake.trackPledgeSubmitButtonClicked(it.first, it.second) }
@@ -1049,6 +1049,10 @@ interface PledgeFragmentViewModel {
                 else -> reward.title() ?: projectName
             }
         }
+
+        private fun shouldTrackPledgeSubmitButtonClicked(pledgeFlowContext: PledgeFlowContext) =
+                pledgeFlowContext == PledgeFlowContext.NEW_PLEDGE
+                        || pledgeFlowContext == PledgeFlowContext.FIX_ERRORED_PLEDGE
 
         private fun storedCards(): Observable<List<StoredCard>> {
             return this.apolloClient.getStoredCards()

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -566,7 +566,7 @@ interface ProjectViewModel {
 
             projectDataAndBackedReward
                     .compose(takeWhen<Pair<ProjectData, Reward>, Void>(this.fixPaymentMethodButtonClicked))
-                    .map { Pair(pledgeData(it.second, it.first, PledgeFlowContext.MANAGE_REWARD), PledgeReason.FIX_PLEDGE) }
+                    .map { Pair(pledgeData(it.second, it.first, PledgeFlowContext.FIX_ERRORED_PLEDGE), PledgeReason.FIX_PLEDGE) }
                     .compose(bindToLifecycle())
                     .subscribe(this.showUpdatePledge)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -1773,6 +1773,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeProgressIsGone.assertValues(false, true)
         this.showUpdatePaymentError.assertValueCount(1)
         this.koalaTest.assertNoValues()
+        this.lakeTest.assertValues("Pledge Submit Button Clicked")
     }
 
     @Test
@@ -1831,6 +1832,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeProgressIsGone.assertValues(false)
         this.showUpdatePaymentSuccess.assertValueCount(1)
         this.koalaTest.assertNoValues()
+        this.lakeTest.assertValues("Pledge Submit Button Clicked")
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -1263,7 +1263,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.fixPaymentMethodButtonClicked()
 
         this.showUpdatePledge.assertValuesAndClear(Pair(PledgeData.builder()
-                .pledgeFlowContext(PledgeFlowContext.MANAGE_REWARD)
+                .pledgeFlowContext(PledgeFlowContext.FIX_ERRORED_PLEDGE)
                 .reward(reward)
                 .projectData(ProjectDataFactory.project(backedProject))
                 .build(), PledgeReason.FIX_PLEDGE))


### PR DESCRIPTION
# 📲 What
Tracking `Pledge Submit Button Clicked` event for errored pledges

# 🤔 Why
We have some events we want to track for the fix pledge flow.

# 🛠 How
## `PledgeFlowContext`
- Added `FIX_ERRORED_PLEDGE` with tracking string `fix_errored_pledge`
## `PledgeFragmentViewModel`
- Tracking `Pledge Submit Button Clicked` when user is fixing their pledge
- Updated tests
## `ProjectViewModel`
- Emitting `showUpdatePledge` with `PledgeFlowContext.FIX_ERRORED_PLEDGE` when a user is fixing their pledge
- Updated test
## `LakeTest`
- Added a test for checkout properties when a user fixing their pledge

# 👀 See
N/A

# 📋 QA
Check the LogCat for the `context_pledge_flow` property when fixing a pledge.

# Story 📖
[NT-1149]


[NT-1149]: https://kickstarter.atlassian.net/browse/NT-1149