### PR TITLE
NT-1648: Email Verification Interstitial UI (#1033)

### DIFF
--- a/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.java
+++ b/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.java
@@ -29,6 +29,7 @@ import com.kickstarter.libs.utils.Secrets;
 import com.kickstarter.libs.utils.ViewUtils;
 import com.kickstarter.libs.utils.WorkUtils;
 import com.kickstarter.services.firebase.ResetDeviceIdWorker;
+import com.kickstarter.ui.fragments.EmailVerificationInterstitialFragment;
 import com.kickstarter.viewmodels.InternalToolsViewModel;
 
 import org.joda.time.format.DateTimeFormat;
@@ -146,6 +147,15 @@ public final class InternalToolsActivity extends BaseActivity<InternalToolsViewM
   public void featureFlagsClick() {
     final Intent featureFlagIntent = new Intent(this, FeatureFlagsActivity.class);
     startActivity(featureFlagIntent);
+  }
+
+  @OnClick(R.id.email_verification_button)
+  public void emailVerificationInterstitialClick() {
+    final EmailVerificationInterstitialFragment fragment = EmailVerificationInterstitialFragment.Companion.newInstance();
+    getSupportFragmentManager()
+            .beginTransaction()
+            .add(R.id.email_verification_interstitial_fragment_container, fragment)
+            .commit();
   }
 
   @OnClick(R.id.reset_device_id)

--- a/app/src/internal/res/layout/internal_tools_layout.xml
+++ b/app/src/internal/res/layout/internal_tools_layout.xml
@@ -245,7 +245,24 @@
         android:layout_marginBottom="@dimen/grid_1"
         android:text="@string/Force_a_crash" />
 
+      <include layout="@layout/horizontal_line_1dp_view" />
+
+      <Button
+          android:id="@+id/email_verification_button"
+          style="@style/Button"
+          app:background="@color/green_alpha_6"
+          android:layout_width="match_parent"
+          android:layout_marginTop="@dimen/grid_1"
+          android:layout_marginBottom="@dimen/grid_1"
+          android:text="@string/email_verification_interstitial" />
+
     </LinearLayout>
 
   </ScrollView>
+
+  <FrameLayout
+      android:id="@+id/email_verification_interstitial_fragment_container"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"/>
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/java/com/kickstarter/ui/fragments/EmailVerificationInterstitialFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/EmailVerificationInterstitialFragment.kt
@@ -1,0 +1,25 @@
+package com.kickstarter.ui.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.kickstarter.R
+import com.kickstarter.libs.BaseFragment
+import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
+import com.kickstarter.viewmodels.EmailVerificationInterstitialFragmentViewModel
+
+@RequiresFragmentViewModel(EmailVerificationInterstitialFragmentViewModel.ViewModel::class)
+class EmailVerificationInterstitialFragment : BaseFragment<EmailVerificationInterstitialFragmentViewModel.ViewModel>() {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        super.onCreateView(inflater, container, savedInstanceState)
+        return inflater.inflate(R.layout.fragment_email_verification_interstitial, container, false)
+    }
+
+    companion object {
+        fun newInstance(): EmailVerificationInterstitialFragment {
+            return EmailVerificationInterstitialFragment()
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
@@ -1,0 +1,12 @@
+package com.kickstarter.viewmodels
+
+import androidx.annotation.NonNull
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.FragmentViewModel
+import com.kickstarter.ui.fragments.EmailVerificationInterstitialFragment
+
+class EmailVerificationInterstitialFragmentViewModel {
+    interface Inputs { }
+    interface Outputs { }
+    class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<EmailVerificationInterstitialFragment>(environment), Outputs, Inputs { }
+}

--- a/app/src/main/res/drawable/ic_email.xml
+++ b/app/src/main/res/drawable/ic_email.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="42dp"
+    android:height="30dp"
+    android:viewportWidth="42"
+    android:viewportHeight="30">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M38.5,1.3L21,16.1L3.5,1.3C3.2,1.1 3.4,0.6 3.8,0.6h34.5C38.6,0.6 38.8,1.1 38.5,1.3zM0.2,3.6c0,-0.3 0.4,-0.5 0.7,-0.3l13.4,11.3L0.9,26.6c-0.3,0.2 -0.7,0 -0.7,-0.3V3.6zM41.1,3.3L27.7,14.6l13.4,12c0.3,0.2 0.7,0 0.7,-0.3V3.6C41.8,3.2 41.4,3 41.1,3.3zM22.5,19l2.7,-2.3l13.4,12c0.3,0.2 0.1,0.7 -0.3,0.7H3.6c-0.4,0 -0.5,-0.5 -0.3,-0.7l13.4,-12l2.7,2.3c0.4,0.4 1,0.6 1.5,0.6C21.5,19.6 22.1,19.4 22.5,19z"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/layout/fragment_email_verification_interstitial.xml
+++ b/app/src/main/res/layout/fragment_email_verification_interstitial.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    android:padding="@dimen/grid_4">
+
+    <ImageView
+        android:id="@+id/email_verification_interstitial_mail_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@null"
+        android:layout_marginBottom="@dimen/grid_3"
+        android:src="@drawable/ic_email"
+        app:layout_constraintBottom_toTopOf="@id/email_verification_interstitial_title"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:tint="@color/gray_alpha_50"/>
+
+    <TextView
+        android:id="@+id/email_verification_interstitial_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/grid_2"
+        android:text="@string/verify_your_email"
+        app:layout_constraintBottom_toTopOf="@id/email_verification_interstitial_subtext"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        style="@style/TextAppearance.AppCompat.Title"/>
+
+    <TextView
+        android:id="@+id/email_verification_interstitial_subtext"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingBottom="@dimen/grid_3"
+        android:paddingEnd="@dimen/grid_7"
+        android:paddingStart="@dimen/grid_7"
+        android:text="@string/complete_this_simple_step_to_help_keep_your_kickstarter_account_secure"
+        android:textColor="@color/black"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/email_verification_interstitial_cta_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/open_inbox"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/email_verification_interstitial_subtext"
+        style="@style/Widget.AppCompat.Button.Colored"/>
+
+    <TextView
+        android:id="@+id/email_verification_interstitial_skip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/grid_3"
+        android:text="@string/ill_do_this_later"
+        android:textAllCaps="false"
+        android:textColor="@color/ksr_green_500"
+        android:textSize="@dimen/subheadline"
+        android:textStyle="bold"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/email_verification_interstitial_cta_button" />
+
+    <TextView
+        android:id="@+id/email_verification_interstitial_resend_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/grid_1_half"
+        android:paddingBottom="@dimen/grid_2"
+        android:text="@string/cant_find_it"
+        android:textColor="@color/black"
+        android:textSize="@dimen/caption_1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toLeftOf="@id/email_verification_interstitial_resend_button" />
+
+    <TextView
+        android:id="@+id/email_verification_interstitial_resend_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingBottom="@dimen/grid_2"
+        android:text="@string/resend_email"
+        android:textAllCaps="false"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:textColor="@color/ksr_green_500"
+        android:textSize="@dimen/caption_1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toRightOf="@id/email_verification_interstitial_resend_text"
+        app:layout_constraintRight_toRightOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings_i18n.xml
+++ b/app/src/main/res/values/strings_i18n.xml
@@ -82,6 +82,7 @@ backers</string>
   <string name="Cancel_pledge" formatted="false">Cancel pledge</string>
   <string name="Cancel_your_pledge" formatted="false">Cancel your pledge</string>
   <string name="Cancellation_reason" formatted="false">Cancellation reason</string>
+  <string name="cant_find_it" formatted="false">Can\'t find it?</string>
   <string name="Card_ending_in_last_four" formatted="false">Card ending in %{last_four}</string>
   <string name="Card_number" formatted="false">Card number</string>
   <string name="Cardholder_name" formatted="false">Cardholder name</string>
@@ -184,6 +185,7 @@ Please tap to retry.</string>
   <string name="Email_must_be_a_valid_email_address" formatted="false">Email must be a valid email address.</string>
   <string name="Email_notifications" formatted="false">Email notifications</string>
   <string name="Email_unverified" formatted="false">This email address is unverified.</string>
+  <string name="email_verification_interstitial" formatted="false">Email Verification Interstitial</string>
   <string name="Ending_in_last_four" formatted="false">Ending in %{last_four}</string>
   <string name="Ending_soon" formatted="false">Ending Soon</string>
   <string name="Enter_an_amount_less_than_max_pledge" formatted="false">Enter an amount less than %{max_pledge}.</string>
@@ -283,6 +285,7 @@ Please tap to retry.</string>
   <string name="If_your_profile_is_public" formatted="false">If your profile is not private, others can also see the projects you\'ve backed, your location, bio and websites.</string>
   <string name="If_your_project_reaches_its_funding_goal_the_backer_will_be_charged_on_project_deadline" formatted="false">If your project reaches its funding goal, the backer will be charged on %{project_deadline}.</string>
   <string name="If_your_project_reaches_its_funding_goal_the_backer_will_be_charged_total_on_project_deadline" formatted="false">If your project reaches its funding goal, the backer will be charged %{total} on %{project_deadline}.</string>
+  <string name="ill_do_this_later" formatted="false">I\'ll do this later</string>
   <string name="Increase_pledge" formatted="false">Increase pledge</string>
   <string name="Individual_Emails" formatted="false">Individual emails</string>
   <string name="Info" formatted="false">Info</string>
@@ -385,6 +388,7 @@ from friends yet.</string>
   <string name="Opens_email_composer" formatted="false">Opens email composer.</string>
   <string name="Opens_filters" formatted="false">Opens filters.</string>
   <string name="Opens_help_sheet" formatted="false">Opens help sheet.</string>
+  <string name="open_inbox" formatted="false">Open Inbox</string>
   <string name="Opens_message_composer" formatted="false">Opens message composer.</string>
   <string name="Opens_pledge_info" formatted="false">Opens pledge info.</string>
   <string name="Opens_project" formatted="false">Opens project.</string>
@@ -469,6 +473,7 @@ daring ideas.</string>
   <string name="Reply_to_user_name" formatted="false">Reply to %{user_name}…</string>
   <string name="Request_my_data" formatted="false">Request my data</string>
   <string name="Request_my_personal_data" formatted="false">Request my personal data</string>
+  <string name="resend_email" formatted="false">Resend email</string>
   <string name="Resend_verification_email" formatted="false">Re-send verification email</string>
   <string name="Retry" formatted="false">Retry</string>
   <string name="Retry_or_select_another_method" formatted="false">Retry or select another method.</string>
@@ -632,6 +637,8 @@ catch your eye?</string>
   <string name="Use_the_hashtag_hashtag_backeditbecause_to_share_what_projects_youre_supporting_and_why_theyre_important_to_you" formatted="false">Use the hashtag #backeditbecause to share what projects you\'re supporting and why they\'re important to you.</string>
   <string name="Use_this_to_keep_track_of_which_rewards_youve_received" formatted="false">Use this to keep track of which rewards you\'ve received.</string>
   <string name="Verification_email_sent" formatted="false">We\'ve just sent you a verification email. Click the link in it and your address will be verified.</string>
+  <string name="verify_your_email" formatted="false">Verify your email address</string>
+  <string name="complete_this_simple_step_to_help_keep_your_kickstarter_account_secure" formatted="false">Complete this simple step to help keep your Kickstarter account secure.</string>
   <string name="Video_disabled_until_the_internet_connection_improves" formatted="false">Video disabled until the internet connection improves</string>
   <string name="View" formatted="false">View</string>
   <string name="View_dashboard" formatted="false">View dashboard</string>


### PR DESCRIPTION
# 📲 What
Included in this PR: 

- Interstitial layout, viewmodel, and fragment
- Button added to internal tools screen to launch the interstitial fragment
- Added new copy 
- Added new email icon drawable

# 👀 See

 ![Screenshot_1604659528](https://user-images.githubusercontent.com/19390326/98358068-23eabe00-1ff4-11eb-8a50-c70f712ebc23.png) ![Screenshot_1604659516](https://user-images.githubusercontent.com/19390326/98358067-23eabe00-1ff4-11eb-93fd-42bc2ca74fdb.png)

# 📋 QA

- Tap on the overflow menu on the discovery screen
- Tap "internal tools" 
- Scroll to the bottom of this screen, should see a green button that reads "Email Verification Interstitial"
- Tap this button, should see the interstitial fragment popup.

# Story 📖

[Build Interstitial Screen UI](https://kickstarter.atlassian.net/browse/NT-1648)
