### PR TITLE
NT-1587: AddOns costs 

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -75,8 +75,10 @@ fragment reward on Reward {
         ... amount
     }
     shippingPreference
-    shippingRules {
-        ... shippingRule
+    shippingRulesExpanded {
+        nodes {
+            ... shippingRule
+        }
     }
     remainingQuantity
     limit

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -722,9 +722,9 @@ private fun rewardTransformer(rewardGr: fragment.Reward): Reward {
         rewardItemsTransformer(it)
     }
 
-    val shippingRules = rewardGr.shippingRules().map {
+    val shippingRules = rewardGr.shippingRulesExpanded()?.nodes()?.map {
         shippingRuleTransformer(it.fragments().shippingRule())
-    }.toList()
+    }?.toList()
 
     return Reward.builder()
             .title(title)


### PR DESCRIPTION
# 📲 What

- **Before** we where fetching field `shippingRules` which do not contains all the possible configurations a creator can do for shipping locations 
- **Now** we fetch the field `shippingRulesExtended` instead that covers all the possible configurations a creator can make (worlwide, european union or other regions, concrete countries ... etc).

# 🛠 How

- in `fragments.graphql` the fragment for reward has been updated to fetch `shippingRulesExpanded` instead of `shippingRule`

# 👀 See
- Take a look into the shipping costs in each addOn here, United states is 0, the rest of the countries is 5
![shipping_costs](https://user-images.githubusercontent.com/4083656/95497771-bd707280-0957-11eb-8d18-4441613591b5.gif)

|  |  |

# 📋 QA

1- Visit project: https://www.kickstarter.com/projects/tommy-chonkers/chonkers-naturally-calming-weighted-stuffed-animals?ref=checkout_rewards_page (in production)

2 - Tap reward Early Backer Bundle ($58)

3 - See add-ons, all of which have $0 shipping (for United States 5 if you're located in other place)

4 - Change shipping selector to Zimbabwe (or any country other than US) or to US (if your place in other country than US)


# Story 📖

[NT-1587: AddOns costs](https://kickstarter.atlassian.net/browse/NT-1587)
