### PR TITLE
NT-1595: Creator view adjustments

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -80,6 +80,7 @@ fragment reward on Reward {
     limitPerBacker
     startsAt
     endsAt
+    rewardType
 }
 
 fragment shippingRule on ShippingRule {

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -717,6 +717,7 @@ private fun rewardTransformer(rewardGr: fragment.Reward, shippingRulesExpanded: 
     val startsAt = rewardGr.startsAt()?.let { DateTime(it) }
     val rewardId = decodeRelayId(rewardGr.id()) ?: -1
     val available = rewardGr.available()
+    val isAddOn = rewardGr.rewardType() == RewardType.ADDON
 
     val shippingPreference = when (rewardGr.shippingPreference()) {
         ShippingPreference.NONE -> Reward.ShippingPreference.NONE
@@ -733,7 +734,6 @@ private fun rewardTransformer(rewardGr: fragment.Reward, shippingRulesExpanded: 
         shippingRuleTransformer(it)
     }
 
-
     return Reward.builder()
             .title(title)
             .convertedMinimum(convertedAmount)
@@ -744,7 +744,7 @@ private fun rewardTransformer(rewardGr: fragment.Reward, shippingRulesExpanded: 
             .startsAt(startsAt)
             .description(desc)
             .estimatedDeliveryOn(estimatedDelivery)
-            .isAddOn(true)
+            .isAddOn(isAddOn)
             .addOnsItems(items)
             .id(rewardId)
             .shippingPreference(shippingPreference.name)

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -38,6 +38,8 @@ import kotlinx.android.synthetic.main.fragment_backing_section_summary_total.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_summary_pledge.*
 import kotlinx.android.synthetic.main.fragment_pledge_section_summary_shipping.*
 import kotlinx.android.synthetic.main.reward_card_details.*
+import rx.android.schedulers.AndroidSchedulers
+import rx.schedulers.Schedulers.io
 
 
 @RequiresFragmentViewModel(BackingFragmentViewModel.ViewModel::class)
@@ -65,8 +67,10 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>() {
                 .subscribe { setBackerImageView(it) }
 
         this.viewModel.outputs.backerName()
+                .observeOn(io())
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
+                .subscribeOn(AndroidSchedulers.mainThread())
                 .subscribe { backer_name.text = it }
 
         this.viewModel.outputs.backerNumber()

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -160,7 +160,13 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>() {
                 .compose(Transformers.observeForUI())
                 .subscribe {
                     ViewUtils.setGone(received_section, it)
-                    ViewUtils.setGone(estimated_delivery_label_2, !it)
+                }
+
+        this.viewModel.outputs.receivedSectionCreatorIsGone()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe {
+                    ViewUtils.setGone(estimated_delivery_label_2, it)
                 }
 
         this.viewModel.outputs.shippingAmount()

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -434,8 +434,6 @@ interface BackingFragmentViewModel {
             isCreator
                     .compose(bindToLifecycle())
                     .subscribe(this.deliveryDisclaimerSectionIsGone)
-
-
         }
 
         private fun getBackingInfo(it: ProjectData): Observable<Backing> {

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -9,6 +9,7 @@ import com.kickstarter.libs.FragmentViewModel
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.rx.transformers.Transformers.*
 import com.kickstarter.libs.utils.*
+import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.models.*
 import com.kickstarter.ui.data.PledgeStatusData
 import com.kickstarter.ui.data.ProjectData
@@ -428,9 +429,8 @@ interface BackingFragmentViewModel {
         private fun joinProjectDataAndReward(projectData: ProjectData): Pair<ProjectData, Reward> {
             val reward = projectData.backing()?.reward()
                     ?: BackingUtils.backedReward(projectData.project())
-                    ?: Reward.builder()
-                            .id(0)
-                            .minimum(projectData.backing()?.amount() ?: 0.0)
+                    ?: RewardFactory.noReward().toBuilder()
+                            .minimum(projectData.backing()?.amount() ?: 1.0)
                             .build()
 
             return Pair(projectData, reward)

--- a/app/src/main/res/layout/backing_toolbar.xml
+++ b/app/src/main/res/layout/backing_toolbar.xml
@@ -23,7 +23,7 @@
     <TextView
       style="@style/ToolbarTitle"
       android:id="@+id/title_text_view"
-      android:text="@string/View_your_pledge" />
+      android:text="@string/project_view_button" />
   </RelativeLayout>
 
 </com.kickstarter.ui.toolbars.KSToolbar>

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -4,7 +4,6 @@ import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
-import com.kickstarter.libs.CurrentUserType
 import com.kickstarter.libs.Either
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUser
@@ -14,6 +13,7 @@ import com.kickstarter.mock.services.MockApolloClient
 import com.kickstarter.models.Backing
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
+import com.kickstarter.models.User
 import com.kickstarter.ui.data.PledgeStatusData
 import com.kickstarter.ui.data.ProjectData
 import com.stripe.android.model.Card
@@ -46,6 +46,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
     private val projectDataAndReward = TestSubscriber.create<Pair<ProjectData, Reward>>()
     private val receivedCheckboxChecked = TestSubscriber.create<Boolean>()
     private val receivedSectionIsGone = TestSubscriber.create<Boolean>()
+    private val receivedSectionCreatorIsGone = TestSubscriber.create<Boolean>()
     private val shippingAmount = TestSubscriber.create<CharSequence>()
     private val shippingLocation = TestSubscriber.create<String>()
     private val shippingSummaryIsGone = TestSubscriber.create<Boolean>()
@@ -76,6 +77,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.projectDataAndReward().subscribe(this.projectDataAndReward)
         this.vm.outputs.receivedCheckboxChecked().subscribe(this.receivedCheckboxChecked)
         this.vm.outputs.receivedSectionIsGone().subscribe(this.receivedSectionIsGone)
+        this.vm.outputs.receivedSectionCreatorIsGone().subscribe(this.receivedSectionCreatorIsGone)
         this.vm.outputs.shippingAmount().map { it.toString() }.subscribe(this.shippingAmount)
         this.vm.outputs.shippingLocation().subscribe(this.shippingLocation)
         this.vm.outputs.shippingSummaryIsGone().subscribe(this.shippingSummaryIsGone)
@@ -842,24 +844,32 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testReceivedSectionIsGone_whenBackingIsNotCollected() {
+    fun testReceivedSectionIsGone_whenBackingIsNotCollectedNotCreator() {
+        val user = UserFactory.user()
+
         val backing = BackingFactory.backing()
                 .toBuilder()
+                .backer(user)
                 .status(Backing.STATUS_PLEDGED)
                 .build()
 
+        val currentUser = MockCurrentUser(UserFactory.creator())
+
         val environment = environment()
                 .toBuilder()
+                .currentUser(currentUser)
                 .apolloClient(mockApolloClientForBacking(backing))
                 .build()
+
         setUpEnvironment(environment)
         this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.backedProject()))
 
         this.receivedSectionIsGone.assertValue(true)
+        this.receivedSectionCreatorIsGone.assertValue(true)
     }
 
     @Test
-    fun testReceivedSectionIsGone_whenBackingIsCollected_actualReward() {
+    fun testReceivedSectionIsGone_whenBackingIsCollectedNoCreator_actualReward() {
         val backing = BackingFactory.backing()
                 .toBuilder()
                 .rewardId(3L)
@@ -874,23 +884,68 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.backedProject()))
 
         this.receivedSectionIsGone.assertValue(false)
+        this.receivedSectionCreatorIsGone.assertValue(true)
     }
 
     @Test
-    fun testReceivedSectionIsGone_whenBackingIsCollected_noReward() {
+    fun testReceivedSectionIsGone_whenBackingIsCollectedAndUserIsCreator_actualReward() {
+        val user = UserFactory.creator()
+
+        val project = ProjectFactory.backedProject()
+                .toBuilder()
+                .creator(user)
+                .build()
+
         val backing = BackingFactory.backing()
                 .toBuilder()
+                .project(project)
+                .rewardId(3L)
+                .status(Backing.STATUS_COLLECTED)
+                .build()
+
+        val currentUser = MockCurrentUser(user)
+        val environment = environment()
+                .toBuilder()
+                .currentUser(currentUser)
+                .apolloClient(mockApolloClientForBacking(backing))
+                .build()
+
+        setUpEnvironment(environment)
+
+        this.vm.inputs.configureWith(ProjectDataFactory.project(project))
+
+        this.receivedSectionIsGone.assertValue(true)
+        this.receivedSectionCreatorIsGone.assertValue(false)
+    }
+
+    @Test
+    fun testReceivedSectionIsGone_whenBackingIsCollectedNoCreator_noReward() {
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .backer(UserFactory.user())
                 .rewardId(null)
                 .status(Backing.STATUS_COLLECTED)
                 .build()
 
+        val creator = UserFactory.creator()
+        val currentUser = MockCurrentUser(creator)
+
         val environment = environment()
                 .toBuilder()
+                .currentUser(currentUser)
                 .apolloClient(mockApolloClientForBacking(backing))
                 .build()
         setUpEnvironment(environment)
-        this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.backedProject()))
 
+        val project = ProjectFactory.project()
+                .toBuilder()
+                .creator(creator)
+                .backing(backing)
+                .build()
+
+        this.vm.inputs.configureWith(ProjectDataFactory.project(project))
+
+        this.receivedSectionCreatorIsGone.assertValue(true)
         this.receivedSectionIsGone.assertValue(true)
     }
 


### PR DESCRIPTION
# 📲 What

- Visual tweecks for the View Pledge screen, creator and backer perspective

# 👀 See

| Before 🐛 | After 🦋 |
- **The title of the creator View Pledge screen reads “View pledge”**
- **The title of the reward is shown in the reward card**
<img width="984" alt="CREATOR-Perspective" src="https://user-images.githubusercontent.com/4083656/99605353-5dd89e80-29bc-11eb-8c6b-bfb767d617c5.png">

- **The estimated delivery date of the reward is shown above the reward card when no reward in Backer perspective**
<img width="943" alt="BACKERNoReward-BackerPerspective" src="https://user-images.githubusercontent.com/4083656/99605347-59ac8100-29bc-11eb-8178-ba100f092daa.png">


| --- | --- |
|  |  |

# 📋 QA
- For the first two points log as a creator, go to a message from a backer and press the view pledge button on the ThreadMessages screen
- For the last point pledge to any reward no reward, the go to the view pledge screen

# Story 📖

[Android creator view pledge adjustments](https://kickstarter.atlassian.net/browse/NT-1595)
