### PR TITLE
EP-379: Fix value for context_page violation on project card clicks

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
@@ -47,7 +47,6 @@ class EventContextValues {
         ADD_ONS("add_ons"),
         CHECKOUT("checkout"),
         DISCOVER("discover"),
-        EXPLORE("explore"),
         PROFILE("profile"),
         PROJECT("project"),
         REWARDS("rewards"),

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -168,7 +168,7 @@ public interface DiscoveryFragmentViewModel {
 
       this.projectCardClicked
               .compose(bindToLifecycle())
-              .subscribe(p -> lake.trackProjectCardClicked(p, EventContextValues.ContextPageName.EXPLORE.getContextName()));
+              .subscribe(p -> lake.trackProjectCardClicked(p, EventContextValues.ContextPageName.DISCOVER.getContextName()));
 
       final Observable<Pair<Project, RefTag>> projectCardClick = this.paramsFromActivity
         .compose(takePairWhen(this.projectCardClicked))


### PR DESCRIPTION
# 📲 What

Previously we were sending the wrong value for the context_page property, `explore`, when tapping a project card from the discover screen. This has been updated to the correct value, `discover`.

# 🤔 Why

This was causing a violation in segment:

<img width="341" alt="Screen Shot 2021-03-11 at 2 03 44 PM" src="https://user-images.githubusercontent.com/19390326/110841266-ae2d8200-8273-11eb-9012-443519706149.png">
<img width="286" alt="Screen Shot 2021-03-11 at 2 03 54 PM" src="https://user-images.githubusercontent.com/19390326/110841267-aec61880-8273-11eb-8f16-5b4a025a5e73.png">

# 🛠 How

Just changed the value from `explore` to `discover` in the `DiscoveryFragmentViewModel`

# 📋 QA

- Open the app
- Tap on a project on the discover screen
- Segment should display the correct value, `context_page = discover`
<img width="405" alt="Screen Shot 2021-03-11 at 2 10 00 PM" src="https://user-images.githubusercontent.com/19390326/110841458-e339d480-8273-11eb-93b3-dc620d1b08e5.png">

# Story 📖

[EP-379: (Android) Fix value for context_page violation on project card clicks ](https://kickstarter.atlassian.net/browse/EP-379)
