### PR TITLE
NT-606: FIX Display a string indicating backing state for creators on View/Manage Pledge screen

### DIFF
--- a/app/src/main/graphql/checkout.graphql
+++ b/app/src/main/graphql/checkout.graphql
@@ -3,9 +3,7 @@ mutation CreateBacking($projectId: ID!, $amount: String!, $paymentType: String!,
     checkout {
       id
       backing {
-        clientSecret
-        requiresAction
-        status
+        ... checkoutBacking
       }
     }
   }
@@ -24,9 +22,7 @@ mutation UpdateBacking($backingId: ID!, $amount: String, $locationId: String,$re
     checkout {
       id
       backing {
-        clientSecret
-        requiresAction
-        status
+        ... checkoutBacking
       }
     }
   }

--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -34,7 +34,9 @@ fragment backing on Backing {
             ... reward
         }
     }
+}
 
+fragment checkoutBacking on Backing {
     clientSecret
     requiresAction
     status

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -92,8 +92,8 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
 
                             // TODO: Add new status field to backing model
                             val backing = Checkout.Backing.builder()
-                                    .clientSecret(checkoutPayload?.backing()?.clientSecret())
-                                    .requiresAction(checkoutPayload?.backing()?.requiresAction()?: false)
+                                    .clientSecret(checkoutPayload?.backing()?.fragments()?.checkoutBacking()?.clientSecret())
+                                    .requiresAction(checkoutPayload?.backing()?.fragments()?.checkoutBacking()?.requiresAction()?: false)
                                     .build()
 
                             ps.onNext(Checkout.builder()
@@ -476,8 +476,8 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
 
                             val checkoutPayload = response.data()?.updateBacking()?.checkout()
                             val backing = Checkout.Backing.builder()
-                                    .clientSecret(checkoutPayload?.backing()?.clientSecret())
-                                    .requiresAction(checkoutPayload?.backing()?.requiresAction()?: false)
+                                    .clientSecret(checkoutPayload?.backing()?.fragments()?.checkoutBacking()?.clientSecret())
+                                    .requiresAction(checkoutPayload?.backing()?.fragments()?.checkoutBacking()?.requiresAction()?: false)
                                     .build()
 
                             ps.onNext(Checkout.builder()


### PR DESCRIPTION
# 📲 What

- if a creator was also an admin, the query from the creators perspective was getting this error for fetching the field `        requiresAction`. With this changes the fields related to the checkout mutation won't be fetched from any query either backer or creator perspective.

# 🤔 Why
- Backing object null if trying to query a checkout related field.
<img width="639" alt="Screen Shot 2020-10-05 at 8 57 12 AM" src="https://user-images.githubusercontent.com/4083656/95132728-17352a80-0715-11eb-980e-95d20bd9b70b.png">

# 🛠 How
- Modified the backing fragment to not fetch fields
 `     clientSecret
        requiresAction
        status
`
- Added new fragment `checkoutBacking` for those same fields 
- modified `CreateBacking` and `UpdateBacking` mutations to use the new fragment

# 👀 See
![wathc_pledge_as_creator](https://user-images.githubusercontent.com/4083656/95133453-31bbd380-0716-11eb-92e2-46b604d0ac53.gif)
|  |  |

# 📋 QA

- Log in as creator @louisaadjadja can help with this step, she provided the credentials : 
![Screen Shot 2020-10-05 at 2 23 38 PM](https://user-images.githubusercontent.com/4083656/95133582-63349f00-0716-11eb-8285-06390b6c34b0.png)
- Go to dashboard -> hit messages -> hit view pledge button. The view/manager pledge screen should have content.
- Pledge to something to check the CreateBacking mutations works as usual
- Update some pledge to check the UpdateBacking mutations keeps working as usual.

# Story 📖

[NT-606](https://kickstarter.atlassian.net/browse/NT-606)
