### PR TITLE
NT-1464: Translucent Add-Ons Header Fix

### DIFF
--- a/app/src/main/res/layout/fragment_rewards.xml
+++ b/app/src/main/res/layout/fragment_rewards.xml
@@ -3,7 +3,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  android:background="@color/ksr_grey_400"
+  android:background="@color/ksr_grey_300"
   android:orientation="vertical"
   android:paddingTop="?android:attr/actionBarSize">
 

--- a/app/src/main/res/layout/pledge_container.xml
+++ b/app/src/main/res/layout/pledge_container.xml
@@ -44,7 +44,7 @@
       android:id="@+id/pledge_toolbar"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:background="@color/transparent"
+      android:background="@color/ksr_grey_300"
       android:focusableInTouchMode="true"
       app:navigationContentDescription="@string/View_project"
       app:navigationIcon="@drawable/ic_arrow_down" />


### PR DESCRIPTION
# 📲 What

Update the background color of the toolbar in the pledge container view

# 🤔 Why

When the user scrolls their add-ons, the toolbar is translucent

# 📋 QA

Open a project with add-ons and verify that the toolbar is no longer translucent

# Story 📖

[NT-1464](https://kickstarter.atlassian.net/browse/NT-1464)
