### PR TITLE
EP-280 : CTA Clicked (sign_up_initiate)

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -11,6 +11,7 @@ import com.kickstarter.libs.utils.EventContextValues.CtaContextName.PLEDGE_SUBMI
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.REWARD_CONTINUE
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.DISCOVER_FILTER
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.LOGIN_INITIATE
+import com.kickstarter.libs.utils.EventContextValues.CtaContextName.SIGN_UP_INITIATE
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.DISCOVER_SORT
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.CAMPAIGN_DETAILS
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.WATCH_PROJECT
@@ -933,6 +934,12 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
 
     fun trackLogInInitiateCtaClicked() {
         val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA.contextName to LOGIN_INITIATE.contextName)
+        props[CONTEXT_PAGE.contextName] = LOGIN_SIGN_UP.contextName
+        client.track(CTA_CLICKED.eventName, props)
+    }
+
+    fun trackSignUpInitiateCtaClicked() {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA.contextName to SIGN_UP_INITIATE.contextName)
         props[CONTEXT_PAGE.contextName] = LOGIN_SIGN_UP.contextName
         client.track(CTA_CLICKED.eventName, props)
     }

--- a/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
@@ -29,7 +29,8 @@ class EventContextValues {
         WATCH_PROJECT("watch_project"),
         LOGIN_INITIATE("log_in_initiate"),
         CAMPAIGN_DETAILS("campaign_details"),
-        CREATOR_DETAILS("creator_details")
+        CREATOR_DETAILS("creator_details"),
+        SIGN_UP_INITIATE("sign_up_initiate"),
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
@@ -158,7 +158,10 @@ public interface LoginToutViewModel {
 
       this.signupClick
         .compose(bindToLifecycle())
-        .subscribe(__ -> this.lake.trackSignUpButtonClicked());
+        .subscribe(__ -> {
+          this.lake.trackSignUpButtonClicked();
+          this.lake.trackSignUpInitiateCtaClicked();
+        });
     }
 
     private void clearFacebookSession(final @NonNull FacebookException e) {

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
@@ -61,8 +61,8 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
 
     this.vm.inputs.signupClick();
     this.startSignupActivity.assertValueCount(1);
-    this.lakeTest.assertValues("Log In or Sign Up Page Viewed", "Sign Up Button Clicked");
-    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", "Sign Up Button Clicked");
+    this.lakeTest.assertValues("Log In or Sign Up Page Viewed", "Sign Up Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", "Sign Up Button Clicked", EventName.CTA_CLICKED.getEventName());
   }
 
   @Test


### PR DESCRIPTION
# 📲 What

Android: CTA Clicked (sign_up_initiate)

# 🤔 Why

Segment Implementation 

# 🛠 How

- Created new method ``` trackSignUpInitiateCtaClicked ``` 
``` 
fun trackSignUpInitiateCtaClicked() {
        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA.contextName to SIGN_UP_INITIATE.contextName)
        props[CONTEXT_PAGE.contextName] = LOGIN_SIGN_UP.contextName
        client.track(CTA_CLICKED.eventName, props)
    }

```

- Called method on ``` Sign up with email ``` button clicked.
``` 
this.signupClick
        .compose(bindToLifecycle())
        .subscribe(__ -> {
          this.lake.trackSignUpButtonClicked();
          this.lake.trackSignUpInitiateCtaClicked();
        });
```

# 👀 See

<img width="360" alt="Screenshot 2021-03-13 at 06 01 23" src="https://user-images.githubusercontent.com/63934292/111303920-6339b300-8655-11eb-97c7-6be0e22de18f.png">


Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

- On the ``` login or sign up ``` page, click ``` Sign up with email ```
- Go to Segment, you should see the new event registered.
- 
<img width="733" alt="Screenshot 2021-03-16 at 12 38 40" src="https://user-images.githubusercontent.com/63934292/111304151-b0b62000-8655-11eb-855c-b2e6000ed1f4.png">


# Story 📖

https://kickstarter.atlassian.net/browse/EP-280
