### PR TITLE
NT-1387: Fix Add-Ons Available tag for Digital Reward

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardViewHolder.kt
@@ -75,7 +75,9 @@ class RewardViewHolder(private val view: View, val delegate: Delegate?, private 
         this.viewModel.outputs.limitContainerIsGone()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { ViewUtils.setGone(this.view.reward_limit_container, it) }
+                .subscribe {
+                    ViewUtils.setGone(this.view.reward_limit_container, it)
+                }
 
         this.viewModel.outputs.remaining()
                 .compose(bindToLifecycle())
@@ -183,9 +185,8 @@ class RewardViewHolder(private val view: View, val delegate: Delegate?, private 
                 .filter { ObjectUtils.isNotNull(it) }
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { hasAddOns ->
-                    if (hasAddOns) this.view.reward_add_ons_available.visibility = View.VISIBLE
-                    else ViewUtils.setGone(this.view.reward_add_ons_available, true)
+                .subscribe {
+                    ViewUtils.setGone(this.view.reward_add_ons_available, !it)
                 }
 
         this.viewModel.outputs.selectedRewardTagIsGone()

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -366,8 +366,8 @@ interface RewardViewHolderViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.shippingSummaryIsGone)
 
-            Observable.combineLatest(this.endDateSectionIsGone, this.remainingIsGone, this.shippingSummaryIsGone)
-            { endDateGone, remainingGone, shippingGone -> endDateGone && remainingGone && shippingGone }
+            Observable.combineLatest(this.endDateSectionIsGone, this.remainingIsGone, this.shippingSummaryIsGone, this.addOnsAvailable)
+            { endDateGone, remainingGone, shippingGone, addOnsAvailable -> endDateGone && remainingGone && shippingGone && !addOnsAvailable }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.limitContainerIsGone)

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -193,7 +193,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/Add_ons"
-                tools:text="Add-ons available" />
+                tools:text="@string/Add_ons" />
 
           </com.google.android.flexbox.FlexboxLayout>
 

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -96,6 +96,25 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testDigitalReward_withAddOns_showAddOnsTag() {
+        setUpEnvironment(environment())
+
+        // - Digital reward
+        val reward = RewardFactory.reward()
+                .toBuilder()
+                .shippingPreference("unrestricted")
+                .shippingType(Reward.SHIPPING_TYPE_NO_SHIPPING)
+                .hasAddons(true)
+                .backersCount(30)
+                .build()
+
+        this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.project()), reward)
+
+        this.hasAddonsAvailable.assertValue(true)
+        this.limitContainerIsGone.assertValue(false)
+    }
+
+    @Test
     fun testBackersCount_whenReward_withNoBackers() {
         setUpEnvironment(environment())
 


### PR DESCRIPTION
# 📲 What

A digital reward can have addOns 

# 👀 See


| Before 🐛 | After 🦋 |
| 
<img width="765" alt="Screen Shot 2020-09-02 at 2 47 55 PM" src="https://user-images.githubusercontent.com/4083656/92040244-57c31200-ed2b-11ea-9e82-cd930b83d562.png">

|  |  |

# 📋 QA

- Make sure that a digital reward with AddOns has the tag shown in the Carousel ⚠️ (the AddOns screen is not gonna load anything for now, it expects a location)

