### PR TITLE
NT-1290: (Fixed) Manage Pledge Add ons UI - No title in reward from creator perspective

### DIFF
--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -584,13 +584,14 @@ private fun createBackingObject(backingGr: fragment.Backing?): Backing {
         }
 
         return@let Reward.builder()
-        .minimum(rewardAmount?: -1.0)
-        .description(reward.description())
-        .isAddOn(false)
-        .estimatedDeliveryOn(DateTime(reward.estimatedDeliveryOn()))
-        .shippingSingleLocation(rewardSingleLocation)
-        .id(rewardId)
-        .build()
+                .title(reward.name())
+                .minimum(rewardAmount?: -1.0)
+                .description(reward.description())
+                .isAddOn(false)
+                .estimatedDeliveryOn(DateTime(reward.estimatedDeliveryOn()))
+                .shippingSingleLocation(rewardSingleLocation)
+                .id(rewardId)
+                .build()
     }
 
     val backerData = backingGr?.backer()?.fragments()?.user()


### PR DESCRIPTION
# 📲 What

* we weren't parsing the title from the graph request for the creator perspective

# 👀 See

| Before 🐛 | After 🦋 |
![Screen Shot 2020-06-29 at 4 13 27 PM](https://user-images.githubusercontent.com/4083656/86065258-0002e480-ba24-11ea-889d-ec00115b86eb.png)

|  |  |

# 📋 QA

* Rewiew as creator

# Story 📖

[Backing Fragment Add-ons UI](https://kickstarter.atlassian.net/browse/NT-1290)
