### PR TITLE
NT-1385: Add ons card UI cleanup + pill updates

### DIFF
--- a/app/src/main/res/drawable/rect_coral_alpha_6.xml
+++ b/app/src/main/res/drawable/rect_coral_alpha_6.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <corners android:radius="@dimen/text_view_corner_radius" />
+    <corners android:radius="@dimen/text_pill_corner_radius" />
     <solid android:color="@color/kds_celebrate_100" />
 </shape>

--- a/app/src/main/res/layout/add_on_items.xml
+++ b/app/src/main/res/layout/add_on_items.xml
@@ -24,13 +24,5 @@
         tools:itemCount="3"
         tools:listitem="@layout/rewards_item_view" />
 
-    <ImageView
-        android:id="@+id/imageView"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@drawable/divider_dark_grey_500_horizontal"
-        android:importantForAccessibility="no"
-        app:layout_constraintTop_toBottomOf="@+id/add_on_item_recycler_view"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_add_on_pledge.xml
+++ b/app/src/main/res/layout/item_add_on_pledge.xml
@@ -33,20 +33,32 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent">
 
+                <include
+                    android:id="@+id/title_container"
+                    layout="@layout/add_on_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="visible"
+                    android:layout_marginTop="@dimen/grid_1"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
+
                 <TextView
                     android:id="@+id/add_on_minimum_text_view"
                     style="@style/Title2Medium"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:textSize="@dimen/subheadline"
                     android:textColor="@color/ksr_green_500"
-                    android:textSize="@dimen/title_reward"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:text="$20" />
+                    app:layout_constraintTop_toBottomOf="@id/title_container"
+                    tools:text="$20 + $5 shipping each" />
 
                 <TextView
                     android:id="@+id/add_on_conversion_text_view"
                     style="@style/FootnotePrimaryMedium"
+                    android:textColor="@color/ksr_dark_grey_500"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/grid_1_half"
@@ -54,28 +66,6 @@
                     app:layout_constraintTop_toBottomOf="@id/add_on_minimum_text_view"
                     tools:text="About $15 USD"
                     tools:visibility="visible"/>
-
-                <include
-                    android:id="@+id/title_container"
-                    layout="@layout/add_on_title"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="visible"
-                    android:layout_marginTop="@dimen/grid_2"
-                    app:layout_constraintTop_toBottomOf="@id/add_on_conversion_text_view"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent" />
-
-                <include
-                    android:id="@+id/items_container"
-                    layout="@layout/add_on_items"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="visible"
-                    android:layout_marginTop="@dimen/grid_5_half"
-                    app:layout_constraintTop_toBottomOf="@id/title_container"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent" />
 
                 <TextView
                     android:id="@+id/add_on_description_text_view"
@@ -86,15 +76,41 @@
                     android:layout_marginBottom="@dimen/grid_2"
                     app:layout_constraintRight_toRightOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/items_container"
+                    app:layout_constraintTop_toBottomOf="@id/add_on_conversion_text_view"
                     tools:text="@string/Pledge_any_amount_to_help_bring_this_project_to_life" />
+
+                <View
+                    android:id="@+id/divider"
+                    android:layout_width="match_parent"
+                    android:layout_marginTop="18dp"
+                    android:layout_height="1dp"
+                    android:background="@drawable/divider_dark_grey_500_horizontal"
+                    android:importantForAccessibility="no"
+                    app:layout_constraintTop_toBottomOf="@+id/add_on_description_text_view"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+
+
+
+                <include
+                    android:id="@+id/items_container"
+                    layout="@layout/add_on_items"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="visible"
+                    android:layout_marginTop="@dimen/grid_5_half"
+                    app:layout_constraintTop_toBottomOf="@id/divider"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
+
+
 
                 <LinearLayout
                     android:id="@+id/pills_container"
                     android:orientation="horizontal"
                     android:layout_width="match_parent"
-                    app:layout_constraintTop_toBottomOf="@id/add_on_description_text_view"
-                    android:layout_marginTop="@dimen/grid_3_half"
+                    app:layout_constraintTop_toBottomOf="@id/items_container"
+                    android:layout_marginTop="18dp"
                     android:layout_height="wrap_content">
 
 

--- a/app/src/main/res/layout/item_add_on_pledge.xml
+++ b/app/src/main/res/layout/item_add_on_pledge.xml
@@ -72,7 +72,7 @@
                     style="@style/BodyPrimary"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/grid_3_half"
+                    android:layout_marginTop="@dimen/grid_3"
                     android:layout_marginBottom="@dimen/grid_2"
                     app:layout_constraintRight_toRightOf="parent"
                     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -131,7 +131,9 @@
   <dimen name="thanks_project_photo_height">117dp</dimen>
 
   <!-- TextViews -->
-  <dimen name="text_view_corner_radius">@dimen/grid_1_half</dimen>
+  <dimen name="text_view_corner_radius">@dimen/grid_1</dimen>
+
+  <dimen name="text_pill_corner_radius">@dimen/grid_1</dimen>
 
   <!-- Toolbars -->
   <dimen name="ks_toolbar_height">56dp</dimen>


### PR DESCRIPTION
# 📲 What

Cleanup the UI for add on cards so that they closer match Figma design, update reward and add on pills to closer match mocks as well.

# 🤔 Why

Add on cards UI differs from reward, so some changes and updates were necessary.

# 🛠 How

Just updated the layout files and styling. 

Note: For **bolding** the amount subheading, that will be done programmatically, so I will add that logic to the ViewHolderViewmodel once I start working on the CTA + stepper functionality. For now I just made the entire textview have a medium font weight, as requested by Colleen.

# 👀 See

<img width="362" alt="Screen Shot 2020-07-15 at 5 28 55 PM" src="https://user-images.githubusercontent.com/7025946/87598045-da7f0780-c6c0-11ea-8655-3d30e1a41a90.png">

# 📋 QA

Instructions for anyone to be able to QA this work.

# Story 📖

https://kickstarter.atlassian.net/secure/RapidBoard.jspa?rapidView=9&modal=detail&selectedIssue=NT-1385