### PR TITLE
NT-1484: Remove shipping cost from the shipping selector.

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModel.kt
@@ -29,15 +29,13 @@ interface ShippingRuleViewHolderViewModel {
 
         private val shippingRuleText = BehaviorSubject.create<String>()
 
-        private val ksCurrency = this.environment.ksCurrency()
-
         val inputs: Inputs = this
         val outputs: Outputs = this
 
         init {
             this.shippingRuleAndProject
                     .filter { ObjectUtils.isNotNull(it.first) }
-                    .map { formattedString(it.first, it.second) }
+                    .map { it.first.location().displayableName() }
                     .compose(bindToLifecycle())
                     .subscribe(this.shippingRuleText)
         }
@@ -45,14 +43,5 @@ interface ShippingRuleViewHolderViewModel {
         override fun configureWith(shippingRule: ShippingRule, project: Project) = this.shippingRuleAndProject.onNext(Pair.create(shippingRule, project))
 
         override fun shippingRuleText(): Observable<String> = this.shippingRuleText
-
-        private fun formattedString(shippingRule: ShippingRule, project: Project): String {
-            val displayableName = shippingRule.location().displayableName()
-            val cost = shippingRule.cost()
-
-            val formattedCost = this.ksCurrency.format(cost, project)
-
-            return "$displayableName $formattedCost"
-        }
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModelTest.kt
@@ -37,7 +37,6 @@ class ShippingRuleViewHolderViewModelTest : KSRobolectricTestCase() {
         val project = ProjectFactory.project()
 
         this.vm.inputs.configureWith(shippingRule, project)
-        val expectedCurrency = environment.ksCurrency().format(30.0, project)
-        this.shippingRuleText.assertValue("Brooklyn, NY $expectedCurrency")
+        this.shippingRuleText.assertValue("Brooklyn, NY")
     }
 }


### PR DESCRIPTION
# 📲 What

Removes the shipping cost from all shipping selectors.

# 🤔 Why

Due to add-ons, the shipping selector showed the shipping cost for the base reward and was not relevant for add-ons as each add-on has it's own shipping cost.

# 🛠 How

Removed the formatting code from the `ShippingRuleViewHolderViewModel`

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
|<img width="356" alt="Screen Shot 2020-09-02 at 5 40 07 PM" src="https://user-images.githubusercontent.com/4837246/92039616-59003900-ed43-11ea-8668-174d6583d794.png">|<img width="347" alt="Screen Shot 2020-09-02 at 5 37 51 PM" src="https://user-images.githubusercontent.com/4837246/92039425-0888db80-ed43-11ea-9cfa-84d592d238af.png">|

# 📋 QA

View a project with add-ons and verify that the shipping selector does not show the shipping costs
Back a project with a reward that needs to be shipped. Verify that the shipping selector does not show the shipping costs

# Story 📖

[NT-1484](https://kickstarter.atlassian.net/browse/NT-1484)
