### PR TITLE
NT-1534: Sold-out add-ons

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -51,6 +51,7 @@ fragment reward on Reward {
     backersCount
     description
     estimatedDeliveryOn
+    available
     items {
         edges {
             quantity

--- a/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.java
@@ -16,6 +16,7 @@ public final class RewardFactory {
   public static @NonNull Reward addOn() {
     return reward().toBuilder()
             .isAddOn(true)
+            .isAvailable(true)
             .limit(10)
             .build();
   }

--- a/app/src/main/java/com/kickstarter/models/Reward.java
+++ b/app/src/main/java/com/kickstarter/models/Reward.java
@@ -10,7 +10,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.List;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringDef;
 import auto.parcel.AutoParcel;

--- a/app/src/main/java/com/kickstarter/models/Reward.java
+++ b/app/src/main/java/com/kickstarter/models/Reward.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.List;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringDef;
 import auto.parcel.AutoParcel;
@@ -37,6 +38,16 @@ public abstract class Reward implements Parcelable, Relay {
   public abstract @Nullable List<RewardsItem> addOnsItems();
   public abstract @Nullable Integer quantity();
   public abstract @Nullable boolean hasAddons();
+
+  /**
+   * This field will be available just for GraphQL, in V1 it would be null
+   * A Reward is available when:
+   * - Limit has not been reached
+   * - ExpireData has not been reached
+   *
+   * @return true is the Reward is available
+   */
+  public abstract @Nullable boolean isAvailable();
 
   /**
    * this field will be available just for GraphQL, in V1 it would be empty
@@ -70,6 +81,7 @@ public abstract class Reward implements Parcelable, Relay {
     public abstract Builder hasAddons(boolean __);
     public abstract Builder shippingRules(List<ShippingRule> __);
     public abstract Builder shippingPreferenceType(ShippingPreference __);
+    public abstract Builder isAvailable(boolean __);
     public abstract Reward build();
   }
 

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -709,6 +709,7 @@ private fun rewardTransformer(rewardGr: fragment.Reward): Reward {
     val remaining = rewardGr.remainingQuantity()
     val endsAt = rewardGr.endsAt()?.let { DateTime(it) } ?: null
     val rewardId = decodeRelayId(rewardGr.id()) ?: -1
+    val available = rewardGr.available()
 
     val shippingPreference = when (rewardGr.shippingPreference()) {
         ShippingPreference.NONE -> Reward.ShippingPreference.NONE
@@ -741,6 +742,7 @@ private fun rewardTransformer(rewardGr: fragment.Reward): Reward {
             .shippingPreferenceType(shippingPreference)
             .shippingType(shippingPreference.name)
             .shippingRules(shippingRules)
+            .isAvailable(available)
             .build()
 }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -208,6 +208,9 @@ class BackingAddOnsFragmentViewModel {
                     }
                     .switchMap { it }
                     .filter { ObjectUtils.isNotNull(it) }
+                    .map { listAddOns ->
+                        listAddOns.filter{ it.isAvailable }
+                    }
                     .subscribe(addOnsFromGraph)
 
             val filteredAddOns = Observable.combineLatest(addonsList, projectData, this.shippingRuleSelected, reward, this.totalSelectedAddOns) { list, pData, rule, rw,


### PR DESCRIPTION
# 📲 What

- update reward graphql-fragment to fetch the "available" field from GraphQL
- updated Reward model and builder to support the "available" field
- when getting addOns from graph filterOut the ones unavailable
- updated RewardFactory addOn object to always available
- new test for unavailable filteredOut addOns

# 🤔 Why

- Previously we where always fetching and offering all addOns for a project, now we just offer the available ones

# 👀 See

- In the before gif we offer 6 addOns
- In the filtered gif we offer 5 addOns (one of the 6 addOns is unavailable) 
![Screen Shot 2020-09-22 at 1 21 51 PM](https://user-images.githubusercontent.com/4083656/93933495-9d458000-fcd6-11ea-9394-69acc31410a0.png)


| Before 🐛 |
![previous](https://user-images.githubusercontent.com/4083656/93933302-4c358c00-fcd6-11ea-984b-0e5a3d66decd.gif)
| After 🦋 |
![filtered](https://user-images.githubusercontent.com/4083656/93933339-5ce60200-fcd6-11ea-8b59-0f51e63dc1cf.gif)

|  |  |

# 📋 QA

- Go to the project https://staging.kickstarter.com/projects/microcosmpublishing/how-to-be-accountable-take-responsibility-change-behavior?ref=checkout_rewards_page
- Select one of the shipping worldwide rewards
- Change your location to United States in case is not that one
- You should see just 5 AddOns, before you should see 6 AddOns

# Story 📖

[Sold-out add-ons](https://kickstarter.atlassian.net/browse/NT-1534)
