### PR TITLE
Backing status bug fix

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -239,11 +239,15 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>()  {
             }
         }
 
-        val spannablePledgeStatus = SpannableString(pledgeStatusText)
-        pledgeStatusData.pledgeTotal?.let { ViewUtils.addBoldSpan(spannablePledgeStatus, it) }
-        pledgeStatusData.projectDeadline?.let { ViewUtils.addBoldSpan(spannablePledgeStatus, it) }
+        pledgeStatusText?.let { statusText ->
+            val spannablePledgeStatus = SpannableString(statusText)
+            pledgeStatusData.pledgeTotal?.let { ViewUtils.addBoldSpan(spannablePledgeStatus, it) }
+            pledgeStatusData.projectDeadline?.let { ViewUtils.addBoldSpan(spannablePledgeStatus, it) }
 
-        backer_pledge_status.text = spannablePledgeStatus
+            backer_pledge_status.text = spannablePledgeStatus
+        }?: run {
+            backer_pledge_status.text = null
+        }
     }
 
 }


### PR DESCRIPTION
# 📲 What
Fixes bug caused by trying to create a `Spannable` from a null `String`

# 🛠 How
- since `pledgeStatusText` is nullable, we need to safely unwrap it before we try to use it. If it's `null`, we should clear the `backer_pledge_status` text.

# 👀 See
N/A

# 📋 QA
I'm not able to repro but can see the crash [here](https://console.firebase.google.com/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/15f73366d66bd44e9aa9dff07a6f60bb?time=last-seven-days&sessionId=5EB5377803E30001381253B8967E8743_DNE_0_v2)

# Story 📖
Need a bug ticket
