### PR TITLE
NT-1652: Connect login flow to interstitial

### DIFF
--- a/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.java
+++ b/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.java
@@ -28,6 +28,7 @@ import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
 import com.kickstarter.libs.utils.Secrets;
 import com.kickstarter.libs.utils.ViewUtils;
 import com.kickstarter.libs.utils.WorkUtils;
+import com.kickstarter.models.User;
 import com.kickstarter.services.firebase.ResetDeviceIdWorker;
 import com.kickstarter.ui.fragments.EmailVerificationInterstitialFragment;
 import com.kickstarter.viewmodels.InternalToolsViewModel;
@@ -151,7 +152,8 @@ public final class InternalToolsActivity extends BaseActivity<InternalToolsViewM
 
   @OnClick(R.id.email_verification_button)
   public void emailVerificationInterstitialClick() {
-    final EmailVerificationInterstitialFragment fragment = EmailVerificationInterstitialFragment.Companion.newInstance();
+    final User user = this.environment().currentUser().getUser();
+    final EmailVerificationInterstitialFragment fragment = EmailVerificationInterstitialFragment.Companion.newInstance(user);
     getSupportFragmentManager()
             .beginTransaction()
             .add(R.id.email_verification_interstitial_fragment_container, fragment)

--- a/app/src/main/java/com/kickstarter/mock/factories/UserFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/UserFactory.java
@@ -16,7 +16,7 @@ public final class UserFactory {
       .build();
   }
 
-  public static User userNotVerified() {
+  public static User userNotVerifiedEmail() {
     return User.builder()
             .avatar(AvatarFactory.avatar())
             .id(IdFactory.id())

--- a/app/src/main/java/com/kickstarter/mock/factories/UserFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/UserFactory.java
@@ -16,6 +16,17 @@ public final class UserFactory {
       .build();
   }
 
+  public static User userNotVerified() {
+    return User.builder()
+            .avatar(AvatarFactory.avatar())
+            .id(IdFactory.id())
+            .isEmailVerified(false)
+            .name("Some Name")
+            .optedOutOfRecommendations(false)
+            .location(LocationFactory.unitedStates())
+            .build();
+  }
+
   public static User socialUser() {
     return user().toBuilder().social(true).build();
   }

--- a/app/src/main/java/com/kickstarter/ui/ArgumentsKey.java
+++ b/app/src/main/java/com/kickstarter/ui/ArgumentsKey.java
@@ -8,4 +8,5 @@ public final class ArgumentsKey {
   public static final String NEW_CARD_PROJECT = "com.kickstarter.ui.fragments.NewCardFragment.project";
   public static final String PLEDGE_PLEDGE_DATA= "com.kickstarter.ui.fragments.PledgeFragment.pledge_data";
   public static final String PLEDGE_PLEDGE_REASON = "com.kickstarter.ui.fragments.PledgeFragment.pledge_reason";
+  public static final String USER = "com.kickstarter.ui.fragments.EmailVerificationInterstitialFragment.user";
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
@@ -18,6 +18,7 @@ import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.extensions.onChange
 import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.ui.extensions.text
+import com.kickstarter.ui.fragments.EmailVerificationInterstitialFragment
 import com.kickstarter.ui.views.ConfirmDialog
 import com.kickstarter.viewmodels.LoginViewModel
 import kotlinx.android.synthetic.main.login_form_view.*
@@ -112,13 +113,14 @@ class LoginActivity : BaseActivity<LoginViewModel.ViewModel>() {
     }
 
     private fun showInterstitialFragment(user: User) {
-        /*val yourFragment: EmailVerificationInterstitialFragment = YourFragment()
-        val fragmentManager: FragmentManager = fragmentManager
-
-        val fragmentTransaction: FragmentTransaction = fragmentManager.beginTransaction()
-        fragmentTransaction.add(R.id.your_activity_layout, YourFragment)
-        fragmentTransaction.addToBackStack(null)
-        fragmentTransaction.commit()*/
+        if (supportFragmentManager.findFragmentByTag(EmailVerificationInterstitialFragment::class.java.simpleName) == null) {
+            val emailValidationFragment: EmailVerificationInterstitialFragment = EmailVerificationInterstitialFragment.newInstance(user)
+            supportFragmentManager.beginTransaction()
+                    .setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
+                    .add(R.id.login_view_id, emailValidationFragment)
+                    .addToBackStack(null)
+                    .commit()
+        }
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
@@ -5,9 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Pair
 import com.kickstarter.R
-import com.kickstarter.ui.extensions.onChange
-import com.kickstarter.ui.extensions.showSnackbar
-import com.kickstarter.ui.extensions.text
 import com.kickstarter.libs.ActivityRequestCodes
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.KSString
@@ -16,11 +13,16 @@ import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft
 import com.kickstarter.libs.utils.ViewUtils
+import com.kickstarter.models.User
 import com.kickstarter.ui.IntentKey
+import com.kickstarter.ui.extensions.onChange
+import com.kickstarter.ui.extensions.showSnackbar
+import com.kickstarter.ui.extensions.text
 import com.kickstarter.ui.views.ConfirmDialog
 import com.kickstarter.viewmodels.LoginViewModel
 import kotlinx.android.synthetic.main.login_form_view.*
 import kotlinx.android.synthetic.main.login_toolbar.*
+
 
 @RequiresActivityViewModel(LoginViewModel.ViewModel::class)
 class LoginActivity : BaseActivity<LoginViewModel.ViewModel>() {
@@ -96,12 +98,27 @@ class LoginActivity : BaseActivity<LoginViewModel.ViewModel>() {
                 .compose(observeForUI())
                 .subscribe({ this.setLoginButtonEnabled(it) })
 
+        this.viewModel.outputs.showInterstitialFragment()
+                .compose(bindToLifecycle())
+                .compose(observeForUI())
+                .subscribe { showInterstitialFragment(it) }
+
         forgot_your_password_text_view.setOnClickListener {
             val intent = Intent(this, ResetPasswordActivity::class.java)
             startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
         }
 
         login_button.setOnClickListener { this.viewModel.inputs.loginClick() }
+    }
+
+    private fun showInterstitialFragment(user: User) {
+        /*val yourFragment: EmailVerificationInterstitialFragment = YourFragment()
+        val fragmentManager: FragmentManager = fragmentManager
+
+        val fragmentTransaction: FragmentTransaction = fragmentManager.beginTransaction()
+        fragmentTransaction.add(R.id.your_activity_layout, YourFragment)
+        fragmentTransaction.addToBackStack(null)
+        fragmentTransaction.commit()*/
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/ui/fragments/EmailVerificationInterstitialFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/EmailVerificationInterstitialFragment.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import com.kickstarter.R
 import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
+import com.kickstarter.models.User
+import com.kickstarter.ui.ArgumentsKey
 import com.kickstarter.viewmodels.EmailVerificationInterstitialFragmentViewModel
 
 @RequiresFragmentViewModel(EmailVerificationInterstitialFragmentViewModel.ViewModel::class)
@@ -18,8 +20,12 @@ class EmailVerificationInterstitialFragment : BaseFragment<EmailVerificationInte
     }
 
     companion object {
-        fun newInstance(): EmailVerificationInterstitialFragment {
-            return EmailVerificationInterstitialFragment()
+        fun newInstance(user: User): EmailVerificationInterstitialFragment {
+            val fragment = EmailVerificationInterstitialFragment()
+            val argument = Bundle()
+            argument.putParcelable(ArgumentsKey.USER, user)
+            fragment.arguments = argument
+            return fragment
         }
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/LoginViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoginViewModel.kt
@@ -8,6 +8,7 @@ import com.kickstarter.libs.utils.BooleanUtils
 import com.kickstarter.libs.utils.LoginHelper
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.StringUtils
+import com.kickstarter.models.User
 import com.kickstarter.services.ApiClientType
 import com.kickstarter.services.apiresponses.AccessTokenEnvelope
 import com.kickstarter.services.apiresponses.ErrorEnvelope
@@ -62,6 +63,9 @@ interface LoginViewModel {
 
         /** Start two factor activity for result.  */
         fun tfaChallenge(): Observable<Void>
+
+        /** Start the Interstitial screen.  */
+        fun showInterstitialFragment(): Observable<User>
     }
 
     class ViewModel(@NonNull val environment: Environment) : ActivityViewModel<LoginActivity>(environment), Inputs, Outputs {
@@ -80,6 +84,7 @@ interface LoginViewModel {
         private val showCreatedPasswordSnackbar = BehaviorSubject.create<Void>()
         private val showResetPasswordSuccessDialog = BehaviorSubject.create<Pair<Boolean, String>>()
         private val tfaChallenge: Observable<Void>
+        private val showInterstitial = BehaviorSubject.create<User>()
 
         private val loginError = PublishSubject.create<ErrorEnvelope>()
 
@@ -227,7 +232,7 @@ interface LoginViewModel {
             if (isValidated) {
                 this.success(accessTokenNotification)
             } else {
-                // TODO: Present Interstitial https://kickstarter.atlassian.net/browse/NT-1652
+                this.showInterstitial.onNext(accessTokenNotification.user())
             }
         }
 
@@ -265,5 +270,7 @@ interface LoginViewModel {
         override fun showResetPasswordSuccessDialog(): BehaviorSubject<Pair<Boolean, String>> = this.showResetPasswordSuccessDialog
 
         override fun tfaChallenge() = this.tfaChallenge
+
+        override fun showInterstitialFragment(): BehaviorSubject<User> = this.showInterstitial
     }
 }

--- a/app/src/main/res/layout/login_layout.xml
+++ b/app/src/main/res/layout/login_layout.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:background="@color/white"
-  android:orientation="vertical">
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/white"
+    android:orientation="vertical">
 
   <com.google.android.material.appbar.AppBarLayout
     android:layout_width="match_parent"
@@ -20,7 +20,9 @@
       android:id="@+id/login_view_id"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:layout_marginTop="@dimen/ks_toolbar_height">
+      android:layout_marginTop="@dimen/ks_toolbar_height"
+      tools:ignore="UselessParent">
+
       <ScrollView
           android:layout_width="match_parent"
           android:layout_height="match_parent"

--- a/app/src/main/res/layout/login_layout.xml
+++ b/app/src/main/res/layout/login_layout.xml
@@ -16,17 +16,23 @@
 
   </com.google.android.material.appbar.AppBarLayout>
 
-  <ScrollView
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-    <include
-      layout="@layout/login_form_view"
+  <FrameLayout
+      android:id="@+id/login_view_id"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginLeft="@dimen/form_margin_x"
-      android:layout_marginRight="@dimen/form_margin_x" />
-  </ScrollView>
+      android:layout_height="match_parent"
+      android:layout_marginTop="@dimen/ks_toolbar_height">
+      <ScrollView
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
+          app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <include
+            layout="@layout/login_form_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/form_margin_x"
+            android:layout_marginRight="@dimen/form_margin_x" />
+      </ScrollView>
+  </FrameLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginViewModelTest.kt
@@ -247,6 +247,8 @@ class LoginViewModelTest : KSRobolectricTestCase() {
 
         setUpEnvironment(environment)
 
+        this.vm.inputs.email("hello@kickstarter.com")
+        this.vm.inputs.password("androidiscool")
         this.vm.inputs.loginClick()
 
         this.showEmailVerificationInterstitial.assertValue(user)

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginViewModelTest.kt
@@ -286,4 +286,26 @@ class LoginViewModelTest : KSRobolectricTestCase() {
 
         this.lakeTest.assertValue("Log In Submit Button Clicked")
     }
+
+    @Test
+    fun testLoginSuccess_whenUserNotValidatedAndDeactivatedFeatureFlag_LoginSuccess() {
+
+        val mockConfig = MockCurrentConfig()
+        mockConfig.config(ConfigFactory.configWithFeaturesEnabled(mapOf(Pair(EMAIL_VERIFICATION_FLOW, false))))
+
+        val environment = environment().toBuilder()
+                .currentConfig(mockConfig)
+                .build()
+
+        setUpEnvironment(environment)
+
+        this.vm.inputs.email("hello@kickstarter.com")
+        this.vm.inputs.password("androidiscool")
+        this.vm.inputs.loginClick()
+
+        this.loginSuccess.assertValue(null)
+        this.showEmailVerificationInterstitial.assertNoValues()
+
+        this.lakeTest.assertValue("Log In Submit Button Clicked")
+    }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginViewModelTest.kt
@@ -281,6 +281,7 @@ class LoginViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.password("androidiscool")
         this.vm.inputs.loginClick()
 
+        this.loginSuccess.assertNoValues()
         this.showEmailVerificationInterstitial.assertValue(user)
 
         this.lakeTest.assertValue("Log In Submit Button Clicked")

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginViewModelTest.kt
@@ -2,12 +2,12 @@ package com.kickstarter.viewmodels
 
 import android.content.Intent
 import com.kickstarter.KSRobolectricTestCase
-import com.kickstarter.libs.CurrentConfigType
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.utils.extensions.EMAIL_VERIFICATION_FLOW
 import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.factories.ApiExceptionFactory
 import com.kickstarter.mock.factories.ConfigFactory
+import com.kickstarter.mock.factories.ConfigFactory.config
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApiClient
 import com.kickstarter.models.User
@@ -31,7 +31,6 @@ class LoginViewModelTest : KSRobolectricTestCase() {
     private val showEmailVerificationInterstitial = TestSubscriber<User>()
 
     fun setUpEnvironment(environment: Environment) {
-        environment.currentConfig().config(ConfigFactory.config())
         this.vm = LoginViewModel.ViewModel(environment)
         this.vm.outputs.genericLoginError().subscribe(this.genericLoginError)
         this.vm.outputs.invalidLoginError().subscribe(this.invalidLoginError)
@@ -72,7 +71,15 @@ class LoginViewModelTest : KSRobolectricTestCase() {
             }
         }
 
-        setUpEnvironment(environment().toBuilder().apiClient(apiClient).build())
+        val mockConfig = MockCurrentConfig()
+        mockConfig.config(config())
+
+        val environment = environment().toBuilder()
+                .currentConfig(mockConfig)
+                .apiClient(apiClient)
+                .build()
+
+        setUpEnvironment(environment)
 
         this.vm.inputs.email("incorrect@kickstarter.com")
         this.vm.inputs.password("lisaiscool")
@@ -92,7 +99,15 @@ class LoginViewModelTest : KSRobolectricTestCase() {
             }
         }
 
-        setUpEnvironment(environment().toBuilder().apiClient(apiClient).build())
+        val mockConfig = MockCurrentConfig()
+        mockConfig.config(config())
+
+        val environment = environment().toBuilder()
+                .currentConfig(mockConfig)
+                .apiClient(apiClient)
+                .build()
+
+        setUpEnvironment(environment)
 
         this.vm.inputs.email("typo@kickstartr.com")
         this.vm.inputs.password("julieiscool")
@@ -112,7 +127,15 @@ class LoginViewModelTest : KSRobolectricTestCase() {
             }
         }
 
-        setUpEnvironment(environment().toBuilder().apiClient(apiClient).build())
+        val mockConfig = MockCurrentConfig()
+        mockConfig.config(config())
+
+        val environment = environment().toBuilder()
+                .currentConfig(mockConfig)
+                .apiClient(apiClient)
+                .build()
+
+        setUpEnvironment(environment)
 
         this.vm.inputs.email("hello@kickstarter.com")
         this.vm.inputs.password("androidiscool")
@@ -208,7 +231,14 @@ class LoginViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testSuccessfulLogin() {
-        setUpEnvironment(environment())
+        val mockConfig = MockCurrentConfig()
+        mockConfig.config(config())
+
+        val environment = environment().toBuilder()
+                .currentConfig(mockConfig)
+                .build()
+
+        setUpEnvironment(environment)
 
         this.vm.outputs.loginSuccess().subscribe(this.loginSuccess)
 
@@ -224,7 +254,7 @@ class LoginViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowInterstitial_whenUserNotValidatedAndActiveFeatureFlag_ShowInterstitial() {
-        val user = UserFactory.userNotVerified()
+        val user = UserFactory.userNotVerifiedEmail()
         val token = "Token"
         val accessTokenEnvelope = AccessTokenEnvelope.builder()
                 .user(user)
@@ -238,11 +268,11 @@ class LoginViewModelTest : KSRobolectricTestCase() {
         }
 
         val mockConfig = MockCurrentConfig()
-        mockConfig.config(ConfigFactory.configWithFeatureEnabled(EMAIL_VERIFICATION_FLOW))
+        mockConfig.config(ConfigFactory.configWithFeaturesEnabled(mapOf(Pair(EMAIL_VERIFICATION_FLOW, true))))
 
         val environment = environment().toBuilder()
-                .apiClient(apiClient)
                 .currentConfig(mockConfig)
+                .apiClient(apiClient)
                 .build()
 
         setUpEnvironment(environment)


### PR DESCRIPTION
# 📲 What

- Attached Interstitial screen into login flow

# 🛠 How

- Created new output in LoginViewModel for the interstitial screen
- Launch EmailVerificationInterstitialFragment new Instance with the user returned from the login request

# 👀 See
![LoginFlow](https://user-images.githubusercontent.com/4083656/98588973-68d75480-2281-11eb-9317-d538f8de9ac5.gif)

|  |  |

# 📋 QA

- Log in with an user that has not validated their email ->user: isatest@test.com, password: isatest
- - if you have the feature flag active: Interstitial screen is shown
- - if you don't have the feature flag active: you can log in into the app without problems

# Story 📖

[NT-1652](https://kickstarter.atlassian.net/browse/NT-1652)
