### PR TITLE
NT-1442: 

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -174,7 +174,7 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
                     .setTitle(getString(R.string.Something_went_wrong_please_try_again))
                     .setPositiveButton(getString(R.string.Retry)) { _, _ ->
                         this.viewModel.inputs.retryButtonPressed() }
-                    .setNegativeButton(getString(R.string.close_alert)) { _, _ -> dismissErrorDialog()}
+                    .setNegativeButton(getString(R.string.general_navigation_buttons_close)) { _, _ -> dismissErrorDialog()}
                     .create()
         }
     }

--- a/app/src/main/res/values/strings_i18n.xml
+++ b/app/src/main/res/values/strings_i18n.xml
@@ -96,7 +96,6 @@ backers</string>
   <string name="Check_your_payment_details" formatted="false">Check your payment details</string>
   <string name="Choose_another_reward" formatted="false">Choose another reward</string>
   <string name="Chooses_location_for_shipping" formatted="false">Chooses %{location} for shipping.</string>
-  <string name="close_alert" formatted="false">Close</string>
   <string name="Close_live_stream" formatted="false">Close live stream</string>
   <string name="Close_project" formatted="false">Close project</string>
   <string name="Closes_filters" formatted="false">Closes filters.</string>


### PR DESCRIPTION
# 📲 What

Changing "Close" string on error dialog button to already existing string. 

# 🤔 Why
Avoid translations for a string that already exists.

# 📋 QA

Navigate to "Cook System by Wolf and Grizzly: Outdoor Cooking Re-imagined" in staging 
- Tap "Back this project"
- Put device into airplane mode
- Select "KS Special | Cookset" reward
- Error dialog should popup with correct copy. 

# Story 📖

[NT-1442](https://kickstarter.atlassian.net/secure/RapidBoard.jspa?rapidView=9&projectKey=NT&modal=detail&selectedIssue=NT-1442&assignee=5efe5a70e0043f0bacaf7706&assignee=5eda9c57222d4d0b8296577e)
