### PR TITLE
NT-1823: isExpanded functionality on BaseFragment

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/BaseFragment.java
+++ b/app/src/main/java/com/kickstarter/libs/BaseFragment.java
@@ -231,7 +231,7 @@ public class BaseFragment<ViewModelType extends FragmentViewModel> extends Fragm
    */
   public void setState(final Boolean state) {
     if (this.viewModel != null) {
-        this.viewModel.isExpanded(state);
+      this.viewModel.isExpanded(state);
     }
   }
 

--- a/app/src/main/java/com/kickstarter/libs/BaseFragment.java
+++ b/app/src/main/java/com/kickstarter/libs/BaseFragment.java
@@ -29,6 +29,7 @@ public class BaseFragment<ViewModelType extends FragmentViewModel> extends Fragm
   FragmentLifecycleType {
 
   private final BehaviorSubject<FragmentEvent> lifecycle = BehaviorSubject.create();
+
   private static final String VIEW_MODEL_KEY = "FragmentViewModel";
   protected ViewModelType viewModel;
   private final BroadcastReceiver optimizelyReadyReceiver = new BroadcastReceiver() {
@@ -217,6 +218,21 @@ public class BaseFragment<ViewModelType extends FragmentViewModel> extends Fragm
     super.onActivityResult(requestCode, resultCode, data);
     Timber.d("onActivityResult %s", this.toString());
     this.viewModel.activityResult(ActivityResult.create(requestCode, resultCode, data));
+  }
+
+  /**
+   * setState will indicate if the fragment has suffer any animation changes on the parents container
+   * - In case no animation externally applied to the fragment call this method with `false` value
+   * - In case some animation externally applied to the Fragment as is the case for:
+   *  `BackingFragment` and `RewardsFragment` call this method with `true` value when needed
+   *
+   * @param state = true in case the fragment is displayed on the screen with full width/height
+   *        state = false in case the fragment is displayed on the screen but hidden or width/Height = 0
+   */
+  public void setState(final Boolean state) {
+    if (this.viewModel != null) {
+        this.viewModel.isExpanded(state);
+    }
   }
 
   private void assignViewModel(final @Nullable Bundle viewModelEnvelope) {

--- a/app/src/main/java/com/kickstarter/libs/FragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/libs/FragmentViewModel.java
@@ -11,6 +11,7 @@ import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import rx.Observable;
+import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 import timber.log.Timber;
 
@@ -24,6 +25,7 @@ public class FragmentViewModel<ViewType extends FragmentLifecycleType> {
 
   private final PublishSubject<ActivityResult> activityResult = PublishSubject.create();
   private final PublishSubject<Bundle> arguments = PublishSubject.create();
+  protected final BehaviorSubject<Boolean> isExpanded = BehaviorSubject.create();
   protected final AnalyticEvents lake;
   protected final PublishSubject<Void> optimizelyReady = PublishSubject.create();
 
@@ -116,5 +118,9 @@ public class FragmentViewModel<ViewType extends FragmentLifecycleType> {
       this.view.switchMap(FragmentLifecycleType::lifecycle)
         .filter(FragmentEvent.DETACH::equals)
     );
+  }
+
+  public void isExpanded(boolean state) {
+    this.isExpanded.onNext(state);
   }
 }

--- a/app/src/main/java/com/kickstarter/libs/FragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/libs/FragmentViewModel.java
@@ -11,7 +11,6 @@ import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import rx.Observable;
-import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 import timber.log.Timber;
 
@@ -25,7 +24,7 @@ public class FragmentViewModel<ViewType extends FragmentLifecycleType> {
 
   private final PublishSubject<ActivityResult> activityResult = PublishSubject.create();
   private final PublishSubject<Bundle> arguments = PublishSubject.create();
-  protected final BehaviorSubject<Boolean> isExpanded = BehaviorSubject.create();
+  protected final PublishSubject<Boolean> isExpanded = PublishSubject.create();
   protected final AnalyticEvents lake;
   protected final PublishSubject<Void> optimizelyReady = PublishSubject.create();
 
@@ -120,7 +119,7 @@ public class FragmentViewModel<ViewType extends FragmentLifecycleType> {
     );
   }
 
-  public void isExpanded(boolean state) {
+  public void isExpanded(final boolean state) {
     this.isExpanded.onNext(state);
   }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -23,6 +23,7 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.R
 import com.kickstarter.libs.ActivityRequestCodes
 import com.kickstarter.libs.BaseActivity
+import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.Either
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.KoalaContext

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -425,6 +425,7 @@ class ProjectActivity :
                 override fun onAnimationCancel(animation: Animator?) {}
 
                 override fun onAnimationEnd(animation: Animator?) {
+                    setFragmentsState(expand)
                     if (expand) {
                         pledge_action_buttons.visibility = View.GONE
                         project_recycler_view.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
@@ -450,6 +451,12 @@ class ProjectActivity :
             })
 
             start()
+        }
+    }
+
+    private fun setFragmentsState(expand: Boolean) {
+        supportFragmentManager.fragments.map { fragment ->
+            (fragment as BaseFragment<*>).setState(expand && fragment.isVisible)
         }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -26,6 +26,7 @@ import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.setGone
 import com.kickstarter.models.Reward
+import com.kickstarter.ui.activities.BackingActivity
 import com.kickstarter.ui.adapters.RewardAndAddOnsAdapter
 import com.kickstarter.ui.data.PledgeStatusData
 import com.kickstarter.ui.data.ProjectData
@@ -252,6 +253,11 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>() {
                 .compose(bindToLifecycle())
                 .subscribe { viewModel.inputs.receivedCheckboxToggled(this.isChecked) }
         }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        this.setState(activity is BackingActivity)
     }
 
     private fun stylizedTextViews(it: String) {

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -218,6 +218,15 @@ interface BackingFragmentViewModel {
                 .filter { ObjectUtils.isNotNull(it) }
                 .share()
 
+            this.isExpanded
+                    .filter { it}
+                    .compose(combineLatestPair(backing))
+                    .map { it.second }
+                    .compose(bindToLifecycle())
+                    .subscribe {
+                        //this.lake.trackManagePledgePageViewed(it)
+                    }
+
             val isCreator = Observable.combineLatest(this.currentUser.observable(), backedProject) { user, project ->
                 Pair(user, project)
             }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -219,13 +219,13 @@ interface BackingFragmentViewModel {
                 .share()
 
             this.isExpanded
-                    .filter { it}
-                    .compose(combineLatestPair(backing))
-                    .map { it.second }
-                    .compose(bindToLifecycle())
-                    .subscribe {
-                        //this.lake.trackManagePledgePageViewed(it)
-                    }
+                .filter { it }
+                .compose(combineLatestPair(backing))
+                .map { it.second }
+                .compose(bindToLifecycle())
+                .subscribe {
+                    // this.lake.trackManagePledgePageViewed(it)
+                }
 
             val isCreator = Observable.combineLatest(this.currentUser.observable(), backedProject) { user, project ->
                 Pair(user, project)

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.FragmentViewModel
+import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
 import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.RewardUtils
@@ -72,7 +73,10 @@ class RewardsFragmentViewModel {
 
         init {
 
-            projectData
+            this.isExpanded
+                .filter { it }
+                .compose(combineLatestPair(this.projectDataInput))
+                .map { it.second }
                 .compose(bindToLifecycle())
                 .subscribe { this.lake.trackRewardsCarouselViewed(it) }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
@@ -46,7 +46,19 @@ class RewardsFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.configureWith(ProjectDataFactory.project(project))
 
-        this.lakeTest.assertValue(EventName.PAGE_VIEWED.eventName)
+        this.vm.isExpanded(true)
+        this.segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
+    }
+
+    @Test
+    fun init_whenViewModelInstantiated_FragmentCollapsed_shouldNotSendPagedViewedEvent() {
+        val project = ProjectFactory.project()
+        setUpEnvironment(environment())
+
+        this.vm.inputs.configureWith(ProjectDataFactory.project(project))
+
+        this.vm.isExpanded(false)
+        this.segmentTrack.assertNoValues()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- `BaseFragmentViewModel` emits if the fragment is expanded or not
- `BaseFragment` has a new method to setUp the state.

# 🤔 Why
- Fuctionallity to know when a Fragment has suffer a transformation via Animation outside the fragment itself

# 👀 See
- For the PageViewed event on the RewardsCarousel you can see this working, every time we show in full screen the rewards carousel the page viewed event should be fired.
- Tests and code already added for the `pageViewed event` for rewards carousel @leighdouglas 
- PlaceHolder on `BackingFragmentViewModel` for the `Manage Pledge Screen PageViewed` event @sunday-okpoluaefe 

|  |  |

# 📋 QA
- Open the Rewards Carousel you'll see that the event is fired just when the carousel is expanded

# Story 📖

[NT-1823](https://kickstarter.atlassian.net/browse/NT-1823)
