### PR TITLE
NT-1442: Android Display an error state if add-ons fail to load

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.ui.fragments
 
 import android.os.Bundle
+import android.util.Log
 import android.util.Pair
 import android.view.LayoutInflater
 import android.view.View
@@ -121,6 +122,8 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
     }
 
     private fun showErrorDialog() {
+        Log.d("HELLOWORLD", "SHOW Error")
+
         if (!errorDialog.isShowing) {
             errorDialog.show()
         }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -46,7 +46,6 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
         super.onViewCreated(view, savedInstanceState)
         setUpShippingAdapter()
         setupRecyclerView()
-
         setupErrorDialog()
 
         this.viewModel.outputs.showPledgeFragment()
@@ -122,7 +121,9 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
     }
 
     private fun showErrorDialog() {
-        errorDialog.show()
+        if (!errorDialog.isShowing) {
+            errorDialog.show()
+        }
     }
 
     private fun dismissErrorDialog() {
@@ -165,24 +166,13 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
                 ?.addToBackStack(NewCardFragment::class.java.simpleName)
                 ?.commit()
     }
-//
-//    private fun setupErrorDialog(pledgeData: PledgeData, pledgeReason: PledgeReason) {
-//        context?.let { context ->
-//            errorDialog = AlertDialog.Builder(context, R.style.AlertDialog)
-//                    .setCancelable(false)
-//                    .setTitle(getString(R.string.Something_went_wrong_please_try_again))
-//                    .setPositiveButton("             ${getString(R.string.Retry)}") { _, _ -> this.viewModel.inputs.configureWith(this.viewModel.arguments()) }
-//                    .setNegativeButton("             ${getString(R.string.close_alert)}") { _, _ -> dismissErrorDialog()}
-//                    .create()
-//        }
-//    }
 
     private fun setupErrorDialog() {
         context?.let { context ->
             errorDialog = AlertDialog.Builder(context, R.style.AlertDialog)
                     .setCancelable(false)
                     .setTitle(getString(R.string.Something_went_wrong_please_try_again))
-                    .setPositiveButton("             ${getString(R.string.Retry)}") { _, _ -> {} }
+                    .setPositiveButton("             ${getString(R.string.Retry)}") { _, _ -> this.viewModel.inputs.retryButtonPressed() }
                     .setNegativeButton("             ${getString(R.string.close_alert)}") { _, _ -> dismissErrorDialog()}
                     .create()
         }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -1,7 +1,6 @@
 package com.kickstarter.ui.fragments
 
 import android.os.Bundle
-import android.util.Log
 import android.util.Pair
 import android.view.LayoutInflater
 import android.view.View

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -122,8 +122,6 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
     }
 
     private fun showErrorDialog() {
-        Log.d("HELLOWORLD", "SHOW Error")
-
         if (!errorDialog.isShowing) {
             errorDialog.show()
         }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -175,7 +175,8 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
             errorDialog = AlertDialog.Builder(context, R.style.AlertDialog)
                     .setCancelable(false)
                     .setTitle(getString(R.string.Something_went_wrong_please_try_again))
-                    .setPositiveButton("             ${getString(R.string.Retry)}") { _, _ -> this.viewModel.inputs.retryButtonPressed() }
+                    .setPositiveButton("             ${getString(R.string.Retry)}") { _, _ ->
+                        this.viewModel.inputs.retryButtonPressed() }
                     .setNegativeButton("             ${getString(R.string.close_alert)}") { _, _ -> dismissErrorDialog()}
                     .create()
         }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -175,9 +175,9 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
             errorDialog = AlertDialog.Builder(context, R.style.AlertDialog)
                     .setCancelable(false)
                     .setTitle(getString(R.string.Something_went_wrong_please_try_again))
-                    .setPositiveButton("             ${getString(R.string.Retry)}") { _, _ ->
+                    .setPositiveButton("                     ${getString(R.string.Retry)}") { _, _ ->
                         this.viewModel.inputs.retryButtonPressed() }
-                    .setNegativeButton("             ${getString(R.string.close_alert)}") { _, _ -> dismissErrorDialog()}
+                    .setNegativeButton("                     ${getString(R.string.close_alert)}") { _, _ -> dismissErrorDialog()}
                     .create()
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -5,6 +5,7 @@ import android.util.Pair
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.kickstarter.R
@@ -27,7 +28,6 @@ import com.kickstarter.ui.viewholders.BackingAddOnViewHolder
 import com.kickstarter.viewmodels.BackingAddOnsFragmentViewModel
 import kotlinx.android.synthetic.main.fragment_backing_addons.*
 import kotlinx.android.synthetic.main.fragment_backing_addons_section_footer.*
-import kotlinx.android.synthetic.main.fragment_rewards.*
 import java.util.concurrent.TimeUnit
 
 @RequiresFragmentViewModel(BackingAddOnsFragmentViewModel.ViewModel::class)
@@ -40,11 +40,14 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
 
     private val backingAddonsAdapter = BackingAddOnsAdapter(this)
     private lateinit var shippingRulesAdapter: ShippingRulesAdapter
+    private lateinit var errorDialog: AlertDialog
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setUpShippingAdapter()
         setupRecyclerView()
+
+        setupErrorDialog()
 
         this.viewModel.outputs.showPledgeFragment()
                 .compose(bindToLifecycle())
@@ -53,7 +56,7 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
 
         this.viewModel.outputs.addOnsList()
                 .compose(bindToLifecycle())
-                .throttleWithTimeout(50,TimeUnit.MILLISECONDS)
+                .throttleWithTimeout(50, TimeUnit.MILLISECONDS)
                 .compose(Transformers.observeForUI())
                 .subscribe {
                     populateAddOns(it)
@@ -68,6 +71,11 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .subscribe { fragment_backing_addons_shipping_rules.setText(it.toString()) }
+
+        this.viewModel.outputs.showErrorDialog()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe { showErrorDialog() }
 
         this.viewModel.outputs.shippingRulesAndProject()
                 .compose(bindToLifecycle())
@@ -113,13 +121,21 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
         }
     }
 
+    private fun showErrorDialog() {
+        errorDialog.show()
+    }
+
+    private fun dismissErrorDialog() {
+        errorDialog.dismiss()
+    }
+
     private fun populateAddOns(projectDataAndAddOnList: Triple<ProjectData, List<Reward>, ShippingRule>) {
         val projectData = projectDataAndAddOnList.first
         val selectedShippingRule = projectDataAndAddOnList.third
         val list = projectDataAndAddOnList
                 .second
                 .map {
-                    Triple(projectData,it, selectedShippingRule)
+                    Triple(projectData, it, selectedShippingRule)
                 }.toList()
 
         backingAddonsAdapter.populateDataForAddOns(list)
@@ -148,6 +164,28 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
                 ?.add(R.id.fragment_container, PledgeFragment.newInstance(pledgeData, pledgeReason), PledgeFragment::class.java.simpleName)
                 ?.addToBackStack(NewCardFragment::class.java.simpleName)
                 ?.commit()
+    }
+//
+//    private fun setupErrorDialog(pledgeData: PledgeData, pledgeReason: PledgeReason) {
+//        context?.let { context ->
+//            errorDialog = AlertDialog.Builder(context, R.style.AlertDialog)
+//                    .setCancelable(false)
+//                    .setTitle(getString(R.string.Something_went_wrong_please_try_again))
+//                    .setPositiveButton("             ${getString(R.string.Retry)}") { _, _ -> this.viewModel.inputs.configureWith(this.viewModel.arguments()) }
+//                    .setNegativeButton("             ${getString(R.string.close_alert)}") { _, _ -> dismissErrorDialog()}
+//                    .create()
+//        }
+//    }
+
+    private fun setupErrorDialog() {
+        context?.let { context ->
+            errorDialog = AlertDialog.Builder(context, R.style.AlertDialog)
+                    .setCancelable(false)
+                    .setTitle(getString(R.string.Something_went_wrong_please_try_again))
+                    .setPositiveButton("             ${getString(R.string.Retry)}") { _, _ -> {} }
+                    .setNegativeButton("             ${getString(R.string.close_alert)}") { _, _ -> dismissErrorDialog()}
+                    .create()
+        }
     }
 
     private fun displayShippingRules(shippingRules: List<ShippingRule>, project: Project) {

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -90,13 +90,13 @@ class BackingAddOnsFragmentViewModel {
         private val shippingRulesAndProject = PublishSubject.create<Pair<List<ShippingRule>, Project>>()
 
         private val projectAndReward: Observable<Pair<Project, Reward>>
-        private val retryButtonPressed = PublishSubject.create<Void>()
+        private val retryButtonPressed = BehaviorSubject.create<Boolean>()
 
         private val showPledgeFragment = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
         private val shippingSelectorIsGone = BehaviorSubject.create<Boolean>()
         private val addOnsListFiltered = PublishSubject.create<Triple<ProjectData, List<Reward>, ShippingRule>>()
         private val isEmptyState = PublishSubject.create<Boolean>()
-        private val showErrorDialog = PublishSubject.create<Boolean>()
+        private val showErrorDialog = BehaviorSubject.create<Boolean>()
         private val totalSelectedAddOns = BehaviorSubject.create(0)
         private val continueButtonPressed = BehaviorSubject.create<Void>()
         private val quantityPerId = PublishSubject.create<Pair<Int, Long>>()
@@ -268,15 +268,28 @@ class BackingAddOnsFragmentViewModel {
                     }
 
             /// Added
+            Observable.combineLatest(this.retryButtonPressed.startWith(false), projectAndReward) { _, projectAndReward ->
+                return@combineLatest this.apiClient.fetchShippingRules(projectAndReward.first, projectAndReward.second).doOnError {
+                    // TODO: Send message to the fragment
+                    Log.d("HELLOWORLD", "API ERROR")
+                    this.showErrorDialog.onNext(true)
+                }.onErrorResumeNext(Observable.empty())
+            }.compose(values())
+                    .map { it.shippingRules() }
+                    .compose(bindToLifecycle())
+                    .subscribe(shippingRules)
+
+
+
             projectAndReward
                     .compose<Pair<Project, Reward>>(takeWhen(this.retryButtonPressed))
                     .compose(bindToLifecycle())
                     .switchMap<ShippingRulesEnvelope> {
-                        this.apiClient.fetchShippingRules(it.first, it.second).doOnCompleted {
+                        this.apiClient.fetchShippingRules(it.first, it.second).doOnError {
                             // TODO: Send message to the fragment
                             Log.d("HELLOWORLD", "API ERROR")
                             this.showErrorDialog.onNext(true)
-                        }
+                        }.onErrorResumeNext(Observable.empty())
                     }
                     .map { it.shippingRules() }
                     .subscribe(shippingRules)
@@ -285,11 +298,11 @@ class BackingAddOnsFragmentViewModel {
                     .compose<Pair<Project, Reward>>(takeWhen(this.retryButtonPressed))
                     .compose(bindToLifecycle())
                     .switchMap {
-                        this.apolloClient.getProjectAddOns(it.first.slug()?.let { it }?: "").doOnCompleted {
+                        this.apolloClient.getProjectAddOns(it.first.slug()?.let { it }?: "").doOnError {
                             // TODO: Send message to the fragment
                             Log.d("HELLOWORLD", "API ERROR")
                             this.showErrorDialog.onNext(true)
-                        }
+                        }.onErrorResumeNext(Observable.empty())
                     }
                     .filter { ObjectUtils.isNotNull(it) }
                     .subscribe(addOnsFromGraph)
@@ -390,7 +403,7 @@ class BackingAddOnsFragmentViewModel {
         override fun shippingRuleSelected(shippingRule: ShippingRule) = this.shippingRuleSelected.onNext(shippingRule)
         override fun continueButtonPressed() = this.continueButtonPressed.onNext(null)
         override fun quantityPerId(quantityPerId: Pair<Int, Long>) = this.quantityPerId.onNext(quantityPerId)
-        override fun retryButtonPressed() = this.retryButtonPressed.onNext(null)
+        override fun retryButtonPressed() = this.retryButtonPressed.onNext(true)
 
         // - Outputs
         @NonNull

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -1,6 +1,5 @@
 package com.kickstarter.viewmodels
 
-import android.util.Log
 import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.libs.Environment
@@ -386,7 +385,7 @@ class BackingAddOnsFragmentViewModel {
                     .shippingRules()
                     ?.map {
                         it.location().id()
-                    } ?: emptyList()
+                    }?: emptyList()
 
             return idLocations.contains(rule.location().id())
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -1,6 +1,5 @@
 package com.kickstarter.viewmodels
 
-import android.util.Log
 import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.libs.Environment
@@ -42,7 +41,7 @@ class BackingAddOnsFragmentViewModel {
         /** Emits the quantity per AddOn Id selected */
         fun quantityPerId(quantityPerId: Pair<Int, Long>)
 
-        /**Envoked when the retry button on the addOn Error alert dialog is pressed */
+        /** Invoked when the retry button on the add-on Error alert dialog is pressed */
         fun retryButtonPressed()
     }
 
@@ -71,7 +70,7 @@ class BackingAddOnsFragmentViewModel {
         /** Emits whether or not the empty state should be shown **/
         fun isEmptyState(): Observable<Boolean>
 
-        /**Emits an alert dialog when add-ons request results in error **/
+        /** Emits an alert dialog when add-ons request results in error **/
         fun showErrorDialog(): Observable<Boolean>
     }
 
@@ -185,7 +184,6 @@ class BackingAddOnsFragmentViewModel {
             shippingRules
                     .filter { it.isNotEmpty() }
                     .compose<Pair<List<ShippingRule>, PledgeReason>>(combineLatestPair(pledgeReason))
-                    .filter { it.second == PledgeReason.PLEDGE }
                     .switchMap { defaultShippingRule(it.first) }
                     .subscribe(this.shippingRuleSelected)
 
@@ -344,11 +342,13 @@ class BackingAddOnsFragmentViewModel {
 
         private fun filterByLocationAndUpdateQuantity(addOns: List<Reward>, pData: ProjectData, rule: ShippingRule, rw: Reward): Triple<ProjectData, List<Reward>, ShippingRule> {
             val filteredAddOns = when (rw.shippingPreference()) {
+                Reward.ShippingPreference.UNRESTRICTED.name,
                 Reward.ShippingPreference.UNRESTRICTED.toString().toLowerCase() -> {
                     addOns.filter {
-                        it.shippingPreferenceType() == Reward.ShippingPreference.UNRESTRICTED || isDigital(it)
+                        it.shippingPreferenceType() == Reward.ShippingPreference.UNRESTRICTED || containsLocation(rule, it) || isDigital(it)
                     }
                 }
+                Reward.ShippingPreference.RESTRICTED.name,
                 Reward.ShippingPreference.RESTRICTED.toString().toLowerCase() -> {
                     addOns.filter { containsLocation(rule, it) || isDigital(it) }
                 }

--- a/app/src/main/res/values/strings_i18n.xml
+++ b/app/src/main/res/values/strings_i18n.xml
@@ -96,6 +96,7 @@ backers</string>
   <string name="Check_your_payment_details" formatted="false">Check your payment details</string>
   <string name="Choose_another_reward" formatted="false">Choose another reward</string>
   <string name="Chooses_location_for_shipping" formatted="false">Chooses %{location} for shipping.</string>
+  <string name="close_alert" formatted="false">Close</string>
   <string name="Close_live_stream" formatted="false">Close live stream</string>
   <string name="Close_project" formatted="false">Close project</string>
   <string name="Closes_filters" formatted="false">Closes filters.</string>

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -31,6 +31,7 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
     private val isEnabledButton = TestSubscriber.create<Boolean>()
     private val totalSelectedAddOns = TestSubscriber.create<Int>()
     private val isEmptyState = TestSubscriber.create<Boolean>()
+    private val showErrorDialog = TestSubscriber.create<Boolean>()
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = BackingAddOnsFragmentViewModel.ViewModel(environment)
@@ -40,6 +41,7 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.isEnabledCTAButton().subscribe(this.isEnabledButton)
         this.vm.outputs.totalSelectedAddOns().subscribe(this.totalSelectedAddOns)
         this.vm.outputs.isEmptyState().subscribe(this.isEmptyState)
+        this.vm.outputs.showErrorDialog().subscribe(this.showErrorDialog)
     }
 
     @Test
@@ -731,8 +733,60 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
-    private fun buildEnvironmentWith(addOns: List<Reward>, shippingRule: ShippingRulesEnvelope, currentConfig: MockCurrentConfig): Environment {
+    @Test
+    fun errorState_whenErrorReturned_shouldShowErrorAlertDialog() {
+        val shippingRuleRw = ShippingRuleFactory.usShippingRule()
+        val shippingRuleAddOn = ShippingRuleFactory.usShippingRule()
+        val addOn = RewardFactory.addOn().toBuilder()
+                .shippingRules(listOf(shippingRuleAddOn, shippingRuleAddOn, shippingRuleAddOn))
+                .shippingPreferenceType(Reward.ShippingPreference.RESTRICTED)
+                .build()
+        val listAddons = listOf(addOn, addOn, addOn)
+        val config = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfig()
+        currentConfig.config(config)
+        setUpEnvironment(buildEnvironmentWith(listAddons, ShippingRulesEnvelope.builder().shippingRules(listOf(shippingRuleRw)).build(), currentConfig))
 
+        buildEnvironmentWithError(currentConfig)
+
+        val rw = RewardFactory.rewardHasAddOns().toBuilder()
+                .shippingType(Reward.ShippingPreference.RESTRICTED.name.toLowerCase())
+                .shippingRules(listOf(shippingRuleRw))
+                .shippingPreferenceType(Reward.ShippingPreference.RESTRICTED)
+                .shippingPreference(Reward.ShippingPreference.RESTRICTED.name.toLowerCase())
+                .build()
+
+        val project = ProjectFactory.project().toBuilder().rewards(listOf(rw)).build()
+        val projectData = ProjectDataFactory.project(project, null, null)
+        val pledgeReason = PledgeFlowContext.forPledgeReason(PledgeReason.PLEDGE)
+
+        val bundle = Bundle()
+        bundle.putParcelable(ArgumentsKey.PLEDGE_PLEDGE_DATA, PledgeData.with(pledgeReason, projectData, rw))
+        bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
+        this.vm.arguments(bundle)
+
+        this.showErrorDialog.assertValue(true)
+    }
+
+    private fun buildEnvironmentWithError(currentConfig: MockCurrentConfig): Environment {
+
+        return environment()
+                .toBuilder()
+                .apolloClient(object : MockApolloClient() {
+                    override fun getProjectAddOns(slug: String): Observable<List<Reward>> {
+                        return Observable.error(ApiExceptionFactory.badRequestException())
+                    }
+                })
+                .apiClient(object : MockApiClient() {
+                    override fun fetchShippingRules(project: Project, reward: Reward): Observable<ShippingRulesEnvelope> {
+                        return Observable.error(ApiExceptionFactory.badRequestException())
+                    }
+                })
+                .currentConfig(currentConfig)
+                .build()
+    }
+
+    private fun buildEnvironmentWith(addOns: List<Reward>, shippingRule: ShippingRulesEnvelope, currentConfig: MockCurrentConfig): Environment {
         return environment()
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -735,25 +735,13 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun errorState_whenErrorReturned_shouldShowErrorAlertDialog() {
-        val shippingRuleRw = ShippingRuleFactory.usShippingRule()
-        val shippingRuleAddOn = ShippingRuleFactory.usShippingRule()
-        val addOn = RewardFactory.addOn().toBuilder()
-                .shippingRules(listOf(shippingRuleAddOn, shippingRuleAddOn, shippingRuleAddOn))
-                .shippingPreferenceType(Reward.ShippingPreference.RESTRICTED)
-                .build()
-        val listAddons = listOf(addOn, addOn, addOn)
         val config = ConfigFactory.configForUSUser()
         val currentConfig = MockCurrentConfig()
         currentConfig.config(config)
-        setUpEnvironment(buildEnvironmentWith(listAddons, ShippingRulesEnvelope.builder().shippingRules(listOf(shippingRuleRw)).build(), currentConfig))
 
-        buildEnvironmentWithError(currentConfig)
+        setUpEnvironment(buildEnvironmentWithError(currentConfig))
 
         val rw = RewardFactory.rewardHasAddOns().toBuilder()
-                .shippingType(Reward.ShippingPreference.RESTRICTED.name.toLowerCase())
-                .shippingRules(listOf(shippingRuleRw))
-                .shippingPreferenceType(Reward.ShippingPreference.RESTRICTED)
-                .shippingPreference(Reward.ShippingPreference.RESTRICTED.name.toLowerCase())
                 .build()
 
         val project = ProjectFactory.project().toBuilder().rewards(listOf(rw)).build()
@@ -765,7 +753,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
         this.vm.arguments(bundle)
 
-        this.vm.showErrorDialog().subscribe{ TestCase.assertTrue(it ) }
+        // Two values -> two failed network calls
+        this.showErrorDialog.assertValues(true, true)
     }
 
     private fun buildEnvironmentWithError(currentConfig: MockCurrentConfig): Environment {

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -765,7 +765,7 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
         this.vm.arguments(bundle)
 
-        this.showErrorDialog.assertValue(true)
+        this.vm.showErrorDialog().subscribe{ TestCase.assertTrue(it ) }
     }
 
     private fun buildEnvironmentWithError(currentConfig: MockCurrentConfig): Environment {

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -322,7 +322,7 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         val currentConfig = MockCurrentConfig()
         currentConfig.config(config)
 
-        setUpEnvironment(buildEnvironmentWith(listAddons, currentConfig))
+        setUpEnvironment(buildEnvironmentWith(listAddons, ShippingRulesEnvelopeFactory.emptyShippingRules(), currentConfig))
 
         // - Digital Reward
         val rw = RewardFactory.rewardHasAddOns().toBuilder()


### PR DESCRIPTION
# 📲 What

Show an error alert dialog when there is an error retrieving the add-ons. Also allow user to tap retry to resend the networks calls to get the add-ons. 

# 🤔 Why

To give user more context on why add-ons are not loading correctly. 

# 🛠 How

Created a new stream that triggers the dialog when the network response is an error. Retry button resends the project data and reason to make a network call.

# 👀 See

![Screenshot_1600286472](https://user-images.githubusercontent.com/19390326/93387559-6f27f200-f837-11ea-8a9e-01cbe89fe0a6.png)

# 📋 QA

- Search for the project "one inch straw"
- Select "back project"
- Turn off wifi or put phone in airplane mode
- Select a pledge with add-ons
- Wait to see the error dialog
- Turn on wifi or turn off airplane mode
- Press "retry"
- After network call finishes, should show add-ons

# Story 📖

[NT-1442](https://kickstarter.atlassian.net/secure/RapidBoard.jspa?rapidView=9&projectKey=NT&modal=detail&selectedIssue=NT-1442&assignee=5efe5a70e0043f0bacaf7706&assignee=5eda9c57222d4d0b8296577e)
