### PR TITLE
NT-1497: Preserve Bonus Support when Editing a Reward with Add-ons

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -446,9 +446,9 @@ interface PledgeFragmentViewModel {
             val backing = projectData
                     .compose<Pair<ProjectData, PledgeReason>>(combineLatestPair(pledgeReason))
                     .filter { it.second != PledgeReason.PLEDGE }
-                    .map { it.first }
-                    .filter { ObjectUtils.isNotNull(it.backing()) }
-                    .map { requireNotNull(it.backing()) }
+                    .map { it.first.backing() ?: it.first.project().backing() }
+                    .filter { ObjectUtils.isNotNull(it) }
+                    .map { requireNotNull(it) }
 
             backing
                     .map { it.locationId() == null }


### PR DESCRIPTION
# 📲 What

Updated the PledgeFragment to check the backing object on the main PledgeData as well as the project object. 

# 🤔 Why

As a user, I may only want to change a portion of the backing and resetting the bonus support is an action that the user might not expect.

# 🛠 How

In the PledgeFragment view, the bonus amount is only checked on the top backing object where in some cases that is null, in those instances we check the project's backing model for the bonus support.

# 📋 QA

- Back a project with add-ons and add a bonus amount.
- Then manage that reward
- Select "choose another reward"
- Select the same reward and update the number of add-ons
- Continue and verify that the original bonus support is present before re-pledging

# Story 📖

[NT-1497](https://kickstarter.atlassian.net/browse/NT-1497)
