### PR TITLE
Max Pledge Fix

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -879,7 +879,7 @@ interface PledgeFragmentViewModel {
 
             val selectedPledgeAmount = Observable.merge(pledgeAmountHeader, threshold, variantSuggestedAmount)
 
-            val pledgeMaximum = currencyMaximum
+            val bonusSupportMaximum = currencyMaximum
                     .compose<Pair<Double, Double>>(combineLatestPair(selectedPledgeAmount))
                     .compose<Pair<Pair<Double, Double>, Reward>>(combineLatestPair(this.selectedReward))
                     .map { if (RewardUtils.isNoReward(it.second)) it.first.first else it.first.first - it.first.second }
@@ -896,7 +896,7 @@ interface PledgeFragmentViewModel {
                         this.pledgeMaximumIsGone.onNext(it)
                     }
 
-            pledgeMaximum
+            bonusSupportMaximum
                     .distinctUntilChanged()
                     .compose<Pair<Double, Project>>(combineLatestPair(project))
                     .map { this.ksCurrency.format(it.first, it.second, RoundingMode.HALF_UP) }
@@ -906,7 +906,7 @@ interface PledgeFragmentViewModel {
                     }
 
             val minAndMaxPledge = rewardMinimum
-                    .compose<Pair<Double, Double>>(combineLatestPair(pledgeMaximum))
+                    .compose<Pair<Double, Double>>(combineLatestPair(currencyMaximum))
 
             pledgeInput
                     .compose<Pair<Double, Pair<Double, Double>>>(combineLatestPair(minAndMaxPledge))
@@ -918,7 +918,7 @@ interface PledgeFragmentViewModel {
 
             val stepAndMaxPledge = stepAmount
                     .map { it.toDouble() }
-                    .compose<Pair<Double, Double>>(combineLatestPair(pledgeMaximum))
+                    .compose<Pair<Double, Double>>(combineLatestPair(currencyMaximum))
 
             pledgeInput
                     .compose<Pair<Double, Pair<Double, Double>>>(combineLatestPair(stepAndMaxPledge))


### PR DESCRIPTION
# 📲 What

When the user selects a reward that equals the max pledge for the currency, the validation logic for the bonus support prevents the user from pledging

# 🤔 Why

The user should be able to pledge a reward that is the maximum for the currency. No bonus support should be added.

# 🛠 How

The currency max is what is used to determine the max. A bonus support max stream is added to update the max error string for the bonus support

# 📋 QA

- Go to the "Picton Magazine" project
- Pledge for the maximum reward (8,500)
- Confirm pledge and ensure the user cannot pledge with bonus support.
