### PR TITLE
NT-1246 Moving Editorial Card Clicked Event into Data Lake 

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -82,13 +82,6 @@ public final class Koala {
     });
   }
 
-  public void trackEditorialCardClicked(final @NonNull DiscoveryParams discoveryParams, final @NonNull Editorial editorial) {
-    final Map<String, Object> props = KoalaUtils.discoveryParamsProperties(discoveryParams);
-    props.put("session_ref_tag", RefTag.collection(editorial.getTagId()).tag());
-
-    this.client.track(LakeEvent.EDITORIAL_CARD_CLICKED, props);
-  }
-
   /**
    * Tracks a project show event.
    *
@@ -632,6 +625,13 @@ public final class Koala {
   //region Discover a Project
   public void trackActivityFeedViewed() {
     this.client.track(LakeEvent.ACTIVITY_FEED_VIEWED);
+  }
+
+  public void trackEditorialCardClicked(final @NonNull DiscoveryParams discoveryParams, final @NonNull Editorial editorial) {
+    final Map<String, Object> props = KoalaUtils.discoveryParamsProperties(discoveryParams);
+    props.put("session_ref_tag", RefTag.collection(editorial.getTagId()).tag());
+
+    this.client.track(LakeEvent.EDITORIAL_CARD_CLICKED, props);
   }
 
   public void trackExplorePageViewed(final @NonNull DiscoveryParams discoveryParams) {

--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -82,12 +82,11 @@ public final class Koala {
     });
   }
 
-  public void trackEditorialCardClicked(final @NonNull Editorial editorial) {
-    this.client.track(KoalaEvent.EDITORIAL_CARD_CLICKED, new HashMap<String, Object>() {
-      {
-        put("ref_tag", RefTag.collection(editorial.getTagId()).tag());
-      }
-    });
+  public void trackEditorialCardClicked(final @NonNull DiscoveryParams discoveryParams, final @NonNull Editorial editorial) {
+    final Map<String, Object> props = KoalaUtils.discoveryParamsProperties(discoveryParams);
+    props.put("session_ref_tag", RefTag.collection(editorial.getTagId()).tag());
+
+    this.client.track(LakeEvent.EDITORIAL_CARD_CLICKED, props);
   }
 
   /**

--- a/app/src/main/java/com/kickstarter/libs/KoalaEvent.java
+++ b/app/src/main/java/com/kickstarter/libs/KoalaEvent.java
@@ -23,7 +23,6 @@ public final class KoalaEvent {
   public static final String DISCOVER_SEARCH_LEGACY = "Discover Search";
   public static final String DISCOVER_SEARCH_RESULTS_LEGACY = "Discover Search Results";
   public static final String DISCOVER_SEARCH_RESULTS_LOAD_MORE_LEGACY = "Discover Search Results Load More";
-  public static final String EDITORIAL_CARD_CLICKED = "Editorial Card Clicked";
   public static final String ERRORED_DELETE_PAYMENT_METHOD = "Errored Delete Payment Method";
   public static final String ERRORED_USER_LOGIN = "Errored User Login";
   public static final String ERRORED_USER_SIGNUP = "Errored User Signup";

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -4,6 +4,7 @@ package com.kickstarter.libs
 
 // region Discover a Project
 const val ACTIVITY_FEED_VIEWED = "Activity Feed Viewed"
+const val EDITORIAL_CARD_CLICKED = "Editorial Card Clicked"
 const val EXPLORE_PAGE_VIEWED = "Explore Page Viewed"
 const val EXPLORE_SORT_CLICKED = "Explore Sort Clicked"
 const val FILTER_CLICKED = "Filter Clicked"

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -219,10 +219,6 @@ public interface DiscoveryFragmentViewModel {
         .compose(bindToLifecycle())
         .subscribe(this.startEditorialActivity);
 
-      this.editorialClicked
-        .compose(bindToLifecycle())
-        .subscribe(this.koala::trackEditorialCardClicked);
-
       this.paramsFromActivity
         .compose(combineLatestPair(userIsLoggedIn))
         .map(pu -> isOnboardingVisible(pu.first, pu.second))
@@ -294,6 +290,11 @@ public interface DiscoveryFragmentViewModel {
       this.discoveryOnboardingLoginToutClick
         .compose(bindToLifecycle())
         .subscribe(v -> this.lake.trackLogInSignUpButtonClicked());
+
+      this.paramsFromActivity
+        .compose(takePairWhen(this.editorialClicked))
+        .compose(bindToLifecycle())
+        .subscribe(paramsAndEditorial -> this.lake.trackEditorialCardClicked(paramsAndEditorial.first, paramsAndEditorial.second));
     }
 
     private boolean activityHasNotBeenSeen(final @Nullable Activity activity) {


### PR DESCRIPTION
# 📲 What
Moving `Editorial Card Clicked` Event into Data Lake 

# 🤔 Why
We used to track `Moving Editorial Card` with 🐨 

# 🛠 How
## `Koala`
- Moved `trackEditorialCardClicked` into `Discover a Project` region
- `trackEditorialCardClicked` now takes in `DiscoveryParams` for `discover` properties and `Editorial` for `session_ref_tag` property
## `KoalaEvent`
- Removed `EDITORIAL_CARD_CLICKED`
## `LakeEvent` 
- Added `EDITORIAL_CARD_CLICKED`

# 👀 See
<img width="432" alt="Screen Shot 2020-05-07 at 4 49 14 PM" src="https://user-images.githubusercontent.com/1289295/81343309-c1cff100-9082-11ea-8d53-993d5df70f2d.png">

# 📋 QA
Click the Lights On card if you're in the feature.

# Story 📖
[NT-1246]


[NT-1246]: https://kickstarter.atlassian.net/browse/NT-1246