### PR TITLE
NT-1318: Add Optimizely SDK Events

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
@@ -15,6 +15,10 @@ interface ExperimentsClientType {
         return ExperimentUtils.attributes(experimentData, appVersion(), OSVersion(), optimizelyEnvironment)
     }
 
+    fun ExperimentsClientType.checkoutTags(experimentRevenueData: ExperimentRevenueData): Map<String, *> {
+        return ExperimentUtils.checkoutTags(experimentRevenueData)
+    }
+
     fun optimizelyProperties(experimentData: ExperimentData): Map<String, Any> {
         val experiments = JSONArray()
         val properties = mapOf("optimizely_api_key" to optimizelyEnvironment().sdkKey,
@@ -35,6 +39,8 @@ interface ExperimentsClientType {
     fun isFeatureEnabled(feature: OptimizelyFeature.Key, experimentData: ExperimentData): Boolean
     fun optimizelyEnvironment(): OptimizelyEnvironment
     fun OSVersion(): String
+    fun track(eventKey: String, experimentData: ExperimentData)
+    fun trackRevenue(eventKey: String, experimentRevenueData: ExperimentRevenueData)
     fun trackingVariation(experimentKey: String, experimentData: ExperimentData): String?
     fun userId() : String
     fun variant(experiment: OptimizelyExperiment.Key, experimentData: ExperimentData): OptimizelyExperiment.Variant?

--- a/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
@@ -16,10 +16,6 @@ interface ExperimentsClientType {
         return ExperimentUtils.attributes(experimentData, appVersion(), OSVersion(), optimizelyEnvironment)
     }
 
-    fun ExperimentsClientType.checkoutTags(experimentRevenueData: ExperimentRevenueData): Map<String, *> {
-        return ExperimentUtils.checkoutTags(experimentRevenueData)
-    }
-
     fun optimizelyProperties(experimentData: ExperimentData): Map<String, Any> {
         val experiments = JSONArray()
         val properties = mapOf("optimizely_api_key" to optimizelyEnvironment().sdkKey,
@@ -41,7 +37,6 @@ interface ExperimentsClientType {
     fun optimizelyEnvironment(): OptimizelyEnvironment
     fun OSVersion(): String
     fun track(eventKey: String, experimentData: ExperimentData)
-    fun trackRevenue(eventKey: String, experimentRevenueData: ExperimentRevenueData)
     fun trackingVariation(experimentKey: String, experimentData: ExperimentData): String?
     fun userId() : String
     fun variant(experiment: OptimizelyExperiment.Key, experimentData: ExperimentData): OptimizelyExperiment.Variant?

--- a/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
@@ -4,6 +4,7 @@ import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.utils.ExperimentData
+import com.kickstarter.libs.utils.ExperimentRevenueData
 import com.kickstarter.libs.utils.ExperimentUtils
 import com.kickstarter.models.User
 import org.json.JSONArray

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
@@ -1,9 +1,0 @@
-@file:JvmName("OptimizelyEvent")
-
-package com.kickstarter.libs
-
-const val APP_COMPLETED_CHECKOUT_OPTIMIZELY = "App Completed Checkout"
-
-// region native_project_page_conversion_creator_details
-const val CREATOR_DETAILS_CLICKED_OPTIMIZELY = "Creator Details Clicked"
-// endregion

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyEvent.kt
@@ -1,0 +1,9 @@
+@file:JvmName("OptimizelyEvent")
+
+package com.kickstarter.libs
+
+const val APP_COMPLETED_CHECKOUT_OPTIMIZELY = "App Completed Checkout"
+
+// region native_project_page_conversion_creator_details
+const val CREATOR_DETAILS_CLICKED_OPTIMIZELY = "Creator Details Clicked"
+// endregion

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
@@ -7,6 +7,7 @@ import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.utils.ExperimentData
+import com.kickstarter.libs.utils.ExperimentRevenueData
 import com.kickstarter.models.User
 import com.optimizely.ab.android.sdk.OptimizelyClient
 import com.optimizely.ab.android.sdk.OptimizelyManager
@@ -27,21 +28,21 @@ class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManag
     override fun userId(): String = FirebaseInstanceId.getInstance().id
 
     override fun enabledFeatures(user: User?): List<String> {
-        return this.optimizelyClient()?.getEnabledFeatures(userId(),
+        return this.optimizelyClient().getEnabledFeatures(userId(),
                 attributes(ExperimentData(user, null, null), this.optimizelyEnvironment))
                 ?: emptyList()
     }
 
     override fun isFeatureEnabled(feature: OptimizelyFeature.Key, experimentData: ExperimentData): Boolean {
-        return optimizelyClient()?.isFeatureEnabled(feature.key, userId(), attributes(experimentData, this.optimizelyEnvironment))?: false
+        return optimizelyClient().isFeatureEnabled(feature.key, userId(), attributes(experimentData, this.optimizelyEnvironment))?: false
     }
 
     override fun variant(experiment: OptimizelyExperiment.Key, experimentData: ExperimentData): OptimizelyExperiment.Variant {
         val user = experimentData.user
         val variationString: String? = if (user?.isAdmin == true) {
-            optimizelyClient()?.getVariation(experiment.key, user.id().toString(), attributes(experimentData, this.optimizelyEnvironment))
+            optimizelyClient().getVariation(experiment.key, user.id().toString(), attributes(experimentData, this.optimizelyEnvironment))
         } else {
-            optimizelyClient()?.activate(experiment.key, userId(), attributes(experimentData, this.optimizelyEnvironment))
+            optimizelyClient().activate(experiment.key, userId(), attributes(experimentData, this.optimizelyEnvironment))
         }?.key
 
         return OptimizelyExperiment.Variant.safeValueOf(variationString)
@@ -49,9 +50,9 @@ class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManag
 
     override fun optimizelyEnvironment(): OptimizelyEnvironment = this.optimizelyEnvironment
 
-    private fun optimizelyClient(): OptimizelyClient? = this.optimizelyManager.optimizely
+    private fun optimizelyClient(): OptimizelyClient = this.optimizelyManager.optimizely
 
     override fun trackingVariation(experimentKey: String, experimentData: ExperimentData): String? {
-        return optimizelyClient()?.getVariation(experimentKey, userId(), attributes(experimentData, this.optimizelyEnvironment))?.key
+        return optimizelyClient().getVariation(experimentKey, userId(), attributes(experimentData, this.optimizelyEnvironment))?.key
     }
 }

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
@@ -21,10 +21,6 @@ class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManag
         optimizelyClient().track(eventKey, userId(), attributes(experimentData, this.optimizelyEnvironment))
     }
 
-    override fun trackRevenue(eventKey: String, experimentRevenueData: ExperimentRevenueData) {
-        optimizelyClient().track(eventKey, userId(), attributes(experimentRevenueData.experimentData, this.optimizelyEnvironment), checkoutTags(experimentRevenueData))
-    }
-
     override fun userId(): String = FirebaseInstanceId.getInstance().id
 
     override fun enabledFeatures(user: User?): List<String> {
@@ -34,7 +30,7 @@ class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManag
     }
 
     override fun isFeatureEnabled(feature: OptimizelyFeature.Key, experimentData: ExperimentData): Boolean {
-        return optimizelyClient().isFeatureEnabled(feature.key, userId(), attributes(experimentData, this.optimizelyEnvironment))?: false
+        return optimizelyClient().isFeatureEnabled(feature.key, userId(), attributes(experimentData, this.optimizelyEnvironment))
     }
 
     override fun variant(experiment: OptimizelyExperiment.Key, experimentData: ExperimentData): OptimizelyExperiment.Variant {

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
@@ -16,6 +16,14 @@ class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManag
 
     override fun OSVersion(): String = Build.VERSION.RELEASE
 
+    override fun track(eventKey: String, experimentData: ExperimentData) {
+        optimizelyClient().track(eventKey, userId(), attributes(experimentData, this.optimizelyEnvironment))
+    }
+
+    override fun trackRevenue(eventKey: String, experimentRevenueData: ExperimentRevenueData) {
+        optimizelyClient().track(eventKey, userId(), attributes(experimentRevenueData.experimentData, this.optimizelyEnvironment), checkoutTags(experimentRevenueData))
+    }
+
     override fun userId(): String = FirebaseInstanceId.getInstance().id
 
     override fun enabledFeatures(user: User?): List<String> {

--- a/app/src/main/java/com/kickstarter/libs/utils/ExperimentUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/ExperimentUtils.kt
@@ -4,7 +4,10 @@ import com.google.firebase.iid.FirebaseInstanceId
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.models.User
+import com.kickstarter.ui.data.CheckoutData
+import com.kickstarter.ui.data.PledgeData
 import java.util.*
+import kotlin.math.roundToInt
 
 object ExperimentUtils {
 
@@ -21,6 +24,21 @@ object ExperimentUtils {
         )
     }
 
+    fun checkoutTags(experimentRevenueData: ExperimentRevenueData): Map<String, Any?> {
+        val amount = experimentRevenueData.checkoutData.amount()
+        val project = experimentRevenueData.pledgeData.projectData().project()
+        val fxRate = project.fxRate()
+        val paymentType = experimentRevenueData.checkoutData.paymentType()
+        val revenue = (amount * fxRate * 100).roundToInt()
+        return mapOf(
+                Pair("checkout_amount", amount),
+                Pair("checkout_payment_type", paymentType.rawValue()),
+                Pair("checkout_revenue_in_usd_cents", revenue),
+                Pair("revenue", revenue),
+                Pair("currency", project.currency())
+        )
+    }
+
     private fun getInstanceId(environment: OptimizelyEnvironment) = when (environment) {
         OptimizelyEnvironment.DEVELOPMENT -> ""
         OptimizelyEnvironment.PRODUCTION -> null
@@ -29,3 +47,4 @@ object ExperimentUtils {
 }
 
 data class ExperimentData(val user: User?, val intentRefTag: RefTag?, val cookieRefTag: RefTag?)
+data class ExperimentRevenueData(val experimentData: ExperimentData, val checkoutData: CheckoutData, val pledgeData: PledgeData)

--- a/app/src/main/java/com/kickstarter/libs/utils/ExperimentUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/ExperimentUtils.kt
@@ -7,7 +7,6 @@ import com.kickstarter.models.User
 import com.kickstarter.ui.data.CheckoutData
 import com.kickstarter.ui.data.PledgeData
 import java.util.*
-import kotlin.math.roundToInt
 
 object ExperimentUtils {
 
@@ -21,21 +20,6 @@ object ExperimentUtils {
                 Pair("session_user_is_logged_in", experimentData.user != null),
                 Pair("user_backed_projects_count", experimentData.user?.backedProjectsCount() ?: 0),
                 Pair("user_country", experimentData.user?.location()?.country() ?: Locale.getDefault().country)
-        )
-    }
-
-    fun checkoutTags(experimentRevenueData: ExperimentRevenueData): Map<String, Any?> {
-        val amount = experimentRevenueData.checkoutData.amount()
-        val project = experimentRevenueData.pledgeData.projectData().project()
-        val fxRate = project.fxRate()
-        val paymentType = experimentRevenueData.checkoutData.paymentType()
-        val revenue = (amount * fxRate * 100).roundToInt()
-        return mapOf(
-                Pair("checkout_amount", amount),
-                Pair("checkout_payment_type", paymentType.rawValue()),
-                Pair("checkout_revenue_in_usd_cents", revenue),
-                Pair("revenue", revenue),
-                Pair("currency", project.currency())
         )
     }
 

--- a/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
@@ -14,8 +14,8 @@ import rx.subjects.PublishSubject
 
 
 open class MockExperimentsClientType(private val variant: OptimizelyExperiment.Variant, private val optimizelyEnvironment: OptimizelyEnvironment) : ExperimentsClientType {
-    constructor(variant: OptimizelyExperiment.Variant) : this(variant, OptimizelyEnvironment.STAGING)
-    constructor() : this(OptimizelyExperiment.Variant.CONTROL, OptimizelyEnvironment.STAGING)
+    constructor(variant: OptimizelyExperiment.Variant) : this(variant, OptimizelyEnvironment.DEVELOPMENT)
+    constructor() : this(OptimizelyExperiment.Variant.CONTROL, OptimizelyEnvironment.DEVELOPMENT)
 
     class ExperimentsEvent internal constructor(internal val eventKey: String, internal val attributes: Map<String, *>, internal val tags: Map<String, *>?)
 

--- a/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
@@ -49,10 +49,6 @@ open class MockExperimentsClientType(private val variant: OptimizelyExperiment.V
         this.experimentEvents.onNext(ExperimentsEvent(eventKey, attributes(experimentData, this.optimizelyEnvironment), null))
     }
 
-    override fun trackRevenue(eventKey: String, experimentRevenueData: ExperimentRevenueData) {
-        this.experimentEvents.onNext(ExperimentsEvent(eventKey, attributes(experimentRevenueData.experimentData, this.optimizelyEnvironment), checkoutTags(experimentRevenueData)))
-    }
-
     override fun userId(): String = "device-id"
 
     override fun variant(experiment: OptimizelyExperiment.Key, experimentData: ExperimentData): OptimizelyExperiment.Variant = this.variant

--- a/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
@@ -6,12 +6,21 @@ import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.utils.ExperimentData
 import com.kickstarter.models.User
+import com.kickstarter.libs.utils.ExperimentRevenueData
 import org.json.JSONArray
 import org.json.JSONObject
+import rx.Observable
+import rx.subjects.PublishSubject
+
 
 open class MockExperimentsClientType(private val variant: OptimizelyExperiment.Variant, private val optimizelyEnvironment: OptimizelyEnvironment) : ExperimentsClientType {
     constructor(variant: OptimizelyExperiment.Variant) : this(variant, OptimizelyEnvironment.STAGING)
     constructor() : this(OptimizelyExperiment.Variant.CONTROL, OptimizelyEnvironment.STAGING)
+
+    class ExperimentsEvent internal constructor(internal val eventKey: String, internal val attributes: Map<String, *>, internal val tags: Map<String, *>?)
+
+    private val experimentEvents : PublishSubject<ExperimentsEvent> = PublishSubject.create()
+    val eventKeys: Observable<String> = this.experimentEvents.map { e -> e.eventKey }
 
     override fun appVersion(): String = "9.9.9"
 
@@ -35,6 +44,14 @@ open class MockExperimentsClientType(private val variant: OptimizelyExperiment.V
     override fun OSVersion(): String = "9"
 
     override fun trackingVariation(experimentKey: String, experimentData: ExperimentData): String? = this.variant.rawValue
+
+    override fun track(eventKey: String, experimentData: ExperimentData) {
+        this.experimentEvents.onNext(ExperimentsEvent(eventKey, attributes(experimentData, this.optimizelyEnvironment), null))
+    }
+
+    override fun trackRevenue(eventKey: String, experimentRevenueData: ExperimentRevenueData) {
+        this.experimentEvents.onNext(ExperimentsEvent(eventKey, attributes(experimentRevenueData.experimentData, this.optimizelyEnvironment), checkoutTags(experimentRevenueData)))
+    }
 
     override fun userId(): String = "device-id"
 

--- a/app/src/main/java/com/kickstarter/viewmodels/CampaignDetailsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CampaignDetailsViewModel.kt
@@ -2,6 +2,7 @@ package com.kickstarter.viewmodels
 
 import android.util.Pair
 import com.kickstarter.libs.ActivityViewModel
+import com.kickstarter.libs.CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
@@ -80,6 +81,13 @@ interface CampaignDetailsViewModel {
                     .compose<ProjectData>(takeWhen(this.pledgeButtonClicked))
                     .compose(bindToLifecycle())
                     .subscribe { this.lake.trackCampaignDetailsPledgeButtonClicked(it) }
+
+            projectData
+                    .compose<Pair<ProjectData, User?>>(combineLatestPair(this.currentUser.observable()))
+                    .map { ExperimentData(it.second, it.first.refTagFromIntent(), it.first.refTagFromCookie()) }
+                    .compose<ExperimentData>(takeWhen(this.pledgeButtonClicked))
+                    .compose(bindToLifecycle())
+                    .subscribe { this.optimizely.track(CAMPAIGN_DETAILS_PLEDGE_BUTTON_CLICKED, it) }
         }
 
         override fun pledgeActionButtonClicked() = this.pledgeButtonClicked.onNext(null)

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -8,6 +8,7 @@ import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.ExperimentsClientType;
 import com.kickstarter.libs.FragmentViewModel;
 import com.kickstarter.libs.KoalaContext;
+import com.kickstarter.libs.LakeEvent;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.models.OptimizelyFeature;
 import com.kickstarter.libs.preferences.IntPreferenceType;
@@ -37,7 +38,6 @@ import com.kickstarter.ui.viewholders.DiscoveryOnboardingViewHolder;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -45,7 +45,6 @@ import rx.Observable;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 
-import static com.kickstarter.libs.LakeEvent.EDITORIAL_CARD_CLICKED;
 import static com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair;
 import static com.kickstarter.libs.rx.transformers.Transformers.ignoreValues;
 import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
@@ -299,9 +298,9 @@ public interface DiscoveryFragmentViewModel {
         .compose(bindToLifecycle())
         .subscribe(paramsAndEditorial -> {
           this.lake.trackEditorialCardClicked(paramsAndEditorial.first.first, paramsAndEditorial.first.second);
-          ExperimentData data = new ExperimentData(paramsAndEditorial.second,
+          final ExperimentData data = new ExperimentData(paramsAndEditorial.second,
             RefTag.collection(paramsAndEditorial.first.second.getTagId()), null);
-          this.optimizely.track(EDITORIAL_CARD_CLICKED, data);
+          this.optimizely.track(LakeEvent.EDITORIAL_CARD_CLICKED, data);
         });
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -773,7 +773,10 @@ interface ProjectViewModel {
                     .compose<ProjectData>(takeWhen(creatorInfoClicked))
                     .filter { it.project().isLive && !it.project().isBacking }
                     .compose(bindToLifecycle())
-                    .subscribe { this.lake.trackCreatorDetailsClicked(it) }
+                    .subscribe {
+                        this.optimizely.track(CREATOR_DETAILS_CLICKED, it.first)
+                        this.lake.trackCreatorDetailsClicked(it)
+                    }
 
             fullProjectDataAndPledgeFlowContext
                     .compose<Pair<ProjectData, PledgeFlowContext?>>(takeWhen(this.nativeProjectActionButtonClicked))

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -769,6 +769,23 @@ interface ProjectViewModel {
                     .subscribe { this.lake.trackCampaignDetailsButtonClicked(it) }
 
             fullProjectDataAndCurrentUser
+                    .map { Pair(ExperimentData(it.second, it.first.refTagFromIntent(), it.first.refTagFromCookie()), it.first.project()) }
+                    .compose<Pair<ExperimentData, Project>>(takeWhen(blurbClicked))
+                    .filter { it.second.isLive && !it.second.isBacking }
+                    .subscribe { this.optimizely.track(CAMPAIGN_DETAILS_BUTTON_CLICKED, it.first) }
+
+            val shouldTrackCTAClickedEvent = this.pledgeActionButtonText
+                    .map { isPledgeCTA(it) }
+                    .compose<Boolean>(takeWhen(this.nativeProjectActionButtonClicked))
+
+            fullProjectDataAndCurrentUser
+                    .map { ExperimentData(it.second, it.first.refTagFromIntent(), it.first.refTagFromCookie()) }
+                    .compose<Pair<ExperimentData, Boolean>>(combineLatestPair(shouldTrackCTAClickedEvent))
+                    .filter { it.second }
+                    .compose(bindToLifecycle())
+                    .subscribe { this.optimizely.track(PROJECT_PAGE_PLEDGE_BUTTON_CLICKED, it.first) }
+
+            fullProjectDataAndCurrentUser
                     .map { it.first }
                     .compose<ProjectData>(takeWhen(creatorInfoClicked))
                     .filter { it.project().isLive && !it.project().isBacking }
@@ -802,6 +819,17 @@ interface ProjectViewModel {
                 R.string.Manage -> KoalaEvent.MANAGE_PLEDGE_BUTTON_CLICKED
                 R.string.View_your_pledge -> KoalaEvent.VIEW_YOUR_PLEDGE_BUTTON_CLICKED
                 else -> KoalaEvent.VIEW_REWARDS_BUTTON_CLICKED
+            }
+        }
+
+        private fun isPledgeCTA(projectActionButtonStringRes: Int) : Boolean {
+            return when (projectActionButtonStringRes) {
+                R.string.Back_this_project -> true
+                R.string.View_the_rewards -> true
+                R.string.See_the_rewards -> true
+                R.string.Manage -> false
+                R.string.View_your_pledge -> false
+                else -> false
             }
         }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -701,6 +701,11 @@ interface ProjectViewModel {
                         this.lake.trackProjectPageViewed(dataWithStoredCookieRefTag, pledgeFlowContext)
                     }
 
+            fullProjectDataAndCurrentUser
+                    .map { Pair(ExperimentData(it.second, it.first.refTagFromIntent(), it.first.refTagFromCookie()), it.first.project()) }
+                    .compose(bindToLifecycle())
+                    .subscribe { this.optimizely.track(PROJECT_PAGE_VIEWED, it.first) }
+
             fullProjectDataAndPledgeFlowContext
                     .compose<Pair<ProjectData, PledgeFlowContext?>>(takeWhen(this.nativeProjectActionButtonClicked))
                     .filter { it.first.project().isLive && !it.first.project().isBacking }

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -773,10 +773,14 @@ interface ProjectViewModel {
                     .compose<ProjectData>(takeWhen(creatorInfoClicked))
                     .filter { it.project().isLive && !it.project().isBacking }
                     .compose(bindToLifecycle())
-                    .subscribe {
-                        this.optimizely.track(CREATOR_DETAILS_CLICKED, it.first)
-                        this.lake.trackCreatorDetailsClicked(it)
-                    }
+                    .subscribe { this.lake.trackCreatorDetailsClicked(it) }
+
+            fullProjectDataAndCurrentUser
+                    .map { Pair(ExperimentData(it.second, it.first.refTagFromIntent(), it.first.refTagFromCookie()), it.first.project()) }
+                    .compose<Pair<ExperimentData, Project>>(takeWhen(creatorInfoClicked))
+                    .filter { it.second.isLive && !it.second.isBacking }
+                    .compose(bindToLifecycle())
+                    .subscribe { this.optimizely.track(CREATOR_DETAILS_CLICKED, it.first) }
 
             fullProjectDataAndPledgeFlowContext
                     .compose<Pair<ProjectData, PledgeFlowContext?>>(takeWhen(this.nativeProjectActionButtonClicked))

--- a/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
+++ b/app/src/test/java/com/kickstarter/KSRobolectricTestCase.java
@@ -33,6 +33,7 @@ import rx.observers.TestSubscriber;
 @Config(shadows = ShadowAndroidXMultiDex.class, sdk = KSRobolectricGradleTestRunner.DEFAULT_SDK)
 public abstract class KSRobolectricTestCase extends TestCase {
   private TestKSApplication application;
+  public TestSubscriber<String> experimentsTest;
   public TestSubscriber<String> koalaTest;
   public TestSubscriber<String> lakeTest;
   private Environment environment;
@@ -43,7 +44,7 @@ public abstract class KSRobolectricTestCase extends TestCase {
     super.setUp();
     final MockCurrentConfig mockCurrentConfig = new MockCurrentConfig();
 
-    final MockExperimentsClientType experimentsClientType = new MockExperimentsClientType();
+    final MockExperimentsClientType experimentsClientType = experimentsClient();
     final MockTrackingClient koalaTrackingClient = koalaTrackingClient(mockCurrentConfig, experimentsClientType);
     final MockTrackingClient lakeTrackingClient = lakeTrackingClient(mockCurrentConfig, experimentsClientType);
 
@@ -87,6 +88,13 @@ public abstract class KSRobolectricTestCase extends TestCase {
 
   protected @NonNull KSString ksString() {
     return new KSString(application().getPackageName(), application().getResources());
+  }
+
+  private MockExperimentsClientType experimentsClient() {
+    this.experimentsTest = new TestSubscriber<>();
+    final MockExperimentsClientType experimentsClientType = new MockExperimentsClientType();
+    experimentsClientType.getEventKeys().subscribe(this.experimentsTest);
+    return experimentsClientType;
   }
 
   private MockTrackingClient koalaTrackingClient(final @NonNull MockCurrentConfig mockCurrentConfig,

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -487,8 +487,8 @@ class LakeTest : KSRobolectricTestCase() {
 
     private fun assertOptimizelyProperties() {
         val expectedProperties = this.propertiesTest.value
-        assertEquals(OptimizelyEnvironment.STAGING.sdkKey, expectedProperties["optimizely_api_key"])
-        assertEquals(OptimizelyEnvironment.STAGING.environmentKey, expectedProperties["optimizely_environment_key"])
+        assertEquals(OptimizelyEnvironment.DEVELOPMENT.sdkKey, expectedProperties["optimizely_api_key"])
+        assertEquals(OptimizelyEnvironment.DEVELOPMENT.environmentKey, expectedProperties["optimizely_environment_key"])
         assertNotNull(expectedProperties["optimizely_experiments"])
         val experiments = expectedProperties["optimizely_experiments"] as JSONArray
         val experiment = experiments[0] as JSONObject

--- a/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
@@ -38,6 +38,7 @@ class CampaignDetailsViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.pledgeActionButtonClicked()
         this.goBackToProject.assertValueCount(1)
         this.lakeTest.assertValue("Campaign Details Pledge Button Clicked")
+        this.experimentsTest.assertValue("Campaign Details Pledge Button Clicked")
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -395,6 +395,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.totalDividerIsGone.assertValue(false)
         this.koalaTest.assertValue("Pledge Screen Viewed")
         this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.experimentsTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -418,6 +419,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.koalaTest.assertValue("Pledge Screen Viewed")
         this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.experimentsTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -445,6 +447,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.koalaTest.assertValue("Pledge Screen Viewed")
         this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.experimentsTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -468,6 +471,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.koalaTest.assertValue("Pledge Screen Viewed")
         this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.experimentsTest.assertValue("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -501,6 +505,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.koalaTest.assertNoValues()
         this.lakeTest.assertNoValues()
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -528,6 +533,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.koalaTest.assertNoValues()
         this.lakeTest.assertNoValues()
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -561,6 +567,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.koalaTest.assertNoValues()
         this.lakeTest.assertNoValues()
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -588,6 +595,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.koalaTest.assertNoValues()
         this.lakeTest.assertNoValues()
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -634,6 +642,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.koalaTest.assertNoValues()
         this.lakeTest.assertNoValues()
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -664,6 +673,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.koalaTest.assertNoValues()
         this.lakeTest.assertNoValues()
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -693,6 +703,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.koalaTest.assertNoValues()
         this.lakeTest.assertNoValues()
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -718,6 +729,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.koalaTest.assertNoValues()
         this.lakeTest.assertNoValues()
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -1625,6 +1637,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
         this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -1828,6 +1841,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showNewCardFragment.assertValue(project)
         this.koalaTest.assertValues("Pledge Screen Viewed", "Add New Card Button Clicked")
         this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -2542,6 +2556,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeError.assertNoValues()
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
         this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -2562,6 +2577,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeError.assertNoValues()
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
         this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -2586,6 +2602,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeError.assertNoValues()
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
         this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -2613,6 +2630,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSCAFlow.assertNoValues()
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
         this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -2640,6 +2658,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSCAFlow.assertValueCount(1)
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
         this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.experimentsTest.assertValues("Checkout Payment Page Viewed")
 
         this.vm.inputs.stripeSetupResultSuccessful(StripeIntentResult.Outcome.SUCCEEDED)
 
@@ -2681,6 +2700,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeError.assertValueCount(1)
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
         this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -2717,6 +2737,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeError.assertValueCount(1)
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
         this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -402,6 +402,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.lakeTest.assertValues("Project Page Viewed", "Campaign Details Button Clicked")
+        this.experimentsTest.assertValue("Campaign Details Button Clicked")
     }
 
     @Test
@@ -415,6 +416,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -428,6 +430,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -441,6 +444,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.blurbVariantClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.lakeTest.assertValues("Project Page Viewed", "Campaign Details Button Clicked")
+        this.experimentsTest.assertValue("Campaign Details Button Clicked")
     }
 
     @Test
@@ -454,6 +458,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.blurbVariantClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -467,6 +472,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.blurbVariantClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -782,6 +788,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.goBack.assertNoValues()
         this.koalaTest.assertValues("Project Page", "Back this Project Button Clicked")
         this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
+        this.experimentsTest.assertValues("Project Page Pledge Button Clicked")
     }
 
     @Test
@@ -794,6 +801,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page", "Back this Project Button Clicked")
         this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
+        this.experimentsTest.assertValues("Project Page Pledge Button Clicked")
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -788,7 +788,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.goBack.assertNoValues()
         this.koalaTest.assertValues("Project Page", "Back this Project Button Clicked")
         this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
-        this.experimentsTest.assertValues("Project Page Pledge Button Clicked")
+        this.experimentsTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
     }
 
     @Test
@@ -801,7 +801,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValue(Pair(true, true))
         this.koalaTest.assertValues("Project Page", "Back this Project Button Clicked")
         this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
-        this.experimentsTest.assertValues("Project Page Pledge Button Clicked")
+        this.experimentsTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -402,7 +402,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.lakeTest.assertValues("Project Page Viewed", "Campaign Details Button Clicked")
-        this.experimentsTest.assertValue("Campaign Details Button Clicked")
+        this.experimentsTest.assertValues("Project Page Viewed", "Campaign Details Button Clicked")
     }
 
     @Test
@@ -416,7 +416,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
+        this.experimentsTest.assertValue("Project Page Viewed")
     }
 
     @Test
@@ -430,7 +430,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
+        this.experimentsTest.assertValue("Project Page Viewed")
     }
 
     @Test
@@ -444,7 +444,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.blurbVariantClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.lakeTest.assertValues("Project Page Viewed", "Campaign Details Button Clicked")
-        this.experimentsTest.assertValue("Campaign Details Button Clicked")
+        this.experimentsTest.assertValues("Project Page Viewed", "Campaign Details Button Clicked")
     }
 
     @Test
@@ -458,7 +458,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.blurbVariantClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
+        this.experimentsTest.assertValue("Project Page Viewed")
     }
 
     @Test
@@ -472,7 +472,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.blurbVariantClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
+        this.experimentsTest.assertValue("Project Page Viewed")
     }
 
     @Test
@@ -486,7 +486,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.creatorNameTextViewClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
         this.lakeTest.assertValues("Project Page Viewed", "Creator Details Clicked")
-        this.experimentsTest.assertValue("Creator Details Clicked")
+        this.experimentsTest.assertValues("Project Page Viewed", "Creator Details Clicked")
     }
 
     @Test
@@ -500,7 +500,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.creatorNameTextViewClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
+        this.experimentsTest.assertValue("Project Page Viewed")
     }
 
     @Test
@@ -514,7 +514,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.creatorNameTextViewClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
+        this.experimentsTest.assertValue("Project Page Viewed")
     }
 
     @Test
@@ -528,7 +528,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.creatorInfoVariantClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
         this.lakeTest.assertValues("Project Page Viewed", "Creator Details Clicked")
-        this.experimentsTest.assertValue("Creator Details Clicked")
+        this.experimentsTest.assertValues("Project Page Viewed", "Creator Details Clicked")
     }
 
     @Test
@@ -542,7 +542,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.creatorInfoVariantClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
+        this.experimentsTest.assertValue("Project Page Viewed")
     }
 
     @Test
@@ -556,7 +556,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.creatorInfoVariantClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
         this.lakeTest.assertValue("Project Page Viewed")
-        this.experimentsTest.assertNoValues()
+        this.experimentsTest.assertValue("Project Page Viewed")
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -480,6 +480,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.creatorNameTextViewClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
         this.lakeTest.assertValues("Project Page Viewed", "Creator Details Clicked")
+        this.experimentsTest.assertValue("Creator Details Clicked")
     }
 
     @Test
@@ -493,6 +494,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.creatorNameTextViewClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
         this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -506,6 +508,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.creatorNameTextViewClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
         this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -519,6 +522,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.creatorInfoVariantClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
         this.lakeTest.assertValues("Project Page Viewed", "Creator Details Clicked")
+        this.experimentsTest.assertValue("Creator Details Clicked")
     }
 
     @Test
@@ -532,6 +536,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.creatorInfoVariantClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
         this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test
@@ -545,6 +550,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.creatorInfoVariantClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
         this.lakeTest.assertValue("Project Page Viewed")
+        this.experimentsTest.assertNoValues()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Send events through the Optimizely SDK instead of just the Data Lake

# 🤔 Why

Events passed to that data lake were not correctly forwarded to Optimizely.

# 🛠 How

Added the following events back to the app. Some events were not in the app originally

Events

- [Creator Details Button Clicked](https://github.com/kickstarter/android-oss/pull/855) 
- [Campaign Details Button Clicked](https://github.com/kickstarter/android-oss/pull/853)
- [Project Page Pledge Button Clicked](https://github.com/kickstarter/android-oss/pull/856)
- [Campaign Details Pledge Button Clicked](https://github.com/kickstarter/android-oss/pull/852)
- Project Page Viewed (Not originally added)
- Checkout Payment Page Viewed (Not originally added)

# 📋 QA

Run the app and ensure that the events are fired correctly

# Story 📖

[NT-1318](https://kickstarter.atlassian.net/browse/NT-1318)
