### PR TITLE
NT-1534: Modify previously backed AddOns if unavailable

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -17,20 +17,18 @@ import com.kickstarter.models.Reward
 import java.math.RoundingMode
 
 object RewardViewUtils {
+
     /**
      * Returns the string resource ID of the rewards button based on project and reward status.
      */
     @StringRes
     fun pledgeButtonText(project: Project, reward: Reward): Int {
         val hasAddOnsSelected = project.backing()?.addOns()?.isNotEmpty() ?: false
-        val hasUnavailableAddOn:Boolean = project.backing()?.addOns()?.firstOrNull {
-            !RewardUtils.isAvailable(project, it)
-        }?.let { true } ?: false
 
         return when {
             BackingUtils.isBacked(project, reward) && !hasAddOnsSelected -> R.string.Selected
             !BackingUtils.isBacked(project, reward) && RewardUtils.isAvailable(project, reward) -> R.string.Select
-            BackingUtils.isBacked(project, reward) && reward.hasAddons() && hasAddOnsSelected && !hasUnavailableAddOn -> R.string.Continue
+            BackingUtils.isBacked(project, reward) && reward.hasAddons() && hasAddOnsSelected -> R.string.Continue
             else -> R.string.No_longer_available
         }
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
@@ -242,7 +242,7 @@ class BackingAddOnViewHolderViewModel {
 
             this.quantity
                     .compose<Pair<Int, Reward>>(combineLatestPair(addOn))
-                    .map { (it.first == it.second.remaining()) || (it.first == it.second.limit())}
+                    .map { maxLimitReached(it) }
                     .compose(bindToLifecycle())
                     .subscribe(this.disableIncreaseButton)
 
@@ -253,6 +253,21 @@ class BackingAddOnViewHolderViewModel {
                     .subscribe(this.quantityPerId)
 
         }
+
+        /**
+         * If the addOns is available check maxLimit will be hitting either the limit or the remaining
+         * if the addOns is not available, maxLimit will be the current selected quantity for that addOn
+         * allowing the user to modify the already backed amount just to decrease it.
+         * @param Pair(selectedQuantity, addOn)
+         * @return true -> limit for that addOn reached
+         *         false -> still available to choose more
+         */
+        private fun maxLimitReached(qPerAddOn: Pair<Int, Reward>): Boolean =
+                if (qPerAddOn.second.isAvailable)
+                    (qPerAddOn.second.remaining()?.let { qPerAddOn.first == it } ?: false) ||
+                            (qPerAddOn.first == qPerAddOn.second.limit())
+                else qPerAddOn.first == qPerAddOn.second.quantity()
+
 
         private fun decrease(amount: Int) = amount - 1
         private fun increase(amount: Int) = amount + 1

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -386,6 +386,9 @@ class BackingAddOnsFragmentViewModel {
 
         private fun modifyOrSelect(backingList: List<Reward>, graphAddOn: Reward): Reward {
             return backingList.firstOrNull { it.id() == graphAddOn.id() }?.let {
+                val update = Pair(it.quantity() ?: 0, it.id())
+                if (update.first > 0)
+                    updateQuantityById(update)
                 return@let it
             }?: graphAddOn
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -219,7 +219,7 @@ class BackingAddOnsFragmentViewModel {
                                 .doOnError {
                                     this.showErrorDialog.onNext(true)
                                     this.shippingSelectorIsGone.onNext(true)
-                    }
+                                }
                                 .onErrorResumeNext(Observable.empty())
                     }
                     .switchMap { it }

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -415,7 +415,7 @@ interface RewardViewHolderViewModel {
             return when {
                 isSelectable(project, rw) && !hasAddOns -> true
                 hasAddOns && !hasBackedAddOns(project) && RewardUtils.isAvailable(project, rw) -> true
-                hasAddOns && hasBackedAddOns(project) -> true
+                hasAddOns && hasBackedAddOns(project) && project.isLive -> true
                 else -> false
             }
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -411,11 +411,13 @@ interface RewardViewHolderViewModel {
         */
         private fun shouldContinueFlow(project: Project, rw: Reward):Boolean {
             val hasAddOns = rw.hasAddons()
+            val backedRwId = project.backing()?.rewardId()
+            val selectingOtherRw = backedRwId != rw.id()
 
             return when {
-                isSelectable(project, rw) && !hasAddOns -> true
-                hasAddOns && !hasBackedAddOns(project) && RewardUtils.isAvailable(project, rw) -> true
-                hasAddOns && hasBackedAddOns(project) && project.isLive -> true
+                !hasAddOns && isSelectable(project, rw) -> true
+                hasAddOns && selectingOtherRw && RewardUtils.isAvailable(project, rw) -> true
+                hasAddOns && hasBackedAddOns(project) && !selectingOtherRw && project.isLive -> true
                 else -> false
             }
         }

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
@@ -12,6 +12,12 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
 
     @Test
     fun testPledgeButtonText() {
+
+        // - Selected reward with addOns if choosing same reward always available unless project ended
+        val project = ProjectFactory.backedProjectWithRewardAndAddOnsLimitReached()
+        val rw = project.backing()?.reward() ?: RewardFactory.noReward()
+        assertEquals(R.string.Continue, RewardViewUtils.pledgeButtonText(project, rw))
+
         assertEquals(R.string.Select, RewardViewUtils.pledgeButtonText(ProjectFactory.project(), RewardFactory.reward()))
         assertEquals(R.string.No_longer_available, RewardViewUtils.pledgeButtonText(ProjectFactory.project(), RewardFactory.ended()))
         assertEquals(R.string.No_longer_available, RewardViewUtils.pledgeButtonText(ProjectFactory.project(), RewardFactory.limitReached()))

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModelTest.kt
@@ -144,7 +144,11 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
     fun increaseStepperDisable_WhenLimitPerRewardReached() {
         setupEnvironment(environment())
 
-        val addOn = RewardFactory.reward().toBuilder().isAddOn(true).remaining(3).rewardsItems(emptyList()).build()
+        val addOn = RewardFactory.reward().toBuilder()
+                .isAddOn(true)
+                .isAvailable(true)
+                .remaining(3)
+                .rewardsItems(emptyList()).build()
 
         val shippingRule = ShippingRuleFactory.usShippingRule()
         this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
@@ -159,10 +163,33 @@ class BackingAddOnViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun increaseStepperDisable_WhenAddOnUnavailable() {
+        setupEnvironment(environment())
+
+        val addOn = RewardFactory.reward().toBuilder()
+                .isAddOn(true)
+                .isAvailable(false)
+                .remaining(3)
+                .quantity(2)
+                .rewardsItems(emptyList()).build()
+
+        val shippingRule = ShippingRuleFactory.usShippingRule()
+        this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))
+
+        this.quantityPerId.assertValue(Pair(2, addOn.id()))
+
+        this.disableIncreaseButton.assertValues(true)
+    }
+
+    @Test
     fun increaseStepperDisable_WhenLimitPerBackingReached() {
         setupEnvironment(environment())
 
-        val addOn = RewardFactory.reward().toBuilder().isAddOn(true).limit(10).rewardsItems(emptyList()).build()
+        val addOn = RewardFactory.reward().toBuilder()
+                .isAvailable(true)
+                .isAddOn(true)
+                .limit(10)
+                .rewardsItems(emptyList()).build()
 
         val shippingRule = ShippingRuleFactory.usShippingRule()
         this.vm.inputs.configureWith(Triple<ProjectData, Reward, ShippingRule>(ProjectDataFactory.project(ProjectFactory.project()), addOn, shippingRule))


### PR DESCRIPTION
# 📲 What

AC description: 
![Screen Shot 2020-10-05 at 8 31 16 AM](https://user-images.githubusercontent.com/4083656/95099826-416ef400-06e5-11eb-8581-ffdf9b3b2af7.png)


# 🤔 Why

- Before if an addOn was unavailable, that addOns was filtered out and the user was unable to modify their selection
- Now we show the unavailable addOn and we let the user modify their selection **BUT just decreasing it**.

# 🛠 How
- Filter out Unavailable addOns in the combined list **JUST IF **  they weren't backed 
- Modified the maxLimit function, if the addOns is unavailable, the actual limit is the quantity, this way the increase button is disabled, and the user is able to **ONLY DECREASE**

# 👀 See
![only_decreasing_if_unavailable](https://user-images.githubusercontent.com/4083656/94962945-31b89b00-04ac-11eb-9d24-b0c1d0a0a7a0.gif)
|  |  |

# 📋 QA

- Go to bots up project, select the Upgraded bot reward, select the 2 left unit for the add on Early prototype 
& mats package -> pledge 
- Choose select another reward -> choose same reward -> make sure the add on Early prototype 
& mats package is in the list and it has 0 items left (that means is unavailable), you can just decrease the selected amount for updating that pledge

# Story 📖

[NT-1534](https://kickstarter.atlassian.net/browse/NT-1534)
