### PR TITLE
NT-1541: Updated Add-ons Quantity Not Updated

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -208,5 +208,6 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
     override fun onDetach() {
         super.onDetach()
         fragment_select_addons_recycler?.adapter = null
+        this.viewModel = null
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -355,7 +355,7 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>() {
 
     override fun onDetach() {
         super.onDetach()
-        reward_add_on_recycler.adapter = null
+        reward_add_on_recycler?.adapter = null
         this.viewModel = null
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -352,4 +352,10 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>() {
         reward_add_on_recycler.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
         reward_add_on_recycler.adapter = rewardsAndAddOnsAdapter
     }
+
+    override fun onDetach() {
+        super.onDetach()
+        reward_add_on_recycler.adapter = null
+        this.viewModel = null
+    }
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -589,6 +589,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         super.onDetach()
         cards_recycler?.adapter = null
         header_summary_list?.adapter = null
+        this.viewModel = null
     }
 
     override fun addNewCardButtonClicked() {

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -119,6 +119,7 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Rewa
     override fun onDetach() {
         super.onDetach()
         rewards_recycler?.adapter = null
+        this.viewModel = null
     }
 
     override fun rewardClicked(reward: Reward) {

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -95,7 +95,6 @@ class RewardsFragmentViewModel {
             val pledgeDataAndReason = this.projectDataInput
                     .compose<Pair<ProjectData, Reward>>(Transformers.takePairWhen(this.rewardClicked))
                     .map { pledgeDataAndPledgeReason(it.first, it.second) }
-                    .distinctUntilChanged()
 
             pledgeDataAndReason
                     .filter { it.second == PledgeReason.PLEDGE}


### PR DESCRIPTION
# 📲 What

- False negative when using .distinctUntilChanged()
- Clean up to avoid memory leaks in the fragments.

# 🛠 How
- Remove the distinctUntilChanged operator
- When onDetach is called remove the viewModel.

# 👀 See
![updatedQuantity](https://user-images.githubusercontent.com/4083656/94304067-bc851d00-ff23-11ea-9c7d-be41d6d5a38e.gif)

|  |  |

# 📋 QA

- Choose the same reward, update your addOns, choose the same reward again without leaving manage your pledge screen, make sure the addOns screen is reflecting your changes.

# Story 📖

[Updated Add-ons Quantity Not Updated](https://kickstarter.atlassian.net/browse/NT-1541)
