### PR TITLE
NT-1777:Refactor Picasso code due to integrate firebase in-app sdk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -226,7 +226,7 @@ dependencies {
     final okhttp_version = "4.8.+"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp_version"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttp_version"
-    implementation "com.squareup.picasso:picasso:2.5.2"
+
     final retrofit_version = "2.9.+"
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:adapter-rxjava:$retrofit_version"
@@ -251,6 +251,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics-ktx'
     implementation 'com.google.firebase:firebase-perf-ktx'
     implementation "com.google.firebase:firebase-messaging"
+    implementation 'com.google.firebase:firebase-inappmessaging-display'
 
     // Testing
     testImplementation "junit:junit:4.12"

--- a/app/src/main/java/com/kickstarter/libs/PushNotifications.java
+++ b/app/src/main/java/com/kickstarter/libs/PushNotifications.java
@@ -11,6 +11,12 @@ import android.graphics.Bitmap;
 import android.os.Build;
 import android.util.Pair;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.TaskStackBuilder;
+import androidx.core.content.ContextCompat;
+
 import com.kickstarter.R;
 import com.kickstarter.libs.qualifiers.ApplicationContext;
 import com.kickstarter.libs.transformations.CircleTransformation;
@@ -37,11 +43,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.app.NotificationCompat;
-import androidx.core.app.TaskStackBuilder;
-import androidx.core.content.ContextCompat;
 import rx.Observable;
 import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
@@ -408,7 +409,7 @@ public final class PushNotifications {
     }
 
     try {
-      RequestCreator requestCreator = Picasso.with(this.context).load(url).transform(new CropSquareTransformation());
+      RequestCreator requestCreator =  Picasso.get().load(url).transform(new CropSquareTransformation());
       if (transformIntoCircle) {
         requestCreator = requestCreator.transform(new CircleTransformation());
       }

--- a/app/src/main/java/com/kickstarter/ui/activities/EditProfileActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/EditProfileActivity.kt
@@ -27,7 +27,7 @@ class EditProfileActivity : BaseActivity<EditProfileViewModel.ViewModel>() {
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
                 .subscribe { url ->
-                    Picasso.with(this).load(url).transform(CircleTransformation()).into(avatar_image_view)
+                    Picasso.get().load(url).transform(CircleTransformation()).into(avatar_image_view)
                 }
 
         this.viewModel.outputs.user()

--- a/app/src/main/java/com/kickstarter/ui/activities/ProfileActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProfileActivity.kt
@@ -41,7 +41,7 @@ class ProfileActivity : BaseActivity<ProfileViewModel.ViewModel>() {
         this.viewModel.outputs.avatarImageViewUrl()
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
-                .subscribe { url -> Picasso.with(this).load(url).transform(CircleTransformation()).into(avatar_image_view) }
+                .subscribe { url ->  Picasso.get().load(url).transform(CircleTransformation()).into(avatar_image_view) }
 
         this.viewModel.outputs.backedCountTextViewHidden()
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
@@ -44,7 +44,7 @@ class SettingsActivity : BaseActivity<SettingsViewModel.ViewModel>() {
         this.viewModel.outputs.avatarImageViewUrl()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
-                .subscribe { url -> Picasso.with(this).load(url).transform(CircleTransformation()).into(profile_picture_image_view) }
+                .subscribe { url ->  Picasso.get().load(url).transform(CircleTransformation()).into(profile_picture_image_view) }
 
         this.viewModel.outputs.logout()
                 .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -15,7 +15,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.jakewharton.rxbinding.view.RxView
 import com.kickstarter.R
-import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.Either
 import com.kickstarter.libs.SwipeRefresher
@@ -28,6 +27,7 @@ import com.kickstarter.models.Reward
 import com.kickstarter.ui.adapters.RewardAndAddOnsAdapter
 import com.kickstarter.ui.data.PledgeStatusData
 import com.kickstarter.ui.data.ProjectData
+import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.viewmodels.BackingFragmentViewModel
 import com.squareup.picasso.Picasso
 import kotlinx.android.synthetic.main.fragment_backing.*
@@ -296,7 +296,7 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>() {
 
     private fun setBackerImageView(url: String) {
         context?.apply {
-            Picasso.with(this).load(url)
+            Picasso.get().load(url)
                     .transform(CircleTransformation())
                     .into(backing_avatar)
         }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ActivitySampleFriendBackingViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ActivitySampleFriendBackingViewHolder.kt
@@ -23,13 +23,12 @@ class ActivitySampleFriendBackingViewHolder(
     }
 
     override fun onBind() {
-        val context = context()
         val user = activity?.user()
         val project = activity?.project()
         if (user != null && project != null) {
             binding.activityTitle.visibility = View.GONE
             user.avatar().small()?.let {
-                Picasso.with(context).load(it)
+                Picasso.get().load(it)
                     .transform(CircleTransformation())
                     .into(binding.activityImage)
             }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ActivitySampleFriendFollowViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ActivitySampleFriendFollowViewHolder.kt
@@ -25,10 +25,9 @@ class ActivitySampleFriendFollowViewHolder(
     }
 
     override fun onBind() {
-        val context = context()
         activity?.user()?.let { user ->
             user.avatar()?.small()?.let {
-                Picasso.with(context).load(it)
+                Picasso.get().load(it)
                     .transform(CircleTransformation())
                     .into(binding.activityImage)
             }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ActivitySampleProjectViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ActivitySampleProjectViewHolder.kt
@@ -32,7 +32,7 @@ class ActivitySampleProjectViewHolder(
         activity?.project()?.let { project ->
             val photo = project.photo()
             photo?.let {
-                Picasso.with(context)
+                Picasso.get()
                     .load(photo.little())
                     .into(binding.activityImage)
             }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CommentViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CommentViewHolder.kt
@@ -43,7 +43,7 @@ class CommentViewHolder(private val binding: CommentCardViewBinding) : KSViewHol
                 }
 
             comment.author()?.avatar()?.small()?.let {
-                Picasso.with(context).load(it)
+                Picasso.get().load(it)
                     .transform(CircleTransformation())
                     .into(binding.avatar)
             }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/FeaturedSearchResultViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/FeaturedSearchResultViewHolder.kt
@@ -54,7 +54,7 @@ class FeaturedSearchResultViewHolder(
     }
 
     private fun setProjectImageUrl(imageUrl: String) {
-        Picasso.with(context()).load(imageUrl).into(binding.projectImageView)
+        Picasso.get().load(imageUrl).into(binding.projectImageView)
     }
 
     override fun onClick(view: View) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/FriendBackingViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/FriendBackingViewHolder.kt
@@ -26,7 +26,7 @@ class FriendBackingViewHolder(
         val projectCategory = activityProject.category() ?: return
         val projectPhoto = activityProject.photo() ?: return
         activityUser.avatar().small()?.let {
-            Picasso.with(context)
+            Picasso.get()
                 .load(it)
                 .transform(CircleTransformation())
                 .into(binding.avatar)
@@ -34,7 +34,7 @@ class FriendBackingViewHolder(
 
         binding.creatorName.text = ksString.format(context.getString(R.string.project_creator_by_creator), "creator_name", projectCreator.name())
         binding.projectName.text = activityProject.name()
-        Picasso.with(context)
+        Picasso.get()
             .load(projectPhoto.little())
             .into(binding.projectPhoto)
         binding.title.text = SocialUtils.friendBackingActivityTitle(

--- a/app/src/main/java/com/kickstarter/ui/viewholders/FriendFollowViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/FriendFollowViewHolder.kt
@@ -12,7 +12,7 @@ class FriendFollowViewHolder(private val binding: ActivityFriendFollowViewBindin
         val context = context()
         val friend = activity().user() ?: return
         friend.avatar().small()?.let {
-            Picasso.with(context)
+            Picasso.get()
                 .load(it)
                 .transform(CircleTransformation())
                 .into(binding.avatar)

--- a/app/src/main/java/com/kickstarter/ui/viewholders/MessageThreadViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/MessageThreadViewHolder.kt
@@ -47,7 +47,7 @@ class MessageThreadViewHolder(private val binding: MessageThreadViewBinding) : K
     }
 
     private fun setParticipantAvatarImageView(avatarUrl: String) {
-        Picasso.with(context()).load(avatarUrl)
+        Picasso.get().load(avatarUrl)
             .transform(CircleTransformation())
             .into(binding.participantAvatarImageView)
     }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/MessageViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/MessageViewHolder.kt
@@ -60,7 +60,7 @@ class MessageViewHolder(private val binding: MessageViewBinding) : KSViewHolder(
     }
 
     private fun setParticipantAvatarImageView(avatarUrl: String) {
-        Picasso.with(context()).load(avatarUrl)
+        Picasso.get().load(avatarUrl)
             .transform(CircleTransformation())
             .into(binding.messageSenderAvatarImageView)
     }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProfileCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProfileCardViewHolder.kt
@@ -32,9 +32,11 @@ class ProfileCardViewHolder(
         if (photo != null) {
             binding.profileCardImage.apply {
                 visibility = View.VISIBLE
-                Picasso.with(context()).load(photo.med())
-                    .placeholder(ContextCompat.getDrawable(context,R.drawable.gray_gradient))
-                    .into(this)
+                ContextCompat.getDrawable(context, R.drawable.gray_gradient)?.let {
+                    Picasso.get().load(photo.med())
+                        .placeholder(it)
+                        .into(this)
+                }
             }
         }
         binding.profileCardName.text = project?.name()

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectCardViewHolder.kt
@@ -213,12 +213,14 @@ class ProjectCardViewHolder(
 
         binding.projectCardPhoto.photo.maxHeight = targetImageHeight
         avatarUrl?.let {
-            Picasso.with(context())
-                .load(it)
-                .resize(targetImageWidth, targetImageHeight) // required to fit properly into apis < 18
-                .centerCrop()
-                .placeholder(ResourcesCompat.getDrawable(context().resources, R.drawable.gray_gradient, null))
-                .into(binding.projectCardPhoto.photo)
+            ResourcesCompat.getDrawable(context().resources, R.drawable.gray_gradient, null)?.let { placeholder ->
+                Picasso.get()
+                    .load(it)
+                    .resize(targetImageWidth, targetImageHeight) // required to fit properly into apis < 18
+                    .centerCrop()
+                    .placeholder(placeholder)
+                    .into(binding.projectCardPhoto.photo)
+            }
         }
     }
 
@@ -227,7 +229,7 @@ class ProjectCardViewHolder(
     }
 
     private fun setFriendAvatarUrl(avatarUrl: String, imageView: ImageView) {
-        Picasso.with(context()).load(avatarUrl)
+        Picasso.get().load(avatarUrl)
             .transform(CircleTransformation())
             .into(imageView)
     }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectContextViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectContextViewHolder.kt
@@ -30,7 +30,7 @@ class ProjectContextViewHolder(
         val photo = project?.photo()
         if (photo != null) {
             binding.projectContextImageView.visibility = View.VISIBLE
-            Picasso.with(context()).load(photo.full()).into(binding.projectContextImageView)
+            Picasso.get().load(photo.full()).into(binding.projectContextImageView)
         } else {
             binding.projectContextImageView.visibility = View.INVISIBLE
         }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectSearchResultViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectSearchResultViewHolder.kt
@@ -53,7 +53,7 @@ class ProjectSearchResultViewHolder(private val binding: ProjectSearchResultView
     }
 
     private fun setProjectImageUrl(imageUrl: String) {
-        Picasso.with(context()).load(imageUrl).into(binding.projectImageView)
+        Picasso.get().load(imageUrl).into(binding.projectImageView)
     }
 
     override fun onClick(view: View) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectSocialViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectSocialViewHolder.kt
@@ -15,7 +15,7 @@ class ProjectSocialViewHolder(private val binding: ProjectSocialViewBinding) : K
 
     override fun onBind() {
         user?.avatar()?.small()?.let {
-            Picasso.with(context())
+            Picasso.get()
                 .load(it)
                 .transform(CircleTransformation())
                 .into(binding.friendImage)

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectStateChangedPositiveViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectStateChangedPositiveViewHolder.kt
@@ -75,7 +75,7 @@ class ProjectStateChangedPositiveViewHolder(
             }
             // TODO: Switch to "You launched a project" if current user launched
             // return context.getString(R.string.creator_launched_a_project, activity.user().name(), activity.project().name());
-            Picasso.with(context)
+            Picasso.get()
                 .load(photo.full())
                 .into(binding.projectPhoto)
         }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectStateChangedViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectStateChangedViewHolder.kt
@@ -22,7 +22,7 @@ class ProjectStateChangedViewHolder(
         val user = activity().user()
         val photo = project?.photo()
         if (project != null && user != null && photo != null) {
-            Picasso.with(context())
+            Picasso.get()
                 .load(photo.little())
                 .into(binding.projectPhoto)
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectUpdateViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectUpdateViewHolder.kt
@@ -31,7 +31,7 @@ class ProjectUpdateViewHolder(
         if (project != null && user != null && photo != null && update != null) {
             val publishedAt = ObjectUtils.coalesce(update.publishedAt(), DateTime())
             binding.projectName.text = project.name()
-            Picasso.with(context)
+            Picasso.get()
                 .load(photo.little())
                 .into(binding.projectPhoto)
             binding.timestamp.text = DateTimeUtils.relative(context, ksString, publishedAt)

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectViewHolder.kt
@@ -55,7 +55,7 @@ class ProjectViewHolder(
         } else {
             binding.avatar
         }
-        Picasso.with(context())
+        Picasso.get()
             .load(url)
             .transform(CircleTransformation())
             .into(avatarImageView)
@@ -65,7 +65,7 @@ class ProjectViewHolder(
         } else {
             binding.creatorAvatarVerified?.avatarVariant
         }
-        Picasso.with(context())
+        Picasso.get()
             .load(url)
             .transform(CircleTransformation())
             .into(avatarVariantImageView)
@@ -123,12 +123,14 @@ class ProjectViewHolder(
         val targetImageHeight = ProjectUtils.photoHeightFromWidthRatio(targetImageWidth)
         binding.projectMediaHeaderLayout.projectPhoto.maxHeight = targetImageHeight
 
-        Picasso.with(context())
-            .load(photo.full())
-            .resize(targetImageWidth, targetImageHeight)
-            .centerCrop()
-            .placeholder(ResourcesCompat.getDrawable(context().resources, R.drawable.gray_gradient, null))
-            .into(binding.projectMediaHeaderLayout.projectPhoto)
+        ResourcesCompat.getDrawable(context().resources, R.drawable.gray_gradient, null)?.let {
+            Picasso.get()
+                .load(photo.full())
+                .resize(targetImageWidth, targetImageHeight)
+                .centerCrop()
+                .placeholder(it)
+                .into(binding.projectMediaHeaderLayout.projectPhoto)
+        }
     }
 
     private fun setCanceledProjectStateView() {
@@ -503,7 +505,7 @@ class ProjectViewHolder(
             .compose(observeForUI())
             .subscribe { url: String? ->
                 url?.let {
-                    Picasso.with(context())
+                    Picasso.get()
                         .load(it)
                         .transform(CircleTransformation())
                         .into(binding.projectSocialImage)

--- a/app/src/main/java/com/kickstarter/ui/viewholders/SurveyViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/SurveyViewHolder.kt
@@ -42,7 +42,7 @@ class SurveyViewHolder(private val binding: ActivitySurveyViewBinding) :
     }
 
     private fun setCreatorAvatarImage(creatorAvatarImage: String) {
-        Picasso.with(context())
+        Picasso.get()
             .load(creatorAvatarImage)
             .transform(CircleTransformation())
             .into(binding.surveyAvatarImage)

--- a/app/src/main/java/com/kickstarter/ui/viewholders/discoverydrawer/LoggedInViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/discoverydrawer/LoggedInViewHolder.kt
@@ -32,7 +32,7 @@ class LoggedInViewHolder(private val binding: DiscoveryDrawerLoggedInViewBinding
                 .compose(bindToLifecycle())
                 .compose(observeForUI())
                 .subscribe {
-                    Picasso.with(context())
+                    Picasso.get()
                             .load(it)
                             .transform(CircleTransformation())
                             .into(binding.userImageView)


### PR DESCRIPTION
# 📲 What

Change Picasso call in viewholder to Picasso.get()

# 🤔 Why

Integrating firebase in-app messaging sdk user higher version from Picasso lib

# 🛠 How
Change Picasso call in viewholder from Picasso.with(context) to Picasso.get()

# 👀 See
<img width="693" alt="Screen Shot 2021-02-17 at 7 08 14 PM" src="https://user-images.githubusercontent.com/1075310/108240452-8a36bf00-7153-11eb-9908-5c17f4c419e4.png">


| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA
test all lists that have images to show

# Story 📖

https://kickstarter.atlassian.net/browse/NT-1777
