### PR TITLE
Broken currency tests: BackingFragmentViewModelTest 

### DIFF
--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -7,6 +7,7 @@ import com.kickstarter.R
 import com.kickstarter.libs.Either
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUser
+import com.kickstarter.libs.utils.DateTimeUtils
 import com.kickstarter.mock.factories.*
 import com.kickstarter.models.Backing
 import com.kickstarter.models.Project
@@ -17,6 +18,7 @@ import com.stripe.android.model.Card
 import org.joda.time.DateTime
 import org.junit.Test
 import rx.observers.TestSubscriber
+import java.math.RoundingMode
 
 class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
     private lateinit var vm: BackingFragmentViewModel.ViewModel
@@ -428,10 +430,11 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
                 .backing(backing)
                 .build()
 
-        setUpEnvironment(environment())
+        val environment = environment()
+        setUpEnvironment(environment)
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
-        this.pledgeAmount.assertValue("$40")
+        this.pledgeAmount.assertValue(expectedCurrency(environment, backedProject, 40.0))
     }
 
     @Test
@@ -449,124 +452,148 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
         setUpEnvironment(environment())
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
-        this.pledgeDate.assertValue("August 28, 2019")
+        this.pledgeDate.assertValue(DateTimeUtils.longDate(pledgeDate))
     }
 
     @Test
     fun testPledgeStatusData_whenProjectIsCanceled() {
+        val deadline = DateTime.parse("2019-11-11T17:10:04+00:00")
         val backedProject = backedProjectWithBackingStatus(Backing.STATUS_PLEDGED)
                 .toBuilder()
                 .state(Project.STATE_CANCELED)
-                .deadline(DateTime.parse("2019-11-11T17:10:04+00:00"))
+                .deadline(deadline)
                 .build()
 
-        setUpEnvironment(environment())
+        val environment = environment()
+        setUpEnvironment(environment)
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
         this.pledgeStatusData.assertValue(PledgeStatusData(R.string.The_creator_canceled_this_project_so_your_payment_method_was_never_charged,
-                "$20", "November 11, 2019"))
+                expectedCurrency(environment, backedProject, 20.0),
+                DateTimeUtils.longDate(deadline)))
     }
 
     @Test
     fun testPledgeStatusData_whenProjectIsUnsuccessful() {
+        val deadline = DateTime.parse("2019-11-11T17:10:04+00:00")
         val backedProject = backedProjectWithBackingStatus(Backing.STATUS_PLEDGED)
                 .toBuilder()
                 .state(Project.STATE_FAILED)
-                .deadline(DateTime.parse("2019-11-11T17:10:04+00:00"))
+                .deadline(deadline)
                 .build()
 
-        setUpEnvironment(environment())
+        val environment = environment()
+        setUpEnvironment(environment)
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
         this.pledgeStatusData.assertValue(PledgeStatusData(R.string.This_project_didnt_reach_its_funding_goal_so_your_payment_method_was_never_charged,
-                "$20", "November 11, 2019"))
+                expectedCurrency(environment, backedProject, 20.0),
+                DateTimeUtils.longDate(deadline)))
     }
 
     @Test
     fun testPledgeStatusData_whenBackingIsCanceled() {
+        val deadline = DateTime.parse("2019-11-11T17:10:04+00:00")
         val backedProject = backedProjectWithBackingStatus(Backing.STATUS_CANCELED)
                 .toBuilder()
-                .deadline(DateTime.parse("2019-11-11T17:10:04+00:00"))
+                .deadline(deadline)
                 .build()
 
-        setUpEnvironment(environment())
+        val environment = environment()
+        setUpEnvironment(environment)
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
         this.pledgeStatusData.assertValue(PledgeStatusData(R.string.You_canceled_your_pledge_for_this_project,
-                "$20", "November 11, 2019"))
+                expectedCurrency(environment, backedProject, 20.0),
+                DateTimeUtils.longDate(deadline)))
     }
 
     @Test
     fun testPledgeStatusData_whenBackingIsCollected() {
+        val deadline = DateTime.parse("2019-11-11T17:10:04+00:00")
         val backedProject = backedProjectWithBackingStatus(Backing.STATUS_COLLECTED)
                 .toBuilder()
-                .deadline(DateTime.parse("2019-11-11T17:10:04+00:00"))
+                .deadline(deadline)
                 .state(Project.STATE_SUCCESSFUL)
                 .build()
 
-        setUpEnvironment(environment())
+        val environment = environment()
+        setUpEnvironment(environment)
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
         this.pledgeStatusData.assertValue(PledgeStatusData(R.string.We_collected_your_pledge_for_this_project,
-                "$20", "November 11, 2019"))
+                expectedCurrency(environment, backedProject, 20.0),
+                DateTimeUtils.longDate(deadline)))
     }
 
     @Test
     fun testPledgeStatusData_whenBackingIsDropped() {
+        val deadline = DateTime.parse("2019-11-11T17:10:04+00:00")
         val backedProject = backedProjectWithBackingStatus(Backing.STATUS_DROPPED)
                 .toBuilder()
-                .deadline(DateTime.parse("2019-11-11T17:10:04+00:00"))
+                .deadline(deadline)
                 .state(Project.STATE_SUCCESSFUL)
                 .build()
 
-        setUpEnvironment(environment())
+        val environment = environment()
+        setUpEnvironment(environment)
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
         this.pledgeStatusData.assertValue(PledgeStatusData(R.string.Your_pledge_was_dropped_because_of_payment_errors,
-                "$20", "November 11, 2019"))
+                expectedCurrency(environment, backedProject, 20.0),
+                DateTimeUtils.longDate(deadline)))
     }
 
     @Test
     fun testPledgeStatusData_whenBackingIsErrored() {
+        val deadline = DateTime.parse("2019-11-11T17:10:04+00:00")
         val backedProject = backedProjectWithBackingStatus(Backing.STATUS_ERRORED)
                 .toBuilder()
-                .deadline(DateTime.parse("2019-11-11T17:10:04+00:00"))
+                .deadline(deadline)
                 .state(Project.STATE_SUCCESSFUL)
                 .build()
 
-        setUpEnvironment(environment())
+        val environment = environment()
+        setUpEnvironment(environment)
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
         this.pledgeStatusData.assertValue(PledgeStatusData(R.string.We_cant_process_your_pledge_Please_update_your_payment_method,
-                "$20", "November 11, 2019"))
+                expectedCurrency(environment, backedProject, 20.0),
+                DateTimeUtils.longDate(deadline)))
     }
 
     @Test
     fun testPledgeStatusData_whenBackingIsPledged() {
+        val deadline = DateTime.parse("2019-11-11T17:10:04+00:00")
         val backedProject = backedProjectWithBackingStatus(Backing.STATUS_PLEDGED)
                 .toBuilder()
-                .deadline(DateTime.parse("2019-11-11T17:10:04+00:00"))
+                .deadline(deadline)
                 .build()
 
-        setUpEnvironment(environment())
+        val environment = environment()
+        setUpEnvironment(environment)
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
         this.pledgeStatusData.assertValue(PledgeStatusData(R.string.If_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline,
-                "$20", "November 11, 2019"))
+                expectedCurrency(environment, backedProject, 20.0),
+                DateTimeUtils.longDate(deadline)))
     }
 
     @Test
     fun testPledgeStatusData_whenBackingIsPreAuth() {
+        val deadline = DateTime.parse("2019-11-11T17:10:04+00:00")
         val backedProject = backedProjectWithBackingStatus(Backing.STATUS_PREAUTH)
                 .toBuilder()
-                .deadline(DateTime.parse("2019-11-11T17:10:04+00:00"))
+                .deadline(deadline)
                 .build()
 
-        setUpEnvironment(environment())
+        val environment = environment()
+        setUpEnvironment(environment)
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
         this.pledgeStatusData.assertValue(PledgeStatusData(R.string.We_re_processing_your_pledge_pull_to_refresh,
-                "$20", "November 11, 2019"))
+                expectedCurrency(environment, backedProject, 20.0),
+                DateTimeUtils.longDate(deadline)))
     }
 
     @Test
@@ -803,19 +830,21 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
 
     @Test
     fun testTotalAmount() {
+        val amount = 10.5
         val backing = BackingFactory.backing()
                 .toBuilder()
-                .amount(10.50)
+                .amount(amount)
                 .build()
         val backedProject = ProjectFactory.backedProject()
                 .toBuilder()
                 .backing(backing)
                 .build()
 
-        setUpEnvironment(environment())
+        val environment = environment()
+        setUpEnvironment(environment)
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
-        this.totalAmount.assertValue("$10.50")
+        this.totalAmount.assertValue(expectedCurrency(environment, backedProject, amount))
     }
 
     private fun backedProjectWithBackingStatus(@Backing.Status backingStatus: String): Project {
@@ -829,5 +858,8 @@ class BackingFragmentViewModelTest :  KSRobolectricTestCase() {
                 .backing(backing)
                 .build()
     }
+
+    private fun expectedCurrency(environment: Environment, project: Project, amount: Double): String =
+            environment.ksCurrency().format(amount, project, RoundingMode.HALF_UP)
 
 }


### PR DESCRIPTION
# 📲 What
Refactoring tests to be agnostic of user's locale

# 🤔 Why
The tests should pass for all locales.

# 🛠 How
- Made helper method `expectedCurrency` that returns the localized currency
- Returning value of `DateTimeUtils. longDate` instead of date string

# 👀 See
N/A

# 📋 QA
N/A

# Story 📖
N/A
