### PR TITLE
EP-153: Rename Properties

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -1,6 +1,7 @@
 package com.kickstarter.libs.utils;
 
 import com.kickstarter.libs.RefTag;
+import com.kickstarter.libs.utils.extensions.CheckoutDataExt;
 import com.kickstarter.models.Activity;
 import com.kickstarter.models.Category;
 import com.kickstarter.models.Location;
@@ -34,7 +35,7 @@ public final class KoalaUtils {
         put("amount", checkoutData.amount());
         put("id", checkoutData.id());
         put("payment_type", checkoutData.paymentType().rawValue());
-        put("revenue_in_usd_cents", Math.round(checkoutData.amount() * project.staticUsdRate() * 100));
+        put("amount_total_usd", (CheckoutDataExt.totalAmount(checkoutData) * project.staticUsdRate()));
         put("shipping_amount", checkoutData.shippingAmount());
         if (checkoutData.bonusAmount() != null) {
           put("bonus_amount", checkoutData.bonusAmount());

--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -35,7 +35,7 @@ public final class KoalaUtils {
         put("amount", checkoutData.amount());
         put("id", checkoutData.id());
         put("payment_type", checkoutData.paymentType().rawValue());
-        put("amount_total_usd", (CheckoutDataExt.totalAmount(checkoutData) * project.staticUsdRate()));
+        put("amount_total_usd", CheckoutDataExt.totalAmount(checkoutData) * project.staticUsdRate());
         put("shipping_amount", checkoutData.shippingAmount());
         if (checkoutData.bonusAmount() != null) {
           put("bonus_amount", checkoutData.bonusAmount());

--- a/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/KoalaUtils.java
@@ -195,7 +195,7 @@ public final class KoalaUtils {
         put("creator_uid", project.creator().id());
         put("currency", project.currency());
         put("current_pledge_amount", project.pledged());
-        put("current_pledge_amount_usd", project.pledged() * project.staticUsdRate());
+        put("current_amount_pledged_usd", project.pledged() * project.staticUsdRate());
         put("deadline", project.deadline() != null ? project.deadline().getMillis() / 1000 : null);
         put("duration", Math.round(ProjectUtils.timeInSecondsOfDuration(project)));
         put("goal", project.goal());

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/CheckoutDataExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/CheckoutDataExt.kt
@@ -1,0 +1,15 @@
+@file:JvmName("CheckoutDataExt")
+package com.kickstarter.libs.utils.extensions
+
+import com.kickstarter.ui.data.CheckoutData
+
+/**
+ * Returns the total amount for a pledge.
+ * @return Total pledge amount includes shipping, bonus support, and add-ons if applicable
+ *
+ * Checkout.amount = bonus support + add-ons + reward
+ * Checkout.shippingAmount = shipping reward + shipping add-ons
+ */
+fun CheckoutData.totalAmount(): Double {
+    return this.amount() + this.shippingAmount()
+}

--- a/app/src/main/java/com/kickstarter/ui/data/CheckoutData.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/CheckoutData.kt
@@ -11,7 +11,7 @@ abstract class CheckoutData : Parcelable {
     abstract fun id(): Long?
     abstract fun paymentType(): CreditCardPaymentType
     abstract fun shippingAmount(): Double
-    abstract fun  bonusAmount(): Double?
+    abstract fun bonusAmount(): Double?
 
     @AutoParcel.Builder
     abstract class Builder {

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -476,7 +476,7 @@ class LakeTest : KSRobolectricTestCase() {
         val expectedProperties = this.propertiesTest.value
         assertEquals(30.0, expectedProperties["checkout_amount"])
         assertEquals("CREDIT_CARD", expectedProperties["checkout_payment_type"])
-        assertEquals(3000L, expectedProperties["checkout_revenue_in_usd_cents"])
+        assertEquals(50.0, expectedProperties["checkout_amount_total_usd"])
         assertEquals(20.0, expectedProperties["checkout_shipping_amount"])
     }
 

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -519,7 +519,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals(3L, expectedProperties["project_creator_uid"])
         assertEquals("USD", expectedProperties["project_currency"])
         assertEquals(50.0, expectedProperties["project_current_pledge_amount"])
-        assertEquals(50.0, expectedProperties["project_current_pledge_amount_usd"])
+        assertEquals(50.0, expectedProperties["project_current_amount_pledged_usd"])
         assertEquals(project.deadline()?.millis?.let { it / 1000 }, expectedProperties["project_deadline"])
         assertEquals(60 * 60 * 24 * 20, expectedProperties["project_duration"])
         assertEquals(100.0, expectedProperties["project_goal"])

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -490,7 +490,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val expectedProperties = this.propertiesTest.value
         assertEquals(30.0, expectedProperties["checkout_amount"])
         assertEquals("CREDIT_CARD", expectedProperties["checkout_payment_type"])
-        assertEquals(3000L, expectedProperties["checkout_revenue_in_usd_cents"])
+        assertEquals(50.0, expectedProperties["checkout_amount_total_usd"])
         assertEquals(20.0, expectedProperties["checkout_shipping_amount"])
     }
 

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -533,7 +533,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals(3L, expectedProperties["project_creator_uid"])
         assertEquals("USD", expectedProperties["project_currency"])
         assertEquals(50.0, expectedProperties["project_current_pledge_amount"])
-        assertEquals(50.0, expectedProperties["project_current_pledge_amount_usd"])
+        assertEquals(50.0, expectedProperties["project_current_amount_pledged_usd"])
         assertEquals(project.deadline()?.millis?.let { it / 1000 }, expectedProperties["project_deadline"])
         assertEquals(60 * 60 * 24 * 20, expectedProperties["project_duration"])
         assertEquals(100.0, expectedProperties["project_goal"])

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/CheckoutDataExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/CheckoutDataExtTest.kt
@@ -1,0 +1,28 @@
+package com.kickstarter.libs.utils.extensions
+
+import com.kickstarter.ui.data.CheckoutData
+import junit.framework.TestCase
+import type.CreditCardPaymentType
+
+class CheckoutDataExtTest: TestCase() {
+
+    fun testTotalAmount_WithoutShipping() {
+        val coData = CheckoutData.builder()
+                .paymentType(CreditCardPaymentType.CREDIT_CARD)
+                .shippingAmount(0.0)
+                .amount(200.0)
+                .build()
+
+        assertEquals(coData.totalAmount(), 200.0)
+    }
+
+    fun testTotalAmount_WithShipping() {
+        val coData = CheckoutData.builder()
+                .paymentType(CreditCardPaymentType.CREDIT_CARD)
+                .shippingAmount(30.0)
+                .amount(200.0)
+                .build()
+
+        assertEquals(coData.totalAmount(), 230.0)
+    }
+}


### PR DESCRIPTION
# 📲 What

- property `project_current_pledge_amount_usd` has been renamed as `project_current_amount_pledged_usd`
- property `checkout_revenue_in_usd_cents` has been exchanged over `checkout_amount_total_usd` is the sum of shipping, bonus support, and add-ons in USD

# 📋 QA
- Pledge a project and take a look into logcat:
<img width="441" alt="Screen Shot 2021-02-10 at 8 54 55 AM" src="https://user-images.githubusercontent.com/4083656/107543026-aba91100-6b7d-11eb-98dd-e73208e4a124.png">

- Pledge to a project with addons with shipping location for addons and reward in other currency different from USD. In this screenshot you can see how 71 uk pounds is transformed to 96.46...USD for the property `checkout_amount_total_usd`
<img width="724" alt="Screen Shot 2021-02-10 at 9 36 28 AM" src="https://user-images.githubusercontent.com/4083656/107550196-92a45e00-6b85-11eb-9896-13fa1503be5d.png">

![Screen Shot 2021-02-10 at 9 36 44 AM](https://user-images.githubusercontent.com/4083656/107550490-f29b0480-6b85-11eb-88f6-bd0a93c391ce.png)



# Story 📖

[EP-153: Rename properties](https://kickstarter.atlassian.net/browse/EP-153)
