### PR TITLE
NT-1525: Update Backed Reward Copy

### DIFF
--- a/app/src/main/assets/json/server-config.json
+++ b/app/src/main/assets/json/server-config.json
@@ -157,6 +157,7 @@
       "Currency_MXN": "$ Mexican Peso (MXN)",
       "Currency_NOK": "kr Norwegian Krone (NOK)",
       "Currency_NZD": "$ New Zealand Dollar (NZD)",
+      "Currency_PLN": "zł Polish Złoty (PLN)",
       "Currency_SEK": "kr Swedish Krona (SEK)",
       "Currency_SGD": "$ Singapore Dollar (SGD)",
       "Currency_USD": "$ US Dollar (USD)",
@@ -803,6 +804,7 @@
       "Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged": "Your project didn’t reach its funding goal, so the backer’s payment method was never charged.",
       "Your_reward": "Your reward",
       "Your_reward_estimated_for_delivery_in_date": "<b>Your reward</b> estimated for delivery in %{delivery_date}",
+      "Your_selection": "Your selection",
       "Your_shipping_destination": "Your shipping destination",
       "Your_shipping_location": "Your shipping location",
       "Youre_a_backer": "You’re a backer!",
@@ -2493,7 +2495,7 @@
         "many": "Weiter mit %{quantity_count} Add-ons",
         "other": "Weiter mit %{quantity_count} Add-ons"
       },
-      "Continue_with_this_reward": "Continue with this reward?",
+      "Continue_with_this_reward": "Weiter mit dieser Belohnung?",
       "Couldnt_add_attachment": "Anhang konnte nicht hinzugefügt werden",
       "Couldnt_open_live_stream_Try_again_later": "Live-Stream konnte nicht geöffnet werden. Bitte versuche es später noch einmal.",
       "Couldnt_remove_attachment": "Anhang konnte nicht entfernt werden",
@@ -2522,6 +2524,7 @@
       "Currency_MXN": "$ Mexikanischer Peso (MXN)",
       "Currency_NOK": "kr Norwegische Krone (NOK)",
       "Currency_NZD": "$ Neuseeland-Dollar (NZD)",
+      "Currency_PLN": "zł Polnishcer Złoty (PLN)",
       "Currency_SEK": "kr Schwedische Krone (SEK)",
       "Currency_SGD": "$ Singapur-Dollar (SGD)",
       "Currency_USD": "$ US-Dollar (USD)",
@@ -2680,7 +2683,7 @@
       "Info": "Info",
       "Introduce_yourself": "Stelle dich vor",
       "Introducing_Lights_On": "Wir stellen vor: Lights On",
-      "It_may_not_offer_some_or_all_of_your_add_ons": "It may not offer some or all of your add-ons.",
+      "It_may_not_offer_some_or_all_of_your_add_ons": "Einige oder alle deiner Add-Ons werden dafür eventuell nicht angeboten.",
       "It_may_take_up_to_24_hours_to_collect_your_data": "Die Zusammenstellung deiner Daten kann bis zu 24 Stunden dauern. Sobald sie zum Download bereitstehen, werden wir dir eine Anleitung dazu per E-Mail schicken. Solltest du nichts von uns hören, versuche es von hier aus noch einmal.",
       "Its_a_way_to_bring_creative_projects_to_life": "Es ist eine Plattform, um kreative Projekte ins Leben zu rufen.",
       "Its_a_way_to_bring_creative_projects_to_life_Learn_more_about_accountability": "Es ist eine Plattform, um kreative Projekte zu verwirklichen. <a href=\"%{trust_link}\">Hier findest du mehr Info zur Rechenschaftspflicht</a>",
@@ -3168,6 +3171,7 @@
       "Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged": "Dein Projekt hat das Finanzierungsziel leider nicht erreicht. Daher wurde die Zahlungsmethode des Unterstützers nicht belastet.",
       "Your_reward": "Deine Belohnung",
       "Your_reward_estimated_for_delivery_in_date": "<b>Deine Belohnung</b> wird voraussichtlich im %{delivery_date} geliefert",
+      "Your_selection": "Deine Auswahl",
       "Your_shipping_destination": "Dein Versandziel",
       "Your_shipping_location": "Dein Versand-Standort",
       "Youre_a_backer": "Du unterstützt das Projekt!",
@@ -4728,16 +4732,7 @@
         "message": "Du scheinst eine sehr alte Version der App zu benutzen. Um fortzufahren, installiere bitte die neueste Version aus dem App Store.",
         "cancel": "Abbrechen",
         "upgrade": "Aktualisierung"
-      },
-      "Continue_with_quantity_add_ons": {
-        "zero": "Weiter mit %{quantity} Add-ons",
-        "one": "Weiter mit %{quantity} Add-on",
-        "two": "Weiter mit %{quantity} Add-ons",
-        "few": "Weiter mit %{quantity} Add-ons",
-        "many": "Weiter mit %{quantity} Add-ons",
-        "other": "Weiter mit %{quantity} Add-ons"
-      },
-      "Continue_with_this_reward_It_doesnt_offer_these_add_ons": "Weiter mit dieser Belohnung? Die folgenden Add-Ons werden dafür nicht angeboten:"
+      }
     },
     "es": {
       "A_little_extra_to_help": "Algo extra para ayudar a que este proyecto se pueda realizar.",
@@ -4867,7 +4862,7 @@
         "many": "Continuar con %{quantity_count} complementos",
         "other": "Continuar con %{quantity_count} complementos"
       },
-      "Continue_with_this_reward": "Continue with this reward?",
+      "Continue_with_this_reward": "¿Continuar con esta recompensa?",
       "Couldnt_add_attachment": "No se pudo añadir el anexo",
       "Couldnt_open_live_stream_Try_again_later": "No se pudo abrir este live stream, por favor inténtalo de nuevo más tarde.",
       "Couldnt_remove_attachment": "No se pudo remover el anexo",
@@ -4896,6 +4891,7 @@
       "Currency_MXN": "$ Peso mexicano (MXN)",
       "Currency_NOK": "kr Corona noruega (NOK)",
       "Currency_NZD": "$ Dólar de Nueva Zelanda (NZD)",
+      "Currency_PLN": "Złoty polaco - zł (PLN)",
       "Currency_SEK": "kr Corona sueca (SEK)",
       "Currency_SGD": "$ Dólar de Singapur (SGD)",
       "Currency_USD": "$ Dólar estadounidense (USD)",
@@ -5054,7 +5050,7 @@
       "Info": "Información",
       "Introduce_yourself": "Preséntate",
       "Introducing_Lights_On": "Presentamos \"Seguimos activos\"",
-      "It_may_not_offer_some_or_all_of_your_add_ons": "It may not offer some or all of your add-ons.",
+      "It_may_not_offer_some_or_all_of_your_add_ons": "Es posible que no ofrezca algunos o todos tus complementos.",
       "It_may_take_up_to_24_hours_to_collect_your_data": "Puede demorar hasta 24 horas recopilar tus datos. Cuando estén listos, te enviaremos instrucciones para descargar tus datos al correo electrónico asociado con esta cuenta. Si no recibes noticias nuestras, vuelve aquí e inténtalo de nuevo.",
       "Its_a_way_to_bring_creative_projects_to_life": "Es una plataforma para dar vida a proyectos creativos.",
       "Its_a_way_to_bring_creative_projects_to_life_Learn_more_about_accountability": "Es una forma de dar vida a proyectos creativos.<a href=\"%{trust_link}\">Más información sobre las responsabilidades</a>",
@@ -5542,6 +5538,7 @@
       "Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged": "Tu proyecto no alcanzó su meta de financiamiento, así que no se realizó ningún cargo al método de pago del patrocinador.",
       "Your_reward": "Tu recompensa",
       "Your_reward_estimated_for_delivery_in_date": "<b>Tu recompensa</b> estimada para entregarse en %{delivery_date}",
+      "Your_selection": "Tu selección",
       "Your_shipping_destination": "Tu destino de envío",
       "Your_shipping_location": "Tu ubicación de envío",
       "Youre_a_backer": "¡Eres un patrocinador!",
@@ -7102,16 +7099,7 @@
         "message": "Parece que estás usando una versión muy antigua de esta aplicación. Por favor descarga la última versión en la App Store para continuar usándola.",
         "cancel": "Cancelar",
         "upgrade": "Actualizar"
-      },
-      "Continue_with_quantity_add_ons": {
-        "zero": "Continuar con %{quantity} complementos",
-        "one": "Continuar con %{quantity} complemento",
-        "two": "Continuar con %{quantity} complementos",
-        "few": "Continuar con %{quantity} complementos",
-        "many": "Continuar con %{quantity} complementos",
-        "other": "Continuar con %{quantity} complementos"
-      },
-      "Continue_with_this_reward_It_doesnt_offer_these_add_ons": "¿Continuar con esta recompensa? No ofrece estos complementos:"
+      }
     },
     "fr": {
       "A_little_extra_to_help": "Du soutien supplémentaire pour faire vivre ce projet.",
@@ -7241,7 +7229,7 @@
         "many": "Continuer avec %{quantity_count} compléments",
         "other": "Continuer avec %{quantity_count} compléments"
       },
-      "Continue_with_this_reward": "Continue with this reward?",
+      "Continue_with_this_reward": "Continuer avec cette récompense ?",
       "Couldnt_add_attachment": "Impossible d'ajouter la pièce jointe",
       "Couldnt_open_live_stream_Try_again_later": "Impossible d'ouvrir la diffusion en direct. Veuillez réessayer plus tard.",
       "Couldnt_remove_attachment": "Impossible de supprimer la pièce jointe",
@@ -7266,10 +7254,11 @@
       "Currency_DKK": "Couronne danoise – kr (DKK)",
       "Currency_GBP": "Livre sterling – £ (GBP)",
       "Currency_HKD": "Dollar de Hong Kong – $ (HKD)",
-      "Currency_JPY": "Yen – ¥ (JPY)",
+      "Currency_JPY": "Yen japonais – ¥ (JPY)",
       "Currency_MXN": "Pesos mexicain – $ (MXN)",
       "Currency_NOK": "Couronne norvégienne – kr (NOK)",
       "Currency_NZD": "Dollar néo-zélandais – $ (NZD)",
+      "Currency_PLN": "Złoty polonais – zł (PLN)",
       "Currency_SEK": "Couronne suédoise – kr (SEK)",
       "Currency_SGD": "Dollar singapourien – $ (SGD)",
       "Currency_USD": "Dollar américain – $ (USD)",
@@ -7428,7 +7417,7 @@
       "Info": "Info",
       "Introduce_yourself": "Présentez-vous ici.",
       "Introducing_Lights_On": "Voici Lueurs d'espoir",
-      "It_may_not_offer_some_or_all_of_your_add_ons": "It may not offer some or all of your add-ons.",
+      "It_may_not_offer_some_or_all_of_your_add_ons": "Une partie ou la totalité des compléments pourraient être indisponibles.",
       "It_may_take_up_to_24_hours_to_collect_your_data": "La préparation de vos données personnelles peut prendre jusqu'à 24 heures. Nous vous enverrons des instructions de téléchargement à l'adresse e-mail associée à ce compte une fois que tout sera prêt. Si vous ne recevez rien, revenez ici pour réessayer.",
       "Its_a_way_to_bring_creative_projects_to_life": "C'est un outil qui permet de donner vie à des projets créatifs.",
       "Its_a_way_to_bring_creative_projects_to_life_Learn_more_about_accountability": "Notre plateforme est un moyen de faire vivre des projets créatifs. <a href=\"%{trust_link}\">En savoir plus sur la notion de responsabilité</a>",
@@ -7916,6 +7905,7 @@
       "Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged": "L'objectif de financement de votre projet n'a pas été atteint, donc le moyen de paiement du contributeur n'a pas été débité.",
       "Your_reward": "Votre récompense",
       "Your_reward_estimated_for_delivery_in_date": "<b>Votre récompense</b> prévue pour %{delivery_date}",
+      "Your_selection": "Votre sélection",
       "Your_shipping_destination": "Destination d'expédition",
       "Your_shipping_location": "Votre destination de livraison",
       "Youre_a_backer": "Vous êtes contributeur !",
@@ -9476,16 +9466,7 @@
         "message": "On dirait que vous utilisez une ancienne version de l'application. Veuillez la mettre à jour depuis l'App Store pour continuer à l'utiliser.",
         "cancel": "Annuler",
         "upgrade": "Mise à jour"
-      },
-      "Continue_with_quantity_add_ons": {
-        "zero": "Continuer avec %{quantity} compléments",
-        "one": "Continuer avec %{quantity} complément",
-        "two": "Continuer avec %{quantity} compléments",
-        "few": "Continuer avec %{quantity} compléments",
-        "many": "Continuer avec %{quantity} compléments",
-        "other": "Continuer avec %{quantity} compléments"
-      },
-      "Continue_with_this_reward_It_doesnt_offer_these_add_ons": "Continuer avec cette récompense ? Les compléments suivants ne sont pas proposés :"
+      }
     },
     "it": {
       "A_little_extra_to_help": "A little extra to help bring this project to life.",
@@ -9644,6 +9625,7 @@
       "Currency_MXN": "$ Mexican Peso (MXN)",
       "Currency_NOK": "kr Norwegian Krone (NOK)",
       "Currency_NZD": "$ New Zealand Dollar (NZD)",
+      "Currency_PLN": "zł Polish Złoty (PLN)",
       "Currency_SEK": "kr Swedish Krona (SEK)",
       "Currency_SGD": "$ Singapore Dollar (SGD)",
       "Currency_USD": "$ US Dollar (USD)",
@@ -10290,6 +10272,7 @@
       "Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged": "Your project didn’t reach its funding goal, so the backer’s payment method was never charged.",
       "Your_reward": "Your reward",
       "Your_reward_estimated_for_delivery_in_date": "<b>Your reward</b> estimated for delivery in %{delivery_date}",
+      "Your_selection": "Your selection",
       "Your_shipping_destination": "Your shipping destination",
       "Your_shipping_location": "Your shipping location",
       "Youre_a_backer": "You’re a backer!",
@@ -11980,7 +11963,7 @@
         "many": "%{quantity_count} 個のアドオンで続行する",
         "other": "%{quantity_count} 個のアドオンで続行する"
       },
-      "Continue_with_this_reward": "Continue with this reward?",
+      "Continue_with_this_reward": "このリワードで続けますか？",
       "Couldnt_add_attachment": "添付ファイルを追加できませんでした",
       "Couldnt_open_live_stream_Try_again_later": "ライブ配信を開けませんでした。後ほどお試しください。",
       "Couldnt_remove_attachment": "添付ファイルを削除できませんでした",
@@ -12009,6 +11992,7 @@
       "Currency_MXN": "$ メキシコペソ (MXN)",
       "Currency_NOK": "kr ノルウェークローネ (NOK)",
       "Currency_NZD": "$ ニュージーランドドル (NZD)",
+      "Currency_PLN": "zł ポーランド通貨ズウォティ(PLN)",
       "Currency_SEK": "kr スウェーデンクローナ (SEK)",
       "Currency_SGD": "$ シンガポールドル (SGD)",
       "Currency_USD": "$ 米ドル (USD)",
@@ -12167,7 +12151,7 @@
       "Info": "インフォメーション",
       "Introduce_yourself": "自己紹介",
       "Introducing_Lights_On": "新企画「Lights On」",
-      "It_may_not_offer_some_or_all_of_your_add_ons": "It may not offer some or all of your add-ons.",
+      "It_may_not_offer_some_or_all_of_your_add_ons": "このリワードでは、アドオン (追加リワード）の一部または全てが提供されない場合があります。",
       "It_may_take_up_to_24_hours_to_collect_your_data": "データの収集には最大で24時間かかる場合があります。ダウンロードの準備が整いましたら、このアカウントに登録されているメールアドレス宛てにデータのダウンロード手順が記載されたメールをお送りします。メールが届かなかった場合には、お手数ですがこちらに戻って再試行してください。",
       "Its_a_way_to_bring_creative_projects_to_life": "クリエイティブなプロジェクトを実現するためのプラットフォームです。",
       "Its_a_way_to_bring_creative_projects_to_life_Learn_more_about_accountability": "クリエイティブなプロジェクトに生命を吹き込む場です。<a href=\"%{trust_link}\">アカウンタビリティについて詳しくみる。</a>",
@@ -12655,6 +12639,7 @@
       "Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged": "あなたのプロジェクトはファンディングゴールに到達しなかったため、お支払い方法への請求は行われませんでした。",
       "Your_reward": "リワード",
       "Your_reward_estimated_for_delivery_in_date": "<b>リワード</b>の配送予定日は%{delivery_date}",
+      "Your_selection": "選択内容",
       "Your_shipping_destination": "配送地域",
       "Your_shipping_location": "配送地域",
       "Youre_a_backer": "バッカーになりました！",
@@ -14215,16 +14200,7 @@
         "message": "引き続き利用するにはApp Storeからアプリのバージョンを更新してください。",
         "cancel": "キャンセル",
         "upgrade": "アップグレード"
-      },
-      "Continue_with_quantity_add_ons": {
-        "zero": "%{quantity} 個のアドオンで続行する",
-        "one": "%{quantity} 個のアドオンで続行する",
-        "two": "%{quantity} 個のアドオンで続行する",
-        "few": "%{quantity} 個のアドオンで続行する",
-        "many": "%{quantity} 個のアドオンで続行する",
-        "other": "%{quantity} 個のアドオンで続行する"
-      },
-      "Continue_with_this_reward_It_doesnt_offer_these_add_ons": "このリワードで続行しますか？このリワードでは以下のアドオン (追加リワード) は提供されません："
+      }
     },
     "zh": {
       "A_little_extra_to_help": "A little extra to help bring this project to life.",
@@ -14383,6 +14359,7 @@
       "Currency_MXN": "$ Mexican Peso (MXN)",
       "Currency_NOK": "kr Norwegian Krone (NOK)",
       "Currency_NZD": "$ New Zealand Dollar (NZD)",
+      "Currency_PLN": "zł Polish Złoty (PLN)",
       "Currency_SEK": "kr Swedish Krona (SEK)",
       "Currency_SGD": "$ Singapore Dollar (SGD)",
       "Currency_USD": "$ US Dollar (USD)",
@@ -15029,6 +15006,7 @@
       "Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged": "Your project didn’t reach its funding goal, so the backer’s payment method was never charged.",
       "Your_reward": "Your reward",
       "Your_reward_estimated_for_delivery_in_date": "<b>Your reward</b> estimated for delivery in %{delivery_date}",
+      "Your_selection": "Your selection",
       "Your_shipping_destination": "Your shipping destination",
       "Your_shipping_location": "Your shipping location",
       "Youre_a_backer": "You’re a backer!",
@@ -16697,6 +16675,14 @@
       "trailing_code": false
     },
     {
+      "name": "GR",
+      "max_pledge": null,
+      "min_pledge": null,
+      "currency_code": "EUR",
+      "currency_symbol": "€",
+      "trailing_code": false
+    },
+    {
       "name": "HK",
       "max_pledge": null,
       "min_pledge": null,
@@ -16769,12 +16755,28 @@
       "trailing_code": true
     },
     {
+      "name": "PL",
+      "max_pledge": null,
+      "min_pledge": null,
+      "currency_code": "PLN",
+      "currency_symbol": "zł",
+      "trailing_code": true
+    },
+    {
       "name": "SE",
       "max_pledge": null,
       "min_pledge": null,
       "currency_code": "SEK",
       "currency_symbol": "kr",
       "trailing_code": true
+    },
+    {
+      "name": "SI",
+      "max_pledge": null,
+      "min_pledge": null,
+      "currency_code": "EUR",
+      "currency_symbol": "€",
+      "trailing_code": false
     },
     {
       "name": "SG",

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -31,7 +31,7 @@
               android:layout_height="@dimen/grid_11_half"
               android:background="@drawable/ic_container"
               android:gravity="center"
-              android:text="@string/You_backed"
+              android:text="@string/Your_selection"
               android:textColor="@color/white"
               android:textSize="@dimen/subheadline"
               android:paddingLeft="@dimen/grid_3"

--- a/app/src/main/res/values-de/strings_i18n.xml
+++ b/app/src/main/res/values-de/strings_i18n.xml
@@ -123,7 +123,7 @@ Bitte antippen und erneut versuchen.</string>
   <string name="Continue_with_quantity_count_add_ons_other" formatted="false">Weiter mit %{quantity_count} Add-ons</string>
   <string name="Continue_with_quantity_count_add_ons_two" formatted="false">Weiter mit %{quantity_count} Add-ons</string>
   <string name="Continue_with_quantity_count_add_ons_zero" formatted="false">Weiter mit %{quantity_count} Add-ons</string>
-  <string name="Continue_with_this_reward" formatted="false">Continue with this reward?</string>
+  <string name="Continue_with_this_reward" formatted="false">Weiter mit dieser Belohnung?</string>
   <string name="Couldnt_add_attachment" formatted="false">Anhang konnte nicht hinzugefügt werden</string>
   <string name="Couldnt_open_live_stream_Try_again_later" formatted="false">Live-Stream konnte nicht geöffnet werden. Bitte versuche es später noch einmal.</string>
   <string name="Couldnt_remove_attachment" formatted="false">Anhang konnte nicht entfernt werden</string>
@@ -151,6 +151,7 @@ Bitte antippen und erneut versuchen.</string>
   <string name="Currency_MXN" formatted="false">$ Mexikanischer Peso (MXN)</string>
   <string name="Currency_NOK" formatted="false">kr Norwegische Krone (NOK)</string>
   <string name="Currency_NZD" formatted="false">$ Neuseeland-Dollar (NZD)</string>
+  <string name="Currency_PLN" formatted="false">zł Polnishcer Złoty (PLN)</string>
   <string name="Currency_SEK" formatted="false">kr Schwedische Krone (SEK)</string>
   <string name="Currency_SGD" formatted="false">$ Singapur-Dollar (SGD)</string>
   <string name="Currency_USD" formatted="false">$ US-Dollar (USD)</string>
@@ -287,7 +288,7 @@ Bitte antippen und erneut versuchen.</string>
   <string name="Info" formatted="false">Info</string>
   <string name="Introduce_yourself" formatted="false">Stelle dich vor</string>
   <string name="Introducing_Lights_On" formatted="false">Wir stellen vor: Lights On</string>
-  <string name="It_may_not_offer_some_or_all_of_your_add_ons" formatted="false">It may not offer some or all of your add-ons.</string>
+  <string name="It_may_not_offer_some_or_all_of_your_add_ons" formatted="false">Einige oder alle deiner Add-Ons werden dafür eventuell nicht angeboten.</string>
   <string name="It_may_take_up_to_24_hours_to_collect_your_data" formatted="false">Die Zusammenstellung deiner Daten kann bis zu 24 Stunden dauern. Sobald sie zum Download bereitstehen, werden wir dir eine Anleitung dazu per E-Mail schicken. Solltest du nichts von uns hören, versuche es von hier aus noch einmal.</string>
   <string name="Its_a_way_to_bring_creative_projects_to_life" formatted="false">Es ist eine Plattform, um kreative Projekte ins Leben zu rufen.</string>
   <string name="Its_a_way_to_bring_creative_projects_to_life_Learn_more_about_accountability" formatted="false">Es ist eine Plattform, um kreative Projekte zu verwirklichen. &lt;a href="%{trust_link}">Hier findest du mehr Info zur Rechenschaftspflicht&lt;/a></string>
@@ -700,6 +701,7 @@ Bitte versuche es später noch einmal.</string>
   <string name="Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged" formatted="false">Dein Projekt hat das Finanzierungsziel leider nicht erreicht. Daher wurde die Zahlungsmethode des Unterstützers nicht belastet.</string>
   <string name="Your_reward" formatted="false">Deine Belohnung</string>
   <string name="Your_reward_estimated_for_delivery_in_date" formatted="false">&lt;b>Deine Belohnung&lt;/b> wird voraussichtlich im %{delivery_date} geliefert</string>
+  <string name="Your_selection" formatted="false">Deine Auswahl</string>
   <string name="Your_shipping_destination" formatted="false">Dein Versandziel</string>
   <string name="Your_shipping_location" formatted="false">Dein Versand-Standort</string>
   <string name="Youre_a_backer" formatted="false">Du unterstützt das Projekt!</string>

--- a/app/src/main/res/values-es/strings_i18n.xml
+++ b/app/src/main/res/values-es/strings_i18n.xml
@@ -123,7 +123,7 @@ Haz clic para volver a intentarlo.</string>
   <string name="Continue_with_quantity_count_add_ons_other" formatted="false">Continuar con %{quantity_count} complementos</string>
   <string name="Continue_with_quantity_count_add_ons_two" formatted="false">Continuar con %{quantity_count} complementos</string>
   <string name="Continue_with_quantity_count_add_ons_zero" formatted="false">Continuar con %{quantity_count} complementos</string>
-  <string name="Continue_with_this_reward" formatted="false">Continue with this reward?</string>
+  <string name="Continue_with_this_reward" formatted="false">¿Continuar con esta recompensa?</string>
   <string name="Couldnt_add_attachment" formatted="false">No se pudo añadir el anexo</string>
   <string name="Couldnt_open_live_stream_Try_again_later" formatted="false">No se pudo abrir este live stream, por favor inténtalo de nuevo más tarde.</string>
   <string name="Couldnt_remove_attachment" formatted="false">No se pudo remover el anexo</string>
@@ -151,6 +151,7 @@ Haz clic para volver a intentarlo.</string>
   <string name="Currency_MXN" formatted="false">$ Peso mexicano (MXN)</string>
   <string name="Currency_NOK" formatted="false">kr Corona noruega (NOK)</string>
   <string name="Currency_NZD" formatted="false">$ Dólar de Nueva Zelanda (NZD)</string>
+  <string name="Currency_PLN" formatted="false">Złoty polaco - zł (PLN)</string>
   <string name="Currency_SEK" formatted="false">kr Corona sueca (SEK)</string>
   <string name="Currency_SGD" formatted="false">$ Dólar de Singapur (SGD)</string>
   <string name="Currency_USD" formatted="false">$ Dólar estadounidense (USD)</string>
@@ -288,7 +289,7 @@ Haz clic para volver a intentarlo.</string>
   <string name="Info" formatted="false">Información</string>
   <string name="Introduce_yourself" formatted="false">Preséntate</string>
   <string name="Introducing_Lights_On" formatted="false">Presentamos "Seguimos activos"</string>
-  <string name="It_may_not_offer_some_or_all_of_your_add_ons" formatted="false">It may not offer some or all of your add-ons.</string>
+  <string name="It_may_not_offer_some_or_all_of_your_add_ons" formatted="false">Es posible que no ofrezca algunos o todos tus complementos.</string>
   <string name="It_may_take_up_to_24_hours_to_collect_your_data" formatted="false">Puede demorar hasta 24 horas recopilar tus datos. Cuando estén listos, te enviaremos instrucciones para descargar tus datos al correo electrónico asociado con esta cuenta. Si no recibes noticias nuestras, vuelve aquí e inténtalo de nuevo.</string>
   <string name="Its_a_way_to_bring_creative_projects_to_life" formatted="false">Es una plataforma para dar vida a proyectos creativos.</string>
   <string name="Its_a_way_to_bring_creative_projects_to_life_Learn_more_about_accountability" formatted="false">Es una forma de dar vida a proyectos creativos.&lt;a href="%{trust_link}">Más información sobre las responsabilidades&lt;/a></string>
@@ -701,6 +702,7 @@ Por favor inténtalo de nuevo más tarde.</string>
   <string name="Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged" formatted="false">Tu proyecto no alcanzó su meta de financiamiento, así que no se realizó ningún cargo al método de pago del patrocinador.</string>
   <string name="Your_reward" formatted="false">Tu recompensa</string>
   <string name="Your_reward_estimated_for_delivery_in_date" formatted="false">&lt;b>Tu recompensa&lt;/b> estimada para entregarse en %{delivery_date}</string>
+  <string name="Your_selection" formatted="false">Tu selección</string>
   <string name="Your_shipping_destination" formatted="false">Tu destino de envío</string>
   <string name="Your_shipping_location" formatted="false">Tu ubicación de envío</string>
   <string name="Youre_a_backer" formatted="false">¡Eres un patrocinador!</string>

--- a/app/src/main/res/values-fr/strings_i18n.xml
+++ b/app/src/main/res/values-fr/strings_i18n.xml
@@ -123,7 +123,7 @@ contributeurs</string>
   <string name="Continue_with_quantity_count_add_ons_other" formatted="false">Continuer avec %{quantity_count} compléments</string>
   <string name="Continue_with_quantity_count_add_ons_two" formatted="false">Continuer avec %{quantity_count} compléments</string>
   <string name="Continue_with_quantity_count_add_ons_zero" formatted="false">Continuer avec %{quantity_count} compléments</string>
-  <string name="Continue_with_this_reward" formatted="false">Continue with this reward?</string>
+  <string name="Continue_with_this_reward" formatted="false">Continuer avec cette récompense ?</string>
   <string name="Couldnt_add_attachment" formatted="false">Impossible d\'ajouter la pièce jointe</string>
   <string name="Couldnt_open_live_stream_Try_again_later" formatted="false">Impossible d\'ouvrir la diffusion en direct. Veuillez réessayer plus tard.</string>
   <string name="Couldnt_remove_attachment" formatted="false">Impossible de supprimer la pièce jointe</string>
@@ -147,10 +147,11 @@ contributeurs</string>
   <string name="Currency_EUR" formatted="false">Euro – € (EUR)</string>
   <string name="Currency_GBP" formatted="false">Livre sterling – £ (GBP)</string>
   <string name="Currency_HKD" formatted="false">Dollar de Hong Kong – $ (HKD)</string>
-  <string name="Currency_JPY" formatted="false">Yen – ¥ (JPY)</string>
+  <string name="Currency_JPY" formatted="false">Yen japonais – ¥ (JPY)</string>
   <string name="Currency_MXN" formatted="false">Pesos mexicain – $ (MXN)</string>
   <string name="Currency_NOK" formatted="false">Couronne norvégienne – kr (NOK)</string>
   <string name="Currency_NZD" formatted="false">Dollar néo-zélandais – $ (NZD)</string>
+  <string name="Currency_PLN" formatted="false">Złoty polonais – zł (PLN)</string>
   <string name="Currency_SEK" formatted="false">Couronne suédoise – kr (SEK)</string>
   <string name="Currency_SGD" formatted="false">Dollar singapourien – $ (SGD)</string>
   <string name="Currency_USD" formatted="false">Dollar américain – $ (USD)</string>
@@ -287,7 +288,7 @@ contributeurs</string>
   <string name="Info" formatted="false">Info</string>
   <string name="Introduce_yourself" formatted="false">Présentez-vous ici.</string>
   <string name="Introducing_Lights_On" formatted="false">Voici Lueurs d\'espoir</string>
-  <string name="It_may_not_offer_some_or_all_of_your_add_ons" formatted="false">It may not offer some or all of your add-ons.</string>
+  <string name="It_may_not_offer_some_or_all_of_your_add_ons" formatted="false">Une partie ou la totalité des compléments pourraient être indisponibles.</string>
   <string name="It_may_take_up_to_24_hours_to_collect_your_data" formatted="false">La préparation de vos données personnelles peut prendre jusqu\'à 24 heures. Nous vous enverrons des instructions de téléchargement à l\'adresse e-mail associée à ce compte une fois que tout sera prêt. Si vous ne recevez rien, revenez ici pour réessayer.</string>
   <string name="Its_a_way_to_bring_creative_projects_to_life" formatted="false">C\'est un outil qui permet de donner vie à des projets créatifs.</string>
   <string name="Its_a_way_to_bring_creative_projects_to_life_Learn_more_about_accountability" formatted="false">Notre plateforme est un moyen de faire vivre des projets créatifs. &lt;a href="%{trust_link}">En savoir plus sur la notion de responsabilité&lt;/a></string>
@@ -701,6 +702,7 @@ Veuillez réessayer ultérieurement.</string>
   <string name="Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged" formatted="false">L\'objectif de financement de votre projet n\'a pas été atteint, donc le moyen de paiement du contributeur n\'a pas été débité.</string>
   <string name="Your_reward" formatted="false">Votre récompense</string>
   <string name="Your_reward_estimated_for_delivery_in_date" formatted="false">&lt;b>Votre récompense&lt;/b> prévue pour %{delivery_date}</string>
+  <string name="Your_selection" formatted="false">Votre sélection</string>
   <string name="Your_shipping_destination" formatted="false">Destination d\'expédition</string>
   <string name="Your_shipping_location" formatted="false">Votre destination de livraison</string>
   <string name="Youre_a_backer" formatted="false">Vous êtes contributeur !</string>

--- a/app/src/main/res/values-ja/strings_i18n.xml
+++ b/app/src/main/res/values-ja/strings_i18n.xml
@@ -121,7 +121,7 @@
   <string name="Continue_with_quantity_count_add_ons_other" formatted="false">%{quantity_count} 個のアドオンで続行する</string>
   <string name="Continue_with_quantity_count_add_ons_two" formatted="false">%{quantity_count} 個のアドオンで続行する</string>
   <string name="Continue_with_quantity_count_add_ons_zero" formatted="false">%{quantity_count} 個のアドオンで続行する</string>
-  <string name="Continue_with_this_reward" formatted="false">Continue with this reward?</string>
+  <string name="Continue_with_this_reward" formatted="false">このリワードで続けますか？</string>
   <string name="Couldnt_add_attachment" formatted="false">添付ファイルを追加できませんでした</string>
   <string name="Couldnt_open_live_stream_Try_again_later" formatted="false">ライブ配信を開けませんでした。後ほどお試しください。</string>
   <string name="Couldnt_remove_attachment" formatted="false">添付ファイルを削除できませんでした</string>
@@ -149,6 +149,7 @@
   <string name="Currency_MXN" formatted="false">$ メキシコペソ (MXN)</string>
   <string name="Currency_NOK" formatted="false">kr ノルウェークローネ (NOK)</string>
   <string name="Currency_NZD" formatted="false">$ ニュージーランドドル (NZD)</string>
+  <string name="Currency_PLN" formatted="false">zł ポーランド通貨ズウォティ(PLN)</string>
   <string name="Currency_SEK" formatted="false">kr スウェーデンクローナ (SEK)</string>
   <string name="Currency_SGD" formatted="false">$ シンガポールドル (SGD)</string>
   <string name="Currency_USD" formatted="false">$ 米ドル (USD)</string>
@@ -285,7 +286,7 @@
   <string name="Info" formatted="false">インフォメーション</string>
   <string name="Introduce_yourself" formatted="false">自己紹介</string>
   <string name="Introducing_Lights_On" formatted="false">新企画「Lights On」</string>
-  <string name="It_may_not_offer_some_or_all_of_your_add_ons" formatted="false">It may not offer some or all of your add-ons.</string>
+  <string name="It_may_not_offer_some_or_all_of_your_add_ons" formatted="false">このリワードでは、アドオン (追加リワード）の一部または全てが提供されない場合があります。</string>
   <string name="It_may_take_up_to_24_hours_to_collect_your_data" formatted="false">データの収集には最大で24時間かかる場合があります。ダウンロードの準備が整いましたら、このアカウントに登録されているメールアドレス宛てにデータのダウンロード手順が記載されたメールをお送りします。メールが届かなかった場合には、お手数ですがこちらに戻って再試行してください。</string>
   <string name="Its_a_way_to_bring_creative_projects_to_life" formatted="false">クリエイティブなプロジェクトを実現するためのプラットフォームです。</string>
   <string name="Its_a_way_to_bring_creative_projects_to_life_Learn_more_about_accountability" formatted="false">クリエイティブなプロジェクトに生命を吹き込む場です。&lt;a href="%{trust_link}">アカウンタビリティについて詳しくみる。&lt;/a></string>
@@ -699,6 +700,7 @@
   <string name="Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged" formatted="false">あなたのプロジェクトはファンディングゴールに到達しなかったため、お支払い方法への請求は行われませんでした。</string>
   <string name="Your_reward" formatted="false">リワード</string>
   <string name="Your_reward_estimated_for_delivery_in_date" formatted="false">&lt;b>リワード&lt;/b>の配送予定日は%{delivery_date}</string>
+  <string name="Your_selection" formatted="false">選択内容</string>
   <string name="Your_shipping_destination" formatted="false">配送地域</string>
   <string name="Your_shipping_location" formatted="false">配送地域</string>
   <string name="Youre_a_backer" formatted="false">バッカーになりました！</string>

--- a/app/src/main/res/values/strings_i18n.xml
+++ b/app/src/main/res/values/strings_i18n.xml
@@ -151,6 +151,7 @@ Please tap to retry.</string>
   <string name="Currency_MXN" formatted="false">$ Mexican Peso (MXN)</string>
   <string name="Currency_NOK" formatted="false">kr Norwegian Krone (NOK)</string>
   <string name="Currency_NZD" formatted="false">$ New Zealand Dollar (NZD)</string>
+  <string name="Currency_PLN" formatted="false">zł Polish Złoty (PLN)</string>
   <string name="Currency_SEK" formatted="false">kr Swedish Krona (SEK)</string>
   <string name="Currency_SGD" formatted="false">$ Singapore Dollar (SGD)</string>
   <string name="Currency_USD" formatted="false">$ US Dollar (USD)</string>
@@ -704,6 +705,7 @@ Please try again later.</string>
   <string name="Your_project_didnt_reach_its_funding_goal_so_the_backers_payment_method_was_never_charged" formatted="false">Your project didn’t reach its funding goal, so the backer’s payment method was never charged.</string>
   <string name="Your_reward" formatted="false">Your reward</string>
   <string name="Your_reward_estimated_for_delivery_in_date" formatted="false">&lt;b>Your reward&lt;/b> estimated for delivery in %{delivery_date}</string>
+  <string name="Your_selection" formatted="false">Your selection</string>
   <string name="Your_shipping_destination" formatted="false">Your shipping destination</string>
   <string name="Your_shipping_location" formatted="false">Your shipping location</string>
   <string name="Youre_a_backer" formatted="false">You’re a backer!</string>


### PR DESCRIPTION
# 📲 What

- new copy for your selected reward tag in rewards carrousel
- pre-existing translations updated


# 👀 See
![Screen Shot 2020-09-29 at 8 42 55 AM](https://user-images.githubusercontent.com/4083656/94581542-12add500-0230-11eb-9bea-b6a46cdf850f.png)

|  |  |

# 📋 QA

- before the tag was saying in english "You backed" now is "Your selection"

# Story 📖

[Android Update Backed Reward Copy](https://kickstarter.atlassian.net/browse/NT-1525)
