### PR TITLE
NT-1806: Automatic Release Process- Step 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,34 @@ jobs:
           name: Deploy Internal to Crashlytics and S3
           command: bundle exec fastlane internal
 
+  release:
+   <<: *base_job
+   steps:
+     - checkout
+     - restore_cache:
+         keys:
+           - v5-android-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+           - v5-android-
+     - restore_cache:
+         keys:
+           - v1-bundler-{{ checksum "Gemfile.lock" }}
+           - v1-bundler-
+     - run:
+         name: Bundle install
+         command: bundle check || bundle install --path vendor/bundle
+     - save_cache:
+         key: v1-bundler-{{ checksum "Gemfile.lock" }}
+         paths:
+           - ./vendor/bundle
+     - attach_workspace:
+         at: ~/project
+     - run:
+         name: Install Firebase CLI
+         command: curl -sL https://firebase.tools | bash
+     - run:
+         name: Deploy Internal to Crashlytics and S3
+         command: bundle exec fastlane external
+
 workflows:
   version: 2
   build_and_test:
@@ -115,6 +143,19 @@ workflows:
           filters:
             branches:
               only: internal
+  release:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build
+      - release:
+          requires:
+            - build
+            - test
+          filters:
+            branches:
+              only: release-.*
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,13 @@ workflows:
           filters:
             branches:
               only: master
+      - create_release:
+          requires:
+            - build
+            - test
+          filters:
+            branches:
+              only: release-.*
       - internal:
           requires:
             - build
@@ -163,13 +170,6 @@ workflows:
       - test:
           requires:
             - build
-      - create_release:
-          requires:
-            - build
-            - test
-          filters:
-            branches:
-              only: release-.*
       - release:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,20 @@ jobs:
           name: push to internal branch
           command: make internal
 
+  create_release:
+    <<: *base_job
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v5-android-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+            - v5-android-
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: push to release branch
+          command: make release
+
   internal:
     <<: *base_job
     steps:
@@ -149,13 +163,20 @@ workflows:
       - test:
           requires:
             - build
-      - release:
+      - create_release:
           requires:
             - build
             - test
           filters:
             branches:
               only: release-.*
+      - release:
+          requires:
+            - build
+            - test
+            filters:
+              branches:
+                only: external
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ workflows:
             - test
           filters:
             branches:
-              only: release-.*
+              only: release-test
       - internal:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ workflows:
             - test
           filters:
             branches:
-              only: release-test
+              only: /release-.*/
       - internal:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,10 +166,10 @@ workflows:
               only: internal
   release:
     jobs:
-      - build
-        filters:
-          branches:
-            only: external
+      - build:
+          filters:
+            branches:
+              only: external
       - test:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,9 +174,9 @@ workflows:
           requires:
             - build
             - test
-            filters:
-              branches:
-                only: external
+          filters:
+            branches:
+              only: external
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,9 @@ workflows:
   release:
     jobs:
       - build
+          filters:
+            branches:
+              only: external
       - test:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,9 +167,9 @@ workflows:
   release:
     jobs:
       - build
-          filters:
-            branches:
-              only: external
+        filters:
+          branches:
+            only: external
       - test:
           requires:
             - build

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ secrets:
 	mkdir -p app/src/main/assets/www/
 	cp vendor/native-secrets/android/WebViewJavascript.html app/src/main/assets/www/WebViewJavascript.html || true
 
+	# Copy Signing files
+	cp vendor/native-secrets/android/signingFiles/signing.gradle app/signing.gradle
+	cp vendor/native-secrets/android/signingFiles/kickstarter.keystore app/kickstarter.keystore
+
 .PHONY: bootstrap bootstrap-circle dependencies secrets
 
 sync_oss_to_private:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ secrets:
 
 	# Copy Signing files
 	cp vendor/native-secrets/android/signingFiles/signing.gradle app/signing.gradle || cp app/signing.gradle.example app/signing.gradle
-	cp vendor/native-secrets/android/signingFiles/kickstarter.keystore app/kickstarter.keystore
+	cp vendor/native-secrets/android/signingFiles/kickstarter.keystore app/kickstarter.keystore 2>/dev/null
 
 .PHONY: bootstrap bootstrap-circle dependencies secrets
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ secrets:
 
 	# Copy Signing files
 	cp vendor/native-secrets/android/signingFiles/signing.gradle app/signing.gradle || cp app/signing.gradle.example app/signing.gradle
-	cp vendor/native-secrets/android/signingFiles/kickstarter.keystore app/kickstarter.keystore 2>/dev/null
+	cp vendor/native-secrets/android/signingFiles/kickstarter.keystore app/kickstarter.keystore || cp app/debug.keystore app/kickstarter.keystore
 
 .PHONY: bootstrap bootstrap-circle dependencies secrets
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ secrets:
 	cp vendor/native-secrets/android/WebViewJavascript.html app/src/main/assets/www/WebViewJavascript.html || true
 
 	# Copy Signing files
-	cp vendor/native-secrets/android/signingFiles/signing.gradle app/signing.gradle
+	cp vendor/native-secrets/android/signingFiles/signing.gradle app/signing.gradle || cp app/signing.gradle.example app/signing.gradle
 	cp vendor/native-secrets/android/signingFiles/kickstarter.keystore app/kickstarter.keystore
 
 .PHONY: bootstrap bootstrap-circle dependencies secrets

--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,15 @@ internal:
 	@git branch -d internal
 
 	@echo "Deploy has been kicked off to CircleCI!"
+
+release:
+	@echo "Adding remotes..."
+	@git remote add private https://github.com/kickstarter/android-private
+
+	@echo "Deploying private/internal"
+
+	@git branch -f external
+	@git push -f private external
+	@git branch -d external
+
+	@echo "Deploy has been kicked off to CircleCI!"


### PR DESCRIPTION
# 📲 What

- New workflow on CI, this workflow will be triggered when a release branch is detected

# 🤔 Why
- We want to have an automatic process for release, this is the first step.

# 👀 See
- Once a release branch is created you will se these jobs triggered on the public android CI environment
![Screen Shot 2021-03-04 at 2 42 22 PM](https://user-images.githubusercontent.com/4083656/110672687-c377b300-8184-11eb-9d9c-dd35d2c08d1d.png)
- Once the previous work on the public android CI is done these jobs will be triggered on the android **private** CI environment. At this point on the job called release a new APK for release is created and published into firebase on the External Release lane
![Screen Shot 2021-03-04 at 3 07 04 PM](https://user-images.githubusercontent.com/4083656/110672941-09cd1200-8185-11eb-80ab-85a385ccbb23.png)

|  |  |

# 📋 QA
- If you want to test this the only thing to do is create a new branch from this branch (master once this PR is merged) on the public repository following the name pattern `release*` you will see how all the previous works mentioned will trigger, but Please keep in mind that this will upload a new APK to firebase, delete that apk manually once tested

# 📋 Next Step to follow up
- Step 2: Generate a signed APK -> https://github.com/kickstarter/native-secrets/pull/82
- We want the signed APK uploaded to the play store as well, not just firebase
 
# Story 📖
[NT-1806](https://kickstarter.atlassian.net/browse/NT-1806)
