### PR TITLE
NT-1751: Reset method from Segment called on LogOut

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -189,7 +189,6 @@ public class ApplicationModule {
     if (context instanceof KSApplication && !((KSApplication) context).isInUnitTests()) {
       segmentClient = new Analytics.Builder(context, apiKey)
               .trackApplicationLifecycleEvents()
-              .recordScreenViews()
               .build();
 
       Analytics.setSingletonInstance(segmentClient);

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -708,6 +708,10 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         client.track(CREATOR_DETAILS_CLICKED, experimentProperties(projectData))
     }
 
+    fun reset() {
+        client.reset()
+    }
+
     //endregion
     private fun experimentProperties(projectData: ProjectData): Map<String, Any> {
         val props = KoalaUtils.projectProperties(projectData.project(), client.loggedInUser())
@@ -734,6 +738,8 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
                 client?.track(eventName, additionalProperties)
             }
         }
+
+        fun reset() = clients.forEach { it?.reset() }
 
         fun loggedInUser(): User? = clients.firstOrNull()?.loggedInUser()
 

--- a/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
@@ -29,7 +29,7 @@ class LakeTrackingClient(
     override fun type() =  Type.LAKE
 
     @Throws(JSONException::class)
-    override fun trackingData(eventName: String, newProperties: Map<String, Any?>): String {
+    override fun trackingData(eventName: String, newProperties: Map<String, Any?>) {
         val data = JSONObject()
         data.put("event", eventName)
 
@@ -45,7 +45,6 @@ class LakeTrackingClient(
         record.put("data", data)
 
         callLakeServiceWithEvent(eventName, record.toString())
-        return record.toString()
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
@@ -1,11 +1,16 @@
 package com.kickstarter.libs
 
 import android.content.Context
+import androidx.work.*
 import com.kickstarter.libs.qualifiers.ApplicationContext
 import com.kickstarter.libs.utils.MapUtils
+import com.kickstarter.libs.utils.WorkUtils
 import com.kickstarter.models.User
+import com.kickstarter.services.LakeWorker
+import com.kickstarter.ui.IntentKey
 import org.json.JSONException
 import org.json.JSONObject
+import java.util.concurrent.TimeUnit
 
 class LakeTrackingClient(
         @param:ApplicationContext private val context: Context,
@@ -17,14 +22,11 @@ class LakeTrackingClient(
     private var config: Config? = null
 
     init {
-
         // Cache the most recent config for default Lake properties.
         this.currentConfig.observable().subscribe { c -> this.config = c }
     }
 
-    override fun type(): Type {
-        return Type.LAKE
-    }
+    override fun type() =  Type.LAKE
 
     @Throws(JSONException::class)
     override fun trackingData(eventName: String, newProperties: Map<String, Any?>): String {
@@ -41,7 +43,32 @@ class LakeTrackingClient(
         val record = JSONObject()
         record.put("partition-key", this.loggedInUser?.id()?.toString() ?: deviceDistinctId())
         record.put("data", data)
+
+        callLakeServiceWithEvent(eventName, record.toString())
         return record.toString()
+    }
+
+    /**
+     * Specific for DataLake we send the the event data to a concrete endpoint
+     * using the LakeWorker.
+     */
+    private fun callLakeServiceWithEvent(eventName: String, data: String) {
+
+        val data = workDataOf(IntentKey.TRACKING_CLIENT_TYPE_TAG to type().tag,
+                IntentKey.EVENT_NAME to eventName,
+                IntentKey.EVENT_DATA to data)
+
+        val requestBuilder =  OneTimeWorkRequestBuilder<LakeWorker>()
+        requestBuilder.apply {
+            val request = this
+                    .setInputData(data)
+                    .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 10, TimeUnit.SECONDS)
+                    .setConstraints(WorkUtils.baseConstraints)
+                    .build()
+
+            WorkManager.getInstance(context)
+                    .enqueueUniqueWork(WorkUtils.uniqueWorkName(type().tag), ExistingWorkPolicy.APPEND, request)
+        }
     }
 
 }

--- a/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
@@ -18,9 +18,6 @@ class LakeTrackingClient(
 
     init {
 
-        // Cache the most recent logged in user for default Lake properties.
-        this.currentUser.observable().subscribe { u -> this.loggedInUser = u }
-
         // Cache the most recent config for default Lake properties.
         this.currentConfig.observable().subscribe { c -> this.config = c }
     }

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -18,11 +18,10 @@ class SegmentTrackingClient(
      * Perform the request to the Segment third party library
      * see https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#track
      */
-    override fun trackingData(eventName: String, newProperties: Map<String, Any?>): String {
+    override fun trackingData(eventName: String, newProperties: Map<String, Any?>) {
         segmentAnalytics?.let { segment ->
             segment.track(eventName, this.getProperties(newProperties))
         }
-        return ""
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -5,6 +5,7 @@ import com.kickstarter.models.User
 import com.segment.analytics.Analytics
 import com.segment.analytics.Properties
 import com.segment.analytics.Traits
+import timber.log.Timber
 
 class SegmentTrackingClient(
         build: Build,
@@ -43,9 +44,27 @@ class SegmentTrackingClient(
      */
     override fun identify(user: User) {
         super.identify(user)
+
+        if (this.build.isDebug && type() == Type.SEGMENT) {
+            user.apply {
+                Timber.d("Queued ${type().tag} Identify userName: ${this.name()} userId: ${ this.id()}")
+            }
+        }
         segmentAnalytics?.let { segment ->
             segment.identify(user.id().toString(), getTraits(user), null)
         }
+    }
+
+    /**
+     * clears the internal stores on Segment SDK for the current user and group
+     * https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#reset
+     */
+    override fun reset() {
+        super.reset()
+        if (this.build.isDebug) {
+            Timber.d("Queued ${type().tag} Reset UserId")
+        }
+        segmentAnalytics?.reset()
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -43,12 +43,10 @@ class SegmentTrackingClient(
      * Perform the request to the Segment third party library
      * see https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#identify
      */
-    override fun identify() {
-        super.identify()
-        this.loggedInUser()?.let { user ->
-            segmentAnalytics?.let { segment ->
-                segment.identify(user.id().toString(), getTraits(user), null)
-            }
+    override fun identify(user: User) {
+        super.identify(user)
+        segmentAnalytics?.let { segment ->
+            segment.identify(user.id().toString(), getTraits(user), null)
         }
     }
 

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -1,8 +1,11 @@
 package com.kickstarter.libs
 
 import android.content.Context
+import com.kickstarter.libs.utils.ObjectUtils
 import com.segment.analytics.Analytics
 import com.segment.analytics.Properties
+import com.segment.analytics.Traits
+import rx.Observable
 
 class SegmentTrackingClient(
         build: Build,
@@ -11,6 +14,22 @@ class SegmentTrackingClient(
         currentUser: CurrentUserType,
         optimizely: ExperimentsClientType,
         private val segmentAnalytics: Analytics?) : TrackingClient(context, currentUser, build, currentConfig, optimizely) {
+
+    init {
+
+        Observable
+                .combineLatest(this.currentUser.isLoggedIn, this.currentUser.observable() ) { isLoggedIn, currentUser ->
+                    if (isLoggedIn) return@combineLatest currentUser
+                    else return@combineLatest null
+                }
+                .filter { ObjectUtils.isNotNull(it) }
+                .map { requireNotNull(it) }
+                .distinctUntilChanged()
+                .subscribe { user ->
+                    val userId = user.id().toString()
+                    this.identify(userId, null)
+                }
+    }
 
     /**
      * Perform the request to the Segment third party library
@@ -35,4 +54,23 @@ class SegmentTrackingClient(
     }
 
     override fun type() = Type.SEGMENT
+
+    /**
+     * Perform the request to the Segment third party library
+     * see https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#identify
+     */
+    override fun identify(userId: String, additionalTraits: Map<String, String>?) {
+        super.identify(userId, additionalTraits)
+
+        val traits = additionalTraits?.let { this.getTraits(it) }
+        segmentAnalytics?.let { segment ->
+            traits?.let { traits ->
+                segment.identify(userId, traits, null)
+            } ?: segment.identify(userId)
+        }
+    }
+
+    private fun getTraits(additionalTraits: Map<String, String>) = Traits().apply {
+        this.putName(additionalTraits["name"])
+    }
 }

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -14,7 +14,6 @@ class SegmentTrackingClient(
         optimizely: ExperimentsClientType,
         private val segmentAnalytics: Analytics?) : TrackingClient(context, currentUser, build, currentConfig, optimizely) {
 
-
     /**
      * Perform the request to the Segment third party library
      * see https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#track
@@ -50,6 +49,11 @@ class SegmentTrackingClient(
         }
     }
 
+    /**
+     * In order to send custom properties to segment for the Identify method we need to use
+     * the method Traits() from the Segment SDK
+     * see https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#identify
+     */
     private fun getTraits(user: User) = Traits().apply {
         this.putName(user.name())
         this.putAvatar(user.avatar().toString())

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -62,7 +62,7 @@ class SegmentTrackingClient(
     override fun reset() {
         super.reset()
         if (this.build.isDebug) {
-            Timber.d("Queued ${type().tag} Reset UserId")
+            Timber.d("Queued ${type().tag} Reset user after logout")
         }
         segmentAnalytics?.reset()
     }

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -1,11 +1,10 @@
 package com.kickstarter.libs
 
 import android.content.Context
-import com.kickstarter.libs.utils.ObjectUtils
+import com.kickstarter.models.User
 import com.segment.analytics.Analytics
 import com.segment.analytics.Properties
 import com.segment.analytics.Traits
-import rx.Observable
 
 class SegmentTrackingClient(
         build: Build,
@@ -15,21 +14,6 @@ class SegmentTrackingClient(
         optimizely: ExperimentsClientType,
         private val segmentAnalytics: Analytics?) : TrackingClient(context, currentUser, build, currentConfig, optimizely) {
 
-    init {
-
-        Observable
-                .combineLatest(this.currentUser.isLoggedIn, this.currentUser.observable() ) { isLoggedIn, currentUser ->
-                    if (isLoggedIn) return@combineLatest currentUser
-                    else return@combineLatest null
-                }
-                .filter { ObjectUtils.isNotNull(it) }
-                .map { requireNotNull(it) }
-                .distinctUntilChanged()
-                .subscribe { user ->
-                    val userId = user.id().toString()
-                    this.identify(userId, null)
-                }
-    }
 
     /**
      * Perform the request to the Segment third party library
@@ -59,18 +43,17 @@ class SegmentTrackingClient(
      * Perform the request to the Segment third party library
      * see https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#identify
      */
-    override fun identify(userId: String, additionalTraits: Map<String, String>?) {
-        super.identify(userId, additionalTraits)
-
-        val traits = additionalTraits?.let { this.getTraits(it) }
-        segmentAnalytics?.let { segment ->
-            traits?.let { traits ->
-                segment.identify(userId, traits, null)
-            } ?: segment.identify(userId)
+    override fun identify() {
+        super.identify()
+        this.loggedInUser()?.let { user ->
+            segmentAnalytics?.let { segment ->
+                segment.identify(user.id().toString(), getTraits(user), null)
+            }
         }
     }
 
-    private fun getTraits(additionalTraits: Map<String, String>) = Traits().apply {
-        this.putName(additionalTraits["name"])
+    private fun getTraits(user: User) = Traits().apply {
+        this.putName(user.name())
+        this.putAvatar(user.avatar().toString())
     }
 }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -41,7 +41,7 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
         // Cache the most recent logged in user for default Lake properties.
         this.currentUser.observable().subscribe { u ->
             this.loggedInUser = u
-            identify()
+            this.loggedInUser?.let { identify(it) }
         }
 
         // Cache the most recent config for default Lake properties.
@@ -68,10 +68,11 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
         }
     }
 
-    override fun identify() {
+    override fun identify(user: User) {
+        this.loggedInUser = user
         if (this.build.isDebug) {
-            loggedInUser?.let {
-                Timber.d("Queued ${type().tag} Identify userName: ${loggedInUser?.name()} userId: ${loggedInUser?.id()}")
+            user.apply {
+                Timber.d("Queued ${type().tag} Identify userName: ${this.name()} userId: ${ this.id()}")
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -59,7 +59,8 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
             val eventData = trackingData(eventName, combinedProperties(additionalProperties))
 
             if (this.build.isDebug) {
-                Timber.d("Queued ${type().tag} $eventName event: $eventData")
+                val dataForLogs = combinedProperties(additionalProperties).toString()
+                Timber.d("Queued ${type().tag} $eventName event: $dataForLogs")
             }
         } catch (e: JSONException) {
             if (this.build.isDebug) {

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -39,7 +39,10 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
     init {
 
         // Cache the most recent logged in user for default Lake properties.
-        this.currentUser.observable().subscribe { u -> this.loggedInUser = u }
+        this.currentUser.observable().subscribe { u ->
+            this.loggedInUser = u
+            identify()
+        }
 
         // Cache the most recent config for default Lake properties.
         this.currentConfig.observable().subscribe { c -> this.config = c }
@@ -65,9 +68,11 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
         }
     }
 
-    override fun identify(userId: String, additionalTraits: Map<String, String>?) {
+    override fun identify() {
         if (this.build.isDebug) {
-            Timber.d("Queued ${type().tag} Identify userId: $userId")
+            loggedInUser?.let {
+                Timber.d("Queued ${type().tag} Identify userName: ${loggedInUser?.name()} userId: ${loggedInUser?.id()}")
+            }
         }
     }
 

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -84,9 +84,9 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
      * Send data to the Tracking clients.
      * implementation differs between Lake and Segment
      * Segment will call a third party dependency, while Lake will send the event to a concrete
-     * endpoint
+     * endpoint.
      */
-    abstract fun trackingData(eventName: String, newProperties: Map<String, Any?>): String
+    abstract fun trackingData(eventName: String, newProperties: Map<String, Any?>)
 
     //Default property values
     override fun brand(): String = android.os.Build.BRAND

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -65,6 +65,12 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
         }
     }
 
+    override fun identify(userId: String, additionalTraits: Map<String, String>?) {
+        if (this.build.isDebug) {
+            Timber.d("Queued ${type().tag} Identify userId: $userId")
+        }
+    }
+
     override fun optimizely(): ExperimentsClientType = this.optimizely
 
     private fun queueEvent(eventName: String, additionalProperties: Map<String, Any>) {

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -69,13 +69,12 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
         }
     }
 
+    override fun reset() {
+        this.loggedInUser = null
+    }
+
     override fun identify(user: User) {
         this.loggedInUser = user
-        if (this.build.isDebug) {
-            user.apply {
-                Timber.d("Queued ${type().tag} Identify userName: ${this.name()} userId: ${ this.id()}")
-            }
-        }
     }
 
     override fun optimizely(): ExperimentsClientType = this.optimizely

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -35,8 +35,11 @@ abstract class TrackingClientType {
     protected abstract fun versionName(): String
     protected abstract fun wifiConnection(): Boolean
 
-    // TODO: Will add methods Screen and Identity those two are specifics to Segment, the implementation on Lake will be empty
+    // TODO: Will add method Screen those two are specifics to Segment, the implementation on Lake will be empty
     abstract fun track(eventName: String, additionalProperties: Map<String, Any>)
+    // - Specific to segment
+    abstract fun identify(userId: String, additionalTraits: Map<String, String>?)
+
     fun track(eventName: String) {
         track(eventName, HashMap())
     }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -35,16 +35,14 @@ abstract class TrackingClientType {
     protected abstract fun versionName(): String
     protected abstract fun wifiConnection(): Boolean
 
-    // TODO: Will add method Screen those two are specifics to Segment, the implementation on Lake will be empty
     abstract fun track(eventName: String, additionalProperties: Map<String, Any>)
-    // - Specific to segment
     abstract fun identify(u: User)
 
     fun track(eventName: String) {
         track(eventName, HashMap())
     }
 
-    private fun lakeProperties(): Map<String, Any> {
+    private fun genericProperties(): Map<String, Any> {
         val hashMap = hashMapOf<String, Any>()
         loggedInUser()?.let {
             hashMap.putAll(KoalaUtils.userProperties(it))
@@ -88,43 +86,12 @@ abstract class TrackingClientType {
         return MapUtils.prefixKeys(properties, "session_")
     }
 
-    private fun koalaProperties(): Map<String, Any> {
-        val properties = hashMapOf<String, Any>()
-
-        loggedInUser()?.let {
-            properties.putAll(KoalaUtils.userProperties(it))
-            properties["user_logged_in"] = true
-        }
-
-        properties.apply {
-            this["app_version"] = versionName()
-            this["brand"] = brand()
-            this["client_platform"] = "android"
-            this["client_type"] = "native"
-            this["device_fingerprint"] = deviceDistinctId()
-            this["device_format"] = deviceFormat()
-            this["device_orientation"] = deviceOrientation()
-            this["distinct_id"] = deviceDistinctId()
-            this["enabled_feature_flags"] = enabledFeatureFlags()
-            this["google_play_services"] = if (isGooglePlayServicesAvailable) "available" else "unavailable"
-            this["is_vo_on"] = isTalkBackOn
-            this["koala_lib"] = "kickstarter_android"
-            this["manufacturer"] = manufacturer()
-            this["model"] = model()
-            this["mp_lib"] = "android"
-            this["os"] = "Android"
-            this["os_version"] = OSVersion()
-            this["time"] = time()
-        }
-
-        return properties
-    }
-
+    /**
+     * We use the same properties for Segment and DataLake
+     */
     fun combinedProperties(additionalProperties: Map<String, Any>): Map<String, Any> {
-        val combinedProperties = HashMap(additionalProperties)
-        if (type() == Type.LAKE || type() == Type.SEGMENT) {
-            combinedProperties.putAll(lakeProperties())
+        return HashMap(additionalProperties).apply {
+            putAll(genericProperties())
         }
-        return combinedProperties
     }
 }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -29,7 +29,7 @@ abstract class TrackingClientType {
     protected abstract fun model(): String
     protected abstract fun OSVersion(): String
     protected abstract fun time(): Long
-    protected abstract fun type(): Type
+    abstract fun type(): Type
     protected abstract fun userAgent(): String?
     protected abstract fun userCountry(user: User): String
     protected abstract fun versionName(): String
@@ -38,7 +38,7 @@ abstract class TrackingClientType {
     // TODO: Will add method Screen those two are specifics to Segment, the implementation on Lake will be empty
     abstract fun track(eventName: String, additionalProperties: Map<String, Any>)
     // - Specific to segment
-    abstract fun identify(userId: String, additionalTraits: Map<String, String>?)
+    abstract fun identify()
 
     fun track(eventName: String) {
         track(eventName, HashMap())

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -37,6 +37,7 @@ abstract class TrackingClientType {
 
     abstract fun track(eventName: String, additionalProperties: Map<String, Any>)
     abstract fun identify(u: User)
+    abstract fun reset()
 
     fun track(eventName: String) {
         track(eventName, HashMap())

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -38,7 +38,7 @@ abstract class TrackingClientType {
     // TODO: Will add method Screen those two are specifics to Segment, the implementation on Lake will be empty
     abstract fun track(eventName: String, additionalProperties: Map<String, Any>)
     // - Specific to segment
-    abstract fun identify()
+    abstract fun identify(u: User)
 
     fun track(eventName: String) {
         track(eventName, HashMap())

--- a/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
@@ -4,6 +4,7 @@ import UpdateUserPasswordMutation
 import androidx.annotation.NonNull
 import com.kickstarter.R
 import com.kickstarter.libs.ActivityViewModel
+import com.kickstarter.libs.AnalyticEvents
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.rx.transformers.Transformers.*
 import com.kickstarter.libs.utils.extensions.MINIMUM_PASSWORD_LENGTH
@@ -43,7 +44,7 @@ interface ChangePasswordViewModel {
         /** Emits when the save button should be enabled. */
         fun saveButtonIsEnabled(): Observable<Boolean>
 
-        /** Emits when the password update was unsuccessful. */
+        /** Emits when the password update was successful. */
         fun success(): Observable<String>
     }
 
@@ -64,6 +65,7 @@ interface ChangePasswordViewModel {
         val outputs: ChangePasswordViewModel.Outputs = this
 
         private val apolloClient: ApolloClientType = this.environment.apolloClient()
+        private val analytics: AnalyticEvents = this.environment.analytics()
 
         init {
 
@@ -97,7 +99,10 @@ interface ChangePasswordViewModel {
             changePasswordNotification
                     .compose(values())
                     .map { it.updateUserAccount()?.user()?.email() }
-                    .subscribe { this.success.onNext(it) }
+                    .subscribe {
+                        this.success.onNext(it)
+                        this.analytics.reset()
+                    }
         }
 
         private fun submit(changePassword: ChangePasswordViewModel.ViewModel.ChangePassword): Observable<UpdateUserPasswordMutation.Data> {

--- a/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
@@ -100,8 +100,8 @@ interface ChangePasswordViewModel {
                     .compose(values())
                     .map { it.updateUserAccount()?.user()?.email() }
                     .subscribe {
-                        this.success.onNext(it)
                         this.analytics.reset()
+                        this.success.onNext(it)
                     }
         }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/CreatePasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CreatePasswordViewModel.kt
@@ -4,6 +4,7 @@ import CreatePasswordMutation
 import androidx.annotation.NonNull
 import com.kickstarter.R
 import com.kickstarter.libs.ActivityViewModel
+import com.kickstarter.libs.AnalyticEvents
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.rx.transformers.Transformers.*
 import com.kickstarter.libs.utils.extensions.MINIMUM_PASSWORD_LENGTH
@@ -41,7 +42,7 @@ interface CreatePasswordViewModel {
         /** Emits when the save button should be enabled. */
         fun saveButtonIsEnabled(): Observable<Boolean>
 
-        /** Emits when the password update was unsuccessful. */
+        /** Emits when the password update was successful. */
         fun success(): Observable<String>
     }
 
@@ -61,6 +62,7 @@ interface CreatePasswordViewModel {
         val outputs: Outputs = this
 
         private val apolloClient: ApolloClientType = this.environment.apolloClient()
+        private val analytics: AnalyticEvents = this.environment.analytics()
 
         init {
 
@@ -92,7 +94,10 @@ interface CreatePasswordViewModel {
             createNewPasswordNotification
                     .compose(values())
                     .map { it.updateUserAccount()?.user()?.email() }
-                    .subscribe { this.success.onNext(it) }
+                    .subscribe {
+                        this.success.onNext(it)
+                        this.analytics.reset()
+                    }
         }
 
         private fun submit(createPassword: CreatePasswordViewModel.ViewModel.CreatePassword): Observable<CreatePasswordMutation.Data> {

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.kt
@@ -2,6 +2,7 @@ package com.kickstarter.viewmodels
 
 import androidx.annotation.NonNull
 import com.kickstarter.libs.ActivityViewModel
+import com.kickstarter.libs.AnalyticEvents
 import com.kickstarter.libs.CurrentUserType
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.rx.transformers.Transformers
@@ -55,6 +56,7 @@ interface SettingsViewModel {
         val inputs: Inputs = this
         val outputs: Outputs = this
 
+        private val analytics: AnalyticEvents = this.environment.analytics()
         init {
 
             this.client.fetchCurrentUser()
@@ -70,7 +72,10 @@ interface SettingsViewModel {
 
             this.confirmLogoutClicked
                     .compose(bindToLifecycle())
-                    .subscribe { this.logout.onNext(null) }
+                    .subscribe {
+                        this.logout.onNext(null)
+                        this.analytics.reset()
+                    }
 
             this.avatarImageViewUrl = this.currentUser.loggedInUser().map { u -> u.avatar().medium() }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.kt
@@ -73,8 +73,8 @@ interface SettingsViewModel {
             this.confirmLogoutClicked
                     .compose(bindToLifecycle())
                     .subscribe {
-                        this.logout.onNext(null)
                         this.analytics.reset()
+                        this.logout.onNext(null)
                     }
 
             this.avatarImageViewUrl = this.currentUser.loggedInUser().map { u -> u.avatar().medium() }

--- a/app/src/test/java/com/kickstarter/KSRobolectrictTestCase.kt
+++ b/app/src/test/java/com/kickstarter/KSRobolectrictTestCase.kt
@@ -34,6 +34,7 @@ abstract class KSRobolectricTestCase : TestCase() {
     lateinit var experimentsTest: TestSubscriber<String>
     lateinit var lakeTest: TestSubscriber<String>
     lateinit var segmentTrack: TestSubscriber<String>
+    lateinit var segmentIdentify: TestSubscriber<Long>
 
     @Before
     @Throws(Exception::class)
@@ -92,9 +93,11 @@ abstract class KSRobolectricTestCase : TestCase() {
 
     private fun segmentTrackingClient(mockCurrentConfig: MockCurrentConfig, experimentsClientType: MockExperimentsClientType): MockTrackingClient {
         segmentTrack = TestSubscriber()
+        segmentIdentify = TestSubscriber()
         val segmentTrackingClient = MockTrackingClient(MockCurrentUser(),
                 mockCurrentConfig, TrackingClientType.Type.SEGMENT, experimentsClientType)
         segmentTrackingClient.eventNames.subscribe(segmentTrack)
+        segmentTrackingClient.identifiedId.subscribe(segmentIdentify)
         return segmentTrackingClient
     }
 }

--- a/app/src/test/java/com/kickstarter/KSRobolectrictTestCase.kt
+++ b/app/src/test/java/com/kickstarter/KSRobolectrictTestCase.kt
@@ -33,7 +33,7 @@ abstract class KSRobolectricTestCase : TestCase() {
 
     lateinit var experimentsTest: TestSubscriber<String>
     lateinit var lakeTest: TestSubscriber<String>
-    lateinit var segmentTest: TestSubscriber<String>
+    lateinit var segmentTrack: TestSubscriber<String>
 
     @Before
     @Throws(Exception::class)
@@ -91,10 +91,10 @@ abstract class KSRobolectricTestCase : TestCase() {
     }
 
     private fun segmentTrackingClient(mockCurrentConfig: MockCurrentConfig, experimentsClientType: MockExperimentsClientType): MockTrackingClient {
-        segmentTest = TestSubscriber()
+        segmentTrack = TestSubscriber()
         val segmentTrackingClient = MockTrackingClient(MockCurrentUser(),
                 mockCurrentConfig, TrackingClientType.Type.SEGMENT, experimentsClientType)
-        segmentTrackingClient.eventNames.subscribe(segmentTest)
+        segmentTrackingClient.eventNames.subscribe(segmentTrack)
         return segmentTrackingClient
     }
 }

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -44,6 +44,12 @@ public final class MockTrackingClient extends TrackingClientType {
     this.identifiedId.onNext(user.id());
   }
 
+  @Override
+  public void reset() {
+    this.loggedInUser = null;
+    this.identifiedId.onNext(null);
+  }
+
   public static class Event {
     private final String name;
     private final Map<String, Object> properties;

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import rx.Observable;
+import rx.functions.Action1;
+import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 
 public final class MockTrackingClient extends TrackingClientType {
@@ -27,8 +29,18 @@ public final class MockTrackingClient extends TrackingClientType {
   public MockTrackingClient(final @NonNull CurrentUserType currentUser, final @NonNull CurrentConfigType currentConfig, final Type type, final @NonNull ExperimentsClientType optimizely) {
     this.type = type;
     this.optimizely = optimizely;
-    currentUser.observable().subscribe(u -> this.loggedInUser = u);
+    currentUser.observable().subscribe(this::propagateUser);
     currentConfig.observable().subscribe(c -> this.config = c);
+  }
+
+  private void propagateUser(User user) {
+    if (user != null) identify(user);
+    this.loggedInUser = user;
+  }
+
+  @Override
+  public void identify(@NotNull User user) {
+    this.identifiedId.onNext(user.id());
   }
 
   public static class Event {
@@ -43,6 +55,7 @@ public final class MockTrackingClient extends TrackingClientType {
   private final @NonNull PublishSubject<Event> events = PublishSubject.create();
   public final @NonNull Observable<String> eventNames = this.events.map(e -> e.name);
   public final @NonNull Observable<Map<String, Object>> eventProperties = this.events.map(e -> e.properties);
+  public final @NonNull BehaviorSubject<Long> identifiedId = BehaviorSubject.create();
 
   @Override
   public void track(final @NotNull String eventName, final @NotNull Map<String, ?> additionalProperties) {
@@ -55,7 +68,8 @@ public final class MockTrackingClient extends TrackingClientType {
   }
 
   @Override
-  protected @NonNull Type type() {
+  @NonNull
+  public Type type() {
     return this.type;
   }
 

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import rx.Observable;
-import rx.functions.Action1;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 
@@ -33,13 +32,15 @@ public final class MockTrackingClient extends TrackingClientType {
     currentConfig.observable().subscribe(c -> this.config = c);
   }
 
-  private void propagateUser(User user) {
-    if (user != null) identify(user);
+  private void propagateUser(final @Nullable User user) {
+    if (user != null) {
+      identify(user);
+    }
     this.loggedInUser = user;
   }
 
   @Override
-  public void identify(@NotNull User user) {
+  public void identify(final @NotNull User user) {
     this.identifiedId.onNext(user.id());
   }
 

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -1,0 +1,622 @@
+package com.kickstarter.libs
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.models.OptimizelyEnvironment
+import com.kickstarter.mock.MockCurrentConfig
+import com.kickstarter.mock.MockExperimentsClientType
+import com.kickstarter.mock.factories.*
+import com.kickstarter.models.Project
+import com.kickstarter.models.User
+import com.kickstarter.services.DiscoveryParams
+import com.kickstarter.ui.data.PledgeData
+import com.kickstarter.ui.data.PledgeFlowContext
+import org.joda.time.DateTime
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+import rx.subjects.BehaviorSubject
+
+class SegmentTest : KSRobolectricTestCase() {
+
+    private val propertiesTest = BehaviorSubject.create<Map<String, Any>>()
+
+    @Test
+    fun testDefaultProperties() {
+        val client = client(null)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackAppOpen()
+
+        this.segmentTrack.assertValue("App Open")
+
+        assertSessionProperties(null)
+        assertContextProperties()
+    }
+
+    @Test
+    fun testDefaultProperties_LoggedInUser() {
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        client.identifiedId.subscribe(this.segmentIdentify)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackAppOpen()
+
+        this.segmentTrack.assertValue("App Open")
+        this.segmentIdentify.assertValue(user.id())
+
+        assertSessionProperties(user)
+        assertContextProperties()
+
+        val expectedProperties = propertiesTest.value
+        assertEquals(15L, expectedProperties["user_uid"])
+        assertEquals("NG", expectedProperties["user_country"])
+    }
+
+    @Test
+    fun testDiscoveryProperties_AllProjects() {
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        client.identifiedId.subscribe(this.segmentIdentify)
+        val segment = AnalyticEvents(listOf(client))
+
+        val params = DiscoveryParams
+                .builder()
+                .sort(DiscoveryParams.Sort.MAGIC)
+                .build()
+
+        segment.trackExplorePageViewed(params)
+        this.segmentIdentify.assertValue(user.id())
+
+        assertSessionProperties(user)
+        assertContextProperties()
+
+        val expectedProperties = propertiesTest.value
+        assertNull(expectedProperties["discover_category_id"])
+        assertNull(expectedProperties["discover_category_name"])
+        assertEquals(true, expectedProperties["discover_everything"])
+        assertEquals(false, expectedProperties["discover_pwl"])
+        assertEquals(false, expectedProperties["discover_recommended"])
+        assertEquals("discovery", expectedProperties["discover_ref_tag"])
+        assertEquals(null, expectedProperties["discover_search_term"])
+        assertEquals(false, expectedProperties["discover_social"])
+        assertEquals("magic", expectedProperties["discover_sort"])
+        assertNull(expectedProperties["discover_subcategory_id"])
+        assertNull(expectedProperties["discover_subcategory_name"])
+        assertEquals(null, expectedProperties["discover_tag"])
+        assertEquals(false, expectedProperties["discover_watched"])
+    }
+
+    @Test
+    fun testDiscoveryProperties_NoCategory() {
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        client.identifiedId.subscribe(this.segmentIdentify)
+        val segment = AnalyticEvents(listOf(client))
+
+        val params = DiscoveryParams
+                .builder()
+                .sort(DiscoveryParams.Sort.POPULAR)
+                .staffPicks(true)
+                .build()
+
+        segment.trackExplorePageViewed(params)
+
+        assertSessionProperties(user)
+        assertContextProperties()
+
+        val expectedProperties = propertiesTest.value
+        assertNull(expectedProperties["discover_category_id"])
+        assertNull(expectedProperties["discover_category_name"])
+        assertEquals(false, expectedProperties["discover_everything"])
+        assertEquals(true, expectedProperties["discover_pwl"])
+        assertEquals(false, expectedProperties["discover_recommended"])
+        assertEquals("recommended_popular", expectedProperties["discover_ref_tag"])
+        assertEquals(null, expectedProperties["discover_search_term"])
+        assertEquals(false, expectedProperties["discover_social"])
+        assertEquals("popularity", expectedProperties["discover_sort"])
+        assertNull(expectedProperties["discover_subcategory_id"])
+        assertNull(expectedProperties["discover_subcategory_name"])
+        assertEquals(null, expectedProperties["discover_tag"])
+        assertEquals(false, expectedProperties["discover_watched"])
+
+        this.segmentIdentify.assertValue(user.id())
+    }
+
+    @Test
+    fun testDiscoveryProperties_Category() {
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        client.identifiedId.subscribe(this.segmentIdentify)
+        val segment = AnalyticEvents(listOf(client))
+
+        val params = DiscoveryParams
+                .builder()
+                .category(CategoryFactory.ceramicsCategory())
+                .sort(DiscoveryParams.Sort.NEWEST)
+                .build()
+
+        segment.trackExplorePageViewed(params)
+
+        assertSessionProperties(user)
+        assertContextProperties()
+
+        val expectedProperties = propertiesTest.value
+        assertEquals(1L, expectedProperties["discover_category_id"])
+        assertEquals("Art", expectedProperties["discover_category_name"])
+        assertEquals(false, expectedProperties["discover_everything"])
+        assertEquals(false, expectedProperties["discover_pwl"])
+        assertEquals(false, expectedProperties["discover_recommended"])
+        assertEquals("category_newest", expectedProperties["discover_ref_tag"])
+        assertEquals(null, expectedProperties["discover_search_term"])
+        assertEquals(false, expectedProperties["discover_social"])
+        assertEquals("newest", expectedProperties["discover_sort"])
+        assertEquals(287L, expectedProperties["discover_subcategory_id"])
+        assertEquals("Ceramics", expectedProperties["discover_subcategory_name"])
+        assertEquals(null, expectedProperties["discover_tag"])
+        assertEquals(false, expectedProperties["discover_watched"])
+
+        this.segmentIdentify.assertValue(user.id())
+    }
+
+    @Test
+    fun testProjectProperties_loggedOutUser() {
+        val project = project()
+
+        val client = client(null)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackProjectPageViewed(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()), PledgeFlowContext.NEW_PLEDGE)
+
+        assertSessionProperties(null)
+        assertContextProperties()
+        assertProjectProperties(project)
+
+        val expectedProperties = propertiesTest.value
+        assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
+        assertEquals(false, expectedProperties["project_user_has_watched"])
+        assertEquals(false, expectedProperties["project_user_is_backer"])
+        assertEquals(false, expectedProperties["project_user_is_project_creator"])
+
+        this.segmentTrack.assertValues("Project Page Viewed")
+
+        this.segmentIdentify.assertNoValues()
+    }
+
+    @Test
+    fun testProjectProperties_LoggedInUser() {
+        val project = project()
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        client.identifiedId.subscribe(this.segmentIdentify)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackProjectPageViewed(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()), PledgeFlowContext.NEW_PLEDGE)
+
+        assertSessionProperties(user)
+        assertProjectProperties(project)
+        assertContextProperties()
+
+        val expectedProperties = propertiesTest.value
+        assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
+        assertEquals(false, expectedProperties["project_user_has_watched"])
+        assertEquals(false, expectedProperties["project_user_is_backer"])
+        assertEquals(false, expectedProperties["project_user_is_project_creator"])
+
+        this.segmentTrack.assertValues("Project Page Viewed")
+        this.segmentIdentify.assertValue(user.id())
+    }
+
+    @Test
+    fun testProjectProperties_LoggedInUser_IsBacker() {
+        val project = ProjectFactory.backedProject()
+                .toBuilder()
+                .id(4)
+                .category(CategoryFactory.ceramicsCategory())
+                .commentsCount(3)
+                .creator(creator())
+                .location(LocationFactory.unitedStates())
+                .updatesCount(5)
+                .build()
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackProjectPageViewed(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()), null)
+
+        assertSessionProperties(user)
+        assertProjectProperties(project)
+        assertContextProperties()
+
+        val expectedProperties = propertiesTest.value
+        assertNull(expectedProperties["context_pledge_flow"])
+        assertEquals(false, expectedProperties["project_user_has_watched"])
+        assertEquals(true, expectedProperties["project_user_is_backer"])
+        assertEquals(false, expectedProperties["project_user_is_project_creator"])
+
+        this.segmentTrack.assertValues("Project Page Viewed")
+    }
+
+    @Test
+    fun testProjectProperties_LoggedInUser_IsProjectCreator() {
+        val project = project().toBuilder().build()
+        val creator = creator()
+        val client = client(creator)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackProjectPageViewed(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()), null)
+
+        assertSessionProperties(creator)
+        assertProjectProperties(project)
+        assertContextProperties()
+
+        val expectedProperties = this.propertiesTest.value
+        assertNull(expectedProperties["context_pledge_flow"])
+        assertEquals(false, expectedProperties["project_user_has_watched"])
+        assertEquals(false, expectedProperties["project_user_is_backer"])
+        assertEquals(true, expectedProperties["project_user_is_project_creator"])
+
+        this.segmentTrack.assertValues("Project Page Viewed")
+    }
+
+    @Test
+    fun testProjectProperties_LoggedInUser_HasStarred() {
+        val project = project().toBuilder().isStarred(true).build()
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackProjectPageViewed(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()), PledgeFlowContext.NEW_PLEDGE)
+
+        assertSessionProperties(user)
+        assertProjectProperties(project)
+        assertContextProperties()
+
+        val expectedProperties = this.propertiesTest.value
+        assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
+        assertEquals(true, expectedProperties["project_user_has_watched"])
+        assertEquals(false, expectedProperties["project_user_is_backer"])
+        assertEquals(false, expectedProperties["project_user_is_project_creator"])
+
+        this.segmentTrack.assertValues("Project Page Viewed")
+    }
+
+    @Test
+    fun testProjectProperties_LoggedInUser_NotBacked() {
+        val project = project()
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        val projectData = ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended())
+        segment.trackProjectPagePledgeButtonClicked(projectData, PledgeFlowContext.NEW_PLEDGE)
+
+        assertSessionProperties(user)
+        assertProjectProperties(project)
+        assertContextProperties()
+
+        val expectedProperties = propertiesTest.value
+        assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
+        assertEquals(false, expectedProperties["project_user_has_watched"])
+        assertEquals(false, expectedProperties["project_user_is_backer"])
+        assertEquals(false, expectedProperties["project_user_is_project_creator"])
+
+        this.segmentTrack.assertValues("Project Page Pledge Button Clicked")
+    }
+
+    @Test
+    fun testPledgeProperties() {
+        val project = project()
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        val projectData = ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended())
+
+        segment.trackSelectRewardButtonClicked(PledgeData.with(PledgeFlowContext.NEW_PLEDGE, projectData, reward()))
+
+        assertSessionProperties(user)
+        assertProjectProperties(project)
+        assertContextProperties()
+        assertPledgeProperties()
+
+        val expectedProperties = propertiesTest.value
+        assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
+        assertEquals(false, expectedProperties["project_user_has_watched"])
+        assertEquals(false, expectedProperties["project_user_is_backer"])
+        assertEquals(false, expectedProperties["project_user_is_project_creator"])
+
+        this.segmentTrack.assertValues("Select Reward Button Clicked")
+    }
+
+    @Test
+    fun testCheckoutProperties_whenNewPledge() {
+        val project = project()
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        val projectData = ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended())
+
+        segment.trackPledgeSubmitButtonClicked(CheckoutDataFactory.checkoutData(20.0, 30.0),
+                PledgeData.with(PledgeFlowContext.NEW_PLEDGE, projectData, reward()))
+
+        assertSessionProperties(user)
+        assertProjectProperties(project)
+        assertContextProperties()
+        assertPledgeProperties()
+        assertCheckoutProperties()
+
+        val expectedProperties = this.propertiesTest.value
+        assertNull(expectedProperties["checkout_id"])
+        assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
+        assertEquals(false, expectedProperties["project_user_has_watched"])
+        assertEquals(false, expectedProperties["project_user_is_backer"])
+        assertEquals(false, expectedProperties["project_user_is_project_creator"])
+
+        this.segmentTrack.assertValues("Pledge Submit Button Clicked")
+    }
+
+    @Test
+    fun testCheckoutProperties_whenFixingPledge() {
+        val project = ProjectFactory.backedProject()
+                .toBuilder()
+                .id(4)
+                .category(CategoryFactory.ceramicsCategory())
+                .commentsCount(3)
+                .creator(creator())
+                .location(LocationFactory.unitedStates())
+                .updatesCount(5)
+                .build()
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        val projectData = ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended())
+
+        segment.trackPledgeSubmitButtonClicked(CheckoutDataFactory.checkoutData(20.0, 30.0),
+                PledgeData.with(PledgeFlowContext.FIX_ERRORED_PLEDGE, projectData, reward()))
+
+        assertSessionProperties(user)
+        assertProjectProperties(project)
+        assertContextProperties()
+        assertPledgeProperties()
+        assertCheckoutProperties()
+
+        val expectedProperties = this.propertiesTest.value
+        assertNull(expectedProperties["checkout_id"])
+        assertEquals("fix_errored_pledge", expectedProperties["context_pledge_flow"])
+        assertEquals(false, expectedProperties["project_user_has_watched"])
+        assertEquals(true, expectedProperties["project_user_is_backer"])
+        assertEquals(false, expectedProperties["project_user_is_project_creator"])
+
+        this.segmentTrack.assertValues("Pledge Submit Button Clicked")
+    }
+
+    @Test
+    fun testSuccessfulCheckoutProperties() {
+        val project = project()
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        val projectData = ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended())
+
+        segment.trackThanksPageViewed(CheckoutDataFactory.checkoutData(3L, 20.0, 30.0),
+                PledgeData.with(PledgeFlowContext.NEW_PLEDGE, projectData, reward()))
+
+        assertSessionProperties(user)
+        assertProjectProperties(project)
+        assertContextProperties()
+        assertPledgeProperties()
+        assertCheckoutProperties()
+
+        val expectedProperties = this.propertiesTest.value
+        assertEquals(3L, expectedProperties["checkout_id"])
+        assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
+        assertEquals(false, expectedProperties["project_user_has_watched"])
+        assertEquals(false, expectedProperties["project_user_is_backer"])
+        assertEquals(false, expectedProperties["project_user_is_project_creator"])
+
+        this.segmentTrack.assertValues("Thanks Page Viewed")
+    }
+
+    @Test
+    fun testOptimizelyProperties() {
+        val project = project()
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackProjectPagePledgeButtonClicked(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()), PledgeFlowContext.NEW_PLEDGE)
+
+        assertSessionProperties(user)
+        assertProjectProperties(project)
+        assertContextProperties()
+        assertOptimizelyProperties()
+
+        val expectedProperties = propertiesTest.value
+        assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
+        assertEquals(false, expectedProperties["project_user_has_watched"])
+        assertEquals(false, expectedProperties["project_user_is_backer"])
+        assertEquals(false, expectedProperties["project_user_is_project_creator"])
+
+        this.segmentTrack.assertValues("Project Page Pledge Button Clicked")
+    }
+
+    private fun client(user: User?) = MockTrackingClient(user?.let { MockCurrentUser(it) }
+            ?: MockCurrentUser(),
+            mockCurrentConfig(),
+            TrackingClientType.Type.SEGMENT,
+            object : MockExperimentsClientType() {
+                override fun enabledFeatures(user: User?): List<String> {
+                    return listOf("optimizely_feature")
+                }
+            })
+
+    private fun assertCheckoutProperties() {
+        val expectedProperties = this.propertiesTest.value
+        assertEquals(30.0, expectedProperties["checkout_amount"])
+        assertEquals("CREDIT_CARD", expectedProperties["checkout_payment_type"])
+        assertEquals(3000L, expectedProperties["checkout_revenue_in_usd_cents"])
+        assertEquals(20.0, expectedProperties["checkout_shipping_amount"])
+    }
+
+    private fun assertContextProperties() {
+        val expectedProperties = this.propertiesTest.value
+        assertEquals(DateTime.parse("2018-11-02T18:42:05Z").millis / 1000, expectedProperties["context_timestamp"])
+    }
+
+    private fun assertOptimizelyProperties() {
+        val expectedProperties = this.propertiesTest.value
+        assertEquals(OptimizelyEnvironment.DEVELOPMENT.sdkKey, expectedProperties["optimizely_api_key"])
+        assertEquals(OptimizelyEnvironment.DEVELOPMENT.environmentKey, expectedProperties["optimizely_environment_key"])
+        assertNotNull(expectedProperties["optimizely_experiments"])
+        val experiments = expectedProperties["optimizely_experiments"] as JSONArray
+        val experiment = experiments[0] as JSONObject
+        assertEquals("test_experiment", experiment["optimizely_experiment_slug"])
+        assertEquals("unknown", experiment["optimizely_variant_id"])
+    }
+
+    private fun assertPledgeProperties() {
+        val expectedProperties = this.propertiesTest.value
+        assertEquals(DateTime.parse("2019-03-26T19:26:09Z").millis / 1000, expectedProperties["pledge_backer_reward_estimated_delivery_on"])
+        assertEquals(false, expectedProperties["pledge_backer_reward_has_items"])
+        assertEquals(2L, expectedProperties["pledge_backer_reward_id"])
+        assertEquals(false, expectedProperties["pledge_backer_reward_is_limited_time"])
+        assertEquals(false, expectedProperties["pledge_backer_reward_is_limited_quantity"])
+        assertEquals(10.0, expectedProperties["pledge_backer_reward_minimum"])
+        assertEquals(true, expectedProperties["pledge_backer_reward_shipping_enabled"])
+        assertEquals("unrestricted", expectedProperties["pledge_backer_reward_shipping_preference"])
+        assertEquals("Digital Bundle", expectedProperties["pledge_backer_reward_title"])
+    }
+
+    private fun assertProjectProperties(project: Project) {
+        val expectedProperties = this.propertiesTest.value
+        assertEquals(100, expectedProperties["project_backers_count"])
+        assertEquals("Ceramics", expectedProperties["project_subcategory"])
+        assertEquals("Art", expectedProperties["project_category"])
+        assertEquals(3, expectedProperties["project_comments_count"])
+        assertEquals("US", expectedProperties["project_country"])
+        assertEquals(3L, expectedProperties["project_creator_uid"])
+        assertEquals("USD", expectedProperties["project_currency"])
+        assertEquals(50.0, expectedProperties["project_current_pledge_amount"])
+        assertEquals(50.0, expectedProperties["project_current_pledge_amount_usd"])
+        assertEquals(project.deadline()?.millis?.let { it / 1000 }, expectedProperties["project_deadline"])
+        assertEquals(60 * 60 * 24 * 20, expectedProperties["project_duration"])
+        assertEquals(100.0, expectedProperties["project_goal"])
+        assertEquals(100.0, expectedProperties["project_goal_usd"])
+        assertEquals(true, expectedProperties["project_has_video"])
+        assertEquals(10 * 24, expectedProperties["project_hours_remaining"])
+        assertEquals(true, expectedProperties["project_is_repeat_creator"])
+        assertEquals(project.launchedAt()?.millis?.let { it / 1000 }, expectedProperties["project_launched_at"])
+        assertEquals("Brooklyn", expectedProperties["project_location"])
+        assertEquals("Some Name", expectedProperties["project_name"])
+        assertEquals(.5f, expectedProperties["project_percent_raised"])
+        assertEquals(4L, expectedProperties["project_pid"])
+        assertEquals(50.0, expectedProperties["project_current_pledge_amount"])
+        assertEquals(2, expectedProperties["project_rewards_count"])
+        assertEquals("live", expectedProperties["project_state"])
+        assertEquals(1.0f, expectedProperties["project_static_usd_rate"])
+        assertEquals(5, expectedProperties["project_updates_count"])
+        assertEquals("discovery", expectedProperties["session_ref_tag"])
+        assertEquals("recommended", expectedProperties["session_referrer_credit"])
+    }
+
+    private fun assertSessionProperties(user: User?) {
+        val expectedProperties = this.propertiesTest.value
+        assertEquals(9999, expectedProperties["session_app_build_number"])
+        assertEquals("9.9.9", expectedProperties["session_app_release_version"])
+        assertEquals("android", expectedProperties["session_client_platform"])
+        assertEquals("native", expectedProperties["session_client_type"])
+        assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_current_variants"])
+        assertEquals("uuid", expectedProperties["session_device_distinct_id"])
+        assertEquals("phone", expectedProperties["session_device_format"])
+        assertEquals("Google", expectedProperties["session_device_manufacturer"])
+        assertEquals("Pixel 3", expectedProperties["session_device_model"])
+        assertEquals("Portrait", expectedProperties["session_device_orientation"])
+        assertEquals("en", expectedProperties["session_display_language"])
+        assertEquals(JSONArray().put("optimizely_feature").put("android_example_feature"), expectedProperties["session_enabled_features"])
+        assertEquals(false, expectedProperties["session_is_voiceover_running"])
+        assertEquals("kickstarter_android", expectedProperties["session_mp_lib"])
+        assertEquals("Android", expectedProperties["session_os"])
+        assertEquals("9", expectedProperties["session_os_version"])
+        assertEquals("agent", expectedProperties["session_user_agent"])
+        assertEquals(user != null, expectedProperties["session_user_is_logged_in"])
+        assertEquals(false, expectedProperties["session_wifi_connection"])
+    }
+
+    private fun mockCurrentConfig() = MockCurrentConfig().apply {
+        val config = ConfigFactory.configWithFeatureEnabled("android_example_feature")
+                .toBuilder()
+                .abExperiments(mapOf(Pair("android_example_experiment", "control")))
+                .build()
+        config(config)
+    }
+
+    private fun creator() =
+            UserFactory.creator().toBuilder()
+                    .id(3)
+                    .backedProjectsCount(17)
+                    .starredProjectsCount(2)
+                    .build()
+
+    private fun project() =
+            ProjectFactory.project().toBuilder()
+                    .id(4)
+                    .category(CategoryFactory.ceramicsCategory())
+                    .creator(creator())
+                    .commentsCount(3)
+                    .location(LocationFactory.unitedStates())
+                    .updatesCount(5)
+                    .build()
+
+    private fun reward() =
+            RewardFactory.rewardWithShipping().toBuilder()
+                    .id(2)
+                    .minimum(10.0)
+                    .build()
+
+    private fun user() =
+            UserFactory.user()
+                    .toBuilder()
+                    .id(15)
+                    .backedProjectsCount(3)
+                    .createdProjectsCount(2)
+                    .location(LocationFactory.nigeria())
+                    .starredProjectsCount(10)
+                    .build()
+
+}

--- a/app/src/test/java/com/kickstarter/viewmodels/ChangePasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ChangePasswordViewModelTest.kt
@@ -8,6 +8,7 @@ import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClient
+import com.kickstarter.models.User
 import org.junit.Test
 import rx.Observable
 import rx.observers.TestSubscriber
@@ -20,6 +21,7 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
     private val progressBarIsVisible = TestSubscriber<Boolean>()
     private val saveButtonIsEnabled = TestSubscriber<Boolean>()
     private val success = TestSubscriber<String>()
+    private val userId = TestSubscriber<Long?>()
 
     private fun setUpEnvironment(environment: Environment) {
         this.vm = ChangePasswordViewModel.ViewModel(environment)
@@ -107,13 +109,9 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun userLoggedIn_whenChangePasswordError_userNotReset() {
-        val userId = TestSubscriber<Long>()
-
         // - create MockTracking client with user logged in
         val user = UserFactory.user()
-        val trackingClient = MockTrackingClient(MockCurrentUser(user),
-                MockCurrentConfig() , TrackingClientType.Type.SEGMENT, MockExperimentsClientType())
-        trackingClient.identifiedId.subscribe(userId)
+        val trackingClient = getMockClientWithUser(user)
 
         // - Mock failed response from apollo
         val apolloClient = object : MockApolloClient() {
@@ -141,13 +139,9 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun serLoggedIn_whenChangePasswordSuccess_userReset() {
-        val userId = TestSubscriber<Long?>()
-
         // - create MockTracking client with user logged in
         val user = UserFactory.user()
-        val trackingClient = MockTrackingClient(MockCurrentUser(user),
-                MockCurrentConfig() , TrackingClientType.Type.SEGMENT, MockExperimentsClientType())
-        trackingClient.identifiedId.subscribe(userId)
+        val trackingClient = getMockClientWithUser(user)
 
         // - Mock success response from apollo
         val apolloClient = object : MockApolloClient() {
@@ -173,4 +167,12 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
 
         userId.assertValues(user.id(), null)
     }
+
+    private fun getMockClientWithUser(user: User) = MockTrackingClient(
+            MockCurrentUser(user),
+            MockCurrentConfig(),
+            TrackingClientType.Type.SEGMENT,
+            MockExperimentsClientType()).apply {
+                this.identifiedId.subscribe(userId)
+            }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/CreatePasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CreatePasswordViewModelTest.kt
@@ -3,8 +3,12 @@ package com.kickstarter.viewmodels
 import CreatePasswordMutation
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
-import com.kickstarter.libs.Environment
+import com.kickstarter.libs.*
+import com.kickstarter.mock.MockCurrentConfig
+import com.kickstarter.mock.MockExperimentsClientType
+import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClient
+import com.kickstarter.models.User
 import org.junit.Test
 import rx.Observable
 import rx.observers.TestSubscriber
@@ -18,6 +22,7 @@ class CreatePasswordViewModelTest : KSRobolectricTestCase() {
     private val progressBarIsVisible = TestSubscriber<Boolean>()
     private val saveButtonIsEnabled = TestSubscriber<Boolean>()
     private val success = TestSubscriber<String>()
+    private val userId = TestSubscriber<Long?>()
 
     private fun setUpEnvironment(environment: Environment) {
         this.vm = CreatePasswordViewModel.ViewModel(environment)
@@ -95,5 +100,72 @@ class CreatePasswordViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.confirmPassword("password")
         this.vm.inputs.createPasswordClicked()
         this.success.assertValue("test@emai")
+    }
+
+    @Test
+    fun userLoggedIn_whenCreatePasswordError_userNotReset() {
+        // - create MockTracking client with user logged in
+        val user = UserFactory.user()
+        val trackingClient = getMockClientWithUser(user)
+
+        // - Mock failed response from apollo
+        val apolloClient = object : MockApolloClient() {
+            override fun createPassword(password: String, confirmPassword: String): Observable<CreatePasswordMutation.Data> {
+                return Observable.error(Exception("Oops"))
+            }
+        }
+
+        // - Create environment with mocked objects
+        val environment = environment().toBuilder()
+                .apolloClient(apolloClient)
+                .analytics(AnalyticEvents(listOf(trackingClient)))
+                .build()
+
+        setUpEnvironment(environment)
+
+        this.vm.inputs.newPassword("passwo")
+        this.vm.inputs.confirmPassword("password")
+        this.vm.inputs.createPasswordClicked()
+        this.error.assertValue("Oops")
+
+        userId.assertValue(user.id())
+    }
+
+    @Test
+    fun userLoggedIn_whenCreatePasswordSuccess_userReset() {
+        // - Create MockTracking client with user logged in
+        val user = UserFactory.user()
+        val trackingClient = getMockClientWithUser(user)
+
+        // - Mock success response from apollo
+        val apolloClient = object : MockApolloClient() {
+            override fun createPassword(password: String, confirmPassword: String): Observable<CreatePasswordMutation.Data> {
+                return Observable.just(CreatePasswordMutation.Data(CreatePasswordMutation.UpdateUserAccount("",
+                        CreatePasswordMutation.User("", "test@emai", true))))
+            }
+        }
+
+        // - Create environment with mocked objects
+        val environment = environment().toBuilder()
+                .apolloClient(apolloClient)
+                .analytics(AnalyticEvents(listOf(trackingClient)))
+                .build()
+
+        setUpEnvironment(environment)
+
+        this.vm.inputs.newPassword("password")
+        this.vm.inputs.confirmPassword("password")
+        this.vm.inputs.createPasswordClicked()
+        this.success.assertValue("test@emai")
+
+        userId.assertValues(user.id(), null)
+    }
+
+    private fun getMockClientWithUser(user: User) = MockTrackingClient(
+            MockCurrentUser(user),
+            MockCurrentConfig(),
+            TrackingClientType.Type.SEGMENT,
+            MockExperimentsClientType()).apply {
+        this.identifiedId.subscribe(userId)
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
@@ -49,6 +49,7 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.loginClick();
     this.startLoginActivity.assertValueCount(1);
     this.lakeTest.assertValues("Log In or Sign Up Page Viewed", "Log In Button Clicked");
+    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", "Log In Button Clicked");
   }
 
   @Test
@@ -60,6 +61,7 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.signupClick();
     this.startSignupActivity.assertValueCount(1);
     this.lakeTest.assertValues("Log In or Sign Up Page Viewed", "Sign Up Button Clicked");
+    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", "Sign Up Button Clicked");
   }
 
   @Test
@@ -77,6 +79,7 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
     this.currentUser.assertValueCount(1);
     this.finishWithSuccessfulResult.assertValueCount(1);
     this.lakeTest.assertValues("Log In or Sign Up Page Viewed", "Facebook Log In or Signup Button Clicked");
+    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", "Facebook Log In or Signup Button Clicked");
   }
 
   @Test
@@ -101,5 +104,6 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
     this.currentUser.assertNoValues();
     this.finishWithSuccessfulResult.assertNoValues();
     this.lakeTest.assertValues("Log In or Sign Up Page Viewed", "Facebook Log In or Signup Button Clicked");
+    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", "Facebook Log In or Signup Button Clicked");
   }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginViewModelTest.kt
@@ -83,6 +83,7 @@ class LoginViewModelTest : KSRobolectricTestCase() {
         this.loginSuccess.assertNoValues()
         this.genericLoginError.assertValueCount(1)
         this.lakeTest.assertValue("Log In Submit Button Clicked")
+        this.segmentTrack.assertValue("Log In Submit Button Clicked")
     }
 
     @Test
@@ -111,6 +112,7 @@ class LoginViewModelTest : KSRobolectricTestCase() {
         this.loginSuccess.assertNoValues()
         this.invalidLoginError.assertValueCount(1)
         this.lakeTest.assertValue("Log In Submit Button Clicked")
+        this.segmentTrack.assertValue("Log In Submit Button Clicked")
     }
 
     @Test
@@ -139,6 +141,7 @@ class LoginViewModelTest : KSRobolectricTestCase() {
         this.loginSuccess.assertNoValues()
         this.tfaChallenge.assertValueCount(1)
         this.lakeTest.assertValue("Log In Submit Button Clicked")
+        this.segmentTrack.assertValue("Log In Submit Button Clicked")
     }
 
     @Test
@@ -243,5 +246,6 @@ class LoginViewModelTest : KSRobolectricTestCase() {
 
         this.loginSuccess.assertValues(null, null)
         this.lakeTest.assertValue("Log In Submit Button Clicked")
+        this.segmentTrack.assertValue("Log In Submit Button Clicked")
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/SettingsViewModelTest.kt
@@ -1,7 +1,9 @@
 package com.kickstarter.viewmodels
 
 import com.kickstarter.KSRobolectricTestCase
-import com.kickstarter.libs.MockCurrentUser
+import com.kickstarter.libs.*
+import com.kickstarter.mock.MockCurrentConfig
+import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.User
 import org.junit.Test
@@ -13,15 +15,20 @@ class SettingsViewModelTest : KSRobolectricTestCase() {
     private val currentUserTest = TestSubscriber<User>()
     private val logout = TestSubscriber<Void>()
     private val showConfirmLogoutPrompt = TestSubscriber<Boolean>()
+    private val userId = TestSubscriber<Long?>()
 
     private fun setUpEnvironment(user: User) {
         val currentUser = MockCurrentUser(user)
         val environment = environment().toBuilder()
                 .currentUser(currentUser)
+                .analytics(AnalyticEvents(listOf(getMockClientWithUser(user))))
                 .build()
 
+        setUpEnvironment(environment)
         currentUser.observable().subscribe(this.currentUserTest)
+    }
 
+    private fun setUpEnvironment(environment: Environment) {
         this.vm = SettingsViewModel.ViewModel(environment)
         this.vm.outputs.logout().subscribe(this.logout)
         this.vm.outputs.showConfirmLogoutPrompt().subscribe(this.showConfirmLogoutPrompt)
@@ -59,5 +66,29 @@ class SettingsViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.logoutClicked()
         this.showConfirmLogoutPrompt.assertValue(true)
+    }
+
+    @Test
+    fun user_whenPressLogout_userReset() {
+        val user = UserFactory.user()
+
+        val environment = environment().toBuilder()
+                .analytics(AnalyticEvents(listOf(getMockClientWithUser(user))))
+                .build()
+
+        setUpEnvironment(environment)
+
+        this.vm.inputs.logoutClicked()
+        this.showConfirmLogoutPrompt.assertValue(true)
+
+        this.userId.assertValues(user.id(), null)
+    }
+
+    private fun getMockClientWithUser(user: User) = MockTrackingClient(
+            MockCurrentUser(user),
+            MockCurrentConfig(),
+            TrackingClientType.Type.SEGMENT,
+            MockExperimentsClientType()).apply {
+        this.identifiedId.subscribe(userId)
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/SettingsViewModelTest.kt
@@ -29,6 +29,7 @@ class SettingsViewModelTest : KSRobolectricTestCase() {
     }
 
     private fun setUpEnvironment(environment: Environment) {
+
         this.vm = SettingsViewModel.ViewModel(environment)
         this.vm.outputs.logout().subscribe(this.logout)
         this.vm.outputs.showConfirmLogoutPrompt().subscribe(this.showConfirmLogoutPrompt)
@@ -72,14 +73,10 @@ class SettingsViewModelTest : KSRobolectricTestCase() {
     fun user_whenPressLogout_userReset() {
         val user = UserFactory.user()
 
-        val environment = environment().toBuilder()
-                .analytics(AnalyticEvents(listOf(getMockClientWithUser(user))))
-                .build()
+        setUpEnvironment(user)
 
-        setUpEnvironment(environment)
-
-        this.vm.inputs.logoutClicked()
-        this.showConfirmLogoutPrompt.assertValue(true)
+        this.vm.inputs.confirmLogoutClicked()
+        this.logout.assertValue(null)
 
         this.userId.assertValues(user.id(), null)
     }

--- a/app/src/test/java/com/kickstarter/viewmodels/SignupViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SignupViewModelTest.java
@@ -63,6 +63,7 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
     formSubmittingTest.assertValues(true, false);
     signupSuccessTest.assertValueCount(1);
     this.lakeTest.assertValues("Sign Up Submit Button Clicked");
+    this.segmentTrack.assertValues("Sign Up Submit Button Clicked");
   }
 
   @Test
@@ -101,6 +102,7 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
     signupSuccessTest.assertValueCount(0);
     signupErrorTest.assertValueCount(1);
     this.lakeTest.assertValues("Sign Up Submit Button Clicked");
+    this.segmentTrack.assertValues("Sign Up Submit Button Clicked");
   }
 
   @Test
@@ -137,6 +139,7 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
     signupSuccessTest.assertValueCount(0);
     signupErrorTest.assertValueCount(1);
     this.lakeTest.assertValues("Sign Up Submit Button Clicked");
+    this.segmentTrack.assertValues("Sign Up Submit Button Clicked");
   }
 
 }


### PR DESCRIPTION
# 📲 What

- `Reset` method from segment SDK needs to be called when a logged in user logs out 

# 🛠 How
- Added new method `reset` on `AnalyticsEvents` and the rest of the hierarchy

# 👀 See

|  |  |

# 📋 QA
- Logout from the app
- Take a look into logcat, you'll see the debug logs for the reset method being called
<img width="1056" alt="Screen Shot 2021-02-04 at 4 26 29 PM" src="https://user-images.githubusercontent.com/4083656/106973177-35cd2180-6707-11eb-94c2-f6b05cca21b6.png">


# Story 📖

[Name of Trello Story](Trello link)
