### PR TITLE
NT- 1462&& NT-1463: UpdateBacking Mutation 

### DIFF
--- a/app/src/main/graphql/checkout.graphql
+++ b/app/src/main/graphql/checkout.graphql
@@ -1,5 +1,5 @@
-mutation CreateBacking($projectId: ID!, $amount: String!, $paymentType: String!, $paymentSourceId: String!, $locationId: String, $rewardId: ID, $rewardIds: [ID!], $refParam: String) {
-  createBacking(input: {projectId: $projectId, amount: $amount, paymentType: $paymentType, paymentSourceId: $paymentSourceId, locationId: $locationId, rewardId: $rewardId, rewardIds: $rewardIds, refParam: $refParam}) {
+mutation CreateBacking($projectId: ID!, $amount: String!, $paymentType: String!, $paymentSourceId: String!, $locationId: String, $rewardIds: [ID!], $refParam: String) {
+  createBacking(input: {projectId: $projectId, amount: $amount, paymentType: $paymentType, paymentSourceId: $paymentSourceId, locationId: $locationId, rewardIds: $rewardIds, refParam: $refParam}) {
     checkout {
       id
       backing {
@@ -19,13 +19,14 @@ mutation CancelBacking($backingId: ID!, $note: String) {
   }
 }
 
-mutation UpdateBacking($backingId: ID!, $amount: String, $locationId: String, $rewardId: ID, $paymentSourceId: String)  {
-  updateBacking(input: { id: $backingId, amount: $amount, locationId: $locationId, rewardId: $rewardId, paymentSourceId: $paymentSourceId}) {
+mutation UpdateBacking($backingId: ID!, $amount: String, $locationId: String,$rewardIds: [ID!], $paymentSourceId: String)  {
+  updateBacking(input: { id: $backingId, amount: $amount, locationId: $locationId, rewardIds: $rewardIds, paymentSourceId: $paymentSourceId}) {
     checkout {
       id
       backing {
         clientSecret
         requiresAction
+        status
       }
     }
   }

--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -34,6 +34,10 @@ fragment backing on Backing {
             ... reward
         }
     }
+
+    clientSecret
+    requiresAction
+    status
 }
 
 fragment project on Project {

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -696,25 +696,19 @@ private fun <T : Any?> handleResponse(it: T, ps: PublishSubject<T>) {
  * and we need to transform it in : D(5),C(1),E(2)
  */
 fun getAddOnsList(addOns: fragment.Backing.AddOns): List<Reward> {
-    val mutableMap = mutableMapOf<Reward, Int>()
 
     val rewardsList = addOns.nodes()?.map { node ->
         rewardTransformer(node.fragments().reward())
     }
 
-    rewardsList?.map {
-        var addOnQuantity = mutableMap.getOrPut(it, {0})
-        if (addOnQuantity != null) addOnQuantity += 1
+    val mapHolder = mutableMapOf<Long, Reward>()
 
-        mutableMap.put(it, addOnQuantity)
+    rewardsList?.forEach {
+        val q = mapHolder[it.id()]?.quantity()?:0
+        mapHolder[it.id()] = it.toBuilder().quantity(q + 1).build()
     }
 
-    return mutableMap.map {
-        it.key
-                .toBuilder()
-                .quantity(it.value)
-                .build()
-    }.toList()
+    return mapHolder.values.toList()
 }
 
 /**

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -71,7 +71,6 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                     .paymentType(PaymentTypes.CREDIT_CARD.rawValue())
                     .paymentSourceId(createBackingData.paymentSourceId)
                     .locationId(createBackingData.locationId?.let { it })
-                    .rewardId(createBackingData.reward?.let { encodeRelayId(it) })
                     .rewardIds(createBackingData.rewardsIds?.let { list -> list.map { encodeRelayId(it) } })
                     .refParam(createBackingData.refTag?.tag())
                     .build()
@@ -459,7 +458,7 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                     .backingId(encodeRelayId(updateBackingData.backing))
                     .amount(updateBackingData.amount.toString())
                     .locationId(updateBackingData.locationId)
-                    .rewardId(updateBackingData.reward?.let { encodeRelayId(it) })
+                    .rewardIds(updateBackingData.rewardsIds?.let { list -> list.map { encodeRelayId(it) } })
                     .paymentSourceId(updateBackingData.paymentSourceId)
                     .build()
 

--- a/app/src/main/java/com/kickstarter/services/mutations/UpdateBackingData.kt
+++ b/app/src/main/java/com/kickstarter/services/mutations/UpdateBackingData.kt
@@ -6,5 +6,5 @@ import com.kickstarter.models.Reward
 data class UpdateBackingData(val backing: Backing,
                              val amount: String? = null,
                              val locationId: String? = null,
-                             val reward: Reward? = null,
+                             val rewardsIds: List<Reward>? = null,
                              val paymentSourceId: String? = null)

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -169,7 +169,6 @@ interface BackingFragmentViewModel {
         private val bonusSupport = BehaviorSubject.create<CharSequence>()
         private val estimatedDelivery = BehaviorSubject.create<String>()
         private val deliveryDisclaimerSectionIsGone = BehaviorSubject.create<Boolean>()
-        private val estimatedDeliveryLabelIsGone = BehaviorSubject.create<Boolean>()
 
         private val apiClient = this.environment.apiClient()
         private val apolloClient = this.environment.apolloClient()

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -1110,7 +1110,7 @@ interface PledgeFragmentViewModel {
             val updateBackingNotification = Observable.combineLatest(backingToUpdate,
                     totalString,
                     locationId,
-                    this.rewardAndAddOns,
+                    extendedListForCheckOut,
                     optionalPaymentMethodId)
             { b, a, l, r, p -> UpdateBackingData(b, a, l, r, p) }
                     .compose<UpdateBackingData>(takeWhen(Observable.merge(updatePledgeClick, updatePaymentClick, fixPaymentClick)))
@@ -1357,10 +1357,6 @@ interface PledgeFragmentViewModel {
                 (sAmountSelectedRw + addOnsCost + addOnsShippingCost + reward.minimum() + bAmount.toInt())
 
             return totalPledgeValue
-        }
-
-        private fun getBacking(backingId: String): Observable<Backing> {
-            return this.apolloClient.getBacking(backingId)
         }
 
         private fun backingShippingRule(shippingRules: List<ShippingRule>, backing: Backing): Observable<ShippingRule> {

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -1107,7 +1107,7 @@ interface PledgeFragmentViewModel {
             val updateBackingNotification = Observable.combineLatest(backingToUpdate,
                     totalString,
                     locationId,
-                    this.selectedReward,
+                    this.rewardAndAddOns,
                     optionalPaymentMethodId)
             { b, a, l, r, p -> UpdateBackingData(b, a, l, r, p) }
                     .compose<UpdateBackingData>(takeWhen(Observable.merge(updatePledgeClick, updatePaymentClick, fixPaymentClick)))


### PR DESCRIPTION
# 📲 What

Update a pledge uses the UpdateCheckout Mutation, updated mutation for holding an array of reward ID's

# 👀 See
<img width="1239" alt="Networking_new_mutation" src="https://user-images.githubusercontent.com/4083656/90415554-19a8cb80-e066-11ea-87da-66a55867dce0.png">

|  |  |

# 📋 QA
- Update a pledge with add-ons

# Story 📖

[Bug on Manage Screen with the shipping amount & bonus amount](https://kickstarter.atlassian.net/browse/NT-1463)
[Update a pledge with add-ons](https://kickstarter.atlassian.net/browse/NT-1462)
