### PR TITLE
NT-1615:copy change

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -26,7 +26,9 @@ object RewardViewUtils {
         val hasAddOnsSelected = project.backing()?.addOns()?.isNotEmpty() ?: false
 
         return when {
-            BackingUtils.isBacked(project, reward) && !hasAddOnsSelected -> R.string.Selected
+            BackingUtils.isBacked(project, reward) && !reward.hasAddons() && !hasAddOnsSelected -> R.string.Selected
+            BackingUtils.isBacked(project, reward) && reward.hasAddons() && !hasAddOnsSelected -> R.string.Continue
+            BackingUtils.isBacked(project, reward) && !hasAddOnsSelected && reward.hasAddons()-> R.string.Selected
             !BackingUtils.isBacked(project, reward) && RewardUtils.isAvailable(project, reward) -> R.string.Select
             BackingUtils.isBacked(project, reward) && reward.hasAddons() && hasAddOnsSelected -> R.string.Continue
             else -> R.string.No_longer_available

--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -26,11 +26,9 @@ object RewardViewUtils {
         val hasAddOnsSelected = project.backing()?.addOns()?.isNotEmpty() ?: false
 
         return when {
-            BackingUtils.isBacked(project, reward) && !reward.hasAddons() && !hasAddOnsSelected -> R.string.Selected
-            BackingUtils.isBacked(project, reward) && reward.hasAddons() && !hasAddOnsSelected -> R.string.Continue
-            BackingUtils.isBacked(project, reward) && !hasAddOnsSelected && reward.hasAddons()-> R.string.Selected
+            BackingUtils.isBacked(project, reward) && !reward.hasAddons() -> R.string.Selected
             !BackingUtils.isBacked(project, reward) && RewardUtils.isAvailable(project, reward) -> R.string.Select
-            BackingUtils.isBacked(project, reward) && reward.hasAddons() && hasAddOnsSelected -> R.string.Continue
+            BackingUtils.isBacked(project, reward) && reward.hasAddons() || hasAddOnsSelected -> R.string.Continue
             else -> R.string.No_longer_available
         }
     }

--- a/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
@@ -164,6 +164,33 @@ public final class ProjectFactory {
             .build();
   }
 
+  public static @NonNull Project backedProjectRewardAvailableAddOnsNotBackedAddOns() {
+    final Project project = project();
+
+    final Reward reward = RewardFactory.reward().toBuilder().hasAddons(true).build();
+
+    final Backing backing = Backing.builder()
+            .amount(10.0f)
+            .backerId(IdFactory.id())
+            .cancelable(true)
+            .id(IdFactory.id())
+            .sequence(1)
+            .reward(reward)
+            .rewardId(reward.id())
+            .paymentSource(PaymentSourceFactory.Companion.visa())
+            .pledgedAt(DateTime.now())
+            .projectId(project.id())
+            .shippingAmount(0.0f)
+            .status(Backing.STATUS_PLEDGED)
+            .build();
+
+    return project
+            .toBuilder()
+            .backing(backing)
+            .isBacking(true)
+            .build();
+  }
+
 
   public static @NonNull Project backedSuccessfulProject() {
     final Project project = successfulProject();

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
@@ -30,6 +30,18 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
         assertEquals(R.string.Selected, RewardViewUtils.pledgeButtonText(backedSuccessfulProject, backedSuccessfulReward))
     }
 
+    /**
+     * Given a backedProject the backed reward has available addOns
+     * when not backed addOns
+     * Then the text for the button should be R.string.Continue
+     */
+    @Test
+    fun rewardBackedHasAvailableAddOns_whenNotBackedAddOns_textContinue() {
+        val backedProjectRwHasAvailableNotBackedAddOns = ProjectFactory.backedProjectRewardAvailableAddOnsNotBackedAddOns()
+        val backedRwAvailableAddOns = requireNotNull(backedProjectRwHasAvailableNotBackedAddOns.backing()?.reward())
+        assertEquals(R.string.Continue, RewardViewUtils.pledgeButtonText(backedProjectRwHasAvailableNotBackedAddOns, backedRwAvailableAddOns))
+    }
+
     @Test
     fun testShippingSummary() {
         val ksString = ksString()


### PR DESCRIPTION
# 📲 What

- Backed reward with available addOns always available button text should read "Continue" instead of "Select"


# 👀 See

| Before 🐛 |
![Screen Shot 2020-10-22 at 3 22 22 PM](https://user-images.githubusercontent.com/4083656/96936160-694aaf80-147a-11eb-83b3-f8c17c7c98ce.png)
 | After 🦋 |
![Screen Shot 2020-10-22 at 3 24 49 PM](https://user-images.githubusercontent.com/4083656/96936381-c6defc00-147a-11eb-93f2-a96bc12e81fd.png)
|  |  |

# 📋 QA

1. Pledge to project project
2. Select a reward that has add-ons available
3. Skip add-ons
4. Complete pledge
5. Enter edit reward flow
6. Actual: Disabled button that reads "Selected" 
Expected: Button reads continue, allows user to continue in flow

# Story 📖

[NT-1615](https://kickstarter.atlassian.net/browse/NT-1615)
