### PR TITLE
NT-1489: Fix Crash when a user views their Account

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/AccountActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/AccountActivity.kt
@@ -28,6 +28,25 @@ class AccountActivity : BaseActivity<AccountViewModel.ViewModel>() {
 
     private lateinit var ksString: KSString
 
+    private val supportedCurrencies: List<CurrencyCode> by lazy {
+        arrayListOf(
+                CurrencyCode.AUD,
+                CurrencyCode.CAD,
+                CurrencyCode.CHF,
+                CurrencyCode.DKK,
+                CurrencyCode.EUR,
+                CurrencyCode.GBP,
+                CurrencyCode.HKD,
+                CurrencyCode.JPY,
+                CurrencyCode.MXN,
+                CurrencyCode.NOK,
+                CurrencyCode.NZD,
+                CurrencyCode.SEK,
+                CurrencyCode.SGD,
+                CurrencyCode.USD
+        )
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_account)
@@ -85,12 +104,12 @@ class AccountActivity : BaseActivity<AccountViewModel.ViewModel>() {
 
     private fun getListOfCurrencies(): List<String> {
         val strings = arrayListOf<String>()
-        for (currency in CurrencyCode.values()) {
+        for (currency in supportedCurrencies) {
             strings.add(getStringForCurrencyCode(currency))
         }
-        return strings.filter { it != CurrencyCode.`$UNKNOWN`.rawValue() }
+        return strings
     }
-
+    
     private fun getStringForCurrencyCode(currency: CurrencyCode): String {
         return when (currency) {
             CurrencyCode.AUD -> getString(R.string.Currency_AUD)
@@ -107,7 +126,7 @@ class AccountActivity : BaseActivity<AccountViewModel.ViewModel>() {
             CurrencyCode.SEK -> getString(R.string.Currency_SEK)
             CurrencyCode.SGD -> getString(R.string.Currency_SGD)
             CurrencyCode.USD -> getString(R.string.Currency_USD)
-            else -> CurrencyCode.`$UNKNOWN`.rawValue()
+            else -> currency.rawValue()
         }
     }
 
@@ -130,8 +149,9 @@ class AccountActivity : BaseActivity<AccountViewModel.ViewModel>() {
     }
 
     private fun setSpinnerSelection(currencyCode: String) {
-        currentCurrencySelection = CurrencyCode.safeValueOf(currencyCode)
-        currency_spinner.setSelection(currentCurrencySelection!!.ordinal)
+        val selectedCurrencyCode = CurrencyCode.safeValueOf(currencyCode)
+        currentCurrencySelection = selectedCurrencyCode
+        currency_spinner.setSelection(supportedCurrencies.indexOf(selectedCurrencyCode))
     }
 
     private fun setUpSpinner() {
@@ -143,9 +163,11 @@ class AccountActivity : BaseActivity<AccountViewModel.ViewModel>() {
             override fun onNothingSelected(parent: AdapterView<*>?) {}
 
             override fun onItemSelected(parent: AdapterView<*>?, view: View?, postion: Int, id: Long) {
-                if (currentCurrencySelection != null && currentCurrencySelection!!.ordinal != postion) {
-                    newCurrencySelection = CurrencyCode.values()[postion]
-                    lazyFollowingOptOutConfirmationDialog().show()
+                currentCurrencySelection?.let {
+                    if (supportedCurrencies.indexOf(it) != postion) {
+                        newCurrencySelection = supportedCurrencies[postion]
+                        lazyFollowingOptOutConfirmationDialog().show()
+                    }
                 }
             }
         }


### PR DESCRIPTION
# 📲 What

Fixed a crash when user's try to access their account.

# 🤔 Why

In Firebase, we received crashes related to the ArrayAdapter. 
[Link to Crash](https://console.firebase.google.com/u/0/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/58ec151aaa1b8752aa817cdf9325fbb7?time=last-seven-days&sessionId=5F4E6DF500E8000157AD6BA2371B8A38_DNE_0_v2)

# 🛠 How

Instead of using the CurrencyCode enum that is generated by graphQL, we are going to use a list a supported enums so in the case where a new currency is added to the backend CurrencyCode we can still display the currencies without a crash.

The reason for the crash was do to a new currency that was added (PLN). The team updated the graphQL models and the next release was unable to handle the new currency. 

[Link to Currency Update PR](https://github.com/kickstarter/kickstarter/pull/19698)

# 📋 QA

Navigate to Settings, then Account and change the user's selected currency

# Story 📖

[NT-1489](https://kickstarter.atlassian.net/browse/NT-1489)
