### PR TITLE
NT-1653: Create account flow

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/LoginHelper.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/LoginHelper.kt
@@ -1,10 +1,13 @@
 package com.kickstarter.libs.utils
 
+import androidx.fragment.app.FragmentManager
+import com.kickstarter.R
 import com.kickstarter.libs.Config
 import com.kickstarter.libs.utils.extensions.EMAIL_VERIFICATION_FLOW
 import com.kickstarter.libs.utils.extensions.isFeatureFlagEnabled
 import com.kickstarter.models.User
 import com.kickstarter.models.extensions.isUserEmailVerified
+import com.kickstarter.ui.fragments.EmailVerificationInterstitialFragment
 
 object LoginHelper {
 
@@ -18,6 +21,9 @@ object LoginHelper {
      *     False in case feature flag active and not verified
      *     True in case not active feature flag
      *     Null in case no current User (not logged)
+     *
+     * Note: this method should be deleted once EMAIL_VERIFICATION_FLOW feature
+     * flag is no longer needed.
      */
     fun hasCurrentUserVerifiedEmail(user: User?, config: Config): Boolean? {
         if (user == null) {
@@ -27,5 +33,28 @@ object LoginHelper {
         return if (config.isFeatureFlagEnabled(EMAIL_VERIFICATION_FLOW)) {
             user.isUserEmailVerified()
         } else true
+    }
+
+    /**
+     * Start the transition to present the EmailVerificationInterstitialFragment
+     * This will be called for Login flows and Account creation flows.
+     *
+     * @param supportFragmentManager
+     * @param user
+     * @param R.id.loginViewId
+     *
+     * Note: R.id.viewId Container ID for the fragment:
+     * layout/login_layout.xml
+     * layout/signup_layout.xml
+     */
+    fun showInterstitialFragment(supportFragmentManager: FragmentManager, user: User, loginViewId: Int) {
+        if (supportFragmentManager.findFragmentByTag(EmailVerificationInterstitialFragment::class.java.simpleName) == null) {
+            val emailValidationFragment: EmailVerificationInterstitialFragment = EmailVerificationInterstitialFragment.newInstance(user)
+            supportFragmentManager.beginTransaction()
+                    .setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
+                    .add(loginViewId, emailValidationFragment)
+                    .addToBackStack(null)
+                    .commit()
+        }
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
@@ -10,15 +10,14 @@ import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
+import com.kickstarter.libs.utils.LoginHelper
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft
 import com.kickstarter.libs.utils.ViewUtils
-import com.kickstarter.models.User
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.extensions.onChange
 import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.ui.extensions.text
-import com.kickstarter.ui.fragments.EmailVerificationInterstitialFragment
 import com.kickstarter.ui.views.ConfirmDialog
 import com.kickstarter.viewmodels.LoginViewModel
 import kotlinx.android.synthetic.main.login_form_view.*
@@ -102,7 +101,7 @@ class LoginActivity : BaseActivity<LoginViewModel.ViewModel>() {
         this.viewModel.outputs.showInterstitialFragment()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { showInterstitialFragment(it) }
+                .subscribe { LoginHelper.showInterstitialFragment(supportFragmentManager, it, R.id.login_view_id) }
 
         forgot_your_password_text_view.setOnClickListener {
             val intent = Intent(this, ResetPasswordActivity::class.java)
@@ -110,17 +109,6 @@ class LoginActivity : BaseActivity<LoginViewModel.ViewModel>() {
         }
 
         login_button.setOnClickListener { this.viewModel.inputs.loginClick() }
-    }
-
-    private fun showInterstitialFragment(user: User) {
-        if (supportFragmentManager.findFragmentByTag(EmailVerificationInterstitialFragment::class.java.simpleName) == null) {
-            val emailValidationFragment: EmailVerificationInterstitialFragment = EmailVerificationInterstitialFragment.newInstance(user)
-            supportFragmentManager.beginTransaction()
-                    .setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
-                    .add(R.id.login_view_id, emailValidationFragment)
-                    .addToBackStack(null)
-                    .commit()
-        }
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/ui/activities/SignupActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/SignupActivity.java
@@ -14,8 +14,6 @@ import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
 import com.kickstarter.libs.utils.LoginHelper;
 import com.kickstarter.libs.utils.SwitchCompatUtils;
 import com.kickstarter.libs.utils.ViewUtils;
-import com.kickstarter.models.User;
-import com.kickstarter.ui.fragments.EmailVerificationInterstitialFragment;
 import com.kickstarter.ui.toolbars.LoginToolbar;
 import com.kickstarter.ui.views.LoginPopupMenu;
 import com.kickstarter.viewmodels.SignupViewModel;

--- a/app/src/main/java/com/kickstarter/ui/activities/SignupActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/SignupActivity.java
@@ -11,6 +11,7 @@ import com.jakewharton.rxbinding.view.RxView;
 import com.kickstarter.R;
 import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
+import com.kickstarter.libs.utils.LoginHelper;
 import com.kickstarter.libs.utils.SwitchCompatUtils;
 import com.kickstarter.libs.utils.ViewUtils;
 import com.kickstarter.models.User;
@@ -80,25 +81,12 @@ public final class SignupActivity extends BaseActivity<SignupViewModel.ViewModel
     this.viewModel.outputs.showInterstitialFragment()
       .compose(bindToLifecycle())
       .observeOn(AndroidSchedulers.mainThread())
-      .subscribe(this::showInterstitialFragment);
+      .subscribe(user -> LoginHelper.INSTANCE.showInterstitialFragment(this.getSupportFragmentManager(), user, R.id.login_view_id));
 
     RxView.clicks(this.newsletterSwitch)
       .skip(1)
       .compose(bindToLifecycle())
       .subscribe(__ -> this.viewModel.inputs.sendNewslettersClick(this.newsletterSwitch.isChecked()));
-  }
-
-  private void showInterstitialFragment(User user) {
-    final String tagName = EmailVerificationInterstitialFragment.class.getSimpleName();
-
-    if (this.getSupportFragmentManager().findFragmentByTag(tagName) == null) {
-      final EmailVerificationInterstitialFragment fragment = EmailVerificationInterstitialFragment.Companion.newInstance(user);
-      this.getSupportFragmentManager().beginTransaction()
-              .setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
-              .add(R.id.login_view_id, fragment)
-              .addToBackStack(null)
-              .commit();
-    }
   }
 
   @OnClick(R.id.disclaimer)

--- a/app/src/main/java/com/kickstarter/ui/activities/SignupActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/SignupActivity.java
@@ -13,6 +13,8 @@ import com.kickstarter.libs.BaseActivity;
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel;
 import com.kickstarter.libs.utils.SwitchCompatUtils;
 import com.kickstarter.libs.utils.ViewUtils;
+import com.kickstarter.models.User;
+import com.kickstarter.ui.fragments.EmailVerificationInterstitialFragment;
 import com.kickstarter.ui.toolbars.LoginToolbar;
 import com.kickstarter.ui.views.LoginPopupMenu;
 import com.kickstarter.viewmodels.SignupViewModel;
@@ -75,10 +77,28 @@ public final class SignupActivity extends BaseActivity<SignupViewModel.ViewModel
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(e -> ViewUtils.showDialog(this, null, e));
 
+    this.viewModel.outputs.showInterstitialFragment()
+      .compose(bindToLifecycle())
+      .observeOn(AndroidSchedulers.mainThread())
+      .subscribe(this::showInterstitialFragment);
+
     RxView.clicks(this.newsletterSwitch)
       .skip(1)
       .compose(bindToLifecycle())
       .subscribe(__ -> this.viewModel.inputs.sendNewslettersClick(this.newsletterSwitch.isChecked()));
+  }
+
+  private void showInterstitialFragment(User user) {
+    final String tagName = EmailVerificationInterstitialFragment.class.getSimpleName();
+
+    if (this.getSupportFragmentManager().findFragmentByTag(tagName) == null) {
+      final EmailVerificationInterstitialFragment fragment = EmailVerificationInterstitialFragment.Companion.newInstance(user);
+      this.getSupportFragmentManager().beginTransaction()
+              .setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
+              .add(R.id.login_view_id, fragment)
+              .addToBackStack(null)
+              .commit();
+    }
   }
 
   @OnClick(R.id.disclaimer)

--- a/app/src/main/java/com/kickstarter/viewmodels/SignupViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SignupViewModel.java
@@ -58,6 +58,9 @@ public interface SignupViewModel {
 
     /** Finish the activity with a successful result. */
     Observable<Void> signupSuccess();
+
+    /** Start the Interstitial screen. */
+    Observable<User> showInterstitialFragment();
   }
 
   final class ViewModel extends ActivityViewModel<SignupActivity> implements Inputs, Outputs {
@@ -148,9 +151,9 @@ public interface SignupViewModel {
 
       if (isValidated) {
         this.success(envelope);
-      } /*else {
-         TODO: Present Interstitial https://kickstarter.atlassian.net/browse/NT-1652
-      }*/
+      } else {
+        this.showInterstitial.onNext(envelope.user());
+      }
     }
 
     private void success(final @NonNull AccessTokenEnvelope envelope) {
@@ -169,6 +172,7 @@ public interface SignupViewModel {
     private final BehaviorSubject<Boolean> formSubmitting = BehaviorSubject.create();
     private final BehaviorSubject<Boolean> formIsValid = BehaviorSubject.create();
     private final BehaviorSubject<Boolean> sendNewslettersIsChecked = BehaviorSubject.create();
+    private final BehaviorSubject<User> showInterstitial = BehaviorSubject.create();
 
     private final PublishSubject<ErrorEnvelope> signupError = PublishSubject.create();
 
@@ -206,6 +210,9 @@ public interface SignupViewModel {
     }
     @Override public @NonNull PublishSubject<Void> signupSuccess() {
       return this.signupSuccess;
+    }
+    @Override public @NonNull Observable<User> showInterstitialFragment() {
+      return this.showInterstitial;
     }
 
     final static class SignupData {

--- a/app/src/main/res/layout/signup_layout.xml
+++ b/app/src/main/res/layout/signup_layout.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:gravity="center_horizontal"
-  android:orientation="vertical">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:gravity="center_horizontal"
+    android:orientation="vertical">
 
   <LinearLayout
     android:layout_width="match_parent"
@@ -12,14 +12,17 @@
     android:orientation="vertical">
 
     <include layout="@layout/login_toolbar" />
-
-    <include
-      layout="@layout/signup_form_view"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginLeft="@dimen/form_margin_x"
-      android:layout_marginRight="@dimen/form_margin_x" />
-
+    <FrameLayout
+        android:id="@+id/login_view_id"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:ignore="UselessParent">
+        <include
+          layout="@layout/signup_form_view"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginLeft="@dimen/form_margin_x"
+          android:layout_marginRight="@dimen/form_margin_x" />
+    </FrameLayout>
   </LinearLayout>
-
 </ScrollView>

--- a/app/src/test/java/com/kickstarter/viewmodels/SignupViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SignupViewModelTest.java
@@ -2,6 +2,7 @@ package com.kickstarter.viewmodels;
 
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.libs.Environment;
+import com.kickstarter.libs.utils.extensions.ConfigExtension;
 import com.kickstarter.mock.MockCurrentConfig;
 import com.kickstarter.mock.factories.ApiExceptionFactory;
 import com.kickstarter.mock.factories.ConfigFactory;
@@ -17,8 +18,6 @@ import org.junit.Test;
 import androidx.annotation.NonNull;
 import rx.Observable;
 import rx.observers.TestSubscriber;
-
-import static com.kickstarter.libs.utils.extensions.ConfigExtension.EMAIL_VERIFICATION_FLOW;
 
 public class SignupViewModelTest extends KSRobolectricTestCase {
 
@@ -164,7 +163,7 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
     };
 
     final MockCurrentConfig mockConfig = new MockCurrentConfig();
-    mockConfig.config(ConfigFactory.configWithFeatureEnabled(EMAIL_VERIFICATION_FLOW));
+    mockConfig.config(ConfigFactory.configWithFeatureEnabled(ConfigExtension.EMAIL_VERIFICATION_FLOW));
 
     final Environment environment = environment().toBuilder()
             .apiClient(apiClient)
@@ -190,7 +189,7 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
   public void testCreationAccountSuccess_whenCreatingAccountDeActiveFeatureFlag_CreationAccountSuccess() {
 
     final MockCurrentConfig mockConfig = new MockCurrentConfig();
-    mockConfig.config(ConfigFactory.configWithFeatureEnabled(EMAIL_VERIFICATION_FLOW));
+    mockConfig.config(ConfigFactory.configWithFeatureEnabled(ConfigExtension.EMAIL_VERIFICATION_FLOW));
 
     final Environment environment = environment().toBuilder()
             .currentConfig(mockConfig)


### PR DESCRIPTION
# 📲 What

- Present Interstitial Screen on CreationAccount flow

# 🛠 How
- Adde new method in LoginHelper.kt `showInterstitialFragment(supportFragmentManager: FragmentManager, user: User, loginViewId: Int)` 
- Added new output to present the Interstitial screen on SignUpViewModel.java
- new tests

# 👀 See
![creation_account_flow](https://user-images.githubusercontent.com/4083656/98605958-1f93fe80-229b-11eb-9fd2-5f383a6c6665.gif)

|  |  |

# 📋 QA

- Create account with feature flag enabled presents the Interstitial screen
- Create account with feature flag disabled do not present Interstitial screen and let's you continue flow.

# Story 📖

[NT-1653](https://kickstarter.atlassian.net/browse/NT-1653)
