### PR TITLE
NT-1626: Android Target API 30

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -245,8 +245,8 @@ dependencies {
     // Testing
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-core:2.8.9"
-    testImplementation "org.robolectric:robolectric:4.3"
-    testImplementation "org.robolectric:shadows-multidex:4.3"
+    testImplementation "org.robolectric:robolectric:4.4"
+    testImplementation "org.robolectric:shadows-multidex:4.4"
     androidTestImplementation 'androidx.annotation:annotation:1.1.0'
     androidTestImplementation "androidx.test:core:1.3.0"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,13 @@
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" /> <!-- Used to determine if network connection Snackbar should be shown. -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.SEND"/>
+            <data android:host="com.kickstarter"/>
+        </intent>
+    </queries>
+
     <application
         android:name=".KSApplication"
         android:allowBackup="true"

--- a/app/src/test/java/com/kickstarter/libs/utils/DateTimeUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/DateTimeUtilsTest.java
@@ -48,9 +48,9 @@ public final class DateTimeUtilsTest extends KSRobolectricTestCase {
 
   @Test
   public void testMediumDateTime() {
-    assertEquals("Dec 17, 2015 6:35:05 PM", DateTimeUtils.mediumDateTime(DateTime.parse("2015-12-17T18:35:05Z"), DateTimeZone.UTC));
-    assertEquals("Dec 17, 2015 1:35:05 PM", DateTimeUtils.mediumDateTime(DateTime.parse("2015-12-17T18:35:05Z"), DateTimeZone.forID("EST")));
-    assertEquals("17 déc. 2015 18:35:05", DateTimeUtils.mediumDateTime(DateTime.parse("2015-12-17T18:35:05Z"), DateTimeZone.UTC, Locale.FRENCH));
+    assertEquals("Dec 17, 2015, 6:35:05 PM", DateTimeUtils.mediumDateTime(DateTime.parse("2015-12-17T18:35:05Z"), DateTimeZone.UTC));
+    assertEquals("Dec 17, 2015, 1:35:05 PM", DateTimeUtils.mediumDateTime(DateTime.parse("2015-12-17T18:35:05Z"), DateTimeZone.forID("EST")));
+    assertEquals("17 déc. 2015 à 18:35:05", DateTimeUtils.mediumDateTime(DateTime.parse("2015-12-17T18:35:05Z"), DateTimeZone.UTC, Locale.FRENCH));
   }
 
   @Test
@@ -154,8 +154,8 @@ public final class DateTimeUtilsTest extends KSRobolectricTestCase {
 
   @Test
   public void testMediumDateShortTime() {
-    assertEquals("Dec 17, 2015 6:35 PM", DateTimeUtils.mediumDateShortTime(DateTime.parse("2015-12-17T18:35:05Z"), DateTimeZone.UTC));
-    assertEquals("Dec 17, 2015 1:35 PM", DateTimeUtils.mediumDateShortTime(DateTime.parse("2015-12-17T18:35:05Z"), DateTimeZone.forID("EST")));
+    assertEquals("Dec 17, 2015, 6:35 PM", DateTimeUtils.mediumDateShortTime(DateTime.parse("2015-12-17T18:35:05Z"), DateTimeZone.UTC));
+    assertEquals("Dec 17, 2015, 1:35 PM", DateTimeUtils.mediumDateShortTime(DateTime.parse("2015-12-17T18:35:05Z"), DateTimeZone.forID("EST")));
     assertEquals("17 déc. 2015 18:35", DateTimeUtils.mediumDateShortTime(DateTime.parse("2015-12-17T18:35:05Z"), DateTimeZone.UTC, Locale.FRENCH));
   }
 

--- a/app/src/test/java/com/kickstarter/libs/utils/NumberUtilsTest.java
+++ b/app/src/test/java/com/kickstarter/libs/utils/NumberUtilsTest.java
@@ -16,11 +16,11 @@ public final class NumberUtilsTest extends TestCase {
   }
 
   public void testFlooredPercentage_withFrenchLocale() {
-    assertEquals("50 %", NumberUtils.flooredPercentage(50.0f, Locale.FRENCH));
+    assertEquals("50\u00A0%", NumberUtils.flooredPercentage(50.0f, Locale.FRENCH));
   }
 
   public void testFlooredPercentage_withGermanLocale() {
-    assertEquals("1.000%", NumberUtils.flooredPercentage(1000.0f, Locale.GERMAN));
+    assertEquals("1.000\u00A0%", NumberUtils.flooredPercentage(1000.0f, Locale.GERMAN));
   }
 
   public void testFormatNumber_int() {
@@ -96,7 +96,7 @@ public final class NumberUtilsTest extends TestCase {
   }
 
   public void testFormatNumber_floatWithCurrencyAndGermanyLocale() {
-    assertEquals("100 $", NumberUtils.format(100.0f, NumberOptions.builder().currencySymbol("$").build(), Locale.GERMANY));
+    assertEquals("100\u00A0$", NumberUtils.format(100.0f, NumberOptions.builder().currencySymbol("$").build(), Locale.GERMANY));
     assertEquals("1.000", NumberUtils.format(1000.0f, NumberOptions.builder().build(), Locale.GERMANY));
     assertEquals("100,12", NumberUtils.format(100.12f, NumberOptions.builder().precision(2).build(), Locale.GERMANY));
   }

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels
 
+import android.os.Looper
 import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.KSRobolectricTestCase
@@ -19,6 +20,7 @@ import com.stripe.android.model.Card
 import junit.framework.TestCase
 import org.joda.time.DateTime
 import org.junit.Test
+import org.robolectric.Shadows
 import rx.Observable
 import rx.observers.TestSubscriber
 import java.math.RoundingMode
@@ -87,6 +89,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.projectDataAndAddOns().subscribe(this.listAddOns)
         this.vm.outputs.bonusSupport().map { it.toString() }.subscribe(this.bonusAmount)
         this.vm.outputs.deliveryDisclaimerSectionIsGone().subscribe(this.disclaimerSectionIsGone)
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectHolderViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectHolderViewModelTest.java
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels;
 
+import android.os.Looper;
 import android.util.Pair;
 
 import com.kickstarter.KSRobolectricTestCase;
@@ -32,6 +33,7 @@ import com.kickstarter.ui.data.ProjectData;
 import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTime;
 import org.junit.Test;
+import org.robolectric.Shadows;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -142,7 +144,7 @@ public final class ProjectHolderViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.setUnsuccessfulProjectStateView().subscribe(this.setUnsuccessfulProjectStateView);
     this.vm.outputs.startProjectSocialActivity().subscribe(this.startProjectSocialActivity);
     this.vm.outputs.updatesCountTextViewText().subscribe(this.updatesCountTextViewText);
-
+    Shadows.shadowOf(Looper.getMainLooper()).idle();
     this.vm.inputs.configureWith(projectData);
   }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -3,6 +3,7 @@ package com.kickstarter.viewmodels
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.os.Looper
 import android.util.Pair
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
@@ -16,6 +17,7 @@ import com.kickstarter.models.Project
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.data.*
 import org.junit.Test
+import org.robolectric.Shadows
 import rx.Observable
 import rx.observers.TestSubscriber
 import java.math.RoundingMode
@@ -99,6 +101,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.startThanksActivity().subscribe(this.startThanksActivity)
         this.vm.outputs.startVideoActivity().subscribe(this.startVideoActivity)
         this.vm.outputs.updateFragments().subscribe(this.updateFragments)
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Upgrading to Android API 30 requires a few updates for our codebase to be compatible. I have added a `queries` element to the Android manifest file for the new package visibility requirements in API 30. Also updated tests to reflect new formatting changes. 

# 🛠 How

- Added a new queries element to android manifest.
- Updated failing tests with new formatting to Date and Number strings. 
    - Dec 17, 2015 6:35 PM -> Dec 17, 2015, 6:35 PM
    - 17 déc. 2015 18:35:05 -> 17 déc. 2015 à 18:35:05
    - 100 $ -> now has a non-breaking space

# 📋 QA

n/a

# Story 📖

[NT-1626: Android Target API 30](https://kickstarter.atlassian.net/browse/NT-1626)
