### PR TITLE
NT-1832: Default Icon for Braze Push Notification

### DIFF
--- a/app/src/main/res/values/braze.xml
+++ b/app/src/main/res/values/braze.xml
@@ -1,4 +1,4 @@
 <resources>
     <drawable name="com_appboy_push_small_notification_icon">@drawable/ic_kickstarter_micro_k</drawable>
-    <integer name="com_appboy_default_notification_accent_color">@color/kds_create_700</integer>
+    <item type="color" name="com_appboy_default_notification_accent_color">@color/kds_create_700</item>
 </resources>

--- a/app/src/main/res/values/braze.xml
+++ b/app/src/main/res/values/braze.xml
@@ -1,0 +1,4 @@
+<resources>
+    <drawable name="com_appboy_push_small_notification_icon">@drawable/ic_kickstarter_micro_k</drawable>
+    <integer name="com_appboy_default_notification_accent_color">@color/kds_create_700</integer>
+</resources>


### PR DESCRIPTION
# 📲 What
- added `braze.xml` resources file
- added default icon 
- added background color for the icon 


# 🛠 How

- Braze SDK will look into `braze.xml` for resources 

# 👀 See

| Before 🐛 | After 🦋 |
<img width="1008" alt="Screen Shot 2021-04-12 at 2 22 50 PM" src="https://user-images.githubusercontent.com/4083656/114464436-9ca10800-9b9a-11eb-9bdd-269f78090e2e.png">

|  |  |

# 📋 QA

- Described on comments on this ticket how to QA this work [Braze-PushNotifications](https://kickstarter.atlassian.net/browse/NT-1830) just make sure the icon now is the `kickstarter` logo

# Story 📖

[NT-1832](https://kickstarter.atlassian.net/browse/NT-1832)
