### PR TITLE
NT-1756: Backing fragment crashes

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/factories/BackingFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/BackingFactory.java
@@ -49,6 +49,27 @@ public final class BackingFactory {
       .build();
   }
 
+  public static @NonNull Backing backingNull() {
+    return Backing.builder()
+            .amount(0.0f)
+            .backer(null)
+            .backerId(UserFactory.user().id())
+            .backerName(null)
+            .backerUrl(null)
+            .cancelable(true)
+            .id(IdFactory.id())
+            .paymentSource(null)
+            .pledgedAt(DateTime.now())
+            .project(null)
+            .projectId(ProjectFactory.project().id())
+            .reward(null)
+            .rewardId(null)
+            .sequence(1)
+            .shippingAmount(0.0f)
+            .status(Backing.STATUS_PLEDGED)
+            .build();
+  }
+
   public static Backing backing(final @NonNull String status) {
     return backing()
       .toBuilder()

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -29,6 +29,7 @@ import com.kickstarter.services.mutations.SavePaymentMethodData
 import com.kickstarter.services.mutations.UpdateBackingData
 import org.joda.time.DateTime
 import rx.Observable
+import rx.schedulers.Schedulers
 import rx.subjects.PublishSubject
 import type.*
 import java.nio.charset.Charset
@@ -132,7 +133,7 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                         }
                     })
             return@defer ps
-        }
+        }.subscribeOn(Schedulers.io())
     }
 
     override fun clearUnseenActivity(): Observable<Int> {
@@ -298,7 +299,7 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                         }
                     })
             return@defer ps
-        }
+        }.subscribeOn(Schedulers.io())
     }
 
     override fun getProjectAddOns(slug: String, locationId: Location): Observable<List<Reward>> {

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -220,6 +220,7 @@ interface BackingFragmentViewModel {
 
             backing
                     .map { it.backerUrl() }
+                    .filter { ObjectUtils.isNotNull(it) }
                     .compose(bindToLifecycle())
                     .subscribe(this.backerAvatar)
 
@@ -237,6 +238,7 @@ interface BackingFragmentViewModel {
 
             backing
                     .map { it.amount() - it.shippingAmount() - it.bonusAmount() }
+                    .filter { ObjectUtils.isNotNull(it) }
                     .compose<Pair<Double, Project>>(combineLatestPair(backedProject))
                     .map { ProjectViewUtils.styleCurrency(it.first, it.second, this.ksCurrency) }
                     .distinctUntilChanged()
@@ -267,6 +269,7 @@ interface BackingFragmentViewModel {
 
             backing
                     .map { it.shippingAmount() }
+                    .filter { ObjectUtils.isNotNull(it) }
                     .compose<Pair<Float, Project>>(combineLatestPair(backedProject))
                     .map { ProjectViewUtils.styleCurrency(it.first.toDouble(), it.second, this.ksCurrency) }
                     .distinctUntilChanged()
@@ -275,6 +278,7 @@ interface BackingFragmentViewModel {
 
             backing
                     .map { it.locationName()?.let { name -> name } }
+                    .filter { ObjectUtils.isNotNull(it) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.shippingLocation)
@@ -282,6 +286,7 @@ interface BackingFragmentViewModel {
 
             backing
                     .map { it.amount()}
+                    .filter { ObjectUtils.isNotNull(it) }
                     .compose<Pair<Double, Project>>(combineLatestPair(backedProject))
                     .map { ProjectViewUtils.styleCurrency(it.first, it.second, this.ksCurrency) }
                     .distinctUntilChanged()
@@ -300,7 +305,7 @@ interface BackingFragmentViewModel {
 
             val paymentSource = backing
                     .map { it.paymentSource() }
-                    .filter { it != null }
+                    .filter { ObjectUtils.isNotNull(it) }
                     .ofType(Backing.PaymentSource::class.java)
 
             val simpleDateFormat = SimpleDateFormat(StoredCard.DATE_FORMAT, Locale.getDefault())
@@ -309,12 +314,14 @@ interface BackingFragmentViewModel {
                     .map { source ->
                         source.expirationDate()?.let { simpleDateFormat.format(it) } ?: ""
                     }
+                    .filter { ObjectUtils.isNotNull(it) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.cardExpiration)
 
             paymentSource
                     .map { cardIssuer(it) }
+                    .filter { ObjectUtils.isNotNull(it) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.cardIssuer)
@@ -327,6 +334,7 @@ interface BackingFragmentViewModel {
 
             paymentSource
                     .map { cardLogo(it) }
+                    .filter { ObjectUtils.isNotNull(it) }
                     .distinctUntilChanged()
                     .compose(bindToLifecycle())
                     .subscribe(this.cardLogo)
@@ -417,6 +425,7 @@ interface BackingFragmentViewModel {
 
             backing
                     .map { it.bonusAmount() }
+                    .filter { ObjectUtils.isNotNull(it) }
                     .compose<Pair<Double, Project>>(combineLatestPair(backedProject))
                     .map { ProjectViewUtils.styleCurrency(it.first, it.second, this.ksCurrency) }
                     .distinctUntilChanged()

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -115,6 +115,28 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testBackingObjectNullFields() {
+        val environment = environment()
+                .toBuilder()
+                .apolloClient(mockApolloClientForBacking(BackingFactory.backingNull()))
+                .build()
+        setUpEnvironment(environment)
+        val project = ProjectFactory.backedProject().toBuilder().backing(BackingFactory.backingNull()).build()
+        this.vm.inputs.configureWith(ProjectDataFactory.project(project))
+
+        this.backerName.assertNoValues()
+        this.backerAvatar.assertNoValues()
+        this.cardExpiration.assertNoValues()
+        this.cardLogo.assertNoValues()
+        this.cardLastFour.assertNoValues()
+        this.cardIssuer.assertNoValues()
+        this.pledgeAmount.assertValue("$0")
+        this.bonusAmount.assertValue("$0")
+        this.shippingAmount.assertValue("$0")
+        this.shippingLocation.assertNoValues()
+    }
+
+    @Test
     fun testBackerNumber() {
         val backing = BackingFactory.backing()
                 .toBuilder()


### PR DESCRIPTION
# 📲 What

- Even though when we parse the response from Graph the BackingObject created should have been initialized properly, see https://github.com/kickstarter/android-oss/blob/b1e6070aaf6ee699d9aa2c31a71417f0c238bae6/app/src/main/java/com/kickstarter/services/KSApolloClient.kt#L630
We've been seeing crashes related with nullability issues, an wrong threads trying to Update the UI, none of it was reproduced locally, if you need more details go to Firebase Dashboard and look for all the crashes related to `BackingFragment`

# 🤔 Why
![Screen Shot 2021-03-09 at 3 03 04 PM](https://user-images.githubusercontent.com/4083656/110555404-6979dd80-80f1-11eb-92c0-4bf6face033f.png)
![Screen Shot 2021-03-09 at 3 02 41 PM](https://user-images.githubusercontent.com/4083656/110555405-6979dd80-80f1-11eb-8ff0-207b24e3f910.png)
![Screen Shot 2021-03-09 at 3 02 30 PM](https://user-images.githubusercontent.com/4083656/110555407-6a127400-80f1-11eb-9b5c-eee3646817f3.png)
![Screen Shot 2021-03-09 at 3 01 31 PM](https://user-images.githubusercontent.com/4083656/110555408-6aab0a80-80f1-11eb-9693-0961ca3c5c8a.png)
![Screen Shot 2021-03-09 at 3 01 56 PM](https://user-images.githubusercontent.com/4083656/110555410-6aab0a80-80f1-11eb-9761-25a7f5a14e15.png)
![Screen Shot 2021-03-09 at 3 02 19 PM](https://user-images.githubusercontent.com/4083656/110555412-6aab0a80-80f1-11eb-8bb2-1b120345afc6.png)


# 🛠 How
- Make sure no value from the ones above showed on the screenshoots is emited being null from the ViewModel to the Fragment

# 👀 See

https://user-images.githubusercontent.com/4083656/110556597-b494f000-80f3-11eb-93a0-22861ed03f53.mp4

|  |  |

# 📋 QA

- Go to your profile and take a look into several of your projects already backed, the older the better
- Got to your messages, select some message and hit the "View Pledge" Button

# Story 📖

[NT-1756](https://kickstarter.atlassian.net/browse/NT-1756)
