### PR TITLE
NT-1587: Query with filtering for shippingRules

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -75,11 +75,6 @@ fragment reward on Reward {
         ... amount
     }
     shippingPreference
-    shippingRulesExpanded {
-        nodes {
-            ... shippingRule
-        }
-    }
     remainingQuantity
     limit
     limitPerBacker
@@ -91,7 +86,6 @@ fragment shippingRule on ShippingRule {
     cost {
         ... amount
     }
-    id
     location {
         ... location
     }
@@ -106,17 +100,13 @@ fragment user on User {
 fragment amount on Money {
     amount
     currency
-    symbol
 }
 
 fragment location on Location {
     county
-    countryName
-    discoverUrl
     displayableName
     id
     name
-    state
 }
 
 fragment payment on CreditCard {

--- a/app/src/main/graphql/project.graphql
+++ b/app/src/main/graphql/project.graphql
@@ -18,10 +18,15 @@ query GetProjectBacking($slug: String!) {
   }
 }
 
-query GetProjectAddOns($slug: String!) {
+query GetProjectAddOns($slug: String!, $locationId: ID!) {
   project(slug: $slug) {
     addOns {
       nodes {
+        shippingRulesExpanded(forLocation: $locationId) {
+          nodes {
+            ... shippingRule
+          }
+        }
         ... reward
       }
     }

--- a/app/src/main/graphql/schema.json
+++ b/app/src/main/graphql/schema.json
@@ -1683,13 +1683,9 @@
               "description": "Whether this checkout requires additional client-side authentication steps\n(e.g. 3DS2) to complete the on-session pledge flow",
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2553,6 +2549,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "forLocation",
+                  "description": "Returns expanded shipping rules given location",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "last",
                   "description": "Returns the last _n_ elements from the list.",
                   "type": {
@@ -2579,6 +2585,26 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "simpleShippingRulesExpanded",
+              "description": "Simple shipping rules expanded as a faster alternative to shippingRulesExpanded since connection type is slow",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SimpleShippingRule",
+                    "ofType": null
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -3334,16 +3360,6 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "forLocation",
-                  "description": "Filters available add ons by given location",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4131,7 +4147,7 @@
             },
             {
               "name": "fxRate",
-              "description": "",
+              "description": "Exchange rate for the current user's currency",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5159,6 +5175,18 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "usdExchangeRate",
+              "description": "Exchange rate to US Dollars (USD), null for draft projects.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -10576,6 +10604,12 @@
               "deprecationReason": null
             },
             {
+              "name": "datalake_fe_events",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "default_to_campaign_on_mobile",
               "description": "",
               "isDeprecated": false,
@@ -10822,18 +10856,6 @@
               "deprecationReason": null
             },
             {
-              "name": "multiple_rewards_add_ons",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "multiple_rewards_quantification",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "native_creator_breakdown_chart",
               "description": "",
               "isDeprecated": false,
@@ -10943,12 +10965,6 @@
             },
             {
               "name": "reward_images",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "reward_tabs_in_build",
               "description": "",
               "isDeprecated": false,
               "deprecationReason": null
@@ -22807,6 +22823,65 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "SimpleShippingRule",
+          "description": "Simple shipping rule for a reward",
+          "fields": [
+            {
+              "name": "cost",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currency",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locationId",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locationName",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "UNION",
           "name": "PaymentSource",
           "description": "Payment sources",
@@ -23435,6 +23510,11 @@
             {
               "kind": "OBJECT",
               "name": "ShortText",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "SingleProjectContainer",
               "ofType": null
             }
           ]
@@ -25262,6 +25342,188 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SingleProjectContainer",
+          "description": "Projects that can be shown in article",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "selectedProject",
+              "description": "The currently selected project",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SingleProjectItem",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "singleProjectItems",
+              "description": "The selected project items in this collection",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SingleProjectItem",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SingleProjectItem",
+          "description": "A selected project to be shown in an editorial layout.",
+          "fields": [
+            {
+              "name": "description",
+              "description": "The project description or, if specified, the project description override",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "imageOverride",
+              "description": "If specified, will override the image of the associated project",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "project",
+              "description": "The project that is featured",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Project",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "projectId",
+              "description": "The project id (pid) of the featured project",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sectionUrl",
+              "description": "The see more url for this featured section",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "The project title or, if specified, the project title override",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -32858,6 +33120,16 @@
               "defaultValue": null
             },
             {
+              "name": "refParam",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "rewardIds",
               "description": "",
               "type": {
@@ -33386,6 +33658,12 @@
             {
               "name": "ShortText",
               "description": "ShortText",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SingleProjectContainer",
+              "description": "SingleProjectContainer",
               "isDeprecated": false,
               "deprecationReason": null
             }

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -23,7 +23,7 @@ open class MockApolloClient : ApolloClientType {
         return Observable.just(BackingFactory.backing())
     }
 
-    override fun getProjectAddOns(slug: String, locationId: Location): Observable<List<Reward>> {
+    override fun getProjectAddOns(slug: String, location: Location): Observable<List<Reward>> {
         val reward = RewardFactory.reward().toBuilder().isAddOn(true).quantity(2).build()
         return Observable.just(listOf(reward, reward))
     }

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -23,7 +23,7 @@ open class MockApolloClient : ApolloClientType {
         return Observable.just(BackingFactory.backing())
     }
 
-    override fun getProjectAddOns(slug: String): Observable<List<Reward>> {
+    override fun getProjectAddOns(slug: String, locationId: Location): Observable<List<Reward>> {
         val reward = RewardFactory.reward().toBuilder().isAddOn(true).quantity(2).build()
         return Observable.just(listOf(reward, reward))
     }

--- a/app/src/main/java/com/kickstarter/models/Location.java
+++ b/app/src/main/java/com/kickstarter/models/Location.java
@@ -9,7 +9,7 @@ import auto.parcel.AutoParcel;
 
 @AutoGson
 @AutoParcel
-public abstract class Location implements Parcelable {
+public abstract class Location implements Parcelable, Relay {
   public abstract long id();
   public abstract @Nullable String city();
   public abstract String country();

--- a/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
+++ b/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
@@ -33,7 +33,7 @@ interface ApolloClientType {
 
     fun getProjectBacking(slug: String): Observable<Backing>
 
-    fun getProjectAddOns(slug: String): Observable<List<Reward>>
+    fun getProjectAddOns(slug: String, locationId: Location): Observable<List<Reward>>
 
     fun getStoredCards(): Observable<List<StoredCard>>
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -504,6 +504,7 @@ class BackingAddOnsFragmentViewModel {
                     }
         }
 
+        // - This will disappear when the query is ready in the backend [CT-649]
         private fun filterByLocation(addOns: List<Reward>, pData: ProjectData, rule: ShippingRule, rw: Reward): Triple<ProjectData, List<Reward>, ShippingRule> {
             val filteredAddOns = when (rw.shippingPreference()) {
                 Reward.ShippingPreference.UNRESTRICTED.name,

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -459,7 +459,7 @@ interface PledgeFragmentViewModel {
             val backingShippingRule = backing
                     .compose<Pair<Backing, Reward>>(combineLatestPair(this.selectedReward))
                     .filter {
-                        RewardUtils.isShippable(it.second) && ObjectUtils.isNotNull(it.first.locationId())
+                        RewardUtils.isShippable(it.second) && ObjectUtils.isNotNull(it.first.locationId()) && !hasBackedAddOns(it)
                     }
                     .map { requireNotNull(it.first.locationId()) }
                     .compose<Pair<Long, List<ShippingRule>>>(combineLatestPair(shippingRules))
@@ -481,8 +481,6 @@ interface PledgeFragmentViewModel {
                     .distinctUntilChanged()
 
             preSelectedShippingRule
-                    .filter { ObjectUtils.isNotNull(it) }
-                    .map { requireNotNull(it) }
                     .compose(bindToLifecycle())
                     .subscribe {
                         this.shippingRule.onNext(it)
@@ -1426,6 +1424,12 @@ interface PledgeFragmentViewModel {
                         }
                     }
         }
+
+        /**
+         * Determine if the user has backed addOns
+         */
+        private fun hasBackedAddOns(it: Pair<Backing, Reward>) =
+                it.first.addOns()?.isNotEmpty() ?: false
 
         private fun getAmountDigital(pledgeAmount: Double, bAmount: Double, pReason: PledgeReason) = pledgeAmount + bAmount
 

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -481,6 +481,8 @@ interface PledgeFragmentViewModel {
                     .distinctUntilChanged()
 
             preSelectedShippingRule
+                    .filter { ObjectUtils.isNotNull(it) }
+                    .map { requireNotNull(it) }
                     .compose(bindToLifecycle())
                     .subscribe {
                         this.shippingRule.onNext(it)
@@ -1429,7 +1431,7 @@ interface PledgeFragmentViewModel {
          * Determine if the user has backed addOns
          */
         private fun hasBackedAddOns(it: Pair<Backing, Reward>) =
-                it.first.addOns()?.isNotEmpty() ?: false
+                it.second.hasAddons() && it.first.addOns()?.isNotEmpty() ?: false
 
         private fun getAmountDigital(pledgeAmount: Double, bAmount: Double, pReason: PledgeReason) = pledgeAmount + bAmount
 

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -9,6 +9,7 @@ import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.factories.*
 import com.kickstarter.mock.services.MockApiClient
 import com.kickstarter.mock.services.MockApolloClient
+import com.kickstarter.models.Location
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.ShippingRule
@@ -931,7 +932,7 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         return environment()
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun getProjectAddOns(slug: String): Observable<List<Reward>> {
+                    override fun getProjectAddOns(slug: String, location: Location): Observable<List<Reward>> {
                         return Observable.error(ApiExceptionFactory.badRequestException())
                     }
                 })
@@ -948,26 +949,13 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         return environment()
                 .toBuilder()
                 .apolloClient(object : MockApolloClient() {
-                    override fun getProjectAddOns(slug: String): Observable<List<Reward>> {
+                    override fun getProjectAddOns(slug: String, location: Location): Observable<List<Reward>> {
                         return Observable.just(addOns)
                     }
                 })
                 .apiClient(object : MockApiClient() {
                     override fun fetchShippingRules(project: Project, reward: Reward): Observable<ShippingRulesEnvelope> {
                         return Observable.just(shippingRule)
-                    }
-                })
-                .currentConfig(currentConfig)
-                .build()
-    }
-
-    private fun buildEnvironmentWith(addOns: List<Reward>, currentConfig: MockCurrentConfig): Environment {
-
-        return environment()
-                .toBuilder()
-                .apolloClient(object : MockApolloClient() {
-                    override fun getProjectAddOns(slug: String): Observable<List<Reward>> {
-                        return Observable.just(addOns)
                     }
                 })
                 .currentConfig(currentConfig)


### PR DESCRIPTION
# 📲 What

- the backend has provided has a new query for filtering shippingRulesExtended by locationId

# 🛠 How

- Modified Rewards graphql fragment to not retrieve shippingRulesExpanded
- modified GetProjectAddOns query receive a new parameter for locationId
- in addOns nodes item use the new ShippingRulesExtended query with the locationId as parameter
- removed unnecessary fields from location graphql fragment
- modified KsApolliClient to parser the new structure for shippingRulesExtended
- When updating backed addOns modify the bakedAddOn item to hold the shippingRules from that same item from graphql
- in pledge fragment do not use the backing shippingRule if the selected reward has backed addOns

# 👀 See

| Before 🐛 | After 🦋 |
- **Before networking**  10 Second
<img width="1549" alt="networking_before" src="https://user-images.githubusercontent.com/4083656/96165908-24e76e80-0ed2-11eb-868d-7ca1212c3dce.png">

- **Now networking** less than 1 second
<img width="1562" alt="networking_now" src="https://user-images.githubusercontent.com/4083656/96165955-33358a80-0ed2-11eb-8736-8aa2f8feef76.png">

- In the gif you can see how for Canada shippingCost is 5, when changing to United states is 0 
![filter-location-small](https://user-images.githubusercontent.com/4083656/96166035-49dbe180-0ed2-11eb-9efa-199e68871fe6.gif)

|  |  |

# 📋 QA

- Use any of the big projects to back addOns 
- After pledging modify your selection changing the shipping rule

# Story 📖

[NT-1587](https://kickstarter.atlassian.net/browse/NT-1587)
