### PR TITLE
Android NT-1442: Hide shipping selector on network error

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -8,6 +8,7 @@ import com.kickstarter.libs.KSString
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
 import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
 import com.kickstarter.libs.utils.ObjectUtils
+import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.RewardUtils.isDigital
 import com.kickstarter.libs.utils.RewardUtils.isShippable
 import com.kickstarter.mock.factories.ShippingRuleFactory
@@ -218,7 +219,6 @@ class BackingAddOnsFragmentViewModel {
                     .filter { ObjectUtils.isNotNull(it) }
                     .subscribe {
                         addOnsFromGraph.onNext(it)
-                        this.shippingSelectorIsGone.onNext(false)
                     }
 
             val filteredAddOns = Observable.combineLatest(addonsList, projectData, this.shippingRuleSelected, reward, this.totalSelectedAddOns) { list, pData, rule, rw,

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -218,10 +218,9 @@ class BackingAddOnsFragmentViewModel {
                     .switchMap { it }
                     .filter { ObjectUtils.isNotNull(it) }
                     .map { listAddOns ->
-                        listAddOns.filter { it.isAvailable }
+                        listAddOns.filter{ it.isAvailable }
                     }
                     .subscribe(addOnsFromGraph)
-
 
             val filteredAddOns = Observable.combineLatest(addonsList, projectData, this.shippingRuleSelected, reward, this.totalSelectedAddOns) { list, pData, rule, rw,
                                                                                                                                                   _ ->

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -217,9 +217,11 @@ class BackingAddOnsFragmentViewModel {
                     }
                     .switchMap { it }
                     .filter { ObjectUtils.isNotNull(it) }
-                    .subscribe {
-                        addOnsFromGraph.onNext(it)
+                    .map { listAddOns ->
+                        listAddOns.filter { it.isAvailable }
                     }
+                    .subscribe(addOnsFromGraph)
+
 
             val filteredAddOns = Observable.combineLatest(addonsList, projectData, this.shippingRuleSelected, reward, this.totalSelectedAddOns) { list, pData, rule, rw,
                                                                                                                                                   _ ->

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -696,7 +696,7 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun emptyState_whenMatchingShippingRule_ShouldNotShowEmptyState() {
+    fun emptyState_whenMatchingShippingRule_shouldNotShowEmptyState() {
         val shippingRuleAddOn = ShippingRuleFactory.usShippingRule()
         val shippingRuleRw = ShippingRuleFactory.usShippingRule()
         val addOn = RewardFactory.addOn().toBuilder()
@@ -734,7 +734,7 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun errorState_whenErrorReturned_shouldShowErrorAlertDialog() {
+    fun errorState_whenErrorReturned_shouldShowErrorAlertDialogAndHideShippingSelector() {
         val config = ConfigFactory.configForUSUser()
         val currentConfig = MockCurrentConfig()
         currentConfig.config(config)
@@ -755,42 +755,7 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
 
         // Two values -> two failed network calls
         this.showErrorDialog.assertValues(true, true)
-    }
-
-    fun addOnsList_whenUnavailable_FilteredOut() {
-        val shippingRule = ShippingRulesEnvelopeFactory.shippingRules()
-        val addOn = RewardFactory.addOn().toBuilder()
-                .shippingRules(shippingRule.shippingRules())
-                .shippingPreferenceType(Reward.ShippingPreference.UNRESTRICTED) // - Reward from GraphQL use this field
-                .build()
-
-        val addOns2 = addOn.toBuilder().isAvailable(false).build()
-        val listAddons = listOf(addOn, addOns2, addOn)
-
-        val config = ConfigFactory.configForUSUser()
-        val currentConfig = MockCurrentConfig()
-        currentConfig.config(config)
-
-        setUpEnvironment(buildEnvironmentWith(listAddons, shippingRule, currentConfig))
-
-        val rw = RewardFactory.rewardHasAddOns().toBuilder()
-                .shippingType(Reward.ShippingPreference.UNRESTRICTED.name.toLowerCase())
-                .shippingRules(shippingRule.shippingRules())
-                .shippingPreferenceType(Reward.ShippingPreference.UNRESTRICTED) // - Reward from GraphQL use this field
-                .shippingPreference(Reward.ShippingPreference.UNRESTRICTED.name.toLowerCase()) // - Reward from V1 use this field
-                .build()
-
-        val project = ProjectFactory.project().toBuilder().rewards(listOf(rw)).build()
-        val projectData = ProjectDataFactory.project(project, null, null)
-        val pledgeReason = PledgeFlowContext.forPledgeReason(PledgeReason.PLEDGE)
-
-        val bundle = Bundle()
-        bundle.putParcelable(ArgumentsKey.PLEDGE_PLEDGE_DATA, PledgeData.with(pledgeReason, projectData, rw))
-        bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
-        this.vm.arguments(bundle)
-
-        val filteredList = listOf(addOn, addOn)
-        this.addOnsList.assertValue(Triple(projectData,filteredList, shippingRule.shippingRules().first()))
+        this.shippingSelectorIsGone.assertValues(true, true, true)
     }
 
     private fun buildEnvironmentWithError(currentConfig: MockCurrentConfig): Environment {

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -758,6 +758,42 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSelectorIsGone.assertValues(true, true, true)
     }
 
+    fun addOnsList_whenUnavailable_FilteredOut() {
+        val shippingRule = ShippingRulesEnvelopeFactory.shippingRules()
+        val addOn = RewardFactory.addOn().toBuilder()
+                .shippingRules(shippingRule.shippingRules())
+                .shippingPreferenceType(Reward.ShippingPreference.UNRESTRICTED) // - Reward from GraphQL use this field
+                .build()
+
+        val addOns2 = addOn.toBuilder().isAvailable(false).build()
+        val listAddons = listOf(addOn, addOns2, addOn)
+
+        val config = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfig()
+        currentConfig.config(config)
+
+        setUpEnvironment(buildEnvironmentWith(listAddons, shippingRule, currentConfig))
+
+        val rw = RewardFactory.rewardHasAddOns().toBuilder()
+                .shippingType(Reward.ShippingPreference.UNRESTRICTED.name.toLowerCase())
+                .shippingRules(shippingRule.shippingRules())
+                .shippingPreferenceType(Reward.ShippingPreference.UNRESTRICTED) // - Reward from GraphQL use this field
+                .shippingPreference(Reward.ShippingPreference.UNRESTRICTED.name.toLowerCase()) // - Reward from V1 use this field
+                .build()
+
+        val project = ProjectFactory.project().toBuilder().rewards(listOf(rw)).build()
+        val projectData = ProjectDataFactory.project(project, null, null)
+        val pledgeReason = PledgeFlowContext.forPledgeReason(PledgeReason.PLEDGE)
+
+        val bundle = Bundle()
+        bundle.putParcelable(ArgumentsKey.PLEDGE_PLEDGE_DATA, PledgeData.with(pledgeReason, projectData, rw))
+        bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
+        this.vm.arguments(bundle)
+
+        val filteredList = listOf(addOn, addOn)
+        this.addOnsList.assertValue(Triple(projectData,filteredList, shippingRule.shippingRules().first()))
+    }
+
     private fun buildEnvironmentWithError(currentConfig: MockCurrentConfig): Environment {
 
         return environment()

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -376,7 +376,7 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
         this.vm.arguments(bundle)
 
-        this.shippingSelectorIsGone.assertValues(true)
+        this.shippingSelectorIsGone.assertValues(false, true)
 
         this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
@@ -411,7 +411,7 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.PLEDGE)
         this.vm.arguments(bundle)
 
-        this.shippingSelectorIsGone.assertValues(true)
+        this.shippingSelectorIsGone.assertValues(false, true)
 
         this.lakeTest.assertValue("Add-Ons Page Viewed")
     }


### PR DESCRIPTION
# 📲 What

We want to hide the shipping selector when there is a network call error to fetch addons, and only show when addons are fetched correctly. 

# 🛠 How

Update `shippingSelectorGone` stream when there is a network error. 

# 👀 See

![shippingSelectorGone](https://user-images.githubusercontent.com/19390326/94033645-2c15d380-fd8f-11ea-8079-84233535ecd8.gif)

# 📋 QA

For error alert dialog:

- Search for the project "fadoodle"
- Select "back project"
- Turn off wifi or put phone in airplane mode
- Select a pledge with add-ons
- Upon error dialog popping up, location selector should disappear
- Before tapping "retry", turn wifi on or take phone off airplane mode
- Press "retry"
- Network call should be successful and location selector should reappear

# Story 📖

[Android Display an error state if add-ons fail to load
](https://kickstarter.atlassian.net/browse/NT-1442)
