### PR TITLE
NT-1512: UI adjustment Expandable header

### DIFF
--- a/app/src/main/res/layout/expandable_header_item.xml
+++ b/app/src/main/res/layout/expandable_header_item.xml
@@ -28,7 +28,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.80" />
+        app:layout_constraintGuide_percent="0.70" />
 
     <TextView
         android:id="@+id/pledge_header_item_amount"
@@ -37,7 +37,7 @@
         android:layout_height="wrap_content"
         android:gravity="end"
         android:ellipsize="end"
-        android:maxLines="2"
+        android:maxLines="1"
         android:layout_marginEnd="@dimen/grid_3"
         android:textColor="@color/ksr_dark_grey_500"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -45,7 +45,7 @@
         app:layout_constraintStart_toEndOf="@+id/guideline_separator"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBaseline_toBaselineOf="@+id/pledge_header_item_title"
-        tools:text="US$40" />
+        tools:text="US$40000000" />
 
     <ImageView
         android:id="@+id/imageView"

--- a/app/src/main/res/layout/fragment_pledge_section_header_reward_sumary.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_header_reward_sumary.xml
@@ -51,14 +51,16 @@
     <TextView
         android:id="@+id/pledge_header_summary_amount"
         style="@style/PledgeCurrency"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/grid_3"
         android:layout_marginEnd="@dimen/grid_3"
         android:maxLines="1"
+        android:gravity="end"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/pledge_header_title"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="40" />
+        tools:text="4000" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/header_animation_guideline"


### PR DESCRIPTION
# 📲 What

- For a long text on the converted amount on a reward-addon the expandable header was showing two lines. Now it's just one.

# 👀 See

| Before 🐛 | After 🦋 |
| 
<img width="956" alt="Screen Shot 2020-09-11 at 8 40 30 AM" src="https://user-images.githubusercontent.com/4083656/92945794-a434de80-f40a-11ea-8ea0-88826c6397d4.png">
 |
|  |  |

# 📋 QA

- Select a reward/addOn in another currency to have longer texts 

# Story 📖

[NT-1512](https://kickstarter.atlassian.net/browse/NT-1512)
