### PR TITLE
EP-335: Page Viewed (sign_up)

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -290,6 +290,14 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         client.track(CTA_CLICKED.eventName, props)
     }
 
+    /**
+     * Tracks a sign up page viewed.
+     */
+    fun trackSignUpPageViewed() {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to SIGN_UP.contextName)
+        client.track(PAGE_VIEWED.eventName, props)
+    }
+
     fun trackLoginSuccess() {
         client.track(KoalaEvent.LOGIN)
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/SignupViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SignupViewModel.java
@@ -1,7 +1,5 @@
 package com.kickstarter.viewmodels;
 
-import android.util.Log;
-
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.CurrentConfigType;
 import com.kickstarter.libs.CurrentUserType;

--- a/app/src/main/java/com/kickstarter/viewmodels/SignupViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SignupViewModel.java
@@ -1,5 +1,7 @@
 package com.kickstarter.viewmodels;
 
+import android.util.Log;
+
 import com.kickstarter.libs.ActivityViewModel;
 import com.kickstarter.libs.CurrentConfigType;
 import com.kickstarter.libs.CurrentUserType;
@@ -103,6 +105,8 @@ public interface SignupViewModel {
                 this.lake.trackSignUpSubmitButtonClicked();
                 this.lake.trackSignUpSubmitCtaClicked();
               });
+
+      this.lake.trackSignUpPageViewed();
     }
 
     private Observable<AccessTokenEnvelope> submit(final @NonNull SignupData data) {

--- a/app/src/test/java/com/kickstarter/viewmodels/SignupViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SignupViewModelTest.java
@@ -63,8 +63,8 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
 
     formSubmittingTest.assertValues(true, false);
     signupSuccessTest.assertValueCount(1);
-    this.lakeTest.assertValues("Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
-    this.segmentTrack.assertValues("Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.lakeTest.assertValues(EventName.PAGE_VIEWED.getEventName(), "Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.segmentTrack.assertValues(EventName.PAGE_VIEWED.getEventName(), "Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
   }
 
   @Test
@@ -102,8 +102,8 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
     formSubmittingTest.assertValues(true, false);
     signupSuccessTest.assertValueCount(0);
     signupErrorTest.assertValueCount(1);
-    this.lakeTest.assertValues("Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
-    this.segmentTrack.assertValues("Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.lakeTest.assertValues(EventName.PAGE_VIEWED.getEventName(), "Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.segmentTrack.assertValues(EventName.PAGE_VIEWED.getEventName(), "Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
   }
 
   @Test
@@ -139,8 +139,8 @@ public class SignupViewModelTest extends KSRobolectricTestCase {
     formSubmittingTest.assertValues(true, false);
     signupSuccessTest.assertValueCount(0);
     signupErrorTest.assertValueCount(1);
-    this.lakeTest.assertValues("Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
-    this.segmentTrack.assertValues("Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.lakeTest.assertValues(EventName.PAGE_VIEWED.getEventName(), "Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.segmentTrack.assertValues(EventName.PAGE_VIEWED.getEventName(), "Sign Up Submit Button Clicked", EventName.CTA_CLICKED.getEventName());
   }
 
 }


### PR DESCRIPTION
# 📲 What

Android: Page Viewed (sign_up)

# 🤔 Why

Segment Implementation 

# 🛠 How

- Created new method ``` trackSignUpPageViewed ``` in ``` AnalyticEvents ```
``` 
/**
     * Tracks sign-up page viewed.
     */
    fun trackSignUpPageViewed() {
        val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to SIGN_UP.contextName)
        client.track(PAGE_VIEWED.eventName, props)
    }

```
- Called method from ``` SignUpViewModel ``` on page initialised
```
...
  this.lake.trackSignUpPageViewed();
...
    
```

# 👀 See

<img width="293" alt="Screenshot 2021-03-17 at 13 07 20" src="https://user-images.githubusercontent.com/63934292/111465485-723a6700-8722-11eb-9637-4b484a00bb27.png">


| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

- Visit the ``` Sign Up ``` screen, you should see the new event registered in the segment console
- 
<img width="730" alt="Screenshot 2021-03-17 at 13 07 28" src="https://user-images.githubusercontent.com/63934292/111465550-8c744500-8722-11eb-8dff-b3823dfdfe45.png">


# Story 📖

https://kickstarter.atlassian.net/browse/EP-335
