### PR TITLE
EP-221: Create event for Rewards Carousel viewed

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -743,7 +743,7 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
     /**
      * Sends data to the client when the rewards carousel is loaded.
      *
-     * @param pledgeData: The selected pledge data.
+     * @param projectData: The selected project data.
      */
     fun trackRewardsCarouselViewed(projectData: ProjectData) {
         val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to REWARDS.contextName)

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -9,6 +9,7 @@ import com.kickstarter.libs.utils.EventContextValues.CtaContextName.REWARD_CONTI
 import com.kickstarter.libs.utils.AnalyticEventsUtils
 import com.kickstarter.libs.utils.EventContextValues.PageViewedContextName.ADD_ONS
 import com.kickstarter.libs.utils.EventContextValues.PageViewedContextName.CHECKOUT
+import com.kickstarter.libs.utils.EventContextValues.PageViewedContextName.REWARDS
 import com.kickstarter.libs.utils.EventName.CTA_CLICKED
 import com.kickstarter.libs.utils.EventName.PAGE_VIEWED
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_CTA
@@ -737,6 +738,17 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA.contextName to ADD_ONS_CONTINUE.contextName)
         props.putAll(AnalyticEventsUtils.pledgeDataProperties(pledgeData, client.loggedInUser()))
         client.track(CTA_CLICKED.eventName, props)
+    }
+
+    /**
+     * Sends data to the client when the rewards carousel is loaded.
+     *
+     * @param pledgeData: The selected pledge data.
+     */
+    fun trackRewardsCarouselViewed(projectData: ProjectData) {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to REWARDS.contextName)
+        props.putAll(AnalyticEventsUtils.projectProperties(projectData.project(), client.loggedInUser()))
+        client.track(PAGE_VIEWED.eventName, props)
     }
 
     //endregion

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -72,6 +72,10 @@ class RewardsFragmentViewModel {
 
         init {
 
+            projectData
+                    .compose(bindToLifecycle())
+                    .subscribe{ this.lake.trackRewardsCarouselViewed(it)}
+
             this.projectDataInput
                     .map { filterOutNotStartedRewards(it) }
                     .compose(bindToLifecycle())
@@ -79,7 +83,7 @@ class RewardsFragmentViewModel {
 
             val project = this.projectData
                     .map { it.project() }
-            
+
             project
                     .filter { it.isBacking }
                     .map { indexOfBackedReward(it) }

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
@@ -4,6 +4,7 @@ import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.EventName
 import com.kickstarter.mock.factories.BackingFactory
 import com.kickstarter.mock.factories.ProjectDataFactory
 import com.kickstarter.mock.factories.ProjectFactory
@@ -36,6 +37,16 @@ class RewardsFragmentViewModelTest: KSRobolectricTestCase() {
         this.vm.outputs.showPledgeFragment().subscribe(this.showPledgeFragment)
         this.vm.outputs.showAddOnsFragment().subscribe(this.showAddOnsFragment)
         this.vm.outputs.showAlert().subscribe(this.showAlert)
+    }
+
+    @Test
+    fun init_whenViewModelInstantiated_shouldSendPagedViewedEventToClient() {
+        val project = ProjectFactory.project()
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(ProjectDataFactory.project(project))
+
+        this.lakeTest.assertValue(EventName.PAGE_VIEWED.eventName)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- Added track event for the rewards carousel screen that fires when the `RewardsFragmentViewModel` is loaded.

# 🤔 Why

Segment Integration. 

# 🛠 How

- Created a new function to our AnalyticsEvents class that handles sending the event name and properties to the client.
- Added this function to our `RewardsFragmentViewModel` when this vm is initialized.

# 👀 See

This is the screen that triggers the event:
![Screenshot_1613763673](https://user-images.githubusercontent.com/19390326/108562021-36e87c00-72cd-11eb-9d9c-2b56733d6577.png)

# 📋 QA

- Select any project
- Tap "Back this project"
- This should open the rewards carousel
- Segment (Page Viewed) should appear in the segment dashboard. There is no datalake event for this analytic event.
- Tapping "Page Viewed"  in segment should show the list of properties sent with this event.
<img width="795" alt="Screen Shot 2021-02-19 at 2 44 01 PM" src="https://user-images.githubusercontent.com/19390326/108562191-7fa03500-72cd-11eb-9c13-80d7f27962a2.png">
<img width="775" alt="Screen Shot 2021-02-19 at 2 44 06 PM" src="https://user-images.githubusercontent.com/19390326/108562172-78792700-72cd-11eb-9f37-c2cd55257b10.png">

# Story 📖

[EP-221: Android: Page Viewed (rewards)](https://kickstarter.atlassian.net/browse/EP-222)
