### PR TITLE
EP-220: Create event for Checkout screen viewed

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -8,10 +8,12 @@ import com.kickstarter.libs.utils.EventContext.CtaContextName.PLEDGE_SUBMIT
 import com.kickstarter.libs.utils.EventContext.CtaContextName.REWARD_CONTINUE
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.AnalyticEventsUtils
+import com.kickstarter.libs.utils.EventContext
 import com.kickstarter.libs.utils.EventContext.PageViewedContextName.ADD_ONS
 import com.kickstarter.libs.utils.EventContext.ContextPropertyName.CONTEXT_CTA
 import com.kickstarter.libs.utils.EventContext.ContextPropertyName.CONTEXT_TYPE
 import com.kickstarter.libs.utils.EventContext.ContextPropertyName.CONTEXT_PAGE
+import com.kickstarter.libs.utils.EventContext.PageViewedContextName.CHECKOUT
 import com.kickstarter.libs.utils.ExperimentData
 import com.kickstarter.models.Activity
 import com.kickstarter.models.Project
@@ -615,6 +617,18 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
     fun trackCheckoutPaymentPageViewed(pledgeData: PledgeData) {
         val props = AnalyticEventsUtils.pledgeDataProperties(pledgeData, client.loggedInUser())
         client.track(CHECKOUT_PAYMENT_PAGE_VIEWED, props)
+    }
+
+    /**
+     * Sends data to the client when the checkout screen is loaded.
+     *
+     * @param checkoutData: The checkout data.
+     * @param pledgeData: The selected pledge data.
+     */
+    fun trackCheckoutScreenViewed(checkoutData: CheckoutData, pledgeData: PledgeData) {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to CHECKOUT.contextName)
+        props.putAll(AnalyticEventsUtils.checkoutDataProperties(checkoutData, pledgeData, client.loggedInUser()))
+        client.track(EventName.PAGE_VIEWED.eventName, props)
     }
 
     fun trackPledgeSubmitButtonClicked(checkoutData: CheckoutData, pledgeData: PledgeData) {

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -11,6 +11,7 @@ import com.kickstarter.libs.MockSharedPreferences
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.models.Country
 import com.kickstarter.libs.utils.DateTimeUtils
+import com.kickstarter.libs.utils.EventContext
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.RefTagUtils
 import com.kickstarter.libs.utils.extensions.trimAllWhitespace
@@ -33,6 +34,7 @@ import rx.observers.TestSubscriber
 import java.math.RoundingMode
 import java.net.CookieManager
 import java.util.*
+import kotlin.math.E
 
 class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
@@ -424,7 +426,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingRulesSectionIsGone.assertValue(false)
         this.shippingSummaryIsGone.assertNoValues()
         this.totalDividerIsGone.assertValue(false)
-        this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertValue("Checkout Payment Page Viewed")
     }
 
@@ -446,8 +448,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertNoValues()
         this.totalDividerIsGone.assertValue(false)
 
-        this.lakeTest.assertValue("Checkout Payment Page Viewed")
-        this.experimentsTest.assertValue("Checkout Payment Page Viewed")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
     @Test
@@ -472,7 +474,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertNoValues()
         this.totalDividerIsGone.assertValue(false)
 
-        this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertValue("Checkout Payment Page Viewed")
     }
 
@@ -496,7 +498,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertNoValues()
         this.totalDividerIsGone.assertValue(false)
 
-        this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertValue("Checkout Payment Page Viewed")
     }
 
@@ -1062,8 +1064,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.pledgeButtonIsEnabled.assertValue(true)
         this.vm.inputs.pledgeButtonClicked()
 
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -1266,7 +1268,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.newCardButtonClicked()
         this.showNewCardFragment.assertValue(project)
-        this.lakeTest.assertValue("Checkout Payment Page Viewed")
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -1939,8 +1941,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Checkout Payment Page Viewed",  EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -1960,8 +1962,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -1985,8 +1987,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName,"Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -2013,8 +2015,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertValueCount(1)
         this.showSCAFlow.assertNoValues()
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -2041,8 +2043,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertNoValues()
         this.showSCAFlow.assertValueCount(1)
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
 
         this.vm.inputs.stripeSetupResultSuccessful(StripeIntentResult.Outcome.SUCCEEDED)
@@ -2083,8 +2085,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertValueCount(1)
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 
@@ -2120,8 +2122,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertValueCount(1)
-        this.lakeTest.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
-        this.segmentTrack.assertValues("Checkout Payment Page Viewed", "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Checkout Payment Page Viewed", EventName.PAGE_VIEWED.eventName, "Pledge Submit Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Checkout Payment Page Viewed")
     }
 


### PR DESCRIPTION
# 📲 What

- Added track event for add-ons screen that fires when the `PledgeViewFragmentViewModel` is loaded.

# 🤔 Why

Segement integration. 

# 🛠 How

- Created a new function in the AnalyticsEvents class that handles sending the event name and properties to the client.
- Added this function to the `PledgeViewFragmentViewModel` when the initialization method is called.
- This event only fires when the checkout is loaded from a new pledge, this does not fire when updating or managing a pledge. 
- 
# 👀 See

This is the screen that fires this event:
![Screenshot_1613674651](https://user-images.githubusercontent.com/19390326/108407577-e819e400-71f1-11eb-9e18-1647c46ba39b.png)

# 📋 QA

- Tap on a live project 
- Tap "Back this project" CTA at bottom of screen
- Select a reward or no reward
- If project has add-ons, press skip CTA or choose an addon and press continue
- Both Segment (Page Viewed) and DataLake (Checkout Payment Page Viewed) should appear in the segment dashboard.
You should see `context_page = "checkout" in the list of properties
<img width="529" alt="Screen Shot 2021-02-18 at 1 55 01 PM" src="https://user-images.githubusercontent.com/19390326/108407912-5f4f7800-71f2-11eb-8db5-ae2c139649c4.png">
<img width="780" alt="Screen Shot 2021-02-18 at 1 56 50 PM" src="https://user-images.githubusercontent.com/19390326/108407919-624a6880-71f2-11eb-8206-4a5b61bcf87e.png">

# Story 📖

[EP-220: Android Page Viewed (checkout)](https://kickstarter.atlassian.net/browse/EP-220)
