### PR TITLE
NT-1141: Refactor existing queries

### DIFF
--- a/app/src/main/graphql/checkout.graphql
+++ b/app/src/main/graphql/checkout.graphql
@@ -31,51 +31,7 @@ mutation UpdateBacking($backingId: ID!, $amount: String, $locationId: String, $r
 }
 
 query GetBacking($backingId: ID!) {
-  backing(id: $backingId){
-    id
-    status
-    sequence
-    pledgedOn
-    backerCompleted
-    cancelable
-    shippingAmount {
-      amount
-      currency
-      symbol
-    }
-    location {
-      id
-      displayableName
-    }
-    amount {
-      amount
-      currency
-      symbol
-    }
-    shippingAmount {
-      amount
-    }
-    reward {
-      id
-      name
-      backersCount
-      description
-      estimatedDeliveryOn
-      items {
-        nodes {
-          name
-        }
-      }
-      amount {
-        amount
-        currency
-        symbol
-      }
-    }
-    backer {
-      imageUrl(blur: false, width: 54)
-      name
-      id
-    }
+  backing(id: $backingId) {
+    ... backing
   }
 }

--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -1,0 +1,88 @@
+fragment backing on Backing {
+    id
+    status
+    sequence
+    cancelable
+    pledgedOn
+    backerCompleted
+    project {
+        ... project
+    }
+    location {
+        ... location
+    }
+    amount {
+        ... amount
+    }
+    paymentSource {
+        ... payment
+    }
+    shippingAmount {
+        ... amount
+    }
+    reward {
+        ... reward
+    }
+    backer {
+        ... user
+    }
+}
+
+fragment project on Project {
+    id
+    slug
+}
+
+fragment reward on Reward {
+    id
+    name
+    backersCount
+    description
+    estimatedDeliveryOn
+    items {
+        edges {
+            quantity
+            node {
+                project{
+                    id
+                }
+                hasBackers
+                id
+                name
+                rewardsCount
+            }
+        }
+    }
+    amount {
+        ... amount
+    }
+}
+
+fragment user on User {
+    name
+    id
+    imageUrl(blur: false, width: 54)
+}
+
+fragment amount on Money {
+    amount
+    currency
+    symbol
+}
+
+fragment location on Location {
+    county
+    countryName
+    discoverUrl
+    displayableName
+    id
+    name
+}
+
+fragment payment on CreditCard {
+    id
+    lastFour
+    expirationDate
+    type
+    state
+}

--- a/app/src/main/graphql/project.graphql
+++ b/app/src/main/graphql/project.graphql
@@ -13,60 +13,7 @@ query GetProjectBacking($slug: String!) {
   project(slug: $slug) {
     id
     backing {
-      id
-      status
-      sequence
-      pledgedOn
-      backerCompleted
-      cancelable
-      shippingAmount {
-        amount
-        currency
-        symbol
-      }
-      location {
-        id
-        displayableName
-      }
-      amount {
-        amount
-        currency
-        symbol
-      }
-      paymentSource {
-        ... on CreditCard {
-          state
-          id
-          lastFour
-          expirationDate
-          type
-        }
-      }
-      shippingAmount {
-        amount
-      }
-      reward {
-        id
-        name
-        backersCount
-        description
-        estimatedDeliveryOn
-        items {
-          nodes {
-            name
-          }
-        }
-        amount {
-          amount
-          currency
-          symbol
-        }
-      }
-      backer {
-        imageUrl(blur: false, width: 54)
-        name
-        id
-      }
+      ... backing
     }
   }
 }

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -570,11 +570,11 @@ private fun createBackingObject(backingGr: fragment.Backing?): Backing {
     val shippingAmount = backingGr?.shippingAmount()?.fragments()
 
     val reward = backingGr?.reward()?.fragments()?.reward()?.let { reward ->
-        val rewardId = decodeRelayId(reward.id()) ?: 0
+        val rewardId = decodeRelayId(reward.id()) ?: -1
         val rewardAmount = reward.amount().fragments().amount().amount()?.toDouble()
         val rewardSingleLocation = Reward.SingleLocation.builder()
                 .localizedName(location?.displayableName())
-                .id(decodeRelayId(location?.id())?: 0)
+                .id(decodeRelayId(location?.id())?: -1)
                 .build()
 
         return@let Reward.builder()
@@ -588,7 +588,7 @@ private fun createBackingObject(backingGr: fragment.Backing?): Backing {
 
     val backerData = backingGr?.backer()?.fragments()?.user()
     val nameBacker = backerData?.name()
-    val backerId= decodeRelayId(backerData?.id()) ?: 0
+    val backerId= decodeRelayId(backerData?.id()) ?: -1
     val avatar = Avatar.builder()
             .medium(backerData?.imageUrl())
             .build()

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -122,6 +122,7 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                         override fun onResponse(response: Response<GetBackingQuery.Data>) {
                             response.data()?.let {data ->
                                 Observable.just(data.backing())
+                                        .filter { it?.fragments()?.backing() != null }
                                         .map { backingObj -> createBackingObject(backingObj?.fragments()?.backing()) }
                                         .filter { ObjectUtils.isNotNull(it) }
                                         .subscribe {
@@ -286,8 +287,9 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
 
                         override fun onResponse(response: Response<GetProjectBackingQuery.Data>) {
                             response.data()?.let {data ->
-                                Observable.just(data.project()?.backing()?.fragments()?.backing())
-                                        .map { backingObj -> createBackingObject(backingObj) }
+                                Observable.just(data.project()?.backing())
+                                        .filter { it?.fragments()?.backing() != null }
+                                        .map { backingObj -> createBackingObject(backingObj?.fragments()?.backing()) }
                                         .subscribe {
                                             ps.onNext(it)
                                             ps.onCompleted()

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -189,6 +189,7 @@ interface BackingFragmentViewModel {
                     .subscribe(this.backerAvatar)
 
             this.projectDataInput
+                    .filter { it.project().isBacking || ProjectUtils.userIsCreator(it.project(), it.user()) }
                     .map { projectData -> joinProjectDataAndReward(projectData) }
                     .compose(bindToLifecycle())
                     .subscribe(this.projectDataAndReward)


### PR DESCRIPTION
# 📲 What

Refactor in queries Project.backing and Backing.backing to use fragments for each subtype 

# 🤔 Why

Reusability - Readability - No code smells 

# 🛠 How
Creating separate fragments for each type and not attaching them to any high level query.

# 👀 See
No UI chenges here 

# 📋 QA

- Check one of your backed projects, hit the manage pledge button, all data should remain the same as before
- Go to any message os your messages with a creator of a project you already backed, go to the thread view, hit the view pledge button, all data should remain as before.
- Log in as creator if you can, go to any message you have with a baker to one of your projects, hit the view pledge, you should see the pledge data as before.
