### PR TITLE
EP-153:Rename properties session_*

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -66,7 +66,7 @@ abstract class TrackingClientType {
             this["app_build_number"] = buildNumber()
             this["app_release_version"] = versionName()
             this["platform"] = "android"
-            this["client_type"] = "native"
+            this["client"] = "native"
             this["current_variants"] = currentVariants() ?: ""
             this["device_distinct_id"] = deviceDistinctId()
             this["device_type"] = deviceFormat()

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -69,7 +69,7 @@ abstract class TrackingClientType {
             this["client_type"] = "native"
             this["current_variants"] = currentVariants() ?: ""
             this["device_distinct_id"] = deviceDistinctId()
-            this["device_format"] = deviceFormat()
+            this["device_type"] = deviceFormat()
             this["device_manufacturer"] = manufacturer()
             this["device_model"] = model()
             this["device_orientation"] = deviceOrientation()

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -65,7 +65,7 @@ abstract class TrackingClientType {
         properties.apply {
             this["app_build_number"] = buildNumber()
             this["app_release_version"] = versionName()
-            this["client_platform"] = "android"
+            this["platform"] = "android"
             this["client_type"] = "native"
             this["current_variants"] = currentVariants() ?: ""
             this["device_distinct_id"] = deviceDistinctId()

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -546,7 +546,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals(9999, expectedProperties["session_app_build_number"])
         assertEquals("9.9.9", expectedProperties["session_app_release_version"])
         assertEquals("android", expectedProperties["session_platform"])
-        assertEquals("native", expectedProperties["session_client_type"])
+        assertEquals("native", expectedProperties["session_client"])
         assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_current_variants"])
         assertEquals("uuid", expectedProperties["session_device_distinct_id"])
         assertEquals("phone", expectedProperties["session_device_type"])

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -549,7 +549,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals("native", expectedProperties["session_client_type"])
         assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_current_variants"])
         assertEquals("uuid", expectedProperties["session_device_distinct_id"])
-        assertEquals("phone", expectedProperties["session_device_format"])
+        assertEquals("phone", expectedProperties["session_device_type"])
         assertEquals("Google", expectedProperties["session_device_manufacturer"])
         assertEquals("Pixel 3", expectedProperties["session_device_model"])
         assertEquals("Portrait", expectedProperties["session_device_orientation"])

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -545,7 +545,7 @@ class LakeTest : KSRobolectricTestCase() {
         val expectedProperties = this.propertiesTest.value
         assertEquals(9999, expectedProperties["session_app_build_number"])
         assertEquals("9.9.9", expectedProperties["session_app_release_version"])
-        assertEquals("android", expectedProperties["session_client_platform"])
+        assertEquals("android", expectedProperties["session_platform"])
         assertEquals("native", expectedProperties["session_client_type"])
         assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_current_variants"])
         assertEquals("uuid", expectedProperties["session_device_distinct_id"])

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -560,7 +560,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals(9999, expectedProperties["session_app_build_number"])
         assertEquals("9.9.9", expectedProperties["session_app_release_version"])
         assertEquals("android", expectedProperties["session_platform"])
-        assertEquals("native", expectedProperties["session_client_type"])
+        assertEquals("native", expectedProperties["session_client"])
         assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_current_variants"])
         assertEquals("uuid", expectedProperties["session_device_distinct_id"])
         assertEquals("phone", expectedProperties["session_device_type"])

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -559,7 +559,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val expectedProperties = this.propertiesTest.value
         assertEquals(9999, expectedProperties["session_app_build_number"])
         assertEquals("9.9.9", expectedProperties["session_app_release_version"])
-        assertEquals("android", expectedProperties["session_client_platform"])
+        assertEquals("android", expectedProperties["session_platform"])
         assertEquals("native", expectedProperties["session_client_type"])
         assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_current_variants"])
         assertEquals("uuid", expectedProperties["session_device_distinct_id"])

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -563,7 +563,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals("native", expectedProperties["session_client_type"])
         assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_current_variants"])
         assertEquals("uuid", expectedProperties["session_device_distinct_id"])
-        assertEquals("phone", expectedProperties["session_device_format"])
+        assertEquals("phone", expectedProperties["session_device_type"])
         assertEquals("Google", expectedProperties["session_device_manufacturer"])
         assertEquals("Pixel 3", expectedProperties["session_device_model"])
         assertEquals("Portrait", expectedProperties["session_device_orientation"])


### PR DESCRIPTION
# 📲 What
- property `session_client_platform` has been renamed to `session_platform`
- property `session_device_format` has been renamed to `session_device_type`
- property `session_client_type` has been renamed as `session_client`

# 👀 See

|  |  |

# 📋 QA
- Look logcat and search for `session_platform`: 
<img width="439" alt="Screen Shot 2021-02-05 at 2 59 13 PM" src="https://user-images.githubusercontent.com/4083656/107097885-d6cce280-67c2-11eb-8bf5-aada8dbc54f5.png">
- Look on logcat and search for `session_device_type`
<img width="1681" alt="Screen Shot 2021-02-05 at 3 11 03 PM" src="https://user-images.githubusercontent.com/4083656/107098638-8b1b3880-67c4-11eb-871c-c95d4aa0d94d.png">
- Look on logcat and search for `session_client`
<img width="998" alt="Screen Shot 2021-02-05 at 3 15 18 PM" src="https://user-images.githubusercontent.com/4083656/107098916-3c21d300-67c5-11eb-9d6b-c9d5d9fa956e.png">

# Story 📖

[https://kickstarter.atlassian.net/browse/EP-153](https://kickstarter.atlassian.net/browse/EP-153)
