### PR TITLE
EP-332: Page Viewed (log_in_sign_up)

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -290,6 +290,17 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         client.track(CTA_CLICKED.eventName, props)
     }
 
+    /**
+     * Tracks a login or sign up button clicked.
+     * @param type
+     * @param page
+     */
+    fun trackLoginOrSignUpPagedViewed() {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to LOGIN_SIGN_UP.contextName)
+        client.track(PAGE_VIEWED.eventName, props)
+    }
+
+
     fun trackLoginSuccess() {
         client.track(KoalaEvent.LOGIN)
     }

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -291,7 +291,7 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
     }
 
     /**
-     * Tracks a login or sign up button clicked.
+     * Tracks a login or sign up page viewed.
      * @param type
      * @param page
      */

--- a/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
@@ -101,7 +101,7 @@ public interface LoginToutViewModel {
         .map(i -> i.getSerializableExtra(IntentKey.LOGIN_REASON))
         .ofType(LoginReason.class)
         .compose(bindToLifecycle())
-        .subscribe( it -> {
+        .subscribe(it -> {
           this.loginReason.onNext(it);
           this.lake.trackLoginOrSignUpPagedViewed();
         });

--- a/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.java
@@ -101,7 +101,10 @@ public interface LoginToutViewModel {
         .map(i -> i.getSerializableExtra(IntentKey.LOGIN_REASON))
         .ofType(LoginReason.class)
         .compose(bindToLifecycle())
-        .subscribe(this.loginReason::onNext);
+        .subscribe( it -> {
+          this.loginReason.onNext(it);
+          this.lake.trackLoginOrSignUpPagedViewed();
+        });
 
       activityResult()
         .compose(bindToLifecycle())

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.java
@@ -49,8 +49,8 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
 
     this.vm.inputs.loginClick();
     this.startLoginActivity.assertValueCount(1);
-    this.lakeTest.assertValues("Log In or Sign Up Page Viewed", "Log In Button Clicked", EventName.CTA_CLICKED.getEventName());
-    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", "Log In Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.lakeTest.assertValues("Log In or Sign Up Page Viewed", EventName.PAGE_VIEWED.getEventName(), "Log In Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", EventName.PAGE_VIEWED.getEventName(), "Log In Button Clicked", EventName.CTA_CLICKED.getEventName());
   }
 
   @Test
@@ -61,8 +61,8 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
 
     this.vm.inputs.signupClick();
     this.startSignupActivity.assertValueCount(1);
-    this.lakeTest.assertValues("Log In or Sign Up Page Viewed", "Sign Up Button Clicked", EventName.CTA_CLICKED.getEventName());
-    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", "Sign Up Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.lakeTest.assertValues("Log In or Sign Up Page Viewed", EventName.PAGE_VIEWED.getEventName(), "Sign Up Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", EventName.PAGE_VIEWED.getEventName(), "Sign Up Button Clicked", EventName.CTA_CLICKED.getEventName());
   }
 
   @Test
@@ -79,8 +79,8 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
     this.vm.facebookAccessToken.onNext("token");
     this.currentUser.assertValueCount(1);
     this.finishWithSuccessfulResult.assertValueCount(1);
-    this.lakeTest.assertValues("Log In or Sign Up Page Viewed", "Facebook Log In or Signup Button Clicked", EventName.CTA_CLICKED.getEventName());
-    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", "Facebook Log In or Signup Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.lakeTest.assertValues("Log In or Sign Up Page Viewed", EventName.PAGE_VIEWED.getEventName(), "Facebook Log In or Signup Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", EventName.PAGE_VIEWED.getEventName(), "Facebook Log In or Signup Button Clicked", EventName.CTA_CLICKED.getEventName());
   }
 
   @Test
@@ -104,7 +104,7 @@ public class LoginToutViewModelTest extends KSRobolectricTestCase {
     this.vm.facebookAccessToken.onNext("token");
     this.currentUser.assertNoValues();
     this.finishWithSuccessfulResult.assertNoValues();
-    this.lakeTest.assertValues("Log In or Sign Up Page Viewed", "Facebook Log In or Signup Button Clicked", EventName.CTA_CLICKED.getEventName());
-    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", "Facebook Log In or Signup Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.lakeTest.assertValues("Log In or Sign Up Page Viewed", EventName.PAGE_VIEWED.getEventName(), "Facebook Log In or Signup Button Clicked", EventName.CTA_CLICKED.getEventName());
+    this.segmentTrack.assertValues("Log In or Sign Up Page Viewed", EventName.PAGE_VIEWED.getEventName(), "Facebook Log In or Signup Button Clicked", EventName.CTA_CLICKED.getEventName());
   }
 }


### PR DESCRIPTION
# 📲 What

Android: Page Viewed (log_in_sign_up)

# 🤔 Why

Segment Implementation 

# 🛠 How

- Created method ``` trackLoginOrSignUpPagedViewed ``` in ``` AnalyticEvents ``` class
```
/**
     * Tracks a login or sign up page viewed.
     * @param type
     * @param page
     */
    fun trackLoginOrSignUpPagedViewed() {
        val props: HashMap<String, Any> = hashMapOf(CONTEXT_PAGE.contextName to LOGIN_SIGN_UP.contextName)
        client.track(PAGE_VIEWED.eventName, props)
    }
```

- Called method from ``` LoginToutViewModel ``` class
```
intent()
        .map(i -> i.getSerializableExtra(IntentKey.LOGIN_REASON))
        .ofType(LoginReason.class)
        .compose(bindToLifecycle())
        .subscribe( it -> {
          this.loginReason.onNext(it);
          this.lake.trackLoginOrSignUpPagedViewed();
        });

```

# 👀 See

<img width="293" alt="Screenshot 2021-03-17 at 15 14 15" src="https://user-images.githubusercontent.com/63934292/111482951-a9197880-8734-11eb-885a-15f4fbfd3b3d.png">


| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA
- Go to the ``` Login or Sign Up ``` screen, You should see the new event registered in the segment console.

<img width="732" alt="Screenshot 2021-03-17 at 15 14 48" src="https://user-images.githubusercontent.com/63934292/111483197-e0882500-8734-11eb-9a4f-2004ff49e5b9.png">


# Story 📖

https://kickstarter.atlassian.net/browse/EP-332
