### PR TITLE
NT-1207 Deep linking to project pledge URL

### DIFF
--- a/app/src/main/java/com/kickstarter/services/KSUri.java
+++ b/app/src/main/java/com/kickstarter/services/KSUri.java
@@ -18,6 +18,10 @@ public final class KSUri {
     return isKickstarterUri(uri, webEndpoint) && Secrets.RegExpPattern.API.matcher(UriUtilsKt.host(uri)).matches();
   }
 
+  public static boolean isCheckoutUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
+    return isKickstarterUri(uri, webEndpoint) && NATIVE_CHECKOUT_PATTERN.matcher(UriUtilsKt.path(uri)).matches();
+  }
+
   public static boolean isDiscoverCategoriesPath(final @NonNull String path) {
     return DISCOVER_CATEGORIES_PATTERN.matcher(path).matches();
   }
@@ -47,8 +51,8 @@ public final class KSUri {
     return isKickstarterUri(uri, webEndpoint) && !isKSFavIcon(uri, webEndpoint);
   }
 
-  public static boolean isCheckoutUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
-    return isKickstarterUri(uri, webEndpoint) && (NATIVE_CHECKOUT_PATTERN.matcher(UriUtilsKt.path(uri)).matches() || NATIVE_CHECKOUT_PATTERN_2.matcher(UriUtilsKt.path(uri)).matches());
+  public static boolean isNewGuestCheckoutUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
+    return isKickstarterUri(uri, webEndpoint) && NEW_GUEST_CHECKOUT_PATTERN.matcher(UriUtilsKt.path(uri)).matches();
   }
 
   public static boolean isProjectUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
@@ -65,6 +69,10 @@ public final class KSUri {
 
   public static boolean isStagingUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
     return isKickstarterUri(uri, webEndpoint) && Secrets.RegExpPattern.STAGING.matcher(UriUtilsKt.host(uri)).matches();
+  }
+
+  public static boolean isCheckoutThanksUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
+    return isKickstarterUri(uri, webEndpoint) && CHECKOUT_THANKS_PATTERN.matcher(UriUtilsKt.path(uri)).matches();
   }
 
   public static boolean isModalUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
@@ -114,9 +122,9 @@ public final class KSUri {
     "\\A\\/projects(\\/[a-zA-Z0-9_-]+)?\\/[a-zA-Z0-9_-]+\\/pledge\\z"
   );
 
-  //  /projects/:creator_param/:project_param/pledge/new
-  private static final Pattern NATIVE_CHECKOUT_PATTERN_2 = Pattern.compile(
-    "\\A\\/projects(\\/[a-zA-Z0-9_-]+)?\\/[a-zA-Z0-9_-]+\\/pledge\\/new\\z"
+  // /checkouts/:checkout_id/guest/new
+  private static final Pattern NEW_GUEST_CHECKOUT_PATTERN = Pattern.compile(
+    "\\A\\/checkouts\\/[a-zA-Z0-9-_]+\\/guest\\/new\\z"
   );
 
   // /projects/:creator_param/:project_param

--- a/app/src/main/java/com/kickstarter/services/KSUri.java
+++ b/app/src/main/java/com/kickstarter/services/KSUri.java
@@ -47,8 +47,8 @@ public final class KSUri {
     return isKickstarterUri(uri, webEndpoint) && !isKSFavIcon(uri, webEndpoint);
   }
 
-  public static boolean isNewGuestCheckoutUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
-    return isKickstarterUri(uri, webEndpoint) && NEW_GUEST_CHECKOUT_PATTERN.matcher(UriUtilsKt.path(uri)).matches();
+  public static boolean isCheckoutUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
+    return isKickstarterUri(uri, webEndpoint) && (NATIVE_CHECKOUT_PATTERN.matcher(UriUtilsKt.path(uri)).matches() || NATIVE_CHECKOUT_PATTERN_2.matcher(UriUtilsKt.path(uri)).matches());
   }
 
   public static boolean isProjectUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
@@ -65,10 +65,6 @@ public final class KSUri {
 
   public static boolean isStagingUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
     return isKickstarterUri(uri, webEndpoint) && Secrets.RegExpPattern.STAGING.matcher(UriUtilsKt.host(uri)).matches();
-  }
-
-  public static boolean isCheckoutThanksUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
-    return isKickstarterUri(uri, webEndpoint) && CHECKOUT_THANKS_PATTERN.matcher(UriUtilsKt.path(uri)).matches();
   }
 
   public static boolean isModalUri(final @NonNull Uri uri, final @NonNull String webEndpoint) {
@@ -113,9 +109,14 @@ public final class KSUri {
   // /discover/places/param
   private static final Pattern DISCOVER_PLACES_PATTERN = Pattern.compile("\\A\\/discover\\/places\\/[a-zA-Z0-9-_]+\\z");
 
-  // /checkouts/:checkout_id/guest/new
-  private static final Pattern NEW_GUEST_CHECKOUT_PATTERN = Pattern.compile(
-    "\\A\\/checkouts\\/[a-zA-Z0-9-_]+\\/guest\\/new\\z"
+  //  /projects/:creator_param/:project_param/pledge
+  private static final Pattern NATIVE_CHECKOUT_PATTERN = Pattern.compile(
+    "\\A\\/projects(\\/[a-zA-Z0-9_-]+)?\\/[a-zA-Z0-9_-]+\\/pledge\\z"
+  );
+
+  //  /projects/:creator_param/:project_param/pledge/new
+  private static final Pattern NATIVE_CHECKOUT_PATTERN_2 = Pattern.compile(
+    "\\A\\/projects(\\/[a-zA-Z0-9_-]+)?\\/[a-zA-Z0-9_-]+\\/pledge\\/new\\z"
   );
 
   // /projects/:creator_param/:project_param

--- a/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.java
@@ -44,6 +44,16 @@ public final class DeepLinkActivity extends BaseActivity<DeepLinkViewModel.ViewM
       .subscribe(this::startProjectActivityForCheckout);
   }
 
+  private @NonNull Intent projectIntent(final @NonNull Uri uri) {
+    final Intent projectIntent = new Intent(this, ProjectActivity.class)
+      .setData(uri);
+    final String ref = UrlUtils.INSTANCE.refTag(uri.toString());
+    if (ref != null) {
+      projectIntent.putExtra(IntentKey.REF_TAG, RefTag.from(ref));
+    }
+    return projectIntent;
+  }
+
   private void startDiscoveryActivity() {
     ApplicationUtils.startNewDiscoveryActivity(this);
     finish();
@@ -59,16 +69,6 @@ public final class DeepLinkActivity extends BaseActivity<DeepLinkViewModel.ViewM
       .putExtra(IntentKey.EXPAND_PLEDGE_SHEET, true);
     startActivity(projectIntent);
     finish();
-  }
-
-  private @NonNull Intent projectIntent(final @NonNull Uri uri) {
-    final Intent projectIntent = new Intent(this, ProjectActivity.class)
-      .setData(uri);
-    final String ref = UrlUtils.INSTANCE.refTag(uri.toString());
-    if (ref != null) {
-      projectIntent.putExtra(IntentKey.REF_TAG, RefTag.from(ref));
-    }
-    return projectIntent;
   }
 
   private void startBrowser(final @NonNull String url) {

--- a/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.java
@@ -37,6 +37,11 @@ public final class DeepLinkActivity extends BaseActivity<DeepLinkViewModel.ViewM
       .compose(bindToLifecycle())
       .compose(observeForUI())
       .subscribe(this::startProjectActivity);
+
+    this.viewModel.outputs.startProjectActivityForCheckout()
+      .compose(bindToLifecycle())
+      .compose(observeForUI())
+      .subscribe(this::startProjectActivityForCheckout);
   }
 
   private void startDiscoveryActivity() {
@@ -45,14 +50,25 @@ public final class DeepLinkActivity extends BaseActivity<DeepLinkViewModel.ViewM
   }
 
   private void startProjectActivity(final @NonNull Uri uri) {
+    startActivity(projectIntent(uri));
+    finish();
+  }
+
+  private void startProjectActivityForCheckout(final @NonNull Uri uri) {
+    final Intent projectIntent = projectIntent(uri)
+      .putExtra(IntentKey.EXPAND_PLEDGE_SHEET, true);
+    startActivity(projectIntent);
+    finish();
+  }
+
+  private @NonNull Intent projectIntent(final @NonNull Uri uri) {
     final Intent projectIntent = new Intent(this, ProjectActivity.class)
       .setData(uri);
     final String ref = UrlUtils.INSTANCE.refTag(uri.toString());
     if (ref != null) {
       projectIntent.putExtra(IntentKey.REF_TAG, RefTag.from(ref));
     }
-    startActivity(projectIntent);
-    finish();
+    return projectIntent;
   }
 
   private void startBrowser(final @NonNull String url) {

--- a/app/src/main/java/com/kickstarter/viewmodels/DeepLinkViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DeepLinkViewModel.java
@@ -54,6 +54,7 @@ public interface DeepLinkViewModel {
 
       uriFromIntent
         .filter(uri -> KSUri.isProjectUri(uri, Secrets.WebEndpoint.PRODUCTION))
+        .filter(uri -> !KSUri.isCheckoutUri(uri, Secrets.WebEndpoint.PRODUCTION))
         .filter(uri -> !KSUri.isProjectPreviewUri(uri, Secrets.WebEndpoint.PRODUCTION))
         .map(this::appendRefTagIfNone)
         .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/DeepLinkViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DeepLinkViewModel.java
@@ -22,20 +22,17 @@ import static com.kickstarter.libs.rx.transformers.Transformers.ignoreValues;
 public interface DeepLinkViewModel {
 
   interface Outputs {
-    /**
-     * Emits when we should start an external browser because we don't want to deep link.
-     */
+    /** Emits when we should start an external browser because we don't want to deep link. */
     Observable<String> startBrowser();
 
-    /**
-     * Emits when we should start the {@link com.kickstarter.ui.activities.DiscoveryActivity}.
-     */
+    /** Emits when we should start the {@link com.kickstarter.ui.activities.DiscoveryActivity}. */
     Observable<Void> startDiscoveryActivity();
 
-    /**
-     * Emits when we should start the {@link com.kickstarter.ui.activities.ProjectActivity}.
-     */
+    /** Emits when we should start the {@link com.kickstarter.ui.activities.ProjectActivity}. */
     Observable<Uri> startProjectActivity();
+
+    /** Emits when we should start the {@link com.kickstarter.ui.activities.ProjectActivity} with pledge sheet expanded. */
+    Observable<Uri> startProjectActivityForCheckout();
   }
 
   final class ViewModel extends ActivityViewModel<DeepLinkActivity> implements Outputs {
@@ -62,6 +59,12 @@ public interface DeepLinkViewModel {
         .compose(bindToLifecycle())
         .subscribe(this.startProjectActivity::onNext);
 
+      uriFromIntent
+        .filter(uri -> KSUri.isCheckoutUri(uri, Secrets.WebEndpoint.PRODUCTION) )
+        .map(this::appendRefTagIfNone)
+        .compose(bindToLifecycle())
+        .subscribe(this.startProjectActivityWithCheckout::onNext);
+
       this.startProjectActivity
         .subscribe(__ -> koala.trackContinueUserActivityAndOpenedDeepLink());
 
@@ -70,6 +73,7 @@ public interface DeepLinkViewModel {
 
       final Observable<Uri> unsupportedDeepLink = uriFromIntent
         .filter(uri -> !lastPathSegmentIsProjects(uri))
+        .filter(uri -> !KSUri.isCheckoutUri(uri, Secrets.WebEndpoint.PRODUCTION))
         .filter(uri -> !KSUri.isProjectUri(uri, Secrets.WebEndpoint.PRODUCTION));
 
       Observable.merge(projectPreview, unsupportedDeepLink)
@@ -96,6 +100,7 @@ public interface DeepLinkViewModel {
     private final BehaviorSubject<String> startBrowser = BehaviorSubject.create();
     private final BehaviorSubject<Void> startDiscoveryActivity = BehaviorSubject.create();
     private final BehaviorSubject<Uri> startProjectActivity = BehaviorSubject.create();
+    private final BehaviorSubject<Uri> startProjectActivityWithCheckout = BehaviorSubject.create();
 
     public final Outputs outputs = this;
 
@@ -107,6 +112,9 @@ public interface DeepLinkViewModel {
     }
     @Override public @NonNull Observable<Uri> startProjectActivity() {
       return this.startProjectActivity;
+    }
+    @Override public @NonNull Observable<Uri> startProjectActivityForCheckout() {
+      return this.startProjectActivityWithCheckout;
     }
   }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/DeepLinkViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DeepLinkViewModel.java
@@ -61,7 +61,7 @@ public interface DeepLinkViewModel {
         .subscribe(this.startProjectActivity::onNext);
 
       uriFromIntent
-        .filter(uri -> KSUri.isCheckoutUri(uri, Secrets.WebEndpoint.PRODUCTION) )
+        .filter(uri -> KSUri.isCheckoutUri(uri, Secrets.WebEndpoint.PRODUCTION))
         .map(this::appendRefTagIfNone)
         .compose(bindToLifecycle())
         .subscribe(this.startProjectActivityWithCheckout::onNext);

--- a/app/src/test/java/com/kickstarter/services/KSUriTest.java
+++ b/app/src/test/java/com/kickstarter/services/KSUriTest.java
@@ -7,6 +7,7 @@ import com.kickstarter.KSRobolectricTestCase;
 import org.junit.Test;
 
 public final class KSUriTest extends KSRobolectricTestCase {
+  private final Uri checkoutUri = Uri.parse("https://www.ksr.com/projects/creator/project/pledge");
   private final Uri discoverCategoriesUri = Uri.parse("https://www.ksr.com/discover/categories/art");
   private final Uri discoverScopeUri = Uri.parse("https://www.kickstarter.com/discover/ending-soon");
   private final Uri discoverPlacesUri = Uri.parse("https://www.ksr.com/discover/places/newest");
@@ -18,6 +19,11 @@ public final class KSUriTest extends KSRobolectricTestCase {
   private final Uri updateUri = Uri.parse("https://www.ksr.com/projects/creator/project/posts/id");
   private final Uri userSurveyUri = Uri.parse("https://www.ksr.com/users/user-param/surveys/survey-id");
   private final String webEndpoint = "https://www.ksr.com";
+
+  @Test
+  public void testKSUri_isCheckoutUri() {
+    assertTrue(KSUri.isCheckoutUri(this.checkoutUri, this.webEndpoint));
+  }
 
   @Test
   public void testKSUri_isDiscoverCategoriesPath() {

--- a/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.java
@@ -15,12 +15,14 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<String> startBrowser = new TestSubscriber<>();
   private final TestSubscriber<Void> startDiscoveryActivity = new TestSubscriber<>();
   private final TestSubscriber<Uri> startProjectActivity = new TestSubscriber<>();
+  private final TestSubscriber<Uri> startProjectActivityForCheckout = new TestSubscriber<>();
 
   protected void setUpEnvironment() {
     this.vm = new DeepLinkViewModel.ViewModel(environment());
     this.vm.outputs.startBrowser().subscribe(this.startBrowser);
     this.vm.outputs.startDiscoveryActivity().subscribe(this.startDiscoveryActivity);
     this.vm.outputs.startProjectActivity().subscribe(this.startProjectActivity);
+    this.vm.outputs.startProjectActivityForCheckout().subscribe(this.startProjectActivityForCheckout);
   }
 
   @Test
@@ -33,6 +35,7 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
     this.startBrowser.assertValue(url);
     this.startDiscoveryActivity.assertNoValues();
     this.startProjectActivity.assertNoValues();
+    this.startProjectActivityForCheckout.assertNoValues();
     this.koalaTest.assertNoValues();
   }
 
@@ -46,6 +49,36 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
     this.startBrowser.assertValue(url);
     this.startDiscoveryActivity.assertNoValues();
     this.startProjectActivity.assertNoValues();
+    this.startProjectActivityForCheckout.assertNoValues();
+    this.koalaTest.assertNoValues();
+  }
+
+  @Test
+  public void testCheckoutDeepLinkWithRefTag_startsProjectActivity() {
+    setUpEnvironment();
+
+    final String url = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap/pledge?ref=discovery";
+    this.vm.intent(intentWithData(url));
+
+    this.startProjectActivity.assertNoValues();
+    this.startBrowser.assertNoValues();
+    this.startDiscoveryActivity.assertNoValues();
+    this.startProjectActivityForCheckout.assertValue(Uri.parse(url));
+    this.koalaTest.assertNoValues();
+  }
+
+  @Test
+  public void testCheckoutDeepLinkWithoutRefTag_startsProjectActivity() {
+    setUpEnvironment();
+
+    final String url = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap/pledge";
+    this.vm.intent(intentWithData(url));
+
+    final String expectedUrl = "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap/pledge?ref=android_deep_link";
+    this.startProjectActivity.assertNoValues();
+    this.startBrowser.assertNoValues();
+    this.startDiscoveryActivity.assertNoValues();
+    this.startProjectActivityForCheckout.assertValue(Uri.parse(expectedUrl));
     this.koalaTest.assertNoValues();
   }
 
@@ -59,6 +92,7 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
     this.startProjectActivity.assertValue(Uri.parse(url));
     this.startBrowser.assertNoValues();
     this.startDiscoveryActivity.assertNoValues();
+    this.startProjectActivityForCheckout.assertNoValues();
     this.koalaTest.assertValues(KoalaEvent.CONTINUE_USER_ACTIVITY, KoalaEvent.OPENED_DEEP_LINK);
   }
 
@@ -73,6 +107,7 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
     this.startProjectActivity.assertValue(Uri.parse(expectedUrl));
     this.startBrowser.assertNoValues();
     this.startDiscoveryActivity.assertNoValues();
+    this.startProjectActivityForCheckout.assertNoValues();
     this.koalaTest.assertValues(KoalaEvent.CONTINUE_USER_ACTIVITY, KoalaEvent.OPENED_DEEP_LINK);
   }
 
@@ -86,6 +121,7 @@ public class DeepLinkViewModelTest extends KSRobolectricTestCase {
     this.startDiscoveryActivity.assertValueCount(1);
     this.startBrowser.assertNoValues();
     this.startProjectActivity.assertNoValues();
+    this.startProjectActivityForCheckout.assertNoValues();
     this.koalaTest.assertValues(KoalaEvent.CONTINUE_USER_ACTIVITY, KoalaEvent.OPENED_DEEP_LINK);
   }
 


### PR DESCRIPTION
# 📲 What
Deep linking to project pledge URL.

# 🤔 Why
Project URLs that end in `/pledge` will be used in errored pledge emails.

# 🛠 How
## `KSUri`
- Added `NATIVE_CHECKOUT_PATTERN` regex that matches pledge URLs
- Added `isCheckoutUri` method that returns if a URI matches that pattern
- Added test
## `DeepLinkViewModel`
- Added output `startProjectActivityForCheckout` that emits when we've deep linked with a pledge URL
- Added test cases that check this only emits for pledge URLs
## `DeepLinkActivity`
- Added `projectIntent` since it's used in 2 places

# 👀 See
![device-2020-04-29-130434 2020-04-29 13_07_26](https://user-images.githubusercontent.com/1289295/80624919-65355c00-8a1a-11ea-8944-69c64e17bc56.gif)

# 📋 QA
Click a pledge URL (if you have deep links enabled)

# Story 📖
[NT-1207]


[NT-1207]: https://kickstarter.atlassian.net/browse/NT-1207