### PR TITLE
NT-1630: Fix UpdateActivity crash 

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.java
@@ -104,6 +104,8 @@ public class UpdateActivity extends BaseActivity<UpdateViewModel.ViewModel> impl
   protected void onDestroy() {
     super.onDestroy();
     this.ksWebView.setDelegate(null);
+    this.ksWebView = null;
+    this.viewModel = null;
   }
 
   private boolean handleProjectUpdateCommentsUriRequest(final @NonNull Request request, final @NonNull WebView webView) {
@@ -112,7 +114,9 @@ public class UpdateActivity extends BaseActivity<UpdateViewModel.ViewModel> impl
   }
 
   private boolean handleProjectUpdateUriRequest(final @NonNull Request request, final @NonNull WebView webView) {
-    this.viewModel.inputs.goToUpdateRequest(request);
+    if (request!= null && webView!= null) {
+      this.viewModel.inputs.goToUpdateRequest(request);
+    }
     return false;
   }
 


### PR DESCRIPTION
# 📲 What

![Screen Shot 2020-10-21 at 4 03 49 PM](https://user-images.githubusercontent.com/4083656/96799024-07754180-13b7-11eb-87fa-10611388dd89.png)


# 🤔 Why
- We cannot reproduce the error, we are just trying to avoid it.

# 🛠 How
- Avoid any possible memory leak from the webView or having the webview runnig but dettached from the Activity cleaning up those two components when onDestroy.

- This PR goes along with another one in [here](https://github.com/kickstarter/native-secrets/pull/75), more detail inside.
- Once that PR is merged run `make secrets` in your local environment.
- Start the QA specified in that PR
|  |  |

# 📋 QA

Instructions for anyone to be able to QA this work.

# Story 📖

[Name of Trello Story](Trello link)
