### PR TITLE
EP-217: Create event for Pledge Submit CTA

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -4,6 +4,7 @@ import com.kickstarter.libs.KoalaContext.*
 import com.kickstarter.libs.KoalaEvent.ProjectAction
 import com.kickstarter.libs.utils.EventContext.CtaContextName.ADD_ONS_CONTINUE
 import com.kickstarter.libs.utils.EventContext.CtaContextName.PLEDGE_INITIATE
+import com.kickstarter.libs.utils.EventContext.CtaContextName.PLEDGE_SUBMIT
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.AnalyticEventsUtils
 import com.kickstarter.libs.utils.ExperimentData
@@ -17,6 +18,7 @@ import com.kickstarter.ui.data.Mailbox
 import kotlin.collections.HashMap
 
 private const val CONTEXT_CTA = "context_cta"
+private const val CONTEXT_TYPE = "context_type"
 
 class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
 
@@ -616,6 +618,19 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
     fun trackPledgeSubmitButtonClicked(checkoutData: CheckoutData, pledgeData: PledgeData) {
         val props = AnalyticEventsUtils.checkoutDataProperties(checkoutData, pledgeData, client.loggedInUser())
         client.track(PLEDGE_SUBMIT_BUTTON_CLICKED, props)
+    }
+
+    /**
+     * Sends data associated with the submit CTA click event to the client.
+     *
+     * @param checkoutData: The checkout data.
+     * @param pledgeData: The selected pledge data.
+     */
+    fun trackPledgeSubmitCTA(checkoutData: CheckoutData, pledgeData: PledgeData) {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA to PLEDGE_SUBMIT.contextName)
+        props[CONTEXT_TYPE] = "credit_card"
+        props.putAll(AnalyticEventsUtils.checkoutDataProperties(checkoutData, pledgeData, client.loggedInUser()))
+        client.track(EventName.CTA_CLICKED.eventName, props)
     }
 
     fun trackManagePledgeButtonClicked(projectData: ProjectData, context: PledgeFlowContext?) {

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -1325,7 +1325,10 @@ interface PledgeFragmentViewModel {
                     .filter { shouldTrackPledgeSubmitButtonClicked(it.second.pledgeFlowContext()) }
                     .compose<Pair<CheckoutData, PledgeData>>(takeWhen(this.pledgeButtonClicked))
                     .compose(bindToLifecycle())
-                    .subscribe { this.lake.trackPledgeSubmitButtonClicked(it.first, it.second) }
+                    .subscribe {
+                        this.lake.trackPledgeSubmitButtonClicked(it.first, it.second)
+                        this.lake.trackPledgeSubmitCTA(it.first, it.second)
+                    }
 
             // - Screen configuration Logic (Different configurations depending on: PledgeReason, Reward type, Shipping, AddOns)
             this.selectedReward

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -11,6 +11,7 @@ import com.kickstarter.libs.MockSharedPreferences
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.models.Country
 import com.kickstarter.libs.utils.DateTimeUtils
+import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.RefTagUtils
 import com.kickstarter.libs.utils.extensions.trimAllWhitespace
 import com.kickstarter.mock.MockCurrentConfig
@@ -1061,8 +1062,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeButtonIsEnabled.assertValue(true)
         this.vm.inputs.pledgeButtonClicked()
 
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -1357,8 +1358,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeButtonIsEnabled.assertValues(true, false, true)
         this.pledgeProgressIsGone.assertValues(false, true)
         this.showUpdatePaymentError.assertValueCount(1)
-        this.lakeTest.assertValues("Pledge Submit Button Clicked", "CTA Clicked")
-        this.segmentTrack.assertValues("Pledge Submit Button Clicked", "CTA Clicked")
+        this.lakeTest.assertValues("Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
     }
 
     @Test
@@ -1415,8 +1416,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeButtonIsEnabled.assertValues(true, false)
         this.pledgeProgressIsGone.assertValues(false)
         this.showUpdatePaymentSuccess.assertValueCount(1)
-        this.lakeTest.assertValues("Pledge Submit Button Clicked", "CTA Clicked")
-        this.segmentTrack.assertValues("Pledge Submit Button Clicked", "CTA Clicked")
+        this.lakeTest.assertValues("Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
     }
 
     @Test
@@ -1938,8 +1939,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -1959,8 +1960,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -1984,8 +1985,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -2012,8 +2013,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertValueCount(1)
         this.showSCAFlow.assertNoValues()
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -2040,8 +2041,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertNoValues()
         this.showSCAFlow.assertValueCount(1)
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
 
         this.vm.inputs.stripeSetupResultSuccessful(StripeIntentResult.Outcome.SUCCEEDED)
@@ -2082,8 +2083,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertValueCount(1)
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -2119,8 +2120,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertValueCount(1)
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -1061,7 +1061,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeButtonIsEnabled.assertValue(true)
         this.vm.inputs.pledgeButtonClicked()
 
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -1356,7 +1357,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeButtonIsEnabled.assertValues(true, false, true)
         this.pledgeProgressIsGone.assertValues(false, true)
         this.showUpdatePaymentError.assertValueCount(1)
-        this.lakeTest.assertValues("Pledge Submit Button Clicked")
+        this.lakeTest.assertValues("Pledge Submit Button Clicked", "CTA Clicked")
+        this.segmentTrack.assertValues("Pledge Submit Button Clicked", "CTA Clicked")
     }
 
     @Test
@@ -1413,7 +1415,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeButtonIsEnabled.assertValues(true, false)
         this.pledgeProgressIsGone.assertValues(false)
         this.showUpdatePaymentSuccess.assertValueCount(1)
-        this.lakeTest.assertValues("Pledge Submit Button Clicked")
+        this.lakeTest.assertValues("Pledge Submit Button Clicked", "CTA Clicked")
+        this.segmentTrack.assertValues("Pledge Submit Button Clicked", "CTA Clicked")
     }
 
     @Test
@@ -1935,7 +1938,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -1955,7 +1959,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -1979,7 +1984,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -2006,7 +2012,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertValueCount(1)
         this.showSCAFlow.assertNoValues()
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -2033,7 +2040,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertNoValues()
         this.showSCAFlow.assertValueCount(1)
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
 
         this.vm.inputs.stripeSetupResultSuccessful(StripeIntentResult.Outcome.SUCCEEDED)
@@ -2074,7 +2082,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertValueCount(1)
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -2110,7 +2119,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertValueCount(1)
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", "CTA Clicked")
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 


### PR DESCRIPTION
# 📲 What

Added track event for "pledge submit" button clicks that fires when the "Pledge" button is pressed on the checkout screen.

# 🤔 Why

Segment Integration

# 🛠 How

- Created a new function to our `AnalyticsEvents` class that handles sending the event name and properties to the client.
- Added this function to the `PledgeFragmentViewModel` when the "Pledge" button is pressed.

# 👀 See
This is the button that fires this event: 
![Screenshot_1612993850](https://user-images.githubusercontent.com/19390326/107682679-a37cce80-6c6e-11eb-8a1c-e1765ad9975e.png)

# 📋 QA

- Tap on a live project
- Tap "Back this project" CTA at bottom of screen
- Select a reward and/or addons
- On the checkout screen, tap "Pledge" 
- Both Segment (CTA Clicked) and DataLake (Pledge Submit Button Clicked) should appear in the segment dashboard. 
You should see `context_cta = "pledge_submit"` as well as `context_type = "credit_card"`
<img width="791" alt="Screen Shot 2021-02-11 at 4 38 23 PM" src="https://user-images.githubusercontent.com/19390326/107702043-b354dc80-6c87-11eb-9023-c16e4566cbc2.png">
<img width="784" alt="Screen Shot 2021-02-11 at 2 18 27 PM" src="https://user-images.githubusercontent.com/19390326/107687228-3b30eb80-6c74-11eb-9d89-208d7dd89393.png">

# Story 📖

[EP-217: Android: CTA Clicked (pledge_submit)](https://kickstarter.atlassian.net/browse/EP-217)
