### PR TITLE
[Android] EP-387: Phase 1 QA Create Property session_country 

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -149,6 +149,8 @@ abstract class TrackingClient(
 
     override fun userCountry(user: User): String = user.location()?.country() ?: this.config?.countryCode() ?: ""
 
+    override fun sessionCountry(): String = this.config?.countryCode() ?: ""
+
     override fun versionName(): String = BuildConfig.VERSION_NAME
 
     override fun wifiConnection(): Boolean {

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -28,6 +28,7 @@ abstract class TrackingClientType {
     protected abstract fun manufacturer(): String
     protected abstract fun model(): String
     protected abstract fun OSVersion(): String
+    protected abstract fun sessionCountry(): String
     protected abstract fun time(): Long
     abstract fun type(): Type
     protected abstract fun userAgent(): String?
@@ -73,6 +74,7 @@ abstract class TrackingClientType {
             this["app_release_version"] = versionName()
             this["platform"] = "native_android"
             this["client"] = "native"
+            this["country"] = sessionCountry()
             this["current_variants"] = currentVariants() ?: ""
             this["device_distinct_id"] = deviceDistinctId()
             this["device_type"] = deviceFormat()

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -179,6 +179,10 @@ public final class MockTrackingClient extends TrackingClientType {
   }
 
   @Override
+  protected String sessionCountry() {
+    return "US";
+  }
+  @Override
   protected String versionName() {
     return "9.9.9";
   }

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -702,6 +702,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals("9.9.9", expectedProperties["session_app_release_version"])
         assertEquals("native_android", expectedProperties["session_platform"])
         assertEquals("native", expectedProperties["session_client"])
+        assertEquals("US", expectedProperties["session_country"])
         assertEquals(JSONArray().put("android_example_experiment[control]"), expectedProperties["session_current_variants"])
         assertEquals("uuid", expectedProperties["session_device_distinct_id"])
         assertEquals("phone", expectedProperties["session_device_type"])


### PR DESCRIPTION
# 📲 What

- Create `session_country` property
- Update `SegmentTest` suite

# 🤔 Why

Segment integration.

# 🛠 How

Added `session_country` to the session properties, which gets its value from the `country code` in the `config` object

# 📋 QA

- Open app
- Fire any event, for example, tap on a project card
- In segment, under that event, you should see the `session_country` property:
![Screen Shot 2021-03-24 at 4 30 42 PM](https://user-images.githubusercontent.com/19390326/112379283-59035e80-8cbe-11eb-8e05-e7f451907270.png)

# Story 📖

[EP-387: [Android] Phase 1 QA Create Property: session_country](https://kickstarter.atlassian.net/browse/EP-387)
