### PR TITLE
NT-1347:(Fixed) No reward amount experiment, helper string

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
@@ -17,8 +17,6 @@ import java.util.List;
 
 import androidx.annotation.NonNull;
 
-import static com.kickstarter.libs.models.OptimizelyExperiment.Variant.*;
-
 public final class RewardUtils {
   private RewardUtils() {}
 
@@ -187,6 +185,14 @@ public final class RewardUtils {
     return (int) Math.floor(seconds / 60.0 / 60.0 / 24.0); // days
   }
 
+  /**
+   * Returns the amount value for each variant, being Control the original value
+   *
+   * @param variant the variant for which you want to get the value
+   * @param reward in case no known variant as save return use the current reward.minimum amount
+   *
+   * @return Double with the amount
+   */
   public static Double rewardAmountByVariant(final OptimizelyExperiment.Variant variant, final Reward reward) {
     Double value = reward.minimum();
     switch (variant) {
@@ -202,7 +208,7 @@ public final class RewardUtils {
       case VARIANT_4:
         value = 50.0;
         break;
-    };
+    }
 
     return value;
   }

--- a/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
@@ -5,6 +5,7 @@ import android.util.Pair;
 
 import com.kickstarter.R;
 import com.kickstarter.libs.KSString;
+import com.kickstarter.libs.models.OptimizelyExperiment;
 import com.kickstarter.models.Project;
 import com.kickstarter.models.Reward;
 import com.kickstarter.models.RewardsItem;
@@ -15,6 +16,8 @@ import org.joda.time.Duration;
 import java.util.List;
 
 import androidx.annotation.NonNull;
+
+import static com.kickstarter.libs.models.OptimizelyExperiment.Variant.*;
 
 public final class RewardUtils {
   private RewardUtils() {}
@@ -182,5 +185,25 @@ public final class RewardUtils {
       return (int) Math.floor(seconds / 60.0 / 60.0); // hours
     }
     return (int) Math.floor(seconds / 60.0 / 60.0 / 24.0); // days
+  }
+
+  public static Double rewardAmountByVariant(final OptimizelyExperiment.Variant variant, final Reward reward) {
+    Double value = reward.minimum();
+    switch (variant) {
+      case CONTROL:
+        value = 1.0;
+        break;
+      case VARIANT_2:
+        value = 10.0;
+        break;
+      case VARIANT_3:
+        value = 20.0;
+        break;
+      case VARIANT_4:
+        value = 50.0;
+        break;
+    };
+
+    return value;
   }
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
@@ -6,6 +6,7 @@ import android.util.Pair;
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.R;
 import com.kickstarter.libs.KSString;
+import com.kickstarter.libs.models.OptimizelyExperiment;
 import com.kickstarter.mock.factories.LocationFactory;
 import com.kickstarter.mock.factories.ProjectFactory;
 import com.kickstarter.mock.factories.RewardFactory;
@@ -304,6 +305,15 @@ public final class RewardUtilsTest extends KSRobolectricTestCase {
 
     final Reward rewardWithWorldWideShipping = RewardFactory.rewardWithShipping();
     assertEquals(Pair.create(R.string.Ships_worldwide, null), RewardUtils.shippingSummary(rewardWithWorldWideShipping));
+  }
+
+  @Test
+  public void minimumRewardAmountByVariant() {
+    final Reward noReward = RewardFactory.noReward();
+    assertEquals(1.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, noReward));
+    assertEquals(10.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_2, noReward));
+    assertEquals(20.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_3, noReward));
+    assertEquals(50.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward));
   }
 
   @Test


### PR DESCRIPTION
# 📲 What

- Helper string must not be updated with the variant amount, meaning that, if we are running this experiment, even though the suggested amount has changed, the helper should remain with the control amount.
- Added helper method on RewardUtils to fetch the amount for each variant

# 🤔 Why

Running experiments on the suggested amount for no rewards

# 🛠 How
The output for the amount in the string helper has been updated, in case is a regular reward, same as before. In case is a `No Reward` use the Control varian amount.

# 👀 See
- On left image, a `No Reward` but with variant 4 active, so the amount should be `50`, but the helper remains the control variant
- On right image a regular reward, no behavior changes in there
<img width="983" alt="Screen Shot 2020-06-29 at 2 24 06 PM" src="https://user-images.githubusercontent.com/4083656/86058304-87952700-ba15-11ea-89c1-e5fb69512ef8.png">


|  |  |

# 📋 QA

* try at least two variants
* try a regular reward

# Story 📖

[No reward experiment](https://kickstarter.atlassian.net/browse/NT-1347)
