### PR TITLE
EP-218: Create event for Select Reward CTA

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -5,6 +5,7 @@ import com.kickstarter.libs.KoalaEvent.ProjectAction
 import com.kickstarter.libs.utils.EventContext.CtaContextName.ADD_ONS_CONTINUE
 import com.kickstarter.libs.utils.EventContext.CtaContextName.PLEDGE_INITIATE
 import com.kickstarter.libs.utils.EventContext.CtaContextName.PLEDGE_SUBMIT
+import com.kickstarter.libs.utils.EventContext.CtaContextName.REWARD_CONTINUE
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.AnalyticEventsUtils
 import com.kickstarter.libs.utils.ExperimentData
@@ -667,6 +668,17 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
     fun trackSelectRewardButtonClicked(pledgeData: PledgeData) {
         val props = AnalyticEventsUtils.pledgeDataProperties(pledgeData, client.loggedInUser())
         client.track(SELECT_REWARD_BUTTON_CLICKED, props)
+    }
+
+    /**
+     * Sends data associated with the select reward CTA click event to the client.
+     *
+     * @param pledgeData: The pledge data.
+     */
+    fun trackSelectRewardCTA(pledgeData: PledgeData) {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA to REWARD_CONTINUE.contextName)
+        props.putAll(AnalyticEventsUtils.pledgeDataProperties(pledgeData, client.loggedInUser()))
+        client.track(EventName.CTA_CLICKED.eventName, props)
     }
 
     fun trackThanksPageViewed(checkoutData: CheckoutData, pledgeData: PledgeData) {

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -313,7 +313,10 @@ interface RewardViewHolderViewModel {
                     .compose<Pair<ProjectData, Reward>>(takeWhen(this.rewardClicked))
                     .map { PledgeData.with(PledgeFlowContext.NEW_PLEDGE, it.first, it.second) }
                     .compose(bindToLifecycle())
-                    .subscribe { this.lake.trackSelectRewardButtonClicked(it) }
+                    .subscribe {
+                        this.lake.trackSelectRewardButtonClicked(it)
+                        this.lake.trackSelectRewardCTA(it)
+                    }
 
             projectAndReward
                     .filter { RewardUtils.isNoReward(it.second) }

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -7,6 +7,7 @@ import com.kickstarter.R
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUser
 import com.kickstarter.libs.models.OptimizelyExperiment
+import com.kickstarter.libs.utils.EventName
 import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.*
 import com.kickstarter.models.Project
@@ -629,8 +630,8 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
         // When a reward from a live project is clicked, start checkout.
         this.vm.inputs.rewardClicked(2)
         this.showPledgeFragment.assertValue(Pair.create(liveProject, reward))
-        this.lakeTest.assertValues("Select Reward Button Clicked", "CTA Clicked")
-        this.segmentTrack.assertValues("Select Reward Button Clicked", "CTA Clicked")
+        this.lakeTest.assertValues("Select Reward Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Select Reward Button Clicked", EventName.CTA_CLICKED.eventName)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -629,7 +629,8 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
         // When a reward from a live project is clicked, start checkout.
         this.vm.inputs.rewardClicked(2)
         this.showPledgeFragment.assertValue(Pair.create(liveProject, reward))
-        this.lakeTest.assertValue("Select Reward Button Clicked")
+        this.lakeTest.assertValues("Select Reward Button Clicked", "CTA Clicked")
+        this.segmentTrack.assertValues("Select Reward Button Clicked", "CTA Clicked")
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Added track event for selecting a reward button clicks that fires when the "Select" button is pressed on the reward carousel.

# 🤔 Why

Segment Integration

# 🛠 How

Created a new function to our `AnalyticsEvents` class that handles sending the event name and properties to the client.
Added this function to the `RewardViewHolderViewModel` when the "Select" button is pressed on a reward in the reward carousel.

# 👀 See

This is the button that fires this event:
![Screenshot_1613077641](https://user-images.githubusercontent.com/19390326/107700658-d088ab80-6c85-11eb-95ca-6afee63a1f58.png)

# 📋 QA

- Tap on a live project
- Tap "Back this project" CTA at bottom of screen
- Tap "Select" on a reward in the reward carousel
- Both Segment (CTA Clicked) and DataLake (Select Reward Button Clicked) should appear in the segment dashboard. You should see `context_cta = "reward_continue"`

<img width="791" alt="Screen Shot 2021-02-11 at 4 21 35 PM" src="https://user-images.githubusercontent.com/19390326/107701355-cb782c00-6c86-11eb-8f39-a1c71d94dc69.png">
<img width="782" alt="Screen Shot 2021-02-11 at 4 21 59 PM" src="https://user-images.githubusercontent.com/19390326/107701335-c4e9b480-6c86-11eb-997a-f3a5d0a8c6f4.png">


# Story 📖

[EP-218: Android: CTA Clicked (reward_continue)](https://kickstarter.atlassian.net/browse/EP-218)
