### PR TITLE
[NO-JIRA]: Remove deprecated method

### DIFF
--- a/app/src/main/java/com/kickstarter/services/interceptors/ApiRequestInterceptor.java
+++ b/app/src/main/java/com/kickstarter/services/interceptors/ApiRequestInterceptor.java
@@ -61,9 +61,9 @@ public final class ApiRequestInterceptor implements Interceptor {
   private HttpUrl url(final @NonNull HttpUrl initialHttpUrl) {
     final HttpUrl.Builder builder = initialHttpUrl.newBuilder()
       .setQueryParameter("client_id", this.clientId);
-    if (this.currentUser.exists()) {
-      builder.setQueryParameter("oauth_token", this.currentUser.getAccessToken());
-    }
+
+    this.currentUser.observable()
+      .subscribe(user -> builder.setQueryParameter("oauth_token", this.currentUser.getAccessToken()));
 
     return builder.build();
   }


### PR DESCRIPTION
# 📲 What

`this.currentUser.exists()` is deprecated and should not be used. Instead in order to get the current user, observable method should be used and subscribe to it.

<img width="608" alt="Screen Shot 2021-03-10 at 2 05 45 PM" src="https://user-images.githubusercontent.com/4083656/110704434-ccc74680-81a9-11eb-8ed0-5a8e3a748932.png">

|  |  |

# 📋 QA
- You should be able to log in and make calls to V1 as usual
