### PR TITLE
NT-1687: Empty Screens on Messages and Activity

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/MessageThreadsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/MessageThreadsActivity.kt
@@ -97,6 +97,11 @@ class MessageThreadsActivity : BaseActivity<MessageThreadsViewModel.ViewModel>()
             .compose(Transformers.observeForUI())
             .subscribe { ViewUtils.setGone(binding.unreadCountTextView, it) }
 
+        viewModel.outputs.isFetchingMessageThreads
+            .compose(bindToLifecycle())
+            .compose(Transformers.observeForUI())
+            .subscribe { binding.messageThreadsSwipeRefreshLayout.isRefreshing = it }
+
         binding.switchMailboxButton.setOnClickListener {
             mailboxSwitchClicked()
         }


### PR DESCRIPTION
# 📲 What

NT-1687: Empty Screens on Messages and Activity

# 🤔 Why

Messages show an empty screen on page load. 

# 🛠 How

- Added an observer to the ``` isFetchingMessageThreads ``` observable and subscribe ``` messageThreadsSwipeRefreshLayout.isRefreshing ``` 

# 👀 See



<img width="320" alt="Screenshot 2021-03-31 at 18 10 32" src="https://user-images.githubusercontent.com/63934292/113184086-af3b4900-924c-11eb-8f56-8437cebad3ba.png">



# 📋 QA

- CLick on ```Messages``` or ```Activity``` screens from the hamburger menu

# Story 📖

https://kickstarter.atlassian.net/browse/NT-1687

