### PR TITLE
NT-1326: (Fixed) Expandable Header UI

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -337,6 +337,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .subscribe {
                     ViewUtils.setGone(total_amount_loading_view, true)
                     total_amount.text = it
+                    pledge_header_summary_amount.text = it
                 }
 
         this.viewModel.outputs.totalAndDeadline()


### PR DESCRIPTION
# 📲 What

After PR conflicts merged& rebases, the total amount for the new summary header was lost

# 👀 See
![Screen Shot 2020-06-29 at 3 25 57 PM](https://user-images.githubusercontent.com/4083656/86062136-e316e300-ba1c-11ea-8e69-245116a7e362.png)


|  |  |

# 📋 QA

* Check the Two lines reward (easier to get one when using a low density device
* total amount in all the rewards in the expandable header

# Story 📖

[Name of Trello Story](Trello link)
