### PR TITLE
NT-1411: Creator crash fixed

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/BackingActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/BackingActivity.java
@@ -13,7 +13,7 @@ import com.kickstarter.viewmodels.BackingViewModel;
 import androidx.annotation.Nullable;
 
 @RequiresActivityViewModel(BackingViewModel.ViewModel.class)
-public final class BackingActivity extends BaseActivity<BackingViewModel.ViewModel> {
+public final class BackingActivity extends BaseActivity<BackingViewModel.ViewModel> implements BackingFragment.BackingDelegate {
 
   @Override
   public void onCreate(final @Nullable Bundle savedInstanceState) {
@@ -23,6 +23,11 @@ public final class BackingActivity extends BaseActivity<BackingViewModel.ViewMod
     this.viewModel.outputs.showBackingFragment()
             .compose(bindToLifecycle())
             .subscribe(this::startBackingFragment);
+
+    this.viewModel.outputs.isRefreshing()
+            .compose(bindToLifecycle())
+            .subscribe(it -> backingFragment().isRefreshing(it));
+
   }
 
   private void startBackingFragment(final BackingWrapper backingWrapper) {
@@ -42,4 +47,12 @@ public final class BackingActivity extends BaseActivity<BackingViewModel.ViewMod
     return  (BackingFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_backing);
   }
 
+  @Override
+  public void refreshProject() {
+    this.viewModel.inputs.refresh();
+  }
+
+  @Override
+  public void showFixPaymentMethod() { }
 }
+

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -241,6 +241,11 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>() {
                 .subscribe { this.viewModel.inputs.receivedCheckboxToggled(estimated_delivery_checkbox.isChecked) }
     }
 
+
+    public fun isRefreshing(isRefreshing: Boolean) {
+        backing_swipe_refresh_layout.isRefreshing = isRefreshing
+    }
+
     private fun setBoldSpanOnTextView(numCharacters: Int, textView: TextView, spanColor: Int) {
         val spannable = SpannableString(textView.text)
         spannable.setSpan(ForegroundColorSpan(spanColor), 0, numCharacters, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -1,13 +1,11 @@
 package com.kickstarter.ui.fragments
 
-import android.graphics.Color
 import android.graphics.Typeface
 import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
 import android.text.style.StyleSpan
-import android.util.Log
 import android.util.Pair
 import android.view.LayoutInflater
 import android.view.View
@@ -24,7 +22,6 @@ import com.kickstarter.libs.SwipeRefresher
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.transformations.CircleTransformation
-import com.kickstarter.libs.utils.ProjectUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.adapters.RewardAndAddOnsAdapter
@@ -241,8 +238,7 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>() {
                 .subscribe { this.viewModel.inputs.receivedCheckboxToggled(estimated_delivery_checkbox.isChecked) }
     }
 
-
-    public fun isRefreshing(isRefreshing: Boolean) {
+    public fun isRefreshing(isRefreshing: Boolean){
         backing_swipe_refresh_layout.isRefreshing = isRefreshing
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels;
 
+import android.util.Log;
 import android.util.Pair;
 
 import com.kickstarter.libs.ActivityViewModel;
@@ -15,58 +16,89 @@ import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.activities.BackingActivity;
 
 import androidx.annotation.NonNull;
+
 import rx.Observable;
 import rx.subjects.PublishSubject;
 
 import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
+import static com.kickstarter.libs.rx.transformers.Transformers.takeWhen;
 
 public interface BackingViewModel {
 
-  interface Outputs {
-    /** Set the backer name TextView's text. */
-    Observable<BackingWrapper> showBackingFragment();
-  }
-
-  final class ViewModel extends ActivityViewModel<BackingActivity> implements Outputs {
-    private final CurrentUserType currentUser;
-    private ApolloClientType apolloClient;
-
-    private final PublishSubject<BackingWrapper> backingWrapper = PublishSubject.create();
-
-    public ViewModel(final @NonNull Environment environment) {
-      super(environment);
-
-      this.currentUser = environment.currentUser();
-      this.apolloClient = environment.apolloClient();
-
-      final Observable<User> loggedInUser = this.currentUser.loggedInUser();
-
-      final Observable<Project> project = intent()
-        .map(i -> i.getParcelableExtra(IntentKey.PROJECT))
-        .ofType(Project.class);
-
-      final Observable<Backing> backingInfo = intent()
-              .map(i -> i.getParcelableExtra(IntentKey.BACKING));
-
-      final Observable<Backing> backing = Observable.combineLatest(project, backingInfo, Pair::create)
-        .switchMap(pb -> this.apolloClient.getBacking(Long.toString(pb.second.id())))
-        .distinctUntilChanged()
-        .filter(bk -> ObjectUtils.isNotNull(bk))
-        .compose(neverError());
-
-      Observable.combineLatest(backing, project, loggedInUser, this::createWrapper)
-              .subscribe(this.backingWrapper::onNext);
+    interface Inputs {
+        void refresh();
     }
 
-    public final Outputs outputs = this;
+    interface Outputs {
+        /**
+         * Set the backer name TextView's text.
+         */
+        Observable<BackingWrapper> showBackingFragment();
 
-    private BackingWrapper createWrapper(final Backing backing, final Project project, final User currentUser) {
-      return new BackingWrapper(backing, currentUser, project);
+        Observable<Boolean> isRefreshing();
     }
 
-    @Override
-    public Observable<BackingWrapper> showBackingFragment() {
-      return this.backingWrapper;
+    final class ViewModel extends ActivityViewModel<BackingActivity> implements Outputs, Inputs {
+        private final CurrentUserType currentUser;
+        private ApolloClientType apolloClient;
+        private PublishSubject<Void> refreshBacking = PublishSubject.create();
+        private PublishSubject<Boolean> isRefreshing = PublishSubject.create();
+
+
+        private final PublishSubject<BackingWrapper> backingWrapper = PublishSubject.create();
+
+        public ViewModel(final @NonNull Environment environment) {
+            super(environment);
+
+            this.currentUser = environment.currentUser();
+            this.apolloClient = environment.apolloClient();
+
+            final Observable<User> loggedInUser = this.currentUser.loggedInUser();
+
+            final Observable<Project> project = intent()
+                    .map(i -> i.getParcelableExtra(IntentKey.PROJECT))
+                    .ofType(Project.class);
+
+            final Observable<Backing> backingInfo = intent()
+                    .map(i -> i.getParcelableExtra(IntentKey.BACKING));
+
+            final Observable<Backing> backing = Observable.combineLatest(project, backingInfo, Pair::create)
+                    .switchMap(pb -> this.apolloClient.getBacking(Long.toString(pb.second.id())))
+                    .distinctUntilChanged()
+                    .filter(bk -> ObjectUtils.isNotNull(bk))
+                    .compose(neverError());
+
+            backing.compose(takeWhen(refreshBacking))
+                    .switchMap(backing1 -> this.apolloClient.getBacking(Long.toString(backing1.id())))
+                    .filter(ObjectUtils::isNotNull)
+                    .subscribe(it -> this.isRefreshing.onNext(false));
+
+            Observable.combineLatest(backing, project, loggedInUser, this::createWrapper)
+                    .subscribe(this.backingWrapper::onNext);
+
+
+        }
+
+        public final Outputs outputs = this;
+        public final Inputs inputs = this;
+
+        private BackingWrapper createWrapper(final Backing backing, final Project project, final User currentUser) {
+            return new BackingWrapper(backing, currentUser, project);
+        }
+
+        @Override
+        public Observable<BackingWrapper> showBackingFragment() {
+            return this.backingWrapper;
+        }
+
+        @Override
+        public void refresh() {
+            this.refreshBacking.onNext(null);
+        }
+
+        @Override
+        public Observable<Boolean> isRefreshing() {
+            return this.isRefreshing;
+        }
     }
-  }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
@@ -1,7 +1,8 @@
 package com.kickstarter.viewmodels;
 
-import android.util.Log;
 import android.util.Pair;
+
+import androidx.annotation.NonNull;
 
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.CurrentUserType;
@@ -15,8 +16,6 @@ import com.kickstarter.services.ApolloClientType;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.activities.BackingActivity;
 
-import androidx.annotation.NonNull;
-
 import rx.Observable;
 import rx.subjects.PublishSubject;
 
@@ -25,80 +24,80 @@ import static com.kickstarter.libs.rx.transformers.Transformers.takeWhen;
 
 public interface BackingViewModel {
 
-    interface Inputs {
-        void refresh();
+  interface Inputs {
+    void refresh();
+  }
+
+  interface Outputs {
+    /**
+     * Set the backer name TextView's text.
+     */
+    Observable<BackingWrapper> showBackingFragment();
+
+    Observable<Boolean> isRefreshing();
+  }
+
+  final class ViewModel extends ActivityViewModel<BackingActivity> implements Outputs, Inputs {
+    private final CurrentUserType currentUser;
+    private ApolloClientType apolloClient;
+    private PublishSubject<Void> refreshBacking = PublishSubject.create();
+    private PublishSubject<Boolean> isRefreshing = PublishSubject.create();
+
+
+    private final PublishSubject<BackingWrapper> backingWrapper = PublishSubject.create();
+
+    public ViewModel(final @NonNull Environment environment) {
+      super(environment);
+
+      this.currentUser = environment.currentUser();
+      this.apolloClient = environment.apolloClient();
+
+      final Observable<User> loggedInUser = this.currentUser.loggedInUser();
+
+      final Observable<Project> project = intent()
+              .map(i -> i.getParcelableExtra(IntentKey.PROJECT))
+              .ofType(Project.class);
+
+      final Observable<Backing> backingInfo = intent()
+              .map(i -> i.getParcelableExtra(IntentKey.BACKING));
+
+      final Observable<Backing> backing = Observable.combineLatest(project, backingInfo, Pair::create)
+              .switchMap(pb -> this.apolloClient.getBacking(Long.toString(pb.second.id())))
+              .distinctUntilChanged()
+              .filter(bk -> ObjectUtils.isNotNull(bk))
+              .compose(neverError());
+
+      backing.compose(takeWhen(refreshBacking))
+              .switchMap(backing1 -> this.apolloClient.getBacking(Long.toString(backing1.id())))
+              .filter(ObjectUtils::isNotNull)
+              .subscribe(it -> this.isRefreshing.onNext(false));
+
+      Observable.combineLatest(backing, project, loggedInUser, this::createWrapper)
+              .subscribe(this.backingWrapper::onNext);
+
+
     }
 
-    interface Outputs {
-        /**
-         * Set the backer name TextView's text.
-         */
-        Observable<BackingWrapper> showBackingFragment();
+    public final Outputs outputs = this;
+    public final Inputs inputs = this;
 
-        Observable<Boolean> isRefreshing();
+    private BackingWrapper createWrapper(final Backing backing, final Project project, final User currentUser) {
+      return new BackingWrapper(backing, currentUser, project);
     }
 
-    final class ViewModel extends ActivityViewModel<BackingActivity> implements Outputs, Inputs {
-        private final CurrentUserType currentUser;
-        private ApolloClientType apolloClient;
-        private PublishSubject<Void> refreshBacking = PublishSubject.create();
-        private PublishSubject<Boolean> isRefreshing = PublishSubject.create();
-
-
-        private final PublishSubject<BackingWrapper> backingWrapper = PublishSubject.create();
-
-        public ViewModel(final @NonNull Environment environment) {
-            super(environment);
-
-            this.currentUser = environment.currentUser();
-            this.apolloClient = environment.apolloClient();
-
-            final Observable<User> loggedInUser = this.currentUser.loggedInUser();
-
-            final Observable<Project> project = intent()
-                    .map(i -> i.getParcelableExtra(IntentKey.PROJECT))
-                    .ofType(Project.class);
-
-            final Observable<Backing> backingInfo = intent()
-                    .map(i -> i.getParcelableExtra(IntentKey.BACKING));
-
-            final Observable<Backing> backing = Observable.combineLatest(project, backingInfo, Pair::create)
-                    .switchMap(pb -> this.apolloClient.getBacking(Long.toString(pb.second.id())))
-                    .distinctUntilChanged()
-                    .filter(bk -> ObjectUtils.isNotNull(bk))
-                    .compose(neverError());
-
-            backing.compose(takeWhen(refreshBacking))
-                    .switchMap(backing1 -> this.apolloClient.getBacking(Long.toString(backing1.id())))
-                    .filter(ObjectUtils::isNotNull)
-                    .subscribe(it -> this.isRefreshing.onNext(false));
-
-            Observable.combineLatest(backing, project, loggedInUser, this::createWrapper)
-                    .subscribe(this.backingWrapper::onNext);
-
-
-        }
-
-        public final Outputs outputs = this;
-        public final Inputs inputs = this;
-
-        private BackingWrapper createWrapper(final Backing backing, final Project project, final User currentUser) {
-            return new BackingWrapper(backing, currentUser, project);
-        }
-
-        @Override
-        public Observable<BackingWrapper> showBackingFragment() {
-            return this.backingWrapper;
-        }
-
-        @Override
-        public void refresh() {
-            this.refreshBacking.onNext(null);
-        }
-
-        @Override
-        public Observable<Boolean> isRefreshing() {
-            return this.isRefreshing;
-        }
+    @Override
+    public Observable<BackingWrapper> showBackingFragment() {
+      return this.backingWrapper;
     }
+
+    @Override
+    public void refresh() {
+      this.refreshBacking.onNext(null);
+    }
+
+    @Override
+    public Observable<Boolean> isRefreshing() {
+      return this.isRefreshing;
+    }
+  }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingViewModel.java
@@ -67,7 +67,7 @@ public interface BackingViewModel {
               .filter(bk -> ObjectUtils.isNotNull(bk))
               .compose(neverError());
 
-      backing.compose(takeWhen(refreshBacking))
+      backing.compose(takeWhen(this.refreshBacking))
               .switchMap(backing1 -> this.apolloClient.getBacking(Long.toString(backing1.id())))
               .filter(ObjectUtils::isNotNull)
               .subscribe(it -> this.isRefreshing.onNext(false));


### PR DESCRIPTION
# 📲 What

When a creator goes to view details about a pledge to their project, the app was crashing on pull to refresh.

# 🤔 Why

The current logic in BackingFragment expects the parent activity to call the appropriate delegate function when refresh is triggered. This is implemented correctly in ProjectActivity, where the BackingFragment is loaded from in the user-context of a backer. For creators, BackingFragment is loaded by BackingActivity, which did not properly implement these delegate functions, so we were crashing due to a ClassCastException. 

# 🛠 How

I implemented the BackingFragment.BackingDelegate interface in BackingActivity, and updated BackingViewModel to re-fetch the backing on pull to refresh, and then update the UI.

# 👀 See

Hard to display this one, so no screenshots.


# 📋 QA

Log in as a creator, go to the Messages for a project you created, view a pledge, and refresh the layout. Confirm that no crash occurs.
# Story 📖

https://kickstarter.atlassian.net/secure/RapidBoard.jspa?rapidView=9&modal=detail&selectedIssue=NT-1411