### PR TITLE
NT-1580 : Forgot password email

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
@@ -10,7 +10,6 @@ import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
-import com.kickstarter.libs.utils.LoginHelper
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft
 import com.kickstarter.libs.utils.ViewUtils
@@ -19,12 +18,10 @@ import com.kickstarter.ui.extensions.hideKeyboard
 import com.kickstarter.ui.extensions.onChange
 import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.ui.extensions.text
-import com.kickstarter.ui.fragments.Callbacks
 import com.kickstarter.ui.views.ConfirmDialog
 import com.kickstarter.viewmodels.LoginViewModel
 import kotlinx.android.synthetic.main.login_form_view.*
 import kotlinx.android.synthetic.main.login_toolbar.*
-
 
 @RequiresActivityViewModel(LoginViewModel.ViewModel::class)
 class LoginActivity : BaseActivity<LoginViewModel.ViewModel>() {
@@ -103,6 +100,7 @@ class LoginActivity : BaseActivity<LoginViewModel.ViewModel>() {
 
         forgot_your_password_text_view.setOnClickListener {
             val intent = Intent(this, ResetPasswordActivity::class.java)
+                    .putExtra(IntentKey.EMAIL, email.text.toString())
             startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
         }
 
@@ -131,9 +129,10 @@ class LoginActivity : BaseActivity<LoginViewModel.ViewModel>() {
     private fun errorMessages() =
             this.viewModel.outputs.invalidLoginError()
                     .map(ObjectUtils.coalesceWith(getString(this.loginDoesNotMatchString)))
-                    .mergeWith(this.viewModel.outputs.genericLoginError()
-                            .map(ObjectUtils.coalesceWith(getString(this.unableToLoginString))))
-
+                    .mergeWith(
+                            this.viewModel.outputs.genericLoginError()
+                                    .map(ObjectUtils.coalesceWith(getString(this.unableToLoginString)))
+                    )
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
         super.onActivityResult(requestCode, resultCode, intent)

--- a/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
@@ -4,14 +4,15 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Pair
 import com.kickstarter.R
-import com.kickstarter.ui.extensions.onChange
-import com.kickstarter.ui.extensions.text
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
+import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.data.LoginReason
+import com.kickstarter.ui.extensions.onChange
+import com.kickstarter.ui.extensions.text
 import com.kickstarter.viewmodels.ResetPasswordViewModel
 import kotlinx.android.synthetic.main.login_toolbar.*
 import kotlinx.android.synthetic.main.reset_password_form_view.*
@@ -49,6 +50,13 @@ class ResetPasswordActivity : BaseActivity<ResetPasswordViewModel.ViewModel>() {
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { ViewUtils.showDialog(this, getString(this.errorTitleString), getString(this.errorMessageString)) }
+
+        this.viewModel.outputs.prefillEmail()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe {
+                    email.setText(it)
+                }
 
         reset_password_button.setOnClickListener { this.viewModel.inputs.resetPasswordClick() }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
@@ -51,16 +51,16 @@ class ResetPasswordActivity : BaseActivity<ResetPasswordViewModel.ViewModel>() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { ViewUtils.showDialog(this, getString(this.errorTitleString), getString(this.errorMessageString)) }
 
+        reset_password_button.setOnClickListener { this.viewModel.inputs.resetPasswordClick() }
+
+        email.onChange { this.viewModel.inputs.email(it) }
+
         this.viewModel.outputs.prefillEmail()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .subscribe {
                     email.setText(it)
                 }
-
-        reset_password_button.setOnClickListener { this.viewModel.inputs.resetPasswordClick() }
-
-        email.onChange { this.viewModel.inputs.email(it) }
     }
 
     override fun exitTransition(): Pair<Int, Int>? {

--- a/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
@@ -67,6 +67,7 @@ interface ResetPasswordViewModel {
                     }
                     .compose(bindToLifecycle())
                     .subscribe(this.prefillEmail)
+
             this.email
                     .map { it.isEmail() }
                     .compose(bindToLifecycle())

--- a/app/src/test/java/com/kickstarter/viewmodels/ResetPasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ResetPasswordViewModelTest.kt
@@ -1,14 +1,17 @@
 package com.kickstarter.viewmodels
 
+import android.content.Intent
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.mock.factories.ApiExceptionFactory
 import com.kickstarter.mock.services.MockApiClient
 import com.kickstarter.models.User
+import com.kickstarter.ui.IntentKey
 import org.junit.Test
 import rx.Observable
 import rx.observers.TestSubscriber
 
 class ResetPasswordViewModelTest : KSRobolectricTestCase() {
+    private val preFillEmail = TestSubscriber<String>()
 
     @Test
     fun testResetPasswordViewModel_formValidation() {
@@ -77,5 +80,15 @@ class ResetPasswordViewModelTest : KSRobolectricTestCase() {
 
         koalaTest.assertValues("Forgot Password View", "Forgot Password Errored")
         this.lakeTest.assertValue("Forgot Password Page Viewed")
+    }
+
+    @Test
+    fun testPrefillEmail() {
+        val vm = ResetPasswordViewModel.ViewModel(environment())
+        vm.outputs.prefillEmail().subscribe(this.preFillEmail)
+        // Start the view model with an email to prefill.
+        vm.intent(Intent().putExtra(IntentKey.EMAIL, "hello@kickstarter.com"))
+
+        this.preFillEmail.assertValue("hello@kickstarter.com")
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ResetPasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ResetPasswordViewModelTest.kt
@@ -11,7 +11,7 @@ import rx.Observable
 import rx.observers.TestSubscriber
 
 class ResetPasswordViewModelTest : KSRobolectricTestCase() {
-    private val preFillEmail = TestSubscriber<String>()
+
 
     @Test
     fun testResetPasswordViewModel_formValidation() {
@@ -84,11 +84,14 @@ class ResetPasswordViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testPrefillEmail() {
+        val preFillEmail = TestSubscriber<String>()
         val vm = ResetPasswordViewModel.ViewModel(environment())
-        vm.outputs.prefillEmail().subscribe(this.preFillEmail)
+        vm.outputs.prefillEmail().subscribe(preFillEmail)
+
         // Start the view model with an email to prefill.
         vm.intent(Intent().putExtra(IntentKey.EMAIL, "hello@kickstarter.com"))
 
-        this.preFillEmail.assertValue("hello@kickstarter.com")
+        preFillEmail.assertValue("hello@kickstarter.com")
+
     }
 }


### PR DESCRIPTION
# 📲 What

fill email field in reset password screen with the email from the login screen  

# 🤔 Why

If the user enters an email address on the login screen and they navigate to the forgot password screen

# 🛠 How

- Pass email from Login Activity through Intent to Reset Password Activity
 

# 👀 See
![device-2021-01-13-184426](https://user-images.githubusercontent.com/1075310/104494797-9a510100-55df-11eb-8b23-c8e899eac395.gif)

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

Instructions for anyone to be able to QA this work.

# Story 📖

NT-1580/Android Forgot Password Email
