### PR TITLE
NT-1751: Small Refactor

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
@@ -29,7 +29,7 @@ class LakeTrackingClient(
     override fun type() =  Type.LAKE
 
     @Throws(JSONException::class)
-    override fun trackingData(eventName: String, newProperties: Map<String, Any?>): String {
+    override fun trackingData(eventName: String, newProperties: Map<String, Any?>) {
         val data = JSONObject()
         data.put("event", eventName)
 
@@ -45,7 +45,6 @@ class LakeTrackingClient(
         record.put("data", data)
 
         callLakeServiceWithEvent(eventName, record.toString())
-        return record.toString()
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
@@ -1,11 +1,16 @@
 package com.kickstarter.libs
 
 import android.content.Context
+import androidx.work.*
 import com.kickstarter.libs.qualifiers.ApplicationContext
 import com.kickstarter.libs.utils.MapUtils
+import com.kickstarter.libs.utils.WorkUtils
 import com.kickstarter.models.User
+import com.kickstarter.services.LakeWorker
+import com.kickstarter.ui.IntentKey
 import org.json.JSONException
 import org.json.JSONObject
+import java.util.concurrent.TimeUnit
 
 class LakeTrackingClient(
         @param:ApplicationContext private val context: Context,
@@ -17,14 +22,11 @@ class LakeTrackingClient(
     private var config: Config? = null
 
     init {
-
         // Cache the most recent config for default Lake properties.
         this.currentConfig.observable().subscribe { c -> this.config = c }
     }
 
-    override fun type(): Type {
-        return Type.LAKE
-    }
+    override fun type() =  Type.LAKE
 
     @Throws(JSONException::class)
     override fun trackingData(eventName: String, newProperties: Map<String, Any?>): String {
@@ -41,7 +43,32 @@ class LakeTrackingClient(
         val record = JSONObject()
         record.put("partition-key", this.loggedInUser?.id()?.toString() ?: deviceDistinctId())
         record.put("data", data)
+
+        callLakeServiceWithEvent(eventName, record.toString())
         return record.toString()
+    }
+
+    /**
+     * Specific for DataLake we send the the event data to a concrete endpoint
+     * using the LakeWorker.
+     */
+    private fun callLakeServiceWithEvent(eventName: String, data: String) {
+
+        val data = workDataOf(IntentKey.TRACKING_CLIENT_TYPE_TAG to type().tag,
+                IntentKey.EVENT_NAME to eventName,
+                IntentKey.EVENT_DATA to data)
+
+        val requestBuilder =  OneTimeWorkRequestBuilder<LakeWorker>()
+        requestBuilder.apply {
+            val request = this
+                    .setInputData(data)
+                    .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 10, TimeUnit.SECONDS)
+                    .setConstraints(WorkUtils.baseConstraints)
+                    .build()
+
+            WorkManager.getInstance(context)
+                    .enqueueUniqueWork(WorkUtils.uniqueWorkName(type().tag), ExistingWorkPolicy.APPEND, request)
+        }
     }
 
 }

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -18,11 +18,10 @@ class SegmentTrackingClient(
      * Perform the request to the Segment third party library
      * see https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#track
      */
-    override fun trackingData(eventName: String, newProperties: Map<String, Any?>): String {
+    override fun trackingData(eventName: String, newProperties: Map<String, Any?>) {
         segmentAnalytics?.let { segment ->
             segment.track(eventName, this.getProperties(newProperties))
         }
-        return ""
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -14,7 +14,6 @@ class SegmentTrackingClient(
         optimizely: ExperimentsClientType,
         private val segmentAnalytics: Analytics?) : TrackingClient(context, currentUser, build, currentConfig, optimizely) {
 
-
     /**
      * Perform the request to the Segment third party library
      * see https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#track
@@ -50,6 +49,11 @@ class SegmentTrackingClient(
         }
     }
 
+    /**
+     * In order to send custom properties to segment for the Identify method we need to use
+     * the method Traits() from the Segment SDK
+     * see https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#identify
+     */
     private fun getTraits(user: User) = Traits().apply {
         this.putName(user.name())
         this.putAvatar(user.avatar().toString())

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -84,9 +84,9 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
      * Send data to the Tracking clients.
      * implementation differs between Lake and Segment
      * Segment will call a third party dependency, while Lake will send the event to a concrete
-     * endpoint
+     * endpoint.
      */
-    abstract fun trackingData(eventName: String, newProperties: Map<String, Any?>): String
+    abstract fun trackingData(eventName: String, newProperties: Map<String, Any?>)
 
     //Default property values
     override fun brand(): String = android.os.Build.BRAND

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -35,16 +35,14 @@ abstract class TrackingClientType {
     protected abstract fun versionName(): String
     protected abstract fun wifiConnection(): Boolean
 
-    // TODO: Will add method Screen those two are specifics to Segment, the implementation on Lake will be empty
     abstract fun track(eventName: String, additionalProperties: Map<String, Any>)
-    // - Specific to segment
     abstract fun identify(u: User)
 
     fun track(eventName: String) {
         track(eventName, HashMap())
     }
 
-    private fun lakeProperties(): Map<String, Any> {
+    private fun genericProperties(): Map<String, Any> {
         val hashMap = hashMapOf<String, Any>()
         loggedInUser()?.let {
             hashMap.putAll(KoalaUtils.userProperties(it))
@@ -88,43 +86,12 @@ abstract class TrackingClientType {
         return MapUtils.prefixKeys(properties, "session_")
     }
 
-    private fun koalaProperties(): Map<String, Any> {
-        val properties = hashMapOf<String, Any>()
-
-        loggedInUser()?.let {
-            properties.putAll(KoalaUtils.userProperties(it))
-            properties["user_logged_in"] = true
-        }
-
-        properties.apply {
-            this["app_version"] = versionName()
-            this["brand"] = brand()
-            this["client_platform"] = "android"
-            this["client_type"] = "native"
-            this["device_fingerprint"] = deviceDistinctId()
-            this["device_format"] = deviceFormat()
-            this["device_orientation"] = deviceOrientation()
-            this["distinct_id"] = deviceDistinctId()
-            this["enabled_feature_flags"] = enabledFeatureFlags()
-            this["google_play_services"] = if (isGooglePlayServicesAvailable) "available" else "unavailable"
-            this["is_vo_on"] = isTalkBackOn
-            this["koala_lib"] = "kickstarter_android"
-            this["manufacturer"] = manufacturer()
-            this["model"] = model()
-            this["mp_lib"] = "android"
-            this["os"] = "Android"
-            this["os_version"] = OSVersion()
-            this["time"] = time()
-        }
-
-        return properties
-    }
-
+    /**
+     * We use the same properties for Segment and DataLake
+     */
     fun combinedProperties(additionalProperties: Map<String, Any>): Map<String, Any> {
-        val combinedProperties = HashMap(additionalProperties)
-        if (type() == Type.LAKE || type() == Type.SEGMENT) {
-            combinedProperties.putAll(lakeProperties())
+        return HashMap(additionalProperties).apply {
+            putAll(genericProperties())
         }
-        return combinedProperties
     }
 }


### PR DESCRIPTION
# 📲 What

- Moved some specific Lake code from the `TrackingClient` class to the `LakeTrackingClient`, on `TrackingClient` we should have generic implementations valid for the two tracking clients(Lake and Segment);
- Added `.disctingUntilChanged` operator when listening to the current user in order to avoid duplicated calls to `Identify`
- Removed koalaProperties specifics to Koala client that was already removed

# 📋 QA
- All test Ok
- Checkout this branch and launch the app, see that the worker for Lake keep working as before, you can check the logcat successfully tracked line
<img width="1040" alt="Screen Shot 2021-02-02 at 11 51 48 AM" src="https://user-images.githubusercontent.com/4083656/106654508-0e325980-654d-11eb-96ff-f6b0a09a7748.png">


# Story 📖

[NT-1751](https://kickstarter.atlassian.net/browse/NT-1751)
