### PR TITLE
[Android] EP-391: Phase 1 QA Fix Properties

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -119,8 +119,8 @@ abstract class TrackingClient(
      * Derives the device's orientation (portrait/landscape) from the `context`.
      */
     override fun deviceOrientation(): String =
-        if (this.context.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) "Landscape"
-        else "Portrait"
+        if (this.context.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) "landscape"
+        else "portrait"
 
     // TODO: will be deleted on https://kickstarter.atlassian.net/browse/EP-187
     override fun enabledFeatureFlags(): JSONArray {

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -566,7 +566,7 @@ class LakeTest : KSRobolectricTestCase() {
         assertEquals("phone", expectedProperties["session_device_type"])
         assertEquals("Google", expectedProperties["session_device_manufacturer"])
         assertEquals("Pixel 3", expectedProperties["session_device_model"])
-        assertEquals("Portrait", expectedProperties["session_device_orientation"])
+        assertEquals("portrait", expectedProperties["session_device_orientation"])
         assertEquals("en", expectedProperties["session_display_language"])
         assertEquals(JSONArray().put("optimizely_feature").put("android_example_feature"), expectedProperties["session_enabled_features"])
         assertEquals(false, expectedProperties["session_is_voiceover_running"])

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -113,7 +113,7 @@ public final class MockTrackingClient extends TrackingClientType {
 
   @Override
   protected String deviceOrientation() {
-    return "Portrait";
+    return "portrait";
   }
 
   @Override

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -813,7 +813,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals("phone", expectedProperties["session_device_type"])
         assertEquals("Google", expectedProperties["session_device_manufacturer"])
         assertEquals("Pixel 3", expectedProperties["session_device_model"])
-        assertEquals("Portrait", expectedProperties["session_device_orientation"])
+        assertEquals("portrait", expectedProperties["session_device_orientation"])
         assertEquals("en", expectedProperties["session_display_language"])
         assertEquals(JSONArray().put("optimizely_feature").put("android_example_feature"), expectedProperties["session_enabled_features"])
         assertEquals(false, expectedProperties["session_is_voiceover_running"])


### PR DESCRIPTION
# 📲 What

- Fix capitalization of values for the `session_device_orientation` property to be all lowercase

# 🤔 Why

Segment integration.

# 🛠 How

- Changed "Portrait" -> "portrait"
- Change "Landscape" -> "landscape" 

# 📋 QA

- Open app and fire any event. For example, tap a project card
- In segment, you should see `session_device_orientation = "portrait" OR "landscape"`
![Screen Shot 2021-03-24 at 6 33 30 PM](https://user-images.githubusercontent.com/19390326/112392297-8573a680-8ccf-11eb-928a-bc258be70ccc.png)

# Story 📖

[EP-391: [Android] Phase 1 QA Fix Properties](https://kickstarter.atlassian.net/browse/EP-391)
