### PR TITLE
NT-1650: The user can navigate to their inbox from the app

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/EmailVerificationInterstitialFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/EmailVerificationInterstitialFragment.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.ui.fragments
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -9,6 +10,7 @@ import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.models.User
 import com.kickstarter.ui.ArgumentsKey
+import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.viewmodels.EmailVerificationInterstitialFragmentViewModel
 import kotlinx.android.synthetic.main.fragment_email_verification_interstitial.*
 
@@ -23,8 +25,15 @@ class EmailVerificationInterstitialFragment : BaseFragment<EmailVerificationInte
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        this.viewModel.outputs.startEmailActivity()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe {
+                    startActivity(Intent.createChooser(Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_EMAIL), "Choose Email"))
+                }
+
         email_verification_interstitial_cta_button.setOnClickListener {
-            this.viewModel.inputs.retryButtonPressed()
+            this.viewModel.inputs.openInboxButtonPressed()
         }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/EmailVerificationInterstitialFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/EmailVerificationInterstitialFragment.kt
@@ -10,6 +10,7 @@ import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.models.User
 import com.kickstarter.ui.ArgumentsKey
 import com.kickstarter.viewmodels.EmailVerificationInterstitialFragmentViewModel
+import kotlinx.android.synthetic.main.fragment_email_verification_interstitial.*
 
 @RequiresFragmentViewModel(EmailVerificationInterstitialFragmentViewModel.ViewModel::class)
 class EmailVerificationInterstitialFragment : BaseFragment<EmailVerificationInterstitialFragmentViewModel.ViewModel>() {
@@ -17,6 +18,14 @@ class EmailVerificationInterstitialFragment : BaseFragment<EmailVerificationInte
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
         return inflater.inflate(R.layout.fragment_email_verification_interstitial, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        email_verification_interstitial_cta_button.setOnClickListener {
+            this.viewModel.inputs.retryButtonPressed()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
@@ -1,6 +1,5 @@
 package com.kickstarter.viewmodels
 
-import android.content.Intent
 import androidx.annotation.NonNull
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.FragmentViewModel

--- a/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
@@ -1,23 +1,44 @@
 package com.kickstarter.viewmodels
 
+import android.content.Intent
 import androidx.annotation.NonNull
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.FragmentViewModel
 import com.kickstarter.ui.fragments.EmailVerificationInterstitialFragment
+import rx.Observable
+import rx.subjects.BehaviorSubject
 
 class EmailVerificationInterstitialFragmentViewModel {
     interface Inputs {
-        /** Invoked when the retry button on the add-on Error alert dialog is pressed */
-        fun retryButtonPressed()
+        /** Invoked when the open inbox button is pressed */
+        fun openInboxButtonPressed()
     }
-    interface Outputs { }
+
+    interface Outputs {
+        fun startEmailActivity(): Observable<Void>
+    }
 
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<EmailVerificationInterstitialFragment>(environment), Outputs, Inputs {
         val inputs = this
         val outputs = this
 
-        override fun retryButtonPressed() {
-            TODO("Not yet implemented")
+        private val openInboxButtonPressed = BehaviorSubject.create<Void>()
+
+        private val startEmailActivity = BehaviorSubject.create<Void>()
+
+
+        init {
+            openInboxButtonPressed
+                    .compose(bindToLifecycle())
+                    .subscribe(this.startEmailActivity)
         }
+
+        // - Inputs
+        override fun openInboxButtonPressed() = this.openInboxButtonPressed.onNext(null)
+
+        // - Outputs
+        override fun startEmailActivity(): Observable<Void> = this.startEmailActivity
     }
+
 }
+

--- a/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
@@ -27,7 +27,7 @@ class EmailVerificationInterstitialFragmentViewModel {
 
 
         init {
-            openInboxButtonPressed
+            this.openInboxButtonPressed
                     .compose(bindToLifecycle())
                     .subscribe(this.startEmailActivity)
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
@@ -6,7 +6,18 @@ import com.kickstarter.libs.FragmentViewModel
 import com.kickstarter.ui.fragments.EmailVerificationInterstitialFragment
 
 class EmailVerificationInterstitialFragmentViewModel {
-    interface Inputs { }
+    interface Inputs {
+        /** Invoked when the retry button on the add-on Error alert dialog is pressed */
+        fun retryButtonPressed()
+    }
     interface Outputs { }
-    class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<EmailVerificationInterstitialFragment>(environment), Outputs, Inputs { }
+
+    class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<EmailVerificationInterstitialFragment>(environment), Outputs, Inputs {
+        val inputs = this
+        val outputs = this
+
+        override fun retryButtonPressed() {
+            TODO("Not yet implemented")
+        }
+    }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModelTest.kt
@@ -3,7 +3,7 @@ package com.kickstarter.viewmodels
 import androidx.annotation.NonNull
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
-import junit.framework.TestCase
+import org.junit.Test
 import rx.observers.TestSubscriber
 
 class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase() {
@@ -13,6 +13,18 @@ class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = EmailVerificationInterstitialFragmentViewModel.ViewModel(environment)
         this.vm.outputs.startEmailActivity().subscribe(startEmailActivity)
+    }
+
+    @Test
+    fun init_whenOpenEmailInboxPressedEmits_shouldEmitToStartEmailActivityStream() {
+        val environment = environment()
+                .toBuilder()
+                .build()
+
+        setUpEnvironment(environment())
+
+        this.vm.inputs.openInboxButtonPressed()
+        this.startEmailActivity.assertValue(null)
     }
 
 

--- a/app/src/test/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModelTest.kt
@@ -1,0 +1,19 @@
+package com.kickstarter.viewmodels
+
+import androidx.annotation.NonNull
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Environment
+import junit.framework.TestCase
+import rx.observers.TestSubscriber
+
+class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase() {
+    private lateinit var vm: EmailVerificationInterstitialFragmentViewModel.ViewModel
+    private val startEmailActivity = TestSubscriber.create<Void>()
+
+    private fun setUpEnvironment(@NonNull environment: Environment) {
+        this.vm = EmailVerificationInterstitialFragmentViewModel.ViewModel(environment)
+        this.vm.outputs.startEmailActivity().subscribe(startEmailActivity)
+    }
+
+
+}

--- a/app/src/test/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModelTest.kt
@@ -17,15 +17,9 @@ class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase
 
     @Test
     fun init_whenOpenEmailInboxPressedEmits_shouldEmitToStartEmailActivityStream() {
-        val environment = environment()
-                .toBuilder()
-                .build()
-
         setUpEnvironment(environment())
 
         this.vm.inputs.openInboxButtonPressed()
         this.startEmailActivity.assertValue(null)
     }
-
-
 }


### PR DESCRIPTION
# 📲 What

When the user taps "Open Inbox", they will either be taken to their default application, or shown a list of apps that they can choose from to open their email. If they have no apps available for email, it will show an "empty state" bottom sheet.

# 🤔 Why

We want users to be able to open their inbox application immediately upon receiving the verification email from kickstarter. 

# 🛠 How

When the user taps on the "Open Inbox" button, the viewmodel responds by sending at intent with parameters attached that indicate we would like to open an email application. This is built into the Android framework. 

# 👀 See

![Nov-10-2020 11-24-53](https://user-images.githubusercontent.com/19390326/98701599-748d4e80-2347-11eb-9d2a-76b40611eefd.gif)

# 📋 QA

- Tap on ovreflow menu
- Tap on "Internal Tools"
- Scroll to bottom, tap "Email Verification Interstitial"
- Tap "Open Inbox"
- Default email app or a list of email applications should appear. 

# Story 📖

[NT-1650: The user can navigate to their inbox from the app](https://kickstarter.atlassian.net/browse/NT-1650)
