### PR TITLE
NT-1564: Min pledge value for no Reward

### DIFF
--- a/app/src/main/assets/json/server-config.json
+++ b/app/src/main/assets/json/server-config.json
@@ -16760,7 +16760,7 @@
       "min_pledge": null,
       "currency_code": "PLN",
       "currency_symbol": "zł",
-      "trailing_code": true
+      "trailing_code": false
     },
     {
       "name": "SE",

--- a/app/src/main/java/com/kickstarter/libs/models/Country.kt
+++ b/app/src/main/java/com/kickstarter/libs/models/Country.kt
@@ -22,7 +22,7 @@ enum class Country(val countryCode: String, val currencyCode: String, val curren
     NL("NL", "EUR", "€", 1, 8_500, false),
     NO("NO", "NOK", "kr", 5, 80_000, true),
     NZ("NZ", "NZD", "$", 1, 14_000, true),
-    PL("PL", "PLN", "zł", 5, 37_250, true),
+    PL("PL", "PLN", "zł", 5, 37_250, false),
     SE("SE", "SEK", "kr", 5, 85_000, true),
     SI("SI", "EUR", "€", 1, 8_500, false),
     SG("SG", "SGD", "$", 2, 13_000, true),

--- a/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
@@ -186,14 +186,16 @@ public final class RewardUtils {
   }
 
   /**
-   * Returns the amount value for each variant, being Control the original value
+   * Returns the amount value for each variant, being Control the original value, and the minimum
+   * the minPledge defined by country
    *
    * @param variant the variant for which you want to get the value
    * @param reward in case no known variant as save return use the current reward.minimum amount
+   * @param minPledge defined by country
    *
    * @return Double with the amount
    */
-  public static Double rewardAmountByVariant(final OptimizelyExperiment.Variant variant, final Reward reward) {
+  public static Double rewardAmountByVariant(final OptimizelyExperiment.Variant variant, final Reward reward, final Integer minPledge) {
     Double value = reward.minimum();
     switch (variant) {
       case CONTROL:
@@ -210,6 +212,6 @@ public final class RewardUtils {
         break;
     }
 
-    return value;
+    return value < minPledge ? minPledge : value;
   }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -401,8 +401,9 @@ interface PledgeFragmentViewModel {
                     .subscribe(this.rewardSummaryIsGone)
 
             //Base pledge amount
-            val rewardMinimum = country
-                    .map { it.minPledge.toDouble() }
+            val rewardMinimum = reward
+                    .compose<Pair<Reward, Country>>(combineLatestPair(country))
+                    .map { getMinimumPledge(it.first, it.second) }
                     .distinctUntilChanged()
 
             rewardMinimum
@@ -1043,6 +1044,9 @@ interface PledgeFragmentViewModel {
                     .compose(bindToLifecycle())
                     .subscribe { this.lake.trackPledgeSubmitButtonClicked(it.first, it.second) }
         }
+
+        private fun getMinimumPledge(rw: Reward, country: Country) =
+                if (RewardUtils.isNoReward(rw)) country.minPledge.toDouble() else rw.minimum()
 
         private fun backingShippingRule(shippingRules: List<ShippingRule>, backing: Backing): Observable<ShippingRule> {
             return Observable.just(shippingRules.firstOrNull { it.location().id() == backing.locationId() })

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -324,23 +324,38 @@ interface PledgeFragmentViewModel {
                     .map { it.getParcelable(ArgumentsKey.PLEDGE_PLEDGE_DATA) as PledgeData? }
                     .ofType(PledgeData::class.java)
 
-            val reward = pledgeData
-                    .map { it.reward() }
-
             val projectData = pledgeData
                     .map { it.projectData() }
 
             val fullProjectDataAndPledgeData = projectData
                     .compose<Pair<ProjectData, PledgeData>>(combineLatestPair(pledgeData))
 
-            reward
-                .map { RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, it) }
-                .distinctUntilChanged()
-                .compose(bindToLifecycle())
-                .subscribe(variantSuggestedAmount)
-
             val project = projectData
                     .map { it.project() }
+
+            val country = project
+                    .map { Country.findByCurrencyCode(it.currency()) }
+                    .filter { it != null }
+                    .distinctUntilChanged()
+                    .ofType(Country::class.java)
+
+            val reward = pledgeData
+                    .map { it.reward() }
+
+            val projectDataAndReward = projectData
+                    .compose<Pair<ProjectData, Reward>>(combineLatestPair(reward))
+
+            Observable.combineLatest(projectDataAndReward, this.currentUser.observable(), country) {
+                data, user, c ->
+                    val experimentData = ExperimentData(user, data.first.refTagFromIntent(), data.first.refTagFromCookie())
+                    val variant = this.optimizely.variant(OptimizelyExperiment.Key.SUGGESTED_NO_REWARD_AMOUNT, experimentData)
+                    RewardUtils.rewardAmountByVariant(variant, data.second, c.minPledge)
+            }
+                    .distinctUntilChanged()
+                    .compose(bindToLifecycle())
+                    .subscribe {
+                        variantSuggestedAmount.onNext(it)
+                    }
 
             val pledgeReason = arguments()
                     .map { it.getSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON) as PledgeReason }
@@ -386,8 +401,8 @@ interface PledgeFragmentViewModel {
                     .subscribe(this.rewardSummaryIsGone)
 
             //Base pledge amount
-            val rewardMinimum = reward
-                    .map { it.minimum() }
+            val rewardMinimum = country
+                    .map { it.minPledge.toDouble() }
                     .distinctUntilChanged()
 
             rewardMinimum
@@ -415,12 +430,6 @@ interface PledgeFragmentViewModel {
 
             val additionalAmountOrZero = additionalPledgeAmount
                     .map { max(0.0, it) }
-
-            val country = project
-                    .map { Country.findByCurrencyCode(it.currency()) }
-                    .filter { it != null }
-                    .distinctUntilChanged()
-                    .ofType(Country::class.java)
 
             val stepAmount = country
                     .map { it.minPledge }
@@ -1033,12 +1042,6 @@ interface PledgeFragmentViewModel {
                     .compose<Pair<CheckoutData, PledgeData>>(takeWhen(this.pledgeButtonClicked))
                     .compose(bindToLifecycle())
                     .subscribe { this.lake.trackPledgeSubmitButtonClicked(it.first, it.second) }
-        }
-
-        private fun getMinimumRewardAmount(rewardAndVariant: Pair<Reward, Double>): Double {
-            return if (RewardUtils.isNoReward(rewardAndVariant.first))
-                    rewardAndVariant.second
-                else rewardAndVariant.first.minimum()
         }
 
         private fun backingShippingRule(shippingRules: List<ShippingRule>, backing: Backing): Observable<ShippingRule> {

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
@@ -310,10 +310,13 @@ public final class RewardUtilsTest extends KSRobolectricTestCase {
   @Test
   public void minimumRewardAmountByVariant() {
     final Reward noReward = RewardFactory.noReward();
-    assertEquals(1.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, noReward));
-    assertEquals(10.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_2, noReward));
-    assertEquals(20.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_3, noReward));
-    assertEquals(50.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward));
+    assertEquals(1.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, noReward, 1));
+    assertEquals(10.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_2, noReward, 1));
+    assertEquals(20.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_3, noReward, 1));
+    assertEquals(50.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward, 1));
+    assertEquals(10.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, noReward, 10));
+    assertEquals(100.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward, 100));
+    assertEquals(5.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward, 5));
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
@@ -316,7 +316,13 @@ public final class RewardUtilsTest extends KSRobolectricTestCase {
     assertEquals(50.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward, 1));
     assertEquals(10.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, noReward, 10));
     assertEquals(100.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward, 100));
-    assertEquals(5.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward, 5));
+    assertEquals(100.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_3, noReward, 100));
+    assertEquals(100.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_2, noReward, 100));
+    assertEquals(100.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, noReward, 100));
+    assertEquals(50.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward, 5));
+    assertEquals(10.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_2, noReward, 5));
+    assertEquals(20.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_3, noReward, 5));
+    assertEquals(5.0, RewardUtils.rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, noReward, 5));
   }
 
   @Test


### PR DESCRIPTION
# 📲 What

- We have the Suggested Amount experiment active for android. We need to check that that any variant amount is lower that the country minimum allowed pledge

# 🛠 How
- Updated values for `trailing_code` to match the backend
- Set the minimum pledge to the county minimum pledge instead of the reward.minimum
- com.kickstarter.libs.utils.RewardUtils#rewardAmountByVariant -> In case some variant amount is lower that the country allowed minimum pledge, return the minimum pledge instead of the variant amount.

# 👀 See
- Poland project with minPledge value 5 
![Screen Shot 2020-09-30 at 3 25 23 PM](https://user-images.githubusercontent.com/4083656/94747500-e4b1b900-0333-11eb-88a4-104df8d857e2.png)

|  |  |

# 📋 QA

- Pledge to a reward no reward from Poland, or Japan or Mexico .. any country with minPledge not 1. Make sure the minimum amount is higher or the same as the minimum Pledge allowed by the country 
<img width="840" alt="Screen Shot 2020-09-30 at 3 53 48 PM" src="https://user-images.githubusercontent.com/4083656/94748017-268f2f00-0335-11eb-9c64-a5e345ab7388.png">


# Story 📖

[Name of Trello Story](Trello link)
