### PR TITLE
NT-1805: Payment with 3DS card flow

### DIFF
--- a/app/src/main/java/com/kickstarter/models/Backing.java
+++ b/app/src/main/java/com/kickstarter/models/Backing.java
@@ -33,7 +33,7 @@ public abstract class Backing implements Parcelable, Relay {
   public abstract @Nullable Long locationId();
   public abstract @Nullable String locationName();
   public abstract @Nullable PaymentSource paymentSource();
-  public abstract DateTime pledgedAt();
+  public abstract @Nullable DateTime pledgedAt();
   public abstract @Nullable Project project();
   public abstract long projectId();
   public abstract @Nullable Reward reward();

--- a/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.kt
@@ -233,12 +233,14 @@ class MessagesActivity : BaseActivity<MessagesViewModel.ViewModel>() {
 
     private fun setBackingInfoView(backingAndProject: Pair<Backing, Project>) {
         val pledgeAmount = ksCurrency.format(backingAndProject.first.amount(), backingAndProject.second, RoundingMode.HALF_UP)
-        val pledgeDate = DateTimeUtils.relative(this, ksString, backingAndProject.first.pledgedAt())
-        binding.messagesBackingInfoView.backingAmountTextView.text = Html.fromHtml(
-            ksString.format(
-                getString(R.string.pledge_amount_pledged_on_pledge_date), "pledge_amount", pledgeAmount, "pledge_date", pledgeDate
+        backingAndProject.first.pledgedAt()?.let {
+            val pledgeDate = DateTimeUtils.relative(this, ksString, it)
+            binding.messagesBackingInfoView.backingAmountTextView.text = Html.fromHtml(
+                    ksString.format(
+                            getString(R.string.pledge_amount_pledged_on_pledge_date), "pledge_amount", pledgeAmount, "pledge_date", pledgeDate
+                    )
             )
-        )
+        }
     }
 
     private fun setDefaultRecyclerViewBottomPadding() =

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -230,7 +230,8 @@ interface BackingFragmentViewModel {
                     .subscribe(this.backerNumber)
 
             backing
-                    .map { DateTimeUtils.longDate(it.pledgedAt()) }
+                    .filter { ObjectUtils.isNotNull(it.pledgedAt()) }
+                    .map { DateTimeUtils.longDate(ObjectUtils.requireNonNull(it.pledgedAt())) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.pledgeDate)

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -493,6 +493,24 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testPledgeDateNull() {
+        val pledgeDate = null
+        val backing = BackingFactory.backing()
+                .toBuilder()
+                .pledgedAt(pledgeDate)
+                .build()
+
+        val environment = environment()
+                .toBuilder()
+                .apolloClient(mockApolloClientForBacking(backing))
+                .build()
+        setUpEnvironment(environment)
+        this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.backedProject()))
+
+        this.pledgeDate.assertNoValues()
+    }
+
+    @Test
     fun testPledgeStatusData_whenProjectIsCanceled() {
         val backing = backingWithStatus(Backing.STATUS_PLEDGED)
         val deadline = DateTime.parse("2019-11-11T17:10:04+00:00")


### PR DESCRIPTION
# 📲 What

- When using a payment method with 3DS auth the payment completes successfully but the app ends app crasing.

# 🤔 Why

Once we have a successful pledge, a new request is made to retrieve the baking information from GraphQl, in order to populate the `Manage Pledge Screen`. On our Backing Data Model we have some non-nullable fields that the app expects to always have results for them (in other words it never expects null values), see https://github.com/kickstarter/android-oss/blob/ed7eb8e1fb1c76d1999ca0270ac840f9271ac790/app/src/main/java/com/kickstarter/models/Backing.java#L36 , but in this concrete type of flow the query `GetProjectBacking` give us the field `pledgeAt` as `null` 

# 🛠 How

- The field `pledgeAt` inside Backing data model has change to be an optional field.

# 👀 See
| Before 🐛 |
https://user-images.githubusercontent.com/4083656/110184694-60250400-7dc5-11eb-8bba-9ae1c550dca1.mp4
| After 🦋 |
*** AUTH succeed**
https://user-images.githubusercontent.com/4083656/110185288-d8d89000-7dc6-11eb-80af-1da7b72ca212.mp4
*** AUTH canceled**
https://user-images.githubusercontent.com/4083656/110185159-7aabad00-7dc6-11eb-94ff-066de8b00057.mp4

|  |  |

# 📋 QA

- Use the first card in this document to pledge to a project https://stripe.com/docs/payments/3d-secure#three-ds-cards . The authentication flow will be triggered just once if the authorization succeeds, if you need to test it more times, remove the payment method, re-install the app and add it again.

# Story 📖

[NT-1805:Crash on android when paying method is a 3D secure card](https://kickstarter.atlassian.net/browse/NT-1805)
