### PR TITLE
NT-1344: Updated checkout with new mutation 

### DIFF
--- a/app/src/main/graphql/checkout.graphql
+++ b/app/src/main/graphql/checkout.graphql
@@ -1,5 +1,5 @@
-mutation CreateBacking($projectId: ID!, $amount: String!, $paymentType: String!, $paymentSourceId: String!, $locationId: String, $rewardId: ID, $rewardIds: [ID!], $refParam: String) {
-  createBacking(input: {projectId: $projectId, amount: $amount, paymentType: $paymentType, paymentSourceId: $paymentSourceId, locationId: $locationId, rewardId: $rewardId, rewardIds: $rewardIds, refParam: $refParam}) {
+mutation CreateBacking($projectId: ID!, $amount: String!, $paymentType: String!, $paymentSourceId: String!, $locationId: String, $rewardIds: [ID!], $refParam: String) {
+  createBacking(input: {projectId: $projectId, amount: $amount, paymentType: $paymentType, paymentSourceId: $paymentSourceId, locationId: $locationId, rewardIds: $rewardIds, refParam: $refParam}) {
     checkout {
       id
       backing {
@@ -19,13 +19,14 @@ mutation CancelBacking($backingId: ID!, $note: String) {
   }
 }
 
-mutation UpdateBacking($backingId: ID!, $amount: String, $locationId: String, $rewardId: ID, $paymentSourceId: String)  {
-  updateBacking(input: { id: $backingId, amount: $amount, locationId: $locationId, rewardId: $rewardId, paymentSourceId: $paymentSourceId}) {
+mutation UpdateBacking($backingId: ID!, $amount: String, $locationId: String,$rewardIds: [ID!], $paymentSourceId: String)  {
+  updateBacking(input: { id: $backingId, amount: $amount, locationId: $locationId, rewardIds: $rewardIds, paymentSourceId: $paymentSourceId}) {
     checkout {
       id
       backing {
         clientSecret
         requiresAction
+        status
       }
     }
   }

--- a/app/src/main/graphql/checkout.graphql
+++ b/app/src/main/graphql/checkout.graphql
@@ -1,10 +1,11 @@
-mutation CreateBacking($projectId: ID!, $amount: String!, $paymentType: String!, $paymentSourceId: String!, $locationId: String, $rewardId: ID, $refParam: String) {
-  createBacking(input: {projectId: $projectId, amount: $amount, paymentType: $paymentType, paymentSourceId: $paymentSourceId, locationId: $locationId, rewardId: $rewardId, refParam: $refParam}) {
+mutation CreateBacking($projectId: ID!, $amount: String!, $paymentType: String!, $paymentSourceId: String!, $locationId: String, $rewardId: ID, $rewardIds: [ID!], $refParam: String) {
+  createBacking(input: {projectId: $projectId, amount: $amount, paymentType: $paymentType, paymentSourceId: $paymentSourceId, locationId: $locationId, rewardId: $rewardId, rewardIds: $rewardIds, refParam: $refParam}) {
     checkout {
       id
       backing {
         clientSecret
         requiresAction
+        status
       }
     }
   }

--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -34,6 +34,10 @@ fragment backing on Backing {
             ... reward
         }
     }
+
+    clientSecret
+    requiresAction
+    status
 }
 
 fragment project on Project {

--- a/app/src/main/graphql/schema.json
+++ b/app/src/main/graphql/schema.json
@@ -4761,22 +4761,6 @@
               "deprecationReason": null
             },
             {
-              "name": "projectSummary",
-              "description": "A list of responses that summarize the project.",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ProjectSummary",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "recommendations",
               "description": "",
               "args": [],
@@ -10508,7 +10492,19 @@
           "interfaces": null,
           "enumValues": [
             {
+              "name": "GR",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "PL",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SI",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -10850,18 +10846,6 @@
               "deprecationReason": null
             },
             {
-              "name": "new_campaign_nav_desktop",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "new_campaign_nav_mobile",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "new_project_build_additional_owners",
               "description": "",
               "isDeprecated": false,
@@ -10929,12 +10913,6 @@
             },
             {
               "name": "project_prelaunch_summaries",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "project_summary",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -18916,78 +18894,6 @@
         },
         {
           "kind": "OBJECT",
-          "name": "ProjectSummary",
-          "description": "",
-          "fields": [
-            {
-              "name": "question",
-              "description": "A question prompt for the creator to summarize their project",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "ProjectSummaryQuestion",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "response",
-              "description": "Response to a question prompt that summarizes the project",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "ProjectSummaryQuestion",
-          "description": "Question prompts for the creator to summarize their project",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "WHAT_IS_THE_PROJECT",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "WHAT_WILL_YOU_DO_WITH_THE_MONEY",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "WHO_ARE_YOU",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
           "name": "Recommendations",
           "description": "Score and model from recommendations engine if a project was fetched via recommendations.",
           "fields": [
@@ -26249,12 +26155,6 @@
               "deprecationReason": null
             },
             {
-              "name": "el",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "es",
               "description": "",
               "isDeprecated": false,
@@ -26274,18 +26174,6 @@
             },
             {
               "name": "ja",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pl",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "sl",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -32723,11 +32611,29 @@
             },
             {
               "name": "rewardId",
-              "description": "Relay encoded Reward ID - legacy",
+              "description": "Relay encoded Reward ID - legacy - mutually exclusive with reward_ids",
               "type": {
                 "kind": "SCALAR",
                 "name": "ID",
                 "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "rewardIds",
+              "description": "List of Relay encoded Reward/Add-on IDs - mutually exclusive with reward_id",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null
             }
@@ -41804,24 +41710,6 @@
               "defaultValue": null
             },
             {
-              "name": "projectSummary",
-              "description": "",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "ProjectSummaryInput",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            },
-            {
               "name": "risks",
               "description": "",
               "type": {
@@ -41899,45 +41787,6 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ID",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "ProjectSummaryInput",
-          "description": "A summary for a project.",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "question",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "ProjectSummaryQuestion",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "response",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
                   "ofType": null
                 }
               },

--- a/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
@@ -208,19 +208,22 @@ public final class RewardUtils {
    */
   public static Double rewardAmountByVariant(final OptimizelyExperiment.Variant variant, final Reward reward) {
     Double value = reward.minimum();
-    switch (variant) {
-      case CONTROL:
-        value = 1.0;
-        break;
-      case VARIANT_2:
-        value = 10.0;
-        break;
-      case VARIANT_3:
-        value = 20.0;
-        break;
-      case VARIANT_4:
-        value = 50.0;
-        break;
+
+    if (isNoReward(reward)) {
+      switch (variant) {
+        case CONTROL:
+          value = 1.0;
+          break;
+        case VARIANT_2:
+          value = 10.0;
+          break;
+        case VARIANT_3:
+          value = 20.0;
+          break;
+        case VARIANT_4:
+          value = 50.0;
+          break;
+      }
     }
 
     return value;

--- a/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.java
@@ -78,6 +78,7 @@ public final class RewardFactory {
 
     return reward().toBuilder()
             .id(rewardId)
+            .minimum(10)
             .isAddOn(true)
             .addOnsItems(
                     Arrays.asList(

--- a/app/src/main/java/com/kickstarter/mock/factories/ShippingRuleFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/ShippingRuleFactory.kt
@@ -19,5 +19,13 @@ class ShippingRuleFactory private constructor() {
                     .location(LocationFactory.germany())
                     .build()
         }
+
+        fun mexicoShippingRule(): ShippingRule {
+            return ShippingRule.builder()
+                    .id(3L)
+                    .cost(10.0)
+                    .location(LocationFactory.mexico())
+                    .build()
+        }
     }
 }

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -72,6 +72,7 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                     .paymentSourceId(createBackingData.paymentSourceId)
                     .locationId(createBackingData.locationId?.let { it })
                     .rewardId(createBackingData.reward?.let { encodeRelayId(it) })
+                    .rewardIds(createBackingData.rewardsIds?.let { list -> list.map { encodeRelayId(it) } })
                     .refParam(createBackingData.refTag?.tag())
                     .build()
 
@@ -89,6 +90,8 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                             }
 
                             val checkoutPayload = response.data()?.createBacking()?.checkout()
+
+                            // TODO: Add new status field to backing model
                             val backing = Checkout.Backing.builder()
                                     .clientSecret(checkoutPayload?.backing()?.clientSecret())
                                     .requiresAction(checkoutPayload?.backing()?.requiresAction()?: false)

--- a/app/src/main/java/com/kickstarter/services/mutations/CreateBackingData.kt
+++ b/app/src/main/java/com/kickstarter/services/mutations/CreateBackingData.kt
@@ -4,4 +4,4 @@ import com.kickstarter.libs.RefTag
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 
-data class CreateBackingData(val project: Project, val amount: String, val paymentSourceId: String, val locationId: String?, val reward: Reward?, val refTag: RefTag?)
+data class CreateBackingData(val project: Project, val amount: String, val paymentSourceId: String, val locationId: String?, val reward: Reward? = null, val rewardsIds: List<Reward>? = null, val refTag: RefTag?)

--- a/app/src/main/java/com/kickstarter/services/mutations/UpdateBackingData.kt
+++ b/app/src/main/java/com/kickstarter/services/mutations/UpdateBackingData.kt
@@ -6,5 +6,5 @@ import com.kickstarter.models.Reward
 data class UpdateBackingData(val backing: Backing,
                              val amount: String? = null,
                              val locationId: String? = null,
-                             val reward: Reward? = null,
+                             val rewardsIds: List<Reward>? = null,
                              val paymentSourceId: String? = null)

--- a/app/src/main/java/com/kickstarter/ui/data/PledgeData.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/PledgeData.kt
@@ -3,6 +3,7 @@ package com.kickstarter.ui.data
 import android.os.Parcelable
 import auto.parcel.AutoParcel
 import com.kickstarter.models.Reward
+import com.kickstarter.models.ShippingRule
 import java.util.List
 
 @AutoParcel
@@ -10,6 +11,7 @@ abstract class PledgeData : Parcelable {
     abstract fun pledgeFlowContext(): PledgeFlowContext
     abstract fun projectData(): ProjectData
     abstract fun addOns(): List<Reward>?
+    abstract fun shippingRule(): ShippingRule?
     abstract fun reward(): Reward
 
     @AutoParcel.Builder
@@ -18,6 +20,7 @@ abstract class PledgeData : Parcelable {
         abstract fun projectData(projectData: ProjectData): Builder
         abstract fun reward(reward: Reward): Builder
         abstract fun addOns(rewards: List<Reward>): Builder
+        abstract fun shippingRule(shippingRule: ShippingRule): Builder
         abstract fun build(): PledgeData
     }
 
@@ -29,14 +32,22 @@ abstract class PledgeData : Parcelable {
             return AutoParcel_PledgeData.Builder()
         }
 
-        fun with(pledgeFlowContext: PledgeFlowContext, projectData: ProjectData, reward: Reward, addOns: List<Reward>? = null) =
-                addOns?.let {
-                    return@let builder()
-                        .pledgeFlowContext(pledgeFlowContext)
-                        .projectData(projectData)
-                        .reward(reward)
-                        .addOns(it)
-                        .build()
+        fun with(pledgeFlowContext: PledgeFlowContext, projectData: ProjectData, reward: Reward, addOns: List<Reward>? = null, shippingRule: ShippingRule? = null) =
+                addOns?.let {addOns ->
+                    shippingRule?.let { shippingRule ->
+                        return@let builder()
+                                .pledgeFlowContext(pledgeFlowContext)
+                                .projectData(projectData)
+                                .reward(reward)
+                                .addOns(addOns)
+                                .shippingRule(shippingRule)
+                                .build()
+                    }?: builder()
+                            .pledgeFlowContext(pledgeFlowContext)
+                            .projectData(projectData)
+                            .reward(reward)
+                            .addOns(addOns)
+                            .build()
                 }?: builder()
                     .pledgeFlowContext(pledgeFlowContext)
                     .projectData(projectData)

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -27,8 +27,6 @@ import com.kickstarter.ui.viewholders.BackingAddOnViewHolder
 import com.kickstarter.viewmodels.BackingAddOnsFragmentViewModel
 import kotlinx.android.synthetic.main.fragment_backing_addons.*
 import kotlinx.android.synthetic.main.fragment_backing_addons_section_footer.*
-import kotlinx.android.synthetic.main.fragment_backing_addons_section_footer.view.*
-import rx.Observable
 
 @RequiresFragmentViewModel(BackingAddOnsFragmentViewModel.ViewModel::class)
 class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewModel>(), ShippingRulesAdapter.Delegate, BackingAddOnViewHolder.ViewListener {
@@ -125,16 +123,12 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
     }
 
     private fun showPledgeFragment(pledgeData: PledgeData, pledgeReason: PledgeReason) {
-        if (this.fragmentManager?.findFragmentByTag(PledgeFragment::class.java.simpleName) == null) {
-            val pledgeFragment = PledgeFragment.newInstance(pledgeData, pledgeReason)
-            this.fragmentManager?.beginTransaction()
-                    ?.setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
-                    ?.add(R.id.fragment_container,
-                            pledgeFragment,
-                            PledgeFragment::class.java.simpleName)
-                    ?.addToBackStack(PledgeFragment::class.java.simpleName)
-                    ?.commit()
-        }
+        fragmentManager
+                ?.beginTransaction()
+                ?.setCustomAnimations(R.anim.slide_up, 0, 0, R.anim.slide_down)
+                ?.add(R.id.fragment_container, PledgeFragment.newInstance(pledgeData, pledgeReason), PledgeFragment::class.java.simpleName)
+                ?.addToBackStack(NewCardFragment::class.java.simpleName)
+                ?.commit()
     }
 
     private fun displayShippingRules(shippingRules: List<ShippingRule>, project: Project) {

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -129,7 +129,6 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                     }
                 }
 
-
         this.viewModel.outputs.decreaseBonusButtonIsEnabled()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -29,6 +29,7 @@ import com.kickstarter.extensions.onChange
 import com.kickstarter.extensions.showErrorToast
 import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
+import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.UrlUtils
@@ -60,8 +61,10 @@ import kotlinx.android.synthetic.main.fragment_pledge_section_header_reward_suma
 import kotlinx.android.synthetic.main.fragment_pledge_section_payment.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_pledge_amount.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_reward_summary.*
+import kotlinx.android.synthetic.main.fragment_pledge_section_editable_shipping.*
+import kotlinx.android.synthetic.main.fragment_pledge_section_editable_shipping.shipping_rules
+import kotlinx.android.synthetic.main.fragment_pledge_section_editable_shipping.view.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_shipping.*
-import kotlinx.android.synthetic.main.fragment_pledge_section_shipping.view.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_summary_pledge.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_summary_shipping.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_total.*
@@ -264,7 +267,10 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.outputs.selectedShippingRule()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { shipping_rules.setText(it.toString()) }
+                .subscribe {
+                    shipping_rules.setText(it.toString())
+                    shipping_rules_static.text = it.toString()
+                }
 
         this.viewModel.outputs.shippingAmount()
                 .compose(bindToLifecycle())
@@ -272,6 +278,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .subscribe {
                     ViewUtils.setGone(shipping_amount_loading_view, true)
                     setPlusTextView(shipping_amount, it)
+                    setPlusTextView(shipping_amount_static, it)
                 }
 
         this.viewModel.outputs.shippingSummaryAmount()
@@ -293,7 +300,10 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.outputs.shippingRulesSectionIsGone()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { ViewUtils.setGone(shipping_rules_row, it) }
+                .subscribe {
+                    ViewUtils.setGone(shipping_rules_row, it)
+                    ViewUtils.setGone(shipping_rules_row_static, !it)
+                }
 
         this.viewModel.outputs.shippingSummaryIsGone()
                 .compose(bindToLifecycle())
@@ -495,10 +505,6 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         RxView.clicks(pledge_footer_continue_button)
                 .compose(bindToLifecycle())
                 .subscribe { this.viewModel.inputs.continueButtonClicked() }
-
-        this.viewModel.outputs.shippingSelectorIsGone()
-                .compose(bindToLifecycle())
-                .subscribe { this.view?.shipping_rules?.let { it1 -> ViewUtils.setGone(it1, it) } }
     }
 
     private fun populateHeaderItems(selectedItems: List<Pair<Project, Reward>>) {
@@ -758,7 +764,6 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
     }
 
     companion object {
-
         fun newInstance(pledgeData: PledgeData, pledgeReason: PledgeReason): PledgeFragment {
             val fragment = PledgeFragment()
             val argument = Bundle()

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -302,7 +302,13 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .compose(observeForUI())
                 .subscribe {
                     ViewUtils.setGone(shipping_rules_row, it)
-                    ViewUtils.setGone(shipping_rules_row_static, !it)
+                }
+
+        this.viewModel.outputs.shippingRuleStaticIsGone()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe {
+                    ViewUtils.setGone(shipping_rules_row_static, it)
                 }
 
         this.viewModel.outputs.shippingSummaryIsGone()

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -29,7 +29,6 @@ import com.kickstarter.extensions.onChange
 import com.kickstarter.extensions.showErrorToast
 import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
-import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.UrlUtils

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -295,7 +295,9 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
                 .filter { ObjectUtils.isNotNull(context) }
-                .subscribe { displayShippingRules(it.first, it.second) }
+                .subscribe {
+                    displayShippingRules(it.first, it.second)
+                }
 
         this.viewModel.outputs.shippingRulesSectionIsGone()
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -162,10 +162,16 @@ class BackingAddOnsFragmentViewModel {
                 _, listAddOns, pledgeData, pledgeReason, shippingRule ->
 
                 val updatedList = updateAddOnsListQuantity(listAddOns)
-                val updatedPledgeData = pledgeData.toBuilder()
-                        .addOns(updatedList as java.util.List<Reward>)
-                        .shippingRule(shippingRule)
-                        .build()
+                var updatedPledgeData: PledgeData
+                updatedPledgeData = if (updatedList.isNotEmpty()) {
+                    pledgeData.toBuilder()
+                            .addOns(updatedList as java.util.List<Reward>)
+                            .shippingRule(shippingRule)
+                            .build()
+                } else {
+                    pledgeData.toBuilder()
+                            .build()
+                }
                 return@combineLatest Pair(updatedPledgeData, pledgeReason)
             }
                     .compose(bindToLifecycle())
@@ -180,7 +186,7 @@ class BackingAddOnsFragmentViewModel {
             this.selectedAmount
                     .filter { it.value > 0 }
                     .forEach { selectedAddOn ->
-                        val item = listAddOns.filter { it.id() == selectedAddOn.key }.first()
+                        val item = listAddOns.first { it.id() == selectedAddOn.key }
                         updatedList.add(item.toBuilder().quantity(selectedAddOn.value).build())
             }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -105,10 +105,6 @@ class BackingAddOnsFragmentViewModel {
             val reward = pledgeData
                     .map { it.reward() }
 
-            this.pledgeDataAndReason
-                    .compose(bindToLifecycle())
-                    .subscribe(this.showPledgeFragment)
-
             val addonsList = project
                     .switchMap { pj -> this.apolloClient.getProjectAddOns(pj.slug()?.let { it }?: "") }
                     .compose(bindToLifecycle())
@@ -162,11 +158,14 @@ class BackingAddOnsFragmentViewModel {
                         updateQuantityById(it)
                     }
 
-            Observable.combineLatest(this.continueButtonPressed, addonsList, pledgeData, pledgeReason) {
-                _, listAddOns, pledgeData, pledgeReason ->
+            Observable.combineLatest(this.continueButtonPressed, addonsList, pledgeData, pledgeReason, this.shippingRuleSelected) {
+                _, listAddOns, pledgeData, pledgeReason, shippingRule ->
 
                 val updatedList = updateAddOnsListQuantity(listAddOns)
-                val updatedPledgeData = pledgeData.toBuilder().addOns(updatedList as java.util.List<Reward>).build()
+                val updatedPledgeData = pledgeData.toBuilder()
+                        .addOns(updatedList as java.util.List<Reward>)
+                        .shippingRule(shippingRule)
+                        .build()
                 return@combineLatest Pair(updatedPledgeData, pledgeReason)
             }
                     .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -169,7 +169,6 @@ interface BackingFragmentViewModel {
         private val bonusSupport = BehaviorSubject.create<CharSequence>()
         private val estimatedDelivery = BehaviorSubject.create<String>()
         private val deliveryDisclaimerSectionIsGone = BehaviorSubject.create<Boolean>()
-        private val estimatedDeliveryLabelIsGone = BehaviorSubject.create<Boolean>()
 
         private val apiClient = this.environment.apiClient()
         private val apolloClient = this.environment.apolloClient()

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -331,6 +331,7 @@ interface PledgeFragmentViewModel {
         private val shippingAmount = BehaviorSubject.create<CharSequence>()
         private val shippingRulesAndProject = BehaviorSubject.create<Pair<List<ShippingRule>, Project>>()
         private val shippingRulesSectionIsGone = BehaviorSubject.create<Boolean>()
+        // - when having add-ons the shipping location is an static field, no changes allowed in there
         private val shippingRuleStaticIsGone = BehaviorSubject.create<Boolean>()
         private val shippingSummaryAmount = BehaviorSubject.create<CharSequence>()
         private val shippingSummaryIsGone = BehaviorSubject.create<Boolean>()
@@ -717,12 +718,13 @@ interface PledgeFragmentViewModel {
                         this.shippingAmount.onNext(ProjectViewUtils.styleCurrency(it.first.cost(), it.second, this.ksCurrency))
                     }
 
+            // - When updating payment, shipping location area should always be gone
             updatingPayment
                     .compose<Pair<Boolean, Reward>>(combineLatestPair(this.selectedReward))
-                    .filter { it.first == true }
+                    .filter { it.first == true && RewardUtils.isShippable(it.second)}
                     .compose(bindToLifecycle())
-                    .subscribe{
-                        this.shippingRulesSectionIsGone.onNext(!RewardUtils.isShippable(it.second))
+                    .subscribe {
+                        this.shippingRulesSectionIsGone.onNext(true )
                     }
 
             // - Calculate total for Reward || Rewards + AddOns with Shipping location

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -998,24 +998,6 @@ interface PledgeFragmentViewModel {
 
             val paymentMethodId: Observable<String> = selectedCardAndPosition.map { it.first.id() }
 
-            /*val createBackingNotification = Observable.combineLatest(project,
-                    total.map { it.toString() },
-                    paymentMethodId,
-                    locationId,
-                    selectedReward,
-                    cookieRefTag)
-            { p, a, id, l, r, c -> CreateBackingData(p, a, id, l, r, c) }
-                    .compose<CreateBackingData>(takeWhen(pledgeButtonClicked))
-                    .switchMap {
-                        this.apolloClient.createBacking(it)
-                                .doOnSubscribe {
-                                    this.pledgeProgressIsGone.onNext(false)
-                                    this.pledgeButtonIsEnabled.onNext(false)
-                                }
-                                .materialize()
-                    }
-                    .share()*/
-
             val createBackingNotification = Observable.combineLatest(project,
                     total.map { it.toString() },
                     paymentMethodId,

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -377,7 +377,7 @@ interface PledgeFragmentViewModel {
         private val shippingRuleUpdated = BehaviorSubject.create<Boolean>(false)
         private val selectedReward = BehaviorSubject.create<Reward>()
         private val rewardAndAddOns = BehaviorSubject.create<List<Reward>>()
-        private val shippingAmountSelectedRw = PublishSubject.create<Double>()
+        private val shippingAmountSelectedRw = BehaviorSubject.create<Double>(0.0)
 
         val inputs: Inputs = this
         val outputs: Outputs = this

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -1110,7 +1110,7 @@ interface PledgeFragmentViewModel {
             val updateBackingNotification = Observable.combineLatest(backingToUpdate,
                     totalString,
                     locationId,
-                    this.selectedReward,
+                    extendedListForCheckOut,
                     optionalPaymentMethodId)
             { b, a, l, r, p -> UpdateBackingData(b, a, l, r, p) }
                     .compose<UpdateBackingData>(takeWhen(Observable.merge(updatePledgeClick, updatePaymentClick, fixPaymentClick)))
@@ -1357,10 +1357,6 @@ interface PledgeFragmentViewModel {
                 (sAmountSelectedRw + addOnsCost + addOnsShippingCost + reward.minimum() + bAmount.toInt())
 
             return totalPledgeValue
-        }
-
-        private fun getBacking(backingId: String): Observable<Backing> {
-            return this.apolloClient.getBacking(backingId)
         }
 
         private fun backingShippingRule(shippingRules: List<ShippingRule>, backing: Backing): Observable<ShippingRule> {

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -656,7 +656,7 @@ interface ProjectViewModel {
 
             this.fragmentStackCount
                     .compose<Pair<Int, Project>>(combineLatestPair(currentProject))
-                    .map { if (it.second.isBacking) it.first > 2 else it.first > 2}
+                    .map { if (it.second.isBacking) it.first > 3 else it.first > 3}
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.scrimIsVisible)

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 import androidx.annotation.NonNull;
 import rx.Observable;
 import rx.Scheduler;
-import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 
@@ -127,18 +126,14 @@ public interface SearchViewModel {
 
       query
         .compose(takePairWhen(pageCount))
-              .subscribeOn(Schedulers.io())
         .filter(qp -> StringUtils.isPresent(qp.first))
-              .observeOn(Schedulers.computation())
         .compose(bindToLifecycle())
         .subscribe(qp -> this.koala.trackSearchResults(qp.first, qp.second));
 
       params
         .compose(takePairWhen(pageCount))
-              .subscribeOn(Schedulers.io())
         .filter(paramsAndPageCount -> paramsAndPageCount.first.sort() != defaultSort && IntegerUtils.intValueOrZero(paramsAndPageCount.second) == 1)
         .map(paramsAndPageCount -> paramsAndPageCount.first)
-              .observeOn(Schedulers.computation())
         .compose(bindToLifecycle())
         .subscribe(this.lake::trackSearchResultsLoaded);
 

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 import androidx.annotation.NonNull;
 import rx.Observable;
 import rx.Scheduler;
+import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 
@@ -126,14 +127,18 @@ public interface SearchViewModel {
 
       query
         .compose(takePairWhen(pageCount))
+              .subscribeOn(Schedulers.io())
         .filter(qp -> StringUtils.isPresent(qp.first))
+              .observeOn(Schedulers.computation())
         .compose(bindToLifecycle())
         .subscribe(qp -> this.koala.trackSearchResults(qp.first, qp.second));
 
       params
         .compose(takePairWhen(pageCount))
+              .subscribeOn(Schedulers.io())
         .filter(paramsAndPageCount -> paramsAndPageCount.first.sort() != defaultSort && IntegerUtils.intValueOrZero(paramsAndPageCount.second) == 1)
         .map(paramsAndPageCount -> paramsAndPageCount.first)
+              .observeOn(Schedulers.computation())
         .compose(bindToLifecycle())
         .subscribe(this.lake::trackSearchResultsLoaded);
 

--- a/app/src/main/res/layout/fragment_pledge.xml
+++ b/app/src/main/res/layout/fragment_pledge.xml
@@ -36,7 +36,11 @@
                 android:paddingStart="@dimen/activity_vertical_margin"
                 android:paddingEnd="@dimen/activity_vertical_margin">
 
-                <include layout="@layout/fragment_pledge_section_shipping" />
+                <include layout="@layout/fragment_pledge_section_shipping"
+                    android:id="@+id/shipping_rules_row_static" />
+
+                <include layout="@layout/fragment_pledge_section_editable_shipping"
+                    android:id="@+id/shipping_rules_row"/>
 
                 <include layout="@layout/fragment_pledge_section_pledge_amount" />
 

--- a/app/src/main/res/layout/fragment_pledge_section_editable_shipping.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_editable_shipping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="@dimen/grid_2"
@@ -11,20 +11,20 @@
     tools:showIn="@layout/fragment_pledge">
 
     <TextView
-        android:id="@+id/shipping_rules_label_static"
+        android:id="@+id/shipping_rules_label"
         style="@style/CalloutPrimaryMedium"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/grid_4"
         android:text="@string/Your_shipping_location"
-        app:layout_constraintBottom_toTopOf="@id/shipping_rules_static"
+        app:layout_constraintBottom_toTopOf="@id/shipping_rules"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/shipping_rules_static"
-        style="@style/CalloutPrimary"
+    <AutoCompleteTextView
+        android:id="@+id/shipping_rules"
+        style="@style/AutocompleteStyle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/grid_1"
@@ -32,12 +32,17 @@
         android:ellipsize="end"
         android:enabled="false"
         android:hint="@string/Shipping"
+        android:imeOptions="actionDone"
+        android:inputType="text"
         android:maxLines="1"
-        android:textColor="@color/ksr_soft_black"
+        android:nextFocusDown="@id/shipping_amount"
+        android:scrollHorizontally="true"
+        android:text="@string/Loading"
+        android:textColor="@color/ksr_green_500"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/shipping_add_symbol"
+        app:layout_constraintEnd_toStartOf="@id/shipping_add_symbol"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/shipping_rules_label_static"
+        app:layout_constraintTop_toBottomOf="@id/shipping_rules_label"
         tools:text="United States" />
 
     <ImageView
@@ -50,12 +55,12 @@
         android:src="@drawable/ic_add"
         android:tint="@color/ksr_dark_grey_400"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/shipping_amount_static"
-        app:layout_constraintStart_toEndOf="@+id/shipping_rules_static"
-        app:layout_constraintTop_toBottomOf="@+id/shipping_rules_label_static" />
+        app:layout_constraintEnd_toStartOf="@id/shipping_amount"
+        app:layout_constraintStart_toEndOf="@id/shipping_rules"
+        app:layout_constraintTop_toBottomOf="@id/shipping_rules_label" />
 
     <TextView
-        android:id="@+id/shipping_amount_static"
+        android:id="@+id/shipping_amount"
         style="@style/PledgeCurrencySecondary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -65,8 +70,21 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1"
-        app:layout_constraintStart_toEndOf="@+id/shipping_add_symbol"
-        app:layout_constraintTop_toBottomOf="@+id/shipping_rules_label_static"
+        app:layout_constraintStart_toEndOf="@id/shipping_add_symbol"
+        app:layout_constraintTop_toBottomOf="@id/shipping_rules_label"
         tools:text="$10" />
+
+    <View
+        android:id="@+id/shipping_amount_loading_view"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/grid_2"
+        android:layout_gravity="center|end"
+        android:layout_marginTop="@dimen/grid_1"
+        android:background="@drawable/pledge_amounts_loading_states"
+        app:layout_constraintBottom_toBottomOf="@id/shipping_amount"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintStart_toEndOf="@id/shipping_add_symbol"
+        app:layout_constraintTop_toBottomOf="@id/shipping_rules_label" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_pledge_section_shipping.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_shipping.xml
@@ -35,13 +35,13 @@
         android:maxLines="1"
         android:textColor="@color/ksr_soft_black"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/shipping_add_symbol"
+        app:layout_constraintEnd_toStartOf="@+id/shipping_add_symbol_static"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/shipping_rules_label_static"
         tools:text="United States" />
 
     <ImageView
-        android:id="@+id/shipping_add_symbol"
+        android:id="@+id/shipping_add_symbol_static"
         android:layout_width="@dimen/grid_3"
         android:layout_height="@dimen/grid_3"
         android:layout_gravity="start|center_vertical"
@@ -65,7 +65,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1"
-        app:layout_constraintStart_toEndOf="@+id/shipping_add_symbol"
+        app:layout_constraintStart_toEndOf="@+id/shipping_add_symbol_static"
         app:layout_constraintTop_toBottomOf="@+id/shipping_rules_label_static"
         tools:text="$10" />
 

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -568,7 +568,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeProgressIsGone.assertNoValues()
         this.pledgeSectionIsGone.assertValue(true)
         this.pledgeSummaryIsGone.assertValue(false)
-        this.shippingRulesSectionIsGone.assertValue(true)
+        this.shippingRulesSectionIsGone.assertValues(false, true)
         this.totalDividerIsGone.assertValue(true)
 
         this.koalaTest.assertNoValues()
@@ -643,7 +643,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeMaximumIsGone.assertNoValues()
         this.pledgeSectionIsGone.assertValue(true)
         this.pledgeSummaryIsGone.assertValue(false)
-        this.shippingRulesSectionIsGone.assertValue(true)
+        this.shippingRulesSectionIsGone.assertValues(false, true)
         this.shippingSummaryIsGone.assertValue(false)
         this.totalDividerIsGone.assertValue(true)
 
@@ -1118,9 +1118,12 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
         this.projectCurrencySymbol.assertValue("$")
         this.shippingAmount.assertNoValues()
-        this.totalAmount.assertValues(expectedCurrency(environment, project, 20.0))
-        this.totalAndDeadline.assertValues(Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)))
-        this.totalAndDeadlineIsVisible.assertValueCount(1)
+        this.totalAmount.assertValues(expectedCurrency(environment, project, 20.0), expectedCurrency(environment, project, 40.0))
+        this.totalAndDeadline.assertValues(
+                Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 40.0), DateTimeUtils.longDate(this.deadline))
+        )
+        this.totalAndDeadlineIsVisible.assertValueCount(2)
 
         this.vm.inputs.pledgeInput("10")
 
@@ -1135,17 +1138,28 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.increasePledgeButtonIsEnabled.assertValue(true)
         this.pledgeAmount.assertValues("20", "40", "10")
         this.vm.inputs.increasePledgeButtonClicked()
-        this.pledgeButtonIsEnabled.assertValues(true)
+        this.pledgeButtonIsEnabled.assertValues(true, false)
         this.pledgeHint.assertValue("20")
         this.pledgeMaximum.assertValues(expectedCurrency(environment, project, 10_000.0))
         this.pledgeMaximumIsGone.assertValue(true)
         this.pledgeMinimum.assertValue(expectedCurrency(environment, project, 20.0))
         this.pledgeTextColor.assertValues(R.color.ksr_green_500, R.color.ksr_red_400)
         this.projectCurrencySymbol.assertValue("$")
-        this.shippingAmount.assertValue(expectedCurrency(environment, project, 0.0))
-        this.totalAmount.assertValues(expectedCurrency(environment, project, 20.0))
-        this.totalAndDeadline.assertValues(Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)))
-        this.totalAndDeadlineIsVisible.assertValueCount(1)
+        this.shippingAmount.assertNoValues()
+        this.totalAmount.assertValues(
+                expectedCurrency(environment, project, 20.0),
+                expectedCurrency(environment, project, 40.0),
+                expectedCurrency(environment, project, 10.0),
+                expectedCurrency(environment, project, 11.0)
+        )
+        this.totalAndDeadline.assertValues(
+                Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 40.0), DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 10.0), DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 11.0), DateTimeUtils.longDate(this.deadline))
+        )
+        this.totalAndDeadlineIsVisible.assertValueCount(4)
+        this.pledgeButtonIsEnabled.assertValues(true, false)
 
         //US max is 10,000
         this.vm.inputs.pledgeInput("10001")
@@ -1161,17 +1175,30 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.decreasePledgeButtonIsEnabled.assertValues(false, true, false, true)
         this.increasePledgeButtonIsEnabled.assertValues(true, false)
         this.pledgeAmount.assertValues("20", "40", "10","11","10,001")
-        this.pledgeButtonIsEnabled.assertValues(true)
+        this.pledgeButtonIsEnabled.assertValues(true, false)
         this.pledgeHint.assertValue("20")
         this.pledgeMaximum.assertValues(expectedCurrency(environment, project, 10_000.0))
         this.pledgeMaximumIsGone.assertValues(true, false)
         this.pledgeMinimum.assertValue(expectedCurrency(environment, project, 20.0))
         this.pledgeTextColor.assertValues(R.color.ksr_green_500, R.color.ksr_red_400)
         this.projectCurrencySymbol.assertValue("$")
-        this.shippingAmount.assertValue(expectedCurrency(environment, project, 0.0))
-        this.totalAmount.assertValues(expectedCurrency(environment, project, 20.0))
-        this.totalAndDeadline.assertValues(Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)))
-        this.totalAndDeadlineIsVisible.assertValueCount(1)
+        this.shippingAmount.assertNoValues()
+        this.totalAmount.assertValues(
+                expectedCurrency(environment, project, 20.0),
+                expectedCurrency(environment, project, 40.0),
+                expectedCurrency(environment, project, 10.0),
+                expectedCurrency(environment, project, 11.0),
+                "$10,001"
+        )
+        this.totalAndDeadline.assertValues(
+                Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 40.0), DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 10.0), DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 11.0), DateTimeUtils.longDate(this.deadline)),
+                Pair("$10,001", DateTimeUtils.longDate(this.deadline))
+        )
+        this.totalAndDeadlineIsVisible.assertValueCount(5)
+        this.pledgeButtonIsEnabled.assertValues(true, false)
 
         //US max is 10,000
         this.vm.inputs.pledgeInput("10000")
@@ -1188,17 +1215,32 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.decreasePledgeButtonIsEnabled.assertValues(false, true, false, true)
         this.increasePledgeButtonIsEnabled.assertValues(true, false)
         this.pledgeAmount.assertValues("20", "40", "10","11","10,001", "10,000")
-        this.pledgeButtonIsEnabled.assertValues(true)
+        this.pledgeButtonIsEnabled.assertValues(true, false, true)
         this.pledgeHint.assertValue("20")
         this.pledgeMaximum.assertValues(expectedCurrency(environment, project, 10_000.0))
         this.pledgeMaximumIsGone.assertValues(true, false, true)
         this.pledgeMinimum.assertValue(expectedCurrency(environment, project, 20.0))
         this.pledgeTextColor.assertValues(R.color.ksr_green_500, R.color.ksr_red_400, R.color.ksr_green_500)
         this.projectCurrencySymbol.assertValue("$")
-        this.shippingAmount.assertValue(expectedCurrency(environment, project, 0.0))
-        this.totalAmount.assertValues(expectedCurrency(environment, project, 20.0))
-        this.totalAndDeadline.assertValues(Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)))
-        this.totalAndDeadlineIsVisible.assertValueCount(1)
+        this.shippingAmount.assertNoValues()
+        this.totalAmount.assertValues(
+                expectedCurrency(environment, project, 20.0),
+                expectedCurrency(environment, project, 40.0),
+                expectedCurrency(environment, project, 10.0),
+                expectedCurrency(environment, project, 11.0),
+                "$10,001",
+                expectedCurrency(environment, project, 10000.0)
+        )
+        this.totalAndDeadline.assertValues(
+                Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 40.0), DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 10.0), DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 11.0), DateTimeUtils.longDate(this.deadline)),
+                Pair("$10,001", DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 10000.0), DateTimeUtils.longDate(this.deadline))
+        )
+        this.totalAndDeadlineIsVisible.assertValueCount(6)
+        this.pledgeButtonIsEnabled.assertValues(true, false, true)
     }
 
     @Test
@@ -2454,23 +2496,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testTotalDoesNotEmit_whenNoSelectedShippingRule() {
-        val environment = environmentForShippingRules(ShippingRulesEnvelopeFactory.emptyShippingRules())
-        setUpEnvironment(environment)
-        this.selectedShippingRule.assertNoValues()
-        this.totalAmount.assertNoValues()
-
-        this.vm.inputs.decreasePledgeButtonClicked()
-        this.totalAmount.assertNoValues()
-
-        this.vm.inputs.increasePledgeButtonClicked()
-        this.totalAmount.assertNoValues()
-
-        this.vm.inputs.pledgeInput("50")
-        this.totalAmount.assertNoValues()
-    }
-
-    @Test
     fun testShowPledgeSuccess_whenNoReward() {
         val project = ProjectFactory.project()
         setUpEnvironment(environmentForLoggedInUser(UserFactory.user()), RewardFactory.noReward(), project)
@@ -2746,7 +2771,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeButtonIsEnabled.assertValues(false, true)
 
         this.vm.inputs.shippingRuleSelected(backingShippingRule)
-        this.selectedShippingRule.assertValues(backingShippingRule, backingShippingRule, germanyShippingRule, backingShippingRule)
+        this.selectedShippingRule.assertValues(backingShippingRule, backingShippingRule,germanyShippingRule, backingShippingRule)
         this.pledgeButtonIsEnabled.assertValues(false, true, false)
 
         this.vm.inputs.bonusInput("500")

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -595,7 +595,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeSectionIsGone.assertValue(true)
         this.pledgeSummaryIsGone.assertValue(true)
         this.headerSectionIsGone.assertValue(true)
-        this.shippingRulesSectionIsGone.assertValue(true)
+        this.shippingRulesSectionIsGone.assertValues(true, true)
+        this.selectedShippingRule.assertNoValues()
         this.shippingSummaryIsGone.assertValue(true)
         this.totalDividerIsGone.assertValue(true)
 
@@ -673,7 +674,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeMaximumIsGone.assertNoValues()
         this.pledgeSectionIsGone.assertValue(true)
         this.pledgeSummaryIsGone.assertValue(true)
-        this.shippingRulesSectionIsGone.assertValue(true)
+        this.shippingRulesSectionIsGone.assertValues(true, true)
+        this.selectedShippingRule.assertNoValues()
         this.shippingSummaryIsGone.assertValue(true)
         this.totalDividerIsGone.assertValue(true)
 
@@ -1550,6 +1552,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment, RewardFactory.noReward(), project)
 
         this.vm.inputs.cardSelected(StoredCardFactory.visa(), 0)
+        this.pledgeButtonIsEnabled.assertValue(true)
         this.vm.inputs.pledgeButtonClicked()
 
         this.koalaTest.assertValues("Pledge Screen Viewed", "Pledge Button Clicked")
@@ -2729,15 +2732,15 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PLEDGE)
 
-        this.selectedShippingRule.assertValue(backingShippingRule)
+        this.selectedShippingRule.assertValues(backingShippingRule, backingShippingRule)
         this.pledgeButtonIsEnabled.assertValues(false)
 
         this.vm.inputs.shippingRuleSelected(germanyShippingRule)
-        this.selectedShippingRule.assertValues(backingShippingRule, germanyShippingRule)
+        this.selectedShippingRule.assertValues(backingShippingRule, backingShippingRule, germanyShippingRule)
         this.pledgeButtonIsEnabled.assertValues(false, true)
 
         this.vm.inputs.shippingRuleSelected(backingShippingRule)
-        this.selectedShippingRule.assertValues(backingShippingRule, germanyShippingRule, backingShippingRule)
+        this.selectedShippingRule.assertValues(backingShippingRule, backingShippingRule, germanyShippingRule, backingShippingRule)
         this.pledgeButtonIsEnabled.assertValues(false, true, false)
 
         this.vm.inputs.bonusInput("500")

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -595,7 +595,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeSectionIsGone.assertValue(true)
         this.pledgeSummaryIsGone.assertValue(true)
         this.headerSectionIsGone.assertValue(true)
-        this.shippingRulesSectionIsGone.assertValues(true, true)
+        this.shippingRulesSectionIsGone.assertValues(true)
         this.selectedShippingRule.assertNoValues()
         this.shippingSummaryIsGone.assertValue(true)
         this.totalDividerIsGone.assertValue(true)
@@ -674,7 +674,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeMaximumIsGone.assertNoValues()
         this.pledgeSectionIsGone.assertValue(true)
         this.pledgeSummaryIsGone.assertValue(true)
-        this.shippingRulesSectionIsGone.assertValues(true, true)
+        this.shippingRulesSectionIsGone.assertValues(true)
         this.selectedShippingRule.assertNoValues()
         this.shippingSummaryIsGone.assertValue(true)
         this.totalDividerIsGone.assertValue(true)
@@ -1053,10 +1053,13 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeMinimum.assertValue(expectedCurrency(environment, project, 20.0))
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
         this.projectCurrencySymbol.assertValue("$")
-        this.shippingAmount.assertValue(expectedCurrency(environment, project, 0.0))
-        this.totalAmount.assertValues(expectedCurrency(environment, project, 20.0))
-        this.totalAndDeadline.assertValues(Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)))
-        this.totalAndDeadlineIsVisible.assertValueCount(1)
+        this.shippingAmount.assertNoValues()
+        this.totalAmount.assertValues(expectedCurrency(environment, project, 20.0), expectedCurrency(environment, project, 21.0))
+        this.pledgeHint.assertValue("20")
+        this.totalAndDeadline.assertValues(
+                Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 21.0), DateTimeUtils.longDate(this.deadline)))
+        this.totalAndDeadlineIsVisible.assertValueCount(2)
 
         this.vm.inputs.decreasePledgeButtonClicked()
 
@@ -1076,11 +1079,14 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeMaximumIsGone.assertValues(true)
         this.pledgeMinimum.assertValue(expectedCurrency(environment, project, 20.0))
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
-        this.projectCurrencySymbol.assertValue("$")
-        this.shippingAmount.assertValue(expectedCurrency(environment, project, 0.0))
-        this.totalAmount.assertValues(expectedCurrency(environment, project, 20.0))
-        this.totalAndDeadline.assertValues(Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)))
-        this.totalAndDeadlineIsVisible.assertValueCount(1)
+        this.shippingAmount.assertNoValues()
+        this.totalAmount.assertValues(expectedCurrency(environment, project, 20.0), expectedCurrency(environment, project, 21.0), expectedCurrency(environment, project, 20.0))
+        this.totalAndDeadline.assertValues(
+                Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 21.0), DateTimeUtils.longDate(this.deadline)),
+                Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline))
+        )
+        this.totalAndDeadlineIsVisible.assertValueCount(3)
     }
 
     @Test
@@ -1111,7 +1117,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeMinimum.assertValue(expectedCurrency(environment, project, 20.0))
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
         this.projectCurrencySymbol.assertValue("$")
-        this.shippingAmount.assertValue(expectedCurrency(environment, project, 0.0))
+        this.shippingAmount.assertNoValues()
         this.totalAmount.assertValues(expectedCurrency(environment, project, 20.0))
         this.totalAndDeadline.assertValues(Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)))
         this.totalAndDeadlineIsVisible.assertValueCount(1)
@@ -2942,7 +2948,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeButtonIsEnabled.assertValue(true)
         this.pledgeHint.assertValue("20")
         this.pledgeTextColor.assertValue(R.color.ksr_green_500)
-        this.shippingAmount.assertValue(expectedCurrency(environment, project, 0.0))
+        this.shippingAmount.assertNoValues()
         this.totalAmount.assertValues(expectedCurrency(environment, project, 20.0))
         this.totalAndDeadline.assertValue(Pair(expectedCurrency(environment, project, 20.0), DateTimeUtils.longDate(this.deadline)))
         this.totalAndDeadlineIsVisible.assertValueCount(1)

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -1039,10 +1039,10 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.scrimIsVisible.assertValues(false)
 
         this.vm.inputs.fragmentStackCount(3)
-        this.scrimIsVisible.assertValues(false, true)
+        this.scrimIsVisible.assertValues(false)
 
         this.vm.inputs.fragmentStackCount(1)
-        this.scrimIsVisible.assertValues(false, true, false)
+        this.scrimIsVisible.assertValues(false)
     }
 
     @Test
@@ -1060,10 +1060,10 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.scrimIsVisible.assertValues(false)
 
         this.vm.inputs.fragmentStackCount(3)
-        this.scrimIsVisible.assertValues(false, true)
+        this.scrimIsVisible.assertValues(false)
 
         this.vm.inputs.fragmentStackCount(2)
-        this.scrimIsVisible.assertValues(false, true, false)
+        this.scrimIsVisible.assertValues(false)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
@@ -313,7 +313,7 @@ public final class ThanksViewModelTest extends KSRobolectricTestCase {
     final CheckoutData checkoutData = CheckoutDataFactory.Companion.checkoutData(3L,
             20.0, 30.0);
     final PledgeData pledgeData = PledgeData.Companion.with(PledgeFlowContext.NEW_PLEDGE,
-            ProjectDataFactory.Companion.project(project), RewardFactory.reward(), Collections.emptyList());
+            ProjectDataFactory.Companion.project(project), RewardFactory.reward(), Collections.emptyList(), null);
     final Intent intent = new Intent()
             .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
             .putExtra(IntentKey.PLEDGE_DATA, pledgeData)


### PR DESCRIPTION
# 📲 What

- Refactor PledgeFragment
- Updated schema.json
- New Checkout mutation

# 🤔 Why
- For pledging to a Reward + AddOns we needed to update the current mutation to a new one

# 🛠 How

- Mutation now has a new field :  list of rewards 

# 👀 See
<img width="947" alt="Screen Shot 2020-08-13 at 10 07 31 AM" src="https://user-images.githubusercontent.com/4083656/90165341-5cf4f880-dd4d-11ea-850c-01e51b53d455.png">
<img width="1011" alt="NOShippingNoReward" src="https://user-images.githubusercontent.com/4083656/90165308-4fd80980-dd4d-11ea-9770-4be5d5b5feb5.png">

# 📋 QA
- try a no reward
- try a no reward with experiment active
- try a no reward + bonus
- try a no reward with experiment active + bonus

- try a digital reward
- try a digital reward + bonus

- try a reward with shipping location
- try a reward with shipping location + bonus

- try a reward(digital) with addOn(digital)
- try a reward(with shipping) with addOn(with shipping)
- try a reward(with shipping) with addOns(with shipping + digital)
- try a reward(with shipping) with addOns(with shipping + shipping)

- try a reward(digital) with addOn(digital) + bonus
- try a reward(with shipping) with addOn(with shipping) + bonus
- try a reward(with shipping) with addOns(with shipping + digital) + bonus
- try a reward(with shipping) with addOns(with shipping + shipping) + bonus

# Story 📖

[NT-1344](https://kickstarter.atlassian.net/browse/NT-1344)
