### PR TITLE
NT-1689: Grey adjustments

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/itemdecorations/TableItemDecoration.kt
+++ b/app/src/main/java/com/kickstarter/ui/itemdecorations/TableItemDecoration.kt
@@ -12,7 +12,7 @@ class TableItemDecoration :RecyclerView.ItemDecoration() {
         super.getItemOffsets(outRect, view, parent, state)
 
         val position = parent.getChildAdapterPosition(view)
-        val backgroundColor = if (position % 2 == 0) R.color.kds_transparent else R.color.kds_support_300
+        val backgroundColor = if (position % 2 == 0) R.color.kds_transparent else R.color.kds_support_100
         view.setBackgroundColor(ContextCompat.getColor(view.context, backgroundColor))
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -49,7 +49,6 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import okhttp3.Response;
 import rx.Notification;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -443,10 +443,6 @@ public interface DiscoveryViewModel {
         .subscribe(this.showQualtricsSurvey);
     }
 
-    private Boolean isSameResponse(final @NonNull Response first, final @NonNull Response second) {
-      return first.code() == second.code() && first.message() == second.message();
-    }
-
     private int currentDrawerMenuIcon(final @Nullable User user) {
       if (ObjectUtils.isNull(user)) {
         return R.drawable.ic_menu;

--- a/app/src/main/res/color/white_enabled_gray_disabled.xml
+++ b/app/src/main/res/color/white_enabled_gray_disabled.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android" android:exitFadeDuration="@android:integer/config_mediumAnimTime">
-  <item android:color="@color/kds_support_300" android:state_enabled="false" />
+  <item android:color="@color/kds_support_200" android:state_enabled="false" />
   <item android:color="@color/kds_white" />
 </selector>

--- a/app/src/main/res/drawable/circle_gray_filled.xml
+++ b/app/src/main/res/drawable/circle_gray_filled.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
-  <solid android:color="@color/kds_support_300"/>
+  <solid android:color="@color/kds_support_100"/>
 </shape>

--- a/app/src/main/res/drawable/circle_gray_outline.xml
+++ b/app/src/main/res/drawable/circle_gray_outline.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
-  <stroke android:color="@color/kds_support_300" android:width="1dp"/>
+  <stroke android:color="@color/kds_support_200" android:width="1dp"/>
 </shape>

--- a/app/src/main/res/drawable/circular_click_indicator_light.xml
+++ b/app/src/main/res/drawable/circular_click_indicator_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-  android:color="@color/ripple_light">
+  android:color="@color/kds_support_100">
   <item android:id="@android:id/mask">
     <shape android:shape="oval">
       <solid android:color="?android:colorPrimary"/>

--- a/app/src/main/res/drawable/rect_grey_rounded.xml
+++ b/app/src/main/res/drawable/rect_grey_rounded.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/kds_support_300" />
+    <solid android:color="@color/kds_support_200" />
     <padding
         android:bottom="@dimen/grid_1"
         android:left="@dimen/grid_2"

--- a/app/src/main/res/drawable/text_view_rect_background.xml
+++ b/app/src/main/res/drawable/text_view_rect_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
   <solid
-    android:color="@color/kds_support_300"/>
+    android:color="@color/kds_support_100"/>
   <padding
     android:bottom="@dimen/grid_1_half"
     android:top="@dimen/grid_1_half"

--- a/app/src/main/res/layout/activity_settings_payment_methods.xml
+++ b/app/src/main/res/layout/activity_settings_payment_methods.xml
@@ -53,7 +53,7 @@
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:layout_marginEnd="@dimen/grid_12"
-            android:background="@color/kds_support_300"
+            android:background="@color/kds_support_100"
             android:visibility="gone" />
 
           <TextView

--- a/app/src/main/res/layout/fragment_backing.xml
+++ b/app/src/main/res/layout/fragment_backing.xml
@@ -86,7 +86,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="@dimen/grid_4"
-                        android:background="@color/kds_support_300"
+                        android:background="@color/kds_support_200"
                         android:gravity="center"
                         android:paddingStart="@dimen/grid_4"
                         android:paddingTop="@dimen/grid_2"

--- a/app/src/main/res/layout/fragment_cancel_pledge.xml
+++ b/app/src/main/res/layout/fragment_cancel_pledge.xml
@@ -5,7 +5,7 @@
   android:id="@+id/cancel_pledge_root"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  android:background="@color/kds_support_300"
+  android:background="@color/kds_support_100"
   android:paddingTop="?android:attr/actionBarSize">
 
   <ScrollView

--- a/app/src/main/res/layout/fragment_pledge_section_accountability.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_accountability.xml
@@ -9,7 +9,7 @@
   android:layout_marginEnd="@dimen/activity_vertical_margin"
   android:layout_marginBottom="@dimen/grid_4"
   android:foreground="@drawable/click_indicator_light"
-  app:cardBackgroundColor="@color/kds_support_100"
+  app:cardBackgroundColor="@color/kds_support_200"
   app:cardCornerRadius="@dimen/grid_2"
   app:cardElevation="@dimen/card_no_elevation">
 

--- a/app/src/main/res/layout/item_errored_backing.xml
+++ b/app/src/main/res/layout/item_errored_backing.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:background="@color/kds_support_300"
+    android:background="@color/kds_support_100"
     android:clipChildren="false"
     android:orientation="horizontal"
     android:padding="@dimen/grid_3">

--- a/app/src/main/res/layout/message_view.xml
+++ b/app/src/main/res/layout/message_view.xml
@@ -33,7 +33,7 @@
         android:paddingEnd="@dimen/grid_3"
         android:paddingTop="@dimen/grid_3"
         android:paddingBottom="@dimen/grid_2"
-        android:background="@color/kds_support_300"
+        android:background="@color/kds_support_100"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:autoLink="web"

--- a/app/src/main/res/layout/qualtrics_prompt.xml
+++ b/app/src/main/res/layout/qualtrics_prompt.xml
@@ -15,7 +15,7 @@
     android:layout_margin="@dimen/grid_2"
     android:visibility="invisible"
     app:cardCornerRadius="@dimen/grid_1"
-    app:cardBackgroundColor="@color/kds_support_300"
+    app:cardBackgroundColor="@color/kds_support_100"
     tools:showIn="@layout/discovery_layout"
     tools:visibility="visible">
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,7 +7,7 @@
   <color name="text_primary">@color/kds_support_700</color>
   <color name="text_secondary">@color/kds_support_400</color>
   <color name="window_background">@color/kds_white</color>
-  <color name="status_bar">@color/kds_support_300</color>
+  <color name="status_bar">@color/kds_support_100</color>
 
   <!-- KDS  -->
   <color name="kds_alert">#A12027</color>
@@ -22,6 +22,7 @@
   <color name="kds_create_700">#028858</color>
   <color name="kds_inform">#B6D9E1</color>
   <color name="kds_support_100">#F3F3F3</color>
+  <color name="kds_support_200">#E6E6E6</color>
   <color name="kds_support_300">#D1D1D1</color>
   <color name="kds_support_400">#696969</color>
   <color name="kds_support_500">#464646</color>
@@ -45,7 +46,7 @@
   <color name="black_alpha_50">#80000000</color>
   <color name="blue_alpha_6">#0f2b60ff</color>
   <color name="blue_darken_10">@color/kds_trust_500</color>
-  <color name="gray_alpha_50">@color/kds_support_300</color>
+  <color name="gray_alpha_50">@color/kds_support_100</color>
   <color name="gray_darken_10">@color/kds_support_300</color>
   <color name="green_alpha_6">#0F009E74</color>
   <color name="green_alpha_10">#1A009E74</color>


### PR DESCRIPTION
- Added KDS-support-200 (#E6E6E6)
- Substitute kds_support_300 over kds_support_100 or kds_support_200

# 👀 See
* **background on the Updates and Comments counter to support-100.**
![updates-and-comments](https://user-images.githubusercontent.com/4083656/101815331-40d34f00-3ad4-11eb-9d46-fe5715e51a97.png)


* **background on the disabled state of the stepper to be support-200.**
![stepper](https://user-images.githubusercontent.com/4083656/101815493-7a0bbf00-3ad4-11eb-82ea-2622ffeecdce.png)


* **background color on the “KSR is not a store” component to KDS-support-200**
<img width="881" alt="ksr_not_store" src="https://user-images.githubusercontent.com/4083656/101816478-ed620080-3ad5-11eb-94ab-fc45c6c1e627.png">


* **state of a pledge to KDS-support-200 to background of the “Delivery dates are not guaranteed” cell to KDS-support-200**
![view_pledge](https://user-images.githubusercontent.com/4083656/101816137-804e6b00-3ad5-11eb-874f-e459527a49c8.png)


* ** background of these circles to KDS-support-100.**
![notifications](https://user-images.githubusercontent.com/4083656/101816552-04a0ee00-3ad6-11eb-84ec-a1ed3c885711.png)


* **status bar globally to support-100.**
![statusBAr](https://user-images.githubusercontent.com/4083656/101816624-197d8180-3ad6-11eb-9759-959d815f10c2.png)

|  |  |


# Story 📖

[NT-1689](https://kickstarter.atlassian.net/browse/NT-1689)
