### PR TITLE
NT-1695: Update dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.3.0'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.4.1'
     }
 }
 
@@ -36,7 +36,7 @@ if (file('signing.gradle').exists()) {
 
 android {
     compileSdkVersion 29
-    buildToolsVersion '29.0.2'
+    buildToolsVersion '29.0.3'
 
     defaultConfig {
         applicationId "com.kickstarter"
@@ -190,23 +190,23 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
-    implementation 'androidx.browser:browser:1.0.0'
+    implementation 'androidx.browser:browser:1.3.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.preference:preference:1.1.0'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0-beta01'
+    implementation 'androidx.recyclerview:recyclerview:1.2.0-beta01'
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'androidx.work:work-runtime-ktx:2.3.4'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'androidx.work:work-runtime-ktx:2.4.0'
+    implementation 'com.android.support.constraint:constraint-layout:2.0.4'
     implementation 'com.apollographql.apollo:apollo-runtime:2.3.0'
     implementation 'com.facebook.android:facebook-android-sdk:5.2.0'
     final auto_parcel_version = "0.3.1"
     implementation "com.github.frankiesardo:auto-parcel:$auto_parcel_version"
     kapt "com.github.frankiesardo:auto-parcel-processor:$auto_parcel_version"
-    implementation "com.google.android.gms:play-services-wallet:18.0.0"
+    implementation "com.google.android.gms:play-services-wallet:18.1.2"
     implementation "com.google.android.exoplayer:exoplayer:2.10.2"
     implementation 'com.google.android:flexbox:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0-alpha08'
-    final dagger_version = "2.11"
+    implementation 'com.google.android.material:material:1.3.0-alpha04'
+    final dagger_version = "2.28.3"
     implementation "com.google.dagger:dagger:$dagger_version"
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
     implementation "com.jakewharton:butterknife:7.0.1"
@@ -216,7 +216,6 @@ dependencies {
     implementation "com.jakewharton.rxbinding:rxbinding-recyclerview-v7:$rx_binding_version"
     implementation "com.jakewharton.rxbinding:rxbinding-support-v4:$rx_binding_version"
     implementation "com.jakewharton.timber:timber:3.0.1"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'com.optimizely.ab:android-sdk:3.0.0'
     implementation 'com.qualtrics:digital:1.3'
     implementation "com.stripe:stripe-android:12.0.1"
@@ -232,7 +231,7 @@ dependencies {
     implementation "com.trello:rxlifecycle:$rx_lifecycle_version"
     implementation "com.trello:rxlifecycle-components:$rx_lifecycle_version"
     implementation 'io.reactivex:rxandroid:1.2.1'
-    implementation "io.reactivex:rxjava:1.1.5"
+    implementation "io.reactivex:rxjava:1.3.8"
     implementation "net.danlew:android.joda:2.7.2"
     implementation "org.jsoup:jsoup:1.12.1"
 
@@ -249,14 +248,14 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.3"
     testImplementation "org.robolectric:shadows-multidex:4.3"
     androidTestImplementation 'androidx.annotation:annotation:1.1.0'
-    androidTestImplementation "androidx.test:core:1.2.0"
+    androidTestImplementation "androidx.test:core:1.3.0"
 
     def espresso = '3.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:' + espresso
     androidTestImplementation 'androidx.test.espresso:espresso-core:' + espresso
     androidTestImplementation 'androidx.test.espresso:espresso-intents:' + espresso
-    androidTestImplementation "androidx.test.ext:junit:1.1.1"
-    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation "androidx.test.ext:junit:1.1.2"
+    androidTestImplementation 'androidx.test:rules:1.3.0'
 }
 
 // SHA and timestamp caching courtesy of https://github.com/gdg-x/frisbee/blob/develop/app/build.gradle#L193-L218


### PR DESCRIPTION
# 📲 What
Now we adopted the latest Kotlin version, that allow us to upgrade some other dependencies that do not require implementation changes to the current code base: 

**Google depencies:**
```
 'androidx.recyclerview:recyclerview:1.1.0-beta01' → 'androidx.recyclerview:recyclerview:1.2.0-beta01'

 'androidx.work:work-runtime-ktx:2.3.4' → 'androidx.work:work-runtime-ktx:2.4.0'

 'com.android.support.constraint:constraint-layout:1.1.3' → 'com.android.support.constraint:constraint-layout:2.0.4'

"com.google.android.gms:play-services-wallet:18.0.0" → "com.google.android.gms:play-services-wallet:18.1.2"

'com.google.android.material:material:1.1.0-alpha08' → 'com.google.android.material:material:1.3.0-alpha04'

"com.google.dagger:dagger:2.11" → "com.google.dagger:dagger:2.28.3"

buildToolsVersion '29.0.2' → buildToolsVersion '29.0.3'
```

**RX dependencies:** 
```
 "io.reactivex:rxjava:1.1.5" →  "io.reactivex:rxjava:1.3.8"
```

**Test depencies:** 

```
 "androidx.test:core:1.2.0" → "androidx.test:core:1.3.0" 

"androidx.test.ext:junit:1.1.1" → 'androidx.test:rules:1.2.0'

 "androidx.test.ext:junit:1.1.2" →  'androidx.test:rules:1.3.0'`
```


# 📋 QA
- Launch the app and check around everything keeps working as expected.

# Story 📖

[NT-1695](https://kickstarter.atlassian.net/browse/NT-1695)
