### PR TITLE
StoredCard Marshmallow bug

### DIFF
--- a/app/src/main/java/com/kickstarter/models/StoredCard.kt
+++ b/app/src/main/java/com/kickstarter/models/StoredCard.kt
@@ -57,7 +57,7 @@ abstract class StoredCard : Parcelable {
             }
         }
 
-        const val DATE_FORMAT = "MM/YYYY"
+        const val DATE_FORMAT = "MM/yyyy"
     }
 
 }


### PR DESCRIPTION
# 📲 What
Reverts `StoredCard.DATE_FORMAT` to fix crash on Marshmallow devices

# 🤔 Why
`Y` is only supported on[ API 24 and above](https://developer.android.com/reference/java/text/SimpleDateFormat.html) 

# 🛠 How
- Date format is back to `yyyy`

# 👀 See
N/A

# 📋 QA
View stored cards

# Story 📖
Need a bug ticket
