### PR TITLE
[NT-1402]- Reward card UI tag

### DIFF
--- a/app/src/main/java/com/kickstarter/models/Reward.java
+++ b/app/src/main/java/com/kickstarter/models/Reward.java
@@ -37,7 +37,7 @@ public abstract class Reward implements Parcelable, Relay {
   public abstract @Nullable boolean isAddOn();
   public abstract @Nullable List<RewardsItem> addOnsItems();
   public abstract @Nullable Integer quantity();
-  public abstract @Nullable Boolean hasAddOns();
+  public abstract @Nullable boolean hasAddOns();
 
   @AutoParcel.Builder
   public abstract static class Builder {
@@ -58,7 +58,7 @@ public abstract class Reward implements Parcelable, Relay {
     public abstract Builder isAddOn(boolean __);
     public abstract Builder addOnsItems(List<RewardsItem> __);
     public abstract Builder quantity(Integer __);
-    public abstract Builder hasAddOns(Boolean __);
+    public abstract Builder hasAddOns(boolean __);
     public abstract Reward build();
   }
 

--- a/app/src/main/java/com/kickstarter/models/Reward.java
+++ b/app/src/main/java/com/kickstarter/models/Reward.java
@@ -37,7 +37,7 @@ public abstract class Reward implements Parcelable, Relay {
   public abstract @Nullable boolean isAddOn();
   public abstract @Nullable List<RewardsItem> addOnsItems();
   public abstract @Nullable Integer quantity();
-  public abstract @Nullable boolean hasAddOns();
+  public abstract @Nullable boolean hasAddons();
 
   @AutoParcel.Builder
   public abstract static class Builder {
@@ -58,7 +58,7 @@ public abstract class Reward implements Parcelable, Relay {
     public abstract Builder isAddOn(boolean __);
     public abstract Builder addOnsItems(List<RewardsItem> __);
     public abstract Builder quantity(Integer __);
-    public abstract Builder hasAddOns(boolean __);
+    public abstract Builder hasAddons(boolean __);
     public abstract Reward build();
   }
 

--- a/app/src/main/java/com/kickstarter/models/Reward.java
+++ b/app/src/main/java/com/kickstarter/models/Reward.java
@@ -2,7 +2,6 @@ package com.kickstarter.models;
 
 import android.os.Parcelable;
 
-import com.kickstarter.libs.Build;
 import com.kickstarter.libs.qualifiers.AutoGson;
 
 import org.joda.time.DateTime;

--- a/app/src/main/java/com/kickstarter/models/Reward.java
+++ b/app/src/main/java/com/kickstarter/models/Reward.java
@@ -2,6 +2,7 @@ package com.kickstarter.models;
 
 import android.os.Parcelable;
 
+import com.kickstarter.libs.Build;
 import com.kickstarter.libs.qualifiers.AutoGson;
 
 import org.joda.time.DateTime;
@@ -36,6 +37,7 @@ public abstract class Reward implements Parcelable, Relay {
   public abstract @Nullable boolean isAddOn();
   public abstract @Nullable List<RewardsItem> addOnsItems();
   public abstract @Nullable Integer quantity();
+  public abstract @Nullable Boolean hasAddOns();
 
   @AutoParcel.Builder
   public abstract static class Builder {
@@ -56,6 +58,7 @@ public abstract class Reward implements Parcelable, Relay {
     public abstract Builder isAddOn(boolean __);
     public abstract Builder addOnsItems(List<RewardsItem> __);
     public abstract Builder quantity(Integer __);
+    public abstract Builder hasAddOns(Boolean __);
     public abstract Reward build();
   }
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardViewHolder.kt
@@ -170,6 +170,16 @@ class RewardViewHolder(private val view: View, val delegate: Delegate?, private 
         RxView.clicks(this.view.reward_pledge_button)
                 .compose(bindToLifecycle())
                 .subscribe { this.viewModel.inputs.rewardClicked(this.adapterPosition) }
+
+        this.viewModel.outputs.hasAddOnsAvailable()
+                .filter { ObjectUtils.isNotNull(it) }
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { hasAddOns ->
+                    if (hasAddOns) this.view.reward_add_ons_available.visibility = View.VISIBLE
+                    else ViewUtils.setGone(this.view.reward_add_ons_available, true)
+                }
+
     }
 
     override fun bindData(data: Any?) {

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -113,6 +113,9 @@ interface RewardViewHolderViewModel {
 
         /** Emits the reward's title when `isReward` is true.  */
         fun titleForReward(): Observable<String?>
+
+        /** Emits if the reward has add-Ons available */
+        fun hasAddOnsAvailable(): Observable<Boolean>
     }
 
     class ViewModel(@NonNull environment: Environment) : ActivityViewModel<RewardViewHolder>(environment), Inputs, Outputs {
@@ -148,6 +151,7 @@ interface RewardViewHolderViewModel {
         private val titleForNoReward = BehaviorSubject.create<Int>()
         private val titleForReward = BehaviorSubject.create<String?>()
         private val titleIsGone = BehaviorSubject.create<Boolean>()
+        private val addOnsAvailable = BehaviorSubject.create<Boolean>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -256,6 +260,11 @@ interface RewardViewHolderViewModel {
             reward
                     .compose(bindToLifecycle())
                     .subscribe(this.reward)
+
+            reward
+                    .map { it.hasAddOns() }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.addOnsAvailable)
 
             projectAndReward
                     .map { expirationDateIsGone(it.first, it.second) }
@@ -462,5 +471,8 @@ interface RewardViewHolderViewModel {
 
         @NonNull
         override fun titleIsGone(): Observable<Boolean> = this.titleIsGone
+
+        @NonNull
+        override fun hasAddOnsAvailable(): Observable<Boolean> = this.addOnsAvailable
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -262,7 +262,7 @@ interface RewardViewHolderViewModel {
                     .subscribe(this.reward)
 
             reward
-                    .map { it.hasAddOns() }
+                    .map { it.hasAddons() }
                     .compose(bindToLifecycle())
                     .subscribe(this.addOnsAvailable)
 

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -172,6 +172,14 @@
             android:layout_height="wrap_content"
             tools:text="Anywhere in the world" />
 
+          <TextView
+              android:id="@+id/reward_add_ons_available"
+              style="@style/RewardPill"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:text="@string/Add_ons_available"
+              tools:text="Add-ons available" />
+
         </com.google.android.flexbox.FlexboxLayout>
 
         </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,5 +71,6 @@
   <string name="Take_our_survey_to_help_us_make_a_better_app_for_you">Take our survey to help us make a better app for you.</string>
   <string name="No_thanks">No thanks</string>
   <string name="Let_s_go">Let\'s go</string>
+  <string name="Add_ons_available">Add-Ons available</string>
 
 </resources>

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -771,7 +771,7 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
     fun testReward_HasAddOnsAvailable() {
         setUpEnvironment(environment())
 
-        this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.project()), RewardFactory.reward().toBuilder().hasAddOns(true).build())
+        this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.project()), RewardFactory.reward().toBuilder().hasAddons(true).build())
         this.hasAddonsAvailable.assertValue(true)
     }
 
@@ -779,7 +779,7 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
     fun testReward_No_HasAddOnsAvailable() {
         setUpEnvironment(environment())
 
-        this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.project()), RewardFactory.reward().toBuilder().hasAddOns(false).build())
+        this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.project()), RewardFactory.reward().toBuilder().hasAddons(false).build())
         this.hasAddonsAvailable.assertValue(false)
     }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -44,6 +44,7 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
     private val titleForNoReward = TestSubscriber<Int>()
     private val titleForReward = TestSubscriber<String?>()
     private val titleIsGone = TestSubscriber<Boolean>()
+    private val hasAddonsAvailable = TestSubscriber<Boolean>()
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = RewardViewHolderViewModel.ViewModel(environment)
@@ -73,6 +74,7 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.titleForNoReward().subscribe(this.titleForNoReward)
         this.vm.outputs.titleForReward().subscribe(this.titleForReward)
         this.vm.outputs.titleIsGone().subscribe(this.titleIsGone)
+        this.vm.outputs.hasAddOnsAvailable().subscribe(this.hasAddonsAvailable)
     }
 
     @Test
@@ -763,6 +765,22 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
         this.titleIsGone.assertValues(false)
         this.titleForReward.assertNoValues()
         this.titleForNoReward.assertValue(R.string.Pledge_without_a_reward)
+    }
+
+    @Test
+    fun testReward_HasAddOnsAvailable() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.project()), RewardFactory.reward().toBuilder().hasAddOns(true).build())
+        this.hasAddonsAvailable.assertValue(true)
+    }
+
+    @Test
+    fun testReward_No_HasAddOnsAvailable() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.project()), RewardFactory.reward().toBuilder().hasAddOns(false).build())
+        this.hasAddonsAvailable.assertValue(false)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

The reward carrousel now indicates in each reward if add-ons are available for that concrete reward

# 🤔 Why

The backer needs to know before hand if the reward has Add-ons associated

# 🛠 How

- Added field "has_addons" to the Reward model to fetch that field from V1 API, optional because GraphQL reward model does not have that field.

# 👀 See

| Emulator |
 ![Screen Shot 2020-07-10 at 10 07 52 AM](https://user-images.githubusercontent.com/4083656/87180999-6bf01300-c296-11ea-8c57-c707daea900b.png) 
| [Figma Design](https://www.figma.com/file/Mgu86KSC8hksuVvD2c2288/Add-Ons%3A-Delivery?node-id=559%3A0) |
![Screen Shot 2020-07-10 at 10 19 59 AM](https://user-images.githubusercontent.com/4083656/87181326-fb95c180-c296-11ea-81d8-991de418d292.png) |
|  |  |



# 📋 QA

- Check in a project with Add-Ons if that tag is available for the reward that has Add-Ons

# Story 📖

[Reward UI tag](https://kickstarter.atlassian.net/browse/NT-1402)
