### PR TITLE
EP-322: Page Viewed (update_pledge)

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -17,6 +17,7 @@ import com.kickstarter.libs.utils.EventContextValues.ContextTypeName.UNWATCH
 import com.kickstarter.libs.utils.EventContextValues.ContextTypeName.CREDIT_CARD
 import com.kickstarter.libs.utils.EventContextValues.PageViewedContextName.ADD_ONS
 import com.kickstarter.libs.utils.EventContextValues.PageViewedContextName.CHECKOUT
+import com.kickstarter.libs.utils.EventContextValues.PageViewedContextName.UPDATE_PLEDGE
 import com.kickstarter.libs.utils.EventContextValues.PageViewedContextName.REWARDS
 import com.kickstarter.libs.utils.EventContextValues.PageViewedContextName.PROJECT
 import com.kickstarter.libs.utils.EventContextValues.PageViewedContextName.THANKS
@@ -734,6 +735,18 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      */
     fun trackCheckoutScreenViewed(checkoutData: CheckoutData, pledgeData: PledgeData) {
         val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to CHECKOUT.contextName)
+        props.putAll(AnalyticEventsUtils.checkoutDataProperties(checkoutData, pledgeData, client.loggedInUser()))
+        client.track(PAGE_VIEWED.eventName, props)
+    }
+
+    /**
+     * Sends data to the client when the update pledge screen is view.
+     *
+     * @param checkoutData: The checkout data.
+     * @param pledgeData: The selected pledge data.
+     */
+    fun trackUpdatePledgePageViewed(checkoutData: CheckoutData, pledgeData: PledgeData) {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to UPDATE_PLEDGE.contextName)
         props.putAll(AnalyticEventsUtils.checkoutDataProperties(checkoutData, pledgeData, client.loggedInUser()))
         client.track(PAGE_VIEWED.eventName, props)
     }

--- a/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
@@ -40,7 +40,8 @@ class EventContextValues {
         CHECKOUT("checkout"),
         PROJECT("project"),
         REWARDS("rewards"),
-        THANKS("thanks")
+        THANKS("thanks"),
+        UPDATE_PLEDGE("update_pledge")
     }
 
     enum class ProjectContextSectionName(val contextName: String) {

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -1322,6 +1322,14 @@ interface PledgeFragmentViewModel {
                         this.lake.trackCheckoutScreenViewed(it.first, it.second)
                     }
 
+             checkoutAndPledgeData
+                    .take(1)
+                    .filter { it.second.pledgeFlowContext() == PledgeFlowContext.MANAGE_REWARD }
+                    .compose(bindToLifecycle())
+                    .subscribe {
+                        this.lake.trackUpdatePledgePageViewed(it.first, it.second)
+                    }
+
             fullProjectDataAndPledgeData
                     .take(1)
                     .filter { it.second.pledgeFlowContext() == PledgeFlowContext.NEW_PLEDGE }

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -33,7 +33,6 @@ import rx.observers.TestSubscriber
 import java.math.RoundingMode
 import java.net.CookieManager
 import java.util.*
-import kotlin.math.E
 
 class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
@@ -530,7 +529,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertNoValues()
         this.totalDividerIsGone.assertValue(false)
 
-        this.lakeTest.assertNoValues()
+        this.lakeTest.assertValue(EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertNoValues()
     }
 
@@ -558,7 +557,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingSummaryIsGone.assertNoValues()
         this.totalDividerIsGone.assertValue(false)
 
-        this.lakeTest.assertNoValues()
+        this.lakeTest.assertValue(EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertNoValues()
     }
 
@@ -589,7 +588,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.shippingRulesSectionIsGone.assertValues(true, true)
         this.totalDividerIsGone.assertValue(true)
 
-        this.lakeTest.assertNoValues()
+        this.lakeTest.assertValue(EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertNoValues()
     }
 
@@ -617,7 +616,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.totalDividerIsGone.assertValue(true)
         this.pledgeButtonIsEnabled.assertValue(true)
 
-        this.lakeTest.assertNoValues()
+        this.lakeTest.assertValue(EventName.PAGE_VIEWED.eventName)
         this.experimentsTest.assertNoValues()
     }
 
@@ -1288,7 +1287,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.newCardButtonClicked()
         this.showNewCardFragment.assertValue(backedProject)
-        this.lakeTest.assertNoValues()
+        this.lakeTest.assertValue(EventName.PAGE_VIEWED.eventName)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- Added segment implementation for UPDATE PLEDGE page viewed event

# 🤔 Why

Segment Integration

# 🛠 How

- Added new method ```trackUpdatePledgePageViewed``` to  ```AnalyticEvents``` class
- Called method from ```PledgeFragmentViewModel``` class on page load

# 👀 See

![Screenshot 2021-03-09 at 14 48 37](https://user-images.githubusercontent.com/63934292/110480264-983e8680-80e6-11eb-97fc-c52f756b4b65.png)



| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

- Navigate to the ```profile page```, select from the list of backed projects
- Click ```Manage``` button 
- From the toolbar options menu, select ``` Update Pledge ```

You should see the new event submitted
![Screenshot 2021-03-09 at 14 01 23](https://user-images.githubusercontent.com/63934292/110479990-439b0b80-80e6-11eb-97b9-5e0614f7dae9.png)


# Story 📖

https://kickstarter.atlassian.net/browse/EP-322
