### PR TITLE
NT- 1290: Add-ons UI in BackingFragment

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -1,8 +1,10 @@
 package com.kickstarter.libs.utils
 
 import android.content.Context
+import android.text.Spannable
 import android.text.SpannableString
 import android.text.Spanned
+import android.text.style.ForegroundColorSpan
 import android.text.style.RelativeSizeSpan
 import android.util.Pair
 import androidx.annotation.StringRes
@@ -65,5 +67,21 @@ object RewardViewUtils {
         }
 
         return spannableString
+    }
+
+    /**
+     * Returns the title for an Add On ie: 1 x TITLE
+     *  [1 x] in green
+     *  TITLE regular string
+     */
+    fun styleTitleForAddOns(context: Context, title: String?, quantity: Int?): SpannableString {
+        val symbol = " x "
+        val numberGreenCharacters = quantity.toString().length + symbol.length
+        val spannable = SpannableString(quantity.toString() + symbol + title)
+        spannable.setSpan(
+                ForegroundColorSpan(context.getColor(R.color.ksr_green_500)),
+                0, numberGreenCharacters,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        return spannable
     }
 }

--- a/app/src/main/java/com/kickstarter/models/Reward.java
+++ b/app/src/main/java/com/kickstarter/models/Reward.java
@@ -35,6 +35,7 @@ public abstract class Reward implements Parcelable, Relay {
   public abstract @Nullable String title();
   public abstract @Nullable boolean isAddOn();
   public abstract @Nullable List<RewardsItem> addOnsItems();
+  public abstract @Nullable Integer quantity();
 
   @AutoParcel.Builder
   public abstract static class Builder {
@@ -54,6 +55,7 @@ public abstract class Reward implements Parcelable, Relay {
     public abstract Builder title(String __);
     public abstract Builder isAddOn(boolean __);
     public abstract Builder addOnsItems(List<RewardsItem> __);
+    public abstract Builder quantity(Integer __);
     public abstract Reward build();
   }
 

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -566,7 +566,6 @@ private fun createBackingObject(backingGr: fragment.Backing?): Backing {
         return@let getAddOnsList(it)
     }
 
-
     val id = decodeRelayId(backingGr?.id())?.let { it } ?: 0
 
     val location = backingGr?.location()?.fragments()?.location()
@@ -660,6 +659,7 @@ private fun <T : Any?> handleResponse(it: T, ps: PublishSubject<T>) {
 }
 
 fun getAddOnsList(addOns: fragment.Backing.AddOns): List<Reward> {
+    val quantity = addOns.nodes()?.size
     val rewardsList = addOns.nodes()?.map { node ->
             val rewardGr = node.fragments().reward()
             val amount = rewardGr.amount().fragments().amount().amount()?.toDouble() ?: 0.0
@@ -673,6 +673,7 @@ fun getAddOnsList(addOns: fragment.Backing.AddOns): List<Reward> {
 
             return@map Reward.builder()
             .minimum(amount)
+            .quantity(quantity)
             .description(desc)
             .estimatedDeliveryOn(estimatedDelivery)
             .isAddOn(true)

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -658,31 +658,47 @@ private fun <T : Any?> handleResponse(it: T, ps: PublishSubject<T>) {
     }
 }
 
+/**
+ * For addOns we receive this kind of data structure :[D, D, D, D, D, C, E, E]
+ * and we need to transform it in : D(5),C(1),E(2)
+ */
 fun getAddOnsList(addOns: fragment.Backing.AddOns): List<Reward> {
-    val quantity = addOns.nodes()?.size
+    val mutableMap = mutableMapOf<Reward, Int>()
+
     val rewardsList = addOns.nodes()?.map { node ->
-            val rewardGr = node.fragments().reward()
-            val amount = rewardGr.amount().fragments().amount().amount()?.toDouble() ?: 0.0
-            val desc = rewardGr.description()
-            val estimatedDelivery = DateTime(rewardGr.estimatedDeliveryOn())
-            val rewardId = decodeRelayId(rewardGr.id()) ?: -1
+        val rewardGr = node.fragments().reward()
+        val amount = rewardGr.amount().fragments().amount().amount()?.toDouble() ?: 0.0
+        val desc = rewardGr.description()
+        val estimatedDelivery = DateTime(rewardGr.estimatedDeliveryOn())
+        val rewardId = decodeRelayId(rewardGr.id()) ?: -1
 
-            val items = rewardGr.items()?.let {
-                return@let getAddonItems(it)
-            }
+        val items = rewardGr.items()?.let {
+            return@let getAddonItems(it)
+        }
 
-            return@map Reward.builder()
-            .minimum(amount)
-            .quantity(quantity)
-            .description(desc)
-            .estimatedDeliveryOn(estimatedDelivery)
-            .isAddOn(true)
-            .addOnsItems(items)
-            .id(rewardId)
-            .build()
-        } ?: emptyList()
+        return@map Reward.builder()
+        .minimum(amount)
+        .description(desc)
+        .estimatedDeliveryOn(estimatedDelivery)
+        .isAddOn(true)
+        .addOnsItems(items)
+        .id(rewardId)
+        .build()
+    }
 
-    return rewardsList.toList()
+    rewardsList?.map {
+        var addOnQuantity = mutableMap.getOrPut(it, {1})
+        if (addOnQuantity != null) addOnQuantity += 1
+
+        mutableMap.put(it, addOnQuantity)
+    }
+
+    return mutableMap.map {
+        return@map it.key
+                .toBuilder()
+                .quantity(it.value)
+                .build()
+    }.toList()
 }
 
 fun getAddonItems(items: fragment.Reward.Items): List<RewardsItem> {

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -577,10 +577,12 @@ private fun createBackingObject(backingGr: fragment.Backing?): Backing {
     val reward = backingGr?.reward()?.fragments()?.reward()?.let { reward ->
         val rewardId = decodeRelayId(reward.id()) ?: -1
         val rewardAmount = reward.amount().fragments().amount().amount()?.toDouble()
-        val rewardSingleLocation = Reward.SingleLocation.builder()
-                .localizedName(location?.displayableName())
-                .id(decodeRelayId(location?.id())?:-1)
-                .build()
+        val rewardSingleLocation = location?.let { location ->
+            return@let Reward.SingleLocation.builder()
+                    .localizedName(location.displayableName())
+                    .id(decodeRelayId(location.id())?:-1)
+                    .build()
+        }
 
         return@let Reward.builder()
                 .minimum(rewardAmount?: -1.0)

--- a/app/src/main/java/com/kickstarter/ui/adapters/RewardAndAddOnsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/RewardAndAddOnsAdapter.kt
@@ -7,9 +7,8 @@ import com.kickstarter.models.Reward
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.ui.viewholders.*
 
-class RewardAndAddOnsAdapter(private val viewListener: RewardAndAddOnsAdapter.ViewListener) : KSAdapter() {
+class RewardAndAddOnsAdapter() : KSAdapter() {
 
-    interface ViewListener:RewardViewHolder.Delegate, AddOnViewHolder.ViewListener
 
     init {
         insertSection(SECTION_REWARD_CARD, emptyList<Reward>())
@@ -24,8 +23,8 @@ class RewardAndAddOnsAdapter(private val viewListener: RewardAndAddOnsAdapter.Vi
 
     override fun viewHolder(layout: Int, view: View): KSViewHolder {
         return when(layout) {
-            R.layout.item_reward -> RewardViewHolder(view, viewListener)
-            R.layout.item_add_on -> AddOnViewHolder(view, viewListener)
+            R.layout.item_reward,
+            R.layout.item_add_on -> AddOnViewHolder(view)
             else -> EmptyViewHolder(view)
         }
     }
@@ -35,7 +34,7 @@ class RewardAndAddOnsAdapter(private val viewListener: RewardAndAddOnsAdapter.Vi
         notifyDataSetChanged()
     }
 
-    fun populateDataForRewad(reward: Pair<ProjectData, Reward>) {
+    fun populateDataForReward(reward: Pair<ProjectData, Reward>) {
         setSection(SECTION_REWARD_CARD, listOf(reward))
         notifyDataSetChanged()
     }

--- a/app/src/main/java/com/kickstarter/ui/adapters/RewardAndAddOnsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/RewardAndAddOnsAdapter.kt
@@ -28,9 +28,9 @@ class RewardAndAddOnsAdapter() : KSAdapter() {
         }
     }
 
-    fun populateDataForAddOns(rewards: Pair<ProjectData, List<Reward>>) {
-        if (rewards.second.isNotEmpty()) {
-            setSection(SECTION_ADD_ONS_CARD, listOf(rewards))
+    fun populateDataForAddOns(rewards: List<Pair<ProjectData,Reward>>) {
+        if (rewards.isNotEmpty()) {
+            setSection(SECTION_ADD_ONS_CARD, rewards)
             notifyDataSetChanged()
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/adapters/RewardAndAddOnsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/RewardAndAddOnsAdapter.kt
@@ -9,14 +9,13 @@ import com.kickstarter.ui.viewholders.*
 
 class RewardAndAddOnsAdapter() : KSAdapter() {
 
-
     init {
         insertSection(SECTION_REWARD_CARD, emptyList<Reward>())
         insertSection(SECTION_ADD_ONS_CARD, emptyList<Reward>())
     }
 
     override fun layout(sectionRow: SectionRow): Int = when (sectionRow.section()){
-        SECTION_REWARD_CARD -> R.layout.item_reward
+        SECTION_REWARD_CARD,
         SECTION_ADD_ONS_CARD -> R.layout.item_add_on
         else -> 0
     }
@@ -29,9 +28,11 @@ class RewardAndAddOnsAdapter() : KSAdapter() {
         }
     }
 
-    fun populateDataForAddOns(rewards: List<Pair<ProjectData, Reward>>) {
-        setSection(SECTION_ADD_ONS_CARD, rewards)
-        notifyDataSetChanged()
+    fun populateDataForAddOns(rewards: Pair<ProjectData, List<Reward>>) {
+        if (rewards.second.isNotEmpty()) {
+            setSection(SECTION_ADD_ONS_CARD, listOf(rewards))
+            notifyDataSetChanged()
+        }
     }
 
     fun populateDataForReward(reward: Pair<ProjectData, Reward>) {

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -169,6 +169,11 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>(){
                 .compose(Transformers.observeForUI())
                 .subscribe { total_summary_amount.text = it }
 
+        this.viewModel.outputs.projectDataAndAddOns()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe { populateAddOns(it) }
+
         SwipeRefresher(
                 this, backing_swipe_refresh_layout, { this.viewModel.inputs.refreshProject() }, { this.viewModel.outputs.swipeRefresherProgressIsVisible() }
         )
@@ -196,6 +201,14 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>(){
 
         val projectAndRw = Pair(project, reward)
         rewardsAndAddOnsAdapter.populateDataForReward(projectAndRw)
+    }
+
+    private fun populateAddOns(projectAndAddOn: Pair<ProjectData, List<Reward>>) {
+        val project = projectAndAddOn.first
+        val addOns  = projectAndAddOn.second
+
+        val projectAndRw = Pair(project, addOns)
+        rewardsAndAddOnsAdapter.populateDataForAddOns(projectAndRw)
     }
 
     private fun setBackerImageView(url: String) {

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -18,6 +18,7 @@ import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.transformations.CircleTransformation
 import com.kickstarter.libs.utils.ViewUtils
+import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.adapters.RewardAndAddOnsAdapter
 import com.kickstarter.ui.data.PledgeStatusData
@@ -170,6 +171,7 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>(){
                 .subscribe { total_summary_amount.text = it }
 
         this.viewModel.outputs.projectDataAndAddOns()
+                .filter { it.second.isNotEmpty() }
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .subscribe { populateAddOns(it) }
@@ -206,9 +208,10 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>(){
     private fun populateAddOns(projectAndAddOn: Pair<ProjectData, List<Reward>>) {
         val project = projectAndAddOn.first
         val addOns  = projectAndAddOn.second
-
-        val projectAndRw = Pair(project, addOns)
-        rewardsAndAddOnsAdapter.populateDataForAddOns(projectAndRw)
+        val listData = addOns.map {
+            Pair(project, it)
+        }.toList()
+        rewardsAndAddOnsAdapter.populateDataForAddOns(listData)
     }
 
     private fun setBackerImageView(url: String) {

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -28,13 +28,12 @@ import kotlinx.android.synthetic.main.fragment_backing.*
 import kotlinx.android.synthetic.main.fragment_backing_section_summary_total.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_summary_pledge.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_summary_shipping.*
-import kotlinx.android.synthetic.main.item_reward.*
 import kotlinx.android.synthetic.main.reward_card_details.*
 
 @RequiresFragmentViewModel(BackingFragmentViewModel.ViewModel::class)
-class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>(), RewardAndAddOnsAdapter.ViewListener {
+class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>(){
 
-    private var rewardsAndAddOnsAdapter = RewardAndAddOnsAdapter(this)
+    private var rewardsAndAddOnsAdapter = RewardAndAddOnsAdapter()
 
     interface BackingDelegate {
         fun refreshProject()
@@ -196,7 +195,7 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>(), Rewar
         val reward = projectAndReward.second
 
         val projectAndRw = Pair(project, reward)
-        rewardsAndAddOnsAdapter.populateDataForRewad(projectAndRw)
+        rewardsAndAddOnsAdapter.populateDataForReward(projectAndRw)
     }
 
     private fun setBackerImageView(url: String) {
@@ -259,9 +258,5 @@ class BackingFragment: BaseFragment<BackingFragmentViewModel.ViewModel>(), Rewar
     private fun setupRecyclerView() {
         reward_add_on_recycler.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
         reward_add_on_recycler.adapter = rewardsAndAddOnsAdapter
-    }
-
-    override fun rewardClicked(reward: Reward) {
-        // TODO in https://kickstarter.atlassian.net/browse/NT-1290
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/AddOnViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/AddOnViewHolder.kt
@@ -5,7 +5,7 @@ import android.view.View
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.kickstarter.R
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
-import com.kickstarter.libs.utils.ObjectUtils.requireNonNull
+import com.kickstarter.libs.utils.RewardViewUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.adapters.RewardItemsAdapter
@@ -43,7 +43,7 @@ class AddOnViewHolder(private val view: View) : KSViewHolder(view) {
         this.viewModel.outputs.titleForNoReward()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { this.view.add_on_title_text_view_no_quantity.setText(it) }
+                .subscribe { this.view.add_on_title_no_spannable.setText(it) }
 
         this.viewModel.outputs.descriptionForReward()
                 .compose(bindToLifecycle())
@@ -65,31 +65,28 @@ class AddOnViewHolder(private val view: View) : KSViewHolder(view) {
                 .compose(observeForUI())
                 .subscribe(ViewUtils.setGone(this.view.items_container))
 
-        this.viewModel.outputs.quantityIsGone()
+        this.viewModel.outputs.isAddonTitleGone()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe {
-                    if (it) {
-                        this.view.add_on_quantity.visibility = View.GONE
-                        this.view.add_on_symbol.visibility = View.GONE
-                        this.view.add_on_title_text_view_no_quantity.visibility = View.VISIBLE
+                .subscribe { shouldHideAddonAmount ->
+                    if (shouldHideAddonAmount) {
+                        this.view.add_on_title_text_view.visibility = View.GONE
+                        this.view.add_on_title_no_spannable.visibility = View.VISIBLE
                     } else {
-                        this.view.add_on_quantity.visibility = View.VISIBLE
-                        this.view.add_on_symbol.visibility = View.VISIBLE
-                        this.view.add_on_minimum_text_view.visibility = View.VISIBLE
-                        this.view.add_on_title_text_view_no_quantity.visibility = View.GONE
+                        this.view.add_on_title_no_spannable.visibility = View.GONE
+                        this.view.add_on_title_text_view.visibility = View.VISIBLE
                     }
                 }
 
         this.viewModel.outputs.titleForReward()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { this.view.add_on_title_text_view.text = it }
+                .subscribe { this.view.add_on_title_no_spannable.text = it }
 
-        this.viewModel.outputs.titleIsGone()
+        this.viewModel.outputs.titleForAddOn()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { ViewUtils.setGone(this.view.add_on_title_text_view, it) }
+                .subscribe { this.view.add_on_title_text_view.text = RewardViewUtils.styleTitleForAddOns(context(), it.first, it.second) }
     }
 
     override fun bindData(data: Any?) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/AddOnViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/AddOnViewHolder.kt
@@ -2,21 +2,89 @@ package com.kickstarter.ui.viewholders
 
 import android.util.Pair
 import android.view.View
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.kickstarter.R
+import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.ObjectUtils.requireNonNull
+import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Reward
+import com.kickstarter.ui.adapters.RewardItemsAdapter
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.AddOnViewHolderViewModel
+import kotlinx.android.synthetic.main.add_on_items.view.*
+import kotlinx.android.synthetic.main.add_on_title.view.*
+import kotlinx.android.synthetic.main.item_add_on.view.*
 
-class AddOnViewHolder(private val view: View, val delegate: ViewListener?) : KSViewHolder(view) {
-
-    interface ViewListener {
-        fun rewardClicked(reward: Reward)
-    }
+class AddOnViewHolder(private val view: View) : KSViewHolder(view) {
 
     private var viewModel = AddOnViewHolderViewModel.ViewModel(environment())
+    private val currencyConversionString = context().getString(R.string.About_reward_amount)
+    private val ksString = environment().ksString()
 
     init {
+        val rewardItemAdapter = setUpItemAdapter()
 
+        this.viewModel.outputs.conversionIsGone()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe(ViewUtils.setGone(this.view.add_on_conversion_text_view))
+
+        this.viewModel.outputs.conversion()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.add_on_conversion_text_view.text = this.ksString.format(this.currencyConversionString,
+                        "reward_amount", it) }
+
+        this.viewModel.outputs.descriptionForNoReward()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.add_on_description_text_view.setText(it) }
+
+        this.viewModel.outputs.descriptionForReward()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.add_on_description_text_view.text = it }
+
+        this.viewModel.outputs.minimumAmountTitle()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.add_on_minimum_text_view.text = it }
+
+        this.viewModel.outputs.rewardItems()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { rewardItemAdapter.rewardsItems(it) }
+
+        this.viewModel.outputs.rewardItemsAreGone()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe(ViewUtils.setGone(this.view.items_container))
+
+        this.viewModel.outputs.quantityIsGone()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe {
+                    if (it) {
+                        this.view.add_on_quantity.visibility = View.GONE
+                        this.view.add_on_symbol.visibility = View.GONE
+                        this.view.add_on_title_text_view_no_quantity.visibility = View.VISIBLE
+                    } else {
+                        this.view.add_on_quantity.visibility = View.VISIBLE
+                        this.view.add_on_symbol.visibility = View.VISIBLE
+                        this.view.add_on_minimum_text_view.visibility = View.VISIBLE
+                        this.view.add_on_title_text_view_no_quantity.visibility = View.GONE
+                    }
+                }
+
+        this.viewModel.outputs.titleForReward()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.add_on_title_text_view.text = it }
+
+        this.viewModel.outputs.titleIsGone()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { ViewUtils.setGone(this.view.add_on_title_text_view, it) }
     }
 
     override fun bindData(data: Any?) {
@@ -26,6 +94,14 @@ class AddOnViewHolder(private val view: View, val delegate: ViewListener?) : KSV
         val reward = requireNonNull(projectAndReward.second, Reward::class.java)
 
         this.viewModel.inputs.configureWith(projectTracking, reward)
+    }
+
+    private fun setUpItemAdapter(): RewardItemsAdapter {
+        val rewardItemAdapter = RewardItemsAdapter()
+        val itemRecyclerView = view.add_on_item_recycler_view
+        itemRecyclerView.adapter = rewardItemAdapter
+        itemRecyclerView.layoutManager = LinearLayoutManager(context())
+        return rewardItemAdapter
     }
 
 }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/AddOnViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/AddOnViewHolder.kt
@@ -40,6 +40,11 @@ class AddOnViewHolder(private val view: View) : KSViewHolder(view) {
                 .compose(observeForUI())
                 .subscribe { this.view.add_on_description_text_view.setText(it) }
 
+        this.viewModel.outputs.titleForNoReward()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { this.view.add_on_title_text_view_no_quantity.setText(it) }
+
         this.viewModel.outputs.descriptionForReward()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())

--- a/app/src/main/java/com/kickstarter/ui/viewholders/AddOnViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/AddOnViewHolder.kt
@@ -88,11 +88,33 @@ class AddOnViewHolder(private val view: View) : KSViewHolder(view) {
     }
 
     override fun bindData(data: Any?) {
+        if (data is (Pair<*, *>)) {
+            if (data.second is Reward) {
+                bindReward(data)
+            } else if (data.second is List<*>) {
+                bindListAddOns(data)
+            }
+        }
+    }
+
+    private fun bindListAddOns(data: Pair<*, *>) {
+        @Suppress("UNCHECKED_CAST")
+        val tracking = data.first as ProjectData
+        val listOfAddOns = data.second as? List<Reward>
+
+        if (!listOfAddOns.isNullOrEmpty()) {
+            listOfAddOns?.forEach { addOn ->
+                val addOn = requireNonNull(addOn)
+                this.viewModel.inputs.configureWith(tracking, addOn)
+            }
+        }
+    }
+
+    private fun bindReward(data: Any?) {
         @Suppress("UNCHECKED_CAST")
         val projectAndReward = requireNonNull(data as Pair<ProjectData, Reward>)
         val projectTracking = requireNonNull(projectAndReward.first, ProjectData::class.java)
         val reward = requireNonNull(projectAndReward.second, Reward::class.java)
-
         this.viewModel.inputs.configureWith(projectTracking, reward)
     }
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/AddOnViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/AddOnViewHolder.kt
@@ -95,32 +95,13 @@ class AddOnViewHolder(private val view: View) : KSViewHolder(view) {
     override fun bindData(data: Any?) {
         if (data is (Pair<*, *>)) {
             if (data.second is Reward) {
-                bindReward(data)
-            } else if (data.second is List<*>) {
-                bindListAddOns(data)
+                bindReward(data as Pair<ProjectData, Reward>)
             }
         }
     }
 
-    private fun bindListAddOns(data: Pair<*, *>) {
-        @Suppress("UNCHECKED_CAST")
-        val tracking = data.first as ProjectData
-        val listOfAddOns = data.second as? List<Reward>
-
-        if (!listOfAddOns.isNullOrEmpty()) {
-            listOfAddOns?.forEach { addOn ->
-                val addOn = requireNonNull(addOn)
-                this.viewModel.inputs.configureWith(tracking, addOn)
-            }
-        }
-    }
-
-    private fun bindReward(data: Any?) {
-        @Suppress("UNCHECKED_CAST")
-        val projectAndReward = requireNonNull(data as Pair<ProjectData, Reward>)
-        val projectTracking = requireNonNull(projectAndReward.first, ProjectData::class.java)
-        val reward = requireNonNull(projectAndReward.second, Reward::class.java)
-        this.viewModel.inputs.configureWith(projectTracking, reward)
+    private fun bindReward(projectAndReward: Pair<ProjectData, Reward>) {
+        this.viewModel.inputs.configureWith(projectAndReward.first, projectAndReward.second)
     }
 
     private fun setUpItemAdapter(): RewardItemsAdapter {

--- a/app/src/main/java/com/kickstarter/viewmodels/AddOnViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/AddOnViewHolderViewModel.kt
@@ -108,7 +108,7 @@ interface AddOnViewHolderViewModel {
                     .subscribe(this.conversionIsGone)
 
             projectAndReward
-                    .map { this.ksCurrency.format(it.second.convertedMinimum(), it.first, true, RoundingMode.HALF_UP, true) }
+                    .map { getCurrency(it) }
                     .compose(bindToLifecycle())
                     .subscribe(this.conversion)
 
@@ -157,6 +157,9 @@ interface AddOnViewHolderViewModel {
                     .subscribe(this.titleForAddOn)
 
         }
+
+        private fun getCurrency(it: Pair<Project, Reward>) =
+                this.ksCurrency.format(it.second.convertedMinimum(), it.first, true, RoundingMode.HALF_UP, true)
 
         private fun buildCurrency(project: Project, reward: Reward): String {
             val completeCurrency = ksCurrency.format(reward.minimum(), project, RoundingMode.HALF_UP)

--- a/app/src/main/java/com/kickstarter/viewmodels/AddOnViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/AddOnViewHolderViewModel.kt
@@ -1,39 +1,161 @@
 package com.kickstarter.viewmodels
 
+import android.text.SpannableString
+import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.KSCurrency
+import com.kickstarter.libs.utils.*
 import com.kickstarter.models.Reward
+import com.kickstarter.models.RewardsItem
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.ui.viewholders.RewardViewHolder
+import rx.Observable
+import rx.subjects.BehaviorSubject
+import rx.subjects.PublishSubject
+import java.math.RoundingMode
 
 interface AddOnViewHolderViewModel {
     interface Inputs {
         /** Configure with the current [ProjectData] and [Reward]. */
         fun configureWith(projectData: ProjectData, reward: Reward)
-
-        /** Call when the user clicks on a reward. */
-        fun rewardClicked(position: Int)
     }
 
     interface Outputs {
+
+        /** Emits `true` if the quantity should be hidden, `false` otherwise.  */
+        fun quantityIsGone(): Observable<Boolean>
+
+        /** Emits the reward's minimum converted to the user's preference  */
+        fun conversion(): Observable<String>
+
+        /** Emits `true` if the conversion should be hidden, `false` otherwise.  */
+        fun conversionIsGone(): Observable<Boolean>
+
+        /** Emits the reward's description when `isNoReward` is true. */
+        fun descriptionForNoReward(): Observable<Int>
+
+        /** Emits the reward's description.  */
+        fun descriptionForReward(): Observable<String?>
+
+        /** Emits the minimum pledge amount in the project's currency.  */
+        fun minimumAmountTitle(): Observable<SpannableString>
+
+        /** Emits the reward's items.  */
+        fun rewardItems(): Observable<List<RewardsItem>>
+
+        /** Emits `true` if the items section should be hidden, `false` otherwise.  */
+        fun rewardItemsAreGone(): Observable<Boolean>
+
+        /** Emits `true` if the title should be hidden, `false` otherwise.  */
+        fun titleIsGone(): Observable<Boolean>
+
+        /** Emits the reward's title when `isReward` is true.  */
+        fun titleForReward(): Observable<String?>
     }
 
-    class ViewModel(@NonNull environment: Environment) : ActivityViewModel<RewardViewHolder>(environment), Inputs, Outputs {
+    class ViewModel(@NonNull environment: Environment) : ActivityViewModel<RewardViewHolder>(environment), Inputs, Outputs{
+
+        private val ksCurrency: KSCurrency = environment.ksCurrency()
+
+        private val projectDataAndReward = PublishSubject.create<Pair<ProjectData, Reward>>()
+        private val quantityIsGone = BehaviorSubject.create<Boolean>()
+        private val conversion = BehaviorSubject.create<String>()
+        private val conversionIsGone = BehaviorSubject.create<Boolean>()
+        private val descriptionForNoReward = BehaviorSubject.create<Int>()
+        private val descriptionForReward = BehaviorSubject.create<String?>()
+        private val minimumAmountTitle = PublishSubject.create<SpannableString>()
+        private val rewardItems = BehaviorSubject.create<List<RewardsItem>>()
+        private val rewardItemsAreGone = BehaviorSubject.create<Boolean>()
+        private val titleForReward = BehaviorSubject.create<String?>()
+        private val titleIsGone = BehaviorSubject.create<Boolean>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
 
         init {
-            // TODO in https://kickstarter.atlassian.net/browse/NT-1290
+            val reward = this.projectDataAndReward
+                    .map { it.second }
+
+            val projectAndReward = this.projectDataAndReward
+                    .map { Pair(it.first.project(), it.second) }
+
+            projectAndReward
+                    .map { RewardViewUtils.styleCurrency(it.second.minimum(), it.first, this.ksCurrency) }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.minimumAmountTitle)
+
+            projectAndReward
+                    .map { it.first }
+                    .map { it.currency() == it.currentCurrency() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.conversionIsGone)
+
+            projectAndReward
+                    .map { this.ksCurrency.format(it.second.convertedMinimum(), it.first, true, RoundingMode.HALF_UP, true) }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.conversion)
+
+            reward
+                    .filter { RewardUtils.isReward(it) }
+                    .map { it.description() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.descriptionForReward)
+
+            reward
+                    .map { it.quantity()?.let { it <= 0 } ?: true }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.quantityIsGone)
+
+            reward
+                    .filter { RewardUtils.isItemized(it) }
+                    .map { it.rewardsItems() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.rewardItems)
+
+            reward
+                    .map { RewardUtils.isItemized(it) }
+                    .map { BooleanUtils.negate(it) }
+                    .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.rewardItemsAreGone)
+
+            reward
+                    .filter { RewardUtils.isReward(it) }
+                    .map { it.title() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.titleForReward)
+
+            reward
+                    .map { RewardUtils.isReward(it) && it.title().isNullOrEmpty() }
+                    .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe(this.titleIsGone)
         }
 
         override fun configureWith(projectData: ProjectData, reward: Reward) {
-            // TODO in https://kickstarter.atlassian.net/browse/NT-1290
+            this.projectDataAndReward.onNext(Pair.create(projectData, reward))
         }
 
-        override fun rewardClicked(position: Int) {
-            // TODO in https://kickstarter.atlassian.net/browse/NT-1290
-        }
+        override fun quantityIsGone(): Observable<Boolean> = this.quantityIsGone
+
+        override fun conversion(): Observable<String> = this.conversion
+
+        override fun conversionIsGone(): Observable<Boolean> = this.conversionIsGone
+
+        override fun descriptionForNoReward(): Observable<Int> = this.descriptionForNoReward
+
+        override fun descriptionForReward(): Observable<String?> = this.descriptionForReward
+
+        override fun minimumAmountTitle(): Observable<SpannableString> = this.minimumAmountTitle
+
+        override fun rewardItems(): Observable<List<RewardsItem>> = this.rewardItems
+
+        override fun rewardItemsAreGone(): Observable<Boolean> = this.rewardItemsAreGone
+
+        override fun titleIsGone(): Observable<Boolean> = this.titleIsGone
+
+        override fun titleForReward(): Observable<String?> = this.titleForReward
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/AddOnViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/AddOnViewHolderViewModel.kt
@@ -1,13 +1,14 @@
 package com.kickstarter.viewmodels
 
-import android.text.SpannableString
 import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.R
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.KSCurrency
+import com.kickstarter.libs.models.Country
 import com.kickstarter.libs.utils.*
+import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.RewardsItem
 import com.kickstarter.ui.data.ProjectData
@@ -19,14 +20,17 @@ import java.math.RoundingMode
 
 interface AddOnViewHolderViewModel {
     interface Inputs {
-        /** Configure with the current [ProjectData] and [Reward]. */
+        /** Configure with the current [ProjectData] and [Reward].
+         * @param projectData we get the Project for currency
+         * @param reward the actual reward, add on, no reward loading on the ViewHolder
+         */
         fun configureWith(projectData: ProjectData, reward: Reward)
     }
 
     interface Outputs {
 
-        /** Emits `true` if the quantity should be hidden, `false` otherwise.  */
-        fun quantityIsGone(): Observable<Boolean>
+        /** Emits `true` if the title for addons should be hidden, `false` otherwise.  */
+        fun isAddonTitleGone(): Observable<Boolean>
 
         /** Emits the reward's minimum converted to the user's preference  */
         fun conversion(): Observable<String>
@@ -41,7 +45,7 @@ interface AddOnViewHolderViewModel {
         fun descriptionForReward(): Observable<String?>
 
         /** Emits the minimum pledge amount in the project's currency.  */
-        fun minimumAmountTitle(): Observable<SpannableString>
+        fun minimumAmountTitle(): Observable<String>
 
         /** Emits the reward's items.  */
         fun rewardItems(): Observable<List<RewardsItem>>
@@ -49,31 +53,37 @@ interface AddOnViewHolderViewModel {
         /** Emits `true` if the items section should be hidden, `false` otherwise.  */
         fun rewardItemsAreGone(): Observable<Boolean>
 
-        /** Emits `true` if the title should be hidden, `false` otherwise.  */
-        fun titleIsGone(): Observable<Boolean>
-
         /** Emits the reward's title when `isReward` is true.  */
         fun titleForReward(): Observable<String?>
 
         /** Emits the reward's title when `noReward` is true.  */
         fun titleForNoReward(): Observable<Int>
+
+        /** Emits a pait with the add on title and the quantity in order to build the stylized title  */
+        fun titleForAddOn(): Observable<Pair<String, Int>>
     }
 
+    /**
+     *  Logic to handle the UI for `Reward`, `No Reward` and `Add On`
+     *  Configuring the View for [AddOnViewHolder]
+     *  - No interaction with the user just displaying information
+     *  - Loading in [AddOnViewHolder] -> [RewardAndAddOnsAdapter] -> [BackingFragment]
+     */
     class ViewModel(@NonNull environment: Environment) : ActivityViewModel<RewardViewHolder>(environment), Inputs, Outputs{
 
         private val ksCurrency: KSCurrency = environment.ksCurrency()
-
+        private val isAddonTitleGone = BehaviorSubject.create<Boolean>()
         private val projectDataAndReward = PublishSubject.create<Pair<ProjectData, Reward>>()
-        private val quantityIsGone = BehaviorSubject.create<Boolean>()
         private val conversion = BehaviorSubject.create<String>()
         private val conversionIsGone = BehaviorSubject.create<Boolean>()
         private val descriptionForNoReward = BehaviorSubject.create<Int>()
         private val titleForNoReward = BehaviorSubject.create<Int>()
         private val descriptionForReward = BehaviorSubject.create<String?>()
-        private val minimumAmountTitle = PublishSubject.create<SpannableString>()
+        private val minimumAmountTitle = PublishSubject.create<String>()
         private val rewardItems = BehaviorSubject.create<List<RewardsItem>>()
         private val rewardItemsAreGone = BehaviorSubject.create<Boolean>()
         private val titleForReward = BehaviorSubject.create<String?>()
+        private val titleForAddOn = BehaviorSubject.create<Pair<String, Int>>()
         private val titleIsGone = BehaviorSubject.create<Boolean>()
 
         val inputs: Inputs = this
@@ -87,7 +97,7 @@ interface AddOnViewHolderViewModel {
                     .map { Pair(it.first.project(), it.second) }
 
             projectAndReward
-                    .map { RewardViewUtils.styleCurrency(it.second.minimum(), it.first, this.ksCurrency) }
+                    .map { buildCurrency(it.first, it.second) }
                     .compose(bindToLifecycle())
                     .subscribe(this.minimumAmountTitle)
 
@@ -109,17 +119,12 @@ interface AddOnViewHolderViewModel {
                     .subscribe(this.descriptionForReward)
 
             reward
-                    .filter { RewardUtils.isNoReward(it) }
+                    .filter { !it.isAddOn && RewardUtils.isNoReward(it)}
                     .compose(bindToLifecycle())
                     .subscribe {
                         this.descriptionForNoReward.onNext(R.string.Thanks_for_bringing_this_project_one_step_closer_to_becoming_a_reality)
                         this.titleForNoReward.onNext(R.string.You_pledged_without_a_reward)
                     }
-
-            reward
-                    .map { it.quantity()?.let { it <= 0 } ?: true }
-                    .compose(bindToLifecycle())
-                    .subscribe(this.quantityIsGone)
 
             reward
                     .filter { RewardUtils.isItemized(it) }
@@ -135,23 +140,41 @@ interface AddOnViewHolderViewModel {
                     .subscribe(this.rewardItemsAreGone)
 
             reward
-                    .filter { RewardUtils.isReward(it) }
+                    .filter { !it.isAddOn && RewardUtils.isReward(it) }
                     .map { it.title() }
                     .compose(bindToLifecycle())
                     .subscribe(this.titleForReward)
 
             reward
-                    .map { RewardUtils.isNoReward(it) }
-                    .distinctUntilChanged()
+                    .map { !it.isAddOn }
                     .compose(bindToLifecycle())
                     .subscribe(this.titleIsGone)
+
+            reward
+                    .filter { it.isAddOn && it.quantity()?.let { q -> q > 0 } ?: false }
+                    .map { reward -> parametersForTitle(reward)}
+                    .compose(bindToLifecycle())
+                    .subscribe(this.titleForAddOn)
+
         }
 
-        override fun configureWith(projectData: ProjectData, reward: Reward) {
-            this.projectDataAndReward.onNext(Pair.create(projectData, reward))
+        private fun buildCurrency(project: Project, reward: Reward): String {
+            val completeCurrency = ksCurrency.format(reward.minimum(), project, RoundingMode.HALF_UP)
+            val country = Country.findByCurrencyCode(project.currency()) ?: ""
+
+            return completeCurrency.removePrefix(country.toString())
         }
 
-        override fun quantityIsGone(): Observable<Boolean> = this.quantityIsGone
+        private fun parametersForTitle(reward: Reward?): Pair<String, Int> {
+            val title = reward?.title()?.let { it } ?: ""
+            val quantity = reward?.quantity()?.let { it } ?: -1
+
+            return Pair(title, quantity)
+        }
+
+        override fun configureWith(projectData: ProjectData, reward: Reward) = this.projectDataAndReward.onNext(Pair.create(projectData, reward))
+
+        override fun isAddonTitleGone(): Observable<Boolean> = this.isAddonTitleGone
 
         override fun conversion(): Observable<String> = this.conversion
 
@@ -163,14 +186,14 @@ interface AddOnViewHolderViewModel {
 
         override fun descriptionForReward(): Observable<String?> = this.descriptionForReward
 
-        override fun minimumAmountTitle(): Observable<SpannableString> = this.minimumAmountTitle
+        override fun minimumAmountTitle(): Observable<String> = this.minimumAmountTitle
 
         override fun rewardItems(): Observable<List<RewardsItem>> = this.rewardItems
 
         override fun rewardItemsAreGone(): Observable<Boolean> = this.rewardItemsAreGone
 
-        override fun titleIsGone(): Observable<Boolean> = this.titleIsGone
-
         override fun titleForReward(): Observable<String?> = this.titleForReward
+
+        override fun titleForAddOn(): Observable<Pair<String, Int>> = this.titleForAddOn
     }
 }

--- a/app/src/main/res/drawable/divider_dark_grey_500_horizontal.xml
+++ b/app/src/main/res/drawable/divider_dark_grey_500_horizontal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-  <solid android:color="@color/ksr_dark_grey_500"/>
+  <solid android:color="@color/ksr_grey_300"/>
   <size android:height="1dp"/>
 </shape>

--- a/app/src/main/res/layout/add_on_items.xml
+++ b/app/src/main/res/layout/add_on_items.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/includes_title"
+        style="@style/RewardSectionTitle"
+        android:text="@string/rewards_info_includes"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/add_on_item_recycler_view" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/add_on_item_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:nestedScrollingEnabled="false"
+        android:overScrollMode="never"
+        app:layout_constraintTop_toBottomOf="@+id/includes_title"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:itemCount="3"
+        tools:listitem="@layout/rewards_item_view" />
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@drawable/divider_dark_grey_500_horizontal"
+        app:layout_constraintTop_toBottomOf="@+id/add_on_item_recycler_view"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/add_on_items.xml
+++ b/app/src/main/res/layout/add_on_items.xml
@@ -29,6 +29,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="@drawable/divider_dark_grey_500_horizontal"
+        android:importantForAccessibility="no"
         app:layout_constraintTop_toBottomOf="@+id/add_on_item_recycler_view"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/add_on_title.xml
+++ b/app/src/main/res/layout/add_on_title.xml
@@ -52,7 +52,7 @@
         tools:text="Make a pledge without a reward" />
 
     <TextView
-        android:id="@+id/reward_title_text_view"
+        android:id="@+id/add_on_title_text_view_no_quantity"
         style="@style/TextPrimary"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/add_on_title.xml
+++ b/app/src/main/res/layout/add_on_title.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+    <TextView
+        android:id="@+id/add_on_quantity"
+        style="@style/Title2Medium"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="8dp"
+        android:textColor="@color/ksr_green_500"
+        android:textSize="@dimen/title_reward"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintRight_toLeftOf="@+id/add_on_symbol"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="2"
+        android:visibility="visible"/>
+
+    <TextView
+        android:id="@+id/add_on_symbol"
+        style="@style/Title2Medium"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="6dp"
+        android:layout_marginStart="6dp"
+        android:textColor="@color/ksr_green_500"
+        android:textSize="@dimen/title_reward"
+        app:layout_constraintEnd_toStartOf="@+id/add_on_title_text_view"
+        app:layout_constraintStart_toEndOf="@id/add_on_quantity"
+        app:layout_constraintBaseline_toBaselineOf="@+id/add_on_quantity"
+        tools:text="x"
+        android:visibility="visible"/>
+
+    <TextView
+        android:id="@+id/add_on_title_text_view"
+        style="@style/TextPrimary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/title_reward"
+        android:textStyle="bold"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="12dp"
+        android:maxLines="1"
+        app:layout_constraintStart_toEndOf="@id/add_on_symbol"
+        app:layout_constraintBaseline_toBaselineOf="@+id/add_on_quantity"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:visibility="visible"
+        tools:text="Make a pledge without a reward" />
+
+    <TextView
+        android:id="@+id/reward_title_text_view"
+        style="@style/TextPrimary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/title_reward"
+        android:textStyle="bold"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="12dp"
+        android:maxLines="1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Make a pledge without a reward"
+        tools:visibility="visible"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/add_on_title.xml
+++ b/app/src/main/res/layout/add_on_title.xml
@@ -4,36 +4,6 @@
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
-    <TextView
-        android:id="@+id/add_on_quantity"
-        style="@style/Title2Medium"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:layout_marginEnd="8dp"
-        android:textColor="@color/ksr_green_500"
-        android:textSize="@dimen/title_reward"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintRight_toLeftOf="@+id/add_on_symbol"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="2"
-        android:visibility="visible"/>
-
-    <TextView
-        android:id="@+id/add_on_symbol"
-        style="@style/Title2Medium"
-        android:layout_width="wrap_content"
-        android:layout_height="0dp"
-        android:layout_marginTop="12dp"
-        android:layout_marginEnd="6dp"
-        android:layout_marginStart="6dp"
-        android:textColor="@color/ksr_green_500"
-        android:textSize="@dimen/title_reward"
-        app:layout_constraintEnd_toStartOf="@+id/add_on_title_text_view"
-        app:layout_constraintStart_toEndOf="@id/add_on_quantity"
-        app:layout_constraintBaseline_toBaselineOf="@+id/add_on_quantity"
-        tools:text="x"
-        android:visibility="visible"/>
 
     <TextView
         android:id="@+id/add_on_title_text_view"
@@ -42,28 +12,28 @@
         android:layout_height="wrap_content"
         android:textSize="@dimen/title_reward"
         android:textStyle="bold"
-        android:layout_marginTop="12dp"
-        android:layout_marginBottom="12dp"
-        android:maxLines="1"
-        app:layout_constraintStart_toEndOf="@id/add_on_symbol"
-        app:layout_constraintBaseline_toBaselineOf="@+id/add_on_quantity"
+        android:layout_marginTop="@dimen/grid_2"
+        android:layout_marginBottom="@dimen/grid_2"
+        android:maxLines="3"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:visibility="visible"
-        tools:text="Make a pledge without a reward" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible"
+        tools:text="Add on here with some title" />
 
     <TextView
-        android:id="@+id/add_on_title_text_view_no_quantity"
+        android:id="@+id/add_on_title_no_spannable"
         style="@style/TextPrimary"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:textSize="@dimen/title_reward"
         android:textStyle="bold"
-        android:layout_marginTop="12dp"
-        android:layout_marginBottom="12dp"
-        android:maxLines="1"
+        android:layout_marginTop="@dimen/grid_2"
+        android:layout_marginBottom="@dimen/grid_2"
+        android:maxLines="3"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Make a pledge without a reward"
-        tools:visibility="visible"/>
+        tools:visibility="gone"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_add_on.xml
+++ b/app/src/main/res/layout/item_add_on.xml
@@ -13,7 +13,7 @@
         android:overScrollMode="never">
 
         <androidx.cardview.widget.CardView
-            android:id="@+id/reward_card"
+            android:id="@+id/add_on_card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
@@ -31,13 +31,11 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent">
 
-
                 <TextView
-                    android:id="@+id/reward_minimum_text_view"
+                    android:id="@+id/add_on_conversion_text_view"
                     style="@style/Title2Medium"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="12dp"
                     android:textColor="@color/ksr_green_500"
                     android:textSize="@dimen/title_reward"
                     app:layout_constraintStart_toStartOf="parent"
@@ -51,98 +49,46 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="3dp"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/reward_minimum_text_view"
-                    tools:text="About $15 USD" />
+                    app:layout_constraintTop_toBottomOf="@id/add_on_conversion_text_view"
+                    tools:text="About $15 USD"
+                    android:visibility="visible"/>
 
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/guideline"
-                    android:layout_width="wrap_content"
+                <include
+                    android:id="@+id/title_container"
+                    layout="@layout/add_on_title"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    app:layout_constraintGuide_percent="0.50" />
-
-                <TextView
-                    android:id="@+id/add_on_quantity"
-                    style="@style/Title2Medium"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="12dp"
-                    android:layout_marginEnd="8dp"
-                    android:textColor="@color/ksr_green_500"
-                    android:textSize="@dimen/title_reward"
+                    android:visibility="visible"
+                    android:layout_marginTop="16dp"
+                    app:layout_constraintTop_toBottomOf="@id/reward_conversion_text_view"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintRight_toLeftOf="@+id/add_on_symbol"
-                    app:layout_constraintTop_toBottomOf="@id/guideline"
-                    tools:text="2" />
+                    app:layout_constraintEnd_toEndOf="parent" />
 
-                <TextView
-                    android:id="@+id/add_on_symbol"
-                    style="@style/Title2Medium"
-                    android:layout_width="wrap_content"
+                <include
+                    android:id="@+id/items_container"
+                    layout="@layout/add_on_items"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="12dp"
-                    android:layout_marginEnd="4dp"
-                    android:layout_marginStart="4dp"
-                    android:textColor="@color/ksr_green_500"
-                    android:textSize="@dimen/title_reward"
-                    app:layout_constraintEnd_toStartOf="@+id/reward_title_text_view"
-                    app:layout_constraintStart_toEndOf="@id/add_on_quantity"
-                    app:layout_constraintTop_toBottomOf="@id/guideline"
-                    tools:text="x" />
+                    android:visibility="visible"
+                    android:layout_marginTop="24dp"
+                    app:layout_constraintTop_toBottomOf="@id/title_container"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
 
                 <TextView
-                    android:id="@+id/reward_title_text_view"
-                    style="@style/TextPrimary"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:textSize="@dimen/title_reward"
-                    android:textStyle="bold"
-                    android:layout_marginTop="12dp"
-                    android:layout_marginBottom="12dp"
-                    android:maxLines="1"
-                    app:layout_constraintStart_toEndOf="@id/add_on_symbol"
-                    app:layout_constraintTop_toBottomOf="@id/guideline"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    tools:text="Make a pledge without a reward" />
-
-                <TextView
-                    android:id="@+id/reward_description_text_view"
+                    android:id="@+id/add_on_description_text_view"
                     style="@style/BodyPrimary"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
                     android:layout_marginBottom="12dp"
                     app:layout_constraintRight_toRightOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/reward_title_text_view"
+                    app:layout_constraintTop_toBottomOf="@id/items_container"
                     tools:text="@string/Pledge_any_amount_to_help_bring_this_project_to_life" />
 
-
-                <LinearLayout
-                    android:id="@+id/rewards_item_section"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/grid_3"
-                    android:focusable="true"
-                    android:orientation="vertical"
-                    android:visibility="gone">
-
-                    <TextView
-                        style="@style/RewardSectionTitle"
-                        android:text="@string/rewards_info_includes" />
-
-                    <androidx.recyclerview.widget.RecyclerView
-                        android:id="@+id/rewards_item_recycler_view"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:nestedScrollingEnabled="false"
-                        android:overScrollMode="never"
-                        tools:itemCount="3"
-                        tools:listitem="@layout/rewards_item_view" />
-
-                </LinearLayout>
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.cardview.widget.CardView>
-
     </androidx.core.widget.NestedScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/app/src/main/res/layout/item_add_on.xml
+++ b/app/src/main/res/layout/item_add_on.xml
@@ -49,11 +49,11 @@
                     style="@style/FootnotePrimaryMedium"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="3dp"
+                    android:layout_marginTop="@dimen/grid_1_half"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/add_on_minimum_text_view"
                     tools:text="About $15 USD"
-                    android:visibility="visible"/>
+                    tools:visibility="visible"/>
 
                 <include
                     android:id="@+id/title_container"
@@ -61,7 +61,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:visibility="visible"
-                    android:layout_marginTop="16dp"
+                    android:layout_marginTop="@dimen/grid_2"
                     app:layout_constraintTop_toBottomOf="@id/add_on_conversion_text_view"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent" />
@@ -72,7 +72,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:visibility="visible"
-                    android:layout_marginTop="24dp"
+                    android:layout_marginTop="@dimen/grid_5_half"
                     app:layout_constraintTop_toBottomOf="@id/title_container"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent" />
@@ -82,8 +82,8 @@
                     style="@style/BodyPrimary"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="12dp"
-                    android:layout_marginBottom="12dp"
+                    android:layout_marginTop="@dimen/grid_2"
+                    android:layout_marginBottom="@dimen/grid_2"
                     app:layout_constraintRight_toRightOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/items_container"

--- a/app/src/main/res/layout/item_add_on.xml
+++ b/app/src/main/res/layout/item_add_on.xml
@@ -43,7 +43,7 @@
                     tools:text="$20" />
 
                 <TextView
-                    android:id="@+id/reward_conversion_text_view"
+                    android:id="@+id/add_on_conversion_text_view"
                     style="@style/FootnotePrimaryMedium"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -60,7 +60,7 @@
                     android:layout_height="wrap_content"
                     android:visibility="visible"
                     android:layout_marginTop="16dp"
-                    app:layout_constraintTop_toBottomOf="@id/reward_conversion_text_view"
+                    app:layout_constraintTop_toBottomOf="@id/add_on_conversion_text_view"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/layout/item_add_on.xml
+++ b/app/src/main/res/layout/item_add_on.xml
@@ -1,22 +1,148 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-  android:id="@+id/add_on_reward_container"
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
-  android:layout_width="@dimen/item_reward_width"
-  android:layout_height="wrap_content"
-  android:orientation="vertical">
+<androidx.coordinatorlayout.widget.CoordinatorLayout android:id="@+id/add_on_reward_container"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <androidx.cardview.widget.CardView
-      android:id="@+id/add_on_reward_card"
-      android:layout_width="match_parent"
-      android:layout_height="300dp"
-      android:layout_gravity="center_horizontal"
-      app:cardCornerRadius="@dimen/reward_card_radius"
-      app:cardElevation="0dp">
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:overScrollMode="never">
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/reward_card"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            app:cardCornerRadius="@dimen/reward_card_radius"
+            app:cardElevation="0dp">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/add_on_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="@dimen/grid_3"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
 
 
-    </androidx.cardview.widget.CardView>
+                <TextView
+                    android:id="@+id/reward_minimum_text_view"
+                    style="@style/Title2Medium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:textColor="@color/ksr_green_500"
+                    android:textSize="@dimen/title_reward"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="$20" />
 
+                <TextView
+                    android:id="@+id/reward_conversion_text_view"
+                    style="@style/FootnotePrimaryMedium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="3dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/reward_minimum_text_view"
+                    tools:text="About $15 USD" />
+
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/guideline"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    app:layout_constraintGuide_percent="0.50" />
+
+                <TextView
+                    android:id="@+id/add_on_quantity"
+                    style="@style/Title2Medium"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginEnd="8dp"
+                    android:textColor="@color/ksr_green_500"
+                    android:textSize="@dimen/title_reward"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintRight_toLeftOf="@+id/add_on_symbol"
+                    app:layout_constraintTop_toBottomOf="@id/guideline"
+                    tools:text="2" />
+
+                <TextView
+                    android:id="@+id/add_on_symbol"
+                    style="@style/Title2Medium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginEnd="4dp"
+                    android:layout_marginStart="4dp"
+                    android:textColor="@color/ksr_green_500"
+                    android:textSize="@dimen/title_reward"
+                    app:layout_constraintEnd_toStartOf="@+id/reward_title_text_view"
+                    app:layout_constraintStart_toEndOf="@id/add_on_quantity"
+                    app:layout_constraintTop_toBottomOf="@id/guideline"
+                    tools:text="x" />
+
+                <TextView
+                    android:id="@+id/reward_title_text_view"
+                    style="@style/TextPrimary"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:textSize="@dimen/title_reward"
+                    android:textStyle="bold"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginBottom="12dp"
+                    android:maxLines="1"
+                    app:layout_constraintStart_toEndOf="@id/add_on_symbol"
+                    app:layout_constraintTop_toBottomOf="@id/guideline"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    tools:text="Make a pledge without a reward" />
+
+                <TextView
+                    android:id="@+id/reward_description_text_view"
+                    style="@style/BodyPrimary"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="12dp"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/reward_title_text_view"
+                    tools:text="@string/Pledge_any_amount_to_help_bring_this_project_to_life" />
+
+
+                <LinearLayout
+                    android:id="@+id/rewards_item_section"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/grid_3"
+                    android:focusable="true"
+                    android:orientation="vertical"
+                    android:visibility="gone">
+
+                    <TextView
+                        style="@style/RewardSectionTitle"
+                        android:text="@string/rewards_info_includes" />
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/rewards_item_recycler_view"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:nestedScrollingEnabled="false"
+                        android:overScrollMode="never"
+                        tools:itemCount="3"
+                        tools:listitem="@layout/rewards_item_view" />
+
+                </LinearLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
+
+    </androidx.core.widget.NestedScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
+

--- a/app/src/main/res/layout/item_add_on.xml
+++ b/app/src/main/res/layout/item_add_on.xml
@@ -4,6 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/grid_2"
+    android:layout_marginBottom="@dimen/grid_2"
     android:orientation="vertical"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 

--- a/app/src/main/res/layout/item_add_on.xml
+++ b/app/src/main/res/layout/item_add_on.xml
@@ -32,7 +32,7 @@
                 app:layout_constraintTop_toTopOf="parent">
 
                 <TextView
-                    android:id="@+id/add_on_conversion_text_view"
+                    android:id="@+id/add_on_minimum_text_view"
                     style="@style/Title2Medium"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -49,7 +49,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="3dp"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/add_on_conversion_text_view"
+                    app:layout_constraintTop_toBottomOf="@id/add_on_minimum_text_view"
                     tools:text="About $15 USD"
                     android:visibility="visible"/>
 

--- a/app/src/main/res/layout/rewards_item_view.xml
+++ b/app/src/main/res/layout/rewards_item_view.xml
@@ -4,15 +4,22 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
-  android:orientation="vertical">
+  android:orientation="horizontal">
+
+  <TextView
+      android:layout_marginLeft="@dimen/grid_2"
+      android:layout_marginRight="@dimen/grid_2"
+      android:layout_width="wrap_content"
+      android:layout_height="match_parent"
+      android:gravity="center"
+      android:text="&#8226;"/>
 
   <TextView
     android:id="@+id/rewards_item_title"
     style="@style/BodyPrimary"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="@dimen/grid_2"
-    android:layout_marginTop="@dimen/grid_2"
+    android:layout_marginBottom="@dimen/grid_1"
+    android:layout_marginTop="@dimen/grid_1"
     tools:text="3 T-Shirts" />
-
 </LinearLayout>

--- a/app/src/main/res/layout/rewards_item_view.xml
+++ b/app/src/main/res/layout/rewards_item_view.xml
@@ -7,12 +7,12 @@
   android:orientation="horizontal">
 
   <TextView
-      android:layout_marginLeft="@dimen/grid_2"
-      android:layout_marginRight="@dimen/grid_2"
-      android:layout_width="wrap_content"
-      android:layout_height="match_parent"
-      android:gravity="center"
-      android:text="&#8226;"/>
+    android:layout_marginLeft="@dimen/grid_2"
+    android:layout_marginRight="@dimen/grid_2"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:text="@string/bullet"/>
 
   <TextView
     android:id="@+id/rewards_item_title"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,5 +71,6 @@
   <string name="Take_our_survey_to_help_us_make_a_better_app_for_you">Take our survey to help us make a better app for you.</string>
   <string name="No_thanks">No thanks</string>
   <string name="Let_s_go">Let\'s go</string>
+  <string name="bullet"><![CDATA[&#8226;]]></string>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -588,7 +588,7 @@
   </style>
 
   <style name="RewardSectionTitle" parent="CalloutPrimaryMedium">
-    <item name="android:textColor">@color/ksr_dark_grey_400</item>
+    <item name="android:textColor">@color/ksr_dark_grey_500</item>
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
   </style>

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnViewHolderViewModelTest.kt
@@ -1,0 +1,67 @@
+package com.kickstarter.viewmodels
+
+import androidx.annotation.NonNull
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Environment
+import com.kickstarter.models.RewardsItem
+import org.junit.Test
+import rx.observers.TestSubscriber
+
+class AddOnViewHolderViewModelTest : KSRobolectricTestCase() {
+    private lateinit var vm: AddOnViewHolderViewModel.ViewModel
+
+    private val quantityIsGone = TestSubscriber.create<Boolean>()
+    private val conversion = TestSubscriber.create<String>()
+    private val conversionIsGone = TestSubscriber.create<Boolean>()
+    private val descriptionForNoReward = TestSubscriber.create<Int>()
+    private val descriptionForReward = TestSubscriber.create<String?>()
+    private val rewardItems = TestSubscriber.create<List<RewardsItem>>()
+    private val rewardItemsAreGone = TestSubscriber.create<Boolean>()
+    private val titleIsGone = TestSubscriber.create<Boolean>()
+    private val titleForReward = TestSubscriber.create<String>()
+    private val titleForNoReward = TestSubscriber.create<Int>()
+
+    private fun setUpEnvironment(@NonNull environment: Environment) {
+        this.vm = AddOnViewHolderViewModel.ViewModel(environment)
+        this.vm.outputs.quantityIsGone().subscribe(this.quantityIsGone)
+        this.vm.outputs.conversion().subscribe(this.conversion)
+        this.vm.outputs.conversionIsGone().subscribe(this.conversionIsGone)
+        this.vm.outputs.descriptionForNoReward().subscribe(this.descriptionForNoReward)
+        this.vm.outputs.descriptionForReward().subscribe(this.descriptionForReward)
+        this.vm.outputs.rewardItems().subscribe(this.rewardItems)
+        this.vm.outputs.rewardItemsAreGone().subscribe(this.rewardItemsAreGone)
+        this.vm.outputs.titleForNoReward().subscribe(this.titleForNoReward)
+        this.vm.outputs.titleForReward().subscribe(this.titleForReward)
+        this.vm.outputs.titleIsGone().subscribe(this.titleIsGone)
+    }
+
+    @Test
+    fun testRewardWithoutAddon() {
+
+    }
+
+    @Test
+    fun testRewardWithOneAddOn() {
+
+    }
+
+    @Test
+    fun testRewardWithMultipleAddons() {
+
+    }
+
+    @Test
+    fun testRewardAndAddOnWithItems() {
+
+    }
+
+    @Test
+    fun testRewardNoRewardNoAddOns() {
+
+    }
+
+    @Test
+    fun testRewardWithAddOnsAndQuantity() {
+
+    }
+}

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnViewHolderViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels
 
+import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
@@ -17,13 +18,13 @@ class AddOnViewHolderViewModelTest : KSRobolectricTestCase() {
     private val descriptionForReward = TestSubscriber.create<String?>()
     private val rewardItems = TestSubscriber.create<List<RewardsItem>>()
     private val rewardItemsAreGone = TestSubscriber.create<Boolean>()
-    private val titleIsGone = TestSubscriber.create<Boolean>()
     private val titleForReward = TestSubscriber.create<String>()
     private val titleForNoReward = TestSubscriber.create<Int>()
+    private val titleForAddOn = TestSubscriber.create<Pair<String, Int>>()
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = AddOnViewHolderViewModel.ViewModel(environment)
-        this.vm.outputs.quantityIsGone().subscribe(this.quantityIsGone)
+        this.vm.outputs.isAddonTitleGone().subscribe(this.quantityIsGone)
         this.vm.outputs.conversion().subscribe(this.conversion)
         this.vm.outputs.conversionIsGone().subscribe(this.conversionIsGone)
         this.vm.outputs.descriptionForNoReward().subscribe(this.descriptionForNoReward)
@@ -32,7 +33,7 @@ class AddOnViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.rewardItemsAreGone().subscribe(this.rewardItemsAreGone)
         this.vm.outputs.titleForNoReward().subscribe(this.titleForNoReward)
         this.vm.outputs.titleForReward().subscribe(this.titleForReward)
-        this.vm.outputs.titleIsGone().subscribe(this.titleIsGone)
+        this.vm.outputs.titleForAddOn().subscribe(this.titleForAddOn)
     }
 
     @Test
@@ -62,6 +63,11 @@ class AddOnViewHolderViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testRewardWithAddOnsAndQuantity() {
+
+    }
+
+    @Test
+    fun testCurrencyIsGone() {
 
     }
 }


### PR DESCRIPTION
# 📲 What
- Now in backing fragment you can see your selected reward plus Add-ons

# 🤔 Why

- The website already allows you to pledge selecting add-ons, now as mobile user if you pledge to some project selecting add-ons as well you will see those reflected in the app.

# 🛠 How

New shared UI for rewards and Add-ons in backing fragment.

# 👀 See
- Reward with Add-Ons
![Screen Shot 2020-06-15 at 8 23 06 AM](https://user-images.githubusercontent.com/4083656/84675808-9cd06880-aee1-11ea-94eb-6ccc64fd1ddc.png)


# 📋 QA

- If you wanna QA this and do not have project with add-ons you can try this: 
Substitute the code in the function `com.kickstarter.ui.adapters.RewardAndAddOnsAdapter#populateDataForAddOns` for the code below: 
```   val rw1 = RewardFactory.backers().toBuilder().isAddOn(true).quantity(7).build()
        val rw2 = RewardFactory.endingSoon().toBuilder().isAddOn(true).quantity(4).build()
        val rw3 = RewardFactory.itemized().toBuilder().isAddOn(true).quantity(1).build()
        val rw4 = RewardFactory.multipleLocationShipping().toBuilder().isAddOn(true).quantity(10).build()
        val projectAndRw2 = listOf(Pair(project, rw1),Pair(project,rw2),Pair(project, rw3), Pair(project,rw4))
        rewardsAndAddOnsAdapter.populateDataForAddOns(projectAndRw2)
```

# Story 📖

[Add- Ons UI](https://kickstarter.atlassian.net/browse/NT-1290)
