### PR TITLE
NT-606: Update strings to reflect backer's state in creator view

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -41,7 +41,7 @@ import kotlinx.android.synthetic.main.reward_card_details.*
 
 
 @RequiresFragmentViewModel(BackingFragmentViewModel.ViewModel::class)
-class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>(){
+class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>() {
 
     private var rewardsAndAddOnsAdapter = RewardAndAddOnsAdapter()
 
@@ -266,7 +266,7 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>(){
 
     private fun populateAddOns(projectAndAddOn: Pair<ProjectData, List<Reward>>) {
         val project = projectAndAddOn.first
-        val addOns  = projectAndAddOn.second
+        val addOns = projectAndAddOn.second
         val listData = addOns.map {
             Pair(project, it)
         }.toList()
@@ -315,6 +315,13 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>(){
                             "total", pledgeStatusData.pledgeTotal,
                             "project_deadline", pledgeStatusData.projectDeadline)
                 }
+
+                R.string.If_your_project_reaches_its_funding_goal_the_backer_will_be_charged_total_on_project_deadline -> {
+                    ksString.format(getString(it),
+                            "total", pledgeStatusData.pledgeTotal,
+                            "project_deadline", pledgeStatusData.projectDeadline)
+                }
+
                 else -> getString(it)
             }
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -9,10 +9,7 @@ import com.kickstarter.libs.FragmentViewModel
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.rx.transformers.Transformers.*
 import com.kickstarter.libs.utils.*
-import com.kickstarter.models.Backing
-import com.kickstarter.models.Project
-import com.kickstarter.models.Reward
-import com.kickstarter.models.StoredCard
+import com.kickstarter.models.*
 import com.kickstarter.ui.data.PledgeStatusData
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.ui.fragments.BackingFragment
@@ -168,7 +165,7 @@ interface BackingFragmentViewModel {
         private val showUpdatePledgeSuccess = PublishSubject.create<Void>()
         private val swipeRefresherProgressIsVisible = BehaviorSubject.create<Boolean>()
         private val totalAmount = BehaviorSubject.create<CharSequence>()
-        private val addOnsList = BehaviorSubject.create<Pair<ProjectData,List<Reward>>>()
+        private val addOnsList = BehaviorSubject.create<Pair<ProjectData, List<Reward>>>()
         private val bonusSupport = BehaviorSubject.create<CharSequence>()
         private val estimatedDelivery = BehaviorSubject.create<String>()
         private val deliveryDisclaimerSectionIsGone = BehaviorSubject.create<Boolean>()
@@ -429,6 +426,7 @@ interface BackingFragmentViewModel {
             return Pair(projectData, reward)
         }
 
+
         private fun cardIssuer(paymentSource: Backing.PaymentSource): Either<String, Int> {
             return when (CreditCardPaymentType.safeValueOf(paymentSource.paymentType())) {
                 CreditCardPaymentType.ANDROID_PAY -> Either.Right(R.string.googlepay_button_content_description)
@@ -448,23 +446,49 @@ interface BackingFragmentViewModel {
         }
 
         private fun pledgeStatusData(project: Project, backing: Backing): PledgeStatusData {
-            val statusStringRes = when (project.state()) {
-                Project.STATE_CANCELED -> R.string.The_creator_canceled_this_project_so_your_payment_method_was_never_charged
-                Project.STATE_FAILED -> R.string.This_project_didnt_reach_its_funding_goal_so_your_payment_method_was_never_charged
-                else -> when (backing.status()) {
-                    Backing.STATUS_CANCELED -> R.string.You_canceled_your_pledge_for_this_project
-                    Backing.STATUS_COLLECTED -> R.string.We_collected_your_pledge_for_this_project
-                    Backing.STATUS_DROPPED -> R.string.Your_pledge_was_dropped_because_of_payment_errors
-                    Backing.STATUS_ERRORED -> R.string.We_cant_process_your_pledge_Please_update_your_payment_method
-                    Backing.STATUS_PLEDGED -> R.string.If_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline
-                    Backing.STATUS_PREAUTH -> R.string.We_re_processing_your_pledge_pull_to_refresh
-                    else -> null
+
+            var statusStringRes: Int? = 0
+
+            environment.currentUser().loggedInUser().subscribe {
+
+                if (!ProjectUtils.userIsCreator(project, it)) {
+                    statusStringRes = when (project.state()) {
+                        Project.STATE_CANCELED -> R.string.The_creator_canceled_this_project_so_your_payment_method_was_never_charged
+                        Project.STATE_FAILED -> R.string.This_project_didnt_reach_its_funding_goal_so_your_payment_method_was_never_charged
+                        else -> when (backing.status()) {
+                            Backing.STATUS_CANCELED -> R.string.You_canceled_your_pledge_for_this_project
+                            Backing.STATUS_COLLECTED -> R.string.We_collected_your_pledge_for_this_project
+                            Backing.STATUS_DROPPED -> R.string.Your_pledge_was_dropped_because_of_payment_errors
+                            Backing.STATUS_ERRORED -> R.string.We_cant_process_your_pledge_Please_update_your_payment_method
+                            Backing.STATUS_PLEDGED -> R.string.If_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline
+                            Backing.STATUS_PREAUTH -> R.string.We_re_processing_your_pledge_pull_to_refresh
+                            else -> null
+                        }
+                    }
+                } else {
+
+                    statusStringRes = when (project.state()) {
+                        Project.STATE_CANCELED -> R.string.You_canceled_this_project_so_the_backers_payment_method_was_never_charged
+                        Project.STATE_FAILED -> R.string.Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged
+                        else -> when (backing.status()) {
+                            Backing.STATUS_CANCELED -> R.string.The_backer_canceled_their_pledge_for_this_project
+                            Backing.STATUS_COLLECTED -> R.string.We_collected_the_backers_pledge_for_this_project
+                            Backing.STATUS_DROPPED -> R.string.This_pledge_was_dropped_because_of_payment_errors
+                            Backing.STATUS_ERRORED -> R.string.We_cant_process_this_pledge_because_of_a_problem_with_the_backers_payment_method
+                            Backing.STATUS_PLEDGED -> R.string.If_your_project_reaches_its_funding_goal_the_backer_will_be_charged_total_on_project_deadline
+                            Backing.STATUS_PREAUTH -> R.string.We_re_processing_this_pledge_pull_to_refresh
+                            else -> null
+                        }
+                    }
                 }
             }
 
+
             val projectDeadline = project.deadline()?.let { DateTimeUtils.longDate(it) }
             val pledgeTotal = backing.amount().let { this.ksCurrency.format(it, project) }
+
             return PledgeStatusData(statusStringRes, pledgeTotal, projectDeadline)
+
         }
 
         override fun configureWith(projectData: ProjectData) {

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -239,8 +239,8 @@ interface BackingFragmentViewModel {
                         this.shippingSummaryIsGone.onNext(it)
                     }
 
-            Observable.combineLatest(backedProject, backing) { p, b -> Pair(p, b) }
-                    .map { pledgeStatusData(it.first, it.second) }
+            Observable.combineLatest(backedProject, backing, environment.currentUser().loggedInUser()) { p, b, user -> Triple(p, b, user) }
+                    .map { pledgeStatusData(it.first, it.second, it.third) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.pledgeStatusData)
@@ -445,40 +445,37 @@ interface BackingFragmentViewModel {
             }
         }
 
-        private fun pledgeStatusData(project: Project, backing: Backing): PledgeStatusData {
+        private fun pledgeStatusData(project: Project, backing: Backing, user: User): PledgeStatusData {
 
-            var statusStringRes: Int? = 0
+            var statusStringRes: Int?
 
-            environment.currentUser().loggedInUser().subscribe {
-
-                if (!ProjectUtils.userIsCreator(project, it)) {
-                    statusStringRes = when (project.state()) {
-                        Project.STATE_CANCELED -> R.string.The_creator_canceled_this_project_so_your_payment_method_was_never_charged
-                        Project.STATE_FAILED -> R.string.This_project_didnt_reach_its_funding_goal_so_your_payment_method_was_never_charged
-                        else -> when (backing.status()) {
-                            Backing.STATUS_CANCELED -> R.string.You_canceled_your_pledge_for_this_project
-                            Backing.STATUS_COLLECTED -> R.string.We_collected_your_pledge_for_this_project
-                            Backing.STATUS_DROPPED -> R.string.Your_pledge_was_dropped_because_of_payment_errors
-                            Backing.STATUS_ERRORED -> R.string.We_cant_process_your_pledge_Please_update_your_payment_method
-                            Backing.STATUS_PLEDGED -> R.string.If_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline
-                            Backing.STATUS_PREAUTH -> R.string.We_re_processing_your_pledge_pull_to_refresh
-                            else -> null
-                        }
+            if (!ProjectUtils.userIsCreator(project, user)) {
+                statusStringRes = when (project.state()) {
+                    Project.STATE_CANCELED -> R.string.The_creator_canceled_this_project_so_your_payment_method_was_never_charged
+                    Project.STATE_FAILED -> R.string.This_project_didnt_reach_its_funding_goal_so_your_payment_method_was_never_charged
+                    else -> when (backing.status()) {
+                        Backing.STATUS_CANCELED -> R.string.You_canceled_your_pledge_for_this_project
+                        Backing.STATUS_COLLECTED -> R.string.We_collected_your_pledge_for_this_project
+                        Backing.STATUS_DROPPED -> R.string.Your_pledge_was_dropped_because_of_payment_errors
+                        Backing.STATUS_ERRORED -> R.string.We_cant_process_your_pledge_Please_update_your_payment_method
+                        Backing.STATUS_PLEDGED -> R.string.If_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline
+                        Backing.STATUS_PREAUTH -> R.string.We_re_processing_your_pledge_pull_to_refresh
+                        else -> null
                     }
-                } else {
+                }
+            } else {
 
-                    statusStringRes = when (project.state()) {
-                        Project.STATE_CANCELED -> R.string.You_canceled_this_project_so_the_backers_payment_method_was_never_charged
-                        Project.STATE_FAILED -> R.string.Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged
-                        else -> when (backing.status()) {
-                            Backing.STATUS_CANCELED -> R.string.The_backer_canceled_their_pledge_for_this_project
-                            Backing.STATUS_COLLECTED -> R.string.We_collected_the_backers_pledge_for_this_project
-                            Backing.STATUS_DROPPED -> R.string.This_pledge_was_dropped_because_of_payment_errors
-                            Backing.STATUS_ERRORED -> R.string.We_cant_process_this_pledge_because_of_a_problem_with_the_backers_payment_method
-                            Backing.STATUS_PLEDGED -> R.string.If_your_project_reaches_its_funding_goal_the_backer_will_be_charged_total_on_project_deadline
-                            Backing.STATUS_PREAUTH -> R.string.We_re_processing_this_pledge_pull_to_refresh
-                            else -> null
-                        }
+                statusStringRes = when (project.state()) {
+                    Project.STATE_CANCELED -> R.string.You_canceled_this_project_so_the_backers_payment_method_was_never_charged
+                    Project.STATE_FAILED -> R.string.Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged
+                    else -> when (backing.status()) {
+                        Backing.STATUS_CANCELED -> R.string.The_backer_canceled_their_pledge_for_this_project
+                        Backing.STATUS_COLLECTED -> R.string.We_collected_the_backers_pledge_for_this_project
+                        Backing.STATUS_DROPPED -> R.string.This_pledge_was_dropped_because_of_payment_errors
+                        Backing.STATUS_ERRORED -> R.string.We_cant_process_this_pledge_because_of_a_problem_with_the_backers_payment_method
+                        Backing.STATUS_PLEDGED -> R.string.If_your_project_reaches_its_funding_goal_the_backer_will_be_charged_total_on_project_deadline
+                        Backing.STATUS_PREAUTH -> R.string.We_re_processing_this_pledge_pull_to_refresh
+                        else -> null
                     }
                 }
             }

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -4,8 +4,10 @@ import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
+import com.kickstarter.libs.CurrentUserType
 import com.kickstarter.libs.Either
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.MockCurrentUser
 import com.kickstarter.libs.utils.DateTimeUtils
 import com.kickstarter.mock.factories.*
 import com.kickstarter.mock.services.MockApolloClient
@@ -499,6 +501,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
 
         val environment = environment()
                 .toBuilder()
+                .currentUser(MockCurrentUser(UserFactory.user()))
                 .apolloClient(mockApolloClientForBacking(backing))
                 .build()
         setUpEnvironment(environment)
@@ -522,6 +525,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environment()
                 .toBuilder()
                 .apolloClient(mockApolloClientForBacking(backing))
+                .currentUser(MockCurrentUser(UserFactory.user()))
                 .build()
         setUpEnvironment(environment)
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
@@ -543,6 +547,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environment()
                 .toBuilder()
                 .apolloClient(mockApolloClientForBacking(backing))
+                .currentUser(MockCurrentUser(UserFactory.user()))
                 .build()
         setUpEnvironment(environment)
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
@@ -565,6 +570,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environment()
                 .toBuilder()
                 .apolloClient(mockApolloClientForBacking(backing))
+                .currentUser(MockCurrentUser(UserFactory.user()))
                 .build()
         setUpEnvironment(environment)
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
@@ -587,6 +593,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environment()
                 .toBuilder()
                 .apolloClient(mockApolloClientForBacking(backing))
+                .currentUser(MockCurrentUser(UserFactory.user()))
                 .build()
         setUpEnvironment(environment)
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
@@ -609,6 +616,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environment()
                 .toBuilder()
                 .apolloClient(mockApolloClientForBacking(backing))
+                .currentUser(MockCurrentUser(UserFactory.user()))
                 .build()
         setUpEnvironment(environment)
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
@@ -630,6 +638,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environment()
                 .toBuilder()
                 .apolloClient(mockApolloClientForBacking(backing))
+                .currentUser(MockCurrentUser(UserFactory.user()))
                 .build()
         setUpEnvironment(environment)
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))
@@ -651,6 +660,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         val environment = environment()
                 .toBuilder()
                 .apolloClient(mockApolloClientForBacking(backing))
+                .currentUser(MockCurrentUser(UserFactory.user()))
                 .build()
         setUpEnvironment(environment)
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject))


### PR DESCRIPTION
# 📲 What

Show the status of a backing to a creator.

# 🤔 Why

Creators will want to see the status of a pledge/backing, to have more context into the status of that pledge.

# 🛠 How

In PledgeFragmentViewModel, I check to see if the currently logged in user is a creator or not. Depending on the case, I fetch a different set of strings from our resource files.

# 👀 See
<img width="519" alt="Screen Shot 2020-06-29 at 9 55 54 AM" src="https://user-images.githubusercontent.com/7025946/86017945-acc46e00-b9f2-11ea-8005-0a6801242f84.png">
<img width="524" alt="Screen Shot 2020-06-29 at 9 55 31 AM" src="https://user-images.githubusercontent.com/7025946/86017956-b057f500-b9f2-11ea-9b22-cf4dfdd96fc7.png">
<img width="530" alt="Screen Shot 2020-06-29 at 9 55 01 AM" src="https://user-images.githubusercontent.com/7025946/86017960-b3eb7c00-b9f2-11ea-8253-4bdfd7afd361.png">


# 📋 QA
The strings for creators show as follows: 

Canceled (by creator) - "You canceled this project, so the backer’s payment method was never charged."

Canceled (by backer) - “The backer canceled their pledge for this project.”

Collected - “We collected the backer’s pledge for this project.”

Dropped - “This pledge was dropped because of payment errors.”

Pledged - “If your project reaches its funding goal, the backer will be charged on November 5, 2019.”

Unsuccessful Project - “Your project didn’t reach its funding goal, so the backer’s payment method was never charged."

Errored - “We can’t process this pledge because of a problem with the backer's payment method.”

# Story 📖

https://kickstarter.atlassian.net/secure/RapidBoard.jspa?rapidView=9&modal=detail&selectedIssue=NT-606