### PR TITLE
EP-153: Rename properties checkout_reward_*

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -151,7 +151,7 @@ public final class KoalaUtils {
   }
 
   public static @NonNull Map<String, Object> pledgeProperties(final @NonNull Reward reward) {
-    return pledgeProperties(reward, "pledge_backer_reward_");
+    return pledgeProperties(reward, "checkout_reward");
   }
 
   public static @NonNull Map<String, Object> pledgeProperties(final @NonNull Reward reward, final @NonNull String prefix) {

--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -151,7 +151,7 @@ public final class KoalaUtils {
   }
 
   public static @NonNull Map<String, Object> pledgeProperties(final @NonNull Reward reward) {
-    return pledgeProperties(reward, "checkout_reward");
+    return pledgeProperties(reward, "checkout_reward_");
   }
 
   public static @NonNull Map<String, Object> pledgeProperties(final @NonNull Reward reward, final @NonNull String prefix) {

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -499,14 +499,14 @@ class LakeTest : KSRobolectricTestCase() {
     private fun assertPledgeProperties() {
         val expectedProperties = this.propertiesTest.value
         assertEquals(DateTime.parse("2019-03-26T19:26:09Z").millis / 1000, expectedProperties["pledge_backer_reward_estimated_delivery_on"])
-        assertEquals(false, expectedProperties["pledge_backer_reward_has_items"])
-        assertEquals(2L, expectedProperties["pledge_backer_reward_id"])
-        assertEquals(false, expectedProperties["pledge_backer_reward_is_limited_time"])
-        assertEquals(false, expectedProperties["pledge_backer_reward_is_limited_quantity"])
-        assertEquals(10.0, expectedProperties["pledge_backer_reward_minimum"])
-        assertEquals(true, expectedProperties["pledge_backer_reward_shipping_enabled"])
-        assertEquals("unrestricted", expectedProperties["pledge_backer_reward_shipping_preference"])
-        assertEquals("Digital Bundle", expectedProperties["pledge_backer_reward_title"])
+        assertEquals(false, expectedProperties["checkout_reward_has_items"])
+        assertEquals(2L, expectedProperties["checkout_reward_id"])
+        assertEquals(false, expectedProperties["checkout_reward_is_limited_time"])
+        assertEquals(false, expectedProperties["checkout_reward_is_limited_quantity"])
+        assertEquals(10.0, expectedProperties["checkout_reward_minimum"])
+        assertEquals(true, expectedProperties["checkout_reward_shipping_enabled"])
+        assertEquals("unrestricted", expectedProperties["checkout_reward_shipping_preference"])
+        assertEquals("Digital Bundle", expectedProperties["checkout_reward_title"])
     }
 
     private fun assertProjectProperties(project: Project) {

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -498,7 +498,7 @@ class LakeTest : KSRobolectricTestCase() {
 
     private fun assertPledgeProperties() {
         val expectedProperties = this.propertiesTest.value
-        assertEquals(DateTime.parse("2019-03-26T19:26:09Z").millis / 1000, expectedProperties["pledge_backer_reward_estimated_delivery_on"])
+        assertEquals(DateTime.parse("2019-03-26T19:26:09Z").millis / 1000, expectedProperties["checkout_reward_estimated_delivery_on"])
         assertEquals(false, expectedProperties["checkout_reward_has_items"])
         assertEquals(2L, expectedProperties["checkout_reward_id"])
         assertEquals(false, expectedProperties["checkout_reward_is_limited_time"])

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -512,7 +512,7 @@ class SegmentTest : KSRobolectricTestCase() {
 
     private fun assertPledgeProperties() {
         val expectedProperties = this.propertiesTest.value
-        assertEquals(DateTime.parse("2019-03-26T19:26:09Z").millis / 1000, expectedProperties["pledge_backer_reward_estimated_delivery_on"])
+        assertEquals(DateTime.parse("2019-03-26T19:26:09Z").millis / 1000, expectedProperties["checkout_reward_estimated_delivery_on"])
         assertEquals(false, expectedProperties["checkout_reward_has_items"])
         assertEquals(2L, expectedProperties["checkout_reward_id"])
         assertEquals(false, expectedProperties["checkout_reward_is_limited_time"])

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -513,14 +513,14 @@ class SegmentTest : KSRobolectricTestCase() {
     private fun assertPledgeProperties() {
         val expectedProperties = this.propertiesTest.value
         assertEquals(DateTime.parse("2019-03-26T19:26:09Z").millis / 1000, expectedProperties["pledge_backer_reward_estimated_delivery_on"])
-        assertEquals(false, expectedProperties["pledge_backer_reward_has_items"])
-        assertEquals(2L, expectedProperties["pledge_backer_reward_id"])
-        assertEquals(false, expectedProperties["pledge_backer_reward_is_limited_time"])
-        assertEquals(false, expectedProperties["pledge_backer_reward_is_limited_quantity"])
-        assertEquals(10.0, expectedProperties["pledge_backer_reward_minimum"])
-        assertEquals(true, expectedProperties["pledge_backer_reward_shipping_enabled"])
-        assertEquals("unrestricted", expectedProperties["pledge_backer_reward_shipping_preference"])
-        assertEquals("Digital Bundle", expectedProperties["pledge_backer_reward_title"])
+        assertEquals(false, expectedProperties["checkout_reward_has_items"])
+        assertEquals(2L, expectedProperties["checkout_reward_id"])
+        assertEquals(false, expectedProperties["checkout_reward_is_limited_time"])
+        assertEquals(false, expectedProperties["checkout_reward_is_limited_quantity"])
+        assertEquals(10.0, expectedProperties["checkout_reward_minimum"])
+        assertEquals(true, expectedProperties["checkout_reward_shipping_enabled"])
+        assertEquals("unrestricted", expectedProperties["checkout_reward_shipping_preference"])
+        assertEquals("Digital Bundle", expectedProperties["checkout_reward_title"])
     }
 
     private fun assertProjectProperties(project: Project) {


### PR DESCRIPTION
# 📲 What
- property `pledge_backer_reward_estimated_delivery_on` as been renamed as `checkout_reward_estimated_delivery_on`
-  property `pledge_backer_reward_is_limited_quantity` as been renamed as `checkout_reward_is_limited_quantity` 
- property `pledge_backer_reward_is_limited_time` as been renamed as `checkout_reward_is_limited_time` 
- property `pledge_backer_reward_shipping_enabled` as been renamed as `checkout_reward_shipping_enabled` 
- property `pledge_backer_reward_shipping_preference` as been renamed as `checkout_reward_shipping_preference` 
- property `pledge_backer_reward_title` as been renamed as `checkout_reward_title`

|  |  |

# 📋 QA

- Pledge to a project, a reward with shipping location, and search in logcat for `checkout_reward_estimated_delivery_on`:
<img width="940" alt="Screen Shot 2021-02-05 at 3 47 08 PM" src="https://user-images.githubusercontent.com/4083656/107100543-94f36a80-67c9-11eb-95e3-36fe852475a8.png">
- Pledge to a project,  and search in logcat for `checkout_reward_is_limited_quantity`:
<img width="781" alt="Screen Shot 2021-02-05 at 3 49 02 PM" src="https://user-images.githubusercontent.com/4083656/107100581-b0f70c00-67c9-11eb-97e9-3082ee5ed265.png">
- Pledge to a project,  and search in logcat for `checkout_reward_is_limited_time`:
<img width="649" alt="Screen Shot 2021-02-05 at 3 49 51 PM" src="https://user-images.githubusercontent.com/4083656/107100621-cd934400-67c9-11eb-93f4-91c382502d3a.png">
- Pledge to a project,  and search in logcat for `checkout_reward_shipping_enabled`:
<img width="809" alt="Screen Shot 2021-02-05 at 3 50 23 PM" src="https://user-images.githubusercontent.com/4083656/107100673-eef43000-67c9-11eb-8ebd-ae4e1a1ac371.png">
- Pledge to a project,  and search in logcat for `checkout_reward_shipping_preference`:
<img width="797" alt="Screen Shot 2021-02-05 at 3 51 59 PM" src="https://user-images.githubusercontent.com/4083656/107100755-24991900-67ca-11eb-9011-77c3b3537caf.png">
- Pledge to a project,  and search in logcat for `checkout_reward_title`:
<img width="766" alt="Screen Shot 2021-02-05 at 3 52 55 PM" src="https://user-images.githubusercontent.com/4083656/107100814-485c5f00-67ca-11eb-9d33-ec9b8e1f1a3c.png">

# Story 📖

[EP-153: Rename properties checkout_reward_*](https://kickstarter.atlassian.net/browse/EP-153)
