### PR TITLE
NT-1768: PerimeterX-Headers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -238,6 +238,9 @@ dependencies {
     // Analytics
     implementation 'com.segment.analytics.android:analytics:4.9.0'
 
+    // Security
+    implementation 'com.perimeterx.sdk:msdk:1.12.13'
+
     // Firebase
     implementation platform('com.google.firebase:firebase-bom:26.0.0')
     implementation 'com.google.firebase:firebase-crashlytics'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -239,7 +239,7 @@ dependencies {
     implementation 'com.segment.analytics.android:analytics:4.9.0'
 
     // Security
-    implementation 'com.perimeterx.sdk:msdk:1.12.13'
+    implementation 'com.perimeterx.sdk:msdk:1.13.1'
 
     // Firebase
     implementation platform('com.google.firebase:firebase-bom:26.0.0')

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.kickstarter">
     <!-- PERMISSIONS -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <!--
     We need coarse location to find projects near a user. Could also see people being uncomfortable with providing

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
     -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" /> <!-- RECEIVE allows the app to register to receive GCM messages -->
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" /> <!-- Used to determine if network connection Snackbar should be shown. -->
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:name=".KSApplication"

--- a/app/src/main/java/com/kickstarter/ApplicationGraph.java
+++ b/app/src/main/java/com/kickstarter/ApplicationGraph.java
@@ -10,6 +10,7 @@ import com.kickstarter.services.firebase.UnregisterTokenWorker;
 import com.kickstarter.ui.views.AppRatingDialog;
 import com.kickstarter.ui.views.IconTextView;
 import com.kickstarter.ui.views.KSWebView;
+import com.perimeterx.msdk.PXManager;
 
 public interface ApplicationGraph {
   Environment environment();
@@ -23,4 +24,5 @@ public interface ApplicationGraph {
   void inject(RegisterTokenWorker __);
   void inject(ResetDeviceIdWorker __);
   void inject(UnregisterTokenWorker __);
+  void inject(PXManager __);
 }

--- a/app/src/main/java/com/kickstarter/ApplicationGraph.java
+++ b/app/src/main/java/com/kickstarter/ApplicationGraph.java
@@ -10,7 +10,6 @@ import com.kickstarter.services.firebase.UnregisterTokenWorker;
 import com.kickstarter.ui.views.AppRatingDialog;
 import com.kickstarter.ui.views.IconTextView;
 import com.kickstarter.ui.views.KSWebView;
-import com.perimeterx.msdk.PXManager;
 
 public interface ApplicationGraph {
   Environment environment();
@@ -24,5 +23,4 @@ public interface ApplicationGraph {
   void inject(RegisterTokenWorker __);
   void inject(ResetDeviceIdWorker __);
   void inject(UnregisterTokenWorker __);
-  void inject(PXManager __);
 }

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -45,6 +45,8 @@ import com.kickstarter.libs.graphql.DateTimeAdapter;
 import com.kickstarter.libs.graphql.Iso8601DateTimeAdapter;
 import com.kickstarter.libs.graphql.EmailAdapter;
 import com.kickstarter.libs.models.OptimizelyEnvironment;
+import com.kickstarter.libs.perimeterx.PerimeterXClient;
+import com.kickstarter.libs.perimeterx.PerimeterXClientType;
 import com.kickstarter.libs.preferences.BooleanPreference;
 import com.kickstarter.libs.preferences.BooleanPreferenceType;
 import com.kickstarter.libs.preferences.IntPreference;
@@ -92,7 +94,6 @@ import org.joda.time.DateTime;
 
 import java.net.CookieManager;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 
 import javax.inject.Singleton;
@@ -230,8 +231,8 @@ public class ApplicationModule {
 
   @Provides
   @Singleton
-  @Nullable
-  static PXManager provideParameterXManager(final @NonNull Build build, final @ApplicationContext @NonNull Context context) {
+  @NonNull
+  static PerimeterXClientType provideParameterXManager(final @ApplicationContext @NonNull Context context) {
     PXManager manager = null;
     if (context instanceof KSApplication && !((KSApplication) context).isInUnitTests()) {
       manager = PXManager.getInstance()
@@ -243,7 +244,7 @@ public class ApplicationModule {
       manager.start(context, Secrets.PERIMETERX_APPID);
     }
 
-    return manager;
+    return new PerimeterXClient(manager);
   }
 
   @Provides
@@ -292,7 +293,7 @@ public class ApplicationModule {
   @Singleton
   @NonNull
   static ApiRequestInterceptor provideApiRequestInterceptor(final @NonNull String clientId,
-    final @NonNull CurrentUserType currentUser, final @NonNull ApiEndpoint endpoint, @Nullable PXManager manager) {
+    final @NonNull CurrentUserType currentUser, final @NonNull ApiEndpoint endpoint, final @NonNull PerimeterXClientType manager) {
     return new ApiRequestInterceptor(clientId, currentUser, endpoint.url(), manager);
   }
 
@@ -300,7 +301,7 @@ public class ApplicationModule {
   @Singleton
   @NonNull
   static GraphQLInterceptor provideGraphQLInterceptor(final @NonNull String clientId,
-    final @NonNull CurrentUserType currentUser, final @NonNull Build build, @Nullable PXManager manager) {
+    final @NonNull CurrentUserType currentUser, final @NonNull Build build, final @NonNull PerimeterXClientType manager) {
     return new GraphQLInterceptor(clientId, currentUser, build, manager);
   }
 
@@ -329,7 +330,7 @@ public class ApplicationModule {
   @Provides
   @Singleton
   @NonNull
-  static KSRequestInterceptor provideKSRequestInterceptor(final @NonNull Build build, @Nullable PXManager manager) {
+  static KSRequestInterceptor provideKSRequestInterceptor(final @NonNull Build build, final @NonNull PerimeterXClientType manager) {
     return new KSRequestInterceptor(build, manager);
   }
 
@@ -363,7 +364,7 @@ public class ApplicationModule {
   @Singleton
   @NonNull
   static WebRequestInterceptor provideWebRequestInterceptor(final @NonNull CurrentUserType currentUser,
-    @NonNull @WebEndpoint final String endpoint, final @NonNull InternalToolsType internalTools, final @NonNull Build build, @Nullable PXManager manager) {
+    @NonNull @WebEndpoint final String endpoint, final @NonNull InternalToolsType internalTools, final @NonNull Build build, @Nullable PerimeterXClientType manager) {
     return new WebRequestInterceptor(currentUser, endpoint, internalTools, build, manager);
   }
 

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -580,7 +580,7 @@ public class ApplicationModule {
   @Provides
   static KSWebViewClient provideKSWebViewClient(final @NonNull OkHttpClient okHttpClient,
     final @WebEndpoint String webEndpoint, final @NonNull PerimeterXClientType manager) {
-    return new KSWebViewClient(okHttpClient, webEndpoint);
+    return new KSWebViewClient(okHttpClient, webEndpoint, manager);
   }
 
   @Provides

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -84,8 +84,6 @@ import com.kickstarter.services.interceptors.KSRequestInterceptor;
 import com.kickstarter.services.interceptors.WebRequestInterceptor;
 import com.kickstarter.ui.SharedPreferenceKey;
 import com.optimizely.ab.android.sdk.OptimizelyManager;
-import com.perimeterx.msdk.ManagerReadyCallback;
-import com.perimeterx.msdk.NewHeadersCallback;
 import com.perimeterx.msdk.PXManager;
 import com.segment.analytics.Analytics;
 import com.stripe.android.Stripe;
@@ -112,6 +110,7 @@ import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
 import rx.Scheduler;
 import rx.schedulers.Schedulers;
+import timber.log.Timber;
 import type.CustomType;
 
 @Module
@@ -232,15 +231,21 @@ public class ApplicationModule {
   @Provides
   @Singleton
   @NonNull
-  static PerimeterXClientType provideParameterXManager(final @ApplicationContext @NonNull Context context) {
+  static PerimeterXClientType providePerimeterXManager(final @NonNull Build build, final @ApplicationContext @NonNull Context context) {
     PXManager manager = null;
     if (context instanceof KSApplication && !((KSApplication) context).isInUnitTests()) {
-      manager = PXManager.getInstance()
-      .setNewHeadersCallback(
-         headers -> System.out.println("New headers called back")
-      )
-      .setManagerReadyCallback(
-         headers -> System.out.println("Manager ready called back"));
+      if (build.isDebug()) {
+        manager = PXManager.getInstance()
+                .setNewHeadersCallback(
+                        headers -> Timber.d("PXManager: NewHeadersCallback :" + headers.toString())
+                )
+                .setManagerReadyCallback(
+                        headers -> Timber.d("PXManager: ManagerReadyCallback :" + headers.toString())
+                );
+      } else {
+        manager = PXManager.getInstance();
+      }
+
       manager.start(context, Secrets.PERIMETERX_APPID);
     }
 

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -236,12 +236,12 @@ public class ApplicationModule {
     if (context instanceof KSApplication && !((KSApplication) context).isInUnitTests()) {
       if (build.isDebug()) {
         manager = PXManager.getInstance()
-                .setNewHeadersCallback(
-                        headers -> Timber.d("PXManager: NewHeadersCallback :" + headers.toString())
-                )
-                .setManagerReadyCallback(
-                        headers -> Timber.d("PXManager: ManagerReadyCallback :" + headers.toString())
-                );
+          .setNewHeadersCallback(
+            headers -> Timber.d("PXManager: NewHeadersCallback :" + headers.toString())
+          )
+          .setManagerReadyCallback(
+            headers -> Timber.d("PXManager: ManagerReadyCallback :" + headers.toString())
+          );
       } else {
         manager = PXManager.getInstance();
       }
@@ -369,7 +369,7 @@ public class ApplicationModule {
   @Singleton
   @NonNull
   static WebRequestInterceptor provideWebRequestInterceptor(final @NonNull CurrentUserType currentUser,
-    @NonNull @WebEndpoint final String endpoint, final @NonNull InternalToolsType internalTools, final @NonNull Build build, @Nullable PerimeterXClientType manager) {
+    @NonNull @WebEndpoint final String endpoint, final @NonNull InternalToolsType internalTools, final @NonNull Build build, final @NonNull PerimeterXClientType manager) {
     return new WebRequestInterceptor(currentUser, endpoint, internalTools, build, manager);
   }
 
@@ -579,7 +579,7 @@ public class ApplicationModule {
 
   @Provides
   static KSWebViewClient provideKSWebViewClient(final @NonNull OkHttpClient okHttpClient,
-    final @WebEndpoint String webEndpoint) {
+    final @WebEndpoint String webEndpoint, final @NonNull PerimeterXClientType manager) {
     return new KSWebViewClient(okHttpClient, webEndpoint);
   }
 

--- a/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClient.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.libs.perimeterx
 
 import com.perimeterx.msdk.PXManager
+import okhttp3.Request
 
 class PerimeterXClient(
         private val manager: PXManager?
@@ -8,6 +9,11 @@ class PerimeterXClient(
 
     override fun manager() = this.manager
 
-    override fun httpHeaders() = PXManager.httpHeaders()?.let { it.toMap() } ?: emptyMap()
+    override fun addHeaderTo(builder: Request.Builder?) {
+        val headers = PXManager.httpHeaders()?.let { it.toMap() } ?: emptyMap()
 
+        headers.forEach { (key, value) ->
+            builder?.addHeader(key, value)
+        }
+    }
 }

--- a/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClient.kt
@@ -1,0 +1,13 @@
+package com.kickstarter.libs.perimeterx
+
+import com.perimeterx.msdk.PXManager
+
+class PerimeterXClient(
+        private val manager: PXManager?
+):PerimeterXClientType {
+
+    override fun manager() = this.manager
+
+    override fun httpHeaders() = PXManager.httpHeaders()?.let { it.toMap() } ?: emptyMap()
+
+}

--- a/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClient.kt
@@ -7,7 +7,7 @@ class PerimeterXClient(
         private val manager: PXManager?
 ):PerimeterXClientType {
 
-    override fun manager() = this.manager
+    override fun getClient() = this.manager
 
     override fun addHeaderTo(builder: Request.Builder?) {
         val headers = PXManager.httpHeaders()?.let { it.toMap() } ?: emptyMap()

--- a/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClientType.kt
@@ -4,6 +4,6 @@ import com.perimeterx.msdk.PXManager
 import okhttp3.Request
 
 interface PerimeterXClientType {
-    fun manager(): PXManager?
+    fun getClient(): PXManager?
     fun addHeaderTo(builder: Request.Builder?)
 }

--- a/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClientType.kt
@@ -1,0 +1,8 @@
+package com.kickstarter.libs.perimeterx
+
+import com.perimeterx.msdk.PXManager
+
+interface PerimeterXClientType {
+    fun manager(): PXManager?
+    fun httpHeaders(): Map<String, String>
+}

--- a/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClientType.kt
@@ -1,8 +1,9 @@
 package com.kickstarter.libs.perimeterx
 
 import com.perimeterx.msdk.PXManager
+import okhttp3.Request
 
 interface PerimeterXClientType {
     fun manager(): PXManager?
-    fun httpHeaders(): Map<String, String>
+    fun addHeaderTo(builder: Request.Builder?)
 }

--- a/app/src/main/java/com/kickstarter/libs/utils/Secrets.java.example
+++ b/app/src/main/java/com/kickstarter/libs/utils/Secrets.java.example
@@ -6,6 +6,7 @@ public final class Secrets {
   private Secrets() {}
 
   public static final Boolean IS_OSS = true;
+  public final static String PERIMETERX_APPID = "PXkickstarter";
 
   public static final class Api {
     public static final class Client {

--- a/app/src/main/java/com/kickstarter/services/interceptors/ApiRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/ApiRequestInterceptor.java
@@ -8,7 +8,6 @@ import com.kickstarter.libs.perimeterx.PerimeterXClientType;
 import com.kickstarter.services.KSUri;
 
 import java.io.IOException;
-import java.util.HashMap;
 
 import androidx.annotation.NonNull;
 import okhttp3.HttpUrl;
@@ -40,11 +39,11 @@ public final class ApiRequestInterceptor implements Interceptor {
       return initialRequest;
     }
 
-    Request.Builder builder = initialRequest.newBuilder()
+    final Request.Builder builder = initialRequest.newBuilder()
             .addHeader("Accept", "application/json")
             .addHeader("Kickstarter-Android-App-UUID", FirebaseInstanceId.getInstance().getId());
 
-    pxManager.addHeaderTo(builder);
+    this.pxManager.addHeaderTo(builder);
 
     return builder
       .url(url(initialRequest.url()))

--- a/app/src/main/java/com/kickstarter/services/interceptors/ApiRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/ApiRequestInterceptor.java
@@ -4,8 +4,8 @@ import android.net.Uri;
 
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.kickstarter.libs.CurrentUserType;
+import com.kickstarter.libs.perimeterx.PerimeterXClientType;
 import com.kickstarter.services.KSUri;
-import com.perimeterx.msdk.PXManager;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -20,10 +20,10 @@ public final class ApiRequestInterceptor implements Interceptor {
   private final String clientId;
   private final CurrentUserType currentUser;
   private final String endpoint;
-  private final PXManager pxManager;
+  private final PerimeterXClientType pxManager;
 
   public ApiRequestInterceptor(final @NonNull String clientId, final @NonNull CurrentUserType currentUser,
-                               final @NonNull String endpoint, PXManager manager) {
+                               final @NonNull String endpoint, final @NonNull PerimeterXClientType manager) {
     this.clientId = clientId;
     this.currentUser = currentUser;
     this.endpoint = endpoint;
@@ -43,11 +43,9 @@ public final class ApiRequestInterceptor implements Interceptor {
       return initialRequest;
     }
 
-    if (pxManager != null) {
-      for (HashMap.Entry<String, String> entry : pxManager.httpHeaders().entrySet()) {
-        key = entry.getKey();
-        value = entry.getValue();
-      }
+    for (HashMap.Entry<String, String> entry : pxManager.httpHeaders().entrySet()) {
+      key = entry.getKey();
+      value = entry.getValue();
     }
 
     return initialRequest.newBuilder()

--- a/app/src/main/java/com/kickstarter/services/interceptors/ApiRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/ApiRequestInterceptor.java
@@ -36,22 +36,17 @@ public final class ApiRequestInterceptor implements Interceptor {
   }
 
   private Request request(final @NonNull Request initialRequest) {
-    String key = "";
-    String value = "";
-
     if (!shouldIntercept(initialRequest)) {
       return initialRequest;
     }
 
-    for (HashMap.Entry<String, String> entry : pxManager.httpHeaders().entrySet()) {
-      key = entry.getKey();
-      value = entry.getValue();
-    }
+    Request.Builder builder = initialRequest.newBuilder()
+            .addHeader("Accept", "application/json")
+            .addHeader("Kickstarter-Android-App-UUID", FirebaseInstanceId.getInstance().getId());
 
-    return initialRequest.newBuilder()
-      .addHeader("Accept", "application/json")
-      .addHeader("Kickstarter-Android-App-UUID", FirebaseInstanceId.getInstance().getId())
-      .addHeader(key, value)
+    pxManager.addHeaderTo(builder);
+
+    return builder
       .url(url(initialRequest.url()))
       .build();
   }

--- a/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
+++ b/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
@@ -4,6 +4,7 @@ import com.google.firebase.iid.FirebaseInstanceId
 import com.kickstarter.libs.Build
 import com.kickstarter.libs.CurrentUserType
 import com.kickstarter.libs.utils.WebUtils
+import com.perimeterx.msdk.PXManager
 import okhttp3.Interceptor
 import okhttp3.Interceptor.Chain
 import okhttp3.Response
@@ -14,7 +15,8 @@ import okhttp3.Response
  */
 class GraphQLInterceptor(private val clientId: String,
                          private val currentUser: CurrentUserType,
-                         private val build: Build) : Interceptor {
+                         private val build: Build,
+                         manager: PXManager) : Interceptor {
     override fun intercept(chain: Chain): Response {
         val original = chain.request()
         val builder = original.newBuilder().method(original.method, original.body)

--- a/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
+++ b/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
@@ -21,23 +21,17 @@ class GraphQLInterceptor(private val clientId: String,
     override fun intercept(chain: Chain): Response {
         val original = chain.request()
         val builder = original.newBuilder().method(original.method, original.body)
-        var headerKey = ""
-        var headerValue = ""
 
         this.currentUser.observable()
                 .subscribe {
                     builder.addHeader("Authorization", "token " + this.currentUser.accessToken)
                 }
 
-        pxManager.httpHeaders().forEach { (key, value) ->
-            headerKey = key
-            headerValue = value
-        }
-
         builder.addHeader("User-Agent", WebUtils.userAgent(this.build))
                 .addHeader("X-KICKSTARTER-CLIENT", this.clientId)
                 .addHeader("Kickstarter-Android-App-UUID", FirebaseInstanceId.getInstance().id)
-                .addHeader(headerKey, headerValue)
+
+        pxManager.addHeaderTo(builder)
 
         return chain.proceed(builder.build())
     }

--- a/app/src/main/java/com/kickstarter/services/interceptors/KSRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/KSRequestInterceptor.java
@@ -1,6 +1,7 @@
 package com.kickstarter.services.interceptors;
 
 import com.kickstarter.libs.Build;
+import com.kickstarter.libs.perimeterx.PerimeterXClient;
 import com.kickstarter.libs.perimeterx.PerimeterXClientType;
 import com.kickstarter.libs.utils.I18nUtils;
 import com.perimeterx.msdk.PXManager;
@@ -17,9 +18,11 @@ import okhttp3.Response;
  */
 public final class KSRequestInterceptor implements Interceptor {
   private final Build build;
+  private final PerimeterXClientType pxManager;
 
-  public KSRequestInterceptor(final @NonNull Build build, PerimeterXClientType manager) {
+  public KSRequestInterceptor(final @NonNull Build build, final @NonNull PerimeterXClientType manager) {
     this.build = build;
+    this.pxManager = manager;
   }
 
   @Override
@@ -28,10 +31,12 @@ public final class KSRequestInterceptor implements Interceptor {
   }
 
   private Request request(final @NonNull Request initialRequest) {
-    return initialRequest.newBuilder()
-      .header("Kickstarter-Android-App", this.build.versionCode().toString())
-      .header("Kickstarter-App-Id", this.build.applicationId())
-      .header("Accept-Language", I18nUtils.language())
-      .build();
+    Request.Builder builder = initialRequest.newBuilder()
+            .header("Kickstarter-Android-App", this.build.versionCode().toString())
+            .header("Kickstarter-App-Id", this.build.applicationId())
+            .header("Accept-Language", I18nUtils.language());
+
+    pxManager.addHeaderTo(builder);
+    return builder.build();
   }
 }

--- a/app/src/main/java/com/kickstarter/services/interceptors/KSRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/KSRequestInterceptor.java
@@ -1,10 +1,8 @@
 package com.kickstarter.services.interceptors;
 
 import com.kickstarter.libs.Build;
-import com.kickstarter.libs.perimeterx.PerimeterXClient;
 import com.kickstarter.libs.perimeterx.PerimeterXClientType;
 import com.kickstarter.libs.utils.I18nUtils;
-import com.perimeterx.msdk.PXManager;
 
 import java.io.IOException;
 
@@ -31,12 +29,12 @@ public final class KSRequestInterceptor implements Interceptor {
   }
 
   private Request request(final @NonNull Request initialRequest) {
-    Request.Builder builder = initialRequest.newBuilder()
+    final Request.Builder builder = initialRequest.newBuilder()
             .header("Kickstarter-Android-App", this.build.versionCode().toString())
             .header("Kickstarter-App-Id", this.build.applicationId())
             .header("Accept-Language", I18nUtils.language());
 
-    pxManager.addHeaderTo(builder);
+    this.pxManager.addHeaderTo(builder);
     return builder.build();
   }
 }

--- a/app/src/main/java/com/kickstarter/services/interceptors/KSRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/KSRequestInterceptor.java
@@ -2,6 +2,7 @@ package com.kickstarter.services.interceptors;
 
 import com.kickstarter.libs.Build;
 import com.kickstarter.libs.utils.I18nUtils;
+import com.perimeterx.msdk.PXManager;
 
 import java.io.IOException;
 
@@ -16,7 +17,7 @@ import okhttp3.Response;
 public final class KSRequestInterceptor implements Interceptor {
   private final Build build;
 
-  public KSRequestInterceptor(final @NonNull Build build) {
+  public KSRequestInterceptor(final @NonNull Build build, PXManager manager) {
     this.build = build;
   }
 

--- a/app/src/main/java/com/kickstarter/services/interceptors/KSRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/KSRequestInterceptor.java
@@ -1,6 +1,7 @@
 package com.kickstarter.services.interceptors;
 
 import com.kickstarter.libs.Build;
+import com.kickstarter.libs.perimeterx.PerimeterXClientType;
 import com.kickstarter.libs.utils.I18nUtils;
 import com.perimeterx.msdk.PXManager;
 
@@ -17,7 +18,7 @@ import okhttp3.Response;
 public final class KSRequestInterceptor implements Interceptor {
   private final Build build;
 
-  public KSRequestInterceptor(final @NonNull Build build, PXManager manager) {
+  public KSRequestInterceptor(final @NonNull Build build, PerimeterXClientType manager) {
     this.build = build;
   }
 

--- a/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import com.kickstarter.libs.Build;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.InternalToolsType;
+import com.kickstarter.libs.perimeterx.PerimeterXClientType;
 import com.kickstarter.libs.utils.WebUtils;
 import com.kickstarter.services.KSUri;
 import com.perimeterx.msdk.PXManager;
@@ -28,7 +29,7 @@ public final class WebRequestInterceptor implements Interceptor {
   private final @NonNull Build build;
 
   public WebRequestInterceptor(final @NonNull CurrentUserType currentUser, final @NonNull String endpoint,
-                               final @NonNull InternalToolsType internalTools, final @NonNull Build build, PXManager manager) {
+                               final @NonNull InternalToolsType internalTools, final @NonNull Build build, PerimeterXClientType manager) {
     this.currentUser = currentUser;
     this.endpoint = endpoint;
     this.internalTools = internalTools;

--- a/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
@@ -29,7 +29,8 @@ public final class WebRequestInterceptor implements Interceptor {
   private final @NonNull PerimeterXClientType pxManager;
 
   public WebRequestInterceptor(final @NonNull CurrentUserType currentUser, final @NonNull String endpoint,
-                               final @NonNull InternalToolsType internalTools, final @NonNull Build build, PerimeterXClientType manager) {
+                               final @NonNull InternalToolsType internalTools, final @NonNull Build build,
+                               final @NonNull PerimeterXClientType manager) {
     this.currentUser = currentUser;
     this.endpoint = endpoint;
     this.internalTools = internalTools;
@@ -57,7 +58,7 @@ public final class WebRequestInterceptor implements Interceptor {
       requestBuilder.addHeader("Authorization", basicAuthorizationHeader);
     }
 
-    pxManager.addHeaderTo(requestBuilder);
+    this.pxManager.addHeaderTo(requestBuilder);
 
     return requestBuilder.build();
   }

--- a/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
@@ -7,6 +7,7 @@ import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.InternalToolsType;
 import com.kickstarter.libs.utils.WebUtils;
 import com.kickstarter.services.KSUri;
+import com.perimeterx.msdk.PXManager;
 
 import java.io.IOException;
 
@@ -27,7 +28,7 @@ public final class WebRequestInterceptor implements Interceptor {
   private final @NonNull Build build;
 
   public WebRequestInterceptor(final @NonNull CurrentUserType currentUser, final @NonNull String endpoint,
-    final @NonNull InternalToolsType internalTools, final @NonNull Build build) {
+                               final @NonNull InternalToolsType internalTools, final @NonNull Build build, PXManager manager) {
     this.currentUser = currentUser;
     this.endpoint = endpoint;
     this.internalTools = internalTools;

--- a/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
@@ -8,7 +8,6 @@ import com.kickstarter.libs.InternalToolsType;
 import com.kickstarter.libs.perimeterx.PerimeterXClientType;
 import com.kickstarter.libs.utils.WebUtils;
 import com.kickstarter.services.KSUri;
-import com.perimeterx.msdk.PXManager;
 
 import java.io.IOException;
 

--- a/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.java
@@ -27,6 +27,7 @@ public final class WebRequestInterceptor implements Interceptor {
   private final @NonNull String endpoint;
   private final @NonNull InternalToolsType internalTools;
   private final @NonNull Build build;
+  private final @NonNull PerimeterXClientType pxManager;
 
   public WebRequestInterceptor(final @NonNull CurrentUserType currentUser, final @NonNull String endpoint,
                                final @NonNull InternalToolsType internalTools, final @NonNull Build build, PerimeterXClientType manager) {
@@ -34,6 +35,7 @@ public final class WebRequestInterceptor implements Interceptor {
     this.endpoint = endpoint;
     this.internalTools = internalTools;
     this.build = build;
+    this.pxManager = manager;
   }
 
   @Override
@@ -55,6 +57,8 @@ public final class WebRequestInterceptor implements Interceptor {
     } else if (shouldAddBasicAuthorizationHeader(initialRequest) && isNotNull(basicAuthorizationHeader)) {
       requestBuilder.addHeader("Authorization", basicAuthorizationHeader);
     }
+
+    pxManager.addHeaderTo(requestBuilder);
 
     return requestBuilder.build();
   }

--- a/app/src/main/java/com/kickstarter/ui/views/KSWebView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/KSWebView.kt
@@ -10,6 +10,7 @@ import android.webkit.WebView.setWebContentsDebuggingEnabled
 import android.widget.FrameLayout
 import com.kickstarter.KSApplication
 import com.kickstarter.R
+import com.kickstarter.libs.Build
 import com.kickstarter.libs.WebViewJavascriptInterface
 import com.kickstarter.services.KSWebViewClient
 import com.kickstarter.services.RequestHandler
@@ -52,7 +53,9 @@ class KSWebView : FrameLayout, KSWebViewClient.Delegate {
             internal_web_view.settings.allowFileAccess = false
             this.client.setDelegate(this)
 
-            setWebContentsDebuggingEnabled(true)
+            if (Build.isInternal()) {
+                setWebContentsDebuggingEnabled(true)
+            }
 
             internal_web_view.addJavascriptInterface(WebViewJavascriptInterface(this.client), "WebViewJavascriptInterface")
 

--- a/config/KSWebViewClient.java
+++ b/config/KSWebViewClient.java
@@ -12,6 +12,7 @@ import com.kickstarter.libs.FormContents;
 import java.util.List;
 
 import okhttp3.OkHttpClient;
+import com.kickstarter.libs.perimeterx.PerimeterXClientType;
 
 public final class KSWebViewClient extends WebViewClient {
 

--- a/config/KSWebViewClient.java
+++ b/config/KSWebViewClient.java
@@ -23,12 +23,14 @@ public final class KSWebViewClient extends WebViewClient {
     void onReceivedError(final @NonNull String url);
   }
 
-  public KSWebViewClient(final @NonNull OkHttpClient client, final @NonNull String webEndpoint) {
-    this(client, webEndpoint, null);
+  public KSWebViewClient(final @NonNull OkHttpClient client, final @NonNull String webEndpoint, final @NonNull PerimeterXClientType manager) {
+    this(client, webEndpoint, null, manager);
   }
 
-  public KSWebViewClient(final @NonNull OkHttpClient client, final @NonNull String webEndpoint,
-    final @Nullable Delegate delegate) {
+  public KSWebViewClient(final @NonNull OkHttpClient client,
+                         final @NonNull String webEndpoint,
+                         final @Nullable Delegate delegate,
+                         final @NonNull PerimeterXClientType manager) {
   }
 
   public void setDelegate(final @Nullable Delegate delegate) {


### PR DESCRIPTION
# 📲 What
Due to the recent security issues we are adding a new authorization layer
- Added dependency
- For each Interceptor, the header is added

|  |  |

# 📋 QA
- Launch the app, open the network profiles, on the request you should see the header.
- Also take a look into: https://github.com/kickstarter/native-secrets/pull/80 having that PR merged is a requirement for this one.
[NT-1768: PerimeterX](https://kickstarter.atlassian.net/browse/NT-1768)