### PR TITLE
NT-1521: Reward Total Cutoff for Large amounts

### DIFF
--- a/app/src/main/res/layout/fragment_pledge_section_header_reward_sumary.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_header_reward_sumary.xml
@@ -39,28 +39,28 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/pledge_header_title"
         app:layout_constraintEnd_toStartOf="@id/guideline_separator"
-        tools:text="Estimated delivery June 2020 " />
+        tools:text="Estimated delivery September 2020 " />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline_separator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.75" />
+        app:layout_constraintGuide_percent="0.60" />
 
     <TextView
         android:id="@+id/pledge_header_summary_amount"
         style="@style/PledgeCurrency"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/grid_3"
         android:layout_marginEnd="@dimen/grid_3"
-        android:maxLines="1"
+        android:layout_marginTop="@dimen/grid_3"
+        android:maxLines="2"
         android:gravity="end"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/pledge_header_title"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="4000" />
+        tools:text="16,100" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/header_animation_guideline"


### PR DESCRIPTION
# 📲 What

Reward header total is cut off for large values. The XML is updated to account for larger amounts

# 🤔 Why

When choosing a larger reward amount the total is cut off.

# 📋 QA

On the one inch straw project, go to the last reward and confirm that the total is viewable.

# Story 📖

[NT-1521](https://kickstarter.atlassian.net/browse/NT-1521)
