### PR TITLE
[NT-1392] Event property for bonus support

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -36,6 +36,10 @@ public final class KoalaUtils {
         put("payment_type", checkoutData.paymentType().rawValue());
         put("revenue_in_usd_cents", Math.round(checkoutData.amount() * project.staticUsdRate() * 100));
         put("shipping_amount", checkoutData.shippingAmount());
+        if (checkoutData.bonusAmount() != null) {
+          put("bonus_amount", checkoutData.bonusAmount());
+          put("bonus_amount_usd", Math.round(checkoutData.bonusAmount() * project.staticUsdRate()));
+        }
       }
     });
 

--- a/app/src/main/java/com/kickstarter/ui/data/CheckoutData.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/CheckoutData.kt
@@ -2,6 +2,7 @@ package com.kickstarter.ui.data
 
 import android.os.Parcelable
 import auto.parcel.AutoParcel
+import fragment.Backing
 import type.CreditCardPaymentType
 
 @AutoParcel
@@ -10,6 +11,7 @@ abstract class CheckoutData : Parcelable {
     abstract fun id(): Long?
     abstract fun paymentType(): CreditCardPaymentType
     abstract fun shippingAmount(): Double
+    abstract fun  bonusAmount(): Double?
 
     @AutoParcel.Builder
     abstract class Builder {
@@ -17,6 +19,7 @@ abstract class CheckoutData : Parcelable {
         abstract fun id(id: Long?): Builder
         abstract fun paymentType(paymentType: CreditCardPaymentType): Builder
         abstract fun shippingAmount(shippingAmount: Double): Builder
+        abstract fun bonusAmount(bonusAmount: Double?): Builder
         abstract fun build(): CheckoutData
     }
 


### PR DESCRIPTION
# 📲 What

Added new fields in already existing properties for bonus support `bonus_amount`, and `bonus_amount_usd`, the event is send when pledge button clicked.

# 👀 See
Pledge to a Hong Kong project : 
<img width="1708" alt="Screen Shot 2020-07-10 at 2 49 03 PM" src="https://user-images.githubusercontent.com/4083656/87205977-8be6fd00-c2bd-11ea-851e-450e2935e1af.png">


# 📋 QA

- take a look into logcat and filter logs by `bonus_amount` once the project is being backed

# Story 📖

[Event for bonus Support](https://kickstarter.atlassian.net/browse/NT-1392)
