### PR TITLE
EP-216: Create event for Pledge Initiate CTA

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -2,7 +2,8 @@ package com.kickstarter.libs
 
 import com.kickstarter.libs.KoalaContext.*
 import com.kickstarter.libs.KoalaEvent.ProjectAction
-import com.kickstarter.libs.utils.EventContext
+import com.kickstarter.libs.utils.EventContext.CtaContextName.ADD_ONS_CONTINUE
+import com.kickstarter.libs.utils.EventContext.CtaContextName.PLEDGE_INITIATE
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.ExperimentData
 import com.kickstarter.libs.utils.KoalaUtils
@@ -13,8 +14,9 @@ import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.services.apiresponses.PushNotificationEnvelope
 import com.kickstarter.ui.data.*
 import com.kickstarter.ui.data.Mailbox
-import java.util.*
 import kotlin.collections.HashMap
+
+private const val CONTEXT_CTA = "context_cta"
 
 class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
 
@@ -625,6 +627,17 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         client.track(PROJECT_PAGE_PLEDGE_BUTTON_CLICKED, props)
     }
 
+    /**
+     * Sends data associated with the initial pledge CTA click event to the client.
+     *
+     * @param projectData: The project data.
+     */
+    fun trackPledgeInitiateCTA(projectData: ProjectData) {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA to PLEDGE_INITIATE.contextName)
+        props.putAll(KoalaUtils.projectProperties(projectData.project(), client.loggedInUser()))
+        client.track(EventName.CTA_CLICKED.eventName, props)
+    }
+
     fun trackSelectRewardButtonClicked(pledgeData: PledgeData) {
         val props = KoalaUtils.pledgeDataProperties(pledgeData, client.loggedInUser())
         client.track(SELECT_REWARD_BUTTON_CLICKED, props)
@@ -657,7 +670,7 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      * @param pledgeData: The selected pledge data.
      */
     fun trackAddOnsContinueCTA(pledgeData: PledgeData) {
-        val props: HashMap<String, Any> = hashMapOf("context_cta" to EventContext.CtaContextName.ADD_ONS_CONTINUE.contextName)
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA to ADD_ONS_CONTINUE.contextName)
         props.putAll(KoalaUtils.pledgeDataProperties(pledgeData, client.loggedInUser()))
         client.track(EventName.CTA_CLICKED.eventName, props)
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -738,7 +738,10 @@ interface ProjectViewModel {
                     .compose<Pair<ProjectData, PledgeFlowContext?>>(takeWhen(this.nativeProjectActionButtonClicked))
                     .filter { it.first.project().isLive && !it.first.project().isBacking }
                     .compose(bindToLifecycle())
-                    .subscribe { this.lake.trackProjectPagePledgeButtonClicked(storeCurrentCookieRefTag(it.first), it.second) }
+                    .subscribe {
+                        this.lake.trackProjectPagePledgeButtonClicked(storeCurrentCookieRefTag(it.first), it.second)
+                        this.lake.trackPledgeInitiateCTA(it.first)
+                    }
 
             fullProjectDataAndPledgeFlowContext
                     .map { it.first }

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -773,8 +773,10 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.pledgeToolbarNavigationClicked()
         this.expandPledgeSheet.assertValues(Pair(true, true), Pair(false, true))
         this.goBack.assertNoValues()
-        this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
+        this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", "CTA Clicked")
         this.experimentsTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
+        this.segmentTrack.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", "CTA Clicked")
+
     }
 
     @Test
@@ -785,8 +787,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.nativeProjectActionButtonClicked()
 
         this.expandPledgeSheet.assertValue(Pair(true, true))
-        this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
+        this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", "CTA Clicked")
         this.experimentsTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
+        this.segmentTrack.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", "CTA Clicked")
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Added track event for "pledge initiate" button clicks that fires when the "Back this project" button is pressed on the projects screen.

# 🤔 Why

Segment integration.

# 🛠 How

- Created a new function to our AnalyticsEvents class that handles sending the event name and properties to the client.
- Added this function to the `ProjectViewModel` when the "Back this project" button is pressed.

# 👀 See
This is the button that fires this event. 
![Screenshot_1612992209](https://user-images.githubusercontent.com/19390326/107574963-4412b600-6bbd-11eb-9311-c5245d4665c7.png)

# 📋 QA

- Tap on a live project
- Tap "Back this project" CTA at bottom of screen 
Both Segment (CTA Clicked) and DataLake (Project Page Pledge Button Clicked) should appear in the segment dashboard:
<img width="793" alt="Screen Shot 2021-02-10 at 4 22 45 PM" src="https://user-images.githubusercontent.com/19390326/107575120-7c19f900-6bbd-11eb-9a20-7828a163ac38.png">

- Tap on CTA Clicked, the list of properties should appear on the right side of the screen:
<img width="785" alt="Screen Shot 2021-02-10 at 4 22 39 PM" src="https://user-images.githubusercontent.com/19390326/107575127-80dead00-6bbd-11eb-8319-76cac8df65d3.png">

# Story 📖

[EP-216: Android: CTA Clicked (pledge_initiate)](https://kickstarter.atlassian.net/browse/EP-216)
