### PR TITLE
NT-1589: Add-on with future start date is available in add-ons screen

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
@@ -50,6 +50,17 @@ public final class RewardUtils {
   }
 
   /**
+   * Returns `true` if the reward is in a valid time range
+   * @return  true if the reward is just limited one one end and that time validation is true
+   * @return  false if the reward is just limited one one end and that time validation is false
+   * @return  true if the reward is limited at both ends and validation is correct
+   * @return  false if the reward is limited at both ends and validation is false
+   */
+  public static boolean isValidTimeRange(final  @NonNull Reward reward) {
+    return RewardUtils.hasStarted(reward) && !RewardUtils.isExpired(reward);
+  }
+
+  /**
    * Returns `true` if the reward has a valid expiration date on Starting date.
    */
   public static boolean isTimeLimitedStart(final @NonNull Reward reward) {

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
@@ -255,15 +255,17 @@ class BackingAddOnViewHolderViewModel {
         }
 
         /**
-         * If the addOns is available check maxLimit will be hitting either the limit or the remaining
-         * if the addOns is not available, maxLimit will be the current selected quantity for that addOn
+         * If the addOns is available and within a valid time range
+         * maxLimit will be hitting either the limit or the remaining
+         * if the addOns is not available, maxLimit will be the current selected quantity
          * allowing the user to modify the already backed amount just to decrease it.
+         *
          * @param Pair(selectedQuantity, addOn)
-         * @return true -> limit for that addOn reached
+         * @return true -> limit for that addOn reached and addOns is in valid timeRange
          *         false -> still available to choose more
          */
         private fun maxLimitReached(qPerAddOn: Pair<Int, Reward>): Boolean =
-                if (qPerAddOn.second.isAvailable)
+                if (qPerAddOn.second.isAvailable && RewardUtils.isValidTimeRange(qPerAddOn.second))
                     (qPerAddOn.second.remaining()?.let { qPerAddOn.first == it } ?: false) ||
                             (qPerAddOn.first == qPerAddOn.second.limit())
                 else qPerAddOn.first == qPerAddOn.second.quantity()

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -8,6 +8,7 @@ import com.kickstarter.libs.KSString
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
 import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
 import com.kickstarter.libs.utils.ObjectUtils
+import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.RewardUtils.isDigital
 import com.kickstarter.libs.utils.RewardUtils.isShippable
 import com.kickstarter.mock.factories.ShippingRuleFactory
@@ -199,7 +200,7 @@ class BackingAddOnsFragmentViewModel {
                     .distinctUntilChanged()
 
             val addonsList = Observable.merge(addOnsFromGraph, combinedList)
-                    .map { filterOutUnAvailableExceptIfBacked(it) }
+                    .map { filterOutUnAvailableOrEndedExceptIfBacked(it) }
                     .distinctUntilChanged()
 
             shippingRules
@@ -269,6 +270,7 @@ class BackingAddOnsFragmentViewModel {
                         updateQuantityById(it.first)
                         this.totalSelectedAddOns.onNext(calculateTotal(it.second.second))
                     }
+
             // - .startWith(Pair(-1,-1L) because we need to trigger this validation everytime the AddOns selection changes
             // - .startWith(ShippingRuleFactory.emptyShippingRule()) because we need to trigger this validation every time the AddOns selection changes for digital rewards as well
             val isButtonEnabled = Observable.combineLatest(
@@ -320,19 +322,19 @@ class BackingAddOnsFragmentViewModel {
         }
 
         /**
-         *  In case selecting the same reward, if any of the addOns is unavailable
-         *  but has been backed do not filter out that addOn and allow to modify the
-         *  selection.
+         *  In case selecting the same reward, if any of the addOns is unavailable or
+         *  has an invalid time range but has been backed do NOT filter out that addOn
+         *  and allow to modify the selection.
          *
-         *  In case selecting another reward, filter out the unavailable ones
+         *  In case selecting another reward or new pledge, filter out the unavailable/invalid time range ones
          *
          *  @param combinedList -> combinedList of Graph addOns and backed ones
-         *  @return List<Reward> -> filtered list depending on availability and if
-         *  the addOns was backed
+         *  @return List<Reward> -> filtered list depending on availability and time range if new pledge
+         *  @return List<Reward> -> not filtered if the addOn item was previously backed
          */
-        private fun filterOutUnAvailableExceptIfBacked(combinedList: List<Reward>): List<Reward> {
-            return combinedList.filter {
-                addOn ->  addOn.quantity()?.let { it > 0 } ?: addOn.isAvailable
+        private fun filterOutUnAvailableOrEndedExceptIfBacked(combinedList: List<Reward>): List<Reward> {
+            return combinedList.filter { addOn ->
+                addOn.quantity()?.let { it > 0 } ?: (addOn.isAvailable && RewardUtils.isValidTimeRange(addOn))
             }
         }
 
@@ -428,13 +430,20 @@ class BackingAddOnsFragmentViewModel {
                 }
             }
 
-            val updatedQuantity = filteredAddOns
-                    .map {
-                        val amount = this.currentSelection[it.id()] ?: -1
-                        return@map if (amount == -1) it else it.toBuilder().quantity(amount).build()
-                    }
+            val updatedQuantity = updateQuantityIfCurrentlySelected(filteredAddOns)
 
-            return Triple(pData, updatedQuantity, rule)
+            val filteredStaredAddOns = updatedQuantity.filter { RewardUtils.isValidTimeRange(it) }
+
+            return Triple(pData, filteredStaredAddOns, rule)
+        }
+
+        /**
+         *  In case the addOn item is currently selected, or previously backed,
+         *  @retrun List<Reward> the list with each item quantity updated
+         */
+        private fun updateQuantityIfCurrentlySelected(filteredAddOns: List<Reward>) = filteredAddOns.map {
+            val amount = this.currentSelection[it.id()] ?: -1
+            return@map if (amount == -1) it else it.toBuilder().quantity(amount).build()
         }
 
         private fun containsLocation(rule: ShippingRule, reward: Reward): Boolean {

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
@@ -319,7 +319,7 @@ public final class RewardUtilsTest extends KSRobolectricTestCase {
   @Test
   public void testRewardNotTimeLimitedStart_hasStarted() {
     // - A reward not limited os starting time should be considered as a reward that has started
-    final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().build();
+    final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns();
     assertEquals(false, RewardUtils.isTimeLimitedStart(rewardLimitedByStart));
     assertEquals(true, RewardUtils.hasStarted(rewardLimitedByStart));
   }
@@ -329,6 +329,62 @@ public final class RewardUtilsTest extends KSRobolectricTestCase {
     final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now().plusDays(1)).build();
     assertEquals(true, RewardUtils.isTimeLimitedStart(rewardLimitedByStart));
     assertEquals(false, RewardUtils.hasStarted(rewardLimitedByStart));
+  }
+
+  @Test
+  public void testRewardTimeLimitedEnd_hasEnded() {
+    final Reward rewardExpired = RewardFactory.rewardHasAddOns().toBuilder().endsAt(DateTime.now().minusDays(1)).build();
+    assertEquals(true, RewardUtils.isExpired(rewardExpired));
+    assertEquals(false, RewardUtils.isValidTimeRange(rewardExpired));
+  }
+
+  @Test
+  public void testValidTimeRage_limitedStart_hasNotStarted() {
+    final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now().plusDays(1)).build();
+    assertEquals(false, RewardUtils.isValidTimeRange(rewardLimitedByStart));
+  }
+
+  @Test
+  public void testValidTimeRage_limitedStart_hasStarted() {
+    final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now()).build();
+    assertEquals(true, RewardUtils.isValidTimeRange(rewardLimitedByStart));
+  }
+
+  @Test
+  public void testValidTimeRage_limitedEnd_hasNotEnded() {
+    final Reward rewardLimitedByEnd = RewardFactory.rewardHasAddOns().toBuilder().endsAt(DateTime.now().plusDays(1)).build();
+    assertEquals(false, RewardUtils.isExpired(rewardLimitedByEnd));
+    assertEquals(true, RewardUtils.isValidTimeRange(rewardLimitedByEnd));
+  }
+
+  @Test
+  public void testValidTimeRange_limitedStartEnd_isValid() {
+    final Reward rewardLimitedBoth = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now()).endsAt(DateTime.now().plusDays(1)).build();
+    assertEquals(false, RewardUtils.isExpired(rewardLimitedBoth));
+    assertEquals(true, RewardUtils.hasStarted(rewardLimitedBoth));
+    assertEquals(true, RewardUtils.isValidTimeRange(rewardLimitedBoth));
+  }
+
+  @Test
+  public void testValidTimeRange_limitedStartEnd_isInvalid() {
+    final Reward rewardLimitedBoth = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now().plusDays(1)).endsAt(DateTime.now().plusDays(2)).build();
+    assertEquals(false, RewardUtils.isExpired(rewardLimitedBoth));
+    assertEquals(false, RewardUtils.hasStarted(rewardLimitedBoth));
+    assertEquals(false, RewardUtils.isValidTimeRange(rewardLimitedBoth));
+  }
+
+  @Test
+  public void testValidTimeRange_NotLimited_isValid() {
+    final Reward rewardLimitedBoth = RewardFactory.rewardHasAddOns();
+    assertEquals(false, RewardUtils.isExpired(rewardLimitedBoth));
+    assertEquals(true, RewardUtils.hasStarted(rewardLimitedBoth));
+    assertEquals(true, RewardUtils.isValidTimeRange(rewardLimitedBoth));
+  }
+
+  @Test
+  public void testValidTimeRage_NotLimitedStart_hasStarted() {
+    final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns();
+    assertEquals(true, RewardUtils.isValidTimeRange(rewardLimitedByStart));
   }
 
   @Test


### PR DESCRIPTION
# 📲 What

**New Pledge:** Currently, add-ons with start dates in the future are being shown in the add-ons screen. These should be hidden from view until the start date set by the creator.

**Updating same reward:** when a user is editing their reward, they are able to tap on the initial reward that they pledged for and then should see all available add-ons, as well as any that are not available that were in their original pledge (with their qty selection retained). this is so that they can adjust the quantity downward, or remove them

**Updating to another reward:** same behaviour as new pledge

# 🛠 How

- RewardUtils new method for checking if a reward is within a valid time range
- Extended `filterOutUnAvailableExceptIfBacked` to `filterOutUnAvailableOrEndedExceptIfBacked` to filter out if the addOn is within a valid time range `JUST IF NOT PREVIOUSLY BAKED.`
- Extended method maxLimitReached, if the addOn is not within a valid time range the maxLimit will be the baked amount 

# 👀 See
- Before 🐛 : You could always see in the list addOns not started yet
![Before](https://user-images.githubusercontent.com/4083656/95386344-00710e00-08a4-11eb-93f3-31df044a0318.png)

- After 🦋  : 
* New pledge Flow -> not visible in the addOns list
* Update pledge Same Reward -> unavailable addOns that where previously baked available to modify `JUST TO REDUCE` the amount
* Update pledge same Reward but not previously baked addon -> not visible in the addOns list
* Update pledge Another Reward -> not visible in the addOns list
![not-started_addOn-gone](https://user-images.githubusercontent.com/4083656/95386450-2dbdbc00-08a4-11eb-82ae-9029685455ff.gif)
|  |  |

# 📋 QA

1. On staging, go to project Bots Up
2. Tap any reward
3. See add-ons list
4. AddOn with name "Add-on that hasn't started yet" not visible anymore

# Story 📖

[NT-1589](https://kickstarter.atlassian.net/browse/NT-1589)
