### PR TITLE
NT-1542: Pledge Amount Missing from Manage Pledge

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -235,8 +235,15 @@ interface BackingFragmentViewModel {
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe {
-                        this.pledgeSummaryIsGone.onNext(it)
                         this.shippingSummaryIsGone.onNext(it)
+                    }
+
+            backing
+                    .map { ObjectUtils.isNull(it.reward()) }
+                    .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe {
+                        this.pledgeSummaryIsGone.onNext(it)
                     }
 
             Observable.combineLatest(backedProject, backing, environment.currentUser().loggedInUser()) { p, b, user -> Triple(p, b, user) }

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -671,10 +671,10 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeSummaryIsGone_whenLocationId_isNull() {
+    fun testPledgeSummaryIsGone_whenReward_isNull() {
         val backing = BackingFactory.backing()
                 .toBuilder()
-                .locationId(null)
+                .reward(null)
                 .build()
 
 
@@ -689,10 +689,10 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPledgeSummaryIsGone_whenLocationId_isNotNull() {
+    fun testPledgeSummaryIsGone_whenReward_isNotNull() {
         val backing = BackingFactory.backing()
                 .toBuilder()
-                .locationId(4L)
+                .reward(RewardFactory.rewardWithShipping())
                 .build()
 
         val environment = environment()


### PR DESCRIPTION
# 📲 What

In the manage pledge view, the pledge line item does not show up when the user backs for a digital reward.

# 🤔 Why

The user should be able to see what their pledged amount is and how that value is separate from the total value and the bonus support.

# 🛠 How

The logic to determine if the pledge line should be visible is no longer based on the location id but on if the reward on the backing object is null.

# 📋 QA

View a project that has a digital reward and back it. Navigate to the manage pledge view to verify the pledge line item.

# Story 📖

[NT-1542](https://kickstarter.atlassian.net/browse/NT-1542)
