### PR TITLE
EP-215: Create event for Add-ons Continue button

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -2,6 +2,8 @@ package com.kickstarter.libs
 
 import com.kickstarter.libs.KoalaContext.*
 import com.kickstarter.libs.KoalaEvent.ProjectAction
+import com.kickstarter.libs.utils.EventContext
+import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.ExperimentData
 import com.kickstarter.libs.utils.KoalaUtils
 import com.kickstarter.models.Activity
@@ -12,6 +14,7 @@ import com.kickstarter.services.apiresponses.PushNotificationEnvelope
 import com.kickstarter.ui.data.*
 import com.kickstarter.ui.data.Mailbox
 import java.util.*
+import kotlin.collections.HashMap
 
 class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
 
@@ -646,6 +649,17 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
     fun trackAddOnsContinueButtonClicked(pledgeData: PledgeData) {
         val props = KoalaUtils.pledgeDataProperties(pledgeData, client.loggedInUser())
         client.track(ADD_ONS_CONTINUED_BUTTON_CLICKED, props)
+    }
+
+    /**
+     * Sends data associated with the add ons continue CTA clicked event to the client.
+     *
+     * @param pledgeData: The selected pledge data.
+     */
+    fun trackAddOnsContinueCTA(pledgeData: PledgeData) {
+        val props: HashMap<String, Any> = hashMapOf("context_cta" to EventContext.CtaContextName.ADD_ONS_CONTINUE.contextName)
+        props.putAll(KoalaUtils.pledgeDataProperties(pledgeData, client.loggedInUser()))
+        client.track(EventName.CTA_CLICKED.eventName, props)
     }
 
     //endregion

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -320,6 +320,7 @@ class BackingAddOnsFragmentViewModel {
                     .compose(bindToLifecycle())
                     .subscribe {
                         this.lake.trackAddOnsContinueButtonClicked(it.first)
+                        this.lake.trackAddOnsContinueCTA(it.first)
                         this.showPledgeFragment.onNext(it)
                     }
         }

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -5,6 +5,7 @@ import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.EventName
 import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.factories.*
 import com.kickstarter.mock.services.MockApiClient
@@ -455,7 +456,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
                     TestCase.assertEquals(it.second, pledgeReason)
                 }
 
-        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
     }
 
     @Test
@@ -522,7 +524,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
                     TestCase.assertEquals(selectedAddOnsList, listAddonsToCheck)
                 }
 
-        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
     }
 
     @Test
@@ -648,7 +651,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
                     TestCase.assertEquals(it.first.addOns(), updateList)
                 }
 
-        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
     }
 
     @Test
@@ -860,7 +864,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
             TestCase.assertEquals(shippingRuleSendToPledge, ShippingRuleFactory.mexicoShippingRule())
         }
 
-        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- Added track event for add-ons continue button clicked that fires when the continue button is pressed on the add-ons screen. 

# 🤔 Why

Segment integration.

# 🛠 How

- Created a new function to our `AnalyticsEvents` class that handles sending the event name and properties to the client. 
- Added this function to our `BackingFragmentViewModel` when the continue button is clicked. 

# 📋 QA

- Sign into your account on staging
- Find a project with add-ons
- Back Project -> Select Reward -> Tap "Continue" on add-ons screen. 
- Both Segment (CTA Clicked) and DataLake (Add-ons Continue Button Clicked) should appear in the segment dashboard:
<img width="797" alt="Screen Shot 2021-02-09 at 6 28 38 PM" src="https://user-images.githubusercontent.com/19390326/107442294-d99e3f00-6b04-11eb-8658-e196629868e6.png">

- In segment, tap CTA Clicked. On the right should appear a list of properties sent with this event. 
<img width="786" alt="Screen Shot 2021-02-09 at 6 28 21 PM" src="https://user-images.githubusercontent.com/19390326/107442403-05b9c000-6b05-11eb-9c83-fc8a77c0442e.png">

# Story 📖

[EP-215: Android: CTA Clicked (add_ons_continue)](https://kickstarter.atlassian.net/browse/EP-215)
