### PR TITLE
NT-1171: (Fixed) Manage Pledge View Backing Info updates

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -205,7 +205,7 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>(){
                     val stringToBold = getString(R.string.rewards_info_estimated_delivery)
                     setBoldSpanOnTextView(stringToBold.length, estimated_delivery_label)
 
-                    estimated_delivery_label_2.text = "${estimated_delivery_label_2.text} $it"
+                    estimated_delivery_label_2.text = "${getString(R.string.Estimated_delivery)} $it"
                     setBoldSpanOnTextView(stringToBold.length, estimated_delivery_label_2)
 
                 }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -272,7 +272,6 @@ interface BackingFragmentViewModel {
                     .subscribe(this.totalAmount)
 
 
-
             backing
                     .map { it.paymentSource() }
                     .map { CreditCardPaymentType.safeValueOf(it?.paymentType()) }

--- a/app/src/main/res/layout/fragment_pledge_section_summary_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_summary_pledge.xml
@@ -23,7 +23,7 @@
 
   <TextView
     android:id="@+id/pledge_summary_amount"
-    style="@style/PledgeCurrency"
+    style="@style/PledgeCurrencySecondary"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:gravity="center_vertical|end"


### PR DESCRIPTION
This PR address the rejected items from the UAT checklist
https://kickstarter.atlassian.net/secure/RapidBoard.jspa?rapidView=9&modal=detail&selectedIssue=NT-1171

# 📲 What

Make changes to the Manage Pledge view to reflect the addition of the bonus support field, and some new UI changes.

# 🤔 Why

To begin adding support for backers who want to pledge a little extra to a project, and to make necessary UI changes that will be needed for add ons.

# 🛠 How

New UI changes that show bonus support, estimated delivery date and checkbox, and minor copy changes.

# 👀 See

<img width="507" alt="Screen Shot 2020-06-16 at 7 50 28 PM" src="https://user-images.githubusercontent.com/7025946/84840368-57a95500-b00d-11ea-9778-c05dbc91826e.png">


# 📋 QA
Users may view Add Ons they have backed on the web when viewing the View/Manage pledge screen 

In the list of numbers, a line called “Bonus” is added beneath shipping that denotes the amount of bonus support added by the backer

In the list of numbers, “Total amount” becomes “Total”

The Reward section is displayed with the title “Your pledge details”

The latest delivery date is displayed above the primary reward

Delivery dates are hidden from reward cards

The “Reward delivered” checkbox is displayed below the estimated delivery date

A section of helper copy/disclaimer copy is displayed above the primary reward

Design matches Figma 

Creators may view Add Ons a user has backed on the web when they view the pledge for a given backer

In the list of numbers, a line called “Bonus” is added beneath shipping that denotes the amount of bonus support added by the backer

In the list of numbers, “Total amount” becomes “Total”

The Reward section is displayed with the title “Pledge details”

The latest delivery date is displayed above the primary reward

Design matches Figma 

# Story 📖

https://kickstarter.atlassian.net/secure/RapidBoard.jspa?rapidView=9&modal=detail&selectedIssue=NT-1171