### PR TITLE
NT-1230: Style Lights On in Editorial view

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/EditorialViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/EditorialViewHolder.kt
@@ -1,7 +1,6 @@
 package com.kickstarter.ui.viewholders
 
 import android.view.View
-import androidx.core.content.ContextCompat
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.ui.data.Editorial
 import com.kickstarter.viewmodels.EditorialViewHolderViewModel
@@ -38,7 +37,6 @@ class EditorialViewHolder(val view: View, val delegate: Delegate) : KSViewHolder
                 .subscribe { this.itemView.editorial_graphic.setImageResource(it) }
 
         this.itemView.setOnClickListener { this.vm.inputs.editorialClicked() }
-
     }
 
     override fun bindData(data: Any?) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/EditorialViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/EditorialViewHolder.kt
@@ -17,8 +17,6 @@ class EditorialViewHolder(val view: View, val delegate: Delegate) : KSViewHolder
 
     init {
 
-        this.itemView.setOnClickListener { this.vm.inputs.editorialClicked() }
-
         this.vm.outputs.ctaTitle()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
@@ -28,11 +26,6 @@ class EditorialViewHolder(val view: View, val delegate: Delegate) : KSViewHolder
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .subscribe { this.itemView.description.setText(it) }
-
-        this.vm.graphic()
-                .compose(bindToLifecycle())
-                .compose(Transformers.observeForUI())
-                .subscribe { this.itemView.item_background.background = ContextCompat.getDrawable(context(),it) }
 
         this.vm.outputs.editorial()
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -221,7 +221,7 @@ public interface DiscoveryFragmentViewModel {
 
       this.editorialClicked
         .compose(bindToLifecycle())
-        .subscribe(this.koala::trackEditorialCardClicked);
+        .subscribe(this.lake::trackEditorialCardClicked);
 
       this.paramsFromActivity
         .compose(combineLatestPair(userIsLoggedIn))

--- a/app/src/main/res/layout/activity_editorial.xml
+++ b/app/src/main/res/layout/activity_editorial.xml
@@ -16,55 +16,61 @@
       android:layout_height="wrap_content"
       app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
-      <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/ks_toolbar_height"
-        android:orientation="vertical">
-
-        <LinearLayout
+      <androidx.constraintlayout.widget.ConstraintLayout
           android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:background="@color/trust_700"
-          android:orientation="vertical">
+          android:layout_height="@dimen/grid_40">
 
-          <TextView
-            android:id="@+id/editorial_title"
-            style="@style/Title2WhiteMedium"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/grid_6"
-            android:layout_marginEnd="@dimen/grid_6"
-            android:layout_marginBottom="@dimen/grid_8"
-            android:gravity="center"
-            tools:text="@string/This_holiday_season_support_a_project_for_no_reward" />
-
-          <com.kickstarter.ui.views.BottomCropImageView
+        <ImageView
             android:id="@+id/editorial_graphic"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:importantForAccessibility="no"
+            android:scaleType="centerCrop"
+            android:src="@drawable/lights_on"
             android:transitionName="editorial"
-            tools:src="@drawable/go_rewardless_header" />
-
-        </LinearLayout>
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
 
         <TextView
-          android:id="@+id/editorial_description"
-          style="@style/CalloutPrimary"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginStart="@dimen/grid_5"
-          android:layout_marginTop="@dimen/grid_4"
-          android:layout_marginEnd="@dimen/grid_5"
-          android:gravity="center"
-          android:textColor="@color/trust_700"
-          tools:text="@string/These_projects_could_use_your_support" />
-      </LinearLayout>
+            android:id="@+id/editorial_title"
+            style="@style/Title2WhiteMedium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:gravity="center"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/guideline"
+            tools:text="@string/Show_up_for_the_spaces_you_love" />
+
+        <TextView
+            android:id="@+id/editorial_description"
+            style="@style/CalloutWhite"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:gravity="center"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/editorial_title"
+            tools:text="@string/Help_local_businesses_keep_the_lights" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_percent="0.40" />
+      </androidx.constraintlayout.widget.ConstraintLayout>
 
       <com.kickstarter.ui.toolbars.KSToolbar
         style="@style/Toolbar"
-        android:backgroundTint="@color/trust_700"
+        android:backgroundTint="@color/transparent"
         app:contentInsetLeft="0dp"
         app:contentInsetStart="0dp"
         app:layout_collapseMode="pin">
@@ -79,7 +85,6 @@
             android:id="@+id/back_button"
             style="@style/ToolbarIconBackButton"
             android:drawableTint="@color/white" />
-
         </RelativeLayout>
 
       </com.kickstarter.ui.toolbars.KSToolbar>

--- a/app/src/main/res/layout/activity_editorial.xml
+++ b/app/src/main/res/layout/activity_editorial.xml
@@ -18,7 +18,7 @@
 
       <androidx.constraintlayout.widget.ConstraintLayout
           android:layout_width="match_parent"
-          android:layout_height="@dimen/grid_40">
+          android:layout_height="wrap_content">
 
         <ImageView
             android:id="@+id/editorial_graphic"
@@ -38,8 +38,8 @@
             style="@style/Title2WhiteMedium"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
+            android:layout_marginStart="@dimen/grid_3"
+            android:layout_marginEnd="@dimen/grid_3"
             android:gravity="center"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -51,14 +51,22 @@
             style="@style/CalloutWhite"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="16dp"
+            android:layout_marginStart="@dimen/grid_3"
+            android:layout_marginTop="@dimen/grid_3_half"
+            android:layout_marginEnd="@dimen/grid_3"
             android:gravity="center"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/editorial_title"
             tools:text="@string/Help_local_businesses_keep_the_lights" />
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="@dimen/ks_toolbar_height"
+            android:visibility="invisible"
+            app:layout_constraintTop_toBottomOf="@+id/editorial_description"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"/>
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/guideline"

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -407,8 +407,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.editorialViewHolderClicked(Editorial.LIGHTS_ON);
 
     this.startEditorialActivity.assertValues(Editorial.GO_REWARDLESS, Editorial.LIGHTS_ON);
-    this.koalaTest.assertValues("Discover List View", "Editorial Card Clicked", "Editorial Card Clicked");
-    this.lakeTest.assertValue("Explore Page Viewed");
+    this.lakeTest.assertValues("Explore Page Viewed", "Editorial Card Clicked", "Editorial Card Clicked");
   }
 
   @Test


### PR DESCRIPTION
# 📲 NT-1230: Style Lights On in Editorial view
- Just new styles
- Make sure data lake event is sent
--- Lake event---
<img width="763" alt="Screen Shot 2020-05-07 at 10 45 35 AM" src="https://user-images.githubusercontent.com/4083656/81330124-828aab80-9054-11ea-8a54-53c03ebb9b0f.png">

---Design | Emulator-----
![Screen Shot 2020-05-07 at 11 06 15 AM](https://user-images.githubusercontent.com/4083656/81330401-e0b78e80-9054-11ea-8426-6c49b406c7fe.png)


# 👀 See
![LightOn](https://user-images.githubusercontent.com/4083656/81330280-b960c180-9054-11ea-8c52-725a8b389dcb.gif)


# 📋 QA
- Scroll on the Editorial page
- Try several devices

# Story 📖

[NT-1230](https://kickstarter.atlassian.net/browse/NT-1230)
[Figma Design](https://www.figma.com/file/Xn3SO6HEQ5kmKo08RyvbLY/Lights-On?node-id=0%3A1)
