### PR TITLE
Sunday/nt 1058 reset password error dialog

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
@@ -50,7 +50,7 @@ class ResetPasswordActivity : BaseActivity<ResetPasswordViewModel.ViewModel>() {
         this.viewModel.outputs.resetError()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { ViewUtils.showDialog(this, getString(this.errorTitleString), getString(this.errorGenericString)) }
+                .subscribe { ViewUtils.showDialog(this, getString(this.errorTitleString), it) }
 
         reset_password_button.setOnClickListener { this.viewModel.inputs.resetPasswordClick() }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
@@ -22,7 +22,7 @@ import rx.android.schedulers.AndroidSchedulers
 class ResetPasswordActivity : BaseActivity<ResetPasswordViewModel.ViewModel>() {
 
     private var forgotPasswordString = R.string.forgot_password_title
-    private var errorMessageString = R.string.forgot_password_error
+    private var errorMessageString = R.string.Something_went_wrong_please_try_again
     private var errorTitleString = R.string.general_error_oops
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
@@ -51,7 +51,7 @@ class ResetPasswordActivity : BaseActivity<ResetPasswordViewModel.ViewModel>() {
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe {
-                    var message: Int = if( it == true ) this.errorNetworkMessageString
+                    val message: Int = if( it == true ) this.errorNetworkMessageString
                     else this.errorMessageString
                     ViewUtils.showDialog(this, getString(this.errorTitleString), getString(message)) }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
@@ -22,7 +22,8 @@ import rx.android.schedulers.AndroidSchedulers
 class ResetPasswordActivity : BaseActivity<ResetPasswordViewModel.ViewModel>() {
 
     private var forgotPasswordString = R.string.forgot_password_title
-    private var errorMessageString = R.string.Something_went_wrong_please_try_again
+    private var errorMessageString = R.string.forgot_password_error
+    private var errorNetworkMessageString = R.string.social_error_no_internet_connection
     private var errorTitleString = R.string.general_error_oops
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -49,7 +50,10 @@ class ResetPasswordActivity : BaseActivity<ResetPasswordViewModel.ViewModel>() {
         this.viewModel.outputs.resetError()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { ViewUtils.showDialog(this, getString(this.errorTitleString), getString(this.errorMessageString)) }
+                .subscribe {
+                    var message: Int = if( it == true ) this.errorNetworkMessageString
+                    else this.errorMessageString
+                    ViewUtils.showDialog(this, getString(this.errorTitleString), getString(message)) }
 
         reset_password_button.setOnClickListener { this.viewModel.inputs.resetPasswordClick() }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
@@ -23,7 +23,7 @@ class ResetPasswordActivity : BaseActivity<ResetPasswordViewModel.ViewModel>() {
 
     private var forgotPasswordString = R.string.forgot_password_title
     private var errorMessageString = R.string.forgot_password_error
-    private var errorNetworkMessageString = R.string.social_error_no_internet_connection
+    private var errorGenericString = R.string.Something_went_wrong_please_try_again
     private var errorTitleString = R.string.general_error_oops
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -50,10 +50,7 @@ class ResetPasswordActivity : BaseActivity<ResetPasswordViewModel.ViewModel>() {
         this.viewModel.outputs.resetError()
                 .compose(bindToLifecycle())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe {
-                    val message: Int = if( it == true ) this.errorNetworkMessageString
-                    else this.errorMessageString
-                    ViewUtils.showDialog(this, getString(this.errorTitleString), getString(message)) }
+                .subscribe { ViewUtils.showDialog(this, getString(this.errorTitleString), getString(this.errorGenericString)) }
 
         reset_password_button.setOnClickListener { this.viewModel.inputs.resetPasswordClick() }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
@@ -130,7 +130,7 @@ interface ResetPasswordViewModel {
             return this.resetError
                     .takeUntil(this.resetSuccess)
                     //.map { it.errorMessage() } /*  null pointer exception is thrown */
-                    .map { "" }
+                    .map { "bad request" }
         }
 
         override fun prefillEmail(): BehaviorSubject<String> = this.prefillEmail

--- a/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
@@ -1,14 +1,15 @@
 package com.kickstarter.viewmodels
 
+import android.util.Log
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.rx.transformers.Transformers
-import com.kickstarter.libs.rx.transformers.Transformers.errors
-import com.kickstarter.libs.rx.transformers.Transformers.values
+import com.kickstarter.libs.rx.transformers.Transformers.*
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.extensions.isEmail
 import com.kickstarter.models.User
 import com.kickstarter.services.ApiClientType
+import com.kickstarter.services.apiresponses.AccessTokenEnvelope
 import com.kickstarter.services.apiresponses.ErrorEnvelope
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.ResetPasswordActivity
@@ -38,7 +39,7 @@ interface ResetPasswordViewModel {
         fun resetSuccess(): Observable<Void>
 
         /** Emits when password reset fails. */
-        fun resetError(): Observable<String>
+        fun resetError(): Observable<Boolean>
 
         /** Fill the view's email address when it's supplied from the intent.  */
         fun prefillEmail(): Observable<String>
@@ -53,7 +54,7 @@ interface ResetPasswordViewModel {
         private val isFormSubmitting = PublishSubject.create<Boolean>()
         private val isFormValid = PublishSubject.create<Boolean>()
         private val resetSuccess = PublishSubject.create<Void>()
-        private val resetError = PublishSubject.create<ErrorEnvelope>()
+        private val resetError = PublishSubject.create<Boolean>()
         private val prefillEmail = BehaviorSubject.create<String>()
 
         val inputs: Inputs = this
@@ -74,8 +75,10 @@ interface ResetPasswordViewModel {
                     .subscribe(this.isFormValid)
 
             val resetPasswordNotification = this.email
-                    .compose<String>(Transformers.takeWhen(this.resetPasswordClick))
+                    .compose<String>(takeWhen(this.resetPasswordClick))
                     .switchMap(this::submitEmail)
+                    .share()
+
 
             resetPasswordNotification
                     .compose(values())
@@ -84,13 +87,22 @@ interface ResetPasswordViewModel {
 
             resetPasswordNotification
                     .compose(errors())
-                    .map { ErrorEnvelope.fromThrowable(it) }
+                    .map {
+                        // host -> internet related error or otherwise -> invalid email address
+                        return@map it?.message!!.contains("host")
+                    }
                     //.filter { ObjectUtils.isNotNull(it) }
                     .compose(bindToLifecycle())
                     .subscribe(this.resetError)
 
             this.lake.trackForgotPasswordPageViewed()
         }
+
+        private fun unwrapNotificationEnvelopeError(notification: Notification<AccessTokenEnvelope>) =
+                if (notification.hasThrowable()) notification.throwable else null
+
+        private fun unwrapNotificationEnvelopeSuccess(notification: Notification<AccessTokenEnvelope>) =
+                if (notification.hasValue()) notification.value else null
 
         private fun success() {
             this.resetSuccess.onNext(null)
@@ -124,10 +136,8 @@ interface ResetPasswordViewModel {
             return this.resetSuccess
         }
 
-        override fun resetError(): Observable<String> {
+        override fun resetError(): Observable<Boolean> {
             return this.resetError
-                    .takeUntil(this.resetSuccess)
-                    .map { "" }
         }
 
         override fun prefillEmail(): BehaviorSubject<String> = this.prefillEmail

--- a/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
@@ -5,14 +5,12 @@ import com.kickstarter.libs.Environment
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.rx.transformers.Transformers.errors
 import com.kickstarter.libs.rx.transformers.Transformers.values
-import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.extensions.isEmail
 import com.kickstarter.models.User
 import com.kickstarter.services.ApiClientType
 import com.kickstarter.services.apiresponses.ErrorEnvelope
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.ResetPasswordActivity
-import com.noveogroup.android.log.Log
 import rx.Notification
 import rx.Observable
 import rx.subjects.BehaviorSubject
@@ -56,6 +54,8 @@ interface ResetPasswordViewModel {
         private val resetSuccess = PublishSubject.create<Void>()
         private val resetError = PublishSubject.create<ErrorEnvelope>()
         private val prefillEmail = BehaviorSubject.create<String>()
+
+        private val ERROR_GENERIC = "Something went wrong, please try again."
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -129,8 +129,8 @@ interface ResetPasswordViewModel {
         override fun resetError(): Observable<String> {
             return this.resetError
                     .takeUntil(this.resetSuccess)
-                    //.map { it.errorMessage() } /*  null pointer exception is thrown */
-                    .map { "bad request" }
+                    .map {  it?.errorMessage() ?: ERROR_GENERIC } /*  null pointer exception is thrown */
+                    //.map { "bad request" }
         }
 
         override fun prefillEmail(): BehaviorSubject<String> = this.prefillEmail

--- a/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
@@ -85,7 +85,7 @@ interface ResetPasswordViewModel {
             resetPasswordNotification
                     .compose(errors())
                     .map { ErrorEnvelope.fromThrowable(it) }
-                    .filter { ObjectUtils.isNotNull(it) }
+                    //.filter { ObjectUtils.isNotNull(it) }
                     .compose(bindToLifecycle())
                     .subscribe(this.resetError)
 
@@ -127,7 +127,7 @@ interface ResetPasswordViewModel {
         override fun resetError(): Observable<String> {
             return this.resetError
                     .takeUntil(this.resetSuccess)
-                    .map { it.errorMessage() }
+                    .map { "" }
         }
 
         override fun prefillEmail(): BehaviorSubject<String> = this.prefillEmail

--- a/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
@@ -17,6 +17,7 @@ import rx.Notification
 import rx.Observable
 import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
+import java.lang.NullPointerException
 
 interface ResetPasswordViewModel {
 
@@ -88,9 +89,14 @@ interface ResetPasswordViewModel {
             resetPasswordNotification
                     .compose(errors())
                     .map {
-                        // host -> internet related error or otherwise -> invalid email address
-                        if( it !=  null) return@map it.localizedMessage!!.contains("host")
-                        else return@map false
+//                        // host -> internet related error or otherwise -> invalid email address
+                        try {
+                            it ?: return@map false
+                            return@map it.localizedMessage!!.contains("host")
+                        }catch (error: NullPointerException){
+                            return@map false
+                        }
+
                     }
                     //.filter { ObjectUtils.isNotNull(it) }
                     .takeUntil(this.resetSuccess)

--- a/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
@@ -89,20 +89,17 @@ interface ResetPasswordViewModel {
                     .compose(errors())
                     .map {
                         // host -> internet related error or otherwise -> invalid email address
-                        return@map it?.message!!.contains("host")
+                        Log.e("ERROR", it?.localizedMessage!!)
+                        return@map it?.localizedMessage!!.contains("host")
                     }
                     //.filter { ObjectUtils.isNotNull(it) }
+                    .takeUntil(this.resetSuccess)
                     .compose(bindToLifecycle())
                     .subscribe(this.resetError)
 
             this.lake.trackForgotPasswordPageViewed()
         }
 
-        private fun unwrapNotificationEnvelopeError(notification: Notification<AccessTokenEnvelope>) =
-                if (notification.hasThrowable()) notification.throwable else null
-
-        private fun unwrapNotificationEnvelopeSuccess(notification: Notification<AccessTokenEnvelope>) =
-                if (notification.hasValue()) notification.value else null
 
         private fun success() {
             this.resetSuccess.onNext(null)

--- a/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
@@ -89,8 +89,8 @@ interface ResetPasswordViewModel {
                     .compose(errors())
                     .map {
                         // host -> internet related error or otherwise -> invalid email address
-                        Log.e("ERROR", it?.localizedMessage!!)
-                        return@map it?.localizedMessage!!.contains("host")
+                        if( it !=  null) return@map it.localizedMessage!!.contains("host")
+                        else return@map false
                     }
                     //.filter { ObjectUtils.isNotNull(it) }
                     .takeUntil(this.resetSuccess)

--- a/app/src/test/java/com/kickstarter/viewmodels/ResetPasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ResetPasswordViewModelTest.kt
@@ -61,14 +61,14 @@ class ResetPasswordViewModelTest : KSRobolectricTestCase() {
                 .build()
 
         val vm = ResetPasswordViewModel.ViewModel(environment)
-        val errorTest = TestSubscriber<String>()
+        val errorTest = TestSubscriber<Boolean>()
 
         vm.outputs.resetError().subscribe(errorTest)
 
         vm.inputs.email("hello@kickstarter.com")
         vm.inputs.resetPasswordClick()
 
-        errorTest.assertValue("bad request")
+        errorTest.assertValue(false)
 
         this.lakeTest.assertValue("Forgot Password Page Viewed")
     }

--- a/app/src/test/java/com/kickstarter/viewmodels/ResetPasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ResetPasswordViewModelTest.kt
@@ -61,14 +61,14 @@ class ResetPasswordViewModelTest : KSRobolectricTestCase() {
                 .build()
 
         val vm = ResetPasswordViewModel.ViewModel(environment)
-        val errorTest = TestSubscriber<Boolean>()
+        val errorTest = TestSubscriber<String>()
 
         vm.outputs.resetError().subscribe(errorTest)
 
         vm.inputs.email("hello@kickstarter.com")
         vm.inputs.resetPasswordClick()
 
-        errorTest.assertValue(false)
+        errorTest.assertValue("bad request")
 
         this.lakeTest.assertValue("Forgot Password Page Viewed")
     }


### PR DESCRIPTION
# 📲 What
- NT-1058: Reset password error dialogs are not shown
- 

# 🤔 Why

Show error dialogs for the failed operation.

# 🛠 How

- Changed observable type to boolean to separate errors related to invalid email and others ( Network timeout etc )
- Removed filter operator from the error observable so errors are passed to the view 

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |
<img width="470" alt="Screenshot 2021-02-24 at 20 11 07" src="https://user-images.githubusercontent.com/63934292/109053850-76ec9c00-76dd-11eb-978d-acefce0a56bf.png">

# 📋 QA

- Navigate to the Forgot Password screen (aka Reset Password) 

- Enter an invalid email (an unregistered email, for example)

- Tap the "Reset password" button
- An error is received from the backend (404) and an error dialog is displayed 

- Submit the "Reset Password" button again (with a registered or unregistered email) 
- An Error or success is shown

# Story 📖

https://kickstarter.atlassian.net/browse/NT-1058
