### PR TITLE
NT-1346: Hide minimum pledge amount for no reward card

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardViewHolder.kt
@@ -95,7 +95,7 @@ class RewardViewHolder(private val view: View, val delegate: Delegate?, private 
         this.viewModel.outputs.shippingSummaryIsGone()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { ViewUtils.setGone(this.view.reward_shipping_summary, it)}
+                .subscribe { ViewUtils.setGone(this.view.reward_shipping_summary, it) }
 
         this.viewModel.outputs.minimumAmountTitle()
                 .compose(bindToLifecycle())
@@ -166,6 +166,14 @@ class RewardViewHolder(private val view: View, val delegate: Delegate?, private 
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
                 .subscribe { ViewUtils.setGone(this.view.reward_estimated_delivery_section, it) }
+
+        this.viewModel.outputs.isMinimumPledgeAmountGone()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe {
+                    ViewUtils.setGone(this.view.reward_conversion_text_view, it)
+                    ViewUtils.setGone(this.view.reward_minimum_text_view, it)
+                }
 
         RxView.clicks(this.view.reward_pledge_button)
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -114,6 +114,10 @@ interface RewardViewHolderViewModel {
 
         /** Emits the reward's title when `isReward` is true.  */
         fun titleForReward(): Observable<String?>
+
+        /** Emits a boolean that determines if the minimum pledge amount should be shown **/
+        fun isMinimumPledgeAmountGone(): Observable<Boolean>
+
     }
 
     class ViewModel(@NonNull environment: Environment) : ActivityViewModel<RewardViewHolder>(environment), Inputs, Outputs {
@@ -151,6 +155,7 @@ interface RewardViewHolderViewModel {
         private val titleForReward = BehaviorSubject.create<String?>()
         private val titleIsGone = BehaviorSubject.create<Boolean>()
         private val variantSuggestedAmount = BehaviorSubject.create<Int?>()
+        private val isMinimumPledgeAmountGone = BehaviorSubject.create<Boolean>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -369,6 +374,10 @@ interface RewardViewHolderViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.estimatedDelivery)
 
+            reward.map{RewardUtils.isNoReward(it)}
+                    .compose(bindToLifecycle())
+                    .subscribe(this.isMinimumPledgeAmountGone)
+
         }
 
         private fun rewardAmountByVariant(variant: OptimizelyExperiment.Variant?):Int? = when(variant) {
@@ -507,5 +516,8 @@ interface RewardViewHolderViewModel {
 
         @NonNull
         override fun titleIsGone(): Observable<Boolean> = this.titleIsGone
+
+        @NonNull
+        override fun isMinimumPledgeAmountGone(): Observable<Boolean> = this.isMinimumPledgeAmountGone
     }
 }


### PR DESCRIPTION
# 📲 What

Hide the minimum pledge amount from no-reward cards.

# 🤔 Why

We want to run experiments with suggested minimum amounts for different audiences, and this change is needed in order to efficiently run that experient.

# 🛠 How

I created a new Observable in RewardViewModelViewhHolder that emits whether or not a reward item is of the "no-reward" type. If that value is true, and it's a no-reward, we hide the amount and conversion text fields.

# 👀 See

<img width="515" alt="Screen Shot 2020-06-17 at 8 23 03 PM" src="https://user-images.githubusercontent.com/7025946/84963893-a7a11e00-b0d8-11ea-9698-0f4a4d615a4c.png">


# 📋 QA

Check to ensure that the $ amount indicator has been removed from the “Pledge without a reward” card in the Reward Carousel for the control as well as all experimental variants 

# Story 📖

https://kickstarter.atlassian.net/secure/RapidBoard.jspa?rapidView=9&modal=detail&selectedIssue=NT-1346