### PR TITLE
NT-1656: Tracking Events

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/Koala.java
+++ b/app/src/main/java/com/kickstarter/libs/Koala.java
@@ -790,6 +790,14 @@ public final class Koala {
   public void trackTwoFactorConfirmationViewed() {
     this.client.track(LakeEvent.TWO_FACTOR_CONFIRMATION_VIEWED);
   }
+
+  public void trackVerificationScreenViewed() {
+    this.client.track(LakeEvent.VERIFICATION_SCREEN_VIEWED);
+  }
+
+  public void trackSkipVerificationButtonClicked() {
+    this.client.track(LakeEvent.SKIP_VERIFICATION_BUTTON_CLICKED);
+  }
   //endregion
 
   //region Experiments

--- a/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeEvent.kt
@@ -40,6 +40,8 @@ const val LOG_IN_SUBMIT_BUTTON_CLICKED = "Log In Submit Button Clicked"
 const val SIGN_UP_BUTTON_CLICKED = "Sign Up Button Clicked"
 const val SIGN_UP_SUBMIT_BUTTON_CLICKED = "Sign Up Submit Button Clicked"
 const val TWO_FACTOR_CONFIRMATION_VIEWED = "Two-Factor Confirmation Viewed"
+const val VERIFICATION_SCREEN_VIEWED = "Verification Screen Viewed"
+const val SKIP_VERIFICATION_BUTTON_CLICKED = "Skip Verification Button Clicked"
 // endregion
 
 // region native_project_page_campaign_details experiment

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
@@ -8,7 +8,6 @@ import android.view.View;
 import android.widget.ImageButton;
 
 import com.google.android.material.appbar.AppBarLayout;
-import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.tabs.TabLayout;
 import com.jakewharton.rxbinding.support.v4.widget.RxDrawerLayout;
 import com.kickstarter.BuildConfig;

--- a/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
@@ -101,7 +101,12 @@ class EmailVerificationInterstitialFragmentViewModel {
 
             this.skipLinkPressed
                     .compose(bindToLifecycle())
-                    .subscribe(this.dismissInterstitial)
+                    .subscribe {
+                        this.lake.trackSkipVerificationButtonClicked()
+                        this.dismissInterstitial.onNext(null)
+                    }
+
+            this.lake.trackVerificationScreenViewed()
         }
 
         // - Inputs

--- a/app/src/test/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModelTest.kt
@@ -84,7 +84,7 @@ class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase
 
         this.vm.inputs.skipButtonPressed()
         this.dismissInterstitial.assertValueCount(1)
-        this.lakeTest.assertValues("Verification Screen Viewed","Skip Verification Button Clicked")
+        this.lakeTest.assertValues("Verification Screen Viewed", "Skip Verification Button Clicked")
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModelTest.kt
@@ -39,6 +39,7 @@ class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase
 
         this.vm.inputs.openInboxButtonPressed()
         this.startEmailActivity.assertValue(null)
+        this.lakeTest.assertValue("Verification Screen Viewed")
     }
 
     @Test
@@ -56,6 +57,7 @@ class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase
         setUpEnvironment(environment)
 
         this.isSkipLinkShown.assertValue(true)
+        this.lakeTest.assertValue("Verification Screen Viewed")
     }
 
     @Test
@@ -73,6 +75,7 @@ class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase
         setUpEnvironment(environment = environment)
 
         this.isSkipLinkShown.assertValue(false)
+        this.lakeTest.assertValue("Verification Screen Viewed")
     }
 
     @Test
@@ -81,6 +84,7 @@ class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase
 
         this.vm.inputs.skipButtonPressed()
         this.dismissInterstitial.assertValueCount(1)
+        this.lakeTest.assertValues("Verification Screen Viewed","Skip Verification Button Clicked")
     }
 
     @Test
@@ -104,6 +108,7 @@ class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase
         this.loadingIndicatorGone.assertValues(false, true)
         this.showSnackbarSuccess.assertValue(R.string.verification_email_sent_inbox)
         this.showSnackbarError.assertNoValues()
+        this.lakeTest.assertValue("Verification Screen Viewed")
     }
 
 
@@ -124,6 +129,7 @@ class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase
         this.loadingIndicatorGone.assertValues(false, true)
         this.showSnackbarError.assertValue(R.string.we_couldnt_resend_this_email_please_try_again)
         this.showSnackbarSuccess.assertNoValues()
+        this.lakeTest.assertValue("Verification Screen Viewed")
     }
 
     companion object {


### PR DESCRIPTION
# 📲 What

Added two new tracking events: 
- when the Interstitial screen is presented: "Verification Screen Viewed"
- when the skip verification button is clicked: "Skip Verification Button Clicked"

# 👀 See
<img width="1724" alt="events" src="https://user-images.githubusercontent.com/4083656/100673276-0ae5dc00-3318-11eb-92f2-372bcf383a58.png">
|  |  |

# 📋 QA

- Take a look into the logs filtering by "TrackingClient" when presenting the interstitial screen you'll see the "Verification Screen Viewed" event
- If the feature flag is active you'll be able to see and press the skip button, so press it and take a look into the logs filtering by "TrackingClient" you'll be able to see the "Skip Verification Button Clicked" event

# Story 📖

[NT-1656](https://kickstarter.atlassian.net/browse/NT-1656)
