### PR TITLE
NT-658 ErroredPledge push notification

### DIFF
--- a/app/src/internal/java/com/kickstarter/ui/views/DebugPushNotificationsView.java
+++ b/app/src/internal/java/com/kickstarter/ui/views/DebugPushNotificationsView.java
@@ -62,6 +62,25 @@ public final class DebugPushNotificationsView extends ScrollView {
     this.deviceRegistrar.unregisterDevice();
   }
 
+  @OnClick(R.id.simulate_errored_pledge_button)
+  public void simulateErroredPledgeButtonClick() {
+    final GCM gcm = GCM.builder()
+      .title("Payment failure")
+      .alert("Response needed! Get your reward for backing SKULL GRAPHIC TEE.")
+      .build();
+
+    final PushNotificationEnvelope envelope = PushNotificationEnvelope.builder()
+      .gcm(gcm)
+      .erroredPledge(
+        PushNotificationEnvelope.ErroredPledge.builder()
+          .projectId(PROJECT_ID)
+          .build()
+      )
+      .build();
+
+    this.pushNotifications.add(envelope);
+  }
+
   @OnClick(R.id.simulate_friend_backing_button)
   public void simulateFriendBackingButtonClick() {
     final GCM gcm = GCM.builder()

--- a/app/src/internal/res/layout/debug_push_notifications_layout.xml
+++ b/app/src/internal/res/layout/debug_push_notifications_layout.xml
@@ -52,6 +52,15 @@
       android:text="@string/debug_push_notifications_simulate_notifications" />
 
     <Button
+      android:id="@+id/simulate_errored_pledge_button"
+      android:layout_marginTop="@dimen/grid_1_half"
+      android:layout_marginBottom="@dimen/grid_1_half"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="@string/debug_push_notifications_errored_pldege"
+      style="@style/BorderButton" />
+
+    <Button
       android:id="@+id/simulate_friend_backing_button"
       android:layout_marginTop="@dimen/grid_1_half"
       android:layout_marginBottom="@dimen/grid_1_half"

--- a/app/src/main/java/com/kickstarter/libs/PushNotifications.java
+++ b/app/src/main/java/com/kickstarter/libs/PushNotifications.java
@@ -33,8 +33,6 @@ import com.kickstarter.ui.activities.UpdateActivity;
 import com.squareup.picasso.Picasso;
 import com.squareup.picasso.RequestCreator;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -202,9 +200,11 @@ public final class PushNotifications {
       return;
     }
 
-    final PendingIntent projectContentIntent = projectContentIntent(envelope, ObjectUtils.toString(erroredPledge.projectId()));
+    final Long projectId = erroredPledge.projectId();
+    final Intent projectIntent = projectIntent(envelope, ObjectUtils.toString(projectId))
+      .putExtra(IntentKey.EXPAND_PLEDGE_SHEET, true);
     final Notification notification = notificationBuilder(gcm.title(), gcm.alert(), CHANNEL_PROJECT_REMINDER)
-      .setContentIntent(projectContentIntent)
+      .setContentIntent(projectContentIntent(envelope, projectIntent))
       .build();
 
     notificationManager().notify(envelope.signature(), notification);
@@ -272,8 +272,9 @@ public final class PushNotifications {
       return;
     }
 
+    final Intent projectIntent = projectIntent(envelope, ObjectUtils.toString(project.id()));
     final Notification notification = notificationBuilder(gcm.title(), gcm.alert(), CHANNEL_PROJECT_REMINDER)
-      .setContentIntent(projectContentIntent(envelope, ObjectUtils.toString(project.id())))
+      .setContentIntent(projectContentIntent(envelope, projectIntent))
       .setLargeIcon(fetchBitmap(project.photo(), false))
       .build();
 
@@ -482,10 +483,9 @@ public final class PushNotifications {
   }
 
   private @NonNull Intent projectIntent(final @NonNull PushNotificationEnvelope envelope, final @NonNull String projectParam) {
-    final Intent intent = new Intent(this.context, ProjectActivity.class)
+    return new Intent(this.context, ProjectActivity.class)
       .putExtra(IntentKey.PROJECT_PARAM, projectParam)
       .putExtra(IntentKey.PUSH_NOTIFICATION_ENVELOPE, envelope)
       .putExtra(IntentKey.REF_TAG, RefTag.push());
-    return intent;
   }
 }

--- a/app/src/main/java/com/kickstarter/services/apiresponses/PushNotificationEnvelope.java
+++ b/app/src/main/java/com/kickstarter/services/apiresponses/PushNotificationEnvelope.java
@@ -95,7 +95,7 @@ public abstract class PushNotificationEnvelope implements Parcelable {
     @AutoParcel.Builder
     public abstract static class Builder {
       public abstract Builder projectId(Long __);
-      public abstract Message build();
+      public abstract ErroredPledge build();
     }
 
     public static Builder builder() {

--- a/app/src/main/java/com/kickstarter/services/apiresponses/PushNotificationEnvelope.java
+++ b/app/src/main/java/com/kickstarter/services/apiresponses/PushNotificationEnvelope.java
@@ -16,6 +16,7 @@ import auto.parcel.AutoParcel;
 @AutoParcel
 public abstract class PushNotificationEnvelope implements Parcelable {
   public abstract @Nullable Activity activity();
+  public abstract @Nullable ErroredPledge erroredPledge();
   public abstract GCM gcm();
   public abstract @Nullable Message message();
   public abstract @Nullable Project project();
@@ -32,6 +33,7 @@ public abstract class PushNotificationEnvelope implements Parcelable {
   @AutoParcel.Builder
   public abstract static class Builder {
     public abstract Builder activity(Activity __);
+    public abstract Builder erroredPledge(ErroredPledge __);
     public abstract Builder gcm(GCM __);
     public abstract Builder message(Message __);
     public abstract Builder project(Project __);
@@ -44,6 +46,10 @@ public abstract class PushNotificationEnvelope implements Parcelable {
   }
 
   public abstract Builder toBuilder();
+
+  public boolean isErroredPledge() {
+    return erroredPledge() != null;
+  }
 
   public boolean isFriendFollow() {
     return activity() != null && activity().category().equals(com.kickstarter.models.Activity.CATEGORY_FOLLOW);
@@ -79,6 +85,22 @@ public abstract class PushNotificationEnvelope implements Parcelable {
     // The server doesn't send unique notification ids, so hashing the alert text is a weak substitute. Probably won't
     // make use of this feature anyhow.
     return gcm().alert().hashCode();
+  }
+
+  @AutoGson
+  @AutoParcel
+  public abstract static class ErroredPledge implements Parcelable {
+    public abstract Long projectId();
+
+    @AutoParcel.Builder
+    public abstract static class Builder {
+      public abstract Builder projectId(Long __);
+      public abstract Message build();
+    }
+
+    public static Builder builder() {
+      return new AutoParcel_PushNotificationEnvelope_ErroredPledge.Builder();
+    }
   }
 
   @AutoGson

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -580,7 +580,7 @@ interface PledgeFragmentViewModel {
 
             pledgeInput
                     .compose<Pair<Double, Pair<Double, Double>>>(combineLatestPair(minAndMaxPledge))
-                    .map { it.first in it.second.first..cit.second.second }
+                    .map { it.first in it.second.first..it.second.second }
                     .map { if (it) R.color.ksr_green_500 else R.color.ksr_red_400 }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -580,7 +580,7 @@ interface PledgeFragmentViewModel {
 
             pledgeInput
                     .compose<Pair<Double, Pair<Double, Double>>>(combineLatestPair(minAndMaxPledge))
-                    .map { it.first in it.second.first..it.second.second }
+                    .map { it.first in it.second.first..cit.second.second }
                     .map { if (it) R.color.ksr_green_500 else R.color.ksr_red_400 }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -329,9 +329,6 @@ interface ProjectViewModel {
                     .startWith(false)
 
             progressBarIsGone
-                    .compose<Pair<Boolean, Boolean>>(combineLatestPair(pledgeSheetExpanded))
-                    .filter { BooleanUtils.isFalse(it.second) }
-                    .map { it.first }
                     .compose(bindToLifecycle())
                     .subscribe(this.retryProgressBarIsGone)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
   <string name="Device_ID">Device ID</string>
   <string name="debug_push_notifications_register_device">Register device</string>
   <string name="debug_push_notifications_device_registration">Device registration</string>
+  <string name="debug_push_notifications_errored_pldege">Errored pledge</string>
   <string name="debug_push_notifications_friend_backing">Friend backing</string>
   <string name="debug_push_notifications_friend_follow">Friend follow</string>
   <string name="debug_push_notifications_message">Message</string>


### PR DESCRIPTION
# 📲 What
Adds support for push notifications containing `ErroredPledge`

# 🤔 Why
We will be turning on pushes for errored pledges.

# 🛠 How
## `PushNotificationEnvelope` 
- Added `ErroredPledge` model
- Added `erroredPledge` field
## `PushNotifications`
- Added new channel notification `CHANNEL_ERRORED_PLEDGES` with high priority
- Added a subscription for when the `PushNotificationEnvelope` contains an `ErroredPledge` object
- Created a helper method `projectIntent` to that returns an `Intent` for a `Project` so we can add more extras
## `ProjectViewModel`
- Fixed bug where the pledge sheet `ProgressBar` was still visible if the `ProjectActivity` was started with an `EXPAND_PLEDGE_SHEET` extra
## `DebugPushNotificationsView`
- Added a button for triggering an `ErroredPledge` push that will take you to the Project page with the pledge sheet expanded
# 👀 See
|  |  |
| --- | --- |
| <img src=https://user-images.githubusercontent.com/1289295/80517305-e0cbd600-8952-11ea-9932-38d77d29f697.png width=330/> | ![device-2020-04-28-131801 2020-04-28 13_19_08](https://user-images.githubusercontent.com/1289295/80517302-e0333f80-8952-11ea-86b8-ca808ee9630e.gif) |

# 📋 QA
TBD

# Story 📖
[NT-658]


[NT-658]: https://kickstarter.atlassian.net/browse/NT-658