### PR TITLE
NT-1232 Sorting `LIGHTS_ON` projects by distance

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/EditorialViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/EditorialViewModel.kt
@@ -82,8 +82,7 @@ interface EditorialViewModel {
                     .subscribe { this.retryContainerIsGone.onNext(false) }
 
             editorial
-                    .map { it.tagId }
-                    .map { DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).tagId(it).build() }
+                    .map { discoveryParams(it) }
                     .compose(bindToLifecycle())
                     .subscribe(this.discoveryParams)
 
@@ -105,6 +104,14 @@ interface EditorialViewModel {
             this.retryContainerClicked
                     .compose(bindToLifecycle())
                     .subscribe(this.refreshDiscoveryFragment)
+        }
+
+        private fun discoveryParams(editorial: Editorial): DiscoveryParams {
+            val sort = when (editorial) {
+                Editorial.LIGHTS_ON -> DiscoveryParams.Sort.DISTANCE
+                else -> DiscoveryParams.Sort.MAGIC
+            }
+            return DiscoveryParams.builder().sort(sort).tagId(editorial.tagId).build()
         }
 
         private fun fetchCategories(): Observable<Notification<MutableList<Category>>>? {

--- a/app/src/test/java/com/kickstarter/viewmodels/EditorialViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/EditorialViewModelTest.kt
@@ -26,7 +26,6 @@ class EditorialViewModelTest : KSRobolectricTestCase() {
     private val rootCategories = TestSubscriber<List<Category>>()
     private val title = TestSubscriber<Int>()
 
-    @Suppress("SameParameterValue")
     private fun setUpEnvironment(environment: Environment, editorial: Editorial) {
         this.vm = EditorialViewModel.ViewModel(environment)
 
@@ -49,12 +48,23 @@ class EditorialViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testDiscoveryParams() {
+    fun testDiscoveryParams_whenGoRewardless() {
         setUpEnvironment(environment(), Editorial.GO_REWARDLESS)
 
         val expectedParams = DiscoveryParams.builder()
                 .sort(DiscoveryParams.Sort.MAGIC)
                 .tagId(Editorial.GO_REWARDLESS.tagId)
+                .build()
+        this.discoveryParams.assertValue(expectedParams)
+    }
+
+    @Test
+    fun testDiscoveryParams_whenLightsOn() {
+        setUpEnvironment(environment(), Editorial.LIGHTS_ON)
+
+        val expectedParams = DiscoveryParams.builder()
+                .sort(DiscoveryParams.Sort.DISTANCE)
+                .tagId(557)
                 .build()
         this.discoveryParams.assertValue(expectedParams)
     }


### PR DESCRIPTION
# 📲 What
Sorting `LIGHTS_ON` projects by distance.

# 🤔 Why
The closer the project, the better.

# 🛠 How
- Added helper method `discoveryParams`  
  - Sorting by distance when viewing `Editorial.LIGHTS_ON`
- Added a nice test

# 👀 See
<img src=https://user-images.githubusercontent.com/1289295/81235796-c5537180-8fc9-11ea-8821-99834fff20ea.png width=330/>

# 📋 QA
Be in the `android_lights_on` feature.
Smash that Lights On card.
It doesn't actually sort but it's what lets the location tags show up!

# Story 📖
[NT-1232]


[NT-1232]: https://kickstarter.atlassian.net/browse/NT-1232