### PR TITLE
EP-219: Create event for Add-ons screen viewed

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -8,7 +8,6 @@ import com.kickstarter.libs.utils.EventContext.CtaContextName.PLEDGE_SUBMIT
 import com.kickstarter.libs.utils.EventContext.CtaContextName.REWARD_CONTINUE
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.AnalyticEventsUtils
-import com.kickstarter.libs.utils.EventContext
 import com.kickstarter.libs.utils.EventContext.PageViewedContextName.ADD_ONS
 import com.kickstarter.libs.utils.EventContext.ContextPropertyName.CONTEXT_CTA
 import com.kickstarter.libs.utils.EventContext.ContextPropertyName.CONTEXT_TYPE

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -8,6 +8,9 @@ import com.kickstarter.libs.utils.EventContext.CtaContextName.PLEDGE_SUBMIT
 import com.kickstarter.libs.utils.EventContext.CtaContextName.REWARD_CONTINUE
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.AnalyticEventsUtils
+import com.kickstarter.libs.utils.EventContext.PageViewedContextName.ADD_ONS
+import com.kickstarter.libs.utils.EventContext.ContextPropertyName.CONTEXT_CTA
+import com.kickstarter.libs.utils.EventContext.ContextPropertyName.CONTEXT_PAGE
 import com.kickstarter.libs.utils.ExperimentData
 import com.kickstarter.models.Activity
 import com.kickstarter.models.Project
@@ -17,9 +20,6 @@ import com.kickstarter.services.apiresponses.PushNotificationEnvelope
 import com.kickstarter.ui.data.*
 import com.kickstarter.ui.data.Mailbox
 import kotlin.collections.HashMap
-
-private const val CONTEXT_CTA = "context_cta"
-private const val CONTEXT_TYPE = "context_type"
 
 class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
 
@@ -660,7 +660,7 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      * @param projectData: The project data.
      */
     fun trackPledgeInitiateCTA(projectData: ProjectData) {
-        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA to PLEDGE_INITIATE.contextName)
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA.contextName to PLEDGE_INITIATE.contextName)
         props.putAll(AnalyticEventsUtils.projectProperties(projectData.project(), client.loggedInUser()))
         client.track(EventName.CTA_CLICKED.eventName, props)
     }
@@ -697,6 +697,17 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         client.track(ADD_ONS_PAGE_VIEWED, props)
     }
 
+    /**
+     * Sends data to the client when the add-ons screen is loaded.
+     *
+     * @param pledgeData: The selected pledge data.
+     */
+    fun trackAddOnsScreenViewed(pledgeData: PledgeData) {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to ADD_ONS.contextName)
+        props.putAll(AnalyticEventsUtils.pledgeDataProperties(pledgeData, client.loggedInUser()))
+        client.track(EventName.PAGE_VIEWED.eventName, props)
+    }
+
     fun trackAddOnsContinueButtonClicked(pledgeData: PledgeData) {
         val props = AnalyticEventsUtils.pledgeDataProperties(pledgeData, client.loggedInUser())
         client.track(ADD_ONS_CONTINUED_BUTTON_CLICKED, props)
@@ -708,7 +719,7 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      * @param pledgeData: The selected pledge data.
      */
     fun trackAddOnsContinueCTA(pledgeData: PledgeData) {
-        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA to ADD_ONS_CONTINUE.contextName)
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA.contextName to ADD_ONS_CONTINUE.contextName)
         props.putAll(AnalyticEventsUtils.pledgeDataProperties(pledgeData, client.loggedInUser()))
         client.track(EventName.CTA_CLICKED.eventName, props)
     }

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -8,8 +8,10 @@ import com.kickstarter.libs.utils.EventContext.CtaContextName.PLEDGE_SUBMIT
 import com.kickstarter.libs.utils.EventContext.CtaContextName.REWARD_CONTINUE
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.AnalyticEventsUtils
+import com.kickstarter.libs.utils.EventContext
 import com.kickstarter.libs.utils.EventContext.PageViewedContextName.ADD_ONS
 import com.kickstarter.libs.utils.EventContext.ContextPropertyName.CONTEXT_CTA
+import com.kickstarter.libs.utils.EventContext.ContextPropertyName.CONTEXT_TYPE
 import com.kickstarter.libs.utils.EventContext.ContextPropertyName.CONTEXT_PAGE
 import com.kickstarter.libs.utils.ExperimentData
 import com.kickstarter.models.Activity
@@ -628,8 +630,8 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      * @param pledgeData: The selected pledge data.
      */
     fun trackPledgeSubmitCTA(checkoutData: CheckoutData, pledgeData: PledgeData) {
-        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA to PLEDGE_SUBMIT.contextName)
-        props[CONTEXT_TYPE] = "credit_card"
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA.contextName to PLEDGE_SUBMIT.contextName)
+        props[CONTEXT_TYPE.contextName] = "credit_card"
         props.putAll(AnalyticEventsUtils.checkoutDataProperties(checkoutData, pledgeData, client.loggedInUser()))
         client.track(EventName.CTA_CLICKED.eventName, props)
     }
@@ -676,7 +678,7 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      * @param pledgeData: The pledge data.
      */
     fun trackSelectRewardCTA(pledgeData: PledgeData) {
-        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA to REWARD_CONTINUE.contextName)
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA.contextName to REWARD_CONTINUE.contextName)
         props.putAll(AnalyticEventsUtils.pledgeDataProperties(pledgeData, client.loggedInUser()))
         client.track(EventName.CTA_CLICKED.eventName, props)
     }

--- a/app/src/main/java/com/kickstarter/libs/utils/EventContext.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContext.kt
@@ -37,4 +37,10 @@ class EventContext {
         REWARDS("rewards"),
         THANKS("thanks")
     }
+
+    enum class ContextPropertyName(val contextName: String) {
+        CONTEXT_CTA("context_cta"),
+        CONTEXT_PAGE("context_page"),
+        CONTEXT_TYPE("context_type")
+    }
 }

--- a/app/src/main/java/com/kickstarter/libs/utils/EventContext.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContext.kt
@@ -38,6 +38,16 @@ class EventContext {
         THANKS("thanks")
     }
 
+    /**
+     * Represents the different context keys for properties sent to analytics
+     *
+     * @param contextName: The name of the context key.
+     *
+     * CONTEXT_CTA: Key that stores the button that was tapped.
+     * CONTEXT_PAGE: Key that stores the page that was viewed.
+     * CONTEXT_TYPE: Key that stores contextual details about an event that was
+     * fired that aren't captured in other context properties
+     */
     enum class ContextPropertyName(val contextName: String) {
         CONTEXT_CTA("context_cta"),
         CONTEXT_PAGE("context_page"),

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -115,7 +115,10 @@ class BackingAddOnsFragmentViewModel {
             pledgeData
                     .take(1)
                     .compose(bindToLifecycle())
-                    .subscribe { this.lake.trackAddOnsPageViewed(it) }
+                    .subscribe {
+                        this.lake.trackAddOnsPageViewed(it)
+                        this.lake.trackAddOnsScreenViewed(it)
+                    }
 
             val pledgeReason = arguments()
                     .map { it.getSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON) as PledgeReason }

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModelTest.kt
@@ -75,7 +75,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.addOnsList.assertValue(Triple(projectData, emptyList(), ShippingRuleFactory.emptyShippingRule()))
         this.isEmptyState.assertValue(true)
 
-        this.lakeTest.assertValue("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -110,7 +111,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.arguments(bundle)
         this.addOnsList.assertValue(Triple(projectData,listAddons, shippingRule.shippingRules().first()))
 
-        this.lakeTest.assertValue("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -145,7 +147,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.arguments(bundle)
         this.addOnsList.assertValue(Triple(projectData,listAddons, shippingRule.shippingRules().first()))
 
-        this.lakeTest.assertValue("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -184,7 +187,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.addOnsList.assertValue(Triple(projectData, emptyList(), shippingRuleRw))
 
-        this.lakeTest.assertValue("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -221,7 +225,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.addOnsList.assertValue(Triple(projectData, listAddons, shippingRuleRw))
 
-        this.lakeTest.assertValue("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -267,7 +272,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
             TestCase.assertEquals(filteredAddOn, addOn2)
         }
 
-        this.lakeTest.assertValue("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -309,7 +315,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.addOnsList.assertValues(Triple(projectData, listAddons, shippingRuleRw), Triple(projectData, emptyList(), shippingRuleAddOn))
 
-        this.lakeTest.assertValue("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -346,7 +353,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.addOnsList.assertValue(Triple(projectData, listAddons, ShippingRuleFactory.emptyShippingRule()))
 
-        this.lakeTest.assertValue("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -382,7 +390,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.shippingSelectorIsGone.assertValues(true)
 
-        this.lakeTest.assertValue("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
 
@@ -417,7 +426,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.shippingSelectorIsGone.assertValues(true)
 
-        this.lakeTest.assertValue("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -456,8 +466,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
                     TestCase.assertEquals(it.second, pledgeReason)
                 }
 
-        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
-        this.segmentTrack.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName, "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName, "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
     }
 
     @Test
@@ -524,8 +534,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
                     TestCase.assertEquals(selectedAddOnsList, listAddonsToCheck)
                 }
 
-        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
-        this.segmentTrack.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName, "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName,"Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
     }
 
     @Test
@@ -582,7 +592,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.isEnabledButton.assertValues(true, false)
         this.addOnsList.assertValue(Triple(projectData, combinedList, shippingRule.shippingRules().first()))
 
-        this.lakeTest.assertValue("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -651,8 +662,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
                     TestCase.assertEquals(it.first.addOns(), updateList)
                 }
 
-        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
-        this.segmentTrack.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName, "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName, "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
     }
 
     @Test
@@ -722,7 +733,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         // - Always 0 first time, them summatory of all addOns quantity every time the list gets updated
         this.totalSelectedAddOns.assertValues(0)
 
-        this.lakeTest.assertValues("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -790,7 +802,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         // - Always 0 first time, them summatory of all addOns quantity every time the list gets updated
         this.totalSelectedAddOns.assertValues(0)
 
-        this.lakeTest.assertValues("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -864,8 +877,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
             TestCase.assertEquals(shippingRuleSendToPledge, ShippingRuleFactory.mexicoShippingRule())
         }
 
-        this.lakeTest.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
-        this.segmentTrack.assertValues("Add-Ons Page Viewed", "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName, "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName, "Add-Ons Continue Button Clicked", EventName.CTA_CLICKED.eventName)
     }
 
     @Test
@@ -904,7 +917,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.addOnsList.assertValue(Triple(projectData, emptyList(), shippingRuleRw))
         this.isEmptyState.assertValue(true)
 
-        this.lakeTest.assertValue("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -942,7 +956,8 @@ class BackingAddOnsFragmentViewModelTest : KSRobolectricTestCase() {
         this.addOnsList.assertValue(Triple(projectData, listAddons, shippingRuleRw))
         this.isEmptyState.assertValue(false)
 
-        this.lakeTest.assertValue("Add-Ons Page Viewed")
+        this.lakeTest.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Add-Ons Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -8,6 +8,7 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.libs.*
 import com.kickstarter.libs.models.OptimizelyExperiment
+import com.kickstarter.libs.utils.EventName
 import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.*
 import com.kickstarter.mock.services.MockApiClient
@@ -773,9 +774,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.pledgeToolbarNavigationClicked()
         this.expandPledgeSheet.assertValues(Pair(true, true), Pair(false, true))
         this.goBack.assertNoValues()
-        this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", "CTA Clicked")
+        this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
-        this.segmentTrack.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", "CTA Clicked")
+        this.segmentTrack.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", EventName.CTA_CLICKED.eventName)
 
     }
 
@@ -787,9 +788,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.nativeProjectActionButtonClicked()
 
         this.expandPledgeSheet.assertValue(Pair(true, true))
-        this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", "CTA Clicked")
+        this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
-        this.segmentTrack.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", "CTA Clicked")
+        this.segmentTrack.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", EventName.CTA_CLICKED.eventName)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- Added track event for add-ons screen that fires when the `BackingAddonsFragmentViewModel` is loaded. 
- Fixed instances of "CTA Clicked" in `ProjectViewModelTest` to use a constant instead of a string literal.

# 🤔 Why

Segment Integration

# 🛠 How

- Created a new function in the `AnalyticsEvents` class that handles sending the event name and properties to the client.
- Added this function to the `BackingAddonsFragmentViewModel` when the initialization method is called.

# 👀 See

This is the screen that fires this event:
![Screenshot_1613083922](https://user-images.githubusercontent.com/19390326/107711145-26188480-6c95-11eb-82d7-4ac196260f72.png)

# 📋 QA

- Tap on a live project that has add-ons
- Tap "Back this project" CTA at bottom of screen
- Select a reward which should then proceed to the add-ons screen 
- Both Segment (Page Viewed) and DataLake (Add-Ons Page Viewed) should appear in the segment dashboard.
- You should see `context_page = "add_ons" in the list of properties
<img width="791" alt="Screen Shot 2021-02-11 at 6 21 04 PM" src="https://user-images.githubusercontent.com/19390326/107711708-13eb1600-6c96-11eb-8510-05fc3177f757.png">
<img width="765" alt="Screen Shot 2021-02-11 at 6 21 13 PM" src="https://user-images.githubusercontent.com/19390326/107711687-0897ea80-6c96-11eb-901f-5e335d601eef.png">

# Story 📖

[EP-219: Android: Page Viewed (add_ons)](https://kickstarter.atlassian.net/browse/EP-219)
