### PR TITLE
EP-223: Create event for Thanks screen viewed

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -703,7 +703,11 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
 
     fun trackThanksScreenViewed(checkoutData: CheckoutData, pledgeData: PledgeData) {
         val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to EventContext.PageViewedContextName.THANKS.contextName)
-        props[CONTEXT_TYPE.contextName] = pledgeData.pledgeFlowContext().trackingString
+        props[CONTEXT_TYPE.contextName] = when (pledgeData.pledgeFlowContext()) {
+            PledgeFlowContext.NEW_PLEDGE -> PledgeFlowContext.NEW_PLEDGE.trackingString
+            PledgeFlowContext.FIX_ERRORED_PLEDGE -> PledgeFlowContext.FIX_ERRORED_PLEDGE.trackingString
+            PledgeFlowContext.CHANGE_REWARD, PledgeFlowContext.MANAGE_REWARD -> "manage_pledge"
+        }
         props.putAll(AnalyticEventsUtils.checkoutDataProperties(checkoutData, pledgeData, client.loggedInUser()))
         client.track(EventName.PAGE_VIEWED.eventName, props)
     }

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -703,7 +703,7 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
 
     fun trackThanksScreenViewed(checkoutData: CheckoutData, pledgeData: PledgeData) {
         val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to EventContext.PageViewedContextName.THANKS.contextName)
-        props[CONTEXT_TYPE] = pledgeData.pledgeFlowContext()
+        props[CONTEXT_TYPE.contextName] = pledgeData.pledgeFlowContext().trackingString
         props.putAll(AnalyticEventsUtils.checkoutDataProperties(checkoutData, pledgeData, client.loggedInUser()))
         client.track(EventName.PAGE_VIEWED.eventName, props)
     }

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -701,6 +701,13 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         client.track(THANKS_PAGE_VIEWED, props)
     }
 
+    fun trackThanksScreenViewed(checkoutData: CheckoutData, pledgeData: PledgeData) {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to EventContext.PageViewedContextName.THANKS.contextName)
+        props[CONTEXT_TYPE] = pledgeData.pledgeFlowContext()
+        props.putAll(AnalyticEventsUtils.checkoutDataProperties(checkoutData, pledgeData, client.loggedInUser()))
+        client.track(EventName.PAGE_VIEWED.eventName, props)
+    }
+
     fun trackFixPledgeButtonClicked(projectData: ProjectData) {
         val props = AnalyticEventsUtils.projectProperties(projectData.project(), client.loggedInUser())
         props["context_pledge_flow"] = PledgeFlowContext.FIX_ERRORED_PLEDGE.trackingString

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -703,11 +703,7 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
 
     fun trackThanksScreenViewed(checkoutData: CheckoutData, pledgeData: PledgeData) {
         val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to EventContext.PageViewedContextName.THANKS.contextName)
-        props[CONTEXT_TYPE.contextName] = when (pledgeData.pledgeFlowContext()) {
-            PledgeFlowContext.NEW_PLEDGE -> PledgeFlowContext.NEW_PLEDGE.trackingString
-            PledgeFlowContext.FIX_ERRORED_PLEDGE -> PledgeFlowContext.FIX_ERRORED_PLEDGE.trackingString
-            PledgeFlowContext.CHANGE_REWARD, PledgeFlowContext.MANAGE_REWARD -> "manage_pledge"
-        }
+        props[CONTEXT_TYPE.contextName] = pledgeData.pledgeFlowContext().trackingString
         props.putAll(AnalyticEventsUtils.checkoutDataProperties(checkoutData, pledgeData, client.loggedInUser()))
         client.track(EventName.PAGE_VIEWED.eventName, props)
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.java
@@ -179,7 +179,10 @@ public interface ThanksViewModel {
 
       checkoutAndPledgeData
         .compose(bindToLifecycle())
-        .subscribe(checkoutDataPledgeData -> this.lake.trackThanksPageViewed(checkoutDataPledgeData.first, checkoutDataPledgeData.second));
+        .subscribe(checkoutDataPledgeData -> {
+          this.lake.trackThanksPageViewed(checkoutDataPledgeData.first, checkoutDataPledgeData.second);
+          this.lake.trackThanksScreenViewed(checkoutDataPledgeData.first, checkoutDataPledgeData.second);
+        });
     }
 
     /**

--- a/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.java
@@ -9,6 +9,7 @@ import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.MockCurrentUser;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.preferences.MockBooleanPreference;
+import com.kickstarter.libs.utils.EventName;
 import com.kickstarter.mock.factories.CategoryFactory;
 import com.kickstarter.mock.factories.CheckoutDataFactory;
 import com.kickstarter.mock.factories.LocationFactory;
@@ -315,7 +316,8 @@ public final class ThanksViewModelTest extends KSRobolectricTestCase {
             .putExtra(IntentKey.PROJECT, project);
     this.vm.intent(intent);
 
-    this.lakeTest.assertValue("Thanks Page Viewed");
+    this.lakeTest.assertValues("Thanks Page Viewed", EventName.PAGE_VIEWED.getEventName());
+    this.segmentTrack.assertValues("Thanks Page Viewed", EventName.PAGE_VIEWED.getEventName());
   }
 
   @Test


### PR DESCRIPTION
# 📲 What

- Added track event for tracking the Thanks screen viewed.

# 🤔 Why

Segment integration.

# 🛠 How

- Created a new function to our `AnalyticsEvent`s class that handles sending the event name and properties to the client.
- Added this function to our `ThanksViewModel` when the vm is initialized. 

# 👀 See
This is the screen that triggers this event:
![Screenshot_1614099857](https://user-images.githubusercontent.com/19390326/108879515-59c9a780-75cf-11eb-82fe-27ba736b3cc7.png)
# 📋 QA

- Sign into your account on staging
- Select a project
- Back this project with any reward
- After successfully completing checkout, you should see the Thanks screen
- Both Segment (Page Viewed) and DataLake (Thanks Page Viewed) should appear in the segment dashboard.
- Tapping "Page Viewed" in segment should show the list of properties sent with this event with the context_page = thanks, and context_type = new_pledge:
<img width="796" alt="Screen Shot 2021-02-23 at 11 36 51 AM" src="https://user-images.githubusercontent.com/19390326/108879881-b4630380-75cf-11eb-98f3-cfb1c11d29bc.png">
<img width="761" alt="Screen Shot 2021-02-23 at 11 36 58 AM" src="https://user-images.githubusercontent.com/19390326/108879883-b4630380-75cf-11eb-9c45-d5965ca2f4ac.png">

# Story 📖

[EP-223: Android Page Viewed (thanks)](https://kickstarter.atlassian.net/browse/EP-223)
