### PR TITLE
NT-1428- Migration from Crashlytics to firebase crashlytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,12 +4,12 @@ buildscript {
     }
 
     dependencies {
-        classpath 'io.fabric.tools:gradle:1.30.0'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.1.0'
     }
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
+apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
@@ -201,7 +201,7 @@ dependencies {
     implementation 'androidx.work:work-runtime-ktx:2.3.4'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.apollographql.apollo:apollo-runtime:1.0.2'
-    implementation("com.crashlytics.sdk.android:crashlytics:2.10.1@aar") {
+    implementation("com.google.firebase:firebase-crashlytics:17.0.0@aar") {
         transitive = true
     }
     // Google Analytics SDK

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -11,7 +11,7 @@ import android.content.res.Resources;
 import android.util.Log;
 
 import com.apollographql.apollo.ApolloClient;
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -640,7 +640,7 @@ public final class ApplicationModule {
 
     optimizelyManager.initialize(context, null, optimizely -> {
       if (!optimizely.isValid()) {
-        Crashlytics.logException(new Throwable("Optimizely failed to initialize."));
+        FirebaseCrashlytics.getInstance().recordException(new Throwable("Optimizely failed to initialize."));
       } else {
         if (build.isDebug()) {
           Log.d(ApplicationModule.class.getSimpleName(), "🔮 Optimizely successfully initialized.");

--- a/app/src/main/java/com/kickstarter/KSApplication.java
+++ b/app/src/main/java/com/kickstarter/KSApplication.java
@@ -2,7 +2,7 @@ package com.kickstarter;
 
 import android.text.TextUtils;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.iid.FirebaseInstanceId;
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 import androidx.annotation.CallSuper;
 import androidx.multidex.MultiDex;
 import androidx.multidex.MultiDexApplication;
-import io.fabric.sdk.android.Fabric;
 import timber.log.Timber;
 
 public class KSApplication extends MultiDexApplication {
@@ -47,7 +46,7 @@ public class KSApplication extends MultiDexApplication {
     }
 
     JodaTimeAndroid.init(this);
-    Fabric.with(this, new Crashlytics());
+    FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(true);
 
     this.component = DaggerApplicationComponent.builder()
       .applicationModule(new ApplicationModule(this))

--- a/app/src/main/java/com/kickstarter/libs/BaseActivity.java
+++ b/app/src/main/java/com/kickstarter/libs/BaseActivity.java
@@ -6,7 +6,7 @@ import android.net.ConnectivityManager;
 import android.os.Bundle;
 import android.util.Pair;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.kickstarter.ApplicationComponent;
 import com.kickstarter.KSApplication;
 import com.kickstarter.R;
@@ -121,7 +121,7 @@ public abstract class BaseActivity<ViewModelType extends ActivityViewModel> exte
     this.back
       .compose(bindUntilEvent(ActivityEvent.STOP))
       .observeOn(AndroidSchedulers.mainThread())
-      .subscribe(__ -> goBack(), Crashlytics::logException);
+      .subscribe(__ -> goBack(), FirebaseCrashlytics.getInstance()::recordException);
 
     ConnectivityReceiver.setConnectivityReceiverListener(this);
   }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -20,7 +20,7 @@ import com.kickstarter.models.User
 import com.kickstarter.services.KoalaWorker
 import com.kickstarter.services.LakeWorker
 import com.kickstarter.ui.IntentKey
-import io.fabric.sdk.android.Fabric
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.json.JSONArray
 import org.json.JSONException
 import timber.log.Timber
@@ -52,7 +52,7 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
             if (this.build.isDebug) {
                 Timber.e("Failed to encode ${type().tag} event: $eventName")
             }
-            Fabric.getLogger().e(TrackingClient::class.java.simpleName, "Failed to encode ${type().tag} event: $eventName")
+            FirebaseCrashlytics.getInstance().log("E/${TrackingClient::class.java.simpleName}: Failed to encode ${type().tag} event: $eventName")
         }
     }
 

--- a/app/src/main/java/com/kickstarter/services/TrackingWorker.kt
+++ b/app/src/main/java/com/kickstarter/services/TrackingWorker.kt
@@ -3,7 +3,7 @@ package com.kickstarter.services
 import android.content.Context
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.libs.Build
 import com.kickstarter.libs.qualifiers.ApplicationContext
 import com.kickstarter.ui.IntentKey
@@ -41,7 +41,7 @@ abstract class TrackingWorker(@ApplicationContext applicationContext: Context, p
         if (this.build.isDebug) {
             Timber.d("Successfully tracked $tag event: $eventName")
         }
-        Crashlytics.log(this.eventName)
+        FirebaseCrashlytics.getInstance().log(this.eventName)
     }
 
     private fun logTrackingError(code: Int, message: String) {
@@ -49,6 +49,6 @@ abstract class TrackingWorker(@ApplicationContext applicationContext: Context, p
         if (this.build.isDebug) {
             Timber.e(errorMessage)
         }
-        Crashlytics.logException(Exception(errorMessage))
+        FirebaseCrashlytics.getInstance().recordException(Exception(errorMessage))
     }
 }

--- a/app/src/main/java/com/kickstarter/services/firebase/RegisterTokenWorker.kt
+++ b/app/src/main/java/com/kickstarter/services/firebase/RegisterTokenWorker.kt
@@ -3,7 +3,7 @@ package com.kickstarter.services.firebase
 import android.content.Context
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.gson.Gson
 import com.google.gson.JsonObject
@@ -64,14 +64,14 @@ class RegisterTokenWorker(@ApplicationContext applicationContext: Context, priva
         if (this.build.isDebug) {
             Timber.d(successMessage)
         }
-        Crashlytics.log(successMessage)
+        FirebaseCrashlytics.getInstance().log(successMessage)
     }
 
     private fun logError(errorMessage: String) {
         if (this.build.isDebug) {
             Timber.e(errorMessage)
         }
-        Crashlytics.logException(Exception(errorMessage))
+        FirebaseCrashlytics.getInstance().recordException(Exception(errorMessage))
     }
 
     companion object {

--- a/app/src/main/java/com/kickstarter/services/firebase/ResetDeviceIdWorker.kt
+++ b/app/src/main/java/com/kickstarter/services/firebase/ResetDeviceIdWorker.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.iid.FirebaseInstanceId
 import com.kickstarter.KSApplication
 import com.kickstarter.libs.Build
@@ -38,14 +38,14 @@ class ResetDeviceIdWorker(@ApplicationContext applicationContext: Context, param
         if (this.build.isDebug) {
             Timber.d(successMessage)
         }
-        Crashlytics.log(successMessage)
+        FirebaseCrashlytics.getInstance().log(successMessage)
     }
 
     private fun logError(ioException: IOException) {
         if (this.build.isDebug) {
             Timber.e(ioException.localizedMessage)
         }
-        Crashlytics.logException(ioException)
+        FirebaseCrashlytics.getInstance().recordException(ioException)
     }
 
     companion object {

--- a/app/src/main/java/com/kickstarter/services/firebase/UnregisterTokenWorker.kt
+++ b/app/src/main/java/com/kickstarter/services/firebase/UnregisterTokenWorker.kt
@@ -3,7 +3,7 @@ package com.kickstarter.services.firebase
 import android.content.Context
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.iid.FirebaseInstanceId
 import com.google.firebase.messaging.FirebaseMessaging
 import com.kickstarter.KSApplication
@@ -37,13 +37,13 @@ class UnregisterTokenWorker(@ApplicationContext applicationContext: Context, pri
         if (this.build.isDebug) {
             Timber.d(successMessage)
         }
-        Crashlytics.log(successMessage)
+        FirebaseCrashlytics.getInstance().log(successMessage)
     }
 
     private fun logError(ioException: IOException) {
         if (this.build.isDebug) {
             Timber.e(ioException.localizedMessage)
         }
-        Crashlytics.logException(ioException)
+        FirebaseCrashlytics.getInstance().recordException(ioException)
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -19,7 +19,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.R
 import com.kickstarter.extensions.hideKeyboard
 import com.kickstarter.extensions.showSnackbar
@@ -695,7 +695,7 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
                 renderProject(backingFragment, rewardsFragment, projectData)
             }
         } catch (e: IllegalStateException) {
-            Crashlytics.logException(e)
+            FirebaseCrashlytics.getInstance().recordException(e)
         }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/adapters/KSAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/KSAdapter.java
@@ -4,7 +4,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.kickstarter.BuildConfig;
 import com.kickstarter.libs.utils.ExceptionUtils;
 import com.kickstarter.ui.viewholders.KSViewHolder;
@@ -101,7 +101,7 @@ public abstract class KSAdapter extends RecyclerView.Adapter<KSViewHolder> {
         ExceptionUtils.rethrowAsRuntimeException(e);
       } else {
         // TODO: alter the exception message to say we are just reporting it and it's not a real crash.
-        Crashlytics.logException(e);
+        FirebaseCrashlytics.getInstance().recordException(e);
       }
     }
   }

--- a/app/src/main/java/com/kickstarter/ui/adapters/KSListAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/KSListAdapter.kt
@@ -7,7 +7,7 @@ import androidx.annotation.LayoutRes
 import androidx.annotation.NonNull
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.BuildConfig
 import com.kickstarter.libs.utils.ExceptionUtils
 import com.kickstarter.ui.viewholders.KSViewHolder
@@ -101,7 +101,7 @@ abstract class KSListAdapter(diffUtil: DiffUtil.ItemCallback<Any>) : ListAdapter
                 ExceptionUtils.rethrowAsRuntimeException(e)
             } else {
                 // TODO: alter the exception message to say we are just reporting it and it's not a real crash.
-                Crashlytics.logException(e)
+                FirebaseCrashlytics.getInstance().recordException(e)
             }
         }
 

--- a/app/src/test/java/com/kickstarter/TestKSApplication.java
+++ b/app/src/test/java/com/kickstarter/TestKSApplication.java
@@ -1,13 +1,15 @@
 package com.kickstarter;
 
 import com.facebook.FacebookSdk;
+import com.google.firebase.FirebaseApp;
 
 public class TestKSApplication extends KSApplication {
 
   @Override
   public void onCreate() {
-    super.onCreate();
     FacebookSdk.sdkInitialize(this);
+    FirebaseApp.initializeApp(this);
+    super.onCreate();
   }
 
   @Override


### PR DESCRIPTION
# 📲 What

- Deprecate crashlytics dependecy to use Firebase crashlytics

# 🤔 Why
- they are shutting down crash reports 
![Screen Shot 2020-10-05 at 2 49 38 PM](https://user-images.githubusercontent.com/4083656/95135907-063ae800-071a-11eb-99dd-3f6915425c8e.png)


# 🛠 How
- Following this migration guide https://firebase.google.com/docs/crashlytics/upgrade-sdk?platform=android&authuser=1

# 👀 See
- Created a few test builds with versions 2.10.0 one for internalRelease variant and another one for externalRelease variant
![Screen Shot 2020-10-05 at 10 47 48 AM](https://user-images.githubusercontent.com/4083656/95136040-3da99480-071a-11eb-8dd0-823dab902c81.png)
![Screen Shot 2020-10-05 at 10 48 14 AM](https://user-images.githubusercontent.com/4083656/95136046-3f735800-071a-11eb-9809-6ec9ddba54e1.png)

|  |  |

# 📋 QA

- Take a look into this PR and follow the QA steaps inside it [internal steps](https://github.com/kickstarter/native-secrets/pull/74)

# Story 📖

[NT-1428](https://kickstarter.atlassian.net/browse/NT-1428)
