### PR TITLE
NT-1482: Add-Ons Analytics Events

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -740,6 +740,18 @@ public final class Koala {
 
     this.client.track(LakeEvent.FIX_PLEDGE_BUTTON_CLICKED, props);
   }
+
+  public void trackAddOnsPageViewed(final @NonNull PledgeData pledgeData) {
+    final Map<String, Object> props = KoalaUtils.pledgeDataProperties(pledgeData, this.client.loggedInUser());
+
+    this.client.track(LakeEvent.ADD_ONS_PAGE_VIEWED, props);
+  }
+
+  public void trackAddOnsContinueButtonClicked(final @NonNull PledgeData pledgeData) {
+    final Map<String, Object> props = KoalaUtils.pledgeDataProperties(pledgeData, this.client.loggedInUser());
+
+    this.client.track(LakeEvent.ADD_ONS_CONTINUED_BUTTON_CLICKED, props);
+  }
   //endregion
 
   //region Log In or Signup

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -21,6 +21,8 @@ const val PLEDGE_SUBMIT_BUTTON_CLICKED = "Pledge Submit Button Clicked"
 const val PROJECT_PAGE_PLEDGE_BUTTON_CLICKED = "Project Page Pledge Button Clicked"
 const val SELECT_REWARD_BUTTON_CLICKED = "Select Reward Button Clicked"
 const val THANKS_PAGE_VIEWED = "Thanks Page Viewed"
+const val ADD_ONS_PAGE_VIEWED = "Add-Ons Page Viewed"
+const val ADD_ONS_CONTINUED_BUTTON_CLICKED = "Add-Ons Continue Button Clicked"
 // endregion
 
 // region Manage a Pledge

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -68,6 +68,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.addOnsList.assertValue(Triple(projectData, emptyList(), ShippingRuleFactory.emptyShippingRule()))
         this.isEmptyState.assertValue(true)
+
+        this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
     @Test
@@ -101,6 +103,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
         this.vm.arguments(bundle)
         this.addOnsList.assertValue(Triple(projectData,listAddons, shippingRule.shippingRules().first()))
+
+        this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
     @Test
@@ -134,6 +138,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
         this.vm.arguments(bundle)
         this.addOnsList.assertValue(Triple(projectData,listAddons, shippingRule.shippingRules().first()))
+
+        this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
     @Test
@@ -171,6 +177,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.arguments(bundle)
 
         this.addOnsList.assertValue(Triple(projectData, emptyList(), shippingRuleRw))
+
+        this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
     @Test
@@ -206,6 +214,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.arguments(bundle)
 
         this.addOnsList.assertValue(Triple(projectData, listAddons, shippingRuleRw))
+
+        this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
     @Test
@@ -250,6 +260,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
             val filteredAddOn = it.second.first()
             TestCase.assertEquals(filteredAddOn, addOn2)
         }
+
+        this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
     @Test
@@ -290,6 +302,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.shippingRuleSelected(shippingRuleAddOn)
 
         this.addOnsList.assertValues(Triple(projectData, listAddons, shippingRuleRw), Triple(projectData, emptyList(), shippingRuleAddOn))
+
+        this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
     @Test
@@ -325,6 +339,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.arguments(bundle)
 
         this.addOnsList.assertValue(Triple(projectData, listAddons, ShippingRuleFactory.emptyShippingRule()))
+
+        this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
     @Test
@@ -359,6 +375,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.arguments(bundle)
 
         this.shippingSelectorIsGone.assertValues(true)
+
+        this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
 
@@ -392,6 +410,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.arguments(bundle)
 
         this.shippingSelectorIsGone.assertValues(true)
+
+        this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
     @Test
@@ -429,6 +449,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
                     TestCase.assertEquals(it.first, pledgeData)
                     TestCase.assertEquals(it.second, pledgeReason)
                 }
+
+        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked")
     }
 
     @Test
@@ -503,6 +525,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
                     TestCase.assertEquals(selectedAddOnsList?.last()?.id(), 99)
                     TestCase.assertEquals(selectedAddOnsList?.last()?.quantity(), 5)
                 }
+
+        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked")
     }
 
     @Test
@@ -555,6 +579,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.isEnabledButton.assertValue(false)
         this.addOnsList.assertValue(Triple(projectData,combinedList, shippingRule.shippingRules().first()))
+
+        this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
     @Test
@@ -624,6 +650,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
                 .subscribe {
                     TestCase.assertEquals(it.first.addOns(), updateList)
                 }
+
+        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked")
     }
 
     @Test
@@ -661,6 +689,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.addOnsList.assertValue(Triple(projectData, emptyList(), shippingRuleRw))
         this.isEmptyState.assertValue(true)
+
+        this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
     @Test
@@ -696,7 +726,9 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.arguments(bundle)
 
         this.addOnsList.assertValue(Triple(projectData, listAddons, shippingRuleRw))
-        this.isEmptyState.assertValue(false);
+        this.isEmptyState.assertValue(false)
+
+        this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
     private fun buildEnvironmentWith(addOns: List<Reward>, shippingRule: ShippingRulesEnvelope, currentConfig: MockCurrentConfig): Environment {


### PR DESCRIPTION
# 📲 What

Add the Add-Ons analytics events to the app. 

# 🤔 Why

Needed to track the impact of Add-Ons

# 🛠 How

Added Add-Ons to the backing add-on fragment with tests.

# Story 📖

[NT-1482](https://kickstarter.atlassian.net/browse/NT-1482)
