### PR TITLE
EP-347/Android: Page Viewed (two_factor_auth)

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -16,7 +16,6 @@ import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_SECTION
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_TYPE
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.ACTIVITY_FEED
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.ADD_ONS
-import com.kickstarter.libs.utils.EventContextValues.ContextPageName.TWO_FACTOR_AUTH
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.CHANGE_PAYMENT
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.CHECKOUT
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.LOGIN
@@ -25,6 +24,7 @@ import com.kickstarter.libs.utils.EventContextValues.ContextPageName.PROJECT
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.REWARDS
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.SIGN_UP
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.THANKS
+import com.kickstarter.libs.utils.EventContextValues.ContextPageName.TWO_FACTOR_AUTH
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.UPDATE_PLEDGE
 import com.kickstarter.libs.utils.EventContextValues.ContextTypeName.CREDIT_CARD
 import com.kickstarter.libs.utils.EventContextValues.ContextTypeName.UNWATCH

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -250,7 +250,6 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      */
     fun trackActivityFeedPageViewed() {
         val props = hashMapOf<String, Any>()
-        props[CONTEXT_CTA.contextName] = ACTIVITY_FEED.contextName
         props[CONTEXT_PAGE.contextName] = ACTIVITY_FEED.contextName
         client.track(PAGE_VIEWED.eventName, props)
     }
@@ -811,9 +810,7 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      * Sends data to the client open TwoFactorAuth screen
      */
     fun trackTwoFactorAuthPageViewed() {
-        val props = hashMapOf<String, Any>()
-        props[CONTEXT_CTA.contextName] = TWO_FACTOR_AUTH.contextName
-        props[CONTEXT_PAGE.contextName] = TWO_FACTOR_AUTH.contextName
+        val props = hashMapOf(CONTEXT_PAGE.contextName to TWO_FACTOR_AUTH.contextName)
         client.track(PAGE_VIEWED.eventName, props)
     }
 

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -16,6 +16,7 @@ import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_SECTION
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_TYPE
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.ACTIVITY_FEED
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.ADD_ONS
+import com.kickstarter.libs.utils.EventContextValues.ContextPageName.TWO_FACTOR_AUTH
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.CHANGE_PAYMENT
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.CHECKOUT
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.LOGIN
@@ -793,6 +794,16 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         props[CONTEXT_SECTION.contextName] = pageSectionContext
         props.putAll(AnalyticEventsUtils.projectProperties(projectData.project(), client.loggedInUser()))
         props.putAll(AnalyticEventsUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()))
+        client.track(PAGE_VIEWED.eventName, props)
+    }
+
+    /**
+     * Sends data to the client open TwoFactorAuth screen
+     */
+    fun trackTwoFactorAuthPageViewed() {
+        val props = hashMapOf<String, Any>()
+        props[CONTEXT_CTA.contextName] = TWO_FACTOR_AUTH.contextName
+        props[CONTEXT_PAGE.contextName] = TWO_FACTOR_AUTH.contextName
         client.track(PAGE_VIEWED.eventName, props)
     }
 

--- a/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
@@ -63,7 +63,8 @@ class EventContextValues {
         CHANGE_PAYMENT("change_payment"),
         LOGIN_SIGN_UP("log_in_sign_up"),
         SIGN_UP("sign_up"),
-        LOGIN("log_in")
+        LOGIN("log_in"),
+        TWO_FACTOR_AUTH("two_factor_auth")
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.java
@@ -106,6 +106,7 @@ public interface TwoFactorViewModel {
         .subscribe();
 
       this.lake.trackTwoFactorConfirmationViewed();
+      this.lake.trackTwoFactorAuthPageViewed();
     }
 
     private void success(final @NonNull AccessTokenEnvelope envelope) {

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -517,7 +517,6 @@ class SegmentTest : KSRobolectricTestCase() {
 
         assertSessionProperties(user)
         assertContextProperties()
-        assertCtaContextProperty(ACTIVITY_FEED.contextName)
         assertPageContextProperty(ACTIVITY_FEED.contextName)
 
         this.segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName)

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -534,7 +534,6 @@ class SegmentTest : KSRobolectricTestCase() {
 
         assertSessionProperties(null)
         assertContextProperties()
-        assertCtaContextProperty(EventContextValues.ContextPageName.TWO_FACTOR_AUTH.contextName)
         assertPageContextProperty(EventContextValues.ContextPageName.TWO_FACTOR_AUTH.contextName)
 
         this.segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName)

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -4,13 +4,22 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_CTA
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_PAGE
-import com.kickstarter.libs.utils.EventContextValues.ContextPageName.*
+import com.kickstarter.libs.utils.EventContextValues
+import com.kickstarter.libs.utils.EventContextValues.ContextPageName.ACTIVITY_FEED
+import com.kickstarter.libs.utils.EventContextValues.ContextPageName.LOGIN
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.EventName.VIDEO_PLAYBACK_COMPLETED
 import com.kickstarter.libs.utils.EventName.VIDEO_PLAYBACK_STARTED
 import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.MockExperimentsClientType
-import com.kickstarter.mock.factories.*
+import com.kickstarter.mock.factories.CategoryFactory
+import com.kickstarter.mock.factories.CheckoutDataFactory
+import com.kickstarter.mock.factories.ConfigFactory
+import com.kickstarter.mock.factories.LocationFactory
+import com.kickstarter.mock.factories.ProjectDataFactory
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.mock.factories.RewardFactory
+import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.Project
 import com.kickstarter.models.User
 import com.kickstarter.services.DiscoveryParams
@@ -525,8 +534,8 @@ class SegmentTest : KSRobolectricTestCase() {
 
         assertSessionProperties(null)
         assertContextProperties()
-        assertCtaContextProperty(TWO_FACTOR_AUTH.contextName)
-        assertPageContextProperty(TWO_FACTOR_AUTH.contextName)
+        assertCtaContextProperty(EventContextValues.ContextPageName.TWO_FACTOR_AUTH.contextName)
+        assertPageContextProperty(EventContextValues.ContextPageName.TWO_FACTOR_AUTH.contextName)
 
         this.segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName)
     }

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -4,21 +4,13 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_CTA
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_PAGE
-import com.kickstarter.libs.utils.EventContextValues.ContextPageName.ACTIVITY_FEED
-import com.kickstarter.libs.utils.EventContextValues.ContextPageName.LOGIN
+import com.kickstarter.libs.utils.EventContextValues.ContextPageName.*
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.EventName.VIDEO_PLAYBACK_COMPLETED
 import com.kickstarter.libs.utils.EventName.VIDEO_PLAYBACK_STARTED
 import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.MockExperimentsClientType
-import com.kickstarter.mock.factories.CategoryFactory
-import com.kickstarter.mock.factories.CheckoutDataFactory
-import com.kickstarter.mock.factories.ConfigFactory
-import com.kickstarter.mock.factories.LocationFactory
-import com.kickstarter.mock.factories.ProjectDataFactory
-import com.kickstarter.mock.factories.ProjectFactory
-import com.kickstarter.mock.factories.RewardFactory
-import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.mock.factories.*
 import com.kickstarter.models.Project
 import com.kickstarter.models.User
 import com.kickstarter.services.DiscoveryParams
@@ -518,6 +510,23 @@ class SegmentTest : KSRobolectricTestCase() {
         assertContextProperties()
         assertCtaContextProperty(ACTIVITY_FEED.contextName)
         assertPageContextProperty(ACTIVITY_FEED.contextName)
+
+        this.segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName)
+    }
+
+    @Test
+    fun testTwoFactorAuthProperties() {
+        val client = client(null)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackTwoFactorAuthPageViewed()
+
+        assertSessionProperties(null)
+        assertContextProperties()
+        assertCtaContextProperty(TWO_FACTOR_AUTH.contextName)
+        assertPageContextProperty(TWO_FACTOR_AUTH.contextName)
 
         this.segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName)
     }

--- a/app/src/test/java/com/kickstarter/viewmodels/TwoFactorViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/TwoFactorViewModelTest.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 
 import com.kickstarter.KSRobolectricTestCase;
 import com.kickstarter.libs.Environment;
+import com.kickstarter.libs.utils.EventName;
 import com.kickstarter.mock.factories.ApiExceptionFactory;
 import com.kickstarter.mock.services.MockApiClient;
 import com.kickstarter.services.ApiClientType;
@@ -47,7 +48,7 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.code("");
     this.formIsValid.assertValues(true, false);
 
-    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
+    this.lakeTest.assertValues("Two-Factor Confirmation Viewed", EventName.PAGE_VIEWED.getEventName());
   }
 
   @Test
@@ -70,7 +71,7 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
     this.formSubmitting.assertValues(true, false);
     this.tfaSuccess.assertValueCount(1);
 
-    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
+    this.lakeTest.assertValues("Two-Factor Confirmation Viewed", EventName.PAGE_VIEWED.getEventName());
   }
 
   @Test
@@ -93,7 +94,7 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
     this.formSubmitting.assertValues(true, false);
     this.tfaSuccess.assertValueCount(1);
 
-    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
+    this.lakeTest.assertValues("Two-Factor Confirmation Viewed", EventName.PAGE_VIEWED.getEventName());
   }
 
   @Test
@@ -112,7 +113,7 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.resendClick();
 
     this.showResendCodeConfirmation.assertValueCount(1);
-    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
+    this.lakeTest.assertValues("Two-Factor Confirmation Viewed", EventName.PAGE_VIEWED.getEventName());
   }
 
   @Test
@@ -131,7 +132,7 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.resendClick();
 
     this.showResendCodeConfirmation.assertValueCount(1);
-    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
+    this.lakeTest.assertValues("Two-Factor Confirmation Viewed", EventName.PAGE_VIEWED.getEventName());
   }
 
   @Test
@@ -168,7 +169,7 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
     this.formSubmitting.assertValues(true, false);
     this.tfaSuccess.assertNoValues();
     this.genericTfaError.assertValueCount(1);
-    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
+    this.lakeTest.assertValues("Two-Factor Confirmation Viewed", EventName.PAGE_VIEWED.getEventName());
   }
 
   @Test
@@ -203,6 +204,6 @@ public class TwoFactorViewModelTest extends KSRobolectricTestCase {
     this.formSubmitting.assertValues(true, false);
     this.tfaSuccess.assertNoValues();
     this.tfaCodeMismatchError.assertValueCount(1);
-    this.lakeTest.assertValue("Two-Factor Confirmation Viewed");
+    this.lakeTest.assertValues("Two-Factor Confirmation Viewed", EventName.PAGE_VIEWED.getEventName());
   }
 }


### PR DESCRIPTION
# 📲 What

Added the two_factor_auth as Page Viewed event

# 🤔 Why

Send segment event for two_factor_auth loads on the TwoFactorActivity Activity  

# 🛠 How

Create  trackTwoFactorAuthPageViewed and call it 
![image](https://user-images.githubusercontent.com/1075310/112315559-ee005a80-8cb2-11eb-9711-7f3e07807041.png)
![image](https://user-images.githubusercontent.com/1075310/112315770-1d16cc00-8cb3-11eb-94f0-b7884212c2a9.png)
![image](https://user-images.githubusercontent.com/1075310/112315840-328bf600-8cb3-11eb-98e4-eda785cec262.png)

![image](https://user-images.githubusercontent.com/1075310/112315673-03758480-8cb3-11eb-91a5-85ab84c5b68c.png)




# 👀 See
<img width="1214" alt="Screen Shot 2021-03-24 at 5 34 51 PM" src="https://user-images.githubusercontent.com/1075310/112338383-6d982480-8cc7-11eb-943a-cb1f784aebfd.png">


# 📋 QA
I had to inject that line to be able to navigate to a two-factor-screen and generate segment event 
![image](https://user-images.githubusercontent.com/1075310/112316532-dd9caf80-8cb3-11eb-8799-0801a32fffaf.png)
# Story 📖

https://kickstarter.atlassian.net/browse/EP-347
