### PR TITLE
NT-1518 | NT-1519 - Fix Firebase Crashlytics Crashes

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -152,8 +152,12 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
                 .subscribe {
-                    pledge_amount.setText(it)
-                    pledge_amount.setSelection(it.length)
+                    var string = it
+                    if (string.length >= 13) {
+                        string = string.substring(0, 12)
+                    }
+                    pledge_amount.setText(string)
+                    pledge_amount.setSelection(string.length)
                 }
 
         this.viewModel.outputs.pledgeHint()

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -152,12 +152,10 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
                 .subscribe {
-                    var string = it
-                    if (string.length >= 13) {
-                        string = string.substring(0, 12)
-                    }
-                    pledge_amount.setText(string)
-                    pledge_amount.setSelection(string.length)
+                    val maxLength = resources.getInteger(R.integer.max_length)
+                    val stringAmount = if (it.length >= maxLength) it.substring(0, maxLength -1) else it
+                    pledge_amount.setText(stringAmount)
+                    pledge_amount.setSelection(stringAmount.length)
                 }
 
         this.viewModel.outputs.pledgeHint()

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -181,6 +181,7 @@ interface BackingFragmentViewModel {
 
             backing
                     .map { it.backerName() }
+                    .filter { ObjectUtils.isNotNull(it) }
                     .compose(bindToLifecycle())
                     .subscribe(this.backerName)
 

--- a/app/src/main/res/layout/fragment_pledge_section_pledge_amount.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_pledge_amount.xml
@@ -129,7 +129,7 @@
       android:imeOptions="actionDone"
       android:importantForAutofill="no"
       android:inputType="numberDecimal"
-      android:maxLength="13"
+      android:maxLength="@integer/max_length"
       tools:ignore="LabelFor"
       tools:targetApi="o"
       tools:text="20" />

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item type="integer" name="max_length">13</item>
+</resources>


### PR DESCRIPTION
# 📲 What

After reviewing the crash reports from the latest releases we found 2 crashes that should be fixed in the next release.

# 🤔 Why

Native is targeting a 99% crash free score for each release and to hit that we need to manage and fix crashes when we release a new version of the app.

# 🛠 How

1. [BackingFragment line 56](https://console.firebase.google.com/u/0/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/e752de039a17ee3800f737f3ba536282?time=last-seven-days&sessionId=5F6A1F9E015E000170AEB3D9D6D07138_DNE_0_v2) - "backer_name" must not be null

Reproducing this issue was difficult, to prevent the backer_name from returning null, I added a check to filter out null before updating the UI

2. [PledgeFragment line 156](https://console.firebase.google.com/u/0/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/85609de14797f08bd51f7c23e13d849e?time=last-seven-days&sessionId=5F6A5E80035100016A0FA42E23328217_DNE_0_v2) - "Caused by java.lang.IndexOutOfBoundsException: setSpan (19 ... 19) ends beyond length 13"

For this particular TextView, there is a max length of 13 and if a string is set that is larger than 13 the app crashes. The fix is to truncate the length of the string so that the max string length is 13

# Story 📖

[NT-1518](https://kickstarter.atlassian.net/browse/NT-1518)
[NT-1519](https://kickstarter.atlassian.net/browse/NT-1519)
