### PR TITLE
NT-1751: Reset method called when user logs out

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -708,6 +708,10 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         client.track(CREATOR_DETAILS_CLICKED, experimentProperties(projectData))
     }
 
+    fun reset() {
+        client.reset()
+    }
+
     //endregion
     private fun experimentProperties(projectData: ProjectData): Map<String, Any> {
         val props = KoalaUtils.projectProperties(projectData.project(), client.loggedInUser())
@@ -734,6 +738,8 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
                 client?.track(eventName, additionalProperties)
             }
         }
+
+        fun reset() = clients.forEach { it?.reset() }
 
         fun loggedInUser(): User? = clients.firstOrNull()?.loggedInUser()
 

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -5,6 +5,7 @@ import com.kickstarter.models.User
 import com.segment.analytics.Analytics
 import com.segment.analytics.Properties
 import com.segment.analytics.Traits
+import timber.log.Timber
 
 class SegmentTrackingClient(
         build: Build,
@@ -43,9 +44,27 @@ class SegmentTrackingClient(
      */
     override fun identify(user: User) {
         super.identify(user)
+
+        if (this.build.isDebug && type() == Type.SEGMENT) {
+            user.apply {
+                Timber.d("Queued ${type().tag} Identify userName: ${this.name()} userId: ${ this.id()}")
+            }
+        }
         segmentAnalytics?.let { segment ->
             segment.identify(user.id().toString(), getTraits(user), null)
         }
+    }
+
+    /**
+     * clears the internal stores on Segment SDK for the current user and group
+     * https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#reset
+     */
+    override fun reset() {
+        super.reset()
+        if (this.build.isDebug) {
+            Timber.d("Queued ${type().tag} Reset user after logout")
+        }
+        segmentAnalytics?.reset()
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -59,7 +59,8 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
             val eventData = trackingData(eventName, combinedProperties(additionalProperties))
 
             if (this.build.isDebug) {
-                Timber.d("Queued ${type().tag} $eventName event: $eventData")
+                val dataForLogs = combinedProperties(additionalProperties).toString()
+                Timber.d("Queued ${type().tag} $eventName event: $dataForLogs")
             }
         } catch (e: JSONException) {
             if (this.build.isDebug) {
@@ -69,13 +70,12 @@ abstract class TrackingClient(@param:ApplicationContext private val context: Con
         }
     }
 
+    override fun reset() {
+        this.loggedInUser = null
+    }
+
     override fun identify(user: User) {
         this.loggedInUser = user
-        if (this.build.isDebug) {
-            user.apply {
-                Timber.d("Queued ${type().tag} Identify userName: ${this.name()} userId: ${ this.id()}")
-            }
-        }
     }
 
     override fun optimizely(): ExperimentsClientType = this.optimizely

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -37,6 +37,7 @@ abstract class TrackingClientType {
 
     abstract fun track(eventName: String, additionalProperties: Map<String, Any>)
     abstract fun identify(u: User)
+    abstract fun reset()
 
     fun track(eventName: String) {
         track(eventName, HashMap())

--- a/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
@@ -4,6 +4,7 @@ import UpdateUserPasswordMutation
 import androidx.annotation.NonNull
 import com.kickstarter.R
 import com.kickstarter.libs.ActivityViewModel
+import com.kickstarter.libs.AnalyticEvents
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.rx.transformers.Transformers.*
 import com.kickstarter.libs.utils.extensions.MINIMUM_PASSWORD_LENGTH
@@ -43,7 +44,7 @@ interface ChangePasswordViewModel {
         /** Emits when the save button should be enabled. */
         fun saveButtonIsEnabled(): Observable<Boolean>
 
-        /** Emits when the password update was unsuccessful. */
+        /** Emits when the password update was successful. */
         fun success(): Observable<String>
     }
 
@@ -64,6 +65,7 @@ interface ChangePasswordViewModel {
         val outputs: ChangePasswordViewModel.Outputs = this
 
         private val apolloClient: ApolloClientType = this.environment.apolloClient()
+        private val analytics: AnalyticEvents = this.environment.analytics()
 
         init {
 
@@ -97,7 +99,10 @@ interface ChangePasswordViewModel {
             changePasswordNotification
                     .compose(values())
                     .map { it.updateUserAccount()?.user()?.email() }
-                    .subscribe { this.success.onNext(it) }
+                    .subscribe {
+                        this.analytics.reset()
+                        this.success.onNext(it)
+                    }
         }
 
         private fun submit(changePassword: ChangePasswordViewModel.ViewModel.ChangePassword): Observable<UpdateUserPasswordMutation.Data> {

--- a/app/src/main/java/com/kickstarter/viewmodels/CreatePasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CreatePasswordViewModel.kt
@@ -4,6 +4,7 @@ import CreatePasswordMutation
 import androidx.annotation.NonNull
 import com.kickstarter.R
 import com.kickstarter.libs.ActivityViewModel
+import com.kickstarter.libs.AnalyticEvents
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.rx.transformers.Transformers.*
 import com.kickstarter.libs.utils.extensions.MINIMUM_PASSWORD_LENGTH
@@ -41,7 +42,7 @@ interface CreatePasswordViewModel {
         /** Emits when the save button should be enabled. */
         fun saveButtonIsEnabled(): Observable<Boolean>
 
-        /** Emits when the password update was unsuccessful. */
+        /** Emits when the password update was successful. */
         fun success(): Observable<String>
     }
 
@@ -61,6 +62,7 @@ interface CreatePasswordViewModel {
         val outputs: Outputs = this
 
         private val apolloClient: ApolloClientType = this.environment.apolloClient()
+        private val analytics: AnalyticEvents = this.environment.analytics()
 
         init {
 
@@ -92,7 +94,10 @@ interface CreatePasswordViewModel {
             createNewPasswordNotification
                     .compose(values())
                     .map { it.updateUserAccount()?.user()?.email() }
-                    .subscribe { this.success.onNext(it) }
+                    .subscribe {
+                        this.success.onNext(it)
+                        this.analytics.reset()
+                    }
         }
 
         private fun submit(createPassword: CreatePasswordViewModel.ViewModel.CreatePassword): Observable<CreatePasswordMutation.Data> {

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.kt
@@ -2,6 +2,7 @@ package com.kickstarter.viewmodels
 
 import androidx.annotation.NonNull
 import com.kickstarter.libs.ActivityViewModel
+import com.kickstarter.libs.AnalyticEvents
 import com.kickstarter.libs.CurrentUserType
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.rx.transformers.Transformers
@@ -55,6 +56,7 @@ interface SettingsViewModel {
         val inputs: Inputs = this
         val outputs: Outputs = this
 
+        private val analytics: AnalyticEvents = this.environment.analytics()
         init {
 
             this.client.fetchCurrentUser()
@@ -70,7 +72,10 @@ interface SettingsViewModel {
 
             this.confirmLogoutClicked
                     .compose(bindToLifecycle())
-                    .subscribe { this.logout.onNext(null) }
+                    .subscribe {
+                        this.analytics.reset()
+                        this.logout.onNext(null)
+                    }
 
             this.avatarImageViewUrl = this.currentUser.loggedInUser().map { u -> u.avatar().medium() }
 

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -44,6 +44,12 @@ public final class MockTrackingClient extends TrackingClientType {
     this.identifiedId.onNext(user.id());
   }
 
+  @Override
+  public void reset() {
+    this.loggedInUser = null;
+    this.identifiedId.onNext(null);
+  }
+
   public static class Event {
     private final String name;
     private final Map<String, Object> properties;

--- a/app/src/test/java/com/kickstarter/viewmodels/CreatePasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CreatePasswordViewModelTest.kt
@@ -3,8 +3,12 @@ package com.kickstarter.viewmodels
 import CreatePasswordMutation
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
-import com.kickstarter.libs.Environment
+import com.kickstarter.libs.*
+import com.kickstarter.mock.MockCurrentConfig
+import com.kickstarter.mock.MockExperimentsClientType
+import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClient
+import com.kickstarter.models.User
 import org.junit.Test
 import rx.Observable
 import rx.observers.TestSubscriber
@@ -18,6 +22,7 @@ class CreatePasswordViewModelTest : KSRobolectricTestCase() {
     private val progressBarIsVisible = TestSubscriber<Boolean>()
     private val saveButtonIsEnabled = TestSubscriber<Boolean>()
     private val success = TestSubscriber<String>()
+    private val userId = TestSubscriber<Long?>()
 
     private fun setUpEnvironment(environment: Environment) {
         this.vm = CreatePasswordViewModel.ViewModel(environment)
@@ -95,5 +100,72 @@ class CreatePasswordViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.confirmPassword("password")
         this.vm.inputs.createPasswordClicked()
         this.success.assertValue("test@emai")
+    }
+
+    @Test
+    fun userLoggedIn_whenCreatePasswordError_userNotReset() {
+        // - create MockTracking client with user logged in
+        val user = UserFactory.user()
+        val trackingClient = getMockClientWithUser(user)
+
+        // - Mock failed response from apollo
+        val apolloClient = object : MockApolloClient() {
+            override fun createPassword(password: String, confirmPassword: String): Observable<CreatePasswordMutation.Data> {
+                return Observable.error(Exception("Oops"))
+            }
+        }
+
+        // - Create environment with mocked objects
+        val environment = environment().toBuilder()
+                .apolloClient(apolloClient)
+                .analytics(AnalyticEvents(listOf(trackingClient)))
+                .build()
+
+        setUpEnvironment(environment)
+
+        this.vm.inputs.newPassword("passwo")
+        this.vm.inputs.confirmPassword("password")
+        this.vm.inputs.createPasswordClicked()
+        this.error.assertValue("Oops")
+
+        userId.assertValue(user.id())
+    }
+
+    @Test
+    fun userLoggedIn_whenCreatePasswordSuccess_userReset() {
+        // - Create MockTracking client with user logged in
+        val user = UserFactory.user()
+        val trackingClient = getMockClientWithUser(user)
+
+        // - Mock success response from apollo
+        val apolloClient = object : MockApolloClient() {
+            override fun createPassword(password: String, confirmPassword: String): Observable<CreatePasswordMutation.Data> {
+                return Observable.just(CreatePasswordMutation.Data(CreatePasswordMutation.UpdateUserAccount("",
+                        CreatePasswordMutation.User("", "test@emai", true))))
+            }
+        }
+
+        // - Create environment with mocked objects
+        val environment = environment().toBuilder()
+                .apolloClient(apolloClient)
+                .analytics(AnalyticEvents(listOf(trackingClient)))
+                .build()
+
+        setUpEnvironment(environment)
+
+        this.vm.inputs.newPassword("password")
+        this.vm.inputs.confirmPassword("password")
+        this.vm.inputs.createPasswordClicked()
+        this.success.assertValue("test@emai")
+
+        userId.assertValues(user.id(), null)
+    }
+
+    private fun getMockClientWithUser(user: User) = MockTrackingClient(
+            MockCurrentUser(user),
+            MockCurrentConfig(),
+            TrackingClientType.Type.SEGMENT,
+            MockExperimentsClientType()).apply {
+        this.identifiedId.subscribe(userId)
     }
 }


### PR DESCRIPTION
# 📲 What

- `Reset` method from segment SDK needs to be called when a logged in user logs out 

# 🛠 How
- Added new method `reset` on `AnalyticsEvents` and the rest of the hierarchy

# 📋 QA
- Logout from the app
- Take a look into logcat, you'll see the debug logs for the reset method being called
<img width="1056" alt="Screen Shot 2021-02-04 at 4 26 29 PM" src="https://user-images.githubusercontent.com/4083656/106973177-35cd2180-6707-11eb-94c2-f6b05cca21b6.png">


# Story 📖

[NT-1751: Call reset on logout](https://kickstarter.atlassian.net/browse/NT-1751)
