### PR TITLE
NT-1587: Improve performance

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
@@ -249,8 +249,8 @@ class BackingAddOnViewHolderViewModel {
             this.quantity
                     .compose<Pair<Int, Reward>>(combineLatestPair(addOn))
                     .map { data -> Pair(data.first, data.second.id()) }
-                    .distinctUntilChanged { item1, item2 ->
-                        item1.first == item2.first && item1.second == item2.second
+                    .distinctUntilChanged { quantityPerId1, quantityPerId2 ->
+                        quantityPerId1.first == quantityPerId2.first && quantityPerId1.second == quantityPerId2.second
                     }
                     .compose(bindToLifecycle())
                     .subscribe(this.quantityPerId)

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnViewHolderViewModel.kt
@@ -249,6 +249,9 @@ class BackingAddOnViewHolderViewModel {
             this.quantity
                     .compose<Pair<Int, Reward>>(combineLatestPair(addOn))
                     .map { data -> Pair(data.first, data.second.id()) }
+                    .distinctUntilChanged { item1, item2 ->
+                        item1.first == item2.first && item1.second == item2.second
+                    }
                     .compose(bindToLifecycle())
                     .subscribe(this.quantityPerId)
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -288,7 +288,7 @@ class BackingAddOnsFragmentViewModel {
                     this.currentSelection,
                     this.quantityPerId
             ) {
-                backedRule, backedList, actualRule, currentSelection ->
+                backedRule, backedList, actualRule, currentSelection, _ ->
                 return@combineLatest isDifferentLocation(backedRule, actualRule) || isDifferentSelection(backedList, currentSelection)
             }
                     .distinctUntilChanged()

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -255,7 +255,7 @@ class BackingAddOnsFragmentViewModel {
             // TODO: this observable will disappear once the filter query is ready https://kickstarter.atlassian.net/browse/CT-649
             val filteredAddOns = Observable.combineLatest(addonsList, projectData, this.shippingRuleSelected, reward) {
                 list, pData, rule, rw ->
-                return@combineLatest filterByLocationAndUpdateQuantity(list, pData, rule, rw)
+                return@combineLatest filterByLocation(list, pData, rule, rw)
             }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
@@ -288,7 +288,7 @@ class BackingAddOnsFragmentViewModel {
                     this.currentSelection,
                     this.quantityPerId
             ) {
-                backedRule, backedList, actualRule, currentSelection, _  ->
+                backedRule, backedList, actualRule, currentSelection ->
                 return@combineLatest isDifferentLocation(backedRule, actualRule) || isDifferentSelection(backedList, currentSelection)
             }
                     .distinctUntilChanged()
@@ -336,6 +336,7 @@ class BackingAddOnsFragmentViewModel {
         ): Observable<Pair<PledgeData, PledgeReason>> {
             return Observable.combineLatest(filteredList, pledgeData, pledgeReason, reward, shippingRule, currentSelection, continueButtonPressed) {
                 listAddOns, pledgeData, pledgeReason, rw, shippingRule, currentSelection, _ ->
+
                 val updatedList = updateQuantity(listAddOns.second, currentSelection)
                 val selectedAddOns = getSelectedAddOns(updatedList)
 
@@ -496,7 +497,7 @@ class BackingAddOnsFragmentViewModel {
         }
 
         // TODO: this logic will disappear, once the backed provide us a query to filter by locationID
-        private fun filterByLocationAndUpdateQuantity(addOns: List<Reward>, pData: ProjectData, rule: ShippingRule, rw: Reward): Triple<ProjectData, List<Reward>, ShippingRule> {
+        private fun filterByLocation(addOns: List<Reward>, pData: ProjectData, rule: ShippingRule, rw: Reward): Triple<ProjectData, List<Reward>, ShippingRule> {
             val filteredAddOns = when (rw.shippingPreference()) {
                 Reward.ShippingPreference.UNRESTRICTED.name,
                 Reward.ShippingPreference.UNRESTRICTED.toString().toLowerCase() -> {

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -285,7 +285,7 @@ class BackingAddOnsFragmentViewModel {
                     backingShippingRule.startWith(ShippingRuleFactory.emptyShippingRule()),
                     addOnsFromBacking,
                     this.shippingRuleSelected,
-                    this.currentSelection,
+                    this.currentSelection.take(1),
                     this.quantityPerId
             ) {
                 backedRule, backedList, actualRule, currentSelection, _ ->
@@ -305,7 +305,7 @@ class BackingAddOnsFragmentViewModel {
                     pledgeReason,
                     reward,
                     this.shippingRuleSelected,
-                    this.currentSelection,
+                    this.currentSelection.take(1),
                     this.continueButtonPressed)
 
             updatedPledgeDataAndReason

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -549,7 +549,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
                 .shippingPreferenceType(Reward.ShippingPreference.UNRESTRICTED) // - Reward from GraphQL use this field
                 .shippingPreference(Reward.ShippingPreference.UNRESTRICTED.name.toLowerCase()) // - Reward from V1 use this field
                 .build()
-        val project = ProjectFactory.project()
+
+        val project = ProjectFactory.project().toBuilder().rewards(listOf(rw)).build()
 
         // -Build the backing with location and list of AddOns
         val backing = BackingFactory.backing(project, UserFactory.user(), rw)
@@ -559,7 +560,6 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
                 .addOns(listAddonsBacked)
                 .build()
         val backedProject = project.toBuilder()
-                .rewards(listOf(rw))
                 .backing(backing)
                 .build()
 
@@ -570,13 +570,13 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         bundle.putParcelable(ArgumentsKey.PLEDGE_PLEDGE_DATA, PledgeData.with(pledgeReason, projectData, rw))
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.UPDATE_REWARD)
 
-        // - input from user or ViewHolder building the item with that quantity when updating pledge
-        this.vm.inputs.quantityPerId(Pair(2, addOn2.id()))
-        this.vm.inputs.quantityPerId(Pair(3, addOn3.id()))
         this.vm.arguments(bundle)
+        // - input from ViewHolder when building the item with the backed info
+        this.vm.inputs.quantityPerId(Pair(2, addOn2.id()))
+        this.vm.inputs.quantityPerId(Pair(1, addOn3.id()))
 
         this.isEnabledButton.assertValues(true, false)
-        this.addOnsList.assertValue(Triple(projectData,combinedList, shippingRule.shippingRules().first()))
+        this.addOnsList.assertValue(Triple(projectData, combinedList, shippingRule.shippingRules().first()))
 
         this.lakeTest.assertValue("Add-Ons Page Viewed")
     }

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -499,35 +499,26 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.quantityPerId(quantityPerIdAddOn1)
         this.vm.inputs.quantityPerId(quantityPerIdAddOn2)
         this.vm.inputs.quantityPerId(quantityPerIdAddOn3)
-        this.vm.inputs.continueButtonPressed()
 
         // - Comparison purposes the quantity of the add-ons has been updated in the previous vm.input.quantityPerId
-        val listAddons1 = listOf(addOn.toBuilder().quantity(7).build(), addOn2, addOn3)
-        val listAddons2 = listOf(addOn.toBuilder().quantity(7).build(), addOn2.toBuilder().quantity(2).build(), addOn3)
-        val listAddons3 = listOf(addOn.toBuilder().quantity(7).build(),
+        val listAddonsToCheck = listOf(addOn.toBuilder().quantity(7).build(),
                 addOn2.toBuilder().quantity(2).build(),
                 addOn3.toBuilder().quantity(5).build())
 
-        this.addOnsList.assertValues(
-                Triple(projectData,listAddons, shippingRule.shippingRules().first()),
-                Triple(projectData,listAddons1, shippingRule.shippingRules().first()),
-                Triple(projectData,listAddons2, shippingRule.shippingRules().first()),
-                Triple(projectData,listAddons3, shippingRule.shippingRules().first()))
+        this.addOnsList.assertValues(Triple(projectData,listAddons, shippingRule.shippingRules().first()))
+        this.totalSelectedAddOns.assertValues(0, 7, 9, 14)
 
+        this.vm.inputs.continueButtonPressed()
+        // - value only when updating pledge
         this.isEnabledButton.assertNoValues()
+
         this.vm.outputs.showPledgeFragment()
                 .subscribe {
                     TestCase.assertEquals(it.first, pledgeData)
                     TestCase.assertEquals(it.second, pledgeReason)
 
                     val selectedAddOnsList = pledgeData.addOns()
-                    TestCase.assertEquals(selectedAddOnsList, 3)
-
-                    TestCase.assertEquals(selectedAddOnsList?.first()?.id(), addOn.id())
-                    TestCase.assertEquals(selectedAddOnsList?.first()?.quantity(), 7)
-
-                    TestCase.assertEquals(selectedAddOnsList?.last()?.id(), 99)
-                    TestCase.assertEquals(selectedAddOnsList?.last()?.quantity(), 5)
+                    TestCase.assertEquals(selectedAddOnsList, listAddonsToCheck)
                 }
 
         this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked")
@@ -579,16 +570,19 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         bundle.putParcelable(ArgumentsKey.PLEDGE_PLEDGE_DATA, PledgeData.with(pledgeReason, projectData, rw))
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.UPDATE_REWARD)
 
+        // - input from user or ViewHolder building the item with that quantity when updating pledge
+        this.vm.inputs.quantityPerId(Pair(2, addOn2.id()))
+        this.vm.inputs.quantityPerId(Pair(3, addOn3.id()))
         this.vm.arguments(bundle)
 
-        this.isEnabledButton.assertValue(false)
+        this.isEnabledButton.assertValues(true, false)
         this.addOnsList.assertValue(Triple(projectData,combinedList, shippingRule.shippingRules().first()))
 
         this.lakeTest.assertValue("Add-Ons Page Viewed")
     }
 
     @Test
-    fun givenBackedAddOns_whenUpdatingRewardReasonIncreaseQuantity_EnabledButtonAndResultList() {
+    fun givenBackedAddOns_whenUpdatingRewardIncreaseQuantity_EnabledButtonAndResultList() {
         val shippingRule = ShippingRulesEnvelopeFactory.shippingRules()
 
         val addOn = RewardFactory.addOn().toBuilder()
@@ -637,21 +631,19 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.UPDATE_REWARD)
 
         this.vm.arguments(bundle)
-
-        val updateList = listOf(addOn, addOn2.toBuilder().quantity(2).build(), addOn3.toBuilder().quantity(7).build())
         this.vm.inputs.quantityPerId(Pair(7, addOn3.id()))
-        this.vm.inputs.continueButtonPressed()
+        this.vm.inputs.quantityPerId(Pair(2, addOn2.id()))
 
-        this.isEnabledButton.assertValues(false, true)
-        this.addOnsList.assertValues(
-                Triple(projectData,combinedList, shippingRule.shippingRules().first()),
-                Triple(projectData,updateList, shippingRule.shippingRules().first())
-        )
+        this.isEnabledButton.assertValues(true)
+        this.addOnsList.assertValues(Triple(projectData,combinedList, shippingRule.shippingRules().first()))
 
         // - Always 0 first time, them summatory of all addOns quantity every time the list gets updated
-        this.totalSelectedAddOns.assertValues(0, 9, 9)
+        this.totalSelectedAddOns.assertValues(0, 7, 9)
+
+        this.vm.inputs.continueButtonPressed()
         this.vm.outputs.showPledgeFragment()
                 .subscribe {
+                    val updateList = listOf(addOn, addOn2.toBuilder().quantity(2).build(), addOn3.toBuilder().quantity(7).build())
                     TestCase.assertEquals(it.first.addOns(), updateList)
                 }
 


### PR DESCRIPTION
# 📲 What

- **BEFORE** : every time the amount was updated, the addOn item was re-builded to reflact that amount, by doing that the rx-chains where triggered again.
- **NOW**: will keep the reference to the selected addOns. We will update the quantity of the items just once the continue button has been pressed.

# 🤔 Why

- On projects with large amount of addOns there was performance issues when selecting the addOns try for example the this project with 25 addOns ->  https://www.kickstarter.com/projects/jake61341/santa-claus-mug-enamel-pin?ref=nav_search&result=project&term=santa%20claus%20pin


# 👀 See
- Select many addOns from a list of 25 addOns
![many-addOns-performance](https://user-images.githubusercontent.com/4083656/95928110-6a425980-0d75-11eb-8ff0-22e8e1febedb.gif)
- memory usage screenshoot
<img width="699" alt="memory-consumption-with-change" src="https://user-images.githubusercontent.com/4083656/95928163-8514ce00-0d75-11eb-8bf1-e4c2d407174d.png">


|  |  |

# 📋 QA
- ⚠️ in order to about the current timeout, if testing this PR, query for now shippingRules instead of shippingRulesExtended in case not digital, here what you need to change 
![Screen Shot 2020-10-13 at 5 03 16 PM](https://user-images.githubusercontent.com/4083656/95928371-0bc9ab00-0d76-11eb-8097-4a857277ac91.png)
- For a digital addOns you can try this one with 31 addOns -> https://www.kickstarter.com/projects/cmdrfalcon/sierra-collectors-quest

- Pledge to a project with many addOns 
- Update that pledge to add/remove addOns -> take a look into the button disabled if same selection
- Update pledge to a digital reward 

# Story 📖

[NT-1587](https://kickstarter.atlassian.net/browse/NT-1587)
