### PR TITLE
NT- 1591:Blanck screen edit reward flow

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -81,6 +81,7 @@ fragment reward on Reward {
     remainingQuantity
     limit
     limitPerBacker
+    startsAt
     endsAt
 }
 

--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -160,7 +160,7 @@ public final class KoalaUtils {
         put("estimated_delivery_on", reward.estimatedDeliveryOn() != null ? reward.estimatedDeliveryOn().getMillis() / 1000 : null);
         put("has_items", RewardUtils.isItemized(reward));
         put("id", reward.id());
-        put("is_limited_time", RewardUtils.isTimeLimited(reward));
+        put("is_limited_time", RewardUtils.isTimeLimitedEnd(reward));
         put("is_limited_quantity", reward.limit() != null);
         put("minimum", reward.minimum());
         put("shipping_enabled", RewardUtils.isShippable(reward));

--- a/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
@@ -28,14 +28,31 @@ public final class RewardUtils {
   }
 
   public static boolean isAvailable(final @NonNull Project project, final @NonNull Reward reward) {
-    return project.isLive() && !RewardUtils.isLimitReached(reward) && !RewardUtils.isExpired(reward);
+    return project.isLive() && !RewardUtils.isLimitReached(reward) && !RewardUtils.isExpired(reward) && hasStarted(reward);
   }
 
   /**
    * Returns `true` if the reward has expired.
    */
   public static boolean isExpired(final @NonNull Reward reward) {
-    return isTimeLimited(reward) && reward.endsAt().isBeforeNow();
+    return isTimeLimitedEnd(reward) && reward.endsAt().isBeforeNow();
+  }
+
+  /**
+   * Returns `true` if the reward has started or not limited by starting time
+   * - > @return true if reward.startsAt == null
+   * - > @return false if reward.startAt < now
+   * - > @return true if reward.startAt >= now
+   */
+  public static boolean hasStarted(final @NonNull Reward reward) {
+    return isTimeLimitedStart(reward) ? (!reward.startsAt().isAfterNow() || reward.startsAt().isEqualNow()) : true;
+  }
+
+  /**
+   * Returns `true` if the reward has a valid expiration date on Starting date.
+   */
+  public static boolean isTimeLimitedStart(final @NonNull Reward reward) {
+    return reward.startsAt() != null && !DateTimeUtils.isEpoch(reward.startsAt());
   }
 
   /**
@@ -104,9 +121,9 @@ public final class RewardUtils {
   }
 
   /**
-   * Returns `true` if the reward has a valid expiration date.
+   * Returns `true` if the reward has a valid expiration date on Ending date.
    */
-  public static boolean isTimeLimited(final @NonNull Reward reward) {
+  public static boolean isTimeLimitedEnd(final @NonNull Reward reward) {
     // TODO: 2019-06-14 remove epoch check after Garrow fixes `current` bug in backend
     return reward.endsAt() != null && !DateTimeUtils.isEpoch(reward.endsAt());
   }

--- a/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
@@ -50,6 +50,17 @@ public final class RewardUtils {
   }
 
   /**
+   * Returns `true` if the reward is in a valid time range
+   * @return  true if the reward is just limited one one end and that time validation is true
+   * @return  false if the reward is just limited one one end and that time validation is false
+   * @return  true if the reward is limited at both ends and validation is correct
+   * @return  false if the reward is limited at both ends and validation is false
+   */
+  public static boolean isValidTimeRange(final  @NonNull Reward reward) {
+    return RewardUtils.hasStarted(reward) && !RewardUtils.isExpired(reward);
+  }
+
+  /**
    * Returns `true` if the reward has a valid expiration date on Starting date.
    */
   public static boolean isTimeLimitedStart(final @NonNull Reward reward) {

--- a/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.java
@@ -28,7 +28,7 @@ public final class RewardUtils {
   }
 
   public static boolean isAvailable(final @NonNull Project project, final @NonNull Reward reward) {
-    return project.isLive() && !RewardUtils.isLimitReached(reward) && !RewardUtils.isExpired(reward) && hasStarted(reward);
+    return project.isLive() && !RewardUtils.isLimitReached(reward) && !RewardUtils.isExpired(reward);
   }
 
   /**
@@ -39,7 +39,8 @@ public final class RewardUtils {
   }
 
   /**
-   * Returns `true` if the reward has started or not limited by starting time
+   * Returns `true` if the reward has started or not limited by starting time.
+   * A reward not limited os starting time should be considered as a reward that has started.
    * - > @return true if reward.startsAt == null
    * - > @return false if reward.startAt < now
    * - > @return true if reward.startAt >= now

--- a/app/src/main/java/com/kickstarter/models/Reward.java
+++ b/app/src/main/java/com/kickstarter/models/Reward.java
@@ -37,6 +37,7 @@ public abstract class Reward implements Parcelable, Relay {
   public abstract @Nullable List<RewardsItem> addOnsItems();
   public abstract @Nullable Integer quantity();
   public abstract @Nullable boolean hasAddons();
+  public abstract @Nullable DateTime startsAt();
 
   /**
    * This field will be available just for GraphQL, in V1 it would be null
@@ -64,6 +65,7 @@ public abstract class Reward implements Parcelable, Relay {
     public abstract Builder convertedMinimum(double __);
     public abstract Builder description(String __);
     public abstract Builder endsAt(DateTime __);
+    public abstract Builder startsAt(DateTime __);
     public abstract Builder id(long __);
     public abstract Builder limit(Integer __);
     public abstract Builder minimum(double __);

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -696,7 +696,7 @@ fun getAddOnsList(addOns: fragment.Backing.AddOns): List<Reward> {
 
 /**
  * Transform the Reward GraphQL data structure into our own Reward data model
- * @param fragment.reward
+ * @param fragment.reward rewardGr
  * @return Reward
  */
 private fun rewardTransformer(rewardGr: fragment.Reward): Reward {
@@ -708,6 +708,7 @@ private fun rewardTransformer(rewardGr: fragment.Reward): Reward {
     val limit = chooseLimit(rewardGr.limit(), rewardGr.limitPerBacker())
     val remaining = rewardGr.remainingQuantity()
     val endsAt = rewardGr.endsAt()?.let { DateTime(it) } ?: null
+    val startsAt = rewardGr.startsAt()?.let { DateTime(it) } ?: null
     val rewardId = decodeRelayId(rewardGr.id()) ?: -1
     val available = rewardGr.available()
 
@@ -733,6 +734,7 @@ private fun rewardTransformer(rewardGr: fragment.Reward): Reward {
             .limit(limit)
             .remaining(remaining)
             .endsAt(endsAt)
+            .startsAt(startsAt)
             .description(desc)
             .estimatedDeliveryOn(estimatedDelivery)
             .isAddOn(true)

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
@@ -255,15 +255,17 @@ class BackingAddOnViewHolderViewModel {
         }
 
         /**
-         * If the addOns is available check maxLimit will be hitting either the limit or the remaining
-         * if the addOns is not available, maxLimit will be the current selected quantity for that addOn
+         * If the addOns is available and within a valid time range
+         * maxLimit will be hitting either the limit or the remaining
+         * if the addOns is not available, maxLimit will be the current selected quantity
          * allowing the user to modify the already backed amount just to decrease it.
+         *
          * @param Pair(selectedQuantity, addOn)
-         * @return true -> limit for that addOn reached
+         * @return true -> limit for that addOn reached and addOns is in valid timeRange
          *         false -> still available to choose more
          */
         private fun maxLimitReached(qPerAddOn: Pair<Int, Reward>): Boolean =
-                if (qPerAddOn.second.isAvailable)
+                if (qPerAddOn.second.isAvailable && RewardUtils.isValidTimeRange(qPerAddOn.second))
                     (qPerAddOn.second.remaining()?.let { qPerAddOn.first == it } ?: false) ||
                             (qPerAddOn.first == qPerAddOn.second.limit())
                 else qPerAddOn.first == qPerAddOn.second.quantity()

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -8,6 +8,7 @@ import com.kickstarter.libs.KSString
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
 import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
 import com.kickstarter.libs.utils.ObjectUtils
+import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.RewardUtils.isDigital
 import com.kickstarter.libs.utils.RewardUtils.isShippable
 import com.kickstarter.mock.factories.ShippingRuleFactory
@@ -199,7 +200,7 @@ class BackingAddOnsFragmentViewModel {
                     .distinctUntilChanged()
 
             val addonsList = Observable.merge(addOnsFromGraph, combinedList)
-                    .map { filterOutUnAvailableExceptIfBacked(it) }
+                    .map { filterOutUnAvailableOrEndedExceptIfBacked(it) }
                     .distinctUntilChanged()
 
             shippingRules
@@ -269,6 +270,7 @@ class BackingAddOnsFragmentViewModel {
                         updateQuantityById(it.first)
                         this.totalSelectedAddOns.onNext(calculateTotal(it.second.second))
                     }
+
             // - .startWith(Pair(-1,-1L) because we need to trigger this validation everytime the AddOns selection changes
             // - .startWith(ShippingRuleFactory.emptyShippingRule()) because we need to trigger this validation every time the AddOns selection changes for digital rewards as well
             val isButtonEnabled = Observable.combineLatest(
@@ -320,19 +322,19 @@ class BackingAddOnsFragmentViewModel {
         }
 
         /**
-         *  In case selecting the same reward, if any of the addOns is unavailable
-         *  but has been backed do not filter out that addOn and allow to modify the
-         *  selection.
+         *  In case selecting the same reward, if any of the addOns is unavailable or
+         *  has an invalid time range but has been backed do NOT filter out that addOn
+         *  and allow to modify the selection.
          *
-         *  In case selecting another reward, filter out the unavailable ones
+         *  In case selecting another reward or new pledge, filter out the unavailable/invalid time range ones
          *
          *  @param combinedList -> combinedList of Graph addOns and backed ones
-         *  @return List<Reward> -> filtered list depending on availability and if
-         *  the addOns was backed
+         *  @return List<Reward> -> filtered list depending on availability and time range if new pledge
+         *  @return List<Reward> -> not filtered if the addOn item was previously backed
          */
-        private fun filterOutUnAvailableExceptIfBacked(combinedList: List<Reward>): List<Reward> {
-            return combinedList.filter {
-                addOn ->  addOn.quantity()?.let { it > 0 } ?: addOn.isAvailable
+        private fun filterOutUnAvailableOrEndedExceptIfBacked(combinedList: List<Reward>): List<Reward> {
+            return combinedList.filter { addOn ->
+                addOn.quantity()?.let { it > 0 } ?: (addOn.isAvailable && RewardUtils.isValidTimeRange(addOn))
             }
         }
 
@@ -428,13 +430,20 @@ class BackingAddOnsFragmentViewModel {
                 }
             }
 
-            val updatedQuantity = filteredAddOns
-                    .map {
-                        val amount = this.currentSelection[it.id()] ?: -1
-                        return@map if (amount == -1) it else it.toBuilder().quantity(amount).build()
-                    }
+            val updatedQuantity = updateQuantityIfCurrentlySelected(filteredAddOns)
 
-            return Triple(pData, updatedQuantity, rule)
+            val filteredStaredAddOns = updatedQuantity.filter { RewardUtils.isValidTimeRange(it) }
+
+            return Triple(pData, filteredStaredAddOns, rule)
+        }
+
+        /**
+         *  In case the addOn item is currently selected, or previously backed,
+         *  @retrun List<Reward> the list with each item quantity updated
+         */
+        private fun updateQuantityIfCurrentlySelected(filteredAddOns: List<Reward>) = filteredAddOns.map {
+            val amount = this.currentSelection[it.id()] ?: -1
+            return@map if (amount == -1) it else it.toBuilder().quantity(amount).build()
         }
 
         private fun containsLocation(rule: ShippingRule, reward: Reward): Boolean {

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -147,7 +147,6 @@ class BackingAddOnsFragmentViewModel {
                         this.currentSelection.clear()
                     }
 
-            // - If changing rewards do not emmit the backing information
             val filteredBackingReward = backingReward
                     .compose<Pair<Reward, Boolean>>(combineLatestPair(isSameReward))
                     .filter { it.second }
@@ -215,7 +214,8 @@ class BackingAddOnsFragmentViewModel {
 
             shippingRules
                     .filter { it.isNotEmpty() }
-                    .compose<Pair<List<ShippingRule>, PledgeReason>>(combineLatestPair(pledgeReason))
+                    .compose<Pair<List<ShippingRule>, Reward>>(combineLatestPair(reward))
+                    .filter { !isDigital(it.second) && isShippable(it.second) }
                     .switchMap { defaultShippingRule(it.first) }
                     .subscribe(this.shippingRuleSelected)
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -147,6 +147,7 @@ class BackingAddOnsFragmentViewModel {
                         this.currentSelection.clear()
                     }
 
+            // - If changing rewards do not emmit the backing information
             val filteredBackingReward = backingReward
                     .compose<Pair<Reward, Boolean>>(combineLatestPair(isSameReward))
                     .filter { it.second }
@@ -159,7 +160,11 @@ class BackingAddOnsFragmentViewModel {
             projectAndReward = project
                     .compose<Pair<Project, Reward>>(combineLatestPair(reward))
 
+            // - If changing rewards do not emmit the backing information
             val backingShippingRule = backing
+                    .compose<Pair<Backing, Boolean>>(combineLatestPair(isSameReward))
+                    .filter { it.second }
+                    .map { it.first }
                     .compose<Pair<Backing, List<ShippingRule>>>(combineLatestPair(shippingRules))
                     .map {
                         it.second.first { rule ->

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -417,10 +417,13 @@ interface RewardViewHolderViewModel {
             return when {
                 !hasAddOns && isSelectable(project, rw) -> true
                 hasAddOns && selectingOtherRw && RewardUtils.isAvailable(project, rw) -> true
-                hasAddOns && hasBackedAddOns(project) && !selectingOtherRw && project.isLive -> true
+                isUpdatingSameRewardWithBackedAddOns(hasAddOns, project, selectingOtherRw, rw) -> true
                 else -> false
             }
         }
+
+        private fun isUpdatingSameRewardWithBackedAddOns(hasAddOns: Boolean, project: Project, selectingOtherRw: Boolean, rw: Reward) =
+                hasAddOns && hasBackedAddOns(project) && !selectingOtherRw && RewardUtils.hasStarted(rw) && project.isLive
 
         private fun rewardAmountByVariant(variant: OptimizelyExperiment.Variant?):Int? = when(variant) {
                 OptimizelyExperiment.Variant.CONTROL -> 1
@@ -460,7 +463,7 @@ interface RewardViewHolderViewModel {
         private fun expirationDateIsGone(project: Project, reward: Reward): Boolean {
             return when {
                 !project.isLive -> true
-                RewardUtils.isTimeLimited(reward) -> RewardUtils.isExpired(reward)
+                RewardUtils.isTimeLimitedEnd(reward) -> RewardUtils.isExpired(reward)
                 else -> true
             }
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -7,6 +7,7 @@ import com.kickstarter.libs.FragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
 import com.kickstarter.libs.utils.BackingUtils
 import com.kickstarter.libs.utils.ObjectUtils
+import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.models.Backing
 import com.kickstarter.models.Project
@@ -71,10 +72,11 @@ class RewardsFragmentViewModel {
         init {
 
             this.projectDataInput
+                    .map { filterOutNotStartedRewards(it) }
                     .compose(bindToLifecycle())
                     .subscribe(this.projectData)
 
-            val project = this.projectDataInput
+            val project = this.projectData
                     .map { it.project() }
             
             project
@@ -169,6 +171,14 @@ class RewardsFragmentViewModel {
                             this.showAddOnsFragment.onNext(it)
                         else this.showPledgeFragment.onNext(it)
                     }
+        }
+
+        private fun filterOutNotStartedRewards(pData: ProjectData): ProjectData {
+            val rewards = pData.project().rewards()?.filter { RewardUtils.hasStarted(it) }
+            val modifiedProject = pData.project().toBuilder().rewards(rewards).build()
+            return pData.toBuilder()
+                    .project(modifiedProject)
+                    .build()
         }
 
         private fun getReward(backingObj: Backing): Reward {

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
@@ -10,6 +10,7 @@ import com.kickstarter.libs.models.OptimizelyExperiment;
 import com.kickstarter.mock.factories.LocationFactory;
 import com.kickstarter.mock.factories.ProjectFactory;
 import com.kickstarter.mock.factories.RewardFactory;
+import com.kickstarter.models.Project;
 import com.kickstarter.models.Reward;
 
 import org.joda.time.DateTime;
@@ -267,8 +268,8 @@ public final class RewardUtilsTest extends KSRobolectricTestCase {
 
   @Test
   public void isTimeLimited() {
-    assertFalse(RewardUtils.isTimeLimited(RewardFactory.reward()));
-    assertTrue(RewardUtils.isTimeLimited(RewardFactory.endingSoon()));
+    assertFalse(RewardUtils.isTimeLimitedEnd(RewardFactory.reward()));
+    assertTrue(RewardUtils.isTimeLimitedEnd(RewardFactory.endingSoon()));
   }
 
   @Test
@@ -305,6 +306,32 @@ public final class RewardUtilsTest extends KSRobolectricTestCase {
 
     final Reward rewardWithWorldWideShipping = RewardFactory.rewardWithShipping();
     assertEquals(Pair.create(R.string.Ships_worldwide, null), RewardUtils.shippingSummary(rewardWithWorldWideShipping));
+  }
+
+  @Test
+  public void testRewardTimeLimitedStartIsAvailable() {
+    final Project isLiveProject = ProjectFactory.project();
+    final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now()).build();
+    assertEquals(true, RewardUtils.hasStarted(rewardLimitedByStart));
+    assertEquals(true, RewardUtils.isAvailable(isLiveProject, rewardLimitedByStart));
+  }
+
+  @Test
+  public void testRewardNotTimeLimitedStartIsAvailable() {
+    final Project isLiveProject = ProjectFactory.project();
+    final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().build();
+    assertEquals(false, RewardUtils.isTimeLimitedStart(rewardLimitedByStart));
+    assertEquals(true, RewardUtils.hasStarted(rewardLimitedByStart));
+    assertEquals(true, RewardUtils.isAvailable(isLiveProject, rewardLimitedByStart));
+  }
+
+  @Test
+  public void testRewardTimeLimitedStartInFutureUnavailable() {
+    final Project isLiveProject = ProjectFactory.project();
+    final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now().plusDays(1)).build();
+    assertEquals(true, RewardUtils.isTimeLimitedStart(rewardLimitedByStart));
+    assertEquals(false, RewardUtils.hasStarted(rewardLimitedByStart));
+    assertEquals(false, RewardUtils.isAvailable(isLiveProject, rewardLimitedByStart));
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
@@ -309,7 +309,7 @@ public final class RewardUtilsTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testRewardTimeLimitedStartIsAvailable() {
+  public void testRewardTimeLimitedStart_hasStarted() {
     final Project isLiveProject = ProjectFactory.project();
     final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now()).build();
     assertEquals(true, RewardUtils.hasStarted(rewardLimitedByStart));
@@ -317,21 +317,18 @@ public final class RewardUtilsTest extends KSRobolectricTestCase {
   }
 
   @Test
-  public void testRewardNotTimeLimitedStartIsAvailable() {
-    final Project isLiveProject = ProjectFactory.project();
+  public void testRewardNotTimeLimitedStart_hasStarted() {
+    // - A reward not limited os starting time should be considered as a reward that has started
     final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().build();
     assertEquals(false, RewardUtils.isTimeLimitedStart(rewardLimitedByStart));
     assertEquals(true, RewardUtils.hasStarted(rewardLimitedByStart));
-    assertEquals(true, RewardUtils.isAvailable(isLiveProject, rewardLimitedByStart));
   }
 
   @Test
-  public void testRewardTimeLimitedStartInFutureUnavailable() {
-    final Project isLiveProject = ProjectFactory.project();
+  public void testRewardTimeLimitedStart_hasNotStarted() {
     final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now().plusDays(1)).build();
     assertEquals(true, RewardUtils.isTimeLimitedStart(rewardLimitedByStart));
     assertEquals(false, RewardUtils.hasStarted(rewardLimitedByStart));
-    assertEquals(false, RewardUtils.isAvailable(isLiveProject, rewardLimitedByStart));
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.java
@@ -319,7 +319,7 @@ public final class RewardUtilsTest extends KSRobolectricTestCase {
   @Test
   public void testRewardNotTimeLimitedStart_hasStarted() {
     // - A reward not limited os starting time should be considered as a reward that has started
-    final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().build();
+    final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns();
     assertEquals(false, RewardUtils.isTimeLimitedStart(rewardLimitedByStart));
     assertEquals(true, RewardUtils.hasStarted(rewardLimitedByStart));
   }
@@ -329,6 +329,62 @@ public final class RewardUtilsTest extends KSRobolectricTestCase {
     final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now().plusDays(1)).build();
     assertEquals(true, RewardUtils.isTimeLimitedStart(rewardLimitedByStart));
     assertEquals(false, RewardUtils.hasStarted(rewardLimitedByStart));
+  }
+
+  @Test
+  public void testRewardTimeLimitedEnd_hasEnded() {
+    final Reward rewardExpired = RewardFactory.rewardHasAddOns().toBuilder().endsAt(DateTime.now().minusDays(1)).build();
+    assertEquals(true, RewardUtils.isExpired(rewardExpired));
+    assertEquals(false, RewardUtils.isValidTimeRange(rewardExpired));
+  }
+
+  @Test
+  public void testValidTimeRage_limitedStart_hasNotStarted() {
+    final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now().plusDays(1)).build();
+    assertEquals(false, RewardUtils.isValidTimeRange(rewardLimitedByStart));
+  }
+
+  @Test
+  public void testValidTimeRage_limitedStart_hasStarted() {
+    final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now()).build();
+    assertEquals(true, RewardUtils.isValidTimeRange(rewardLimitedByStart));
+  }
+
+  @Test
+  public void testValidTimeRage_limitedEnd_hasNotEnded() {
+    final Reward rewardLimitedByEnd = RewardFactory.rewardHasAddOns().toBuilder().endsAt(DateTime.now().plusDays(1)).build();
+    assertEquals(false, RewardUtils.isExpired(rewardLimitedByEnd));
+    assertEquals(true, RewardUtils.isValidTimeRange(rewardLimitedByEnd));
+  }
+
+  @Test
+  public void testValidTimeRange_limitedStartEnd_isValid() {
+    final Reward rewardLimitedBoth = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now()).endsAt(DateTime.now().plusDays(1)).build();
+    assertEquals(false, RewardUtils.isExpired(rewardLimitedBoth));
+    assertEquals(true, RewardUtils.hasStarted(rewardLimitedBoth));
+    assertEquals(true, RewardUtils.isValidTimeRange(rewardLimitedBoth));
+  }
+
+  @Test
+  public void testValidTimeRange_limitedStartEnd_isInvalid() {
+    final Reward rewardLimitedBoth = RewardFactory.rewardHasAddOns().toBuilder().startsAt(DateTime.now().plusDays(1)).endsAt(DateTime.now().plusDays(2)).build();
+    assertEquals(false, RewardUtils.isExpired(rewardLimitedBoth));
+    assertEquals(false, RewardUtils.hasStarted(rewardLimitedBoth));
+    assertEquals(false, RewardUtils.isValidTimeRange(rewardLimitedBoth));
+  }
+
+  @Test
+  public void testValidTimeRange_NotLimited_isValid() {
+    final Reward rewardLimitedBoth = RewardFactory.rewardHasAddOns();
+    assertEquals(false, RewardUtils.isExpired(rewardLimitedBoth));
+    assertEquals(true, RewardUtils.hasStarted(rewardLimitedBoth));
+    assertEquals(true, RewardUtils.isValidTimeRange(rewardLimitedBoth));
+  }
+
+  @Test
+  public void testValidTimeRage_NotLimitedStart_hasStarted() {
+    final Reward rewardLimitedByStart = RewardFactory.rewardHasAddOns();
+    assertEquals(true, RewardUtils.isValidTimeRange(rewardLimitedByStart));
   }
 
   @Test


### PR DESCRIPTION
# 📲 What

- Bug when changing reward from digital to one with location

# 🤔 Why

- **Before**: emmiting default location to selectedShipping rule always, Emmiting shipping location from Backing object
- **now** : default location is emmited just in case the reward isShippable and not digital, emmited shipping location from backing object just if it's the same reward.
-  added new test modified previous one

# 👀 See
- Update reward from digital to another one with location 
![from-digital-to-located](https://user-images.githubusercontent.com/4083656/95516376-ff0f1680-0973-11eb-997f-b1fb7c3e7aca.gif)

- Updated reward from located to a digital one
![from-located-to-digital](https://user-images.githubusercontent.com/4083656/95516416-0df5c900-0974-11eb-9bed-a26bc28b1126.gif)

|  |  |

# 📋 QA

1 - Navigate to a project (Bring Back Weekly World News on staging)
2 - Select a reward with no shipping
3 - Pledge to a digital reward
4 - Tap overflow menu, selected Edit Reward
5 - Choose a reward that includes shipping and offers add-ons

Expected: Shipping selector populates available countries, available add-ons are listed, and the skip button is active.

# Story 📖

[NT-1591](https://kickstarter.atlassian.net/browse/NT-1591)
