### PR TITLE
NT-1694: Update facebook SDK version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -198,7 +198,7 @@ dependencies {
     implementation 'androidx.work:work-runtime-ktx:2.3.4'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.apollographql.apollo:apollo-runtime:2.3.0'
-    implementation 'com.facebook.android:facebook-android-sdk:5.2.0'
+    implementation 'com.facebook.android:facebook-android-sdk:7.1.0'
     final auto_parcel_version = "0.3.1"
     implementation "com.github.frankiesardo:auto-parcel:$auto_parcel_version"
     kapt "com.github.frankiesardo:auto-parcel-processor:$auto_parcel_version"


### PR DESCRIPTION
# 📲 What

- Update to latest Facebook SDK

# 🤔 Why
- Spike on crashes related to Facebook SDK 
- [Firebase report](https://console.firebase.google.com/u/1/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/060f7462f52530baa36a02097ec5a4b1?time=last-seven-days&sessionEventKey=5FCE67A802B0000156333B2EFFFF4B3B_1482014854853983481)
![Screen Shot 2020-12-07 at 10 55 22 AM](https://user-images.githubusercontent.com/4083656/101392556-c22fa500-387a-11eb-929a-4d71ff392dbf.png)


# 👀 See

![log_in_facebook](https://user-images.githubusercontent.com/4083656/101392785-04f17d00-387b-11eb-867f-afd797d442ec.gif)

|  |  |

# 📋 QA

- Make sure you are on production not staging and try to log in using Facebook

# Story 📖

[NT-1694](https://kickstarter.atlassian.net/browse/NT-1694)
