### PR TITLE
NT-1549: Edit Reward Flow

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -146,7 +146,14 @@ class BackingAddOnsFragmentViewModel {
                         this.currentSelection.clear()
                     }
 
-            val reward = Observable.merge(rewardPledge, backingReward)
+            val filteredBackingReward = backingReward
+                    .compose<Pair<Reward, Boolean>>(combineLatestPair(isSameReward))
+                    .filter { it.second }
+                    .filter { ObjectUtils.isNotNull(it) }
+                    .map { requireNotNull(it) }
+                    .map { it.first }
+
+            val reward = Observable.merge(rewardPledge, filteredBackingReward)
 
             projectAndReward = project
                     .compose<Pair<Project, Reward>>(combineLatestPair(reward))


### PR DESCRIPTION
# 📲 What

There is a `reward` stream that combines the selected reward, `rewardPledge` and the user's backing `backingReward`. If there is no backing the rewardPledge is used. In the case where the user updates their pledge with another reward, the  `backingReward` is not null and is used as the main reward even though the user selected another reward.

# 🤔 Why

The bug that was created happens when they change their reward from non digital to digital. When this happens rewards that are non digital are showing..

# 📋 QA

Steps to reproduce in the ticket

# Story 📖

[NT-1549](https://kickstarter.atlassian.net/browse/NT-1549)
