### PR TITLE
NT-1385: (Add on card UI) Hide add on divider

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
@@ -36,7 +36,10 @@ class BackingAddOnViewHolder(private val view: View) : KSViewHolder(view) {
         this.viewModel.outputs.rewardItemsAreGone()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
-                .subscribe { ViewUtils.setGone(this.view.items_container, it) }
+                .subscribe {
+                    ViewUtils.setGone(this.view.items_container, it)
+                    ViewUtils.setGone(this.view.divider, it)
+                }
 
 
         this.viewModel.outputs.rewardItems()


### PR DESCRIPTION
# 📲 What

Hide the divider when add on reward list is not visible

# 🤔 Why

The divider separates sections, so having there when there is no section to separate from makes no sense.

# 🛠 How

When the reward items list gets hidden, also hide the divider by setting it's visibility to GONE.

# 👀 See

<img width="431" alt="Screen Shot 2020-07-23 at 10 13 12 AM" src="https://user-images.githubusercontent.com/7025946/88296971-5be02680-cccd-11ea-893a-ec236029dab5.png">


# 📋 QA


# Story 📖

[Name of Trello Story](Trello link)
