### PR TITLE
[Android] EP-390: Phase 1 QA Feedback Priority 2 properties

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -113,6 +113,9 @@ object AnalyticEventsUtils {
         val properties = HashMap<String, Any>()
         properties["backed_projects_count"] = user.backedProjectsCount() ?: 0
         properties["launched_projects_count"] = user.memberProjectsCount() ?: 0
+        properties["created_projects_count"] = user.createdProjectsCount() ?: 0
+        properties["facebook_connected"] = user.facebookConnected() ?: false
+        properties["watched_projects_count"] = user.starredProjectsCount() ?: 0
         properties["uid"] = user.id().toString()
         properties["is_admin"] = user.isAdmin ?: false
 

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -106,6 +106,9 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals(0, expectedProperties["user_launched_projects_count"])
         assertEquals("12", expectedProperties["user_uid"])
         assertEquals("US", expectedProperties["user_country"])
+        assertEquals(0, expectedProperties["user_created_projects_count"])
+        assertEquals(false, expectedProperties["user_facebook_connected"])
+        assertEquals(0, expectedProperties["user_watched_projects_count"])
     }
 
     @Test
@@ -831,6 +834,9 @@ class SegmentTest : KSRobolectricTestCase() {
         val expectedProperties = this.propertiesTest.value
         assertEquals(3, expectedProperties["user_backed_projects_count"])
         assertEquals(5, expectedProperties["user_launched_projects_count"])
+        assertEquals(6, expectedProperties["user_created_projects_count"])
+        assertEquals(true, expectedProperties["user_facebook_connected"])
+        assertEquals(14, expectedProperties["user_watched_projects_count"])
         assertEquals("15", expectedProperties["user_uid"])
         assertEquals("NG", expectedProperties["user_country"])
         assertEquals(isAdmin, expectedProperties["user_is_admin"])
@@ -890,6 +896,8 @@ class SegmentTest : KSRobolectricTestCase() {
             .backedProjectsCount(3)
             .memberProjectsCount(5)
             .createdProjectsCount(2)
+            .facebookConnected(true)
+            .createdProjectsCount(6)
             .location(LocationFactory.nigeria())
             .starredProjectsCount(10)
             .build()

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -836,7 +836,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals(5, expectedProperties["user_launched_projects_count"])
         assertEquals(6, expectedProperties["user_created_projects_count"])
         assertEquals(true, expectedProperties["user_facebook_connected"])
-        assertEquals(14, expectedProperties["user_watched_projects_count"])
+        assertEquals(10, expectedProperties["user_watched_projects_count"])
         assertEquals("15", expectedProperties["user_uid"])
         assertEquals("NG", expectedProperties["user_country"])
         assertEquals(isAdmin, expectedProperties["user_is_admin"])


### PR DESCRIPTION
# 📲 What

Added 3 new props to user properties: 
- `user_created_projects_count`
- `user_facebook_connected`
- `user_watched_projects_count`

Updated the `SegmentTest` suite

# 🤔 Why

Segment integration.

# 🛠 How

- Added all three properties to the` userProperties()` function in the `AnalyticEventsUtils` ext
- Updated the `assertUserProperties()` function in the `SegmentTest` class as well as the test case that checks we are returning the correct value if the fields from v1 that are populating these properties are null

# 📋 QA

- Open app and fire any event. For example, tap on a project card
- In segment, you should see the three new properties:
![Screen Shot 2021-03-24 at 7 07 10 PM](https://user-images.githubusercontent.com/19390326/112395821-7f80c400-8cd5-11eb-9abc-70940bc68f81.png)

# Story 📖

[EP-390: [Android] Create Properties Phase 1 QA Feedback Priority 2](https://kickstarter.atlassian.net/browse/EP-390)
