### PR TITLE
NT-1539: Unprompted Edit Rewards Alert

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -56,7 +56,7 @@ class RewardsFragmentViewModel {
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<RewardsFragment>(environment), Inputs, Outputs {
 
         private val projectDataInput = PublishSubject.create<ProjectData>()
-        private var rewardClicked = PublishSubject.create<Pair<Reward, Boolean>>()
+        private val rewardClicked = BehaviorSubject.create<Pair<Reward, Boolean>>()
         private val alertButtonPressed = PublishSubject.create<Void>()
 
         private val backedRewardPosition = PublishSubject.create<Int>()

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -5,7 +5,6 @@ import androidx.annotation.NonNull
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.FragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
-import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
 import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
 import com.kickstarter.libs.utils.BackingUtils
 import com.kickstarter.libs.utils.ObjectUtils
@@ -57,7 +56,7 @@ class RewardsFragmentViewModel {
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<RewardsFragment>(environment), Inputs, Outputs {
 
         private val projectDataInput = PublishSubject.create<ProjectData>()
-        private val rewardClicked = PublishSubject.create<Reward>()
+        private var rewardClicked = PublishSubject.create<Pair<Reward, Boolean>>()
         private val alertButtonPressed = PublishSubject.create<Void>()
 
         private val backedRewardPosition = PublishSubject.create<Int>()
@@ -79,11 +78,6 @@ class RewardsFragmentViewModel {
             val project = this.projectDataInput
                     .map { it.project() }
 
-            val backedReward = project
-                    .map { it.backing()?.let { backing -> getReward(backing) } }
-                    .filter { ObjectUtils.isNotNull(it) }
-                    .map { requireNotNull(it) }
-
             project
                     .filter { it.isBacking }
                     .map { indexOfBackedReward(it) }
@@ -92,8 +86,8 @@ class RewardsFragmentViewModel {
                     .subscribe(this.backedRewardPosition)
 
             val pledgeDataAndReason = this.projectDataInput
-                    .compose<Pair<ProjectData, Reward>>(Transformers.takePairWhen(this.rewardClicked))
-                    .map { pledgeDataAndPledgeReason(it.first, it.second) }
+                    .compose<Pair<ProjectData, Pair<Reward, Boolean>>>(Transformers.takePairWhen(this.rewardClicked))
+                    .map { pledgeDataAndPledgeReason(it.first, it.second.first) }
                     .distinctUntilChanged()
 
             pledgeDataAndReason
@@ -107,12 +101,45 @@ class RewardsFragmentViewModel {
                             this.showAddOnsFragment.onNext(it)
                         else
                             this.showPledgeFragment.onNext(it)
-
                     }
 
-            pledgeDataAndReason
-                    .compose<Pair<PledgeData, PledgeReason>>(takeWhen(this.rewardClicked))
-                    .compose<Pair<Pair<PledgeData, PledgeReason>, Reward>>(combineLatestPair(backedReward))
+            subscribeRewardClickedForUpdateReward()
+
+            project
+                    .map { it.rewards()?.size?: 0 }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.rewardsCount)
+
+            this.showAlert
+                    .compose<Pair<PledgeData, PledgeReason>>(takeWhen(alertButtonPressed))
+                    .compose(bindToLifecycle())
+                    .subscribe {
+                        if (it.first.reward().hasAddons())
+                            this.showAddOnsFragment.onNext(it)
+                        else this.showPledgeFragment.onNext(it)
+                    }
+        }
+
+        private fun subscribeRewardClickedForUpdateReward() {
+            val project = this.projectDataInput
+                    .map { it.project() }
+
+            val backedReward = project
+                    .map { it.backing()?.let { backing -> getReward(backing) } }
+                    .filter { ObjectUtils.isNotNull(it) }
+                    .map { requireNotNull(it) }
+
+            val defaultRewardClicked = Pair(Reward.builder().id(0).minimum(0.0).build(), false)
+            Observable
+                    .combineLatest(this.rewardClicked.startWith(defaultRewardClicked), this.projectDataInput, backedReward) { rewardPair, projectData, backedReward ->
+                        if (!rewardPair.second) {
+                            return@combineLatest null
+                        } else {
+                            return@combineLatest Pair(pledgeDataAndPledgeReason(projectData, rewardPair.first), backedReward)
+                        }
+                    }
+                    .filter { ObjectUtils.isNotNull(it) }
+                    .map { requireNotNull(it) }
                     .compose(bindToLifecycle())
                     .subscribe {
                         val pledgeAndData = it.first
@@ -138,21 +165,9 @@ class RewardsFragmentViewModel {
                                 }
                             }
                         }
+                        this.rewardClicked.onNext(defaultRewardClicked)
                     }
 
-            project
-                    .map { it.rewards()?.size?: 0 }
-                    .compose(bindToLifecycle())
-                    .subscribe(this.rewardsCount)
-
-            this.showAlert
-                    .compose<Pair<PledgeData, PledgeReason>>(takeWhen(alertButtonPressed))
-                    .compose(bindToLifecycle())
-                    .subscribe {
-                        if (it.first.reward().hasAddons())
-                            this.showAddOnsFragment.onNext(it)
-                        else this.showPledgeFragment.onNext(it)
-                    }
         }
 
         private fun getReward(backingObj: Backing): Reward {
@@ -192,7 +207,7 @@ class RewardsFragmentViewModel {
         }
 
         override fun rewardClicked(reward: Reward) {
-            this.rewardClicked.onNext(reward)
+            this.rewardClicked.onNext(Pair(reward, true))
         }
 
         override fun alertButtonPressed() = this.alertButtonPressed.onNext(null)


### PR DESCRIPTION
# 📲 What

Added a additional filter and check to prevent the alert from presenting when navigated away from the app.

# 🤔 Why

When the user updates their pledge, and decides to select another reward a modal pops up confirming that their selected add-ons might not be available if they switch. This alert also pops up when the user navigates to another app and comes back to the kickstarter app.

# 🛠 How

The project activity notifies the other sub fragments when the user resumes their session and this toggles an update to the reward clicked stream. If the user already prompted the modal before, this modal will come up again. The fix was to apply a filter on the reward clicked so that the alert only shows when it is prompted from a selection of the reward

# 📋 QA

See steps to reproduce in ticket

# Story 📖

[NT-1539](https://kickstarter.atlassian.net/browse/NT-1539)
