### PR TITLE
NT-1539: Unprompted Edit Rewards Alert

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -169,7 +169,7 @@ class BackingAddOnsFragmentViewModel {
 
             // - In case of digital Reward to follow the same flow as the rest of use cases use and empty shippingRule
             reward
-                    .filter { isDigital(it) || !isShippable(it)}
+                    .filter { isDigital(it) || !isShippable(it) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe {

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -56,7 +56,7 @@ class RewardsFragmentViewModel {
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<RewardsFragment>(environment), Inputs, Outputs {
 
         private val projectDataInput = PublishSubject.create<ProjectData>()
-        private var rewardClicked = PublishSubject.create<Pair<Reward, Boolean>>()
+        private val rewardClicked = BehaviorSubject.create<Pair<Reward, Boolean>>()
         private val alertButtonPressed = PublishSubject.create<Void>()
 
         private val backedRewardPosition = PublishSubject.create<Int>()

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -4,7 +4,6 @@ import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.FragmentViewModel
-import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
 import com.kickstarter.libs.utils.BackingUtils
 import com.kickstarter.libs.utils.ObjectUtils
@@ -56,7 +55,7 @@ class RewardsFragmentViewModel {
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<RewardsFragment>(environment), Inputs, Outputs {
 
         private val projectDataInput = PublishSubject.create<ProjectData>()
-        private val rewardClicked = BehaviorSubject.create<Pair<Reward, Boolean>>()
+        private val rewardClicked = PublishSubject.create<Pair<Reward, Boolean>>()
         private val alertButtonPressed = PublishSubject.create<Void>()
 
         private val backedRewardPosition = PublishSubject.create<Int>()
@@ -85,25 +84,7 @@ class RewardsFragmentViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.backedRewardPosition)
 
-            val pledgeDataAndReason = this.projectDataInput
-                    .compose<Pair<ProjectData, Pair<Reward, Boolean>>>(Transformers.takePairWhen(this.rewardClicked))
-                    .map { pledgeDataAndPledgeReason(it.first, it.second.first) }
-                    .distinctUntilChanged()
-
-            pledgeDataAndReason
-                    .filter { it.second == PledgeReason.PLEDGE}
-                    .compose<Pair<PledgeData, PledgeReason>>(takeWhen(this.rewardClicked))
-                    .compose(bindToLifecycle())
-                    .subscribe {
-                        val rw = it.first.reward()
-
-                        if (rw.hasAddons())
-                            this.showAddOnsFragment.onNext(it)
-                        else
-                            this.showPledgeFragment.onNext(it)
-                    }
-
-            subscribeRewardClickedForUpdateReward()
+            subscribeRewardClicked()
 
             project
                     .map { it.rewards()?.size?: 0 }
@@ -120,7 +101,7 @@ class RewardsFragmentViewModel {
                     }
         }
 
-        private fun subscribeRewardClickedForUpdateReward() {
+        private fun subscribeRewardClicked() {
             val project = this.projectDataInput
                     .map { it.project() }
 
@@ -130,6 +111,34 @@ class RewardsFragmentViewModel {
                     .map { requireNotNull(it) }
 
             val defaultRewardClicked = Pair(Reward.builder().id(0).minimum(0.0).build(), false)
+
+            Observable
+                    .combineLatest(this.rewardClicked.startWith(defaultRewardClicked), this.projectDataInput) { rewardPair, projectData ->
+                        if (!rewardPair.second) {
+                            return@combineLatest null
+                        } else {
+                            return@combineLatest pledgeDataAndPledgeReason(projectData, rewardPair.first)
+                        }
+                    }
+                    .filter { ObjectUtils.isNotNull(it) }
+                    .map { requireNotNull(it) }
+                    .compose(bindToLifecycle())
+                    .subscribe {
+                        val pledgeAndData = it
+                        val newRw = it.first.reward()
+                        val reason = it.second
+
+                        when(reason) {
+                            PledgeReason.PLEDGE -> {
+                                if (newRw.hasAddons())
+                                    this.showAddOnsFragment.onNext(pledgeAndData)
+                                else
+                                    this.showPledgeFragment.onNext(pledgeAndData)
+                            }
+                        }
+                        this.rewardClicked.onNext(defaultRewardClicked)
+                    }
+
             Observable
                     .combineLatest(this.rewardClicked.startWith(defaultRewardClicked), this.projectDataInput, backedReward) { rewardPair, projectData, backedReward ->
                         if (!rewardPair.second) {

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -84,27 +84,6 @@ class RewardsFragmentViewModel {
                     .compose(bindToLifecycle())
                     .subscribe(this.backedRewardPosition)
 
-            subscribeRewardClicked()
-
-            project
-                    .map { it.rewards()?.size?: 0 }
-                    .compose(bindToLifecycle())
-                    .subscribe(this.rewardsCount)
-
-            this.showAlert
-                    .compose<Pair<PledgeData, PledgeReason>>(takeWhen(alertButtonPressed))
-                    .compose(bindToLifecycle())
-                    .subscribe {
-                        if (it.first.reward().hasAddons())
-                            this.showAddOnsFragment.onNext(it)
-                        else this.showPledgeFragment.onNext(it)
-                    }
-        }
-
-        private fun subscribeRewardClicked() {
-            val project = this.projectDataInput
-                    .map { it.project() }
-
             val backedReward = project
                     .map { it.backing()?.let { backing -> getReward(backing) } }
                     .filter { ObjectUtils.isNotNull(it) }
@@ -177,6 +156,19 @@ class RewardsFragmentViewModel {
                         this.rewardClicked.onNext(defaultRewardClicked)
                     }
 
+            project
+                    .map { it.rewards()?.size?: 0 }
+                    .compose(bindToLifecycle())
+                    .subscribe(this.rewardsCount)
+
+            this.showAlert
+                    .compose<Pair<PledgeData, PledgeReason>>(takeWhen(alertButtonPressed))
+                    .compose(bindToLifecycle())
+                    .subscribe {
+                        if (it.first.reward().hasAddons())
+                            this.showAddOnsFragment.onNext(it)
+                        else this.showPledgeFragment.onNext(it)
+                    }
         }
 
         private fun getReward(backingObj: Backing): Reward {


### PR DESCRIPTION
# 📲 What

Added a additional filter and check to prevent the alert from presenting when navigated away from the app.

# 🤔 Why

When the user updates their pledge, and decides to select another reward a modal pops up confirming that their selected add-ons might not be available if they switch. This alert also pops up when the user navigates to another app and comes back to the kickstarter app.

# 🛠 How

The project activity notifies the other sub fragments when the user resumes their session and this toggles an update to the reward clicked stream. If the user already prompted the modal before, this modal will come up again. The fix was to apply a filter on the reward clicked so that the alert only shows when it is prompted from a selection of the reward

# 📋 QA

See steps to reproduce in ticket

# Story 📖

[NT-1539](https://kickstarter.atlassian.net/browse/NT-1539)