### PR TITLE
NT-1411: Crash on Creator Pledge Screen

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -210,7 +210,7 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>() {
                     pledge_details_label.text = getString(R.string.Pledge_details)
                     ViewUtils.setGone(received_section, true)
                     ViewUtils.setGone(delivery_disclaimer_section, it)
-                    ViewUtils.setGone(estimated_delivery_label_2, false)
+                    ViewUtils.setGone(estimated_delivery_label_2, true)
                 }
 
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -419,10 +419,12 @@ interface BackingFragmentViewModel {
         }
 
         private fun joinProjectDataAndReward(projectData: ProjectData): Pair<ProjectData, Reward> {
-            val reward = projectData.backing()?.let {
-                it.reward()
-            } ?: BackingUtils.backedReward(projectData.project())
-            ?: Reward.builder().build()
+            val reward = projectData.backing()?.reward()
+                    ?: BackingUtils.backedReward(projectData.project())
+                    ?: Reward.builder()
+                            .id(0)
+                            .minimum(projectData.backing()?.amount() ?: 0.0)
+                            .build()
 
             return Pair(projectData, reward)
         }


### PR DESCRIPTION
# 📲 What

Added a basic add-on if the backer pledge without a reward. 

# 🤔 Why

The crash was due to the basic reward missing "id" and "minimum". Without this information the builder crashed.

# 🛠 How

In order to fix the issue the "id" and "minimum" was added to the reward object to correct pass a completed reward object.

# 📋 QA

Using the credentials for the creator account in the ticket below, navigate to the Dashboard, then messages and then select the first message. After that select the "view pledge" CTA

# Story 📖

[NT-1411](https://kickstarter.atlassian.net/browse/NT-1411)
