### PR TITLE
NT-1680: Send Email when interstitial presented

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.java
@@ -8,7 +8,6 @@ import android.view.View;
 import android.widget.ImageButton;
 
 import com.google.android.material.appbar.AppBarLayout;
-import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.tabs.TabLayout;
 import com.jakewharton.rxbinding.support.v4.widget.RxDrawerLayout;
 import com.kickstarter.BuildConfig;

--- a/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModel.kt
@@ -44,6 +44,9 @@ class EmailVerificationInterstitialFragmentViewModel {
 
         /** Dismiss the Interstitial Screen */
         fun dismissInterstitial(): Observable<Void>
+
+        /** On presenting the Fragment a verification email has been sent**/
+        fun emailSent(): Observable<Void>
     }
 
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<EmailVerificationInterstitialFragment>(environment), Outputs, Inputs {
@@ -57,6 +60,7 @@ class EmailVerificationInterstitialFragmentViewModel {
         private val showSnackbarSuccess = PublishSubject.create<Int>()
         private val startEmailActivity = PublishSubject.create<Void>()
         private val skipLinkPressed = PublishSubject.create<Void>()
+        private val emailSent = PublishSubject.create<Void>()
 
         private val apolloClient = this.environment.apolloClient()
         private val isSkipLinkShown = BehaviorSubject.create<Boolean>()
@@ -65,6 +69,15 @@ class EmailVerificationInterstitialFragmentViewModel {
         private val currentConfig = this.environment.currentConfig().observable()
 
         init {
+
+            this.apolloClient.sendVerificationEmail()
+                    .materialize()
+                    .share()
+                    .compose(bindToLifecycle())
+                    .subscribe {
+                        this.emailSent.onNext(null)
+                    }
+
             this.currentConfig
                     .compose(bindToLifecycle())
                     .subscribe {
@@ -116,6 +129,7 @@ class EmailVerificationInterstitialFragmentViewModel {
         override fun showSnackbarError(): Observable<Int> = this.showSnackbarError
         override fun showSnackbarSuccess(): Observable<Int> = this.showSnackbarSuccess
         override fun dismissInterstitial(): Observable<Void> = this.dismissInterstitial
+        override fun emailSent(): Observable<Void> = this.emailSent
     }
 
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/EmailVerificationInterstitialFragmentViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels
 
+import SendEmailVerificationMutation
 import androidx.annotation.NonNull
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
@@ -8,6 +9,7 @@ import com.kickstarter.libs.utils.extensions.EMAIL_VERIFICATION_SKIP
 import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.factories.ConfigFactory
 import com.kickstarter.mock.services.MockApolloClient
+import junit.framework.TestCase
 import org.junit.Test
 import rx.Observable
 import rx.observers.TestSubscriber
@@ -20,6 +22,7 @@ class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase
     private val showSnackbarSuccess = TestSubscriber.create<Int>()
     private val showSnackbarError = TestSubscriber.create<Int>()
     private val loadingIndicatorGone = TestSubscriber.create<Boolean>()
+    private val emailSent = TestSubscriber.create<Void>()
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
 
@@ -31,6 +34,7 @@ class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase
         this.vm.outputs.showSnackbarSuccess().subscribe(showSnackbarSuccess)
         this.vm.outputs.showSnackbarError().subscribe(showSnackbarError)
         this.vm.outputs.loadingIndicatorGone().subscribe(loadingIndicatorGone)
+        this.vm.outputs.emailSent().subscribe(emailSent)
     }
 
     @Test
@@ -124,6 +128,15 @@ class EmailVerificationInterstitialFragmentViewModelTest : KSRobolectricTestCase
         this.loadingIndicatorGone.assertValues(false, true)
         this.showSnackbarError.assertValue(R.string.we_couldnt_resend_this_email_please_try_again)
         this.showSnackbarSuccess.assertNoValues()
+    }
+
+    @Test
+    fun init_whenPresentingInterstitial_sendEmail() {
+        setUpEnvironment(environment())
+
+        this.vm.outputs.emailSent().subscribe {
+            TestCase.assertNull(it)
+        }
     }
 
     companion object {


### PR DESCRIPTION
# 📲 What

- When the interstitial is presented we send the validation email

# 👀 See
![getEmailWhenPresented](https://user-images.githubusercontent.com/4083656/100683933-31af0d00-332e-11eb-95ca-3ab80361262e.gif)

|  |  |

# 📋 QA

- Every time you open the Interstitial with an user logged in you should get an email.

# Story 📖

[NT-1680](https://kickstarter.atlassian.net/browse/NT-1680)
