### PR TITLE
NT-1625: Fix crash 

### DIFF
--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -331,9 +331,9 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
     }
 
     private fun getAddOnsFromProject(addOnsGr: GetProjectAddOnsQuery.AddOns): List<Reward> {
-       return addOnsGr.nodes()?.map {
-           val shippingRulesGr = it.shippingRulesExpanded()?.nodes()?.map { it.fragments().shippingRule() } ?: emptyList()
-           rewardTransformer(it.fragments().reward(), shippingRulesGr)
+       return addOnsGr.nodes()?.map { node ->
+           val shippingRulesGr = node.shippingRulesExpanded()?.nodes()?.map { it.fragments().shippingRule() } ?: emptyList()
+           rewardTransformer(node.fragments().reward(), shippingRulesGr)
         }?.toList() ?: emptyList()
     }
 
@@ -614,7 +614,7 @@ private fun createBackingObject(backingGr: fragment.Backing?): Backing {
     }
 
     val backerData = backingGr?.backer()?.fragments()?.user()
-    val nameBacker = backerData?.name()
+    val nameBacker = backerData?.let { it.name() } ?: ""
     val backerId= decodeRelayId(backerData?.id()) ?: -1
     val avatar = Avatar.builder()
             .medium(backerData?.imageUrl())


### PR DESCRIPTION
# 📲 What
- In case using the GraphQL query for backing we receive a backing object, without backer information, feed empty instead of null to the dataModel.

# 🛠 How

- avoid null on backer name
- avoid shadowing it parameter

# 👀 See
[Crash report](https://console.firebase.google.com/u/1/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/310732673fa17a383580c28e897e2993?time=last-twenty-four-hours&versions=2.9.0%20(2010151641)&sessionEventKey=5F9076F502EC00017613A6D13BB67AFF_1464580771640330662)
![Screen Shot 2020-10-22 at 11 05 12 AM](https://user-images.githubusercontent.com/4083656/96911991-7d7cb580-1456-11eb-885e-b29d01e6d2b1.png)
|  |  |

# 📋 QA

- we could not reproduce it

# Story 📖

[NT-1625](https://kickstarter.atlassian.net/browse/NT-1625)
