### PR TITLE
NT-1390: Previously selected reward logic

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -29,8 +29,8 @@ object RewardViewUtils {
 
         return when {
             BackingUtils.isBacked(project, reward) && !hasAddOnsSelected -> R.string.Selected
-            RewardUtils.isAvailable(project, reward) && !hasAddOnsSelected -> R.string.Select
-            reward.hasAddons() && hasAddOnsSelected && !hasUnavailableAddOn -> R.string.Continue
+            !BackingUtils.isBacked(project, reward) && RewardUtils.isAvailable(project, reward) -> R.string.Select
+            BackingUtils.isBacked(project, reward) && reward.hasAddons() && hasAddOnsSelected && !hasUnavailableAddOn -> R.string.Continue
             else -> R.string.No_longer_available
         }
     }

--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -22,9 +22,15 @@ object RewardViewUtils {
      */
     @StringRes
     fun pledgeButtonText(project: Project, reward: Reward): Int {
+        val hasAddOnsSelected = project.backing()?.addOns()?.isNotEmpty() ?: false
+        val hasUnavailableAddOn:Boolean = project.backing()?.addOns()?.firstOrNull {
+            !RewardUtils.isAvailable(project, it)
+        }?.let { true } ?: false
+
         return when {
-            BackingUtils.isBacked(project, reward) -> R.string.Selected
-            RewardUtils.isAvailable(project, reward) -> R.string.Select
+            BackingUtils.isBacked(project, reward) && !hasAddOnsSelected -> R.string.Selected
+            RewardUtils.isAvailable(project, reward) && !hasAddOnsSelected -> R.string.Select
+            reward.hasAddons() && hasAddOnsSelected && !hasUnavailableAddOn -> R.string.Continue
             else -> R.string.No_longer_available
         }
     }

--- a/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
@@ -8,7 +8,10 @@ import com.kickstarter.models.User;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import androidx.annotation.NonNull;
 import type.CreditCardTypes;
@@ -90,6 +93,76 @@ public final class ProjectFactory {
       .backing(backing)
       .isBacking(true)
       .build();
+  }
+
+  public static @NonNull Project backedProjectWithAddOnsLimitReached() {
+    final Project project = project();
+
+    final Reward reward = RewardFactory.reward().toBuilder().hasAddons(true).build();
+    final Reward add1 = RewardFactory.addOn()
+            .toBuilder()
+            .remaining(0)
+            .limit(0)
+            .quantity(1)
+            .build();
+
+    final List<Reward> addOns = new ArrayList<Reward>();
+    addOns.add(add1);
+
+    final Backing backing = Backing.builder()
+            .amount(10.0f)
+            .backerId(IdFactory.id())
+            .addOns(addOns)
+            .cancelable(true)
+            .id(IdFactory.id())
+            .sequence(1)
+            .reward(reward)
+            .rewardId(reward.id())
+            .paymentSource(PaymentSourceFactory.Companion.visa())
+            .pledgedAt(DateTime.now())
+            .projectId(project.id())
+            .shippingAmount(0.0f)
+            .status(Backing.STATUS_PLEDGED)
+            .build();
+
+    return project
+            .toBuilder()
+            .backing(backing)
+            .isBacking(true)
+            .build();
+  }
+
+  public static @NonNull Project backedProjectWithAddOns() {
+    final Project project = project();
+
+    final Reward reward = RewardFactory.reward().toBuilder().hasAddons(true).build();
+    final Reward add1 = RewardFactory.addOn();
+
+    final List<Reward> addOns = new ArrayList<Reward>();
+    addOns.add(add1);
+    addOns.add(add1);
+
+    final Backing backing = Backing.builder()
+            .amount(10.0f)
+            .backerId(IdFactory.id())
+            .addOns(addOns)
+            .cancelable(true)
+            .id(IdFactory.id())
+            .sequence(1)
+            .reward(reward)
+            .rewardId(reward.id())
+            .paymentSource(PaymentSourceFactory.Companion.visa())
+            .pledgedAt(DateTime.now())
+            .projectId(project.id())
+            .shippingAmount(0.0f)
+            .status(Backing.STATUS_PLEDGED)
+            .build();
+
+    return project
+            .toBuilder()
+            .backing(backing)
+            .isBacking(true)
+            .build();
   }
 
 

--- a/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
@@ -10,7 +10,6 @@ import org.joda.time.DateTimeZone;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import androidx.annotation.NonNull;

--- a/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.java
@@ -16,6 +16,7 @@ public final class RewardFactory {
   public static @NonNull Reward addOn() {
     return reward().toBuilder()
             .isAddOn(true)
+            .limit(10)
             .build();
   }
 

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -721,10 +721,10 @@ private fun rewardTransformer(rewardGr: fragment.Reward): Reward {
     val convertedAmount = rewardGr.convertedAmount().fragments().amount().amount()?.toDouble() ?: 0.0
     val desc = rewardGr.description()
     val title = rewardGr.name()
-    val estimatedDelivery = DateTime(rewardGr.estimatedDeliveryOn())
+    val estimatedDelivery = rewardGr.estimatedDeliveryOn()?.let { DateTime(it) } ?: null
     val limit = chooseLimit(rewardGr.limit(), rewardGr.limitPerBacker())
     val remaining = rewardGr.remainingQuantity()
-    val endsAt = DateTime(rewardGr.endsAt())
+    val endsAt = rewardGr.endsAt()?.let { DateTime(it) } ?: null
     val rewardId = decodeRelayId(rewardGr.id()) ?: -1
 
     val shippingPreference = when (rewardGr.shippingPreference()) {

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -416,7 +416,7 @@ interface RewardViewHolderViewModel {
             }?.let { true } ?: false
 
            return when {
-               isSelectable(project, rw) && !rw.hasAddons() -> true
+               isSelectable(project, rw) && backing == null -> true
                isSelectable(project, rw) && backing != null && !hasBackedAddOns(project) -> true
                BackingUtils.isBacked(project, rw) &&
                        RewardUtils.isAvailable(project, rw) &&

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -213,7 +213,9 @@ interface RewardViewHolderViewModel {
                     .map { RewardViewUtils.pledgeButtonText(it.first, it.second) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
-                    .subscribe(this.buttonCTA)
+                    .subscribe {
+                        this.buttonCTA.onNext(it)
+                    }
 
             projectAndReward
                     .map { it.first }
@@ -250,11 +252,13 @@ interface RewardViewHolderViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.descriptionIsGone)
 
-            this.projectDataAndReward
-                    .map { isSelectable(it.first.project(), it.second) }
+            projectAndReward
+                    .map { buttonEnabledCases(it.first, it.second) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
-                    .subscribe(this.buttonIsEnabled)
+                    .subscribe {
+                        this.buttonIsEnabled.onNext(it)
+                    }
 
             projectAndReward
                     .map { it.first.isLive && RewardUtils.isLimited(it.second) }
@@ -399,6 +403,29 @@ interface RewardViewHolderViewModel {
 
         }
 
+        /**
+         * Use cases for enabling/disabling the Button
+         * - If the selected reward has no addOns the CTA button will be enable if available
+         * - Enabled if the previously selected base reward has available add-ons
+         * - If the previously selected base reward has no available add-ons, the CTA button on the base reward would be disabled
+        */
+        private fun buttonEnabledCases(project: Project, rw: Reward):Boolean {
+            val backing = project.backing()
+            val hasUnavailableAddOn:Boolean = project.backing()?.addOns()?.firstOrNull {
+                !RewardUtils.isAvailable(project, it)
+            }?.let { true } ?: false
+
+           return when {
+               isSelectable(project, rw) && !rw.hasAddons() -> true
+               isSelectable(project, rw) && backing != null && !hasBackedAddOns(project) -> true
+               BackingUtils.isBacked(project, rw) &&
+                       RewardUtils.isAvailable(project, rw) &&
+                       backing != null && hasBackedAddOns(project) &&
+                       !hasUnavailableAddOn -> true
+               else -> false
+           }
+        }
+
         private fun rewardAmountByVariant(variant: OptimizelyExperiment.Variant?):Int? = when(variant) {
                 OptimizelyExperiment.Variant.CONTROL -> 1
                 OptimizelyExperiment.Variant.VARIANT_2 -> 10
@@ -441,6 +468,8 @@ interface RewardViewHolderViewModel {
                 else -> true
             }
         }
+
+        private fun hasBackedAddOns(project: Project) = !project.backing()?.addOns().isNullOrEmpty()
 
         private fun isSelectable(@NonNull project: Project, @NonNull reward: Reward): Boolean {
             if (BackingUtils.isBacked(project, reward)) {

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -189,6 +189,17 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testButtonEnabled_whenProjectIsLive_Available_Add_Ons() {
+        setUpEnvironment(environment())
+
+        val project = ProjectFactory.project()
+        val rw = RewardFactory.rewardHasAddOns()
+        this.vm.inputs.configureWith(ProjectDataFactory.project(project), rw)
+        this.buttonIsGone.assertValue(false)
+        this.buttonIsEnabled.assertValue(true)
+    }
+
+    @Test
     fun testButtonDisabled_whenProjectIsLiveAndBacked_Unavailable_Add_Ons() {
         setUpEnvironment(environment())
 

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -156,7 +156,40 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testButtonUIOutputs_whenProjectIsLiveAndBacked_backedReward() {
+    fun testButtonCTA_whenProjectIsLiveAndBacked_Available_Add_Ons() {
+        setUpEnvironment(environment())
+
+        val backedLiveProject = ProjectFactory.backedProjectWithAddOns()
+        val rw = backedLiveProject.backing()?.reward()
+        this.vm.inputs.configureWith(ProjectDataFactory.project(backedLiveProject), requireNotNull(rw))
+        this.buttonIsGone.assertValue(false)
+        this.buttonCTA.assertValuesAndClear(R.string.Continue)
+    }
+
+    @Test
+    fun testButtonEnabled_whenProjectIsLiveAndBacked_Available_Add_Ons() {
+        setUpEnvironment(environment())
+
+        val backedLiveProject = ProjectFactory.backedProjectWithAddOns()
+        val rw = backedLiveProject.backing()?.reward()
+        this.vm.inputs.configureWith(ProjectDataFactory.project(backedLiveProject), requireNotNull(rw))
+        this.buttonIsGone.assertValue(false)
+        this.buttonIsEnabled.assertValue(true)
+    }
+
+    @Test
+    fun testButtonDisabled_whenProjectIsLiveAndBacked_Unavailable_Add_Ons() {
+        setUpEnvironment(environment())
+
+        val backedLiveProject = ProjectFactory.backedProjectWithAddOnsLimitReached()
+        val rw = backedLiveProject.backing()?.reward()
+        this.vm.inputs.configureWith(ProjectDataFactory.project(backedLiveProject), requireNotNull(rw))
+        this.buttonIsGone.assertValue(false)
+        this.buttonIsEnabled.assertValue(false)
+    }
+
+    @Test
+    fun testButtonUIOutputs_whenProjectIsLiveAndBacked_AvailableAddOns() {
         setUpEnvironment(environment())
 
         val backedLiveProject = ProjectFactory.backedProject()
@@ -579,18 +612,18 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
         // A backed reward from a live project should not be enabled.
         val backedLiveProject = ProjectFactory.backedProject()
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedLiveProject), backedLiveProject.backing()?.reward()!!)
-        this.buttonIsEnabled.assertValues(true, false)
+        this.buttonIsEnabled.assertValues(true, false, true, false)
 
         // A backed reward from an ended project should not be enabled.
         val backedSuccessfulProject = ProjectFactory.backedProject().toBuilder()
                 .state(Project.STATE_SUCCESSFUL)
                 .build()
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedSuccessfulProject), backedSuccessfulProject.backing()?.reward()!!)
-        this.buttonIsEnabled.assertValues(true, false)
+        this.buttonIsEnabled.assertValues(true, false, true, false)
 
         // A reward with its limit reached should not be enabled.
         this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.project()), RewardFactory.limitReached())
-        this.buttonIsEnabled.assertValues(true, false)
+        this.buttonIsEnabled.assertValues(true, false, true, false, true, false)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -167,6 +167,17 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testButtonCTA_whenProjectIsLiveAndBacked_Other_Reward() {
+        setUpEnvironment(environment())
+
+        val backedLiveProject = ProjectFactory.backedProjectWithAddOns()
+        val rw = RewardFactory.reward()
+        this.vm.inputs.configureWith(ProjectDataFactory.project(backedLiveProject), rw)
+        this.buttonIsGone.assertValue(false)
+        this.buttonCTA.assertValuesAndClear(R.string.Select)
+    }
+
+    @Test
     fun testButtonEnabled_whenProjectIsLiveAndBacked_Available_Add_Ons() {
         setUpEnvironment(environment())
 


### PR DESCRIPTION
# 📲 What

- New logic for the CTA button string and when it should be activated.

# 👀 See
![choose_another_reward](https://user-images.githubusercontent.com/4083656/91104931-ab46a900-e623-11ea-8839-f32fdb6bc4c3.gif)
<img width="415" alt="Screen Shot 2020-08-24 at 4 05 29 PM" src="https://user-images.githubusercontent.com/4083656/91104952-b8fc2e80-e623-11ea-8316-3c37d1b57031.png">

|  |  |

# 📋 QA

- Change reward from one without Add-ons to another one without add-ons, no changes should be appreciated there on the button logic
- Change reward to the same reward with available add-ons, the button should be enabled
- Change reward to the same reward withOut available add-ons, the button should be disabled

# Story 📖

[NT-1390: Previously selected reward logic](https://kickstarter.atlassian.net/browse/NT-1390)
