### PR TITLE
[NT-1453] Bonus Support Max Pledge String Fix

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -881,7 +881,8 @@ interface PledgeFragmentViewModel {
 
             val pledgeMaximum = currencyMaximum
                     .compose<Pair<Double, Double>>(combineLatestPair(selectedPledgeAmount))
-                    .map { it.first - it.second }
+                    .compose<Pair<Pair<Double, Double>, Reward>>(combineLatestPair(this.selectedReward))
+                    .map { if (RewardUtils.isNoReward(it.second)) it.first.first else it.first.first - it.first.second }
 
             val pledgeMaximumIsGone = currencyMaximum
                     .compose<Pair<Double, Double>>(combineLatestPair(total))

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -883,9 +883,9 @@ interface PledgeFragmentViewModel {
                     .compose<Pair<Double, Double>>(combineLatestPair(selectedPledgeAmount))
                     .map { it.first - it.second }
 
-            val pledgeMaximumIsGone = pledgeMaximum
+            val pledgeMaximumIsGone = currencyMaximum
                     .compose<Pair<Double, Double>>(combineLatestPair(total))
-                    .map { it.first > it.second }
+                    .map { it.first >= it.second }
                     .distinctUntilChanged()
 
             pledgeMaximumIsGone
@@ -896,8 +896,6 @@ interface PledgeFragmentViewModel {
                     }
 
             pledgeMaximum
-                    .compose<Pair<Double, Boolean>>(combineLatestPair(pledgeMaximumIsGone))
-                    .map { it.first }
                     .distinctUntilChanged()
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
                     .map { this.ksCurrency.format(it.first, it.second, RoundingMode.HALF_UP) }


### PR DESCRIPTION
# 📲 What

Fixed an issue where the maximum pledge amount is showing for the incorrect value of the max pledge.

# 🤔 Why

When the user adds bonus support, the max amount should be the following:
X = [max pledge amount] – [base reward + base reward shipping + addons + addons shipping]

# 🛠 How

The stream that determines if the bonus support amount error string should show is based off of the PledgeMaximum instead of the CurrencyMaximum.

# 📋 QA

- Navigate to any project and select a non digital reward and enter the correct bonus support. The Total can equal 10,000 for USD projects but to never exceed that amount

# Story 📖

[NT-1453](https://kickstarter.atlassian.net/browse/NT-1453)
