### PR TITLE
NT-1454: Android Add-ons Button Polish

### DIFF
--- a/app/src/main/res/layout/item_add_on_pledge.xml
+++ b/app/src/main/res/layout/item_add_on_pledge.xml
@@ -21,6 +21,7 @@
                 android:id="@+id/add_on_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:clipToPadding="false"
                 android:padding="@dimen/grid_3"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -202,23 +203,24 @@
                         tools:text="1" />
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
-                <androidx.appcompat.widget.AppCompatTextView
+                <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/initial_state_add_on"
                     android:layout_width="0dp"
                     android:layout_height="@dimen/grid_7"
                     android:layout_marginTop="@dimen/grid_9_half"
                     android:gravity="center"
-                    android:textStyle="bold"
+                    android:textAllCaps="false"
                     android:textColor="@color/white"
                     android:background="@drawable/border_rounded_solid_black"
                     android:text="@string/Add"
-                    style="@style/TextPrimary"
+                    style="@style/TextAppearance.AppCompat.Button"
                     android:textSize="@dimen/callout"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/pills_container"
                     tools:text="Add"
-                    tools:visibility="visible"/>
+                    tools:visibility="visible"
+                    android:elevation="@dimen/grid_8"/>
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.cardview.widget.CardView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
# 📲 What

Design polish on add-ons "Add" button. 

# 🤔 Why

To align add-ons with standard Kickstarter button style. 

# 🛠 How

Update XML from `AppCompatTextView` into an `AppCompatButton`, add an elevation attribute, and correct the text appearance to be a button. 

# 👀 See

| Before 🐛 | After 🦋 |
![Screenshot_1602696024](https://user-images.githubusercontent.com/19390326/96156000-93322e00-0ede-11eb-9b3a-b2048a18bac8.png) ![Screenshot_1602776985](https://user-images.githubusercontent.com/19390326/96155550-0dae7e00-0ede-11eb-8581-c4e1e32fd7b1.png)

|  |  |

# 📋 QA

- Select project with add-ons
- Tap "Back Project"
- Tap a reward with add-ons
- View "Add" button on add-on card

# Story 📖

[NT-1454: Android Add-ons Button Polish](https://kickstarter.atlassian.net/browse/NT-1454?atlOrigin=eyJpIjoiMTlkNmZhZGQ0ZDFlNDhjYzg2N2Q3MzE4OWIwYjYxNDYiLCJwIjoiaiJ9)
