### PR TITLE
NT-1232: Revert Distance sorting

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/EditorialViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/EditorialViewModel.kt
@@ -82,7 +82,8 @@ interface EditorialViewModel {
                     .subscribe { this.retryContainerIsGone.onNext(false) }
 
             editorial
-                    .map { discoveryParams(it) }
+                    .map { it.tagId }
+                    .map { DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).tagId(it).build() }
                     .compose(bindToLifecycle())
                     .subscribe(this.discoveryParams)
 
@@ -104,14 +105,6 @@ interface EditorialViewModel {
             this.retryContainerClicked
                     .compose(bindToLifecycle())
                     .subscribe(this.refreshDiscoveryFragment)
-        }
-
-        private fun discoveryParams(editorial: Editorial): DiscoveryParams {
-            val sort = when (editorial) {
-                Editorial.LIGHTS_ON -> DiscoveryParams.Sort.DISTANCE
-                else -> DiscoveryParams.Sort.MAGIC
-            }
-            return DiscoveryParams.builder().sort(sort).tagId(editorial.tagId).build()
         }
 
         private fun fetchCategories(): Observable<Notification<MutableList<Category>>>? {

--- a/app/src/test/java/com/kickstarter/viewmodels/EditorialViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/EditorialViewModelTest.kt
@@ -63,7 +63,7 @@ class EditorialViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment(), Editorial.LIGHTS_ON)
 
         val expectedParams = DiscoveryParams.builder()
-                .sort(DiscoveryParams.Sort.DISTANCE)
+                .sort(DiscoveryParams.Sort.MAGIC)
                 .tagId(557)
                 .build()
         this.discoveryParams.assertValue(expectedParams)


### PR DESCRIPTION
# 📲 What

Filter filter just by tagId: 557 -> Lights On in android , remove distance filtering

# 🤔 Why

It seems the distance filtering is not working on the backend, for the MVP we just filter by tagId.

# 📋 QA

- Make sure to use staging and to have the device Id added to the android optimizely audience.

# Story 📖

[NT-1232](https://kickstarter.atlassian.net/browse/NT-1232)
