### PR TITLE
EP-163: Create properties checkout

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -4,13 +4,14 @@ import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.utils.RewardUtils.isItemized
 import com.kickstarter.libs.utils.RewardUtils.isShippable
 import com.kickstarter.libs.utils.RewardUtils.isTimeLimitedEnd
-import com.kickstarter.libs.utils.extensions.totalAmount
+import com.kickstarter.libs.utils.extensions.*
 import com.kickstarter.models.*
 import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.ui.data.CheckoutData
 import com.kickstarter.ui.data.PledgeData
 import java.util.*
 import kotlin.math.ceil
+import kotlin.math.round
 import kotlin.math.roundToInt
 
 object AnalyticEventsUtils {
@@ -22,12 +23,17 @@ object AnalyticEventsUtils {
             put("amount", checkoutData.amount())
             checkoutData.id()?.let { put("id", it) }
             put("payment_type", checkoutData.paymentType().rawValue())
-            put("amount_total_usd", checkoutData.totalAmount() * project.staticUsdRate())
+            put("amount_total_usd", checkoutData.totalAmount(project.staticUsdRate()))
             put("shipping_amount", checkoutData.shippingAmount())
-            checkoutData.bonusAmount()?.let { bAmount ->
-                put("bonus_amount", bAmount)
-                put("bonus_amount_usd", Math.round(bAmount * project.staticUsdRate()))
+            put("shipping_amount_usd", checkoutData.shippingAmount(project.staticUsdRate()))
+            checkoutData.bonusAmount()?.let {
+                put("bonus_amount", checkoutData.bonus())
+                put("bonus_amount_usd", checkoutData.bonus(project.staticUsdRate()))
             }
+            put("reward_minimum_usd", pledgeData.rewardCost(project.staticUsdRate()))
+            put("add_ons_count_total", pledgeData.totalQuantity())
+            put("add_ons_count_unique", pledgeData.totalCountUnique())
+            put("add_ons_minimum_usd", pledgeData.addOnsCost(project.staticUsdRate()))
         }
 
         return MapUtils.prefixKeys(properties, prefix)
@@ -205,7 +211,7 @@ object AnalyticEventsUtils {
                 properties.putAll(updateProperties(project, update, loggedInUser))
             }
         }
-
+f
         return properties
     }
 

--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -26,11 +26,8 @@ object AnalyticEventsUtils {
             put("amount_total_usd", checkoutData.totalAmount(project.staticUsdRate()))
             put("shipping_amount", checkoutData.shippingAmount())
             put("shipping_amount_usd", checkoutData.shippingAmount(project.staticUsdRate()))
-            checkoutData.bonusAmount()?.let {
-                put("bonus_amount", checkoutData.bonus())
-                put("bonus_amount_usd", checkoutData.bonus(project.staticUsdRate()))
-            }
-            put("reward_minimum_usd", pledgeData.rewardCost(project.staticUsdRate()))
+            put("bonus_amount", checkoutData.bonus())
+            put("bonus_amount_usd", checkoutData.bonus(project.staticUsdRate()))
             put("add_ons_count_total", pledgeData.totalQuantity())
             put("add_ons_count_unique", pledgeData.totalCountUnique())
             put("add_ons_minimum_usd", pledgeData.addOnsCost(project.staticUsdRate()))
@@ -115,14 +112,16 @@ object AnalyticEventsUtils {
     fun pledgeDataProperties(pledgeData: PledgeData, loggedInUser: User?): MutableMap<String, Any> {
         val projectData = pledgeData.projectData()
         val props = projectProperties(projectData.project(), loggedInUser)
-        props.putAll(pledgeProperties(pledgeData.reward()))
+        props.putAll(pledgeProperties(pledgeData))
         props.putAll(refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()))
         props["context_pledge_flow"] = pledgeData.pledgeFlowContext().trackingString
         return props
     }
 
     @JvmOverloads
-    fun pledgeProperties(reward: Reward, prefix: String = "checkout_reward_"): Map<String, Any> {
+    fun pledgeProperties(pledgeData: PledgeData, prefix: String = "checkout_reward_"): Map<String, Any> {
+        val reward = pledgeData.reward()
+        val project = pledgeData.projectData().project()
         val properties = HashMap<String, Any>().apply {
             reward.estimatedDeliveryOn()?.let { deliveryDate ->
                 put("estimated_delivery_on", deliveryDate.millis / 1000 )
@@ -133,6 +132,7 @@ object AnalyticEventsUtils {
             put("is_limited_quantity", reward.limit() != null)
             put("minimum", reward.minimum())
             put("shipping_enabled", isShippable(reward))
+            put("minimum_usd", pledgeData.rewardCost(project.staticUsdRate()))
             reward.shippingPreference()?.let { put("shipping_preference", it) }
             reward.title()?.let { put("title", it) }
         }

--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -211,7 +211,6 @@ object AnalyticEventsUtils {
                 properties.putAll(updateProperties(project, update, loggedInUser))
             }
         }
-f
         return properties
     }
 

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/CheckoutDataExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/CheckoutDataExt.kt
@@ -2,7 +2,6 @@
 package com.kickstarter.libs.utils.extensions
 
 import com.kickstarter.ui.data.CheckoutData
-import kotlin.math.round
 
 /**
  * Returns the total amount for a pledge.
@@ -13,9 +12,7 @@ import kotlin.math.round
  *
  * @return Double
  */
-fun CheckoutData.totalAmount(): Double {
-    return this.amount() + this.shippingAmount()
-}
+fun CheckoutData.totalAmount() = this.amount() + this.shippingAmount()
 
 /**
  * Returns the total amount for a pledge in USD.
@@ -26,7 +23,7 @@ fun CheckoutData.totalAmount(): Double {
  *
  * @return Double
  */
-fun CheckoutData.totalAmount(usdRate: Float) = round(this.totalAmount() * usdRate)
+fun CheckoutData.totalAmount(usdRate: Float) = this.totalAmount() * usdRate
 
 /**
  * Returns the bonus amount added to the pledge
@@ -40,11 +37,11 @@ fun CheckoutData.bonus() = this.bonusAmount()?.let { it } ?: 0.0
  *
  * @return Double
  */
-fun CheckoutData.bonus(usdRate: Float) = round(this.bonus() * usdRate)
+fun CheckoutData.bonus(usdRate: Float) = this.bonus() * usdRate
 
 /**
  * Returns the shipping amount in USD
  *
  * @return Double
  */
-fun CheckoutData.shippingAmount(usdRate: Float) = round(this.shippingAmount() * usdRate)
+fun CheckoutData.shippingAmount(usdRate: Float) = this.shippingAmount() * usdRate

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/CheckoutDataExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/CheckoutDataExt.kt
@@ -2,6 +2,7 @@
 package com.kickstarter.libs.utils.extensions
 
 import com.kickstarter.ui.data.CheckoutData
+import kotlin.math.round
 
 /**
  * Returns the total amount for a pledge.
@@ -9,7 +10,41 @@ import com.kickstarter.ui.data.CheckoutData
  *
  * Checkout.amount = bonus support + add-ons + reward
  * Checkout.shippingAmount = shipping reward + shipping add-ons
+ *
+ * @return Double
  */
 fun CheckoutData.totalAmount(): Double {
     return this.amount() + this.shippingAmount()
 }
+
+/**
+ * Returns the total amount for a pledge in USD.
+ * @return Total pledge amount includes shipping, bonus support, and add-ons if applicable
+ *
+ * Checkout.amount = bonus support + add-ons + reward
+ * Checkout.shippingAmount = shipping reward + shipping add-ons
+ *
+ * @return Double
+ */
+fun CheckoutData.totalAmount(usdRate: Float) = round(this.totalAmount() * usdRate)
+
+/**
+ * Returns the bonus amount added to the pledge
+ *
+ * @return Double
+ */
+fun CheckoutData.bonus() = this.bonusAmount()?.let { it } ?: 0.0
+
+/**
+ * Returns the bonus amount added to the pledge in USD
+ *
+ * @return Double
+ */
+fun CheckoutData.bonus(usdRate: Float) = round(this.bonus() * usdRate)
+
+/**
+ * Returns the shipping amount in USD
+ *
+ * @return Double
+ */
+fun CheckoutData.shippingAmount(usdRate: Float) = round(this.shippingAmount() * usdRate)

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/PledgeDataExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/PledgeDataExt.kt
@@ -1,0 +1,47 @@
+@file:JvmName("PledgeDataExt")
+package com.kickstarter.libs.utils.extensions
+
+import com.kickstarter.ui.data.PledgeData
+import kotlin.math.round
+
+
+/**
+ * Total count of selected add-ons (including multiple quantities of a single add-on)
+ *
+ * @return Integer
+ */
+fun PledgeData.totalQuantity(): Int {
+    var addOnsQuantity = 0
+    this.addOns()?.forEach { addOn ->
+        addOnsQuantity += addOn.quantity() ?: 0
+    }
+
+    return addOnsQuantity
+}
+
+/**
+ * Total count of unique selected add-ons
+ *
+ * @return Integer
+ */
+fun PledgeData.totalCountUnique() = this.addOns()?.size ?: 0
+
+/**
+ * The total amount for all selected add-ons, converted to USD
+ *
+ * @return Double: e.g. 25.00
+ */
+fun PledgeData.addOnsCost(usdRate: Float): Double {
+    val amount = this.addOns()?.map { addOn ->
+        addOn.minimum() * (addOn.quantity() ?: 0)
+    }?.sum() ?: 0
+
+    return round(amount.toDouble() * usdRate)
+}
+
+/**
+ * The lowest amount a backer can pledge for the reward (in USD)
+ *
+ * @return Double: e.g. 25.00
+ */
+fun PledgeData.rewardCost(usdRate: Float): Double = round(this.reward().minimum() * usdRate)

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/PledgeDataExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/PledgeDataExt.kt
@@ -2,7 +2,6 @@
 package com.kickstarter.libs.utils.extensions
 
 import com.kickstarter.ui.data.PledgeData
-import kotlin.math.round
 
 
 /**
@@ -36,7 +35,7 @@ fun PledgeData.addOnsCost(usdRate: Float): Double {
         addOn.minimum() * (addOn.quantity() ?: 0)
     }?.sum() ?: 0
 
-    return round(amount.toDouble() * usdRate)
+    return amount.toDouble() * usdRate
 }
 
 /**
@@ -44,4 +43,4 @@ fun PledgeData.addOnsCost(usdRate: Float): Double {
  *
  * @return Double: e.g. 25.00
  */
-fun PledgeData.rewardCost(usdRate: Float): Double = round(this.reward().minimum() * usdRate)
+fun PledgeData.rewardCost(usdRate: Float): Double = this.reward().minimum() * usdRate

--- a/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.java
@@ -21,6 +21,24 @@ public final class RewardFactory {
             .build();
   }
 
+  public static @NonNull Reward addOnSingle() {
+    return reward().toBuilder()
+            .quantity(1)
+            .isAddOn(true)
+            .isAvailable(true)
+            .limit(10)
+            .build();
+  }
+
+  public static @NonNull Reward addOnMultiple() {
+    return reward().toBuilder()
+            .quantity(5)
+            .isAddOn(true)
+            .isAvailable(true)
+            .limit(10)
+            .build();
+  }
+
   public static @NonNull Reward rewardHasAddOns() {
     return reward().toBuilder()
             .hasAddons(true)

--- a/app/src/main/java/com/kickstarter/ui/data/CheckoutData.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/CheckoutData.kt
@@ -2,7 +2,6 @@ package com.kickstarter.ui.data
 
 import android.os.Parcelable
 import auto.parcel.AutoParcel
-import fragment.Backing
 import type.CreditCardPaymentType
 
 @AutoParcel

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -502,6 +502,11 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals("CREDIT_CARD", expectedProperties["checkout_payment_type"])
         assertEquals(50.0, expectedProperties["checkout_amount_total_usd"])
         assertEquals(20.0, expectedProperties["checkout_shipping_amount"])
+        assertEquals(20.0, expectedProperties["checkout_shipping_amount_usd"])
+        assertEquals(0, expectedProperties["checkout_add_ons_count_total"])
+        assertEquals(0, expectedProperties["checkout_add_ons_count_unique"])
+        assertEquals(0.0, expectedProperties["checkout_add_ons_minimum_usd"])
+        assertEquals(0.0, expectedProperties["checkout_bonus_amount_usd"])
     }
 
     private fun assertContextProperties() {
@@ -529,6 +534,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals(false, expectedProperties["checkout_reward_is_limited_time"])
         assertEquals(false, expectedProperties["checkout_reward_is_limited_quantity"])
         assertEquals(10.0, expectedProperties["checkout_reward_minimum"])
+        assertEquals(10.0, expectedProperties["checkout_reward_minimum_usd"])
         assertEquals(true, expectedProperties["checkout_reward_shipping_enabled"])
         assertEquals("unrestricted", expectedProperties["checkout_reward_shipping_preference"])
         assertEquals("Digital Bundle", expectedProperties["checkout_reward_title"])

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/CheckoutDataExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/CheckoutDataExtTest.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.libs.utils.extensions
 
+import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.ui.data.CheckoutData
 import junit.framework.TestCase
 import type.CreditCardPaymentType
@@ -24,5 +25,51 @@ class CheckoutDataExtTest: TestCase() {
                 .build()
 
         assertEquals(coData.totalAmount(), 230.0)
+    }
+
+    fun testBonus_withUSDProject() {
+        val project = ProjectFactory.project()
+        val coData = CheckoutData.builder()
+                .paymentType(CreditCardPaymentType.CREDIT_CARD)
+                .shippingAmount(30.0)
+                .amount(200.0)
+                .build()
+
+        assertEquals(coData.bonus(), coData.bonus(project.staticUsdRate()))
+    }
+
+    fun testBonus_withCAProject() {
+        val project = ProjectFactory.caProject()
+        val coData = CheckoutData.builder()
+                .paymentType(CreditCardPaymentType.CREDIT_CARD)
+                .shippingAmount(30.0)
+                .amount(200.0)
+                .build()
+
+        val expectedBonusUSD = coData.bonus() * project.staticUsdRate()
+        assertEquals(expectedBonusUSD, coData.bonus(project.staticUsdRate()))
+    }
+
+    fun testShipping_withUSDProject() {
+        val project = ProjectFactory.project()
+        val coData = CheckoutData.builder()
+                .paymentType(CreditCardPaymentType.CREDIT_CARD)
+                .shippingAmount(30.0)
+                .amount(200.0)
+                .build()
+
+        assertEquals(coData.shippingAmount(), coData.shippingAmount(project.staticUsdRate()))
+    }
+
+    fun testShipping_withCAProject() {
+        val project = ProjectFactory.caProject()
+        val coData = CheckoutData.builder()
+                .paymentType(CreditCardPaymentType.CREDIT_CARD)
+                .shippingAmount(30.0)
+                .amount(200.0)
+                .build()
+
+        val expectedShippingInUSD = coData.shippingAmount() * project.staticUsdRate()
+        assertEquals(expectedShippingInUSD, coData.shippingAmount(project.staticUsdRate()))
     }
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/PledgeDataExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/PledgeDataExtTest.kt
@@ -1,15 +1,60 @@
 package com.kickstarter.libs.utils.extensions
 
+import com.kickstarter.mock.factories.ProjectDataFactory.Companion.project
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.mock.factories.RewardFactory
+import com.kickstarter.models.Reward
+import com.kickstarter.ui.data.PledgeData.Companion.with
+import com.kickstarter.ui.data.PledgeFlowContext
 import junit.framework.TestCase
 
 class PledgeDataExtTest : TestCase() {
 
     fun testAddOnsCountTotalEmpty() {
+        val project = ProjectFactory.project()
+        val rw = RewardFactory.reward()
+        val addOns = emptyList<Reward>() as java.util.List<Reward>
+        val pledgeData = with(PledgeFlowContext.NEW_PLEDGE,
+                project(project), rw, addOns, null)
+
+        assertEquals(pledgeData.totalCountUnique(), 0)
+        assertEquals(pledgeData.totalQuantity(), 0)
     }
 
     fun testAddOnsCountTotal_whenMultipleQuantity_singleAddOn() {
+        val project = ProjectFactory.project()
+        val rw = RewardFactory.rewardHasAddOns()
+        val addOn = RewardFactory.addOnSingle()
+        val addOns = listOf(addOn, addOn) as java.util.List<Reward>
+        val pledgeData = with(PledgeFlowContext.NEW_PLEDGE,
+                project(project), rw, addOns, null)
+
+        assertEquals(pledgeData.totalCountUnique(), addOns.size)
+        assertEquals(pledgeData.totalQuantity(), 2)
     }
 
     fun testAddOnsCountTotal_whenMultipleQuantity_multipleAddOns() {
+        val project = ProjectFactory.project()
+        val rw = RewardFactory.rewardHasAddOns()
+        val addOn = RewardFactory.addOnMultiple()
+        val addOns = listOf(addOn, addOn) as java.util.List<Reward>
+        val pledgeData = with(PledgeFlowContext.NEW_PLEDGE,
+                project(project), rw, addOns, null)
+
+        assertEquals(pledgeData.totalCountUnique(), addOns.size)
+        assertEquals(pledgeData.totalQuantity(), 10)
+    }
+
+    fun testAddOnsCountTotal_whenSingleAndMultiple_total() {
+        val project = ProjectFactory.project()
+        val rw = RewardFactory.rewardHasAddOns()
+        val addOnSingle = RewardFactory.addOnSingle()
+        val addOnMultiple = RewardFactory.addOnMultiple()
+        val addOns = listOf(addOnSingle, addOnMultiple) as java.util.List<Reward>
+        val pledgeData = with(PledgeFlowContext.NEW_PLEDGE,
+                project(project), rw, addOns, null)
+
+        assertEquals(pledgeData.totalCountUnique(), addOns.size)
+        assertEquals(pledgeData.totalQuantity(), 6)
     }
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/PledgeDataExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/PledgeDataExtTest.kt
@@ -57,4 +57,53 @@ class PledgeDataExtTest : TestCase() {
         assertEquals(pledgeData.totalCountUnique(), addOns.size)
         assertEquals(pledgeData.totalQuantity(), 6)
     }
+
+    fun testAddOnsCost_whenUSDProject() {
+        val project = ProjectFactory.project()
+        val rw = RewardFactory.rewardHasAddOns()
+        val addOnSingle = RewardFactory.addOnSingle().toBuilder().minimum(30.0).build()
+        val addOnMultiple = RewardFactory.addOnMultiple().toBuilder().minimum(5.0).build()
+        val addOns = listOf(addOnSingle, addOnMultiple) as java.util.List<Reward>
+        val pledgeData = with(PledgeFlowContext.NEW_PLEDGE,
+                project(project), rw, addOns, null)
+
+        val expectedValue = 30.0 + (5.0 * 5)
+        assertEquals(pledgeData.addOnsCost(project.staticUsdRate()), expectedValue)
+    }
+
+    fun testAddOnsCost_whenCAProject() {
+        val project = ProjectFactory.caProject()
+        val rw = RewardFactory.rewardHasAddOns()
+        // - quantity = 1 on addOnSingle
+        val addOnSingle = RewardFactory.addOnSingle().toBuilder().minimum(30.0).build()
+        // - quantity = 5 on addOnMultiple
+        val addOnMultiple = RewardFactory.addOnMultiple().toBuilder().minimum(5.0).build()
+        val addOns = listOf(addOnSingle, addOnMultiple) as java.util.List<Reward>
+        val pledgeData = with(PledgeFlowContext.NEW_PLEDGE,
+                project(project), rw, addOns, null)
+
+        val expectedValue = (30.0 + (5.0 * 5)) * project.staticUsdRate()
+        assertEquals(pledgeData.addOnsCost(project.staticUsdRate()), expectedValue)
+    }
+
+    fun testRewardCost_whenUSDProject() {
+        val project = ProjectFactory.project()
+        val rw = RewardFactory.rewardHasAddOns()
+        val addOns = emptyList<Reward>() as java.util.List<Reward>
+        val pledgeData = with(PledgeFlowContext.NEW_PLEDGE,
+                project(project), rw, addOns, null)
+
+        assertEquals(pledgeData.rewardCost(project.staticUsdRate()), rw.minimum())
+    }
+
+    fun testRewardCost_whenCAProject() {
+        val project = ProjectFactory.caProject()
+        val rw = RewardFactory.rewardHasAddOns()
+        val addOns = emptyList<Reward>() as java.util.List<Reward>
+        val pledgeData = with(PledgeFlowContext.NEW_PLEDGE,
+                project(project), rw, addOns, null)
+
+        val expectedValue = rw.minimum() * project.staticUsdRate()
+        assertEquals(pledgeData.rewardCost(project.staticUsdRate()), expectedValue)
+    }
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/PledgeDataExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/PledgeDataExtTest.kt
@@ -1,0 +1,15 @@
+package com.kickstarter.libs.utils.extensions
+
+import junit.framework.TestCase
+
+class PledgeDataExtTest : TestCase() {
+
+    fun testAddOnsCountTotalEmpty() {
+    }
+
+    fun testAddOnsCountTotal_whenMultipleQuantity_singleAddOn() {
+    }
+
+    fun testAddOnsCountTotal_whenMultipleQuantity_multipleAddOns() {
+    }
+}


### PR DESCRIPTION
# 📲 What

Added properties: 
- checkout_add_ons_count_total
- checkout_add_ons_count_unique
- checkout_add_ons_minimum_usd
- checkout_bonus_amount_usd
- checkout_reward_minimum_usd
- checkout_shipping_amount_usd:

# 🛠 How
- All addOns related properties are collected on Checkout step, but storaged on pledgeData.

# 👀 See
![Project_WithAddOns_Unique](https://user-images.githubusercontent.com/4083656/109882326-8e241000-7c2e-11eb-98bc-e1dfad66fc91.png)
<img width="510" alt="Project_WAddOns" src="https://user-images.githubusercontent.com/4083656/109882329-8f553d00-7c2e-11eb-96a9-bd58c4fb8fe7.png">
![Project_WOAddOns_No_USD](https://user-images.githubusercontent.com/4083656/109882330-8fedd380-7c2e-11eb-81eb-eb259b8de83e.png)
|  |  |

# 📋 QA
- Pledge to a project with addOns, if the project is from US the values will be the same as you see on the `Manage your pledge ` screen
- Pledge to a project with addOns, but a project from other country different from US, on this new properties you'll se the conversion from the project currency to us dolars

# Story 📖

[EP-163](Thttps://kickstarter.atlassian.net/browse/EP-163)
