### PR TITLE
EP-281 : CTA Clicked (sign_up_submit)

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -15,6 +15,7 @@ import com.kickstarter.libs.utils.EventContextValues.CtaContextName.DISCOVER_SOR
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.CAMPAIGN_DETAILS
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.WATCH_PROJECT
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.CREATOR_DETAILS
+import com.kickstarter.libs.utils.EventContextValues.CtaContextName.SIGN_UP_SUBMIT
 import com.kickstarter.libs.utils.EventContextValues.ContextTypeName.WATCH
 import com.kickstarter.libs.utils.EventContextValues.ContextTypeName.UNWATCH
 import com.kickstarter.libs.utils.EventContextValues.ContextTypeName.CREDIT_CARD
@@ -25,6 +26,7 @@ import com.kickstarter.libs.utils.EventContextValues.ContextPageName.LOGIN_SIGN_
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.REWARDS
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.PROJECT
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.THANKS
+import com.kickstarter.libs.utils.EventContextValues.ContextPageName.SIGN_UP
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.ACTIVITY_FEED
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.SEARCH
 import com.kickstarter.libs.utils.EventContextValues.DiscoveryContextType.PWL
@@ -951,6 +953,16 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
 
     fun trackSignUpButtonClicked() {
         client.track(SIGN_UP_BUTTON_CLICKED)
+    }
+
+    /**
+     * Sends data to the client when the submit button is clicked.
+     *
+     */
+    fun trackSignUpSubmitCtaClicked() {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA.contextName to SIGN_UP_SUBMIT.contextName)
+        props[CONTEXT_PAGE.contextName] = SIGN_UP.contextName
+        client.track(CTA_CLICKED.eventName, props)
     }
 
     fun trackSignUpSubmitButtonClicked() {

--- a/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
@@ -29,7 +29,8 @@ class EventContextValues {
         WATCH_PROJECT("watch_project"),
         LOGIN_INITIATE("log_in_initiate"),
         CAMPAIGN_DETAILS("campaign_details"),
-        CREATOR_DETAILS("creator_details")
+        CREATOR_DETAILS("creator_details"),
+        SIGN_UP_SUBMIT("sign_up_submit")
     }
 
     /**
@@ -56,7 +57,8 @@ class EventContextValues {
         SEARCH("search"),
         THANKS("thanks"),
         UPDATE_PLEDGE("update_pledge"),
-        LOGIN_SIGN_UP("log_in_sign_up")
+        LOGIN_SIGN_UP("log_in_sign_up"),
+        SIGN_UP("sign_up")
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/viewmodels/SignupViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SignupViewModel.java
@@ -99,7 +99,10 @@ public interface SignupViewModel {
 
       this.signupClick
               .compose(bindToLifecycle())
-              .subscribe(__ -> this.lake.trackSignUpSubmitButtonClicked());
+              .subscribe(__ -> {
+                this.lake.trackSignUpSubmitButtonClicked();
+                this.lake.trackSignUpSubmitCtaClicked();
+              });
     }
 
     private Observable<AccessTokenEnvelope> submit(final @NonNull SignupData data) {

--- a/app/src/test/java/com/kickstarter/viewmodels/SignupViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SignupViewModelTest.java
@@ -2,6 +2,7 @@ package com.kickstarter.viewmodels;
 
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.libs.Environment;
+import com.kickstarter.libs.utils.EventName;
 import com.kickstarter.mock.factories.ApiExceptionFactory;
 import com.kickstarter.mock.factories.ConfigFactory;
 import com.kickstarter.mock.services.MockApiClient;
@@ -62,8 +63,8 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
 
     formSubmittingTest.assertValues(true, false);
     signupSuccessTest.assertValueCount(1);
-    this.lakeTest.assertValues("Sign Up Submit Button Clicked");
-    this.segmentTrack.assertValues("Sign Up Submit Button Clicked");
+    this.lakeTest.assertValues("Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.segmentTrack.assertValues("Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
   }
 
   @Test
@@ -101,8 +102,8 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
     formSubmittingTest.assertValues(true, false);
     signupSuccessTest.assertValueCount(0);
     signupErrorTest.assertValueCount(1);
-    this.lakeTest.assertValues("Sign Up Submit Button Clicked");
-    this.segmentTrack.assertValues("Sign Up Submit Button Clicked");
+    this.lakeTest.assertValues("Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.segmentTrack.assertValues("Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
   }
 
   @Test
@@ -138,8 +139,8 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
     formSubmittingTest.assertValues(true, false);
     signupSuccessTest.assertValueCount(0);
     signupErrorTest.assertValueCount(1);
-    this.lakeTest.assertValues("Sign Up Submit Button Clicked");
-    this.segmentTrack.assertValues("Sign Up Submit Button Clicked");
+    this.lakeTest.assertValues("Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.segmentTrack.assertValues("Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
   }
 
 }


### PR DESCRIPTION
# 📲 What

Android: CTA Clicked (sign_up_submit)

# 🤔 Why

Segment Implementation 

# 🛠 How

- Added new method ``` trackSignUpSubmitCtaClicked ``` to ``` AnalyticEvents ```
``` 

/**
     * Sends data to the client when the submit button is clicked.
     *
     */
    fun trackSignUpSubmitCtaClicked() {
        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA.contextName to SIGN_UP_SUBMIT.contextName)
        props[CONTEXT_PAGE.contextName] = SIGN_UP.contextName
        client.track(CTA_CLICKED.eventName, props)
    }

```

- Called method from ``` SignupViewModel ``` on ``` Sign Up ``` button clicked
``` 
this.signupClick
              .compose(bindToLifecycle())
              .subscribe(__ -> {
                this.lake.trackSignUpSubmitButtonClicked();
                this.lake.trackSignUpSubmitCtaClicked();
              });
```

# 👀 See

<img width="290" alt="Screenshot 2021-03-16 at 13 06 29" src="https://user-images.githubusercontent.com/63934292/111307455-c4638580-8659-11eb-9d1c-b648a8d47fcf.png">


| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

- On the ``` Sign Up ``` page, fill in all required fields
- Click the ``` Sign up ``` button
- Go to segment console, you should see the new event registered
- 
<img width="728" alt="Screenshot 2021-03-16 at 13 11 42" src="https://user-images.githubusercontent.com/63934292/111307659-0b517b00-865a-11eb-8c9a-a6536be8d4e8.png">


# Story 📖

https://kickstarter.atlassian.net/browse/EP-281
