### PR TITLE
Selected Shipping Rule cost for Add-ons

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/adapters/BackingAddOnsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/BackingAddOnsAdapter.kt
@@ -1,9 +1,9 @@
 package com.kickstarter.ui.adapters
 
-import android.util.Pair
 import android.view.View
 import com.kickstarter.R
 import com.kickstarter.models.Reward
+import com.kickstarter.models.ShippingRule
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.ui.viewholders.BackingAddOnViewHolder
 import com.kickstarter.ui.viewholders.EmptyViewHolder
@@ -27,7 +27,7 @@ class BackingAddOnsAdapter : KSAdapter() {
         }
     }
 
-    fun populateDataForAddOns(rewards: List<Pair<ProjectData,Reward>>) {
+    fun populateDataForAddOns(rewards: List<Triple<ProjectData, Reward, ShippingRule>>) {
         if (rewards.isNotEmpty()) {
             setSection(SECTION_BACKING_ADD_ONS_CARD, rewards)
             notifyDataSetChanged()

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -24,7 +24,6 @@ import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.BackingAddOnsFragmentViewModel
 import kotlinx.android.synthetic.main.fragment_backing_addons.*
-import kotlinx.android.synthetic.main.fragment_pledge_section_shipping.*
 
 @RequiresFragmentViewModel(BackingAddOnsFragmentViewModel.ViewModel::class)
 class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewModel>(), ShippingRulesAdapter.Delegate {
@@ -68,11 +67,11 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
 
     private fun populateAddOns(projectDataAndAddOnList: Triple<ProjectData, List<Reward>, ShippingRule>) {
         val projectData = projectDataAndAddOnList.first
-
+        val selectedShippingRule = projectDataAndAddOnList.third
         val list = projectDataAndAddOnList
                 .second
                 .map {
-                    Pair(projectData,it)
+                    Triple(projectData,it, selectedShippingRule)
                 }.toList()
 
         backingAddonsAdapter.populateDataForAddOns(list)

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -66,7 +66,7 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
                 .subscribe { displayShippingRules(it.first, it.second) }
     }
 
-    private fun populateAddOns(projectDataAndAddOnList: Pair<ProjectData, List<Reward>>) {
+    private fun populateAddOns(projectDataAndAddOnList: Triple<ProjectData, List<Reward>, ShippingRule>) {
         val projectData = projectDataAndAddOnList.first
 
         val list = projectDataAndAddOnList

--- a/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
@@ -1,6 +1,5 @@
 package com.kickstarter.ui.viewholders
 
-import android.util.Pair
 import android.view.View
 import androidx.annotation.NonNull
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -9,6 +8,7 @@ import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Reward
+import com.kickstarter.models.ShippingRule
 import com.kickstarter.ui.adapters.RewardItemsAdapter
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.BackingAddOnViewHolderViewModel
@@ -78,7 +78,9 @@ class BackingAddOnViewHolder(private val view: View) : KSViewHolder(view) {
         this.viewModel.outputs.conversion()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
-                .subscribe { this.view.add_on_conversion.text = "About $it" }
+                .subscribe {
+                    this.view.add_on_conversion.text = this.ksString.format(context().getString(R.string.About_reward_amount), "reward_amount", it.toString())
+                }
 
 
         this.viewModel.outputs.backerLimitPillIsGone()
@@ -94,12 +96,17 @@ class BackingAddOnViewHolder(private val view: View) : KSViewHolder(view) {
         this.viewModel.outputs.backerLimit()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
-                .subscribe { this.view.addon_backer_limit.text = "Limit $it" }
+                .subscribe {
+                    this.view.addon_backer_limit.text = this.ksString.format(context().getString(R.string.limit_limit_per_backer), "limit_per_backer", it)
+                }
 
         this.viewModel.outputs.remainingQuantity()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
-                .subscribe { this.view.addon_quantity_remaining.text = "$it left" }
+                .subscribe {
+                    this.view.addon_quantity_remaining.text =
+                            this.ksString.format(context().getString(R.string.rewards_info_time_left), "time", it)
+                }
 
         this.viewModel.outputs.deadlineCountdownIsGone()
                 .compose(bindToLifecycle())
@@ -123,10 +130,12 @@ class BackingAddOnViewHolder(private val view: View) : KSViewHolder(view) {
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .subscribe {
-                    val rewardAndShippingString = context().getString(R.string.reward_amount_plus_shipping_cost_each)
-                    val stringSections = rewardAndShippingString.split("+")
-                    val shippingString = stringSections[1]
-                    this.view.add_on_shipping_amount.text = this.ksString.format(shippingString, "shipping_amount", it)
+                    if  (it.isNotEmpty()) {
+                        val rewardAndShippingString = context().getString(R.string.reward_amount_plus_shipping_cost_each)
+                        val stringSections = rewardAndShippingString.split("+")
+                        val shippingString = "+" + stringSections[1]
+                        this.view.add_on_shipping_amount.text = this.ksString.format(shippingString, "shipping_cost", it)
+                    }
                 }
 
         this.viewModel.outputs.addButtonIsGone()
@@ -197,14 +206,14 @@ class BackingAddOnViewHolder(private val view: View) : KSViewHolder(view) {
     }
 
     override fun bindData(data: Any?) {
-        if (data is (Pair<*, *>)) {
+        if (data is (Triple<*, *, *>)) {
             if (data.second is Reward) {
-                bindAddonsList(data as Pair<ProjectData, Reward>)
+                bindAddonsList(data as Triple<ProjectData, Reward, ShippingRule>)
             }
         }
     }
 
-    private fun bindAddonsList(projectDataAndAddOn: Pair<ProjectData, Reward>) {
+    private fun bindAddonsList(projectDataAndAddOn: Triple<ProjectData, Reward, ShippingRule>) {
         this.viewModel.inputs.configureWith(projectDataAndAddOn)
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -38,7 +38,7 @@ class BackingAddOnsFragmentViewModel {
         fun showPledgeFragment(): Observable<Pair<PledgeData, PledgeReason>>
 
         /** Emits a Pair containing the projectData and the list for Add-ons associated to that project. */
-        fun addOnsList(): Observable<Pair<ProjectData, List<Reward>>>
+        fun addOnsList(): Observable<Triple<ProjectData, List<Reward>, ShippingRule>>
 
         /** Emits the current selected shipping rule. */
         fun selectedShippingRule(): Observable<ShippingRule>
@@ -56,7 +56,7 @@ class BackingAddOnsFragmentViewModel {
         private val shippingRulesAndProject = PublishSubject.create<Pair<List<ShippingRule>, Project>>()
 
         private val showPledgeFragment = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
-        private val addOnsList = PublishSubject.create<Pair<ProjectData, List<Reward>>>()
+        private val addOnsList = PublishSubject.create<Triple<ProjectData, List<Reward>, ShippingRule>>()
 
         private val apolloClient = this.environment.apolloClient()
         private val apiClient = environment.apiClient()
@@ -129,7 +129,7 @@ class BackingAddOnsFragmentViewModel {
                     }
         }
 
-        private fun filterAddOnsByLocation(addOns: List<Reward>, pData: ProjectData, rule: ShippingRule, rw: Reward): Pair<ProjectData, List<Reward>> {
+        private fun filterAddOnsByLocation(addOns: List<Reward>, pData: ProjectData, rule: ShippingRule, rw: Reward): Triple<ProjectData, List<Reward>, ShippingRule> {
            val filteredAddOns = when (rw.shippingPreference()){
                 Reward.ShippingPreference.UNRESTRICTED.toString().toLowerCase() -> {
                     addOns.filter {
@@ -146,7 +146,7 @@ class BackingAddOnsFragmentViewModel {
                 }
             }
 
-            return Pair(pData, filteredAddOns)
+            return Triple(pData, filteredAddOns, rule)
         }
 
         private fun containsLocation(rule: ShippingRule, reward: Reward): Boolean {

--- a/app/src/main/res/layout/item_add_on_pledge.xml
+++ b/app/src/main/res/layout/item_add_on_pledge.xml
@@ -60,7 +60,8 @@
                     android:visibility="gone"
                     app:layout_constraintStart_toEndOf="@id/add_on_minimum"
                     app:layout_constraintTop_toBottomOf="@id/title_container"
-                    tools:text=" + $5 shipping each" />
+                    tools:text=" + $5 shipping each"
+                    tools:visibility="visible"/>
 
                 <TextView
                     android:id="@+id/add_on_conversion"

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModelTest.kt
@@ -6,6 +6,7 @@ import com.kickstarter.libs.Environment
 import com.kickstarter.mock.factories.ProjectDataFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.RewardFactory
+import com.kickstarter.mock.factories.ShippingRuleFactory
 import com.kickstarter.models.Reward
 import com.kickstarter.models.ShippingRule
 import com.kickstarter.ui.data.ProjectData
@@ -42,7 +43,8 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
         setupEnvironment(environment())
 
         val addOn = RewardFactory.reward().toBuilder().isAddOn(true).limit(null).build()
-        this.vm.inputs.configureWith(android.util.Pair<ProjectData, Reward>(ProjectDataFactory.project(ProjectFactory.project()), addOn))
+        val shippingRule = ShippingRuleFactory.usShippingRule()
+        this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
 
         this.backerLimitIsGone.assertValue(true)
     }
@@ -52,7 +54,8 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
         setupEnvironment(environment())
 
         val addOn = RewardFactory.reward().toBuilder().isAddOn(true).remaining(null).build()
-        this.vm.inputs.configureWith(android.util.Pair<ProjectData, Reward>(ProjectDataFactory.project(ProjectFactory.project()), addOn))
+        val shippingRule = ShippingRuleFactory.usShippingRule()
+        this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
 
         this.remainingQuantityIsGone.assertValue(true)
     }
@@ -62,7 +65,8 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
         setupEnvironment(environment())
 
         val addOn = RewardFactory.reward().toBuilder().isAddOn(true).endsAt(null).build()
-        this.vm.inputs.configureWith(android.util.Pair<ProjectData, Reward>(ProjectDataFactory.project(ProjectFactory.project()), addOn))
+        val shippingRule = ShippingRuleFactory.usShippingRule()
+        this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
 
         this.countdownIsGone.assertValue(true)
     }
@@ -73,7 +77,8 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
 
         val addOn = RewardFactory.reward().toBuilder().isAddOn(true).shippingRules(emptyList<ShippingRule>()).build()
 
-        this.vm.inputs.configureWith(android.util.Pair<ProjectData, Reward>(ProjectDataFactory.project(ProjectFactory.project()), addOn))
+        val shippingRule = ShippingRuleFactory.usShippingRule()
+        this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
 
         this.shippingAmountIsGone.assertValue(true)
     }
@@ -84,7 +89,8 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
 
         val addOn = RewardFactory.reward().toBuilder().isAddOn(true).rewardsItems(emptyList()).build()
 
-        this.vm.inputs.configureWith(android.util.Pair<ProjectData, Reward>(ProjectDataFactory.project(ProjectFactory.project()), addOn))
+        val shippingRule = ShippingRuleFactory.usShippingRule()
+        this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
 
         this.rewardItemsAreGone.assertValue(true)
     }
@@ -95,7 +101,8 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
 
         val addOn = RewardFactory.reward().toBuilder().isAddOn(true).rewardsItems(emptyList()).build()
 
-        this.vm.inputs.configureWith(android.util.Pair<ProjectData, Reward>(ProjectDataFactory.project(ProjectFactory.project()), addOn))
+        val shippingRule = ShippingRuleFactory.usShippingRule()
+        this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
 
         this.addButtonGone.assertValue(false)
         this.quantity.assertValue(0)
@@ -107,7 +114,8 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
 
         val addOn = RewardFactory.reward().toBuilder().isAddOn(true).rewardsItems(emptyList()).build()
 
-        this.vm.inputs.configureWith(android.util.Pair<ProjectData, Reward>(ProjectDataFactory.project(ProjectFactory.project()), addOn))
+        val shippingRule = ShippingRuleFactory.usShippingRule()
+        this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
 
         this.vm.inputs.increaseButtonPressed()
         this.addButtonGone.assertValues(false, true)
@@ -120,7 +128,8 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
 
         val addOn = RewardFactory.reward().toBuilder().isAddOn(true).rewardsItems(emptyList()).build()
 
-        this.vm.inputs.configureWith(android.util.Pair<ProjectData, Reward>(ProjectDataFactory.project(ProjectFactory.project()), addOn))
+        val shippingRule = ShippingRuleFactory.usShippingRule()
+        this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
 
         this.vm.inputs.increaseButtonPressed()
         this.vm.inputs.increaseButtonPressed()
@@ -136,7 +145,8 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
 
         val addOn = RewardFactory.reward().toBuilder().isAddOn(true).remaining(3).rewardsItems(emptyList()).build()
 
-        this.vm.inputs.configureWith(android.util.Pair<ProjectData, Reward>(ProjectDataFactory.project(ProjectFactory.project()), addOn))
+        val shippingRule = ShippingRuleFactory.usShippingRule()
+        this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
 
         this.vm.inputs.increaseButtonPressed()
         this.vm.inputs.increaseButtonPressed()
@@ -153,7 +163,8 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
 
         val addOn = RewardFactory.reward().toBuilder().isAddOn(true).rewardsItems(emptyList()).build()
 
-        this.vm.inputs.configureWith(android.util.Pair<ProjectData, Reward>(ProjectDataFactory.project(ProjectFactory.project()), addOn))
+        val shippingRule = ShippingRuleFactory.usShippingRule()
+        this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
 
         this.vm.inputs.increaseButtonPressed()
         this.vm.inputs.increaseButtonPressed()
@@ -177,7 +188,8 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
 
         val addOn = RewardFactory.reward().toBuilder().isAddOn(true).rewardsItems(emptyList()).build()
 
-        this.vm.inputs.configureWith(android.util.Pair<ProjectData, Reward>(ProjectDataFactory.project(ProjectFactory.project()), addOn))
+        val shippingRule = ShippingRuleFactory.usShippingRule()
+        this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
 
         this.vm.inputs.increaseButtonPressed()
         this.vm.inputs.increaseButtonPressed()
@@ -194,7 +206,8 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
 
         val addOn = RewardFactory.reward().toBuilder().isAddOn(true).rewardsItems(emptyList()).build()
 
-        this.vm.inputs.configureWith(android.util.Pair<ProjectData, Reward>(ProjectDataFactory.project(ProjectFactory.project()), addOn))
+        val shippingRule = ShippingRuleFactory.usShippingRule()
+        this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
 
         this.vm.inputs.increaseButtonPressed()
         this.vm.inputs.increaseButtonPressed()

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -90,7 +90,7 @@ class BackingAddOnsFragmentViewModelTest: KSRobolectricTestCase() {
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
         this.vm.arguments(bundle)
 
-        this.addOnsList.assertValue(Pair(projectData,listAddons))
+        this.addOnsList.assertValue(Triple(projectData,listAddons, shippingRule.shippingRules().first()))
     }
 
     @Test
@@ -124,7 +124,7 @@ class BackingAddOnsFragmentViewModelTest: KSRobolectricTestCase() {
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
         this.vm.arguments(bundle)
 
-        this.addOnsList.assertValue(Pair(projectData,listAddons))
+        this.addOnsList.assertValue(Triple(projectData,listAddons, shippingRule.shippingRules().first()))
     }
 
     @Test
@@ -159,7 +159,7 @@ class BackingAddOnsFragmentViewModelTest: KSRobolectricTestCase() {
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
         this.vm.arguments(bundle)
 
-        this.addOnsList.assertValue(Pair(projectData, emptyList()))
+        this.addOnsList.assertValue(Triple(projectData, emptyList(), shippingRuleRw))
     }
 
     @Test
@@ -194,7 +194,7 @@ class BackingAddOnsFragmentViewModelTest: KSRobolectricTestCase() {
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
         this.vm.arguments(bundle)
 
-        this.addOnsList.assertValue(Pair(projectData, listAddons))
+        this.addOnsList.assertValue(Triple(projectData, listAddons, shippingRuleRw))
     }
 
     @Test
@@ -272,12 +272,12 @@ class BackingAddOnsFragmentViewModelTest: KSRobolectricTestCase() {
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
         this.vm.arguments(bundle)
 
-        this.addOnsList.assertValue(Pair(projectData, listAddons))
+        this.addOnsList.assertValue(Triple(projectData, listAddons, shippingRuleRw))
 
         val shippingRuleAddOn = ShippingRuleFactory.germanyShippingRule()
         this.vm.inputs.shippingRuleSelected(shippingRuleAddOn)
 
-        this.addOnsList.assertValues(Pair(projectData, listAddons),Pair(projectData, emptyList()))
+        this.addOnsList.assertValues(Triple(projectData, listAddons, shippingRuleRw), Triple(projectData, emptyList(), shippingRuleAddOn))
     }
 
     @Test
@@ -310,7 +310,7 @@ class BackingAddOnsFragmentViewModelTest: KSRobolectricTestCase() {
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
         this.vm.arguments(bundle)
 
-        this.addOnsList.assertValue(Pair(projectData, listAddons))
+        this.addOnsList.assertValue(Triple(projectData, listAddons, shippingRuleRw))
     }
 
     @Test
@@ -349,7 +349,7 @@ class BackingAddOnsFragmentViewModelTest: KSRobolectricTestCase() {
         this.vm.arguments(bundle)
 
         val listAddonsFiltered = listAddons.filter { it.id() == addOn.id() }
-        this.addOnsList.assertValue(Pair(projectData, listAddonsFiltered))
+        this.addOnsList.assertValue(Triple(projectData, listAddonsFiltered, shippingRuleRw))
     }
 
 

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -11,6 +11,7 @@ import com.kickstarter.mock.services.MockApiClient
 import com.kickstarter.mock.services.MockApolloClient
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
+import com.kickstarter.models.ShippingRule
 import com.kickstarter.services.apiresponses.ShippingRulesEnvelope
 import com.kickstarter.ui.ArgumentsKey
 import com.kickstarter.ui.data.PledgeData
@@ -24,7 +25,7 @@ import rx.observers.TestSubscriber
 
 class BackingAddOnsFragmentViewModelTest: KSRobolectricTestCase() {
     private lateinit var vm: BackingAddOnsFragmentViewModel.ViewModel
-    private val addOnsList = TestSubscriber.create<Pair<ProjectData, List<Reward>>>()
+    private val addOnsList = TestSubscriber.create<Triple<ProjectData, List<Reward>, ShippingRule>>()
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = BackingAddOnsFragmentViewModel.ViewModel(environment)


### PR DESCRIPTION
# 📲 What

- Display the shipping rule cost in each Add-on matching the selected shipping rule
- Fixed some translation strings
- Updated tests

# 🛠 How

- Added new field shippingRule to the BackingAddonViewHolder

# 👀 See
<img width="875" alt="Screen Shot 2020-07-27 at 4 19 41 PM" src="https://user-images.githubusercontent.com/4083656/88602294-641ac780-d027-11ea-8ea3-5044f23758f0.png">


# 📋 QA

- Change the location, make sure the Add-on card reflects the shipping cost changing

