### PR TITLE
EP-378: Update discover sort property to send correct value

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -51,12 +51,7 @@ object AnalyticEventsUtils {
             put("ref_tag", DiscoveryParamsUtils.refTag(params).tag())
             params.term()?.let { put("search_term", it) }
             put("social", BooleanUtils.isIntTrue(params.social()))
-            put("sort", params.sort()?.let {
-                when (it) {
-                    DiscoveryParams.Sort.ENDING_SOON -> "ending_soon"
-                    else -> it.toString()
-                }
-            } ?: "")
+            put("sort", params.sort()?.toString() ?: "")
             params.tagId()?.let { put("tag", it) }
             put("watched", BooleanUtils.isIntTrue(params.starred()))
 


### PR DESCRIPTION
# 📲 What

Previously we were sending the wrong value, `ending_soon`, for the ending soon sort tab. This has been updated to the correct value, `end_date`

# 🤔 Why

This was causing violations in segment:

<img width="342" alt="Screen Shot 2021-03-11 at 1 45 08 PM" src="https://user-images.githubusercontent.com/19390326/110838568-9e606e80-8270-11eb-956e-87cf523eebf1.png">
<img width="253" alt="Screen Shot 2021-03-11 at 1 45 16 PM" src="https://user-images.githubusercontent.com/19390326/110838569-9e606e80-8270-11eb-9a6b-ce98499c692e.png">

# 🛠 How

Small change to the way we are grabbing this property.

# 📋 QA

- Open the app
- Tap "Ending Soon"
- Segment should display the correct value, `discover_sort = end_date`
<img width="423" alt="Screen Shot 2021-03-11 at 1 52 50 PM" src="https://user-images.githubusercontent.com/19390326/110839149-41b18380-8271-11eb-92cd-4b1b382a6331.png">

# Story 📖

[EP-378: (Android) Fix discover_sort property value violation](https://kickstarter.atlassian.net/browse/EP-378)
