### PR TITLE
NT-1242 Support for Optimizely feature flags

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
@@ -2,8 +2,10 @@ package com.kickstarter.libs
 
 import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.libs.models.OptimizelyExperiment
+import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.utils.ExperimentData
 import com.kickstarter.libs.utils.ExperimentUtils
+import com.kickstarter.models.User
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -29,6 +31,8 @@ interface ExperimentsClientType {
     }
 
     fun appVersion(): String
+    fun enabledFeatures(user: User?): List<String>
+    fun isFeatureEnabled(feature: OptimizelyFeature.Key, experimentData: ExperimentData): Boolean
     fun optimizelyEnvironment(): OptimizelyEnvironment
     fun OSVersion(): String
     fun trackingVariation(experimentKey: String, experimentData: ExperimentData): String?

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
@@ -5,7 +5,9 @@ import com.google.firebase.iid.FirebaseInstanceId
 import com.kickstarter.BuildConfig
 import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.libs.models.OptimizelyExperiment
+import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.utils.ExperimentData
+import com.kickstarter.models.User
 import com.optimizely.ab.android.sdk.OptimizelyClient
 import com.optimizely.ab.android.sdk.OptimizelyManager
 
@@ -15,6 +17,15 @@ class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManag
     override fun OSVersion(): String = Build.VERSION.RELEASE
 
     override fun userId(): String = FirebaseInstanceId.getInstance().id
+
+    override fun enabledFeatures(user: User?): List<String> {
+        return this.optimizelyClient().getEnabledFeatures(userId(),
+                attributes(ExperimentData(user, null, null), this.optimizelyEnvironment))
+    }
+
+    override fun isFeatureEnabled(feature: OptimizelyFeature.Key, experimentData: ExperimentData): Boolean {
+        return optimizelyClient().isFeatureEnabled(feature.key, userId(), attributes(experimentData, this.optimizelyEnvironment))
+    }
 
     override fun variant(experiment: OptimizelyExperiment.Key, experimentData: ExperimentData): OptimizelyExperiment.Variant {
         val user = experimentData.user

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
@@ -19,20 +19,21 @@ class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManag
     override fun userId(): String = FirebaseInstanceId.getInstance().id
 
     override fun enabledFeatures(user: User?): List<String> {
-        return this.optimizelyClient().getEnabledFeatures(userId(),
+        return this.optimizelyClient()?.getEnabledFeatures(userId(),
                 attributes(ExperimentData(user, null, null), this.optimizelyEnvironment))
+                ?: emptyList()
     }
 
     override fun isFeatureEnabled(feature: OptimizelyFeature.Key, experimentData: ExperimentData): Boolean {
-        return optimizelyClient().isFeatureEnabled(feature.key, userId(), attributes(experimentData, this.optimizelyEnvironment))
+        return optimizelyClient()?.isFeatureEnabled(feature.key, userId(), attributes(experimentData, this.optimizelyEnvironment))?: false
     }
 
     override fun variant(experiment: OptimizelyExperiment.Key, experimentData: ExperimentData): OptimizelyExperiment.Variant {
         val user = experimentData.user
         val variationString: String? = if (user?.isAdmin == true) {
-            optimizelyClient().getVariation(experiment.key, user.id().toString(), attributes(experimentData, this.optimizelyEnvironment))
+            optimizelyClient()?.getVariation(experiment.key, user.id().toString(), attributes(experimentData, this.optimizelyEnvironment))
         } else {
-            optimizelyClient().activate(experiment.key, userId(), attributes(experimentData, this.optimizelyEnvironment))
+            optimizelyClient()?.activate(experiment.key, userId(), attributes(experimentData, this.optimizelyEnvironment))
         }?.key
 
         return OptimizelyExperiment.Variant.safeValueOf(variationString)
@@ -40,9 +41,9 @@ class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManag
 
     override fun optimizelyEnvironment(): OptimizelyEnvironment = this.optimizelyEnvironment
 
-    private fun optimizelyClient(): OptimizelyClient = this.optimizelyManager.optimizely
+    private fun optimizelyClient(): OptimizelyClient? = this.optimizelyManager.optimizely
 
     override fun trackingVariation(experimentKey: String, experimentData: ExperimentData): String? {
-        return optimizelyClient().getVariation(experimentKey, userId(), attributes(experimentData, this.optimizelyEnvironment))?.key
+        return optimizelyClient()?.getVariation(experimentKey, userId(), attributes(experimentData, this.optimizelyEnvironment))?.key
     }
 }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -121,7 +121,15 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
     }
 
     override fun enabledFeatureFlags(): JSONArray? {
-        return ConfigUtils.enabledFeatureFlags(this.config)
+        return JSONArray(this.optimizely.enabledFeatures(this.loggedInUser))
+                .apply {
+                    val configFlags = ConfigUtils.enabledFeatureFlags(this@TrackingClient.config)
+                    configFlags?.let {
+                        for (index in 0 until it.length()) {
+                            put(it.getJSONObject(index))
+                        }
+                    }
+                }
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -126,7 +126,7 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
                     val configFlags = ConfigUtils.enabledFeatureFlags(this@TrackingClient.config)
                     configFlags?.let {
                         for (index in 0 until it.length()) {
-                            put(it.getJSONObject(index))
+                            put(it.get(index))
                         }
                     }
                 }

--- a/app/src/main/java/com/kickstarter/libs/models/OptimizelyFeature.kt
+++ b/app/src/main/java/com/kickstarter/libs/models/OptimizelyFeature.kt
@@ -1,0 +1,7 @@
+package com.kickstarter.libs.models
+
+class OptimizelyFeature {
+    enum class Key(val key: String) {
+        LIGHTS_ON("android_lights_on")
+    }
+}

--- a/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
@@ -3,7 +3,9 @@ package com.kickstarter.mock
 import com.kickstarter.libs.ExperimentsClientType
 import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.libs.models.OptimizelyExperiment
+import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.utils.ExperimentData
+import com.kickstarter.models.User
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -12,6 +14,10 @@ open class MockExperimentsClientType(private val variant: OptimizelyExperiment.V
     constructor() : this(OptimizelyExperiment.Variant.CONTROL, OptimizelyEnvironment.STAGING)
 
     override fun appVersion(): String = "9.9.9"
+
+    override fun enabledFeatures(user: User?): List<String> = emptyList()
+
+    override fun isFeatureEnabled(feature: OptimizelyFeature.Key, experimentData: ExperimentData): Boolean = false
 
     override fun optimizelyEnvironment(): OptimizelyEnvironment = this.optimizelyEnvironment
 

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -554,7 +554,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals("Pixel 3", expectedProperties["session_device_model"])
         assertEquals("Portrait", expectedProperties["session_device_orientation"])
         assertEquals("en", expectedProperties["session_display_language"])
-        assertEquals(JSONArray().put("optimizely_experiment").put("android_example_feature"), expectedProperties["session_enabled_features"])
+        assertEquals(JSONArray().put("optimizely_feature").put("android_example_feature"), expectedProperties["session_enabled_features"])
         assertEquals(false, expectedProperties["session_is_voiceover_running"])
         assertEquals("kickstarter_android", expectedProperties["session_mp_lib"])
         assertEquals("Android", expectedProperties["session_os"])

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -463,7 +463,14 @@ class LakeTest : KSRobolectricTestCase() {
     }
 
     private fun client(user: User?) = MockTrackingClient(user?.let { MockCurrentUser(it) }
-            ?: MockCurrentUser(), mockCurrentConfig(), TrackingClientType.Type.LAKE, MockExperimentsClientType())
+            ?: MockCurrentUser(),
+            mockCurrentConfig(),
+            TrackingClientType.Type.LAKE,
+            object : MockExperimentsClientType() {
+                override fun enabledFeatures(user: User?): List<String> {
+                    return listOf("optimizely_feature")
+                }
+            })
 
     private fun assertCheckoutProperties() {
         val expectedProperties = this.propertiesTest.value
@@ -547,7 +554,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals("Pixel 3", expectedProperties["session_device_model"])
         assertEquals("Portrait", expectedProperties["session_device_orientation"])
         assertEquals("en", expectedProperties["session_display_language"])
-        assertEquals(JSONArray().put("android_example_feature"), expectedProperties["session_enabled_features"])
+        assertEquals(JSONArray().put("optimizely_experiment").put("android_example_feature"), expectedProperties["session_enabled_features"])
         assertEquals(false, expectedProperties["session_is_voiceover_running"])
         assertEquals("kickstarter_android", expectedProperties["session_mp_lib"])
         assertEquals("Android", expectedProperties["session_os"])

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -6,6 +6,7 @@ import com.kickstarter.models.User;
 
 import org.joda.time.DateTime;
 import org.json.JSONArray;
+import org.json.JSONException;
 
 import java.util.Map;
 
@@ -89,7 +90,17 @@ public final class MockTrackingClient extends TrackingClientType {
 
   @Override
   protected JSONArray enabledFeatureFlags() {
-    return ConfigUtils.INSTANCE.enabledFeatureFlags(this.config);
+    final JSONArray combinedFeatures = new JSONArray(this.optimizely.enabledFeatures(this.loggedInUser));
+    final JSONArray configFeatures = ConfigUtils.INSTANCE.enabledFeatureFlags(this.config);
+    if (configFeatures != null) {
+      for (int i = 0; i < configFeatures.length(); i++) {
+        try {
+          combinedFeatures.put(configFeatures.get(i));
+        } catch (JSONException ignored) {
+        }
+      }
+    }
+    return combinedFeatures;
   }
 
   @Override


### PR DESCRIPTION
# 📲 What
Adding support for consuming feature flags from Optimizely.

# 🤔 Why
We're going to use feature flags from Optimizely.

# 🛠 How
## `OptimizelyFeature`
- Added enum for optimizely feature flags
- Added `Key.LIGHTS_ON` with value `android_lights_on` from Optimizely
## `ExperimentsClientType`
- Added 2 new abstract methods, `enabledFeatures` for tracking and `isFeaturedEnabled` for individual feature flag values
- Implemented in both subclasses, `OptimizelyExperimentsClient` and `MockExperimentsClientType`
## `OptimizelyExperimentsClient`
- A tracking call can fire before Optimizely is initialized so `optimizelyClient` now returns an `OptimizelyClient?`
## `TrackingClient` and `MockTrackingClient`
- `enabledFeatureFlags` now returns optimizely and config feature flags
- Updated `LakeTest` to assert that Optimizely flags are tracked

# 👀 See
<img width="498" alt="Screen Shot 2020-05-04 at 5 11 06 PM" src="https://user-images.githubusercontent.com/1289295/81014157-568be200-8e2a-11ea-8fa2-8ae9e0d6d407.png">

# 📋 QA
N/A
I plan to add displaying the features in the Internal Tools in the next PR!

# Story 📖
[NT-1242]

[NT-1242]: https://kickstarter.atlassian.net/browse/NT-1242