### PR TITLE
EP-424: Page Viewed (search)

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -853,6 +853,12 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         client.track(CTA_CLICKED.eventName, props)
     }
 
+    /**
+     * Sends data associated with the search results page viewed to segment.
+     * @param discoveryParams: DiscoveryParams
+     * @param count: Int
+     * @param sort: DiscoveryParams.Sort
+     */
     fun trackSearchResultPageViewed(discoveryParams: DiscoveryParams, count: Int, sort: DiscoveryParams.Sort) {
         val props = AnalyticEventsUtils.discoveryParamsProperties(discoveryParams).toMutableMap()
         props[CONTEXT_PAGE.contextName] = SEARCH.contextName

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -859,8 +859,8 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      * @param count: Int
      * @param sort: DiscoveryParams.Sort
      */
-    fun trackSearchResultPageViewed(discoveryParams: DiscoveryParams, count: Int) {
-        val props = AnalyticEventsUtils.discoveryParamsProperties(discoveryParams).toMutableMap()
+    fun trackSearchResultPageViewed(discoveryParams: DiscoveryParams, count: Int, sort: DiscoveryParams.Sort) {
+        val props = AnalyticEventsUtils.discoveryParamsProperties(discoveryParams, sort).toMutableMap()
         props[CONTEXT_PAGE.contextName] = SEARCH.contextName
         discoveryParams.term()?.let { props["discover_search_term"] = it }
         props["discover_search_results_count"] = count

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -854,9 +854,13 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         client.track(CTA_CLICKED.eventName, props)
     }
 
-    fun trackSearchResultPageViewed(discoveryParams: DiscoveryParams) {
-        val props = AnalyticEventsUtils.discoveryParamsProperties(discoveryParams)
-        client.track(SEARCH_PAGE_VIEWED, props)
+    fun trackSearchResultPageViewed(discoveryParams: DiscoveryParams, count: Int, sort: DiscoveryParams.Sort) {
+        val props = AnalyticEventsUtils.discoveryParamsProperties(discoveryParams).toMutableMap()
+        props[CONTEXT_PAGE.contextName] = SEARCH.contextName
+        props[DISCOVER_SORT.contextName] = sort.name.toLowerCase(Locale.ROOT)
+        discoveryParams.term()?.let { props["discover_search_term"] = it }
+        props["discover_search_results_count"] = count
+        client.track(PAGE_VIEWED.eventName, props)
     }
 
     fun trackSearchPageViewed(discoveryParams: DiscoveryParams) {

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -859,10 +859,9 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      * @param count: Int
      * @param sort: DiscoveryParams.Sort
      */
-    fun trackSearchResultPageViewed(discoveryParams: DiscoveryParams, count: Int, sort: DiscoveryParams.Sort) {
+    fun trackSearchResultPageViewed(discoveryParams: DiscoveryParams, count: Int) {
         val props = AnalyticEventsUtils.discoveryParamsProperties(discoveryParams).toMutableMap()
         props[CONTEXT_PAGE.contextName] = SEARCH.contextName
-        props[DISCOVER_SORT.contextName] = sort.name.toLowerCase(Locale.ROOT)
         discoveryParams.term()?.let { props["discover_search_term"] = it }
         props["discover_search_results_count"] = count
         client.track(PAGE_VIEWED.eventName, props)

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -854,6 +854,11 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         client.track(CTA_CLICKED.eventName, props)
     }
 
+    fun trackSearchResultPageViewed(discoveryParams: DiscoveryParams) {
+        val props = AnalyticEventsUtils.discoveryParamsProperties(discoveryParams)
+        client.track(SEARCH_PAGE_VIEWED, props)
+    }
+
     fun trackSearchPageViewed(discoveryParams: DiscoveryParams) {
         val props = AnalyticEventsUtils.discoveryParamsProperties(discoveryParams)
         client.track(SEARCH_PAGE_VIEWED, props)

--- a/app/src/main/java/com/kickstarter/libs/braze/BrazeClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/braze/BrazeClient.kt
@@ -10,7 +10,6 @@ import com.appboy.configuration.AppboyConfig
 import com.appboy.support.AppboyLogger
 import com.google.firebase.messaging.RemoteMessage
 import com.kickstarter.libs.Build
-import com.kickstarter.libs.utils.Secrets
 
 /**
  * Remote PushNotifications specification
@@ -76,10 +75,10 @@ open class BrazeClient(
     override fun getIdSender(): String {
         var senderId = ""
         if (build.isRelease && Build.isExternal()) {
-            //senderId = Secrets.FirebaseSenderID.PRODUCTION
+            // senderId = Secrets.FirebaseSenderID.PRODUCTION
         }
         if (build.isDebug || Build.isInternal()) {
-            //senderId = Secrets.FirebaseSenderID.STAGING
+            // senderId = Secrets.FirebaseSenderID.STAGING
         }
 
         return senderId

--- a/app/src/main/java/com/kickstarter/libs/braze/BrazeClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/braze/BrazeClient.kt
@@ -76,10 +76,10 @@ open class BrazeClient(
     override fun getIdSender(): String {
         var senderId = ""
         if (build.isRelease && Build.isExternal()) {
-             senderId = Secrets.FirebaseSenderID.PRODUCTION
+            senderId = Secrets.FirebaseSenderID.PRODUCTION
         }
         if (build.isDebug || Build.isInternal()) {
-             senderId = Secrets.FirebaseSenderID.STAGING
+            senderId = Secrets.FirebaseSenderID.STAGING
         }
 
         return senderId

--- a/app/src/main/java/com/kickstarter/libs/braze/BrazeClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/braze/BrazeClient.kt
@@ -10,6 +10,7 @@ import com.appboy.configuration.AppboyConfig
 import com.appboy.support.AppboyLogger
 import com.google.firebase.messaging.RemoteMessage
 import com.kickstarter.libs.Build
+import com.kickstarter.libs.utils.Secrets
 
 /**
  * Remote PushNotifications specification
@@ -75,10 +76,10 @@ open class BrazeClient(
     override fun getIdSender(): String {
         var senderId = ""
         if (build.isRelease && Build.isExternal()) {
-            // senderId = Secrets.FirebaseSenderID.PRODUCTION
+             senderId = Secrets.FirebaseSenderID.PRODUCTION
         }
         if (build.isDebug || Build.isInternal()) {
-            // senderId = Secrets.FirebaseSenderID.STAGING
+             senderId = Secrets.FirebaseSenderID.STAGING
         }
 
         return senderId

--- a/app/src/main/java/com/kickstarter/libs/braze/BrazeClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/braze/BrazeClient.kt
@@ -76,10 +76,10 @@ open class BrazeClient(
     override fun getIdSender(): String {
         var senderId = ""
         if (build.isRelease && Build.isExternal()) {
-            senderId = Secrets.FirebaseSenderID.PRODUCTION
+            //senderId = Secrets.FirebaseSenderID.PRODUCTION
         }
         if (build.isDebug || Build.isInternal()) {
-            senderId = Secrets.FirebaseSenderID.STAGING
+            //senderId = Secrets.FirebaseSenderID.STAGING
         }
 
         return senderId

--- a/app/src/main/java/com/kickstarter/mock/factories/DiscoverEnvelopeFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/DiscoverEnvelopeFactory.java
@@ -18,6 +18,13 @@ public final class DiscoverEnvelopeFactory {
           .api(DiscoverEnvelope.UrlsEnvelope.ApiEnvelope.builder().moreProjects("").build())
           .build()
       )
+      .stats(
+        DiscoverEnvelope
+          .StatsEnvelope
+          .builder()
+          .count(10)
+          .build()
+      )
       .build();
   }
 }

--- a/app/src/main/java/com/kickstarter/mock/services/MockApiClient.java
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApiClient.java
@@ -150,6 +150,13 @@ public class MockApiClient implements ApiClientType {
             )
             .build()
         )
+        .stats(
+              DiscoverEnvelope
+                .StatsEnvelope
+                .builder()
+                .count(10)
+                .build()
+        )
         .build()
     );
   }

--- a/app/src/main/java/com/kickstarter/services/apiresponses/DiscoverEnvelope.java
+++ b/app/src/main/java/com/kickstarter/services/apiresponses/DiscoverEnvelope.java
@@ -14,13 +14,13 @@ import auto.parcel.AutoParcel;
 public abstract class DiscoverEnvelope implements Parcelable {
   public abstract List<Project> projects();
   public abstract UrlsEnvelope urls();
-  public abstract UrlsEnvelope.StatsEnvelop stats();
+  public abstract StatsEnvelope stats();
 
   @AutoParcel.Builder
   public abstract static class Builder {
     public abstract Builder projects(List<Project> __);
     public abstract Builder urls(UrlsEnvelope __);
-    public abstract Builder stats(UrlsEnvelope.StatsEnvelop __);
+    public abstract Builder stats(StatsEnvelope __);
     public abstract DiscoverEnvelope build();
   }
 
@@ -63,19 +63,21 @@ public abstract class DiscoverEnvelope implements Parcelable {
       }
     }
 
-    @AutoGson
-    @AutoParcel
-    public abstract static class StatsEnvelop implements Parcelable {
-      public abstract Integer count();
+  }
 
-      @AutoParcel.Builder
-      public abstract static class Builder {
-        public abstract Builder count(Integer __);
-        public abstract StatsEnvelop build();
-      }
-      public static Builder builder() {
-        return new AutoParcel_DiscoverEnvelope_UrlsEnvelope_StatsEnvelop.Builder();
-      }
+  @AutoGson
+  @AutoParcel
+  public abstract static class StatsEnvelope implements Parcelable {
+    public abstract Integer count();
+
+    @AutoParcel.Builder
+    public abstract static class Builder {
+      public abstract Builder count(Integer __);
+      public abstract StatsEnvelope build();
+    }
+    public static Builder builder() {
+      return new AutoParcel_DiscoverEnvelope_StatsEnvelope.Builder();
     }
   }
+
 }

--- a/app/src/main/java/com/kickstarter/services/apiresponses/DiscoverEnvelope.java
+++ b/app/src/main/java/com/kickstarter/services/apiresponses/DiscoverEnvelope.java
@@ -14,11 +14,13 @@ import auto.parcel.AutoParcel;
 public abstract class DiscoverEnvelope implements Parcelable {
   public abstract List<Project> projects();
   public abstract UrlsEnvelope urls();
+  public abstract UrlsEnvelope.StatsEnvelop stats();
 
   @AutoParcel.Builder
   public abstract static class Builder {
     public abstract Builder projects(List<Project> __);
     public abstract Builder urls(UrlsEnvelope __);
+    public abstract Builder stats(UrlsEnvelope.StatsEnvelop __);
     public abstract DiscoverEnvelope build();
   }
 
@@ -58,6 +60,21 @@ public abstract class DiscoverEnvelope implements Parcelable {
 
       public static Builder builder() {
         return new AutoParcel_DiscoverEnvelope_UrlsEnvelope_ApiEnvelope.Builder();
+      }
+    }
+
+    @AutoGson
+    @AutoParcel
+    public abstract static class StatsEnvelop implements Parcelable {
+      public abstract Integer count();
+
+      @AutoParcel.Builder
+      public abstract static class Builder {
+        public abstract Builder count(Integer __);
+        public abstract StatsEnvelop build();
+      }
+      public static Builder builder() {
+        return new AutoParcel_DiscoverEnvelope_UrlsEnvelope_StatsEnvelop.Builder();
       }
     }
   }

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -144,6 +144,14 @@ public interface SearchViewModel {
 
       params
           .compose(takePairWhen(pageCount))
+          .filter(paramsAndPageCount -> paramsAndPageCount.first.sort() != defaultSort && IntegerUtils.intValueOrZero(paramsAndPageCount.second) == 1)
+          .map(paramsAndPageCount -> paramsAndPageCount.first)
+          .observeOn(Schedulers.io())
+          .compose(bindToLifecycle())
+          .subscribe(this.lake::trackSearchResultsLoaded);
+
+      params
+          .compose(takePairWhen(pageCount))
           .compose(takePairWhen(this.discoverEnvelope))
           .observeOn(Schedulers.io())
           .compose(bindToLifecycle())
@@ -151,14 +159,6 @@ public interface SearchViewModel {
           .subscribe(it -> {
             this.lake.trackSearchResultPageViewed(it.first.first, it.second.stats().count(), defaultSort);
           });
-
-      params
-          .compose(takePairWhen(pageCount))
-          .filter(paramsAndPageCount -> paramsAndPageCount.first.sort() != defaultSort && IntegerUtils.intValueOrZero(paramsAndPageCount.second) == 1)
-          .map(paramsAndPageCount -> paramsAndPageCount.first)
-          .observeOn(Schedulers.io())
-          .compose(bindToLifecycle())
-          .subscribe(this.lake::trackSearchResultsLoaded);
 
       this.lake.trackSearchButtonClicked();
       this.lake.trackSearchCTAButtonClicked(defaultParams);

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -147,7 +147,7 @@ public interface SearchViewModel {
           .compose(takePairWhen(this.discoverEnvelope))
           .observeOn(Schedulers.io())
           .compose(bindToLifecycle())
-          .filter(it -> ObjectUtils.isNotNull(it.first.first.term()) && IntegerUtils.intValueOrZero(it.first.second) == 1)
+          .filter(it -> ObjectUtils.isNotNull(it.first.first.term()) && IntegerUtils.intValueOrZero(it.first.second) == 1 )
           .subscribe(it -> {
             this.lake.trackSearchResultPageViewed(it.first.first, it.second.stats().count(), defaultSort);
           });
@@ -158,7 +158,9 @@ public interface SearchViewModel {
           .map(paramsAndPageCount -> paramsAndPageCount.first)
           .observeOn(Schedulers.io())
           .compose(bindToLifecycle())
-          .subscribe(this.lake::trackSearchResultsLoaded);
+          .subscribe( it -> {
+            this.lake.trackSearchResultsLoaded(it);
+          });
 
       this.lake.trackSearchButtonClicked();
       this.lake.trackSearchCTAButtonClicked(defaultParams);

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -59,8 +59,11 @@ public interface SearchViewModel {
 
   final class ViewModel extends ActivityViewModel<SearchActivity> implements Inputs, Outputs {
 
+    private PublishSubject<DiscoverEnvelope> discoverEnvelope = PublishSubject.create();
+
     public ViewModel(final @NonNull Environment environment) {
       super(environment);
+
 
       final ApiClientType apiClient = environment.apiClient();
       final Scheduler scheduler = environment.scheduler();
@@ -70,6 +73,8 @@ public interface SearchViewModel {
         .filter(StringExt::isPresent)
         .debounce(300, TimeUnit.MILLISECONDS, scheduler)
         .map(s -> DiscoveryParams.builder().term(s).build());
+
+
 
       final Observable<DiscoveryParams> popularParams = this.search
         .filter(ObjectUtils::isNotNull)
@@ -85,7 +90,7 @@ public interface SearchViewModel {
           .startOverWith(params)
           .envelopeToListOfData(
                   envelope -> {
-                    Log.e("HERE", envelope.stats().count() + "COUNT");
+                    discoverEnvelope.onNext(envelope);
                     return envelope.projects();
                   }
           )

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -7,7 +7,6 @@ import com.kickstarter.libs.ApiPaginator;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.libs.utils.EventContextValues;
-import com.kickstarter.libs.utils.IntegerUtils;
 import com.kickstarter.libs.utils.ListUtils;
 import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.libs.utils.extensions.StringExt;
@@ -143,23 +142,14 @@ public interface SearchViewModel {
           return this.projectAndRefTag(searchTerm, currentProjects, projectClicked);
         });
 
-      searchParams
-          .compose(takePairWhen(pageCount))
+      this.search
           .compose(takePairWhen(this.discoverEnvelope))
           .observeOn(Schedulers.io())
           .compose(bindToLifecycle())
-          .filter(it -> ObjectUtils.isNotNull(it.first.first.term()) && IntegerUtils.intValueOrZero(it.first.second) == 1)
+          .filter(it -> ObjectUtils.isNotNull(it.first) && StringExt.isPresent(it.first))
           .subscribe(it -> {
-            this.lake.trackSearchResultPageViewed(it.first.first, it.second.stats().count());
+            this.lake.trackSearchResultPageViewed(defaultParams, it.second.stats().count(), defaultSort);
           });
-
-      params
-          .compose(takePairWhen(pageCount))
-          .filter(paramsAndPageCount -> paramsAndPageCount.first.sort() != defaultSort && IntegerUtils.intValueOrZero(paramsAndPageCount.second) == 1)
-          .map(paramsAndPageCount -> paramsAndPageCount.first)
-          .observeOn(Schedulers.io())
-          .compose(bindToLifecycle())
-          .subscribe(this.lake::trackSearchResultsLoaded);
 
       this.lake.trackSearchButtonClicked();
       this.lake.trackSearchCTAButtonClicked(defaultParams);

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -144,7 +144,6 @@ public interface SearchViewModel {
 
       this.search
           .compose(takePairWhen(this.discoverEnvelope))
-          .observeOn(Schedulers.io())
           .compose(bindToLifecycle())
           .filter(it -> ObjectUtils.isNotNull(it.first) && StringExt.isPresent(it.first))
           .subscribe(it -> {

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import androidx.annotation.NonNull;
+
 import rx.Observable;
 import rx.Scheduler;
 import rx.schedulers.Schedulers;
@@ -142,14 +143,14 @@ public interface SearchViewModel {
           return this.projectAndRefTag(searchTerm, currentProjects, projectClicked);
         });
 
-      params
+      searchParams
           .compose(takePairWhen(pageCount))
           .compose(takePairWhen(this.discoverEnvelope))
           .observeOn(Schedulers.io())
           .compose(bindToLifecycle())
-          .filter(it -> ObjectUtils.isNotNull(it.first.first.term()) && IntegerUtils.intValueOrZero(it.first.second) == 1 )
+          .filter(it -> ObjectUtils.isNotNull(it.first.first.term()) && IntegerUtils.intValueOrZero(it.first.second) == 1)
           .subscribe(it -> {
-            this.lake.trackSearchResultPageViewed(it.first.first, it.second.stats().count(), defaultSort);
+            this.lake.trackSearchResultPageViewed(it.first.first, it.second.stats().count());
           });
 
       params
@@ -158,9 +159,7 @@ public interface SearchViewModel {
           .map(paramsAndPageCount -> paramsAndPageCount.first)
           .observeOn(Schedulers.io())
           .compose(bindToLifecycle())
-          .subscribe( it -> {
-            this.lake.trackSearchResultsLoaded(it);
-          });
+          .subscribe(this.lake::trackSearchResultsLoaded);
 
       this.lake.trackSearchButtonClicked();
       this.lake.trackSearchCTAButtonClicked(defaultParams);

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -58,7 +58,7 @@ public interface SearchViewModel {
 
   final class ViewModel extends ActivityViewModel<SearchActivity> implements Inputs, Outputs {
 
-    private PublishSubject<DiscoverEnvelope> discoverEnvelope = PublishSubject.create();
+    private final PublishSubject<DiscoverEnvelope> discoverEnvelope = PublishSubject.create();
 
     public ViewModel(final @NonNull Environment environment) {
       super(environment);

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -144,14 +144,6 @@ public interface SearchViewModel {
 
       params
           .compose(takePairWhen(pageCount))
-          .filter(paramsAndPageCount -> paramsAndPageCount.first.sort() != defaultSort && IntegerUtils.intValueOrZero(paramsAndPageCount.second) == 1)
-          .map(paramsAndPageCount -> paramsAndPageCount.first)
-          .observeOn(Schedulers.io())
-          .compose(bindToLifecycle())
-          .subscribe(this.lake::trackSearchResultsLoaded);
-
-      params
-          .compose(takePairWhen(pageCount))
           .compose(takePairWhen(this.discoverEnvelope))
           .observeOn(Schedulers.io())
           .compose(bindToLifecycle())
@@ -159,6 +151,14 @@ public interface SearchViewModel {
           .subscribe(it -> {
             this.lake.trackSearchResultPageViewed(it.first.first, it.second.stats().count(), defaultSort);
           });
+
+      params
+          .compose(takePairWhen(pageCount))
+          .filter(paramsAndPageCount -> paramsAndPageCount.first.sort() != defaultSort && IntegerUtils.intValueOrZero(paramsAndPageCount.second) == 1)
+          .map(paramsAndPageCount -> paramsAndPageCount.first)
+          .observeOn(Schedulers.io())
+          .compose(bindToLifecycle())
+          .subscribe(this.lake::trackSearchResultsLoaded);
 
       this.lake.trackSearchButtonClicked();
       this.lake.trackSearchCTAButtonClicked(defaultParams);

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import androidx.annotation.NonNull;
-
-import kotlin.Triple;
 import rx.Observable;
 import rx.Scheduler;
 import rx.subjects.BehaviorSubject;

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -23,7 +23,6 @@ import androidx.annotation.NonNull;
 
 import rx.Observable;
 import rx.Scheduler;
-import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 

--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import androidx.annotation.NonNull;
+
 import rx.Observable;
 import rx.Scheduler;
 import rx.subjects.BehaviorSubject;
@@ -151,7 +152,7 @@ public interface SearchViewModel {
                   && IntegerUtils.intValueOrZero(it.second) == 1)
           .distinct()
           .subscribe(it -> {
-            this.lake.trackSearchResultPageViewed(defaultParams, it.first.second.stats().count(), defaultSort);
+            this.lake.trackSearchResultPageViewed(it.first.first, it.first.second.stats().count(), defaultSort);
           });
 
       this.lake.trackSearchButtonClicked();

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -193,6 +193,45 @@ class SegmentTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testSearchResultPageViewed_Properties() {
+        val user = user()
+        val client = client(user)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        client.identifiedId.subscribe(this.segmentIdentify)
+        val segment = AnalyticEvents(listOf(client))
+
+        val params = DiscoveryParams
+            .builder()
+            .term("test")
+            .sort(DiscoveryParams.Sort.POPULAR)
+            .staffPicks(true)
+            .build()
+
+        segment.trackSearchResultPageViewed(params, 200, DiscoveryParams.Sort.POPULAR)
+
+        assertSessionProperties(user)
+        assertContextProperties()
+        assertUserProperties(false)
+
+        val expectedProperties = propertiesTest.value
+        assertEquals("test", expectedProperties["discover_search_term"])
+        assertEquals(200, expectedProperties["discover_search_results_count"])
+        assertEquals(false, expectedProperties["discover_everything"])
+        assertEquals(true, expectedProperties["discover_pwl"])
+        assertEquals(false, expectedProperties["discover_recommended"])
+        assertEquals("recommended_popular", expectedProperties["discover_ref_tag"])
+        assertEquals(false, expectedProperties["discover_social"])
+        assertEquals("popular", expectedProperties["discover_sort"])
+        assertNull(expectedProperties["discover_subcategory_id"])
+        assertNull(expectedProperties["discover_subcategory_name"])
+        assertEquals(null, expectedProperties["discover_tag"])
+        assertEquals(false, expectedProperties["discover_watched"])
+
+        this.segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
+    }
+
+    @Test
     fun testDiscoveryProperties_NoCategory() {
         val user = user()
         val client = client(user)

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -208,7 +208,7 @@ class SegmentTest : KSRobolectricTestCase() {
             .staffPicks(true)
             .build()
 
-        segment.trackSearchResultPageViewed(params, 200, DiscoveryParams.Sort.POPULAR)
+        segment.trackSearchResultPageViewed(params, 200)
 
         assertSessionProperties(user)
         assertContextProperties()

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -208,7 +208,7 @@ class SegmentTest : KSRobolectricTestCase() {
             .staffPicks(true)
             .build()
 
-        segment.trackSearchResultPageViewed(params, 200)
+        segment.trackSearchResultPageViewed(params, 200, DiscoveryParams.Sort.POPULAR)
 
         assertSessionProperties(user)
         assertContextProperties()

--- a/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
@@ -82,9 +82,9 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
 
     // Typing more search terms doesn't emit more values
     this.vm.inputs.search("hello world!");
-    this.searchProjectsPresent.assertValues(false, true);
-    scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", "Search Results Loaded");
+    //this.searchProjectsPresent.assertValues(false, true);
+    scheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", "Search Results Loaded", EventName.PAGE_VIEWED.getEventName());
 
     // Waiting enough time emits search results
     scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);

--- a/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
@@ -78,7 +78,7 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
     this.searchProjectsPresent.assertValues(false, true);
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked",  EventName.CTA_CLICKED.getEventName(), "Search Page Viewed");
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed");
 
     // Typing more search terms doesn't emit more values
     this.vm.inputs.search("hello world!");

--- a/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
@@ -79,13 +79,13 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
     this.searchProjectsPresent.assertValues(false, true);
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed");
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", EventName.PAGE_VIEWED.getEventName());
 
     // Typing more search terms doesn't emit more values
     this.vm.inputs.search("hello world!");
     this.searchProjectsPresent.assertValues(false, true);
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", EventName.PAGE_VIEWED.getEventName());
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", EventName.PAGE_VIEWED.getEventName(), EventName.PAGE_VIEWED.getEventName());
 
     // Waiting enough time emits search results
     scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);

--- a/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
@@ -84,7 +84,7 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.search("hello world!");
     this.searchProjectsPresent.assertValues(false, true);
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", "Search Results Loaded", EventName.PAGE_VIEWED.getEventName());
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", "Search Results Loaded");
 
     // Waiting enough time emits search results
     scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);

--- a/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
@@ -82,8 +82,8 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
 
     // Typing more search terms doesn't emit more values
     this.vm.inputs.search("hello world!");
-    //this.searchProjectsPresent.assertValues(false, true);
-    scheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);
+    this.searchProjectsPresent.assertValues(false, true);
+    scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
     this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", "Search Results Loaded", EventName.PAGE_VIEWED.getEventName());
 
     // Waiting enough time emits search results

--- a/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
@@ -85,7 +85,7 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.search("hello world!");
     this.searchProjectsPresent.assertValues(false, true);
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", "Search Results Loaded", EventName.PAGE_VIEWED.getEventName());
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", EventName.PAGE_VIEWED.getEventName());
 
     // Waiting enough time emits search results
     scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);

--- a/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
@@ -1,22 +1,18 @@
 package com.kickstarter.viewmodels;
 
 import com.kickstarter.KSRobolectricTestCase;
-import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
-import com.kickstarter.libs.MockCurrentUser;
 import com.kickstarter.libs.RefTag;
 import com.kickstarter.mock.factories.DiscoverEnvelopeFactory;
 import com.kickstarter.mock.factories.ProjectFactory;
 import com.kickstarter.mock.services.MockApiClient;
 import com.kickstarter.models.Project;
-import com.kickstarter.services.ApiClientType;
 import com.kickstarter.services.DiscoveryParams;
 import com.kickstarter.services.apiresponses.DiscoverEnvelope;
 import com.kickstarter.libs.utils.EventName;
 
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -83,14 +79,13 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
     this.searchProjectsPresent.assertValues(false, true);
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", "Page Viewed");
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed");
 
     // Typing more search terms doesn't emit more values
     this.vm.inputs.search("hello world!");
     this.searchProjectsPresent.assertValues(false, true);
-    scheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", EventName.PAGE_VIEWED.getEventName(),
-            "Search Results Loaded", EventName.PAGE_VIEWED.getEventName());
+    scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", "Search Results Loaded", EventName.PAGE_VIEWED.getEventName());
 
     // Waiting enough time emits search results
     scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);

--- a/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
@@ -46,32 +46,6 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     this.vm.outputs.searchProjects().map(ps -> ps.size() > 0).subscribe(this.searchProjectsPresent);
   }
 
-  @Test
-  public void testSearchResultPageViewed () {
-
-    final CurrentUserType currentUser = new MockCurrentUser();
-    final ApiClientType apiClient = new MockApiClient() {
-      @Override
-      public @NonNull Observable<DiscoverEnvelope> fetchProjects(final @NonNull DiscoveryParams params) {
-        if (params.isSavedProjects()) {
-          return Observable.just(DiscoverEnvelopeFactory.discoverEnvelope(new ArrayList<>()));
-        } else {
-          return super.fetchProjects(params);
-        }
-      }
-    };
-
-    final Environment environment = environment().toBuilder()
-            .apiClient(apiClient)
-            .currentUser(currentUser)
-            .build();
-
-    setUpEnvironment(environment);
-
-    this.vm.search("hello");
-    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), EventName.PAGE_VIEWED.getEventName(), "Search Results Loaded");
-
-  }
 
   @Test
   public void testPopularProjectsLoadImmediately() {
@@ -109,13 +83,14 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
     this.searchProjectsPresent.assertValues(false, true);
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed");
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", "Page Viewed");
 
     // Typing more search terms doesn't emit more values
     this.vm.inputs.search("hello world!");
     this.searchProjectsPresent.assertValues(false, true);
-    scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", "Search Results Loaded", EventName.PAGE_VIEWED.getEventName());
+    scheduler.advanceTimeBy(2000, TimeUnit.MILLISECONDS);
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", EventName.PAGE_VIEWED.getEventName(),
+            "Search Results Loaded", EventName.PAGE_VIEWED.getEventName());
 
     // Waiting enough time emits search results
     scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);

--- a/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
@@ -67,12 +67,12 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     // Searching shouldn't emit values immediately
     this.vm.inputs.search("hello");
     this.searchProjectsPresent.assertNoValues();
-    this.lakeTest.assertValues("Search Button Clicked",  EventName.CTA_CLICKED.getEventName(), "Search Page Viewed");
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed");
 
     // Waiting a small amount time shouldn't emit values
     scheduler.advanceTimeBy(200, TimeUnit.MILLISECONDS);
     this.searchProjectsPresent.assertNoValues();
-    this.lakeTest.assertValues("Search Button Clicked",  EventName.CTA_CLICKED.getEventName(), "Search Page Viewed");
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed");
 
     // Waiting the rest of the time makes the search happen
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
@@ -84,7 +84,7 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     this.vm.inputs.search("hello world!");
     this.searchProjectsPresent.assertValues(false, true);
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked",  EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", "Search Results Loaded");
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", "Search Results Loaded", EventName.PAGE_VIEWED.getEventName());
 
     // Waiting enough time emits search results
     scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);

--- a/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/SearchViewModelTest.java
@@ -79,13 +79,13 @@ public class SearchViewModelTest extends KSRobolectricTestCase {
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
     this.searchProjectsPresent.assertValues(false, true);
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", EventName.PAGE_VIEWED.getEventName());
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed");
 
     // Typing more search terms doesn't emit more values
     this.vm.inputs.search("hello world!");
     this.searchProjectsPresent.assertValues(false, true);
     scheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", EventName.PAGE_VIEWED.getEventName(), EventName.PAGE_VIEWED.getEventName());
+    this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed", EventName.PAGE_VIEWED.getEventName());
 
     // Waiting enough time emits search results
     scheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
# 📲 What

Android: Page Viewed (search)

# 🤔 Why

Datalake Event to Convert for Segment

When the user types a search term, the app currently makes a network call to fetch the results. When the results return from the API, call the Page Viewed event with the search term in the discover_search_term property with the correct total count in the discover_search_results_count

# 🛠 How

- Created method ``` trackSearchResultPageViewed ``` in ``` AnalyticEvents ```
```
/**
     * Sends data associated with the search results page viewed to segment.
     * @param discoveryParams: DiscoveryParams
     * @param count: Int
     * @param sort: DiscoveryParams.Sort
     */
    fun trackSearchResultPageViewed(discoveryParams: DiscoveryParams, count: Int, sort: DiscoveryParams.Sort) {
        val props = AnalyticEventsUtils.discoveryParamsProperties(discoveryParams).toMutableMap()
        props[CONTEXT_PAGE.contextName] = SEARCH.contextName
        props[DISCOVER_SORT.contextName] = sort.name.toLowerCase(Locale.ROOT)
        discoveryParams.term()?.let { props["discover_search_term"] = it }
        props["discover_search_results_count"] = count
        client.track(PAGE_VIEWED.eventName, props)
    }

```

- Called method from ``` SearchViewModel ``` on search results loaded from server
``` 
    params
          .compose(takePairWhen(this.discoverEnvelope))
          .compose(combineLatestPair(pageCount))
          .compose(bindToLifecycle())
          .filter(it -> ObjectUtils.isNotNull(it.first.first.term())
                  && StringExt.isPresent(it.first.first.term())
                  && it.first.first.sort() != defaultSort
                  && IntegerUtils.intValueOrZero(it.second) == 1)
          .distinct()
          .subscribe(it -> {
            this.lake.trackSearchResultPageViewed(defaultParams, it.first.second.stats().count(), defaultSort);
          });
```

- Added unit tests to segment event and properties 
``` SegmentTest ```
```
 @Test
    fun testSearchResultPageViewed_Properties() {
        val user = user()
        val client = client(user)
        client.eventNames.subscribe(this.segmentTrack)
        client.eventProperties.subscribe(this.propertiesTest)
        client.identifiedId.subscribe(this.segmentIdentify)
        val segment = AnalyticEvents(listOf(client))

        val params = DiscoveryParams
            .builder()
            .term("test")
            .sort(DiscoveryParams.Sort.POPULAR)
            .staffPicks(true)
            .build()

        segment.trackSearchResultPageViewed(params, 200, DiscoveryParams.Sort.POPULAR)

        assertSessionProperties(user)
        assertContextProperties()
        assertUserProperties(false)

        val expectedProperties = propertiesTest.value
        assertEquals("test", expectedProperties["discover_search_term"])
        assertEquals(200, expectedProperties["discover_search_results_count"])
        assertEquals(false, expectedProperties["discover_everything"])
        assertEquals(true, expectedProperties["discover_pwl"])
        assertEquals(false, expectedProperties["discover_recommended"])
        assertEquals("recommended_popular", expectedProperties["discover_ref_tag"])
        assertEquals(false, expectedProperties["discover_social"])
        assertEquals("popular", expectedProperties["discover_sort"])
        assertNull(expectedProperties["discover_subcategory_id"])
        assertNull(expectedProperties["discover_subcategory_name"])
        assertEquals(null, expectedProperties["discover_tag"])
        assertEquals(false, expectedProperties["discover_watched"])

        this.segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
    }

```

``` SearchViewModelTest ```
```
this.lakeTest.assertValues("Search Button Clicked", EventName.CTA_CLICKED.getEventName(), "Search Page Viewed",  EventName.PAGE_VIEWED.getEventName());
```


# 👀 See

![Screenshot 2021-04-09 at 03 34 30](https://user-images.githubusercontent.com/63934292/114120837-33dd3580-98e5-11eb-9471-326c1ab30fbf.png)


| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

- Click on the search button from the global nav
- Type a search string into the search box, you should see the new event registered in segment console

<img width="368" alt="Screenshot 2021-04-09 at 03 36 47" src="https://user-images.githubusercontent.com/63934292/114120849-393a8000-98e5-11eb-9261-6f08740c1f82.png">


# Story 📖

https://kickstarter.atlassian.net/browse/EP-424
