### PR TITLE
NT-1534: Android Sold-out add-ons fix

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
@@ -94,10 +94,10 @@ public final class ProjectFactory {
       .build();
   }
 
-  public static @NonNull Project backedProjectWithAddOnsLimitReached() {
+  public static @NonNull Project backedProjectWithRewardAndAddOnsLimitReached() {
     final Project project = project();
 
-    final Reward reward = RewardFactory.reward().toBuilder().hasAddons(true).build();
+    final Reward reward = RewardFactory.reward().toBuilder().hasAddons(true).limit(10).build();
     final Reward add1 = RewardFactory.addOn()
             .toBuilder()
             .remaining(0)

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -288,23 +288,19 @@ class BackingAddOnsFragmentViewModel {
                     addOn.quantity()?.let { it > 0 } ?: false
                 }
 
-                val updatedPledgeData = when (finalList.isNotEmpty()) {
-                    isDigital(rw) -> {
-                        pledgeData.toBuilder()
-                                .addOns(finalList as java.util.List<Reward>)
+                val updatedPledgeData = if (finalList.isNotEmpty()) {
+                        if (isShippable(rw) && !isDigital(rw)) {
+                            pledgeData.toBuilder()
+                                    .addOns(finalList as java.util.List<Reward>)
+                                    .shippingRule(shippingRule)
+                                    .build()
+                        } else pledgeData.toBuilder()
                                 .build()
                     }
-                    isShippable(rw) -> {
-                        pledgeData.toBuilder()
-                                .addOns(finalList as java.util.List<Reward>)
-                                .shippingRule(shippingRule)
-                                .build()
-                    }
-                    else -> {
+                    else {
                         pledgeData.toBuilder()
                                 .build()
                     }
-                }
                 return@combineLatest Pair(updatedPledgeData, pledgeReason)
             }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -295,6 +295,7 @@ class BackingAddOnsFragmentViewModel {
                                     .shippingRule(shippingRule)
                                     .build()
                         } else pledgeData.toBuilder()
+                                .addOns(finalList as java.util.List<Reward>)
                                 .build()
                     }
                     else {

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -406,20 +406,16 @@ interface RewardViewHolderViewModel {
         /**
          * Use cases for enabling/disabling access to launch the next fragment
          * - If the selected reward has no addOns the CTA button will be enable if available
-         * - Enabled if the previously selected base reward has available add-ons
-         * - If the previously selected base reward has no available add-ons, the CTA button on the base reward would be disabled
+         * - If the previously selected reward has addOns but not BackedAddOns CTA button available is reward available
+         * - If the previously selected reward has add-ons and has Backed addOns, CTA button available (they still can update the addOns selection)
         */
         private fun shouldContinueFlow(project: Project, rw: Reward):Boolean {
             val hasAddOns = rw.hasAddons()
-            val hasUnavailableAddOn:Boolean = project.backing()?.addOns()?.firstOrNull {
-                !RewardUtils.isAvailable(project, it)
-            }?.let { true } ?: false
-            val isRwAvailable = RewardUtils.isAvailable(project, rw)
 
             return when {
                 isSelectable(project, rw) && !hasAddOns -> true
-                hasAddOns && isSelectable(project, rw) -> true
-                hasAddOns && hasBackedAddOns(project) && isRwAvailable && !hasUnavailableAddOn -> true
+                hasAddOns && !hasBackedAddOns(project) && RewardUtils.isAvailable(project, rw) -> true
+                hasAddOns && hasBackedAddOns(project) -> true
                 else -> false
             }
         }

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -219,14 +219,14 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testButtonDisabled_whenProjectIsLiveAndBacked_Unavailable_Add_Ons() {
+    fun testButtonEnabled_whenProjectIsLiveAndBacked_BackedAddOns() {
         setUpEnvironment(environment())
 
-        val backedLiveProject = ProjectFactory.backedProjectWithAddOnsLimitReached()
+        val backedLiveProject = ProjectFactory.backedProjectWithRewardAndAddOnsLimitReached()
         val rw = backedLiveProject.backing()?.reward()
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedLiveProject), requireNotNull(rw))
         this.buttonIsGone.assertValue(false)
-        this.buttonIsEnabled.assertValue(false)
+        this.buttonIsEnabled.assertValue(true)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- If you backed addOns, the Choose new reward let you ALWAYS edit that same reward to modify your addons selection, no matter the state of that reward.

# 🤔 Why
- You may have the reward unavailable and still be able to update your addOns selection because the are available (availability of addOns to offer is handled in the AddOns Screen)

# 🛠 How
- Modified pre-existing logic

# 👀 See
- No actual project to test with that I've found, but test covering that use case updated and passing.

|  |  |

# 📋 QA

- I haven't found a project to test with but follow this scenario: 
1 - Find a limited reward with just one reward left if possible and with addOns (pledge to the reward + addons)
2- Choose another reward flow -> 
BEFORE: Choosing same reward was impossible because that reward wasn't selectable (disabled button).
NOW: You can choose that same reward, and update the addOns selection 

# Story 📖

[Android Sold-out add-ons fix](https://kickstarter.atlassian.net/browse/NT-1534)
