### PR TITLE
NT-1384: Add-ons list

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/adapters/BackingAddOnsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/BackingAddOnsAdapter.kt
@@ -1,0 +1,37 @@
+package com.kickstarter.ui.adapters
+
+import android.view.View
+import com.kickstarter.R
+import com.kickstarter.models.Reward
+import com.kickstarter.ui.data.ProjectData
+import com.kickstarter.ui.viewholders.BackingAddOnViewHolder
+import com.kickstarter.ui.viewholders.EmptyViewHolder
+import com.kickstarter.ui.viewholders.KSViewHolder
+
+class BackingAddOnsAdapter : KSAdapter() {
+
+    init {
+        insertSection(SECTION_BACKING_ADD_ONS_CARD, emptyList<Reward>())
+    }
+
+    override fun layout(sectionRow: SectionRow): Int = when (sectionRow.section()){
+        SECTION_BACKING_ADD_ONS_CARD -> R.layout.item_add_on
+        else -> 0
+    }
+
+    override fun viewHolder(layout: Int, view: View): KSViewHolder {
+        return when(layout) {
+            R.layout.item_add_on -> BackingAddOnViewHolder(view)
+            else -> EmptyViewHolder(view)
+        }
+    }
+
+    fun populateDataForAddOns(rewards: List<Pair<ProjectData,Reward>>) {
+        setSection(SECTION_BACKING_ADD_ONS_CARD, rewards)
+        notifyDataSetChanged()
+    }
+
+    companion object {
+        private const val SECTION_BACKING_ADD_ONS_CARD = 0
+    }
+}

--- a/app/src/main/java/com/kickstarter/ui/adapters/BackingAddOnsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/BackingAddOnsAdapter.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.ui.adapters
 
+import android.util.Pair
 import android.view.View
 import com.kickstarter.R
 import com.kickstarter.models.Reward
@@ -15,7 +16,7 @@ class BackingAddOnsAdapter : KSAdapter() {
     }
 
     override fun layout(sectionRow: SectionRow): Int = when (sectionRow.section()){
-        SECTION_BACKING_ADD_ONS_CARD -> R.layout.item_add_on
+        SECTION_BACKING_ADD_ONS_CARD -> R.layout.item_add_on_pledge
         else -> 0
     }
 
@@ -27,8 +28,10 @@ class BackingAddOnsAdapter : KSAdapter() {
     }
 
     fun populateDataForAddOns(rewards: List<Pair<ProjectData,Reward>>) {
-        setSection(SECTION_BACKING_ADD_ONS_CARD, rewards)
-        notifyDataSetChanged()
+        if (rewards.isNotEmpty()) {
+            setSection(SECTION_BACKING_ADD_ONS_CARD, rewards)
+            notifyDataSetChanged()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -14,12 +14,10 @@ import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.ArgumentsKey
 import com.kickstarter.ui.adapters.BackingAddOnsAdapter
-import com.kickstarter.ui.adapters.RewardAndAddOnsAdapter
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.BackingAddOnsFragmentViewModel
-import kotlinx.android.synthetic.main.fragment_backing.*
 import kotlinx.android.synthetic.main.fragment_backing_addons.*
 
 @RequiresFragmentViewModel(BackingAddOnsFragmentViewModel.ViewModel::class)
@@ -60,6 +58,12 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
                 }.toList()
 
         backingAddonsAdapter.populateDataForAddOns(list)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        // TODO: consider changing this on the BaseFragment
+        this.viewModel.arguments(arguments)
     }
 
     private fun setupRecyclerView() {

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -5,14 +5,22 @@ import android.util.Pair
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.kickstarter.R
 import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
+import com.kickstarter.models.Reward
 import com.kickstarter.ui.ArgumentsKey
+import com.kickstarter.ui.adapters.BackingAddOnsAdapter
+import com.kickstarter.ui.adapters.RewardAndAddOnsAdapter
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeReason
+import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.BackingAddOnsFragmentViewModel
+import kotlinx.android.synthetic.main.fragment_backing.*
+import kotlinx.android.synthetic.main.fragment_backing_addons.*
 
 @RequiresFragmentViewModel(BackingAddOnsFragmentViewModel.ViewModel::class)
 class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewModel>() {
@@ -22,17 +30,41 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
         return inflater.inflate(R.layout.fragment_backing_addons, container, false)
     }
 
+    private val backingAddonsAdapter = BackingAddOnsAdapter()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setupRecyclerView()
 
         this.viewModel.outputs.showPledgeFragment()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .subscribe { showPledgeFragment(it.first, it.second) }
+
+        this.viewModel.outputs.AddOnsList()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe {
+                    populateAddOns(it)
+                }
     }
 
-    fun configureWith(pledgeDataAndReason: Pair<PledgeData, PledgeReason>) {
-        this.viewModel.inputs.configureWith(pledgeDataAndReason)
+
+    private fun populateAddOns(projectDataAndAddOnList: Pair<ProjectData, List<Reward>>) {
+        val projectData = projectDataAndAddOnList.first
+
+        val list = projectDataAndAddOnList
+                .second
+                .map {
+                    Pair(projectData,it)
+                }.toList()
+
+        backingAddonsAdapter.populateDataForAddOns(list)
+    }
+
+    private fun setupRecyclerView() {
+        fragment_backing_addons_list.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+        fragment_backing_addons_list.adapter = backingAddonsAdapter
     }
 
     private fun showPledgeFragment(pledgeData: PledgeData, pledgeReason: PledgeReason) {

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -47,7 +47,6 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
                 }
     }
 
-
     private fun populateAddOns(projectDataAndAddOnList: Pair<ProjectData, List<Reward>>) {
         val projectData = projectDataAndAddOnList.first
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
@@ -2,22 +2,44 @@ package com.kickstarter.ui.viewholders
 
 import android.util.Pair
 import android.view.View
+import com.kickstarter.libs.rx.transformers.Transformers
+import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.BackingAddOnViewHolderViewModel
+import kotlinx.android.synthetic.main.add_on_title.view.*
+import kotlinx.android.synthetic.main.item_add_on.view.*
+import kotlinx.android.synthetic.main.item_lights_on.view.*
 
 class BackingAddOnViewHolder (private val view: View) : KSViewHolder(view) {
 
     private var viewModel = BackingAddOnViewHolderViewModel.ViewModel(environment())
 
     init {
+        this.viewModel.outputs.titleForAddOn()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe{
+                    this.view.add_on_title_no_spannable.text = it
+                }
+
+        this.viewModel.outputs.description()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe {
+                    this.view.add_on_description_text_view.text = it
+                }
     }
 
     override fun bindData(data: Any?) {
         if (data is (Pair<*, *>)) {
             if (data.second is Reward) {
-                bindData(data as Pair<ProjectData, Reward>)
+                bindAddonsList(data as Pair<ProjectData, Reward>)
             }
         }
+    }
+
+    private fun bindAddonsList(projectDataAndAddOn: Pair<ProjectData, Reward>) {
+        this.viewModel.inputs.configureWith(projectDataAndAddOn)
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
@@ -1,0 +1,23 @@
+package com.kickstarter.ui.viewholders
+
+import android.util.Pair
+import android.view.View
+import com.kickstarter.models.Reward
+import com.kickstarter.ui.data.ProjectData
+import com.kickstarter.viewmodels.BackingAddOnViewHolderViewModel
+
+class BackingAddOnViewHolder (private val view: View) : KSViewHolder(view) {
+
+    private var viewModel = BackingAddOnViewHolderViewModel.ViewModel(environment())
+
+    init {
+    }
+
+    override fun bindData(data: Any?) {
+        if (data is (Pair<*, *>)) {
+            if (data.second is Reward) {
+                bindData(data as Pair<ProjectData, Reward>)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
@@ -16,19 +16,7 @@ class BackingAddOnViewHolder (private val view: View) : KSViewHolder(view) {
     private var viewModel = BackingAddOnViewHolderViewModel.ViewModel(environment())
 
     init {
-        this.viewModel.outputs.titleForAddOn()
-                .compose(bindToLifecycle())
-                .compose(Transformers.observeForUI())
-                .subscribe{
-                    this.view.add_on_title_no_spannable.text = it
-                }
-
-        this.viewModel.outputs.description()
-                .compose(bindToLifecycle())
-                .compose(Transformers.observeForUI())
-                .subscribe {
-                    this.view.add_on_description_text_view.text = it
-                }
+        // TODO: https://kickstarter.atlassian.net/browse/NT-1385
     }
 
     override fun bindData(data: Any?) {

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
@@ -1,0 +1,42 @@
+package com.kickstarter.viewmodels
+
+import android.util.Pair
+import androidx.annotation.NonNull
+import com.kickstarter.libs.ActivityViewModel
+import com.kickstarter.libs.Environment
+import com.kickstarter.models.Reward
+import com.kickstarter.ui.data.ProjectData
+import com.kickstarter.ui.viewholders.BackingAddOnViewHolder
+import rx.subjects.PublishSubject
+
+class BackingAddOnViewHolderViewModel {
+    interface Inputs {
+        /** Configure with the current [ProjectData] and [Reward].
+         * @param projectData we get the Project for currency
+         * @param reward the actual addOn loading on the ViewHolder
+         */
+        fun configureWith(projectData: ProjectData, reward: Reward)
+    }
+
+    interface Outputs {
+    }
+
+    /**
+     *  Logic to handle the UI for backing `Add On` card
+     *  Configuring the View for [BackingAddOnViewHolder]
+     *  - No interaction with the user just displaying information
+     *  - Loading in [BackingAddOnViewHolder] -> [BackingAddOnsAdapter] -> [BackingAddOnsFragment]
+     */
+    class ViewModel(@NonNull environment: Environment) : ActivityViewModel<BackingAddOnViewHolder>(environment), Inputs, Outputs {
+        private val projectDataAndAddOn = PublishSubject.create<Pair<ProjectData, Reward>>()
+
+        val inputs: Inputs = this
+        val outputs: Outputs = this
+
+        init {
+
+        }
+
+        override fun configureWith(projectData: ProjectData, reward: Reward) = this.projectDataAndAddOn.onNext(Pair.create(projectData, reward))
+    }
+}

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
@@ -4,21 +4,29 @@ import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.ui.viewholders.BackingAddOnViewHolder
+import rx.Observable
 import rx.subjects.PublishSubject
 
 class BackingAddOnViewHolderViewModel {
     interface Inputs {
         /** Configure with the current [ProjectData] and [Reward].
          * @param projectData we get the Project for currency
-         * @param reward the actual addOn loading on the ViewHolder
+         * @param AddOn  the actual addOn item loading on the ViewHolder
          */
-        fun configureWith(projectData: ProjectData, reward: Reward)
+        fun configureWith(projectDataAndAddOn: Pair<ProjectData, Reward>)
     }
 
     interface Outputs {
+        /** Emits a pair with the add on title and the quantity in order to build the stylized title  */
+        fun titleForAddOn(): Observable<String>
+
+        /** Emits the reward's description.  */
+        fun description(): Observable<String>
+
     }
 
     /**
@@ -29,14 +37,32 @@ class BackingAddOnViewHolderViewModel {
      */
     class ViewModel(@NonNull environment: Environment) : ActivityViewModel<BackingAddOnViewHolder>(environment), Inputs, Outputs {
         private val projectDataAndAddOn = PublishSubject.create<Pair<ProjectData, Reward>>()
+        private val title = PublishSubject.create<String>()
+        private val description = PublishSubject.create<String>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
 
         init {
 
+            val addOn = projectDataAndAddOn
+                    .map { it.second }
+
+            addOn
+                    .map { it.title() }
+                    .subscribe(this.title)
+
+            addOn
+                    .map { it.description() }
+                    .filter { ObjectUtils.isNotNull(it) }
+                    .subscribe(this.description)
+
         }
 
-        override fun configureWith(projectData: ProjectData, reward: Reward) = this.projectDataAndAddOn.onNext(Pair.create(projectData, reward))
+        override fun configureWith(projectDataAndAddOn: Pair<ProjectData, Reward>) = this.projectDataAndAddOn.onNext(projectDataAndAddOn)
+
+        override fun titleForAddOn() = this.title
+
+        override fun description() = this.description
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -4,34 +4,37 @@ import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.FragmentViewModel
-import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
-import com.kickstarter.libs.utils.ObjectUtils
-import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.ArgumentsKey
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeReason
-import com.kickstarter.ui.fragments.RewardsFragment
+import com.kickstarter.ui.data.ProjectData
+import com.kickstarter.ui.fragments.BackingAddOnsFragment
 import rx.Observable
 import rx.subjects.PublishSubject
 
 class BackingAddOnsFragmentViewModel {
+
     interface Inputs {
-        /** Emits the pledgeData and Reason needed to work with in BackingAddOnsFragment.kt */
+        /** Configure with the current [ProjectData] and [Reward].
+         * @param projectData we get the Project for currency
+         */
         fun configureWith(pledgeDataAndReason: Pair<PledgeData, PledgeReason>)
     }
 
     interface Outputs {
         fun showPledgeFragment(): Observable<Pair<PledgeData, PledgeReason>>
+        fun AddOnsList(): Observable<Pair<ProjectData, List<Reward>>>
     }
 
-    class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<RewardsFragment>(environment), Inputs, Outputs {
+    class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<BackingAddOnsFragment>(environment), Outputs, Inputs {
         val inputs = this
         val outputs = this
 
         private val pledgeDataAndReason = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
         private val showPledgeFragment = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
+        private val addOnsList = PublishSubject.create<Pair<ProjectData, List<Reward>>>()
 
         init {
 
@@ -42,28 +45,32 @@ class BackingAddOnsFragmentViewModel {
             val pledgeReason = arguments()
                     .map { it.getSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON) as PledgeReason }
 
-            // - Get the reward either from intent or via input configureWith
-            val project = pledgeDataAndReason
-                    .map { it.first.projectData().project() }
-                    .compose<Pair<Project, PledgeData>>(combineLatestPair(pledgeData))
-                    .map { if (ObjectUtils.isNull(it.first)) it.second.projectData().project() else it.first }
+            val projectData = pledgeData
+                    .map { it.projectData() }
 
-            // - Get the reward either from intent or via input configureWith
-            val reward = pledgeDataAndReason
-                    .map { it.first.reward() }
-                    .compose<Pair<Reward, PledgeData>>(combineLatestPair(pledgeData))
-                    .map { if (ObjectUtils.isNull(it.first)) it.second.reward() else it.first }
+            val project = projectData
+                    .map { it.project() }
+
+            val reward = pledgeData
+                    .map { it.reward() }
 
             this.pledgeDataAndReason
                     .compose(bindToLifecycle())
                     .subscribe(this.showPledgeFragment)
+
+            // TODO: Add-ons query will be added in here in exchange of the reward
+            projectData
+                    .compose<Pair<ProjectData, Reward>>(combineLatestPair(reward))
+                    .compose(bindToLifecycle())
+                    .subscribe {
+                        this.addOnsList.onNext(Pair(it.first, listOf(it.second, it.second)))
+                    }
         }
 
         @NonNull
         override fun showPledgeFragment(): Observable<Pair<PledgeData, PledgeReason>> = this.showPledgeFragment
+        override fun configureWith(pledgeDataAndReason: Pair<PledgeData, PledgeReason>) = this.pledgeDataAndReason.onNext(pledgeDataAndReason)
 
-        override fun configureWith(pledgeDataAndReason: Pair<PledgeData, PledgeReason>) {
-            this.pledgeDataAndReason.onNext(pledgeDataAndReason)
-        }
+        override fun AddOnsList() = this.addOnsList
     }
 }

--- a/app/src/main/res/layout/fragment_backing_addons.xml
+++ b/app/src/main/res/layout/fragment_backing_addons.xml
@@ -56,7 +56,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/fragment_backing_addons_call_out"
             tools:itemCount="2"
-            tools:listitem="@layout/item_add_on"/>
+            tools:listitem="@layout/item_add_on_pledge"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_backing_addons.xml
+++ b/app/src/main/res/layout/fragment_backing_addons.xml
@@ -16,7 +16,7 @@
         android:paddingTop="?android:attr/actionBarSize">
 
         <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/backing_addons_title"
+            android:id="@+id/fragment_backing_addons_title"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/grid_3"
@@ -32,7 +32,7 @@
         </androidx.appcompat.widget.AppCompatTextView>
 
         <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/call_out"
+            android:id="@+id/fragment_backing_addons_call_out"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/grid_3"
@@ -42,8 +42,21 @@
             android:text="@string/Your_shipping_location"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/backing_addons_title">
+            app:layout_constraintTop_toBottomOf="@+id/fragment_backing_addons_title">
         </androidx.appcompat.widget.AppCompatTextView>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/fragment_backing_addons_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/grid_3"
+            android:layout_marginStart="@dimen/grid_3"
+            android:layout_marginTop="@dimen/grid_2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/fragment_backing_addons_call_out"
+            tools:itemCount="2"
+            tools:listitem="@layout/item_add_on"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>


### PR DESCRIPTION
# 📲 What
Structure for the Add-ons list ready. In next PR's we will add the add-ons query from Grapgh, Currently hardcoded 2 rewards as placeholder in order to facilitate the work in [Add-ons card UI: NT-1385](https://kickstarter.atlassian.net/browse/NT-1385)

# 🤔 Why

Avoid conflicts and separate work for those working on the Add-on Card UI, and the Filtering by location/ fetching Add-ons work

# 👀 See

![Screen Shot 2020-07-14 at 3 30 07 PM](https://user-images.githubusercontent.com/4083656/87482909-4c831e00-c5e7-11ea-9cd6-492f1d855b5c.png)


# Story 📖

[Add-ons list](https://kickstarter.atlassian.net/browse/NT-1384)
