### PR TITLE
NT-1516: Update the Bonus Support Base Amount

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
@@ -202,14 +202,16 @@ public final class RewardUtils {
   }
 
   /**
-   * Returns the amount value for each variant, being Control the original value
+   * Returns the amount value for each variant, being Control the original value, and the minimum
+   * the minPledge defined by country
    *
    * @param variant the variant for which you want to get the value
    * @param reward in case no known variant as save return use the current reward.minimum amount
+   * @param minPledge defined by country
    *
    * @return Double with the amount
    */
-  public static Double rewardAmountByVariant(final OptimizelyExperiment.Variant variant, final Reward reward) {
+  public static Double rewardAmountByVariant(final OptimizelyExperiment.Variant variant, final Reward reward, final Integer minPledge) {
     Double value = reward.minimum();
 
     if (isNoReward(reward)) {
@@ -229,6 +231,6 @@ public final class RewardUtils {
       }
     }
 
-    return value;
+    return value < minPledge ? minPledge : value;
   }
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
@@ -315,6 +315,7 @@ public final class RewardUtilsTest extends KSRobolectricTestCase {
     assertEquals(20.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_3, noReward, 1));
     assertEquals(50.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward, 1));
     assertEquals(10.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, noReward, 10));
+    assertEquals(100.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward, 100));
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
@@ -310,10 +310,11 @@ public final class RewardUtilsTest extends KSRobolectricTestCase {
   @Test
   public void minimumRewardAmountByVariant() {
     final Reward noReward = RewardFactory.noReward();
-    assertEquals(1.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, noReward));
-    assertEquals(10.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_2, noReward));
-    assertEquals(20.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_3, noReward));
-    assertEquals(50.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward));
+    assertEquals(1.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, noReward, 1));
+    assertEquals(10.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_2, noReward, 1));
+    assertEquals(20.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_3, noReward, 1));
+    assertEquals(50.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward, 1));
+    assertEquals(10.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, noReward, 10));
   }
 
   @Test


### PR DESCRIPTION
# 📲 What

- The minimum pledge allowed is specified by country, but when we added the RewardMinimum experiment we specified for the Control variant the amount "1". Changing involuntarily for some countries like Mexico (with minPledge 10MX ) the NoReward amount when control variant active to 1MX.
- Previously the stepper increased amount was the minPledge, now is always increased by 1.

# 🤔 Why

If control variant active the No Reward pledge amount was incorrect for some countries with minimum pledge higher than the control variant (IE: Mexico or japan with minPledges 10MX, and 100¥)

# 🛠 How

- When the stepper button is pressed just update by 1 the amount
- In RewardUtils if the amount active in the experiment is lower than the minimumPledge, use the minPledge value.

# 👀 See
- Mexico 
![min_pledge_and_stepper](https://user-images.githubusercontent.com/4083656/93824062-b1767800-fc17-11ea-8126-a226ffbe3656.gif)

- Japan
![japan_min](https://user-images.githubusercontent.com/4083656/93824088-b9361c80-fc17-11ea-9a61-54af6824caf8.gif)


|  |  |

# 📋 QA

- Pledge to a Mexican or japanese project, with a No Reward reward, make sure the amount we show in the pledgeInput is 10Mx or 100¥
- make sure the stepper increase the amount by 1.

# Story 📖

[Update the Bonus Support Base Amount](https://kickstarter.atlassian.net/browse/NT-1516)
