### PR TITLE
NT-1634: Persist reward delivered checkbox

### DIFF
--- a/app/src/main/java/com/kickstarter/models/Backing.java
+++ b/app/src/main/java/com/kickstarter/models/Backing.java
@@ -27,6 +27,7 @@ public abstract class Backing implements Parcelable, Relay {
   public abstract @Nullable DateTime backerCompletedAt();
   public abstract boolean cancelable();
   public abstract @Nullable DateTime completedAt();
+  public abstract @Nullable boolean completedByBacker();
   public abstract long id();
   public abstract @Nullable Location location();
   public abstract @Nullable Long locationId();
@@ -54,6 +55,7 @@ public abstract class Backing implements Parcelable, Relay {
     public abstract Builder backerCompletedAt(DateTime __);
     public abstract Builder cancelable(boolean __);
     public abstract Builder completedAt(DateTime __);
+    public abstract Builder completedByBacker(boolean __);
     public abstract Builder id(long __);
     public abstract Builder location(Location __);
     public abstract Builder locationId(Long __);

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -619,6 +619,7 @@ private fun createBackingObject(backingGr: fragment.Backing?): Backing {
     val avatar = Avatar.builder()
             .medium(backerData?.imageUrl())
             .build()
+    val completedByBacker = backingGr?.backerCompleted() ?: false
 
     val backer = User.builder()
             .id(backerId)
@@ -646,6 +647,7 @@ private fun createBackingObject(backingGr: fragment.Backing?): Backing {
             .shippingAmount(shippingAmount?.amount()?.amount()?.toFloat() ?: 0f)
             .status(backingGr?.status()?.rawValue())
             .cancelable(backingGr?.cancelable() ?: false)
+            .completedByBacker(completedByBacker)
             .build()
 }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -157,7 +157,7 @@ interface BackingFragmentViewModel {
         private val pledgeStatusData = BehaviorSubject.create<PledgeStatusData>()
         private val pledgeSummaryIsGone = BehaviorSubject.create<Boolean>()
         private val projectDataAndReward = BehaviorSubject.create<Pair<ProjectData, Reward>>()
-        private val receivedCheckboxChecked = BehaviorSubject.create<Boolean>(false)
+        private val receivedCheckboxChecked = BehaviorSubject.create<Boolean>()
         private val receivedSectionIsGone = BehaviorSubject.create<Boolean>()
         private val shippingAmount = BehaviorSubject.create<CharSequence>()
         private val shippingLocation = BehaviorSubject.create<String>()
@@ -337,7 +337,6 @@ interface BackingFragmentViewModel {
 
             backing
                     .map { it.completedByBacker() }
-                    .map { ObjectUtils.isNotNull(it) }
                     .compose(bindToLifecycle<Boolean>())
                     .subscribe {
                         this.receivedCheckboxChecked.onNext(it)

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -337,10 +337,9 @@ interface BackingFragmentViewModel {
 
             backing
                     .map { it.completedByBacker() }
+                    .distinctUntilChanged()
                     .compose(bindToLifecycle<Boolean>())
-                    .subscribe {
-                        this.receivedCheckboxChecked.onNext(it)
-                    }
+                    .subscribe(this.receivedCheckboxChecked)
 
             backing
                     .compose<Pair<Backing, Project>>(combineLatestPair(backedProject))

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -157,7 +157,7 @@ interface BackingFragmentViewModel {
         private val pledgeStatusData = BehaviorSubject.create<PledgeStatusData>()
         private val pledgeSummaryIsGone = BehaviorSubject.create<Boolean>()
         private val projectDataAndReward = BehaviorSubject.create<Pair<ProjectData, Reward>>()
-        private val receivedCheckboxChecked = BehaviorSubject.create<Boolean>()
+        private val receivedCheckboxChecked = BehaviorSubject.create<Boolean>(false)
         private val receivedSectionIsGone = BehaviorSubject.create<Boolean>()
         private val shippingAmount = BehaviorSubject.create<CharSequence>()
         private val shippingLocation = BehaviorSubject.create<String>()
@@ -336,11 +336,12 @@ interface BackingFragmentViewModel {
                     .subscribe { this.notifyDelegateToShowFixPledge.onNext(null) }
 
             backing
-                    .map { it.backerCompletedAt() }
+                    .map { it.completedByBacker() }
                     .map { ObjectUtils.isNotNull(it) }
-                    .distinctUntilChanged()
                     .compose(bindToLifecycle<Boolean>())
-                    .subscribe(this.receivedCheckboxChecked)
+                    .subscribe {
+                        this.receivedCheckboxChecked.onNext(it)
+                    }
 
             backing
                     .compose<Pair<Backing, Project>>(combineLatestPair(backedProject))

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -791,10 +791,10 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testReceivedCheckboxChecked_whenReceived() {
+    fun testReceivedCheckboxChecked_whenChecked() {
         val backing = BackingFactory.backing()
                 .toBuilder()
-                .backerCompletedAt(DateTime.now())
+                .completedByBacker(true)
                 .build()
 
         val environment = environment()
@@ -805,6 +805,23 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.backedProject()))
 
         this.receivedCheckboxChecked.assertValue(true)
+    }
+
+    @Test
+    fun testReceivedCheckboxChecked_whenUnchecked() {
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .completedByBacker(false)
+                .build()
+
+        val environment = environment()
+                .toBuilder()
+                .apolloClient(mockApolloClientForBacking(backing))
+                .build()
+        setUpEnvironment(environment)
+        this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.backedProject()))
+
+        this.receivedCheckboxChecked.assertValue(false)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- Reward delivered checkbox not being persisted

# 🤔 Why
- When the migration to graphql took place, we did not realize the field `DateTime backerCompletedAt` from V1, in graphQl is `backerCompleted`

# 🛠 How
- We already query the field `backerCompleted` when getting the backing, in the Pr we serialize it into a new field on Backing Object `completedByBacker`

# 👀 See
![persist_selection_checkbox](https://user-images.githubusercontent.com/4083656/97762153-e56d7480-1ac4-11eb-9aef-8dd4588ebe6d.gif)
|  |  |

# 📋 QA

1. Tap into profile
2. Tap into a project you've backed
3. Tap View your pledge
4. See "Reward delivered?" checkbox
5. Tap checkbox
6. Return to profile
7. Repeat steps 1-4
Expected:  "Reward delivered?" checkbox is checked

# Story 📖

[NT-1634](https://kickstarter.atlassian.net/browse/NT-1634)
