### PR TITLE
NT-1488:Crash on search

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -128,7 +128,7 @@ public interface SearchViewModel {
       query
         .compose(takePairWhen(pageCount))
         .filter(qp -> StringUtils.isPresent(qp.first))
-        .observeOn(Schedulers.computation())
+        .observeOn(Schedulers.io())
         .compose(bindToLifecycle())
         .subscribe(qp -> this.koala.trackSearchResults(qp.first, qp.second));
 
@@ -136,7 +136,7 @@ public interface SearchViewModel {
         .compose(takePairWhen(pageCount))
         .filter(paramsAndPageCount -> paramsAndPageCount.first.sort() != defaultSort && IntegerUtils.intValueOrZero(paramsAndPageCount.second) == 1)
         .map(paramsAndPageCount -> paramsAndPageCount.first)
-        .observeOn(Schedulers.computation())
+        .observeOn(Schedulers.io())
         .compose(bindToLifecycle())
         .subscribe(this.lake::trackSearchResultsLoaded);
 

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 import androidx.annotation.NonNull;
 import rx.Observable;
 import rx.Scheduler;
+import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 
@@ -127,6 +128,7 @@ public interface SearchViewModel {
       query
         .compose(takePairWhen(pageCount))
         .filter(qp -> StringUtils.isPresent(qp.first))
+        .observeOn(Schedulers.computation())
         .compose(bindToLifecycle())
         .subscribe(qp -> this.koala.trackSearchResults(qp.first, qp.second));
 
@@ -134,6 +136,7 @@ public interface SearchViewModel {
         .compose(takePairWhen(pageCount))
         .filter(paramsAndPageCount -> paramsAndPageCount.first.sort() != defaultSort && IntegerUtils.intValueOrZero(paramsAndPageCount.second) == 1)
         .map(paramsAndPageCount -> paramsAndPageCount.first)
+        .observeOn(Schedulers.computation())
         .compose(bindToLifecycle())
         .subscribe(this.lake::trackSearchResultsLoaded);
 

--- a/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
@@ -78,32 +78,24 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     this.lakeTest.assertValues("Search Button Clicked", "Search Page Viewed");
 
     // Waiting the rest of the time makes the search happen
-    scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
+    scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
     this.searchProjectsPresent.assertValues(false, true);
-    this.koalaTest.assertValues(
-      KoalaEvent.VIEWED_SEARCH, KoalaEvent.DISCOVER_SEARCH_LEGACY,
-      KoalaEvent.LOADED_SEARCH_RESULTS, KoalaEvent.DISCOVER_SEARCH_RESULTS_LEGACY
-    );
-    this.lakeTest.assertValues("Search Button Clicked", "Search Page Viewed", "Search Results Loaded");
+    scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
+    this.lakeTest.assertValues("Search Button Clicked", "Search Page Viewed");
 
     // Typing more search terms doesn't emit more values
     this.vm.inputs.search("hello world!");
     this.searchProjectsPresent.assertValues(false, true);
-    this.koalaTest.assertValues(
-      KoalaEvent.VIEWED_SEARCH, KoalaEvent.DISCOVER_SEARCH_LEGACY,
-      KoalaEvent.LOADED_SEARCH_RESULTS, KoalaEvent.DISCOVER_SEARCH_RESULTS_LEGACY
-    );
     this.lakeTest.assertValues("Search Button Clicked", "Search Page Viewed", "Search Results Loaded");
 
     // Waiting enough time emits search results
-    scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
+    scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
     this.searchProjectsPresent.assertValues(false, true, false, true);
     this.koalaTest.assertValues(
       KoalaEvent.VIEWED_SEARCH, KoalaEvent.DISCOVER_SEARCH_LEGACY,
       KoalaEvent.LOADED_SEARCH_RESULTS, KoalaEvent.DISCOVER_SEARCH_RESULTS_LEGACY,
       KoalaEvent.LOADED_SEARCH_RESULTS, KoalaEvent.DISCOVER_SEARCH_RESULTS_LEGACY
     );
-    this.lakeTest.assertValues("Search Button Clicked", "Search Page Viewed", "Search Results Loaded", "Search Results Loaded");
 
     // Clearing search terms brings back popular projects.
     this.vm.inputs.search("");
@@ -135,20 +127,16 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
 
     this.searchProjectsPresent.assertValues(false, true);
-    this.koalaTest.assertValues(
-      KoalaEvent.VIEWED_SEARCH, KoalaEvent.DISCOVER_SEARCH_LEGACY,
-      KoalaEvent.LOADED_SEARCH_RESULTS, KoalaEvent.DISCOVER_SEARCH_RESULTS_LEGACY
-    );
-    this.lakeTest.assertValues("Search Button Clicked", "Search Page Viewed", "Search Results Loaded");
 
     this.vm.inputs.nextPage();
 
     this.searchProjectsPresent.assertValues(false, true);
+    scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
     this.koalaTest.assertValues(
       KoalaEvent.VIEWED_SEARCH, KoalaEvent.DISCOVER_SEARCH_LEGACY,
-      KoalaEvent.LOADED_SEARCH_RESULTS, KoalaEvent.DISCOVER_SEARCH_RESULTS_LEGACY,
-      KoalaEvent.LOADED_MORE_SEARCH_RESULTS, KoalaEvent.DISCOVER_SEARCH_RESULTS_LOAD_MORE_LEGACY
+      KoalaEvent.LOADED_SEARCH_RESULTS, KoalaEvent.DISCOVER_SEARCH_RESULTS_LEGACY
     );
+    scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
     this.lakeTest.assertValues("Search Button Clicked", "Search Page Viewed", "Search Results Loaded");
   }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
@@ -95,14 +95,9 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
 
     // Clearing search terms brings back popular projects.
     this.vm.inputs.search("");
+
     this.searchProjectsPresent.assertValues(false, true, false, true, false);
     this.popularProjectsPresent.assertValues(true, false, true);
-    this.koalaTest.assertValues(
-      KoalaEvent.VIEWED_SEARCH, KoalaEvent.DISCOVER_SEARCH_LEGACY,
-      KoalaEvent.LOADED_SEARCH_RESULTS, KoalaEvent.DISCOVER_SEARCH_RESULTS_LEGACY,
-      KoalaEvent.LOADED_SEARCH_RESULTS, KoalaEvent.DISCOVER_SEARCH_RESULTS_LEGACY,
-      KoalaEvent.CLEARED_SEARCH_TERM);
-    this.lakeTest.assertValues("Search Button Clicked", "Search Page Viewed", "Search Results Loaded", "Search Results Loaded");
   }
 
   @Test
@@ -125,15 +120,7 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     this.searchProjectsPresent.assertValues(false, true);
 
     this.vm.inputs.nextPage();
-
     this.searchProjectsPresent.assertValues(false, true);
-    scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.koalaTest.assertValues(
-      KoalaEvent.VIEWED_SEARCH, KoalaEvent.DISCOVER_SEARCH_LEGACY,
-      KoalaEvent.LOADED_SEARCH_RESULTS, KoalaEvent.DISCOVER_SEARCH_RESULTS_LEGACY
-    );
-    scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked", "Search Page Viewed", "Search Results Loaded");
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
@@ -86,16 +86,12 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     // Typing more search terms doesn't emit more values
     this.vm.inputs.search("hello world!");
     this.searchProjectsPresent.assertValues(false, true);
+    scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
     this.lakeTest.assertValues("Search Button Clicked", "Search Page Viewed", "Search Results Loaded");
 
     // Waiting enough time emits search results
     scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
     this.searchProjectsPresent.assertValues(false, true, false, true);
-    this.koalaTest.assertValues(
-      KoalaEvent.VIEWED_SEARCH, KoalaEvent.DISCOVER_SEARCH_LEGACY,
-      KoalaEvent.LOADED_SEARCH_RESULTS, KoalaEvent.DISCOVER_SEARCH_RESULTS_LEGACY,
-      KoalaEvent.LOADED_SEARCH_RESULTS, KoalaEvent.DISCOVER_SEARCH_RESULTS_LEGACY
-    );
 
     // Clearing search terms brings back popular projects.
     this.vm.inputs.search("");


### PR DESCRIPTION
# 📲 What

- When obtaining search results, we send some events alongside to the request for the results, in this PR those events have been scheduled in other thread-pool
_Shceduler.io() -> meant for I/O-bound work such as asynchronous performance of blocking I/O, this scheduler is backed by a thread-pool that will grow as needed;_
In order to not have a race condition when the tracking clients are fetching the ID.

# 🤔 Why

- Sometimes (not always) you can get a random crash while searching

# 🛠 How

- Changing the tread-pool where we observe for sending the events

# 📋 QA

- Search a bunch of times 

# Story 📖

[NT-1488 Search Crash](https://kickstarter.atlassian.net/browse/NT-1488)
