### PR TITLE
[NT-1474]: Refresh backing fragment

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/adapters/RewardAndAddOnsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/RewardAndAddOnsAdapter.kt
@@ -29,10 +29,8 @@ class RewardAndAddOnsAdapter() : KSAdapter() {
     }
 
     fun populateDataForAddOns(rewards: List<Pair<ProjectData,Reward>>) {
-        if (rewards.isNotEmpty()) {
-            setSection(SECTION_ADD_ONS_CARD, rewards)
-            notifyDataSetChanged()
-        }
+        setSection(SECTION_ADD_ONS_CARD, rewards)
+        notifyDataSetChanged()
     }
 
     fun populateDataForReward(reward: Pair<ProjectData, Reward>) {

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -22,6 +22,7 @@ import com.kickstarter.libs.SwipeRefresher
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.transformations.CircleTransformation
+import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.adapters.RewardAndAddOnsAdapter
@@ -184,7 +185,7 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>() {
                 .subscribe { total_summary_amount.text = it }
 
         this.viewModel.outputs.projectDataAndAddOns()
-                .filter { it.second.isNotEmpty() }
+                .filter { ObjectUtils.isNotNull(it) }
                 .distinctUntilChanged()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -140,7 +140,7 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Rewa
     }
 
     private fun showPledgeFragment(pledgeData: PledgeData, pledgeReason: PledgeReason) {
-        if (this.fragmentManager?.findFragmentByTag(PledgeFragment::class.java.simpleName) == null) {
+        if (this.isVisible && this.fragmentManager?.findFragmentByTag(PledgeFragment::class.java.simpleName) == null) {
             val pledgeFragment = PledgeFragment.newInstance(pledgeData, pledgeReason)
             this.fragmentManager?.beginTransaction()
                     ?.setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
@@ -153,7 +153,7 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Rewa
     }
 
     private fun showAddonsFragment(pledgeDataAndReason: Pair<PledgeData, PledgeReason>) {
-        if (this.fragmentManager?.findFragmentByTag(BackingAddOnsFragment::class.java.simpleName) == null) {
+        if (this.isVisible && this.fragmentManager?.findFragmentByTag(BackingAddOnsFragment::class.java.simpleName) == null) {
             val addOnsFragment = BackingAddOnsFragment.newInstance(pledgeDataAndReason)
             this.fragmentManager?.beginTransaction()
                     ?.setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -95,7 +95,8 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Rewa
     }
 
     private fun showAlert() {
-        dialog.show()
+        if (this.isVisible)
+            dialog.show()
     }
 
     private fun scrollToReward(position: Int) {

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -545,8 +545,16 @@ interface ProjectViewModel {
             val backing = backedProject
                     .switchMap {
                         this.apolloClient.getProjectBacking(it.slug()?: "")
+                                .doOnSubscribe {
+                                    progressBarIsGone.onNext(false)
+                                }
+                                .doAfterTerminate {
+                                    progressBarIsGone.onNext(true)
+                                }
+                                .materialize()
                     }
                     .compose(neverError())
+                    .compose(values())
                     .filter { ObjectUtils.isNotNull(it) }
                     .share()
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -690,7 +690,7 @@ interface ProjectViewModel {
 
             this.fragmentStackCount
                     .compose<Pair<Int, Project>>(combineLatestPair(currentProject))
-                    .map { if (it.second.isBacking) it.first > 3 else it.first > 2}
+                    .map { if (it.second.isBacking) it.first > 4 else it.first > 3 }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.scrimIsVisible)

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -560,13 +560,12 @@ interface ProjectViewModel {
 
             // - Update fragments with the backing data
             projectData
-                    .filter { it.project().hasRewards() && it.project().isBacking }
+                    .filter { it.project().hasRewards() }
                     .compose<Pair<ProjectData, Backing>>(combineLatestPair(backing))
                     .map {
                         val updatedProject = it.first.project().toBuilder().backing(it.second).build()
                         projectData(it.first.refTagFromIntent(), it.first.refTagFromCookie(), updatedProject)
                     }
-                    .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.updateFragments)
 
@@ -691,7 +690,7 @@ interface ProjectViewModel {
 
             this.fragmentStackCount
                     .compose<Pair<Int, Project>>(combineLatestPair(currentProject))
-                    .map { if (it.second.isBacking) it.first > 3 else it.first > 3}
+                    .map { if (it.second.isBacking) it.first > 3 else it.first > 2}
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.scrimIsVisible)

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -1388,6 +1388,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
                 ProjectDataFactory.project(refreshedProject))
         this.showUpdatePledgeSuccess.assertValueCount(1)
         this.updateFragments.assertValues(ProjectDataFactory.project(initialBackedProject),
+                ProjectDataFactory.project(refreshedProject),
                 ProjectDataFactory.project(refreshedProject))
     }
 
@@ -1413,6 +1414,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
                 ProjectDataFactory.project(refreshedProject))
         this.showUpdatePledgeSuccess.assertValueCount(1)
         this.updateFragments.assertValues(ProjectDataFactory.project(initialBackedProject),
+                ProjectDataFactory.project(refreshedProject),
                 ProjectDataFactory.project(refreshedProject))
     }
 


### PR DESCRIPTION
# 📲 What

- The backing fragment was not reflecting the update pledge changes, or changing reward changes unless fragment re-created again

- Allow to load emptyList on AddOns section for the rewards and addOns recyclerView (changing your addOns selection to 0 addOns, or changing from a reward with addOns to one without it was not updating the RecyclerView UI).

- Do not present Any fragment or Dialog unless the current fragment is visible.


# 🛠 How

- Added .materialize() operator when fetching the BackingObject in ProjectViewModel

# 👀 See
![refreshed-backing-fragment](https://user-images.githubusercontent.com/4083656/92662109-01b61780-f2b3-11ea-9ea9-d9e4658af1de.gif)
|  |  |

# 📋 QA

- Change from a reward with AddOns to a Reward without AddOns, the BackingFragment should change without any user interaction to reflect the new selection (look at the gif if any doubts)

# Story 📖

[NT-1474](https://kickstarter.atlassian.net/browse/NT-1474)
