### PR TITLE
[Android] EP-389: Phase 1 QA Feedback Priority 1 properties

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -107,7 +107,7 @@ abstract class TrackingClient(
 
     override fun buildNumber(): Int = BuildConfig.VERSION_CODE
 
-    override fun currentVariants(): JSONArray? = this.config?.currentVariants()
+    override fun currentVariants(): Array<String>? = this.config?.currentVariants()
 
     override fun deviceDistinctId(): String = FirebaseInstanceId.getInstance().id
 

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -20,7 +20,7 @@ abstract class TrackingClientType {
 
     protected abstract fun brand(): String
     protected abstract fun buildNumber(): Int
-    protected abstract fun currentVariants(): JSONArray?
+    protected abstract fun currentVariants(): Array<String>?
     protected abstract fun deviceDistinctId(): String
     protected abstract fun deviceFormat(): String
     protected abstract fun deviceOrientation(): String

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -74,8 +74,8 @@ abstract class TrackingClientType {
             this["app_release_version"] = versionName()
             this["platform"] = "native_android"
             this["client"] = "native"
+            this["variants_internal"] = currentVariants() ?: ""
             this["country"] = sessionCountry()
-            this["current_variants"] = currentVariants() ?: ""
             this["device_distinct_id"] = deviceDistinctId()
             this["device_type"] = deviceFormat()
             this["device_manufacturer"] = manufacturer()

--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -112,7 +112,7 @@ object AnalyticEventsUtils {
     fun userProperties(user: User, prefix: String = "user_"): Map<String, Any> {
         val properties = HashMap<String, Any>()
         properties["backed_projects_count"] = user.backedProjectsCount() ?: 0
-        properties["launched_projects_count"] = user.memberProjectsCount() ?: 0
+        properties["launched_projects_count"] = 15
         properties["uid"] = user.id().toString()
         properties["is_admin"] = user.isAdmin ?: false
 

--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -111,6 +111,8 @@ object AnalyticEventsUtils {
     @JvmOverloads
     fun userProperties(user: User, prefix: String = "user_"): Map<String, Any> {
         val properties = HashMap<String, Any>()
+        properties["backed_projects_count"] = user.backedProjectsCount() ?: 0
+        properties["launched_projects_count"] = user.memberProjectsCount() ?: 0
         properties["uid"] = user.id().toString()
         properties["is_admin"] = user.isAdmin ?: false
 

--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -112,7 +112,7 @@ object AnalyticEventsUtils {
     fun userProperties(user: User, prefix: String = "user_"): Map<String, Any> {
         val properties = HashMap<String, Any>()
         properties["backed_projects_count"] = user.backedProjectsCount() ?: 0
-        properties["launched_projects_count"] = 15
+        properties["launched_projects_count"] = user.memberProjectsCount() ?: 0
         properties["uid"] = user.id().toString()
         properties["is_admin"] = user.isAdmin ?: false
 

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ConfigExtension.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ConfigExtension.kt
@@ -21,17 +21,18 @@ fun Config.isFeatureFlagEnabled(text: String): Boolean {
 /**
  * @return The actual list of variants
  */
-fun Config.currentVariants(): JSONArray? {
+fun Config.currentVariants(): Array<String>? {
     return this
         ?.abExperiments()
         ?.toSortedMap()
         ?.let {
-            JSONArray().apply {
+            mutableListOf<String>().apply {
                 for (feature in it) {
-                    put("${feature.key}[${feature.value}]")
+                    add("${feature.key}[${feature.value}]")
                 }
             }
         }
+        ?.toTypedArray()
 }
 
 /**

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -562,7 +562,6 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals("9.9.9", expectedProperties["session_app_release_version"])
         assertEquals("native_android", expectedProperties["session_platform"])
         assertEquals("native", expectedProperties["session_client"])
-        assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_current_variants"])
         assertEquals("uuid", expectedProperties["session_device_distinct_id"])
         assertEquals("phone", expectedProperties["session_device_type"])
         assertEquals("Google", expectedProperties["session_device_manufacturer"])
@@ -577,6 +576,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals("agent", expectedProperties["session_user_agent"])
         assertEquals(user != null, expectedProperties["session_user_is_logged_in"])
         assertEquals(false, expectedProperties["session_wifi_connection"])
+        assertEquals("android_example_experiment[control]", (expectedProperties["session_variants_internal"] as Array<*>).first())
     }
 
     private fun mockCurrentConfig() = MockCurrentConfig().apply {

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -97,7 +97,7 @@ public final class MockTrackingClient extends TrackingClientType {
   }
 
   @Override
-  protected JSONArray currentVariants() {
+  protected String[] currentVariants() {
     return ConfigExtension.currentVariants(this.config);
   }
 

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -20,6 +20,7 @@ import com.kickstarter.mock.factories.ProjectDataFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.mock.factories.AvatarFactory
 import com.kickstarter.models.Project
 import com.kickstarter.models.User
 import com.kickstarter.services.DiscoveryParams
@@ -66,11 +67,7 @@ class SegmentTest : KSRobolectricTestCase() {
 
         assertSessionProperties(user)
         assertContextProperties()
-
-        val expectedProperties = propertiesTest.value
-        assertEquals("15", expectedProperties["user_uid"])
-        assertEquals(false, expectedProperties["user_is_admin"])
-        assertEquals("NG", expectedProperties["user_country"])
+        assertUserProperties(false)
     }
 
     @Test
@@ -84,10 +81,31 @@ class SegmentTest : KSRobolectricTestCase() {
 
         segment.trackAppOpen()
 
+        assertUserProperties(true)
+    }
+
+    @Test
+    fun testDefaultProperties_loggedInUser_nullProperties() {
+        val user =
+                User.builder()
+                        .avatar(AvatarFactory.avatar())
+                        .name("Kickstarter")
+                        .id(12)
+                        .build()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        client.identifiedId.subscribe(this.segmentIdentify)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackActivityFeedPageViewed()
+
         val expectedProperties = propertiesTest.value
-        assertEquals("15", expectedProperties["user_uid"])
-        assertEquals(true, expectedProperties["user_is_admin"])
-        assertEquals("NG", expectedProperties["user_country"])
+        assertEquals(0, expectedProperties["user_backed_projects_count"])
+        assertEquals(false, expectedProperties["user_is_admin"])
+        assertEquals(0, expectedProperties["user_launched_projects_count"])
+        assertEquals("12", expectedProperties["user_uid"])
+        assertEquals("US", expectedProperties["user_country"])
     }
 
     @Test
@@ -145,6 +163,7 @@ class SegmentTest : KSRobolectricTestCase() {
 
         assertSessionProperties(user)
         assertContextProperties()
+        assertUserProperties(false)
 
         val expectedProperties = propertiesTest.value
         assertNull(expectedProperties["discover_category_id"])
@@ -183,6 +202,7 @@ class SegmentTest : KSRobolectricTestCase() {
 
         assertSessionProperties(user)
         assertContextProperties()
+        assertUserProperties(false)
 
         val expectedProperties = propertiesTest.value
         assertEquals("1", expectedProperties["discover_category_id"])
@@ -218,6 +238,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertProjectProperties(project)
 
         val expectedProperties = propertiesTest.value
+        assertNull(expectedProperties["user_uid"])
         assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
         assertEquals(false, expectedProperties["project_user_has_watched"])
         assertEquals(false, expectedProperties["project_user_is_backer"])
@@ -240,6 +261,7 @@ class SegmentTest : KSRobolectricTestCase() {
         segment.trackProjectPageViewed(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()), PledgeFlowContext.NEW_PLEDGE)
 
         val expectedProperties = this.propertiesTest.value
+        assertNull(expectedProperties["user_uid"])
         assertEquals(true, expectedProperties["project_has_add_ons"])
     }
 
@@ -305,6 +327,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertSessionProperties(user)
         assertProjectProperties(project)
         assertContextProperties()
+        assertUserProperties(false)
 
         val expectedProperties = propertiesTest.value
         assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
@@ -338,6 +361,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertSessionProperties(user)
         assertProjectProperties(project)
         assertContextProperties()
+        assertUserProperties(false)
 
         val expectedProperties = propertiesTest.value
         assertNull(expectedProperties["context_pledge_flow"])
@@ -364,7 +388,15 @@ class SegmentTest : KSRobolectricTestCase() {
         assertContextProperties()
 
         val expectedProperties = this.propertiesTest.value
+
         assertNull(expectedProperties["context_pledge_flow"])
+
+        assertEquals(17, expectedProperties["user_backed_projects_count"])
+        assertEquals(false, expectedProperties["user_is_admin"])
+        assertEquals(10, expectedProperties["user_launched_projects_count"])
+        assertEquals("3", expectedProperties["user_uid"])
+        assertEquals("US", expectedProperties["user_country"])
+
         assertEquals(false, expectedProperties["project_user_has_watched"])
         assertEquals(false, expectedProperties["project_user_is_backer"])
         assertEquals(true, expectedProperties["project_user_is_project_creator"])
@@ -386,6 +418,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertSessionProperties(user)
         assertProjectProperties(project)
         assertContextProperties()
+        assertUserProperties(false)
 
         val expectedProperties = this.propertiesTest.value
         assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
@@ -411,6 +444,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertSessionProperties(user)
         assertProjectProperties(project)
         assertContextProperties()
+        assertUserProperties(false)
 
         val expectedProperties = propertiesTest.value
         assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
@@ -438,6 +472,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertProjectProperties(project)
         assertContextProperties()
         assertPledgeProperties()
+        assertUserProperties(false)
 
         val expectedProperties = propertiesTest.value
         assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
@@ -469,6 +504,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertContextProperties()
         assertPledgeProperties()
         assertCheckoutProperties()
+        assertUserProperties(false)
 
         val expectedProperties = this.propertiesTest.value
         assertNull(expectedProperties["checkout_id"])
@@ -509,6 +545,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertContextProperties()
         assertPledgeProperties()
         assertCheckoutProperties()
+        assertUserProperties(false)
 
         val expectedProperties = this.propertiesTest.value
         assertNull(expectedProperties["checkout_id"])
@@ -541,6 +578,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertContextProperties()
         assertPledgeProperties()
         assertCheckoutProperties()
+        assertUserProperties(false)
 
         val expectedProperties = this.propertiesTest.value
         assertEquals("3", expectedProperties["checkout_id"])
@@ -565,6 +603,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertSessionProperties(user)
         assertContextProperties()
         assertPageContextProperty(ACTIVITY_FEED.contextName)
+        assertUserProperties(false)
 
         this.segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName)
     }
@@ -600,6 +639,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertProjectProperties(project)
         assertContextProperties()
         assertOptimizelyProperties()
+        assertUserProperties(false)
 
         val expectedProperties = propertiesTest.value
         assertEquals("new_pledge", expectedProperties["context_pledge_flow"])
@@ -629,6 +669,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertSessionProperties(user)
         assertProjectProperties(project)
         assertContextProperties()
+        assertUserProperties(false)
 
         segment.trackVideoStarted(project, videoLength, videoStartedPosition)
 
@@ -655,6 +696,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertContextProperties()
 
         val properties = this.propertiesTest.value
+        assertNull(properties["user_uid"])
         assertEquals(LOGIN.contextName, properties[CONTEXT_PAGE.contextName])
 
         this.segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
@@ -766,6 +808,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals("9.9.9", expectedProperties["session_app_release_version"])
         assertEquals("native_android", expectedProperties["session_platform"])
         assertEquals("native", expectedProperties["session_client"])
+        assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_variants_internal"])
         assertEquals("US", expectedProperties["session_country"])
         assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_current_variants"])
         assertEquals("uuid", expectedProperties["session_device_distinct_id"])
@@ -783,6 +826,15 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals(user != null, expectedProperties["session_user_is_logged_in"])
         assertEquals(false, expectedProperties["session_wifi_connection"])
         assertEquals(getOptimizelySession()["variants_optimizely"]?.first(), (expectedProperties["session_variants_optimizely"] as Array<*>).first())
+    }
+
+    private fun assertUserProperties(isAdmin: Boolean) {
+        val expectedProperties = this.propertiesTest.value
+        assertEquals(3, expectedProperties["user_backed_projects_count"])
+        assertEquals(5, expectedProperties["user_launched_projects_count"])
+        assertEquals("15", expectedProperties["user_uid"])
+        assertEquals("NG", expectedProperties["user_country"])
+        assertEquals(isAdmin, expectedProperties["user_is_admin"])
     }
 
     private fun assertCtaContextProperty(contextName: String) {
@@ -837,6 +889,7 @@ class SegmentTest : KSRobolectricTestCase() {
             .toBuilder()
             .id(15)
             .backedProjectsCount(3)
+            .memberProjectsCount(5)
             .createdProjectsCount(2)
             .location(LocationFactory.nigeria())
             .starredProjectsCount(10)

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -12,15 +12,15 @@ import com.kickstarter.libs.utils.EventName.VIDEO_PLAYBACK_COMPLETED
 import com.kickstarter.libs.utils.EventName.VIDEO_PLAYBACK_STARTED
 import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.MockExperimentsClientType
+import com.kickstarter.mock.factories.AvatarFactory
 import com.kickstarter.mock.factories.CategoryFactory
-import com.kickstarter.mock.factories.CheckoutDataFactory
-import com.kickstarter.mock.factories.ConfigFactory
-import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.mock.factories.ProjectDataFactory
 import com.kickstarter.mock.factories.ProjectFactory
-import com.kickstarter.mock.factories.RewardFactory
+import com.kickstarter.mock.factories.LocationFactory
+import com.kickstarter.mock.factories.CheckoutDataFactory
+import com.kickstarter.mock.factories.ConfigFactory
 import com.kickstarter.mock.factories.UserFactory
-import com.kickstarter.mock.factories.AvatarFactory
+import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.models.Project
 import com.kickstarter.models.User
 import com.kickstarter.services.DiscoveryParams
@@ -87,11 +87,11 @@ class SegmentTest : KSRobolectricTestCase() {
     @Test
     fun testDefaultProperties_loggedInUser_nullProperties() {
         val user =
-                User.builder()
-                        .avatar(AvatarFactory.avatar())
-                        .name("Kickstarter")
-                        .id(12)
-                        .build()
+            User.builder()
+                .avatar(AvatarFactory.avatar())
+                .name("Kickstarter")
+                .id(12)
+                .build()
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
@@ -810,7 +810,6 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals("native", expectedProperties["session_client"])
         assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_variants_internal"])
         assertEquals("US", expectedProperties["session_country"])
-        assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_current_variants"])
         assertEquals("uuid", expectedProperties["session_device_distinct_id"])
         assertEquals("phone", expectedProperties["session_device_type"])
         assertEquals("Google", expectedProperties["session_device_manufacturer"])

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -808,7 +808,6 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals("9.9.9", expectedProperties["session_app_release_version"])
         assertEquals("native_android", expectedProperties["session_platform"])
         assertEquals("native", expectedProperties["session_client"])
-        assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_variants_internal"])
         assertEquals("US", expectedProperties["session_country"])
         assertEquals("uuid", expectedProperties["session_device_distinct_id"])
         assertEquals("phone", expectedProperties["session_device_type"])
@@ -825,6 +824,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals(user != null, expectedProperties["session_user_is_logged_in"])
         assertEquals(false, expectedProperties["session_wifi_connection"])
         assertEquals(getOptimizelySession()["variants_optimizely"]?.first(), (expectedProperties["session_variants_optimizely"] as Array<*>).first())
+        assertEquals("android_example_experiment[control]", (expectedProperties["session_variants_internal"] as Array<*>).first())
     }
 
     private fun assertUserProperties(isAdmin: Boolean) {

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -14,13 +14,13 @@ import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.AvatarFactory
 import com.kickstarter.mock.factories.CategoryFactory
-import com.kickstarter.mock.factories.ProjectDataFactory
-import com.kickstarter.mock.factories.ProjectFactory
-import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.mock.factories.CheckoutDataFactory
 import com.kickstarter.mock.factories.ConfigFactory
-import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.mock.factories.LocationFactory
+import com.kickstarter.mock.factories.ProjectDataFactory
+import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.RewardFactory
+import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.Project
 import com.kickstarter.models.User
 import com.kickstarter.services.DiscoveryParams

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/ConfigExtensionTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/ConfigExtensionTest.kt
@@ -35,17 +35,18 @@ class ConfigExtensionTest : KSRobolectricTestCase() {
     @Test
     fun currentVariants_whenExperimentsEmpty_currentVariantsShouldBeEmpty() {
         val configEmpty = ConfigFactory.configWithExperiments(Collections.emptyMap())
-        assertEquals(JSONArray(), configEmpty.currentVariants())
+        assertEquals(0, configEmpty.currentVariants()?.size)
     }
 
     @Test
-    fun currentVarients_whenGivenOneExperiment_shouldReturnOneCurrentVariant() {
+    fun currentVariants_whenGivenOneExperiment_shouldReturnOneCurrentVariant() {
         val configWithExperiment = ConfigFactory.configWithExperiment("pledge_button_copy", "experiment")
-        assertEquals(JSONArray().apply { put("pledge_button_copy[experiment]") }, configWithExperiment.currentVariants())
+        assertEquals(1, configWithExperiment.currentVariants()?.size)
+        assertEquals("pledge_button_copy[experiment]", configWithExperiment.currentVariants()?.get(0))
     }
 
     @Test
-    fun currentVarients_whenGivenMapOfExperiments_shouldReturnCorrectNumberOfCurrentVariants() {
+    fun currentVariants_whenGivenMapOfExperiments_shouldReturnCorrectNumberOfCurrentVariants() {
         val configWithExperiments = ConfigFactory.configWithExperiments(
             mapOf(
                 Pair("pledge_button_copy", "experiment"),
@@ -53,11 +54,9 @@ class ConfigExtensionTest : KSRobolectricTestCase() {
             )
         )
 
-        val correctValue = JSONArray().apply {
-            put("add_new_card_vertical[control]")
-            put("pledge_button_copy[experiment]")
-        }
-        assertEquals(correctValue, configWithExperiments.currentVariants())
+        assertEquals(2, configWithExperiments.currentVariants()?.size)
+        assertEquals("add_new_card_vertical[control]", configWithExperiments.currentVariants()?.get(0))
+        assertEquals("pledge_button_copy[experiment]", configWithExperiments.currentVariants()?.get(1))
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- Updated `session_current_variants -> session_variants_internal`
- Added `user_backed_projects_count` to user properties
- Added `user_launched_projects_count` to user properties
- Updated `currentVariants` to return an array instead of a string
- Updated the `SegmentTest` and `LakeTest` class

# 🤔 Why

Segment integration.

# 🛠 How

- Updated the property `session_current_variants` in the `sessionProperties()` function in the `TrackingClient` class, and updated the method that is populating this field to return an array instead of a string. Updated the tests for this new logic as well. 
- Created the property `user_backed_projects_count` in the `userProperties()` function in the `AnalyticEventsUtils` ext
- Created the property `user_launched_projects_count` in the `userProperties()` function in the `AnalyticEventsUtils` ext
- Updated all tests in the `SegmentTestClass` that are calling an event where user properties would be sent

# 📋 QA

- To test this, you should fire off an event in the android app and see that the correct property is in segment.
- The user properties will only fire when the user is logged in

Example:
- Open App and login if necessary, make sure the account you are using has **backed** AND **launched** projects
- Tap on a project
- In segment, you should see the "Page Viewed" event with `context_page = project`. You should also see the following properties:
![Screen Shot 2021-03-24 at 4 02 15 PM](https://user-images.githubusercontent.com/19390326/112377865-9cf56400-8cbc-11eb-9cfc-f85dc4bbe0d4.png)

The raw JSON for this property should look like this: 
![Screen Shot 2021-03-24 at 4 02 26 PM](https://user-images.githubusercontent.com/19390326/112377879-a088eb00-8cbc-11eb-9c5b-84eb7bf4ec4c.png)

# Story 📖

[EP-389: [Android] Create Properties: Phase 1 QA Feedback Priority 1](https://kickstarter.atlassian.net/browse/EP-389)
