### PR TITLE
Show selected addOns in pledge header

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/adapters/ExpandableHeaderAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/ExpandableHeaderAdapter.kt
@@ -21,9 +21,9 @@ class ExpandableHeaderAdapter: KSAdapter() {
         }
     }
 
-    fun populateData(rewards: Pair<String, String>) {
+    fun populateData(rewards: List<Pair<String, String>>) {
         if (rewards != null) {
-            setSection(SECTION_REWARD_SUMMARY, listOf(rewards))
+            setSection(SECTION_REWARD_SUMMARY, rewards)
             notifyDataSetChanged()
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -9,7 +9,6 @@ import android.text.*
 import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
 import android.text.style.URLSpan
-import androidx.transition.TransitionManager
 import android.util.Pair
 import android.view.LayoutInflater
 import android.view.View
@@ -21,6 +20,7 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.transition.ChangeBounds
+import androidx.transition.TransitionManager
 import com.jakewharton.rxbinding.view.RxView
 import com.kickstarter.KSApplication
 import com.kickstarter.R
@@ -503,7 +503,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .subscribe { this.view?.shipping_rules?.let { it1 -> ViewUtils.setGone(it1, it) } }
     }
 
-    private fun populateHeaderItems(titleAndAmount: Pair<String, String>) {
+    private fun populateHeaderItems(titleAndAmount: List<Pair<String, String>>) {
         headerAdapter.populateData(titleAndAmount)
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -245,7 +245,7 @@ interface PledgeFragmentViewModel {
         fun headerSectionIsGone(): Observable<Boolean>
 
         /** Emits a Pair containing reward/add-on title and the amount */
-        fun titleAndAmount(): Observable<Pair<String, String>>
+        fun titleAndAmount(): Observable<List<Pair<String, String>>>
 
         /** Emits a boolean determining if the minimum pledge amount subtitle should be shown */
         fun isPledgeMinimumSubtitleGone(): Observable<Boolean>
@@ -350,7 +350,7 @@ interface PledgeFragmentViewModel {
         private val totalDividerIsGone = BehaviorSubject.create<Boolean>()
 
         private val headerSectionIsGone = BehaviorSubject.create<Boolean>()
-        private val titleAndAmount = BehaviorSubject.create<Pair<String, String>>()
+        private val titleAndAmount = BehaviorSubject.create<List<Pair<String, String>>>()
         private val isPledgeMinimumSubtitleGone = BehaviorSubject.create<Boolean>()
         private val isBonusSupportSectionGone = BehaviorSubject.create<Boolean>()
         private val bonusAmount = BehaviorSubject.create<String>()
@@ -476,6 +476,7 @@ interface PledgeFragmentViewModel {
                     .filter { !RewardUtils.isNoReward(it) }
                     .compose<Pair<Reward, String>>(combineLatestPair(this.pledgeMinimum))
                     .map { Pair(it.first.title() ?: "", it.second) }
+                    .map { listOf(it) }
                     .compose(bindToLifecycle())
                     .subscribe(this.titleAndAmount)
 
@@ -1482,7 +1483,7 @@ interface PledgeFragmentViewModel {
         override fun headerSectionIsGone(): Observable<Boolean> = this.headerSectionIsGone
 
         @NonNull
-        override fun titleAndAmount(): Observable<Pair<String, String>> = this.titleAndAmount
+        override fun titleAndAmount(): Observable<List<Pair<String, String>>> = this.titleAndAmount
 
         @NonNull
         override fun isPledgeMinimumSubtitleGone(): Observable<Boolean> = this.isPledgeMinimumSubtitleGone


### PR DESCRIPTION
# 📲 What

Show a list of selected addOns in the expandable pledge header


# 🛠 How

Change the output `titleAndAmount` in PledgeFragmentViewModel to hold a list of items instead of just one item.

# 👀 See

![Screenshot_20200730-161809](https://user-images.githubusercontent.com/7025946/88970673-d33f2880-d280-11ea-84f3-b6162ed2ee8d.png)


# 📋 QA

Instructions for anyone to be able to QA this work.

# Story 📖

https://kickstarter.atlassian.net/secure/RapidBoard.jspa?rapidView=9&modal=detail&selectedIssue=NT-1421