### PR TITLE
[NT-1520] - Update UI in RewardsFragment when canceling a pledge

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -563,7 +563,10 @@ interface ProjectViewModel {
                     .filter { it.project().hasRewards() }
                     .compose<Pair<ProjectData, Backing>>(combineLatestPair(backing))
                     .map {
-                        val updatedProject = it.first.project().toBuilder().backing(it.second).build()
+                        val updatedProject = if (it.first.project().isBacking)
+                            it.first.project().toBuilder().backing(it.second).build()
+                        else it.first.project()
+
                         projectData(it.first.refTagFromIntent(), it.first.refTagFromCookie(), updatedProject)
                     }
                     .compose(bindToLifecycle())


### PR DESCRIPTION
# 📲 What

- ProjectData was always updated with the outdated backing object

# 🤔 Why

- We fetch project from V1, but backing Object from Graph. In this situation the observable for backingObject still had the previous emission, so added additional logic to make sure we update the project data only if needed


# 👀 See

![cancel-pledge-updating-fragments](https://user-images.githubusercontent.com/4083656/92959155-28de2780-f420-11ea-9969-4d30c2f44224.gif)


# 📋 QA

- Pledge to a project, hit manage your pledge, cancel the pledge. Then hit again back this project button, the reward carousel should be in a non backed state without the "You backed" tag

# Story 📖

[NT-1520](https://kickstarter.atlassian.net/browse/NT-1520)
