### PR TITLE
NT-1243 Displaying enabled Optimizely feature flags in Internal Tools

### DIFF
--- a/app/src/internal/java/com/kickstarter/ui/activities/FeatureFlagsActivity.kt
+++ b/app/src/internal/java/com/kickstarter/ui/activities/FeatureFlagsActivity.kt
@@ -22,14 +22,23 @@ class FeatureFlagsActivity : BaseActivity<FeatureFlagsViewModel.ViewModel>() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_feature_flags)
 
-        val featureFlagAdapter = FeatureFlagsAdapter()
-        config_flags.adapter = featureFlagAdapter
+        val configFlagsAdapter = FeatureFlagsAdapter()
+        config_flags.adapter = configFlagsAdapter
         config_flags.addItemDecoration(TableItemDecoration())
 
-        this.viewModel.outputs.features()
+        val optimizelyFlagsAdapter = FeatureFlagsAdapter()
+        optimizely_flags.adapter = optimizelyFlagsAdapter
+        optimizely_flags.addItemDecoration(TableItemDecoration())
+
+        this.viewModel.outputs.configFeatures()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { featureFlagAdapter.takeFlags(it) }
+                .subscribe { configFlagsAdapter.takeFlags(it) }
+
+        this.viewModel.outputs.optimizelyFeatures()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { optimizelyFlagsAdapter.takeFlags(it) }
     }
 
     private fun displayPreference(@StringRes labelRes: Int, booleanPreferenceType: BooleanPreferenceType, overrideContainer: View) {

--- a/app/src/internal/java/com/kickstarter/viewmodels/FeatureFlagsViewModel.kt
+++ b/app/src/internal/java/com/kickstarter/viewmodels/FeatureFlagsViewModel.kt
@@ -1,25 +1,29 @@
 package com.kickstarter.viewmodels
 
 import androidx.annotation.NonNull
-import com.kickstarter.libs.ActivityViewModel
-import com.kickstarter.libs.CurrentConfigType
-import com.kickstarter.libs.Environment
+import com.kickstarter.libs.*
 import com.kickstarter.ui.activities.FeatureFlagsActivity
-import com.kickstarter.ui.activities.ProjectActivity
 import rx.Observable
 import rx.subjects.BehaviorSubject
 
 interface FeatureFlagsViewModel {
     interface Inputs
     interface Outputs {
-        fun features(): Observable<List<Pair<String, Boolean>>>
+        /** Emits "android_" prefixed feature flags from the [Config]. */
+        fun configFeatures(): Observable<List<Pair<String, Boolean>>>
+
+        /** Emits [OptimizelyExperimentsClient] feature flags. */
+        fun optimizelyFeatures(): Observable<List<Pair<String, Boolean>>>
     }
 
     class ViewModel(@NonNull val environment: Environment) : ActivityViewModel<FeatureFlagsActivity>(environment), Inputs, Outputs {
 
         private val currentConfig: CurrentConfigType = environment.currentConfig()
+        private val currentUser: CurrentUserType = environment.currentUser()
+        private val optimizely: ExperimentsClientType = environment.optimizely()
 
-        private val features = BehaviorSubject.create<List<Pair<String, Boolean>>>()
+        private val configFeatures = BehaviorSubject.create<List<Pair<String, Boolean>>>()
+        private val optimizelyFeatures = BehaviorSubject.create<List<Pair<String, Boolean>>>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -33,9 +37,18 @@ interface FeatureFlagsViewModel {
                     .map { it.sortedBy { entry -> entry.key } }
                     .map { it.map { entry -> Pair(entry.key, entry.value) }.toList() }
                     .compose(bindToLifecycle())
-                    .subscribe(this.features)
+                    .subscribe(this.configFeatures)
+
+            this.currentUser
+                    .observable()
+                    .map { this.optimizely.enabledFeatures(it) }
+                    .map { it.map { entry -> Pair(entry, true) }.toList() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.optimizelyFeatures)
         }
 
-        override fun features(): Observable<List<Pair<String, Boolean>>> = this.features
+        override fun configFeatures(): Observable<List<Pair<String, Boolean>>> = this.configFeatures
+
+        override fun optimizelyFeatures(): Observable<List<Pair<String, Boolean>>> = this.optimizelyFeatures
     }
 }

--- a/app/src/internal/res/layout/activity_feature_flags.xml
+++ b/app/src/internal/res/layout/activity_feature_flags.xml
@@ -23,27 +23,60 @@
       android:layout_height="wrap_content"
       android:orientation="vertical">
 
+      <TextView
+        style="@style/CalloutSecondaryMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/grid_3"
+        android:paddingStart="@dimen/activity_vertical_margin"
+        android:paddingEnd="@dimen/activity_vertical_margin"
+        android:text="@string/Config" />
+
       <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/config_flags"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:nestedScrollingEnabled="false"
         android:orientation="vertical"
+        android:overScrollMode="never"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
         tools:itemCount="3"
         tools:listitem="@layout/item_feature_flag" />
 
-      <include layout="@layout/horizontal_line_1dp_view"/>
+      <include layout="@layout/horizontal_line_1dp_view" />
 
       <TextView
-        android:paddingStart="@dimen/activity_vertical_margin"
-        android:paddingEnd="@dimen/activity_vertical_margin"
-        android:layout_marginTop="@dimen/grid_3"
-        style="@style/CalloutPrimaryMedium"
+        style="@style/CalloutSecondaryMedium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/Overrides"/>
+        android:layout_marginTop="@dimen/grid_3"
+        android:paddingStart="@dimen/activity_vertical_margin"
+        android:paddingEnd="@dimen/activity_vertical_margin"
+        android:text="@string/Optimizely" />
+
+      <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/optimizely_flags"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:nestedScrollingEnabled="false"
+        android:orientation="vertical"
+        android:overScrollMode="never"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
+        tools:itemCount="0"
+        tools:listitem="@layout/item_feature_flag" />
+
+      <include layout="@layout/horizontal_line_1dp_view" />
+
+      <TextView
+        style="@style/CalloutSecondaryMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/grid_3"
+        android:paddingStart="@dimen/activity_vertical_margin"
+        android:paddingEnd="@dimen/activity_vertical_margin"
+        android:text="@string/Overrides" />
     </LinearLayout>
 
   </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
   <string name="Commit_SHA">Commit SHA</string>
   <string name="Changelog">Changelog</string>
   <string name="Change_endpoint">Change API endpoint</string>
+  <string name="Config">Config</string>
   <string name="Custom">Custom</string>
   <string name="Development_settings">Development Settings</string>
   <string name="Device_ID">Device ID</string>
@@ -47,6 +48,7 @@
   <string name="Network">Network</string>
   <string name="Not_implemented_yet">Not implemented yet, coming soon!</string>
   <string name="Open_downloads_folder">Open Downloads folder</string>
+  <string name="Optimizely">Optimizely</string>
   <string name="Overrides">Overrides</string>
   <string name="payment_method_last_four">•••• %{last_four}</string>
   <string name="playground_playground">Playground</string>

--- a/app/src/testInternal/java/com/kickstarter/viewmodels/FeatureFlagsViewModelTest.kt
+++ b/app/src/testInternal/java/com/kickstarter/viewmodels/FeatureFlagsViewModelTest.kt
@@ -2,42 +2,61 @@ package com.kickstarter.viewmodels
 
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.mock.MockCurrentConfig
+import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.ConfigFactory
+import com.kickstarter.models.User
 import org.junit.Test
 import rx.observers.TestSubscriber
 
 class FeatureFlagsViewModelTest : KSRobolectricTestCase() {
     private lateinit var vm: FeatureFlagsViewModel.ViewModel
 
-    private val features = TestSubscriber<List<Pair<String, Boolean>>>()
+    private val configFeatures = TestSubscriber<List<Pair<String, Boolean>>>()
+    private val optimizelyFeatures = TestSubscriber<List<Pair<String, Boolean>>>()
 
-    private fun setUpEnvironment(features: Map<String, Boolean>?) {
+    private fun setUpEnvironment(features: Map<String, Boolean>?, optimizelyFeatures: List<String>) {
         val mockConfig = MockCurrentConfig()
         mockConfig.config(ConfigFactory.config().toBuilder()
                 .features(features)
                 .build())
-        val environment = environment().toBuilder().currentConfig(mockConfig).build()
+        val environment = environment()
+                .toBuilder()
+                .currentConfig(mockConfig)
+                .optimizely(object: MockExperimentsClientType() {
+                    override fun enabledFeatures(user: User?): List<String> {
+                        return optimizelyFeatures
+                    }
+                })
+                .build()
         this.vm = FeatureFlagsViewModel.ViewModel(environment)
 
-        this.vm.outputs.features().subscribe(this.features)
+        this.vm.outputs.configFeatures().subscribe(this.configFeatures)
+        this.vm.outputs.optimizelyFeatures().subscribe(this.optimizelyFeatures)
     }
 
     @Test
-    fun testFeatures_whenNull() {
-        setUpEnvironment(null)
+    fun testConfigFeatures_whenFeaturesMapIsNull() {
+        setUpEnvironment(null, emptyList())
 
-        this.features.assertValue(listOf())
+        this.configFeatures.assertValue(listOf())
     }
 
     @Test
-    fun testFeatures() {
+    fun testConfigFeatures_whenFeaturesMapIsNotNull() {
         val features = mapOf(Pair("ios_feature_one", true),
                 Pair("ios_feature_two", false),
                 Pair("android_feature_one", true),
                 Pair("android_feature_two", false))
-        setUpEnvironment(features)
+        setUpEnvironment(features, emptyList())
 
-        this.features.assertValue(listOf(Pair("android_feature_one", true),
+        this.configFeatures.assertValue(listOf(Pair("android_feature_one", true),
                 Pair("android_feature_two", false)))
+    }
+
+    @Test
+    fun testOptimizelyFeatures() {
+        setUpEnvironment(null, listOf("android_optimizely_feature"))
+
+        this.optimizelyFeatures.assertValue(listOf(Pair("android_optimizely_feature", true)))
     }
 }


### PR DESCRIPTION
# 📲 What
Displaying enabled Optimizely feature flags in Internal Tools

# 🤔 Why
So users on an internal build can see if they're in an Optimizely feature. 

# 🛠 How
## `FeatureFlagsActivity`
- Displaying `optimizelyFeatures` in new `optimizely_flags` `RecyclerView`
## `FeatureFlagsViewModel`
- Added output `optimizelyFeatures` that emits `OptimizelyExperimentsClient` enabled features
- Added test

# 👀 See
| After 🦋 |
| --- | 
| <img src=https://user-images.githubusercontent.com/1289295/81017541-acfc1f00-8e30-11ea-9f5a-22bac218a3fd.png width=330/> |

# 📋 QA
N/A

# Story 📖
[NT-1243]


[NT-1243]: https://kickstarter.atlassian.net/browse/NT-1243