### PR TITLE
Backing Add Ons Alert Dialog Cleanup

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -172,9 +172,9 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
             errorDialog = AlertDialog.Builder(context, R.style.AlertDialog)
                     .setCancelable(false)
                     .setTitle(getString(R.string.Something_went_wrong_please_try_again))
-                    .setPositiveButton("                     ${getString(R.string.Retry)}") { _, _ ->
+                    .setPositiveButton(getString(R.string.Retry)) { _, _ ->
                         this.viewModel.inputs.retryButtonPressed() }
-                    .setNegativeButton("                     ${getString(R.string.close_alert)}") { _, _ -> dismissErrorDialog()}
+                    .setNegativeButton(getString(R.string.close_alert)) { _, _ -> dismissErrorDialog()}
                     .create()
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -87,8 +87,8 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Rewa
                     .setCancelable(false)
                     .setTitle(getString(R.string.Continue_with_this_reward))
                     .setMessage(getString(R.string.It_may_not_offer_some_or_all_of_your_add_ons))
-                    .setNegativeButton("             ${getString(R.string.No_go_back)}") { _, _ -> {} }
-                    .setPositiveButton("             ${getString(R.string.Yes_continue)}") { _, _ ->
+                    .setNegativeButton(getString(R.string.No_go_back)) { _, _ -> {} }
+                    .setPositiveButton(getString(R.string.Yes_continue)) { _, _ ->
                         this.viewModel.inputs.alertButtonPressed()
                     }.create()
         }


### PR DESCRIPTION
# 📲 What

Remove stacking from alert dialog buttons. Buttons should appear side by side. 

# 🤔 Why

Removing whitespace from alert dialog button text to avoid distortion on certain devices caused by screensize. 

# 👀 See

![Screenshot_1600789716](https://user-images.githubusercontent.com/19390326/93907696-ab41d380-fccb-11ea-9ff5-754326ea6d48.png) ![Screenshot_1600790064](https://user-images.githubusercontent.com/19390326/93907698-ab41d380-fccb-11ea-84b6-12a3658b450e.png)

# 📋 QA

For error alert dialog:
- Search for the project "fadoodle"
- Select "back project"
- Turn off wifi or put phone in airplane mode
- Select a pledge with add-ons
- Wait to see the error dialog

For rewards alert dialog:
- Search for the project "fadoodle"
- Select "back project"
- Select a pledge with add-ons
- Pledge to project
- Go to manage project
- Select "change reward"
- Select reward with no add-ons
- View alert dialog