### PR TITLE
NT-1388:cta-button-logic

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/data/PledgeData.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/PledgeData.kt
@@ -3,11 +3,13 @@ package com.kickstarter.ui.data
 import android.os.Parcelable
 import auto.parcel.AutoParcel
 import com.kickstarter.models.Reward
+import java.util.List
 
 @AutoParcel
 abstract class PledgeData : Parcelable {
     abstract fun pledgeFlowContext(): PledgeFlowContext
     abstract fun projectData(): ProjectData
+    abstract fun addOns(): List<Reward>?
     abstract fun reward(): Reward
 
     @AutoParcel.Builder
@@ -15,6 +17,7 @@ abstract class PledgeData : Parcelable {
         abstract fun pledgeFlowContext(pledgeFlowContext: PledgeFlowContext): Builder
         abstract fun projectData(projectData: ProjectData): Builder
         abstract fun reward(reward: Reward): Builder
+        abstract fun addOns(rewards: List<Reward>): Builder
         abstract fun build(): PledgeData
     }
 
@@ -26,12 +29,18 @@ abstract class PledgeData : Parcelable {
             return AutoParcel_PledgeData.Builder()
         }
 
-        fun with(pledgeFlowContext: PledgeFlowContext, projectData: ProjectData, reward: Reward): PledgeData {
-            return PledgeData.builder()
+        fun with(pledgeFlowContext: PledgeFlowContext, projectData: ProjectData, reward: Reward, addOns: List<Reward>? = null) =
+                addOns?.let {
+                    return@let builder()
+                        .pledgeFlowContext(pledgeFlowContext)
+                        .projectData(projectData)
+                        .reward(reward)
+                        .addOns(it)
+                        .build()
+                }?: builder()
                     .pledgeFlowContext(pledgeFlowContext)
                     .projectData(projectData)
                     .reward(reward)
                     .build()
-        }
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -27,6 +27,7 @@ import com.kickstarter.ui.viewholders.BackingAddOnViewHolder
 import com.kickstarter.viewmodels.BackingAddOnsFragmentViewModel
 import kotlinx.android.synthetic.main.fragment_backing_addons.*
 import kotlinx.android.synthetic.main.fragment_backing_addons_section_footer.*
+import kotlinx.android.synthetic.main.fragment_backing_addons_section_footer.view.*
 import rx.Observable
 
 @RequiresFragmentViewModel(BackingAddOnsFragmentViewModel.ViewModel::class)
@@ -83,6 +84,10 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
                     ViewUtils.setGone(fragment_backing_addons_shipping_rules, it)
                     ViewUtils.setGone(fragment_backing_addons_call_out, it)
                 }
+
+        backing_addons_footer_button.setOnClickListener {
+            this.viewModel.inputs.continueButtonPressed()
+        }
     }
 
     private fun selectProperString(totalSelected: Int): String {

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -162,4 +162,9 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
     override fun quantityHasChanged(quantity: Int) {
         this.viewModel.inputs.selectedAddonsQuantity(quantity)
     }
+
+    override fun quantityPerId(quantityPerId: Pair<Int, Long>) {
+        this.viewModel.inputs.quantityPerId(quantityPerId)
+    }
+
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -26,6 +26,7 @@ import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.ui.viewholders.BackingAddOnViewHolder
 import com.kickstarter.viewmodels.BackingAddOnsFragmentViewModel
 import kotlinx.android.synthetic.main.fragment_backing_addons.*
+import kotlinx.android.synthetic.main.fragment_backing_addons_section_footer.*
 import rx.Observable
 
 @RequiresFragmentViewModel(BackingAddOnsFragmentViewModel.ViewModel::class)
@@ -71,8 +72,8 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .filter { ObjectUtils.isNotNull(it) }
-                .subscribe {
-                    //TODO: use this to update the ACButton https://kickstarter.atlassian.net/browse/NT-1388
+                .subscribe { total ->
+                    backing_addons_footer_button.text = selectProperString(total)
                 }
       
         this.viewModel.outputs.shippingSelectorIsGone()
@@ -82,6 +83,16 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
                     ViewUtils.setGone(fragment_backing_addons_shipping_rules, it)
                     ViewUtils.setGone(fragment_backing_addons_call_out, it)
                 }
+    }
+
+    private fun selectProperString(totalSelected: Int): String {
+        val ksString = this.viewModel.environment.ksString()
+        return when {
+            totalSelected == 0 -> ksString.format(getString(R.string.Skip_add_ons),"","")
+            totalSelected == 1 -> ksString.format(getString(R.string.Continue_with_quantity_add_ons_one),"quantity", totalSelected.toString())
+            totalSelected > 1 -> ksString.format(getString(R.string.Continue_with_quantity_add_ons_many),"quantity", totalSelected.toString())
+            else -> ""
+        }
     }
 
     private fun populateAddOns(projectDataAndAddOnList: Triple<ProjectData, List<Reward>, ShippingRule>) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.ui.viewholders
 
+import android.util.Pair
 import android.view.View
 import androidx.annotation.NonNull
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -14,13 +15,13 @@ import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.BackingAddOnViewHolderViewModel
 import kotlinx.android.synthetic.main.add_on_items.view.*
 import kotlinx.android.synthetic.main.add_on_title.view.*
-import kotlinx.android.synthetic.main.fragment_backing_addons_section_footer.view.*
 import kotlinx.android.synthetic.main.item_add_on_pledge.view.*
 
 class BackingAddOnViewHolder(private val view: View, viewListener: ViewListener) : KSViewHolder(view) {
 
     interface ViewListener {
         fun quantityHasChanged(quantity: Int)
+        fun quantityPerId(quantityPerId: Pair<Int, Long>)
     }
 
     private var viewModel = BackingAddOnViewHolderViewModel.ViewModel(environment())
@@ -170,10 +171,12 @@ class BackingAddOnViewHolder(private val view: View, viewListener: ViewListener)
                     }
                 }
 
-        this.viewModel.outputs.quantity()
+        this.viewModel.outputs.quantityPerId()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
-                .subscribe { quantity ->
+                .subscribe { quantityPerId ->
+                    quantityPerId?.let { viewListener.quantityPerId(it) }
+                    val quantity = quantityPerId.first
                     this.view.decrease_quantity_add_on.isEnabled = (quantity != 0)
                     this.view.quantity_add_on.text = quantity.toString()
                 }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
@@ -14,6 +14,7 @@ import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.BackingAddOnViewHolderViewModel
 import kotlinx.android.synthetic.main.add_on_items.view.*
 import kotlinx.android.synthetic.main.add_on_title.view.*
+import kotlinx.android.synthetic.main.fragment_backing_addons_section_footer.view.*
 import kotlinx.android.synthetic.main.item_add_on_pledge.view.*
 
 class BackingAddOnViewHolder(private val view: View, viewListener: ViewListener) : KSViewHolder(view) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/BackingAddOnViewHolder.kt
@@ -155,7 +155,6 @@ class BackingAddOnViewHolder(private val view: View, viewListener: ViewListener)
                             this.view.stepper_container_add_on.visibility = View.VISIBLE
                         }
                         this.view.initial_state_add_on.isEnabled = false
-                        this.view.decrease_quantity_add_on.isEnabled = true
                         this.view.increase_quantity_add_on.isEnabled = true
                     }
                     else {
@@ -166,7 +165,6 @@ class BackingAddOnViewHolder(private val view: View, viewListener: ViewListener)
                             this.view.stepper_container_add_on.visibility = View.GONE
                         }
                         this.view.initial_state_add_on.isEnabled = true
-                        this.view.decrease_quantity_add_on.isEnabled = false
                         this.view.increase_quantity_add_on.isEnabled = false
                     }
                 }
@@ -174,8 +172,9 @@ class BackingAddOnViewHolder(private val view: View, viewListener: ViewListener)
         this.viewModel.outputs.quantity()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
-                .subscribe {
-                    this.view.quantity_add_on.text = it.toString()
+                .subscribe { quantity ->
+                    this.view.decrease_quantity_add_on.isEnabled = (quantity != 0)
+                    this.view.quantity_add_on.text = quantity.toString()
                 }
 
         this.viewModel.outputs.disableIncreaseButton()

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
@@ -90,8 +90,8 @@ class BackingAddOnViewHolderViewModel {
         /** Emits if the `Add` button should be hide*/
         fun addButtonIsGone(): Observable<Boolean>
 
-        /** Emits quantity selected*/
-        fun quantity(): Observable<Int>
+        /** Emits quantity selected for which id*/
+        fun quantityPerId(): PublishSubject<Pair<Int, Long>>
 
         /** Emits if the amount selected reach the limit available*/
         fun disableIncreaseButton(): Observable<Boolean>
@@ -129,6 +129,7 @@ class BackingAddOnViewHolderViewModel {
         private val addButtonIsGone = PublishSubject.create<Boolean>()
         private val quantity = PublishSubject.create<Int>()
         private val disableIncreaseButton = PublishSubject.create<Boolean>()
+        private val quantityPerId = PublishSubject.create<Pair<Int, Long>>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -243,6 +244,13 @@ class BackingAddOnViewHolderViewModel {
                     .map { (it.first == LIMIT) || (it.first == it.second.remaining()) }
                     .compose(bindToLifecycle())
                     .subscribe(this.disableIncreaseButton)
+
+            this.quantity
+                    .compose<Pair<Int, Reward>>(combineLatestPair(addOn))
+                    .map { data -> Pair(data.first, data.second.id()) }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.quantityPerId)
+
         }
 
         private fun decrease(amount: Int) = amount - 1
@@ -305,7 +313,7 @@ class BackingAddOnViewHolderViewModel {
 
         override fun addButtonIsGone(): PublishSubject<Boolean> = this.addButtonIsGone
 
-        override fun quantity(): PublishSubject<Int> = this.quantity
+        override fun quantityPerId(): PublishSubject<Pair<Int, Long>> = this.quantityPerId
 
         override fun disableIncreaseButton(): Observable<Boolean> = this.disableIncreaseButton
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -166,13 +166,12 @@ class BackingAddOnsFragmentViewModel {
                 _, listAddOns, pledgeData, pledgeReason ->
 
                 val updatedList = updateAddOnsListQuantity(listAddOns)
-                pledgeData.toBuilder().addOns(updatedList as java.util.List<Reward>)
-                return@combineLatest Pair(pledgeData, pledgeReason)
+                val updatedPledgeData = pledgeData.toBuilder().addOns(updatedList as java.util.List<Reward>).build()
+                return@combineLatest Pair(updatedPledgeData, pledgeReason)
             }
                     .compose(bindToLifecycle())
                     .subscribe {
-                        // TODO: add a new field on PledgeData holding listAddons: List<Reward>
-                        this.showPledgeFragment.onNext(Pair(it.first, it.second))
+                        this.showPledgeFragment.onNext(it)
                     }
         }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -7,7 +7,6 @@ import com.kickstarter.libs.FragmentViewModel
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
-import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.RewardUtils.isDigital
@@ -21,6 +20,7 @@ import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.ui.fragments.BackingAddOnsFragment
 import rx.Observable
+import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
 
 class BackingAddOnsFragmentViewModel {
@@ -39,6 +39,9 @@ class BackingAddOnsFragmentViewModel {
 
         /** Emits when the CTA button has been pressed */
         fun continueButtonPressed()
+
+        /** Emits the quantity per AddOn Id selected */
+        fun quantityPerId(quantityPerId: Pair<Int, Long>)
     }
 
     interface Outputs {
@@ -65,7 +68,7 @@ class BackingAddOnsFragmentViewModel {
         val inputs = this
         val outputs = this
 
-        private val pledgeDataAndReason = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
+        private val pledgeDataAndReason = BehaviorSubject.create<Pair<PledgeData, PledgeReason>>()
         private val shippingRuleSelected = PublishSubject.create<ShippingRule>()
         private val shippingRulesAndProject = PublishSubject.create<Pair<List<ShippingRule>, Project>>()
 
@@ -73,9 +76,11 @@ class BackingAddOnsFragmentViewModel {
         private val shippingSelectorIsGone = PublishSubject.create<Boolean>()
         private val addOnsList = PublishSubject.create<Triple<ProjectData, List<Reward>, ShippingRule>>()
         private val selectedAddOns = PublishSubject.create<Int>()
-        private val totalSelectedAddOns = PublishSubject.create<Int>()
-        private val continueButtonPressed = PublishSubject.create<Void>()
+        private val totalSelectedAddOns = BehaviorSubject.create(0)
+        private val continueButtonPressed = BehaviorSubject.create<Void>()
         private var totalAmount = 0
+        private val quantityPerId = PublishSubject.create<Pair<Int, Long>>()
+        private val selectedAmount: MutableMap<Long, Int> = mutableMapOf()
 
         private val apolloClient = this.environment.apolloClient()
         private val apiClient = environment.apiClient()
@@ -151,21 +156,41 @@ class BackingAddOnsFragmentViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.shippingSelectorIsGone)
 
-            addOnsList.map { !hasShippableAddOn(it.second) }
+            this.quantityPerId
                     .compose(bindToLifecycle())
-                    .subscribe(this.shippingSelectorIsGone)
+                    .subscribe {
+                        updateQuantityById(it)
+                    }
 
-            this.continueButtonPressed
-                    .compose<Pair<Void, Int>>(combineLatestPair(this.totalSelectedAddOns))
-                    .map { it.second }
-                    .compose<Pair<Int, PledgeData>>(combineLatestPair(pledgeData))
-                    .map { it.second }
-                    .compose<Pair<PledgeData, PledgeReason>>(combineLatestPair(pledgeReason))
+            Observable.combineLatest(this.continueButtonPressed, addonsList, pledgeData, pledgeReason) {
+                _, listAddOns, pledgeData, pledgeReason ->
+
+                val updatedList = updateAddOnsListQuantity(listAddOns)
+                pledgeData.toBuilder().addOns(updatedList as java.util.List<Reward>)
+                return@combineLatest Pair(pledgeData, pledgeReason)
+            }
                     .compose(bindToLifecycle())
                     .subscribe {
                         // TODO: add a new field on PledgeData holding listAddons: List<Reward>
                         this.showPledgeFragment.onNext(Pair(it.first, it.second))
                     }
+        }
+
+        private fun updateAddOnsListQuantity(listAddOns: List<Reward>): List<Reward> {
+            val updatedList = mutableListOf<Reward>()
+
+            this.selectedAmount
+                    .filter { it.value > 0 }
+                    .forEach { selectedAddOn ->
+                        val item = listAddOns.filter { it.id() == selectedAddOn.key }.first()
+                        updatedList.add(item.toBuilder().quantity(selectedAddOn.value).build())
+            }
+
+            return updatedList.toList()
+        }
+
+        private fun updateQuantityById(it: Pair<Int, Long>) {
+            this.selectedAmount[it.second] = it.first
         }
 
         private fun defaultShippingRule(shippingRules: List<ShippingRule>): Observable<ShippingRule> {
@@ -176,12 +201,6 @@ class BackingAddOnsFragmentViewModel {
                                 ?: shippingRules.first()
                     }
         }
-
-
-        private fun hasShippableAddOn(addOns: List<Reward>): Boolean {
-            return addOns.any { RewardUtils.isShippable(it) }
-        }
-
 
         private fun filterAddOnsByLocation(addOns: List<Reward>, pData: ProjectData, rule: ShippingRule, rw: Reward): Triple<ProjectData, List<Reward>, ShippingRule> {
            val filteredAddOns = when (rw.shippingPreference()){
@@ -218,14 +237,15 @@ class BackingAddOnsFragmentViewModel {
         override fun shippingRuleSelected(shippingRule: ShippingRule) = this.shippingRuleSelected.onNext(shippingRule)
         override fun selectedAddonsQuantity(quantity: Int) = this.selectedAddOns.onNext(quantity)
         override fun continueButtonPressed() = this.continueButtonPressed.onNext(null)
+        override fun quantityPerId(quantityPerId: Pair<Int, Long>) = this.quantityPerId.onNext(quantityPerId)
 
         // - Outputs
         @NonNull
         override fun showPledgeFragment(): Observable<Pair<PledgeData, PledgeReason>> = this.showPledgeFragment
-        override fun addOnsList() = this.addOnsList
+        override fun addOnsList(): PublishSubject<Triple<ProjectData, List<Reward>, ShippingRule>> = this.addOnsList
         override fun selectedShippingRule(): Observable<ShippingRule> = this.shippingRuleSelected
         override fun shippingRulesAndProject(): Observable<Pair<List<ShippingRule>, Project>> = this.shippingRulesAndProject
         override fun totalSelectedAddOns(): Observable<Int> = this.totalSelectedAddOns
-        override fun shippingSelectorIsGone() = this.shippingSelectorIsGone
+        override fun shippingSelectorIsGone(): PublishSubject<Boolean> = this.shippingSelectorIsGone
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -392,6 +392,7 @@ interface PledgeFragmentViewModel {
                     .map { it.projectData() }
 
             val addOns = pledgeData
+                    .filter { !it.addOns().isNullOrEmpty() }
                     .map { it.addOns() as List<Reward> }
 
             val fullProjectDataAndPledgeData = projectData

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -656,7 +656,7 @@ interface ProjectViewModel {
 
             this.fragmentStackCount
                     .compose<Pair<Int, Project>>(combineLatestPair(currentProject))
-                    .map { if (it.second.isBacking) it.first > 2 else it.first > 1}
+                    .map { if (it.second.isBacking) it.first > 2 else it.first > 2}
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.scrimIsVisible)

--- a/app/src/main/res/layout/fragment_backing_addons.xml
+++ b/app/src/main/res/layout/fragment_backing_addons.xml
@@ -11,7 +11,9 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:overScrollMode="never">
+        android:overScrollMode="never"
+        android:layout_marginBottom="@dimen/grid_14">
+
         <androidx.constraintlayout.widget.ConstraintLayout
         android:background="@color/ksr_grey_300"
         android:layout_width="match_parent"
@@ -94,4 +96,5 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>
+    <include layout="@layout/fragment_backing_addons_section_footer" />
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_backing_addons.xml
+++ b/app/src/main/res/layout/fragment_backing_addons.xml
@@ -11,8 +11,7 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:overScrollMode="never"
-        android:layout_marginBottom="@dimen/grid_14">
+        android:overScrollMode="never">
 
         <androidx.constraintlayout.widget.ConstraintLayout
         android:background="@color/ksr_grey_300"
@@ -87,6 +86,7 @@
             android:layout_marginEnd="@dimen/grid_3"
             android:layout_marginStart="@dimen/grid_3"
             android:layout_marginTop="@dimen/grid_2"
+            android:layout_marginBottom="@dimen/grid_17"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/fragment_backing_addons_shipping_rules"

--- a/app/src/main/res/layout/fragment_backing_addons_section_footer.xml
+++ b/app/src/main/res/layout/fragment_backing_addons_section_footer.xml
@@ -38,7 +38,7 @@
             android:layout_height="@dimen/grid_5"
             android:background="@color/transparent"
             android:backgroundTint="@color/white"
-            android:contentDescription=""
+            android:contentDescription="@null"
             android:importantForAccessibility="no"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_backing_addons_section_footer.xml
+++ b/app/src/main/res/layout/fragment_backing_addons_section_footer.xml
@@ -12,7 +12,7 @@
     app:cardCornerRadius="@dimen/card_container_radius"
     tools:showIn="@layout/fragment_backing_addons">
 
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/fragment_backing_addons_section_footer.xml
+++ b/app/src/main/res/layout/fragment_backing_addons_section_footer.xml
@@ -24,6 +24,7 @@
             android:layout_marginBottom="@dimen/grid_3"
             android:layout_marginEnd="@dimen/grid_3"
             android:layout_marginStart="@dimen/grid_3"
+            android:text="@string/Skip_add_ons"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_backing_addons_section_footer.xml
+++ b/app/src/main/res/layout/fragment_backing_addons_section_footer.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/pledge_footer"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/grid_20"
+    android:layout_gravity="bottom"
+    android:layout_marginBottom="-30dp"
+    android:focusable="true"
+    app:cardCornerRadius="@dimen/card_container_radius"
+    tools:showIn="@layout/fragment_backing_addons">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <Button
+            android:id="@+id/backing_addons_footer_button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:enabled="true"
+            android:layout_marginTop="@dimen/grid_3"
+            android:layout_marginBottom="@dimen/grid_3"
+            android:layout_marginEnd="@dimen/grid_3"
+            android:layout_marginStart="@dimen/grid_3"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/backing_addons_footer_placeholder"
+            tools:text="@string/Skip_add_ons"/>
+
+        <ImageView
+            android:id="@+id/backing_addons_footer_placeholder"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/grid_5"
+            android:backgroundTint="@color/white"
+            android:background="@color/transparent"
+            android:contentDescription=""
+            android:importantForAccessibility="no"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/backing_addons_footer_button"
+            app:layout_constraintBottom_toBottomOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/fragment_backing_addons_section_footer.xml
+++ b/app/src/main/res/layout/fragment_backing_addons_section_footer.xml
@@ -7,11 +7,12 @@
     android:layout_height="@dimen/grid_20"
     android:layout_gravity="bottom"
     android:layout_marginBottom="-30dp"
+    android:elevation="2dp"
     android:focusable="true"
     app:cardCornerRadius="@dimen/card_container_radius"
     tools:showIn="@layout/fragment_backing_addons">
-    <androidx.constraintlayout.widget.ConstraintLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -19,29 +20,29 @@
             android:id="@+id/backing_addons_footer_button"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:enabled="true"
-            android:layout_marginTop="@dimen/grid_3"
-            android:layout_marginBottom="@dimen/grid_3"
-            android:layout_marginEnd="@dimen/grid_3"
             android:layout_marginStart="@dimen/grid_3"
+            android:layout_marginTop="@dimen/grid_3"
+            android:layout_marginEnd="@dimen/grid_3"
+            android:layout_marginBottom="@dimen/grid_3"
+            android:enabled="true"
             android:text="@string/Skip_add_ons"
+            app:layout_constraintBottom_toTopOf="@+id/backing_addons_footer_placeholder"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/backing_addons_footer_placeholder"
-            tools:text="@string/Skip_add_ons"/>
+            tools:text="@string/Skip_add_ons" />
 
         <ImageView
             android:id="@+id/backing_addons_footer_placeholder"
             android:layout_width="0dp"
             android:layout_height="@dimen/grid_5"
-            android:backgroundTint="@color/white"
             android:background="@color/transparent"
+            android:backgroundTint="@color/white"
             android:contentDescription=""
             android:importantForAccessibility="no"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/backing_addons_footer_button"
-            app:layout_constraintBottom_toBottomOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/backing_addons_footer_button" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels
 
+import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
@@ -22,7 +23,7 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
     private val countdownIsGone = TestSubscriber.create<Boolean>()
     private val shippingAmountIsGone = TestSubscriber.create<Boolean>()
     private val rewardItemsAreGone = TestSubscriber.create<Boolean>()
-    private val quantity = TestSubscriber.create<Int>()
+    private val quantityPerId = TestSubscriber.create<Pair<Int, Long>>()
     private val disableIncreaseButton = TestSubscriber.create<Boolean>()
     private val addButtonGone = TestSubscriber.create<Boolean>()
 
@@ -33,7 +34,7 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.deadlineCountdownIsGone().subscribe(this.countdownIsGone)
         this.vm.outputs.shippingAmountIsGone().subscribe(this.shippingAmountIsGone)
         this.vm.outputs.rewardItemsAreGone().subscribe(this.rewardItemsAreGone)
-        this.vm.outputs.quantity().subscribe(this.quantity)
+        this.vm.outputs.quantityPerId().subscribe(this.quantityPerId)
         this.vm.outputs.disableIncreaseButton().subscribe(this.disableIncreaseButton)
         this.vm.outputs.addButtonIsGone().subscribe(this.addButtonGone)
     }
@@ -105,7 +106,7 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
 
         this.addButtonGone.assertValue(false)
-        this.quantity.assertValue(0)
+        this.quantityPerId.assertValue(Pair(0, addOn.id()))
     }
 
     @Test
@@ -119,7 +120,7 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.increaseButtonPressed()
         this.addButtonGone.assertValues(false, true)
-        this.quantity.assertValues(0, 1)
+        this.quantityPerId.assertValues(Pair(0, addOn.id()), Pair(1, addOn.id()))
     }
 
     @Test
@@ -136,7 +137,7 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.increaseButtonPressed()
 
         this.addButtonGone.assertValues(false, true, true, true)
-        this.quantity.assertValues(0, 1, 2, 3)
+        this.quantityPerId.assertValues(Pair(0, addOn.id()), Pair(1, addOn.id()), Pair(2, addOn.id()), Pair(3, addOn.id()))
     }
 
     @Test
@@ -153,7 +154,7 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.increaseButtonPressed()
 
         this.addButtonGone.assertValues(false, true, true, true)
-        this.quantity.assertValues(0, 1, 2, 3)
+        this.quantityPerId.assertValues(Pair(0, addOn.id()), Pair(1, addOn.id()), Pair(2, addOn.id()), Pair(3, addOn.id()))
         this.disableIncreaseButton.assertValues(false, false, false, true)
     }
 
@@ -178,7 +179,18 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.increaseButtonPressed()
 
         this.addButtonGone.assertValues(false, true, true, true, true, true, true, true, true, true, true)
-        this.quantity.assertValues(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        this.quantityPerId.assertValues(
+                Pair(0, addOn.id()),
+                Pair(1, addOn.id()),
+                Pair(2, addOn.id()),
+                Pair(3, addOn.id()),
+                Pair(4, addOn.id()),
+                Pair(5, addOn.id()),
+                Pair(6, addOn.id()),
+                Pair(7, addOn.id()),
+                Pair(8, addOn.id()),
+                Pair(9, addOn.id()),
+                Pair(10, addOn.id()))
         this.disableIncreaseButton.assertValues(false, false, false, false, false, false, false,false, false, false, true)
     }
 
@@ -197,7 +209,7 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.decreaseButtonPressed()
 
         this.addButtonGone.assertValues(false, true, true, true, true)
-        this.quantity.assertValues(0, 1, 2, 3, 2)
+        this.quantityPerId.assertValues(Pair(0, addOn.id()), Pair(1, addOn.id()), Pair(2, addOn.id()), Pair(3, addOn.id()), Pair(2, addOn.id()))
     }
 
     @Test
@@ -217,6 +229,13 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.decreaseButtonPressed()
 
         this.addButtonGone.assertValues(false, true, true, true, true, true, false)
-        this.quantity.assertValues(0, 1, 2, 3, 2, 1,0)
+        this.quantityPerId.assertValues(
+                Pair(0, addOn.id()),
+                Pair(1, addOn.id()),
+                Pair(2, addOn.id()),
+                Pair(3, addOn.id()),
+                Pair(2, addOn.id()),
+                Pair(1, addOn.id()),
+                Pair(0, addOn.id()))
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -1036,6 +1036,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.scrimIsVisible.assertValue(false)
 
         this.vm.inputs.fragmentStackCount(2)
+        this.scrimIsVisible.assertValues(false)
+
+        this.vm.inputs.fragmentStackCount(3)
         this.scrimIsVisible.assertValues(false, true)
 
         this.vm.inputs.fragmentStackCount(1)

--- a/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
@@ -30,6 +30,7 @@ import com.kickstarter.ui.data.PledgeFlowContext;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import androidx.annotation.NonNull;
 import rx.observers.TestSubscriber;
@@ -312,7 +313,7 @@ public final class ThanksViewModelTest extends KSRobolectricTestCase {
     final CheckoutData checkoutData = CheckoutDataFactory.Companion.checkoutData(3L,
             20.0, 30.0);
     final PledgeData pledgeData = PledgeData.Companion.with(PledgeFlowContext.NEW_PLEDGE,
-            ProjectDataFactory.Companion.project(project), RewardFactory.reward());
+            ProjectDataFactory.Companion.project(project), RewardFactory.reward(), Collections.emptyList());
     final Intent intent = new Intent()
             .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
             .putExtra(IntentKey.PLEDGE_DATA, pledgeData)


### PR DESCRIPTION
# 📲 What

- CTA button to continue with our without Add-ons
- String informing amount of add-ons selected

# 🤔 Why

- Backing with Add-ons from mobile app 

# 🛠 How

- ViewListener from each item in the RecyclerView informs the FragmentViewModel the amount selected for each row
- The Fragment ViewModel holds a structure containing the quantity per AddOnID selected
- The total amount selected gets updated everytime the stepper is pressed in any row

# 👀 See

![AddOnsFlow](https://user-images.githubusercontent.com/4083656/89059981-06cc9200-d317-11ea-81ed-e00d398adac5.gif)

|  |  |

# 📋 QA

- Reach Pledge Screen with Add-ons
- Reach pledge Screen without Add-ons
- Reach pledge Screen without seeing BackingAddons screen

# Story 📖

[Add-Ons cta button logic](https://kickstarter.atlassian.net/browse/NT-1388)
