### PR TITLE
Disable pledge button if shipping selection is invalid

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -14,7 +14,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import android.widget.Toast
 import androidx.annotation.NonNull
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -442,7 +442,6 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         }
     }
 
-
     private fun displayShippingRules(shippingRules: List<ShippingRule>, project: Project) {
         shipping_rules.isEnabled = true
         adapter.populateShippingRules(shippingRules, project)

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -5,9 +5,7 @@ import android.content.Intent
 import android.graphics.Rect
 import android.net.Uri
 import android.os.Bundle
-import android.text.SpannableString
-import android.text.SpannableStringBuilder
-import android.text.TextPaint
+import android.text.*
 import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
 import android.text.style.URLSpan
@@ -16,6 +14,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import android.widget.Toast
 import androidx.annotation.NonNull
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -56,6 +55,7 @@ import kotlinx.android.synthetic.main.fragment_pledge_section_payment.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_pledge_amount.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_reward_summary.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_shipping.*
+import kotlinx.android.synthetic.main.fragment_pledge_section_shipping.view.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_summary_pledge.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_summary_shipping.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_total.*
@@ -437,7 +437,12 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.inputs.shippingRuleSelected(rule)
         activity?.hideKeyboard()
         shipping_rules.clearFocus()
+
+        if(!pledge_footer_pledge_button.isEnabled){
+            pledge_footer_pledge_button.isEnabled = true
+        }
     }
+
 
     private fun displayShippingRules(shippingRules: List<ShippingRule>, project: Project) {
         shipping_rules.isEnabled = true
@@ -516,6 +521,21 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
             adapter = ShippingRulesAdapter(it, R.layout.item_shipping_rule, arrayListOf(), this)
             shipping_rules.setAdapter(adapter)
         }
+
+        this.view?.shipping_rules?.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(s: Editable?) {
+
+                if (s.toString().isNullOrBlank()) {
+                    pledge_footer_pledge_button.isEnabled = false
+                }
+            }
+
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+            }
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+            }
+        })
     }
 
     private fun setClickableHtml(string: String, textView: TextView) {


### PR DESCRIPTION
# 📲 What

On the pledge screen, the pledge button was still active even if the user cleared their shipping selection, making it invalid.

# 🤔 Why

Seems to be a possible cause for errors, if we're allowing users to make a pledge(spend money), without first confirming that a reward can even be shipped to their location.

# 🛠 How

I added an OnTextChangedListener to the shipping address AutoCompleteTextView. Each time the text is changed, I check if it's null, empty, or blank (only blank spaces). If so, I disable the pledge button. When the user selects a valid location from the shipping dropdown, I re-enable the pledge button.

I'm not 100% sure if this correct as I couldn't see where we were getting the shipping locations from. So, in the case that the user can select a location from the dropdown, and that location is "invalid"...this fix won't work. My assumption here is that the shipping location dropdown only shows valid locations that a reward could be sent to.

# 👀 See
| Before 🐛 
<img width="506" alt="Screen Shot 2020-06-08 at 7 48 10 PM" src="https://user-images.githubusercontent.com/7025946/84090932-0bcd2f00-a9c1-11ea-928d-3ec6ccdc34c1.png">

| After 🦋 |
<img width="520" alt="Screen Shot 2020-06-08 at 7 37 30 PM" src="https://user-images.githubusercontent.com/7025946/84090950-15569700-a9c1-11ea-9074-6cfb1034c69e.png">

|  |  |

# 📋 QA

1. On the android app, open a project with rewards that have shipping 

2. Select a reward with shipping 

3. On the pledge screen, select a payment method if one is not auto-selected

4. Tap on the shipping location field and delete the entry 

5. Tap outside the field and observe the Pledge button

6. Observe that the pledge button is disabled

# Story 📖

https://kickstarter.atlassian.net/secure/RapidBoard.jspa?rapidView=9&modal=detail&selectedIssue=NT-1217