### PR TITLE
EP- 247: Android: Page Viewed (discover)

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -30,6 +30,7 @@ import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_TYPE
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_PAGE
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_SECTION
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_LOCATION
+import com.kickstarter.libs.utils.EventContextValues.CtaContextName.DISCOVER
 import com.kickstarter.libs.utils.EventContextValues.LocationContextName.DISCOVER_ADVANCED
 import com.kickstarter.libs.utils.EventContextValues.LocationContextName.DISCOVER_OVERLAY
 import com.kickstarter.libs.utils.EventContextValues.LocationContextName.GLOBAL_NAV
@@ -40,6 +41,7 @@ import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.services.apiresponses.PushNotificationEnvelope
 import com.kickstarter.ui.data.*
 import com.kickstarter.ui.data.Mailbox
+import java.util.*
 import kotlin.collections.HashMap
 
 class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
@@ -612,6 +614,19 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
     fun trackFilterClicked(discoveryParams: DiscoveryParams) {
         val props = AnalyticEventsUtils.discoveryParamsProperties(discoveryParams)
         client.track(FILTER_CLICKED, props)
+    }
+
+
+    /**
+     * Sends data to the client when items in the discovery sort is selected.
+     *
+     * @param discoveryParams: The discovery parameters.
+     */
+    fun trackDiscoveryPageViewed(discoveryParams: DiscoveryParams) {
+        val props = AnalyticEventsUtils.discoveryParamsProperties(discoveryParams).toMutableMap()
+        props[DISCOVER_SORT.contextName] = discoveryParams.sort()?.name?.toLowerCase(Locale.ROOT) ?: ""
+        props[CONTEXT_PAGE.contextName] = DISCOVER.contextName
+        client.track(PAGE_VIEWED.eventName, props)
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -41,7 +41,7 @@ import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.services.apiresponses.PushNotificationEnvelope
 import com.kickstarter.ui.data.*
 import com.kickstarter.ui.data.Mailbox
-import java.util.*
+import java.util.Locale
 import kotlin.collections.HashMap
 
 class AnalyticEvents(trackingClients: List<TrackingClientType?>) {

--- a/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
@@ -19,7 +19,8 @@ class EventContextValues {
         REWARD_CONTINUE("reward_continue"),
         DISCOVER_SORT("discover_sort"),
         DISCOVER_FILTER("discover_filter"),
-        SEARCH("search")
+        SEARCH("search"),
+        DISCOVER("discover"),
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/libs/utils/EventKeys.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventKeys.kt
@@ -15,5 +15,6 @@ enum class ContextPropertyKeyName(val contextName: String) {
     CONTEXT_PAGE("context_page"),
     CONTEXT_SECTION("context_section"),
     CONTEXT_TYPE("context_type"),
-    CONTEXT_LOCATION("context_location")
+    CONTEXT_LOCATION("context_location"),
+    CONTEXT_DISCOVER_SORT("discover_sort")
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels;
 
+import android.util.Log;
 import android.util.Pair;
 
 import com.kickstarter.libs.ApiPaginator;
@@ -262,7 +263,10 @@ public interface DiscoveryFragmentViewModel {
         .compose(combineLatestPair(paginator.loadingPage().distinctUntilChanged()))
         .filter(paramsAndPage -> paramsAndPage.second == 1)
         .compose(bindToLifecycle())
-        .subscribe(paramsAndLoggedIn -> this.lake.trackExplorePageViewed(paramsAndLoggedIn.first));
+        .subscribe(paramsAndLoggedIn -> {
+          this.lake.trackDiscoveryPageViewed(paramsAndLoggedIn.first);
+          this.lake.trackExplorePageViewed(paramsAndLoggedIn.first);
+        });
 
       this.discoveryOnboardingLoginToutClick
         .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -1,6 +1,5 @@
 package com.kickstarter.viewmodels;
 
-import android.util.Log;
 import android.util.Pair;
 
 import com.kickstarter.libs.ApiPaginator;

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -2,7 +2,6 @@ package com.kickstarter.viewmodels;
 
 import android.content.Intent;
 import android.net.Uri;
-import android.util.Log;
 import android.util.Pair;
 
 import com.kickstarter.R;
@@ -48,7 +47,6 @@ import java.util.List;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import rx.Notification;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -432,7 +432,6 @@ public interface DiscoveryViewModel {
         })
         .compose(bindToLifecycle())
         .subscribe(this.showQualtricsSurvey);
-
     }
 
     private int currentDrawerMenuIcon(final @Nullable User user) {

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.java
@@ -2,6 +2,7 @@ package com.kickstarter.viewmodels;
 
 import android.content.Intent;
 import android.net.Uri;
+import android.util.Log;
 import android.util.Pair;
 
 import com.kickstarter.R;
@@ -433,6 +434,7 @@ public interface DiscoveryViewModel {
         })
         .compose(bindToLifecycle())
         .subscribe(this.showQualtricsSurvey);
+
     }
 
     private int currentDrawerMenuIcon(final @Nullable User user) {

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -27,6 +27,7 @@ import com.kickstarter.services.DiscoveryParams;
 import com.kickstarter.services.apiresponses.ActivityEnvelope;
 import com.kickstarter.services.apiresponses.DiscoverEnvelope;
 import com.kickstarter.ui.data.Editorial;
+import com.kickstarter.libs.utils.EventName;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
@@ -83,12 +84,12 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
 
     // Should emit current fragment's projects.
     this.hasProjects.assertValues(true);
-    this.lakeTest.assertValue("Explore Page Viewed");
+    this.lakeTest.assertValues(EventName.PAGE_VIEWED.getEventName(), "Explore Page Viewed");
 
     //Page is refreshed
     this.vm.inputs.refresh();
     this.hasProjects.assertValues(true, true);
-    this.lakeTest.assertValue("Explore Page Viewed");
+    this.lakeTest.assertValues(EventName.PAGE_VIEWED.getEventName(), "Explore Page Viewed");
   }
 
   @Test
@@ -100,7 +101,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
 
     // Should emit current fragment's projects.
     this.hasProjects.assertValues(true);
-    this.lakeTest.assertValue("Explore Page Viewed");
+    this.lakeTest.assertValues(EventName.PAGE_VIEWED.getEventName(), "Explore Page Viewed");
 
     // Select a new category.
     this.vm.inputs.paramsFromActivity(
@@ -112,7 +113,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
 
     // New projects load with new params.
     this.hasProjects.assertValues(true, true, true);
-    this.lakeTest.assertValues("Explore Page Viewed", "Explore Page Viewed");
+    this.lakeTest.assertValues(EventName.PAGE_VIEWED.getEventName(), "Explore Page Viewed", EventName.PAGE_VIEWED.getEventName(), "Explore Page Viewed");
 
     this.vm.inputs.clearPage();
     this.hasProjects.assertValues(true, true, true, false);
@@ -126,12 +127,12 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     setUpInitialHomeAllProjectsParams();
 
     this.projects.assertValueCount(1);
-    this.lakeTest.assertValue("Explore Page Viewed");
+    this.lakeTest.assertValues(EventName.PAGE_VIEWED.getEventName(), "Explore Page Viewed");
 
     // Popular tab clicked.
     this.vm.inputs.paramsFromActivity(DiscoveryParams.builder().sort(DiscoveryParams.Sort.POPULAR).build());
     this.projects.assertValueCount(3);
-    this.lakeTest.assertValues("Explore Page Viewed", "Explore Page Viewed");
+    this.lakeTest.assertValues(EventName.PAGE_VIEWED.getEventName(), "Explore Page Viewed", EventName.PAGE_VIEWED.getEventName(), "Explore Page Viewed");
   }
 
   @Test
@@ -400,7 +401,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.editorialViewHolderClicked(Editorial.LIGHTS_ON);
 
     this.startEditorialActivity.assertValues(Editorial.GO_REWARDLESS, Editorial.LIGHTS_ON);
-    this.lakeTest.assertValues("Explore Page Viewed", "Editorial Card Clicked", "Editorial Card Clicked");
+    this.lakeTest.assertValues(EventName.PAGE_VIEWED.getEventName(), "Explore Page Viewed", "Editorial Card Clicked", "Editorial Card Clicked");
   }
 
   @Test
@@ -420,7 +421,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.projectCardViewHolderClicked(project);
 
     this.startProjectActivity.assertValue(Pair.create(project, RefTag.collection(518)));
-    this.lakeTest.assertValue("Explore Page Viewed");
+    this.lakeTest.assertValues(EventName.PAGE_VIEWED.getEventName(), "Explore Page Viewed");
   }
 
   @Test
@@ -435,7 +436,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.projectCardViewHolderClicked(project);
 
     this.startProjectActivity.assertValue(Pair.create(project, RefTag.discovery()));
-    this.lakeTest.assertValue("Explore Page Viewed");
+    this.lakeTest.assertValues(EventName.PAGE_VIEWED.getEventName(), "Explore Page Viewed");
   }
 
   @Test


### PR DESCRIPTION
# 📲 What

Android: Page Viewed (discover)
- Add segment implementation for discovery sort page views
- For every sort - page selected, an event is submitted

# 🤔 Why

- Data lake Event to Convert for Segment
- To track sort page selected events on the discovery page

# 🛠 How

- Created a new method in the AnalyticEvent class to submit the new event to segment
- Called method from DiscoveryFragmentViewModel class for every page selected

# 👀 See

![Screenshot 2021-03-01 at 22 03 50](https://user-images.githubusercontent.com/63934292/109677729-3af08580-7b7a-11eb-9f04-0a89bfc61257.png)


| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

- On the discovery page select "MAGIC, POPULAR,  NEWEST OR ENDING SOON"
- Go to segment console/dashboard, you should see the event registered

![Screenshot 2021-03-02 at 17 00 41](https://user-images.githubusercontent.com/63934292/109678371-d84bb980-7b7a-11eb-8531-dc2d9c07b0ce.png)


# Story 📖

https://kickstarter.atlassian.net/browse/EP-247