### PR TITLE
EP-221: Create event for Project screen viewed

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -10,11 +10,13 @@ import com.kickstarter.libs.utils.AnalyticEventsUtils
 import com.kickstarter.libs.utils.EventContextValues.PageViewedContextName.ADD_ONS
 import com.kickstarter.libs.utils.EventContextValues.PageViewedContextName.CHECKOUT
 import com.kickstarter.libs.utils.EventContextValues.PageViewedContextName.REWARDS
+import com.kickstarter.libs.utils.EventContextValues.PageViewedContextName.PROJECT
 import com.kickstarter.libs.utils.EventName.CTA_CLICKED
 import com.kickstarter.libs.utils.EventName.PAGE_VIEWED
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_CTA
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_TYPE
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_PAGE
+import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_SECTION
 import com.kickstarter.libs.utils.ExperimentData
 import com.kickstarter.models.Activity
 import com.kickstarter.models.Project
@@ -597,6 +599,20 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
             props["context_pledge_flow"] = pledgeFlowContext.trackingString
         }
         client.track(PROJECT_PAGE_VIEWED, props)
+    }
+
+    /**
+     * Sends data to the client when the projects screen is loaded.
+     *
+     * @param pledgeData: The selected pledge data.
+     * @param pageSectionContext: The section of the project page being viewed.
+     */
+    fun trackProjectScreenViewed(projectData: ProjectData, pageSectionContext: String) {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to PROJECT.contextName)
+        props[CONTEXT_SECTION.contextName] = pageSectionContext
+        props.putAll(AnalyticEventsUtils.projectProperties(projectData.project(), client.loggedInUser()))
+        props.putAll(AnalyticEventsUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()))
+        client.track(PAGE_VIEWED.eventName, props)
     }
 
     fun trackSearchButtonClicked() {

--- a/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
@@ -37,4 +37,10 @@ class EventContextValues {
         REWARDS("rewards"),
         THANKS("thanks")
     }
+
+    enum class ProjectContextSectionName(val contextName: String) {
+        CAMPAIGN("campaign"),
+        OVERVIEW("overview"),
+        UPDATES("updates")
+    }
 }

--- a/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
@@ -40,6 +40,7 @@ class EventContextValues {
 
     enum class ProjectContextSectionName(val contextName: String) {
         CAMPAIGN("campaign"),
+        COMMENTS("comments"),
         OVERVIEW("overview"),
         UPDATES("updates")
     }

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectDataExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectDataExt.kt
@@ -1,0 +1,13 @@
+package com.kickstarter.libs.utils.extensions
+
+import android.content.SharedPreferences
+import com.kickstarter.libs.utils.RefTagUtils
+import com.kickstarter.ui.data.ProjectData
+import java.net.CookieManager
+
+fun ProjectData.storeCurrentCookieRefTag(cookieManager: CookieManager, sharedPreferences: SharedPreferences): ProjectData {
+        return this
+                .toBuilder()
+                .refTagFromCookie(RefTagUtils.storedCookieRefTagForProject(this.project(), cookieManager, sharedPreferences))
+                .build()
+    }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -612,15 +612,17 @@ class ProjectActivity : BaseActivity<ProjectViewModel.ViewModel>(), CancelPledge
         startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 
-    private fun startProjectUpdatesActivity(project: Project) {
+    private fun startProjectUpdatesActivity(projectAndData:  Pair<Project, ProjectData> ) {
         val intent = Intent(this, ProjectUpdatesActivity::class.java)
-                .putExtra(IntentKey.PROJECT, project)
+                .putExtra(IntentKey.PROJECT, projectAndData.first)
+                .putExtra(IntentKey.PROJECT_DATA, projectAndData.second)
         startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 
-    private fun startCommentsActivity(project: Project) {
+    private fun startCommentsActivity(projectAndData: Pair<Project, ProjectData>) {
         val intent = Intent(this, CommentsActivity::class.java)
-                .putExtra(IntentKey.PROJECT, project)
+                .putExtra(IntentKey.PROJECT, projectAndData.first)
+                .putExtra(IntentKey.PROJECT_DATA, projectAndData.second)
         startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectUpdatesActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectUpdatesActivity.java
@@ -15,7 +15,6 @@ import com.kickstarter.models.Project;
 import com.kickstarter.models.Update;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.adapters.UpdatesAdapter;
-import com.kickstarter.ui.data.ProjectData;
 import com.kickstarter.ui.toolbars.KSToolbar;
 import com.kickstarter.viewmodels.ProjectUpdatesViewModel;
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectUpdatesActivity.java
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectUpdatesActivity.java
@@ -15,6 +15,7 @@ import com.kickstarter.models.Project;
 import com.kickstarter.models.Update;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.adapters.UpdatesAdapter;
+import com.kickstarter.ui.data.ProjectData;
 import com.kickstarter.ui.toolbars.KSToolbar;
 import com.kickstarter.viewmodels.ProjectUpdatesViewModel;
 

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.java
@@ -9,6 +9,7 @@ import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Either;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.utils.BooleanUtils;
+import com.kickstarter.libs.utils.EventContextValues;
 import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.libs.utils.extensions.ProjectDataExtKt;
 import com.kickstarter.libs.utils.extensions.StringExt;
@@ -39,7 +40,6 @@ import static com.kickstarter.libs.rx.transformers.Transformers.ignoreValues;
 import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
 import static com.kickstarter.libs.rx.transformers.Transformers.takeWhen;
 import static com.kickstarter.libs.rx.transformers.Transformers.values;
-import static com.kickstarter.libs.utils.EventContextValues.ProjectContextSectionName;
 
 public interface CommentsViewModel {
 
@@ -133,7 +133,7 @@ public interface CommentsViewModel {
         .map(it -> ProjectDataExtKt.storeCurrentCookieRefTag(it, this.cookieManager, this.sharedPreferences))
         .compose(bindToLifecycle())
         .subscribe(
-          projectAndData -> this.lake.trackProjectScreenViewed(projectAndData, ProjectContextSectionName.COMMENTS.getContextName())
+          projectAndData -> this.lake.trackProjectScreenViewed(projectAndData, EventContextValues.ProjectContextSectionName.COMMENTS.getContextName())
         );
 
       final Observable<Project> initialProject = projectOrUpdate

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.java
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels;
 
+import android.content.SharedPreferences;
 import android.util.Pair;
 
 import com.kickstarter.libs.ActivityViewModel;
@@ -9,6 +10,7 @@ import com.kickstarter.libs.Either;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.utils.BooleanUtils;
 import com.kickstarter.libs.utils.ObjectUtils;
+import com.kickstarter.libs.utils.extensions.ProjectDataExtKt;
 import com.kickstarter.libs.utils.extensions.StringExt;
 import com.kickstarter.models.Comment;
 import com.kickstarter.models.Project;
@@ -20,7 +22,9 @@ import com.kickstarter.services.apiresponses.ErrorEnvelope;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.activities.CommentsActivity;
 import com.kickstarter.ui.adapters.data.CommentsData;
+import com.kickstarter.ui.data.ProjectData;
 
+import java.net.CookieManager;
 import java.util.List;
 
 import androidx.annotation.NonNull;
@@ -35,6 +39,7 @@ import static com.kickstarter.libs.rx.transformers.Transformers.ignoreValues;
 import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
 import static com.kickstarter.libs.rx.transformers.Transformers.takeWhen;
 import static com.kickstarter.libs.rx.transformers.Transformers.values;
+import static com.kickstarter.libs.utils.EventContextValues.ProjectContextSectionName.UPDATES;
 
 public interface CommentsViewModel {
 
@@ -92,13 +97,17 @@ public interface CommentsViewModel {
 
   final class ViewModel extends ActivityViewModel<CommentsActivity> implements Inputs, Outputs {
     private final ApiClientType client;
+    private final CookieManager cookieManager;
     private final CurrentUserType currentUser;
+    private final SharedPreferences sharedPreferences;
 
     public ViewModel(final @NonNull Environment environment) {
       super(environment);
 
       this.client = environment.apiClient();
+      this.cookieManager = environment.cookieManager();
       this.currentUser = environment.currentUser();
+      this.sharedPreferences = environment.sharedPreferences();
 
       final Observable<User> currentUser = Observable.merge(
         this.currentUser.observable(),
@@ -114,6 +123,18 @@ public interface CommentsViewModel {
             : new Either.Right<Project, Update>(i.getParcelableExtra(IntentKey.UPDATE));
         })
         .filter(ObjectUtils::isNotNull);
+
+      final Observable<ProjectData> projectData = intent()
+              .map(i -> i.getParcelableExtra(IntentKey.PROJECT_DATA))
+              .ofType(ProjectData.class)
+              .take(1);
+
+      projectData
+              .map(it -> ProjectDataExtKt.storeCurrentCookieRefTag(it, cookieManager, sharedPreferences))
+              .compose(bindToLifecycle())
+              .subscribe(
+                      projectAndData -> this.lake.trackProjectScreenViewed(projectAndData, UPDATES.getContextName())
+              );
 
       final Observable<Project> initialProject = projectOrUpdate
         .flatMap(pOrU ->

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.java
@@ -39,7 +39,7 @@ import static com.kickstarter.libs.rx.transformers.Transformers.ignoreValues;
 import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
 import static com.kickstarter.libs.rx.transformers.Transformers.takeWhen;
 import static com.kickstarter.libs.rx.transformers.Transformers.values;
-import static com.kickstarter.libs.utils.EventContextValues.ProjectContextSectionName.COMMENTS;
+import static com.kickstarter.libs.utils.EventContextValues.ProjectContextSectionName;
 
 public interface CommentsViewModel {
 
@@ -130,11 +130,11 @@ public interface CommentsViewModel {
               .take(1);
 
       projectData
-              .map(it -> ProjectDataExtKt.storeCurrentCookieRefTag(it, cookieManager, sharedPreferences))
-              .compose(bindToLifecycle())
-              .subscribe(
-                      projectAndData -> this.lake.trackProjectScreenViewed(projectAndData, COMMENTS.getContextName())
-              );
+        .map(it -> ProjectDataExtKt.storeCurrentCookieRefTag(it, this.cookieManager, this.sharedPreferences))
+        .compose(bindToLifecycle())
+        .subscribe(
+          projectAndData -> this.lake.trackProjectScreenViewed(projectAndData, ProjectContextSectionName.COMMENTS.getContextName())
+        );
 
       final Observable<Project> initialProject = projectOrUpdate
         .flatMap(pOrU ->

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.java
@@ -39,7 +39,7 @@ import static com.kickstarter.libs.rx.transformers.Transformers.ignoreValues;
 import static com.kickstarter.libs.rx.transformers.Transformers.neverError;
 import static com.kickstarter.libs.rx.transformers.Transformers.takeWhen;
 import static com.kickstarter.libs.rx.transformers.Transformers.values;
-import static com.kickstarter.libs.utils.EventContextValues.ProjectContextSectionName.UPDATES;
+import static com.kickstarter.libs.utils.EventContextValues.ProjectContextSectionName.COMMENTS;
 
 public interface CommentsViewModel {
 
@@ -133,7 +133,7 @@ public interface CommentsViewModel {
               .map(it -> ProjectDataExtKt.storeCurrentCookieRefTag(it, cookieManager, sharedPreferences))
               .compose(bindToLifecycle())
               .subscribe(
-                      projectAndData -> this.lake.trackProjectScreenViewed(projectAndData, UPDATES.getContextName())
+                      projectAndData -> this.lake.trackProjectScreenViewed(projectAndData, COMMENTS.getContextName())
               );
 
       final Observable<Project> initialProject = projectOrUpdate

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectUpdatesViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectUpdatesViewModel.java
@@ -28,7 +28,7 @@ import rx.subjects.PublishSubject;
 import static com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair;
 import static com.kickstarter.libs.rx.transformers.Transformers.takePairWhen;
 import static com.kickstarter.libs.rx.transformers.Transformers.takeWhen;
-import static com.kickstarter.libs.utils.EventContextValues.ProjectContextSectionName.UPDATES;
+import static com.kickstarter.libs.utils.EventContextValues.ProjectContextSectionName;
 
 public interface ProjectUpdatesViewModel {
 
@@ -80,10 +80,10 @@ public interface ProjectUpdatesViewModel {
         .take(1);
 
       projectData
-        .map(it -> ProjectDataExtKt.storeCurrentCookieRefTag(it, cookieManager, sharedPreferences))
+        .map(it -> ProjectDataExtKt.storeCurrentCookieRefTag(it, this.cookieManager, this.sharedPreferences))
         .compose(bindToLifecycle())
         .subscribe(
-           projectAndData -> this.lake.trackProjectScreenViewed(projectAndData, UPDATES.getContextName())
+          projectAndData -> this.lake.trackProjectScreenViewed(projectAndData, ProjectContextSectionName.UPDATES.getContextName())
         );
 
       final Observable<Project> startOverWith = Observable.merge(

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectUpdatesViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectUpdatesViewModel.java
@@ -7,6 +7,7 @@ import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.ApiPaginator;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.utils.BooleanUtils;
+import com.kickstarter.libs.utils.EventContextValues;
 import com.kickstarter.libs.utils.ListUtils;
 import com.kickstarter.libs.utils.extensions.ProjectDataExtKt;
 import com.kickstarter.models.Project;
@@ -28,7 +29,6 @@ import rx.subjects.PublishSubject;
 import static com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair;
 import static com.kickstarter.libs.rx.transformers.Transformers.takePairWhen;
 import static com.kickstarter.libs.rx.transformers.Transformers.takeWhen;
-import static com.kickstarter.libs.utils.EventContextValues.ProjectContextSectionName;
 
 public interface ProjectUpdatesViewModel {
 
@@ -83,7 +83,7 @@ public interface ProjectUpdatesViewModel {
         .map(it -> ProjectDataExtKt.storeCurrentCookieRefTag(it, this.cookieManager, this.sharedPreferences))
         .compose(bindToLifecycle())
         .subscribe(
-          projectAndData -> this.lake.trackProjectScreenViewed(projectAndData, ProjectContextSectionName.UPDATES.getContextName())
+          projectAndData -> this.lake.trackProjectScreenViewed(projectAndData, EventContextValues.ProjectContextSectionName.UPDATES.getContextName())
         );
 
       final Observable<Project> startOverWith = Observable.merge(

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -9,6 +9,7 @@ import com.kickstarter.libs.*
 import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.rx.transformers.Transformers.*
 import com.kickstarter.libs.utils.*
+import com.kickstarter.libs.utils.EventContextValues.ProjectContextSectionName.OVERVIEW
 import com.kickstarter.libs.utils.extensions.backedReward
 import com.kickstarter.libs.utils.extensions.isErrored
 import com.kickstarter.models.Backing
@@ -194,7 +195,7 @@ interface ProjectViewModel {
         fun startCampaignWebViewActivity(): Observable<ProjectData>
 
         /** Emits when we should start [com.kickstarter.ui.activities.CommentsActivity].  */
-        fun startCommentsActivity(): Observable<Project>
+        fun startCommentsActivity(): Observable<Pair<Project, ProjectData>>
 
         /** Emits when we should start the creator bio [com.kickstarter.ui.activities.CreatorBioActivity].  */
         fun startCreatorBioWebViewActivity(): Observable<Project>
@@ -209,7 +210,7 @@ interface ProjectViewModel {
         fun startMessagesActivity(): Observable<Project>
 
         /** Emits when we should start [com.kickstarter.ui.activities.ProjectUpdatesActivity].  */
-        fun startProjectUpdatesActivity(): Observable<Project>
+        fun startProjectUpdatesActivity(): Observable<Pair<Project, ProjectData>>
 
         /** Emits when we the pledge was successful and should start the [com.kickstarter.ui.activities.ThanksActivity]. */
         fun startThanksActivity(): Observable<Pair<CheckoutData, PledgeData>>
@@ -284,12 +285,12 @@ interface ProjectViewModel {
         private val showUpdatePledge = PublishSubject.create<Pair<PledgeData, PledgeReason>>()
         private val showUpdatePledgeSuccess = PublishSubject.create<Void>()
         private val startCampaignWebViewActivity = PublishSubject.create<ProjectData>()
-        private val startCommentsActivity = PublishSubject.create<Project>()
+        private val startCommentsActivity = PublishSubject.create<Pair<Project, ProjectData>>()
         private val startCreatorBioWebViewActivity = PublishSubject.create<Project>()
         private val startCreatorDashboardActivity = PublishSubject.create<Project>()
         private val startLoginToutActivity = PublishSubject.create<Void>()
         private val startMessagesActivity = PublishSubject.create<Project>()
-        private val startProjectUpdatesActivity = PublishSubject.create<Project>()
+        private val startProjectUpdatesActivity = PublishSubject.create<Pair<Project, ProjectData>>()
         private val startThanksActivity = PublishSubject.create<Pair<CheckoutData, PledgeData>>()
         private val startVideoActivity = PublishSubject.create<Project>()
         private val updateFragments = BehaviorSubject.create<ProjectData>()
@@ -450,6 +451,7 @@ interface ProjectViewModel {
 
             currentProject
                     .compose<Project>(takeWhen(this.commentsTextViewClicked))
+                    .compose<Pair<Project, ProjectData>>(combineLatestPair(projectData))
                     .compose(bindToLifecycle())
                     .subscribe(this.startCommentsActivity)
 
@@ -460,6 +462,7 @@ interface ProjectViewModel {
 
             currentProject
                     .compose<Project>(takeWhen(this.updatesTextViewClicked))
+                    .compose<Pair<Project, ProjectData>>(combineLatestPair(projectData))
                     .compose(bindToLifecycle())
                     .subscribe(this.startProjectUpdatesActivity)
 
@@ -727,6 +730,7 @@ interface ProjectViewModel {
                         val dataWithStoredCookieRefTag = storeCurrentCookieRefTag(data)
 
                         this.lake.trackProjectPageViewed(dataWithStoredCookieRefTag, pledgeFlowContext)
+                        this.lake.trackProjectScreenViewed(dataWithStoredCookieRefTag, OVERVIEW.contextName)
                     }
 
             fullProjectDataAndCurrentUser
@@ -1074,7 +1078,7 @@ interface ProjectViewModel {
         override fun startCampaignWebViewActivity(): Observable<ProjectData> = this.startCampaignWebViewActivity
 
         @NonNull
-        override fun startCommentsActivity(): Observable<Project> = this.startCommentsActivity
+        override fun startCommentsActivity(): Observable<Pair<Project, ProjectData>> = this.startCommentsActivity
 
         @NonNull
         override fun startCreatorBioWebViewActivity(): Observable<Project> = this.startCreatorBioWebViewActivity
@@ -1092,7 +1096,7 @@ interface ProjectViewModel {
         override fun startThanksActivity(): Observable<Pair<CheckoutData, PledgeData>> = this.startThanksActivity
 
         @NonNull
-        override fun startProjectUpdatesActivity(): Observable<Project> = this.startProjectUpdatesActivity
+        override fun startProjectUpdatesActivity(): Observable<Pair<Project, ProjectData>> = this.startProjectUpdatesActivity
 
         @NonNull
         override fun startVideoActivity(): Observable<Project> = this.startVideoActivity

--- a/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CampaignDetailsViewModelTest.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.models.OptimizelyExperiment
+import com.kickstarter.libs.utils.EventName
 import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.ProjectDataFactory
 import com.kickstarter.mock.factories.ProjectFactory
@@ -32,12 +33,19 @@ class CampaignDetailsViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun init_whenCalled_shouldSendTrackingEvent() {
+        setUpEnvironment(environment(), ProjectDataFactory.project(ProjectFactory.project()))
+
+        this.lakeTest.assertValue(EventName.PAGE_VIEWED.eventName)
+    }
+
+    @Test
     fun testGoBackToProject_whenPledgeActionButtonClicked() {
         setUpEnvironment(environment(), ProjectDataFactory.project(ProjectFactory.project()))
 
         this.vm.inputs.pledgeActionButtonClicked()
         this.goBackToProject.assertValueCount(1)
-        this.lakeTest.assertValue("Campaign Details Pledge Button Clicked")
+        this.lakeTest.assertValues(EventName.PAGE_VIEWED.eventName, "Campaign Details Pledge Button Clicked")
         this.experimentsTest.assertValue("Campaign Details Pledge Button Clicked")
     }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.java
@@ -7,7 +7,9 @@ import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.MockCurrentUser;
+import com.kickstarter.libs.utils.EventName;
 import com.kickstarter.mock.factories.ApiExceptionFactory;
+import com.kickstarter.mock.factories.ProjectDataFactory;
 import com.kickstarter.mock.factories.ProjectFactory;
 import com.kickstarter.mock.factories.UpdateFactory;
 import com.kickstarter.mock.factories.UserFactory;
@@ -20,6 +22,7 @@ import com.kickstarter.services.ApiClientType;
 import com.kickstarter.services.apiresponses.CommentsEnvelope;
 import com.kickstarter.ui.IntentKey;
 import com.kickstarter.ui.adapters.data.CommentsData;
+import com.kickstarter.ui.data.ProjectData;
 
 import org.junit.Test;
 
@@ -30,6 +33,28 @@ import rx.Observable;
 import rx.observers.TestSubscriber;
 
 public class CommentsViewModelTest extends KSRobolectricTestCase {
+
+  @Test
+  public void init_whenViewModelInstantiated_shouldSendPageViewedEvent() {
+    final ApiClientType apiClient = new MockApiClient() {
+      @Override
+      public @NonNull Observable<CommentsEnvelope> fetchComments(final @NonNull Update update) {
+        return Observable.empty();
+      }
+    };
+
+    final Environment env = environment().toBuilder().apiClient(apiClient).build();
+    final CommentsViewModel.ViewModel vm = new CommentsViewModel.ViewModel(env);
+
+    Project project = ProjectFactory.project();
+    ProjectData projectData = ProjectDataFactory.Companion.project(project);
+
+    vm.intent(new Intent()
+            .putExtra(IntentKey.PROJECT_DATA, projectData)
+            .putExtra(IntentKey.PROJECT, project));
+
+    this.lakeTest.assertValue(EventName.PAGE_VIEWED.getEventName());
+  }
 
   @Test
   public void testCommentsViewModel_EmptyState() {

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.java
@@ -46,8 +46,8 @@ public class CommentsViewModelTest extends KSRobolectricTestCase {
     final Environment env = environment().toBuilder().apiClient(apiClient).build();
     final CommentsViewModel.ViewModel vm = new CommentsViewModel.ViewModel(env);
 
-    Project project = ProjectFactory.project();
-    ProjectData projectData = ProjectDataFactory.Companion.project(project);
+    final Project project = ProjectFactory.project();
+    final ProjectData projectData = ProjectDataFactory.Companion.project(project);
 
     vm.intent(new Intent()
             .putExtra(IntentKey.PROJECT_DATA, projectData)

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectUpdatesViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectUpdatesViewModelTest.java
@@ -46,7 +46,7 @@ public class ProjectUpdatesViewModelTest extends KSRobolectricTestCase {
 
   @Test
   public void init_whenViewModelInstantiated_shouldTrackPageViewEvent() {
-    Project project = ProjectFactory.project();
+    final Project project = ProjectFactory.project();
     setUpEnvironment(environment(), project, ProjectDataFactory.Companion.project(project));
 
     this.lakeTest.assertValue(EventName.PAGE_VIEWED.getEventName());
@@ -54,7 +54,7 @@ public class ProjectUpdatesViewModelTest extends KSRobolectricTestCase {
 
   @Test
   public void testHorizontalProgressBarIsGone() {
-    Project project = ProjectFactory.project();
+    final Project project = ProjectFactory.project();
     setUpEnvironment(environment(), project, ProjectDataFactory.Companion.project(project));
 
     this.horizontalProgressBarIsGone.assertValues(false, true);
@@ -62,7 +62,7 @@ public class ProjectUpdatesViewModelTest extends KSRobolectricTestCase {
 
   @Test
   public void testIsFetchingUpdates() {
-    Project project = ProjectFactory.project();
+    final Project project = ProjectFactory.project();
     setUpEnvironment(environment(), project, ProjectDataFactory.Companion.project(project));
 
     this.isFetchingUpdates.assertValues(true, false);

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectUpdatesViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectUpdatesViewModelTest.java
@@ -5,6 +5,8 @@ import android.util.Pair;
 
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.libs.Environment;
+import com.kickstarter.libs.utils.EventName;
+import com.kickstarter.mock.factories.ProjectDataFactory;
 import com.kickstarter.mock.factories.ProjectFactory;
 import com.kickstarter.mock.factories.UpdateFactory;
 import com.kickstarter.mock.services.MockApiClient;
@@ -12,6 +14,7 @@ import com.kickstarter.models.Project;
 import com.kickstarter.models.Update;
 import com.kickstarter.services.apiresponses.UpdatesEnvelope;
 import com.kickstarter.ui.IntentKey;
+import com.kickstarter.ui.data.ProjectData;
 
 import org.junit.Test;
 
@@ -30,7 +33,7 @@ public class ProjectUpdatesViewModelTest extends KSRobolectricTestCase {
   private final TestSubscriber<Pair<Project, List<Update>>> projectAndUpdates = new TestSubscriber<>();
   private final TestSubscriber<Pair<Project, Update>> startUpdateActivity = new TestSubscriber<>();
 
-  private void setUpEnvironment(final @NonNull Environment env, final @NonNull Project project) {
+  private void setUpEnvironment(final @NonNull Environment env, final @NonNull Project project, final @NonNull ProjectData projectData) {
     this.vm = new ProjectUpdatesViewModel.ViewModel(env);
     this.vm.outputs.horizontalProgressBarIsGone().subscribe(this.horizontalProgressBarIsGone);
     this.vm.outputs.isFetchingUpdates().subscribe(this.isFetchingUpdates);
@@ -38,19 +41,29 @@ public class ProjectUpdatesViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.startUpdateActivity().subscribe(this.startUpdateActivity);
 
     // Configure the view model with a project intent.
-    this.vm.intent(new Intent().putExtra(IntentKey.PROJECT, project));
+    this.vm.intent(new Intent().putExtra(IntentKey.PROJECT, project).putExtra(IntentKey.PROJECT_DATA, projectData));
+  }
+
+  @Test
+  public void init_whenViewModelInstantiated_shouldTrackPageViewEvent() {
+    Project project = ProjectFactory.project();
+    setUpEnvironment(environment(), project, ProjectDataFactory.Companion.project(project));
+
+    this.lakeTest.assertValue(EventName.PAGE_VIEWED.getEventName());
   }
 
   @Test
   public void testHorizontalProgressBarIsGone() {
-    setUpEnvironment(environment(), ProjectFactory.project());
+    Project project = ProjectFactory.project();
+    setUpEnvironment(environment(), project, ProjectDataFactory.Companion.project(project));
 
     this.horizontalProgressBarIsGone.assertValues(false, true);
   }
 
   @Test
   public void testIsFetchingUpdates() {
-    setUpEnvironment(environment(), ProjectFactory.project());
+    Project project = ProjectFactory.project();
+    setUpEnvironment(environment(), project, ProjectDataFactory.Companion.project(project));
 
     this.isFetchingUpdates.assertValues(true, false);
   }
@@ -75,7 +88,7 @@ public class ProjectUpdatesViewModelTest extends KSRobolectricTestCase {
             .build()
         );
       }
-    }).build(), project);
+    }).build(), project, ProjectDataFactory.Companion.project(project));
 
     this.projectAndUpdates.assertValues(Pair.create(project, updates));
   }
@@ -95,7 +108,7 @@ public class ProjectUpdatesViewModelTest extends KSRobolectricTestCase {
                         .build()
         );
       }
-    }).build(), project);
+    }).build(), project, ProjectDataFactory.Companion.project(project));
 
     this.projectAndUpdates.assertValues(Pair.create(project, Collections.emptyList()));
     this.isFetchingUpdates.assertValues(true, false);
@@ -120,7 +133,7 @@ public class ProjectUpdatesViewModelTest extends KSRobolectricTestCase {
             .build()
         );
       }
-    }).build(), project);
+    }).build(), project, ProjectDataFactory.Companion.project(project));
 
     this.vm.inputs.updateClicked(update);
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -51,12 +51,12 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     private val showUpdatePledge = TestSubscriber<Pair<PledgeData, PledgeReason>>()
     private val showUpdatePledgeSuccess = TestSubscriber<Void>()
     private val startCampaignWebViewActivity = TestSubscriber<ProjectData>()
-    private val startCommentsActivity = TestSubscriber<Project>()
+    private val startCommentsActivity = TestSubscriber<Pair<Project, ProjectData>>()
     private val startCreatorBioWebViewActivity = TestSubscriber<Project>()
     private val startCreatorDashboardActivity = TestSubscriber<Project>()
     private val startLoginToutActivity = TestSubscriber<Void>()
     private val startMessagesActivity = TestSubscriber<Project>()
-    private val startProjectUpdatesActivity = TestSubscriber<Project>()
+    private val startProjectUpdatesActivity = TestSubscriber<Pair<Project, ProjectData>>()
     private val startThanksActivity = TestSubscriber<Pair<CheckoutData, PledgeData>>()
     private val startVideoActivity = TestSubscriber<Project>()
     private val updateFragments = TestSubscriber<ProjectData>()
@@ -121,7 +121,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.reloadProjectContainerIsGone.assertValue(true)
         this.reloadProgressBarIsGone.assertValues(false, true)
         this.updateFragments.assertValue(ProjectDataFactory.project(refreshedProject))
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -166,7 +167,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.reloadProjectContainerIsGone.assertValues(false, true, true)
         this.reloadProgressBarIsGone.assertValues(false, true, false, true)
         this.updateFragments.assertValue(ProjectDataFactory.project(refreshedProject))
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -191,7 +193,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.projectData.assertValue(ProjectDataFactory.project(project))
         this.reloadProgressBarIsGone.assertValues(false, true)
         this.updateFragments.assertValue(ProjectDataFactory.project(project))
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -231,7 +234,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.reloadProgressBarIsGone.assertValues(false, true, false, true)
         this.reloadProjectContainerIsGone.assertValues(false, true, true)
         this.updateFragments.assertValue(ProjectDataFactory.project(refreshedProject))
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -296,7 +300,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart_outline, R.drawable.icon__heart)
         this.showSavedPromptTest.assertValueCount(1)
 
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -324,7 +329,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         val expectedName = "Best Project 2K19"
         val expectedShareUrl = "https://www.kck.str/projects/" + creator.id().toString() + "/" + slug + "?ref=android_project_share"
         this.showShareSheet.assertValues(Pair(expectedName, expectedShareUrl))
-        this.lakeTest.assertValue("Project Page Viewed")
+
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -389,7 +396,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
-        this.lakeTest.assertValues("Project Page Viewed", "Campaign Details Button Clicked")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName, "Campaign Details Button Clicked")
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName, "Campaign Details Button Clicked")
         this.experimentsTest.assertValues("Project Page Viewed", "Campaign Details Button Clicked")
     }
 
@@ -403,7 +411,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertValue("Project Page Viewed")
     }
 
@@ -417,7 +426,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbTextViewClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertValue("Project Page Viewed")
     }
 
@@ -431,7 +441,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbVariantClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
-        this.lakeTest.assertValues("Project Page Viewed", "Campaign Details Button Clicked")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName, "Campaign Details Button Clicked")
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName, "Campaign Details Button Clicked")
         this.experimentsTest.assertValues("Project Page Viewed", "Campaign Details Button Clicked")
     }
 
@@ -445,7 +456,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbVariantClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertValue("Project Page Viewed")
     }
 
@@ -459,7 +471,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.blurbVariantClicked()
         this.startCampaignWebViewActivity.assertValues(ProjectDataFactory.project(project))
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertValue("Project Page Viewed")
     }
 
@@ -473,7 +486,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.creatorNameTextViewClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
-        this.lakeTest.assertValues("Project Page Viewed", "Creator Details Clicked")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName, "Creator Details Clicked")
         this.experimentsTest.assertValues("Project Page Viewed", "Creator Details Clicked")
     }
 
@@ -487,7 +500,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.creatorNameTextViewClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertValue("Project Page Viewed")
     }
 
@@ -501,7 +515,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.creatorNameTextViewClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertValue("Project Page Viewed")
     }
 
@@ -515,7 +530,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.creatorInfoVariantClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
-        this.lakeTest.assertValues("Project Page Viewed", "Creator Details Clicked")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName, "Creator Details Clicked")
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName, "Creator Details Clicked")
         this.experimentsTest.assertValues("Project Page Viewed", "Creator Details Clicked")
     }
 
@@ -529,7 +545,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.creatorInfoVariantClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertValue("Project Page Viewed")
     }
 
@@ -543,7 +560,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.creatorInfoVariantClicked()
         this.startCreatorBioWebViewActivity.assertValues(project)
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertValue("Project Page Viewed")
     }
 
@@ -562,18 +580,23 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testStartCommentsActivity() {
         val project = ProjectFactory.project()
+        val projectData = ProjectDataFactory.project(project)
+        val projectAndData = Pair.create(project, projectData)
+
         setUpEnvironment(environment())
 
         // Start the view model with a project.
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
 
         this.vm.inputs.commentsTextViewClicked()
-        this.startCommentsActivity.assertValues(project)
+        this.startCommentsActivity.assertValues(projectAndData)
     }
 
     @Test
     fun testStartProjectUpdatesActivity() {
         val project = ProjectFactory.project()
+        val projectData = ProjectDataFactory.project(project)
+        val projectAndData = Pair.create(project, projectData)
         setUpEnvironment(environment())
 
         // Start the view model with a project.
@@ -581,7 +604,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         // Click on Updates button.
         this.vm.inputs.updatesTextViewClicked()
-        this.startProjectUpdatesActivity.assertValues(project)
+        this.startProjectUpdatesActivity.assertValues(projectAndData)
     }
 
     @Test
@@ -774,9 +797,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.pledgeToolbarNavigationClicked()
         this.expandPledgeSheet.assertValues(Pair(true, true), Pair(false, true))
         this.goBack.assertNoValues()
-        this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName, "Project Page Pledge Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
-        this.segmentTrack.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName, "Project Page Pledge Button Clicked", EventName.CTA_CLICKED.eventName)
 
     }
 
@@ -788,9 +811,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.nativeProjectActionButtonClicked()
 
         this.expandPledgeSheet.assertValue(Pair(true, true))
-        this.lakeTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName, "Project Page Pledge Button Clicked", EventName.CTA_CLICKED.eventName)
         this.experimentsTest.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked")
-        this.segmentTrack.assertValues("Project Page Viewed", "Project Page Pledge Button Clicked", EventName.CTA_CLICKED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName, "Project Page Pledge Button Clicked", EventName.CTA_CLICKED.eventName)
     }
 
     @Test
@@ -801,7 +824,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.nativeProjectActionButtonClicked()
 
         this.expandPledgeSheet.assertValue(Pair(true, true))
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -813,7 +837,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.nativeProjectActionButtonClicked()
 
-        this.lakeTest.assertValues("Project Page Viewed","Manage Pledge Button Clicked")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName, "Manage Pledge Button Clicked")
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName, "Manage Pledge Button Clicked")
     }
 
     @Test
@@ -824,7 +849,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.nativeProjectActionButtonClicked()
 
         this.expandPledgeSheet.assertValue(Pair(true, true))
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -835,7 +861,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.nativeProjectActionButtonClicked()
 
         this.expandPledgeSheet.assertValue(Pair(true, true))
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -846,7 +873,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.activityResult(ActivityResult.create(ActivityRequestCodes.SHOW_REWARDS, Activity.RESULT_OK, null))
 
         this.expandPledgeSheet.assertValue(Pair(true, true))
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -857,7 +885,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.activityResult(ActivityResult.create(ActivityRequestCodes.SHOW_REWARDS, Activity.RESULT_CANCELED, null))
 
         this.expandPledgeSheet.assertNoValues()
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -869,7 +898,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.intent(intent)
 
         this.expandPledgeSheet.assertValues(Pair(true, true))
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -881,7 +911,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.intent(intent)
 
         this.expandPledgeSheet.assertNoValues()
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -892,7 +923,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.intent(intent)
 
         this.expandPledgeSheet.assertNoValues()
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -1149,7 +1181,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.cancelPledgeClicked()
 
         this.showCancelPledgeFragment.assertValue(backedProject)
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -1171,7 +1204,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.cancelPledgeClicked()
 
         this.showCancelPledgeFragment.assertNoValues()
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -1186,7 +1220,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.contactCreatorClicked()
 
         this.startMessagesActivity.assertValue(backedProject)
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -1238,7 +1273,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.viewRewardsClicked()
 
         this.revealRewardsFragment.assertValueCount(1)
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     @Test
@@ -1252,7 +1288,8 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.viewRewardsClicked()
 
         this.revealRewardsFragment.assertValueCount(1)
-        this.lakeTest.assertValue("Project Page Viewed")
+        this.lakeTest.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
+        this.segmentTrack.assertValues("Project Page Viewed", EventName.PAGE_VIEWED.eventName)
     }
 
     // TODO this will be fixed in https://kickstarter.atlassian.net/browse/NT-1390


### PR DESCRIPTION
# 📲 What

- Created a new function to our `AnalyticsEvents` class that handles sending the event name and properties to the client, including which section of the project page is viewed.
- Added this function to our `ProjectViewModel` and all associated sections of the project page when their viewmodels are initialized.

# 🤔 Why

Segment Integration.

# 🛠 How

- There are 4 "context_sections" that send events in the projects flow: 
1. "overview" the project screen: Updated the event in the `ProjectViewModel`
2. "coments" the comments screen of the project: Added an event to the `CommentsViewModel`
3. "campaign" the campaign details screen of the project: Added event to the `CampaignDetailsViewModel`
4. "updates" the project updates screen: Added event to the `ProjectUpdatesViewModel`

I also had to send additional intent extras that included data required for properties. 

# 👀 See

"overview", "campaign", "updates", "comments" sections, respectively. 
![Screenshot_1613770776](https://user-images.githubusercontent.com/19390326/108564584-5bdeee00-72d1-11eb-91c0-817833bb2d39.png) ![Screenshot_1613770785](https://user-images.githubusercontent.com/19390326/108564585-5bdeee00-72d1-11eb-914e-836167101682.png) ![Screenshot_1613770793](https://user-images.githubusercontent.com/19390326/108564586-5bdeee00-72d1-11eb-8650-cdd5bccd310c.png) ![Screenshot_1613770799](https://user-images.githubusercontent.com/19390326/108564587-5bdeee00-72d1-11eb-97d2-8936c01cffc2.png)


# 📋 QA

- Select a project
- Segment should display "Page Viewed" with a property `context_section = "overview"`
- Tap on "Read more about this campaign ->" or "Campaign". This should open the project campaign details webview.
- Segment should display "Page Viewed" with a property `context_section = "campaign"`
- Tap the back arrow to return to the previous project overview screen.
- Tap "Updates". This should bring you to the project updates screen. 
- Segment should display "Page Viewed" with a property `context_section = "updates"`
- Tap the back arrow to return to the previous project overview screen.
- Tap "Comments". This should bring you to the project comments screen. 
- Segment should display "Page Viewed" with a property `context_section = "comments"`

<img width="434" alt="Screen Shot 2021-02-18 at 7 06 31 PM" src="https://user-images.githubusercontent.com/19390326/108565218-4fa76080-72d2-11eb-89ea-2406a6bfb760.png">
<img width="428" alt="Screen Shot 2021-02-18 at 7 06 38 PM" src="https://user-images.githubusercontent.com/19390326/108565220-503ff700-72d2-11eb-97e9-03c8a1d3b34c.png">
<img width="428" alt="Screen Shot 2021-02-18 at 7 06 50 PM" src="https://user-images.githubusercontent.com/19390326/108565221-503ff700-72d2-11eb-8031-5d9262e7f30f.png">
<img width="431" alt="Screen Shot 2021-02-18 at 8 25 11 PM" src="https://user-images.githubusercontent.com/19390326/108565222-503ff700-72d2-11eb-80d1-8345b1a43fe7.png">

# Story 📖

[EP-221: Android Page Viewed (project)](https://kickstarter.atlassian.net/browse/EP-221)
