### PR TITLE
NT-1383: New add-ons screen

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -1,0 +1,61 @@
+package com.kickstarter.ui.fragments
+
+import android.os.Bundle
+import android.util.Pair
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.kickstarter.R
+import com.kickstarter.libs.BaseFragment
+import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
+import com.kickstarter.libs.rx.transformers.Transformers
+import com.kickstarter.ui.ArgumentsKey
+import com.kickstarter.ui.data.PledgeData
+import com.kickstarter.ui.data.PledgeReason
+import com.kickstarter.viewmodels.BackingAddOnsFragmentViewModel
+
+@RequiresFragmentViewModel(BackingAddOnsFragmentViewModel.ViewModel::class)
+class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewModel>() {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        super.onCreateView(inflater, container, savedInstanceState)
+        return inflater.inflate(R.layout.fragment_backing_addons, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        this.viewModel.outputs.showPledgeFragment()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe { showPledgeFragment(it.first, it.second) }
+    }
+
+    fun configureWith(pledgeDataAndReason: Pair<PledgeData, PledgeReason>) {
+        this.viewModel.inputs.configureWith(pledgeDataAndReason)
+    }
+
+    private fun showPledgeFragment(pledgeData: PledgeData, pledgeReason: PledgeReason) {
+        if (this.fragmentManager?.findFragmentByTag(PledgeFragment::class.java.simpleName) == null) {
+            val pledgeFragment = PledgeFragment.newInstance(pledgeData, pledgeReason)
+            this.fragmentManager?.beginTransaction()
+                    ?.setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
+                    ?.add(R.id.fragment_container,
+                            pledgeFragment,
+                            PledgeFragment::class.java.simpleName)
+                    ?.addToBackStack(PledgeFragment::class.java.simpleName)
+                    ?.commit()
+        }
+    }
+
+    companion object {
+        fun newInstance(pledgeDataAndReason: Pair<PledgeData, PledgeReason>): BackingAddOnsFragment {
+            val fragment = BackingAddOnsFragment()
+            val argument = Bundle()
+            argument.putParcelable(ArgumentsKey.PLEDGE_PLEDGE_DATA, pledgeDataAndReason.first)
+            argument.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, pledgeDataAndReason.second)
+            fragment.arguments = argument
+            return fragment
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -126,7 +126,7 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Rewa
             val addOnsFragment = BackingAddOnsFragment.newInstance(pledgeDataAndReason)
             this.fragmentManager?.beginTransaction()
                     ?.setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
-                    ?.replace(R.id.fragment_container,
+                    ?.add(R.id.fragment_container,
                             addOnsFragment,
                             BackingAddOnsFragment::class.java.simpleName)
                     ?.addToBackStack(BackingAddOnsFragment::class.java.simpleName)

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.ui.fragments
 
 import android.os.Bundle
+import android.util.Pair
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -48,6 +49,13 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Rewa
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
                 .subscribe { showPledgeFragment(it.first, it.second) }
+
+        this.viewModel.outputs.showAddOnsFragment()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe {
+                    showAddonsFragment(it)
+                }
 
         this.viewModel.outputs.rewardsCount()
                 .compose(bindToLifecycle())
@@ -109,6 +117,19 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Rewa
                             pledgeFragment,
                             PledgeFragment::class.java.simpleName)
                     ?.addToBackStack(PledgeFragment::class.java.simpleName)
+                    ?.commit()
+        }
+    }
+
+    private fun showAddonsFragment(pledgeDataAndReason: Pair<PledgeData, PledgeReason>) {
+        if (this.fragmentManager?.findFragmentByTag(BackingAddOnsFragment::class.java.simpleName) == null) {
+            val addOnsFragment = BackingAddOnsFragment.newInstance(pledgeDataAndReason)
+            this.fragmentManager?.beginTransaction()
+                    ?.setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
+                    ?.replace(R.id.fragment_container,
+                            addOnsFragment,
+                            BackingAddOnsFragment::class.java.simpleName)
+                    ?.addToBackStack(BackingAddOnsFragment::class.java.simpleName)
                     ?.commit()
         }
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -1,0 +1,69 @@
+package com.kickstarter.viewmodels
+
+import android.util.Pair
+import androidx.annotation.NonNull
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.FragmentViewModel
+import com.kickstarter.libs.rx.transformers.Transformers
+import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
+import com.kickstarter.libs.utils.ObjectUtils
+import com.kickstarter.models.Project
+import com.kickstarter.models.Reward
+import com.kickstarter.ui.ArgumentsKey
+import com.kickstarter.ui.data.PledgeData
+import com.kickstarter.ui.data.PledgeReason
+import com.kickstarter.ui.fragments.RewardsFragment
+import rx.Observable
+import rx.subjects.PublishSubject
+
+class BackingAddOnsFragmentViewModel {
+    interface Inputs {
+        /** Emits the pledgeData and Reason needed to work with in BackingAddOnsFragment.kt */
+        fun configureWith(pledgeDataAndReason: Pair<PledgeData, PledgeReason>)
+    }
+
+    interface Outputs {
+        fun showPledgeFragment(): Observable<Pair<PledgeData, PledgeReason>>
+    }
+
+    class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<RewardsFragment>(environment), Inputs, Outputs {
+        val inputs = this
+        val outputs = this
+
+        private val pledgeDataAndReason = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
+        private val showPledgeFragment = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
+
+        init {
+
+            val pledgeData = arguments()
+                    .map { it.getParcelable(ArgumentsKey.PLEDGE_PLEDGE_DATA) as PledgeData? }
+                    .ofType(PledgeData::class.java)
+
+            val pledgeReason = arguments()
+                    .map { it.getSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON) as PledgeReason }
+
+            // - Get the reward either from intent or via input configureWith
+            val project = pledgeDataAndReason
+                    .map { it.first.projectData().project() }
+                    .compose<Pair<Project, PledgeData>>(combineLatestPair(pledgeData))
+                    .map { if (ObjectUtils.isNull(it.first)) it.second.projectData().project() else it.first }
+
+            // - Get the reward either from intent or via input configureWith
+            val reward = pledgeDataAndReason
+                    .map { it.first.reward() }
+                    .compose<Pair<Reward, PledgeData>>(combineLatestPair(pledgeData))
+                    .map { if (ObjectUtils.isNull(it.first)) it.second.reward() else it.first }
+
+            this.pledgeDataAndReason
+                    .compose(bindToLifecycle())
+                    .subscribe(this.showPledgeFragment)
+        }
+
+        @NonNull
+        override fun showPledgeFragment(): Observable<Pair<PledgeData, PledgeReason>> = this.showPledgeFragment
+
+        override fun configureWith(pledgeDataAndReason: Pair<PledgeData, PledgeReason>) {
+            this.pledgeDataAndReason.onNext(pledgeDataAndReason)
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -38,6 +38,9 @@ class RewardsFragmentViewModel {
 
         /** Emits when we should show the [com.kickstarter.ui.fragments.PledgeFragment].  */
         fun showPledgeFragment(): Observable<Pair<PledgeData, PledgeReason>>
+
+        /** Emits when we should show the [com.kickstarter.ui.fragments.BackingAddOnsFragment].  */
+        fun showAddOnsFragment(): Observable<Pair<PledgeData, PledgeReason>>
     }
 
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<RewardsFragment>(environment), Inputs, Outputs {
@@ -49,6 +52,7 @@ class RewardsFragmentViewModel {
         private val projectData = BehaviorSubject.create<ProjectData>()
         private val rewardsCount = BehaviorSubject.create<Int>()
         private val showPledgeFragment = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
+        private val showAddOnsFragment = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -71,9 +75,17 @@ class RewardsFragmentViewModel {
 
             this.projectDataInput
                     .compose<Pair<ProjectData, Reward>>(Transformers.takePairWhen(this.rewardClicked))
+                    .filter { !it.second.hasAddons() }
                     .map { pledgeDataAndPledgeReason(it.first, it.second) }
                     .compose(bindToLifecycle())
                     .subscribe(this.showPledgeFragment)
+
+            this.projectDataInput
+                    .compose<Pair<ProjectData, Reward>>(Transformers.takePairWhen(this.rewardClicked))
+                    .filter { it.second.hasAddons() }
+                    .map { pledgeDataAndPledgeReason(it.first, it.second) }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.showAddOnsFragment)
 
             project
                     .map { it.rewards()?.size?: 0 }
@@ -118,5 +130,8 @@ class RewardsFragmentViewModel {
 
         @NonNull
         override fun showPledgeFragment(): Observable<Pair<PledgeData, PledgeReason>> = this.showPledgeFragment
+
+        @NonNull
+        override fun showAddOnsFragment(): Observable<Pair<PledgeData, PledgeReason>> = this.showAddOnsFragment
     }
 }

--- a/app/src/main/res/layout/fragment_backing_addons.xml
+++ b/app/src/main/res/layout/fragment_backing_addons.xml
@@ -1,23 +1,72 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/backing_addons_content"
+    android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/fragment_container"
-    android:paddingTop="?android:attr/actionBarSize">
+    android:background="@color/ksr_grey_300"
+    android:orientation="vertical">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:background="@color/ksr_grey_300"
+        android:layout_width="match_parent"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_height="match_parent"
+        android:id="@+id/fragment_container"
+        android:paddingTop="?android:attr/actionBarSize">
 
-    <androidx.appcompat.widget.AppCompatTextView
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/grid_3"
-        android:layout_marginStart="@dimen/grid_3"
-        style="@style/Headline"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="Customize your reward with optional add-ons.">
-    </androidx.appcompat.widget.AppCompatTextView>
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/backing_addons_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/grid_3"
+            android:layout_marginStart="@dimen/grid_3"
+            android:layout_marginTop="@dimen/grid_2"
+            android:text="@string/customize_your_reward"
+            style="@style/Headline"
+            android:textSize="@dimen/title_2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Customize your reward with optional add-ons.">
+        </androidx.appcompat.widget.AppCompatTextView>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/call_out"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/grid_3"
+            android:layout_marginStart="@dimen/grid_3"
+            android:layout_marginTop="@dimen/grid_2"
+            style="@style/CalloutPrimary"
+            android:text="@string/Your_shipping_location"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/backing_addons_title">
+        </androidx.appcompat.widget.AppCompatTextView>
+
+        <AutoCompleteTextView
+            android:id="@+id/shipping_rules"
+            style="@style/AutocompleteStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/grid_1"
+            android:layout_marginEnd="@dimen/grid_3"
+            android:ellipsize="end"
+            android:enabled="false"
+            android:hint="@string/Shipping"
+            android:imeOptions="actionDone"
+            android:inputType="text"
+            android:maxLines="1"
+            android:nextFocusDown="@id/shipping_amount"
+            android:scrollHorizontally="true"
+            android:text="@string/Loading"
+            android:textColor="@color/ksr_green_500"
+            app:layout_constraintEnd_toStartOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/shipping_rules_label"
+            tools:text="United States" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_backing_addons.xml
+++ b/app/src/main/res/layout/fragment_backing_addons.xml
@@ -46,27 +46,5 @@
             app:layout_constraintTop_toBottomOf="@+id/backing_addons_title">
         </androidx.appcompat.widget.AppCompatTextView>
 
-        <AutoCompleteTextView
-            android:id="@+id/shipping_rules"
-            style="@style/AutocompleteStyle"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/grid_1"
-            android:layout_marginEnd="@dimen/grid_3"
-            android:ellipsize="end"
-            android:enabled="false"
-            android:hint="@string/Shipping"
-            android:imeOptions="actionDone"
-            android:inputType="text"
-            android:maxLines="1"
-            android:nextFocusDown="@id/shipping_amount"
-            android:scrollHorizontally="true"
-            android:text="@string/Loading"
-            android:textColor="@color/ksr_green_500"
-            app:layout_constraintEnd_toStartOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/shipping_rules_label"
-            tools:text="United States" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_backing_addons.xml
+++ b/app/src/main/res/layout/fragment_backing_addons.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/backing_addons_content"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/ksr_grey_300"
     android:orientation="vertical">
+
     <androidx.constraintlayout.widget.ConstraintLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:background="@color/ksr_grey_300"
         android:layout_width="match_parent"
-        xmlns:tools="http://schemas.android.com/tools"
         android:layout_height="match_parent"
         android:id="@+id/fragment_container"
         android:paddingTop="?android:attr/actionBarSize">

--- a/app/src/main/res/layout/fragment_backing_addons.xml
+++ b/app/src/main/res/layout/fragment_backing_addons.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_height="match_parent"
+    android:id="@+id/fragment_container"
+    android:paddingTop="?android:attr/actionBarSize">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/grid_3"
+        android:layout_marginStart="@dimen/grid_3"
+        style="@style/Headline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Customize your reward with optional add-ons.">
+    </androidx.appcompat.widget.AppCompatTextView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_pledge_section_shipping.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_shipping.xml
@@ -17,7 +17,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/grid_4"
-
         android:text="@string/Your_shipping_location"
         app:layout_constraintBottom_toTopOf="@id/shipping_rules"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,5 +72,6 @@
   <string name="No_thanks">No thanks</string>
   <string name="Let_s_go">Let\'s go</string>
   <string name="Add_ons_available">Add-Ons available</string>
+    <string name="customize_your_reward">Customize your reward with optional add-ons</string>
 
 </resources>

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
@@ -23,6 +23,7 @@ class RewardsFragmentViewModelTest: KSRobolectricTestCase() {
     private val projectData = TestSubscriber.create<ProjectData>()
     private val rewardsCount = TestSubscriber.create<Int>()
     private val showPledgeFragment = TestSubscriber<Pair<PledgeData, PledgeReason>>()
+    private val showAddOnsFragment = TestSubscriber<Pair<PledgeData, PledgeReason>>()
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = RewardsFragmentViewModel.ViewModel(environment)
@@ -30,6 +31,7 @@ class RewardsFragmentViewModelTest: KSRobolectricTestCase() {
         this.vm.outputs.projectData().subscribe(this.projectData)
         this.vm.outputs.rewardsCount().subscribe(this.rewardsCount)
         this.vm.outputs.showPledgeFragment().subscribe(this.showPledgeFragment)
+        this.vm.outputs.showAddOnsFragment().subscribe(this.showAddOnsFragment)
     }
 
     @Test
@@ -77,9 +79,27 @@ class RewardsFragmentViewModelTest: KSRobolectricTestCase() {
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(project))
 
-        val reward = RewardFactory.reward()
+        val reward = RewardFactory.reward().toBuilder().hasAddons(false).build()
         this.vm.inputs.rewardClicked(reward)
         this.showPledgeFragment.assertValue(Pair(PledgeData.builder()
+                .pledgeFlowContext(PledgeFlowContext.NEW_PLEDGE)
+                .reward(reward)
+                .projectData(ProjectDataFactory.project(project))
+                .build(), PledgeReason.PLEDGE))
+        this.showAddOnsFragment.assertNoValues()
+    }
+
+    @Test
+    fun testShowAddonsFragment_whenBackingProject() {
+        val project = ProjectFactory.project()
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(ProjectDataFactory.project(project))
+
+        val reward = RewardFactory.reward().toBuilder().hasAddons(true).build()
+        this.vm.inputs.rewardClicked(reward)
+        this.showPledgeFragment.assertNoValues()
+        this.showAddOnsFragment.assertValue(Pair(PledgeData.builder()
                 .pledgeFlowContext(PledgeFlowContext.NEW_PLEDGE)
                 .reward(reward)
                 .projectData(ProjectDataFactory.project(project))


### PR DESCRIPTION
# 📲 What
If a Reward has add-ons available when hitting continue show a new fragment, it will have for now just two string

# 👀 See

![Add-ons-screen](https://user-images.githubusercontent.com/4083656/87362459-8e4a9080-c523-11ea-8b31-c0094880fdc5.gif)


# 📋 QA
- hitting a reward with add-ons will show a new screen
- hitting a reward without add-ons, or a no-reward will show the PledgeFragment.

# Story 📖

[Add-ons screen](https://kickstarter.atlassian.net/browse/NT-1383)
