### PR TITLE
NT-1148: Fix pledge button clicked event

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -724,6 +724,12 @@ public final class Koala {
 
     this.client.track(LakeEvent.THANKS_PAGE_VIEWED, props);
   }
+
+  public void trackFixPledgeButtonClicked(final @NonNull ProjectData projectData) {
+    final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
+
+    this.client.track(LakeEvent.FIX_PLEDGE_BUTTON_CLICKED, props);
+  }
   //endregion
 
   //region Log In or Signup

--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -727,6 +727,7 @@ public final class Koala {
 
   public void trackFixPledgeButtonClicked(final @NonNull ProjectData projectData) {
     final Map<String, Object> props = KoalaUtils.projectProperties(projectData.project(), this.client.loggedInUser());
+    props.put("context_pledge_flow", PledgeFlowContext.FIX_ERRORED_PLEDGE.getTrackingString());
 
     this.client.track(LakeEvent.FIX_PLEDGE_BUTTON_CLICKED, props);
   }

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -20,6 +20,7 @@ const val PLEDGE_SUBMIT_BUTTON_CLICKED = "Pledge Submit Button Clicked"
 const val PROJECT_PAGE_PLEDGE_BUTTON_CLICKED = "Project Page Pledge Button Clicked"
 const val SELECT_REWARD_BUTTON_CLICKED = "Select Reward Button Clicked"
 const val THANKS_PAGE_VIEWED = "Thanks Page Viewed"
+const val FIX_PLEDGE_BUTTON_CLICKED = "Fix Pledge Button Clicked"
 // endregion
 
 // region Log In or Signup

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -20,8 +20,11 @@ const val PLEDGE_SUBMIT_BUTTON_CLICKED = "Pledge Submit Button Clicked"
 const val PROJECT_PAGE_PLEDGE_BUTTON_CLICKED = "Project Page Pledge Button Clicked"
 const val SELECT_REWARD_BUTTON_CLICKED = "Select Reward Button Clicked"
 const val THANKS_PAGE_VIEWED = "Thanks Page Viewed"
-const val FIX_PLEDGE_BUTTON_CLICKED = "Fix Pledge Button Clicked"
 // endregion
+
+// region Manage a Pledge
+const val FIX_PLEDGE_BUTTON_CLICKED = "Fix Pledge Button Clicked"
+//endregion
 
 // region Log In or Signup
 const val FACEBOOK_LOG_IN_OR_SIGNUP_BUTTON_CLICKED = "Facebook Log In or Signup Button Clicked"

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -782,7 +782,6 @@ interface ProjectViewModel {
                     .compose<ProjectData>(takeWhen(this.fixPaymentMethodButtonClicked))
                     .compose(bindToLifecycle())
                     .subscribe{ this.lake.trackFixPledgeButtonClicked(it) }
-
         }
 
         private fun eventName(projectActionButtonStringRes: Int) : String {

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -778,11 +778,10 @@ interface ProjectViewModel {
                     .compose(bindToLifecycle())
                     .subscribe { this.lake.trackCreatorDetailsClicked(it) }
 
-            fullProjectDataAndPledgeFlowContext
-                    .compose<Pair<ProjectData, PledgeFlowContext?>>(takeWhen(this.fixPaymentMethodButtonClicked))
-                    .filter { it.second == PledgeFlowContext.FIX_ERRORED_PLEDGE }
+            projectData
+                    .compose<ProjectData>(takeWhen(this.fixPaymentMethodButtonClicked))
                     .compose(bindToLifecycle())
-                    .subscribe{ this.lake.trackFixPledgeButtonClicked(it.first) }
+                    .subscribe{ this.lake.trackFixPledgeButtonClicked(it) }
 
         }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -777,6 +777,13 @@ interface ProjectViewModel {
                     .filter { it.project().isLive && !it.project().isBacking }
                     .compose(bindToLifecycle())
                     .subscribe { this.lake.trackCreatorDetailsClicked(it) }
+
+            fullProjectDataAndPledgeFlowContext
+                    .compose<Pair<ProjectData, PledgeFlowContext?>>(takeWhen(this.fixPaymentMethodButtonClicked))
+                    .filter { it.second == PledgeFlowContext.FIX_ERRORED_PLEDGE }
+                    .compose(bindToLifecycle())
+                    .subscribe{ this.lake.trackFixPledgeButtonClicked(it.first) }
+
         }
 
         private fun eventName(projectActionButtonStringRes: Int) : String {

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -1268,7 +1268,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
                 .projectData(ProjectDataFactory.project(backedProject))
                 .build(), PledgeReason.FIX_PLEDGE))
         this.koalaTest.assertValue("Project Page")
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed","Fix Pledge Button Clicked")
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
-  Added event for Fix pledge button inside View your pledge
<img width="356" alt="Screen Shot 2020-04-28 at 11 57 07 AM" src="https://user-images.githubusercontent.com/4083656/80526345-73667800-8947-11ea-934b-429d125c48ec.png">

# 🤔 Why

New tracking events

# 📋 QA

When hitting that red button take a look into your logcat
<img width="1708" alt="Screen Shot 2020-04-28 at 12 03 05 PM" src="https://user-images.githubusercontent.com/4083656/80526918-672eea80-8948-11ea-90e4-1c84a5f40f3b.png">


# Story 📖

[Fix pledge button clicked event](https://kickstarter.atlassian.net/browse/NT-1148)
