### PR TITLE
NT-1347: Suggested reward amount experiment for no reward

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/models/OptimizelyExperiment.kt
+++ b/app/src/main/java/com/kickstarter/libs/models/OptimizelyExperiment.kt
@@ -10,10 +10,10 @@ class OptimizelyExperiment {
 
     enum class Variant(val rawValue: String?) {
         CONTROL(null),
-        VARIANT_1("variant-1"),
-        VARIANT_2("variant-2"),
-        VARIANT_3("variant-3"),
-        VARIANT_4("variant-4");
+        VARIANT_1("variant_1"),
+        VARIANT_2("variation_2"),
+        VARIANT_3("variation_3"),
+        VARIANT_4("variation_4");
 
         companion object {
             fun safeValueOf(rawValue: String?): Variant {

--- a/app/src/main/java/com/kickstarter/libs/models/OptimizelyExperiment.kt
+++ b/app/src/main/java/com/kickstarter/libs/models/OptimizelyExperiment.kt
@@ -4,13 +4,16 @@ class OptimizelyExperiment {
     enum class Key(val key: String) {
         PLEDGE_CTA_COPY("pledge_cta_copy"),
         CAMPAIGN_DETAILS("native_project_page_campaign_details"),
-        CREATOR_DETAILS("native_project_page_conversion_creator_details")
+        CREATOR_DETAILS("native_project_page_conversion_creator_details"),
+        SUGGESTED_NO_REWARD_AMOUNT("suggested_no_reward_amount")
     }
 
     enum class Variant(val rawValue: String?) {
         CONTROL(null),
         VARIANT_1("variant-1"),
-        VARIANT_2("variant-2");
+        VARIANT_2("variant-2"),
+        VARIANT_3("variant-3"),
+        VARIANT_4("variant-4");
 
         companion object {
             fun safeValueOf(rawValue: String?): Variant {

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -150,7 +150,7 @@ interface RewardViewHolderViewModel {
         private val titleForNoReward = BehaviorSubject.create<Int>()
         private val titleForReward = BehaviorSubject.create<String?>()
         private val titleIsGone = BehaviorSubject.create<Boolean>()
-        private val variantSuggestedAmount = BehaviorSubject.create<Int>()
+        private val variantSuggestedAmount = BehaviorSubject.create<Int?>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -174,10 +174,12 @@ interface RewardViewHolderViewModel {
 
             val reward = this.projectDataAndReward
                     .map { it.second }
+                    .compose<Pair<Reward, Int?>>(combineLatestPair(variantSuggestedAmount))
+                    .map { updateReward(it) }
 
             val project = this.projectDataAndReward
                     .map { it.first.project() }
-            
+
             val projectAndReward = this.projectDataAndReward
                     .map { Pair(it.first.project(), it.second) }
 
@@ -369,6 +371,14 @@ interface RewardViewHolderViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.estimatedDelivery)
 
+        }
+
+        private fun updateReward(rewardAndVariant: Pair<Reward, Int?>):Reward {
+            val reward = rewardAndVariant.first
+
+            val updatedMinimum = rewardAndVariant.second?.let { it.toDouble()  } ?: reward.minimum()
+
+            return reward.toBuilder().minimum(updatedMinimum).build()
         }
 
         private fun buttonIsGone(project: Project, reward: Reward, userCreatedProject: Boolean): Boolean {

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -373,10 +373,21 @@ interface RewardViewHolderViewModel {
 
         }
 
+        /**
+         * In case the `suggested_no_reward_amount` is active and the selected reward is no reward
+         * update the value with one of the variants. Otherwise return the reward as it is
+         *
+         * @param rewardAndVariant contains the selected reward and the variant value
+         *
+         * @return reward if modified value if needed
+         */
         private fun updateReward(rewardAndVariant: Pair<Reward, Int?>):Reward {
             val reward = rewardAndVariant.first
 
-            val updatedMinimum = rewardAndVariant.second?.let { it.toDouble()  } ?: reward.minimum()
+            val updatedMinimum = rewardAndVariant.second?.let {
+                if (RewardUtils.isNoReward(reward)) it.toDouble()
+                else reward.minimum()
+            } ?: reward.minimum()
 
             return reward.toBuilder().minimum(updatedMinimum).build()
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -170,15 +170,16 @@ interface RewardViewHolderViewModel {
             val reward = this.projectDataAndReward
                     .map { it.second }
                     .compose<Pair<Reward, Int?>>(combineLatestPair(variantSuggestedAmount))
+                    .distinctUntilChanged()
                     .map { updateReward(it) }
 
             val project = this.projectDataAndReward
                     .map { it.first.project() }
 
-            val projectAndReward = this.projectDataAndReward
-                    .map { it.first }
-                    .compose<Pair<ProjectData, Reward>>(combineLatestPair(reward))
-                    .map { Pair(it.first.project(), it.second) }
+            val projectAndReward = project
+                    .compose<Pair<Project, Reward>>(combineLatestPair(reward))
+                    .map { Pair(it.first, it.second) }
+                    .distinctUntilChanged()
 
             projectAndReward
                     .map { RewardViewUtils.styleCurrency(it.second.minimum(), it.first, this.ksCurrency) }
@@ -237,8 +238,8 @@ interface RewardViewHolderViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.descriptionIsGone)
 
-            projectAndReward
-                    .map { isSelectable(it.first, it.second) }
+            this.projectDataAndReward
+                    .map { isSelectable(it.first.project(), it.second) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.buttonIsEnabled)

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -6,6 +6,8 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUser
+import com.kickstarter.libs.models.OptimizelyExperiment
+import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.*
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
@@ -780,6 +782,56 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
                 .build()
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject), RewardFactory.noReward())
         this.titleIsGone.assertValue(false)
+        this.titleForReward.assertNoValues()
+        this.titleForNoReward.assertValue(R.string.You_pledged_without_a_reward)
+    }
+
+    @Test
+    fun testNoRewardSuggestedAmountExperimentVariant4() {
+        val environment = environment()
+                .toBuilder()
+                .optimizely(MockExperimentsClientType(OptimizelyExperiment.Variant.VARIANT_4))
+                .build()
+        setUpEnvironment(environment)
+
+        val noRewardBacking = BackingFactory.backing()
+                .toBuilder()
+                .reward(RewardFactory.noReward())
+                .rewardId(null)
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(noRewardBacking)
+                .build()
+        this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject), RewardFactory.noReward())
+
+        this.titleIsGone.assertValue(false)
+        this.minimumAmountTitle.assertValue("$50")
+        this.titleForReward.assertNoValues()
+        this.titleForNoReward.assertValue(R.string.You_pledged_without_a_reward)
+    }
+
+    @Test
+    fun testNoRewardSuggestedAmountExperimentVariant2() {
+        val environment = environment()
+                .toBuilder()
+                .optimizely(MockExperimentsClientType(OptimizelyExperiment.Variant.VARIANT_2))
+                .build()
+        setUpEnvironment(environment)
+
+        val noRewardBacking = BackingFactory.backing()
+                .toBuilder()
+                .reward(RewardFactory.noReward())
+                .rewardId(null)
+                .build()
+        val backedProject = ProjectFactory.backedProject()
+                .toBuilder()
+                .backing(noRewardBacking)
+                .build()
+        this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject), RewardFactory.noReward())
+
+        this.titleIsGone.assertValue(false)
+        this.minimumAmountTitle.assertValue("$10")
         this.titleForReward.assertNoValues()
         this.titleForNoReward.assertValue(R.string.You_pledged_without_a_reward)
     }


### PR DESCRIPTION
# 📲 What
Added a new experiment with several variants: 
![Screen Shot 2020-06-15 at 4 21 25 PM](https://user-images.githubusercontent.com/4083656/84715044-47697b00-af24-11ea-9da1-11eede70a486.png)

# 🤔 Why

Increase revenue from No reward options experiment

# 👀 See
Control Variant
![Screen Shot 2020-06-15 at 3 54 53 PM](https://user-images.githubusercontent.com/4083656/84715149-85ff3580-af24-11ea-8252-21337aa282b6.png)

Variant 4 
![Screen Shot 2020-06-15 at 3 53 46 PM](https://user-images.githubusercontent.com/4083656/84715174-91526100-af24-11ea-9d19-80b1a4f538d3.png)


# 📋 QA
- Log in on staging with a non-admin user
- make sure you have the deviceId added in the whitelist and in the android audiences

# Story 📖

[Implement Variants](https://kickstarter.atlassian.net/browse/NT-1347)
