### PR TITLE
NT-1821: Switch prelaunch display logic to use display_prelaunch field from v1 API

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
@@ -483,7 +483,7 @@ public final class ProjectFactory {
 
     return project()
       .toBuilder()
-      .prelaunchActivated(true)
+      .displayPrelaunch(true)
       .urls(Project.Urls.builder().web(web).build())
       .build();
   }

--- a/app/src/main/java/com/kickstarter/models/Project.java
+++ b/app/src/main/java/com/kickstarter/models/Project.java
@@ -37,6 +37,7 @@ public abstract class Project implements Parcelable, Relay {
   public abstract String currencySymbol(); // e.g.: $
   public abstract String currentCurrency(); // e.g.: User's Preferred currency USD
   public abstract boolean currencyTrailingCode();
+  public abstract @Nullable Boolean displayPrelaunch();
   public abstract @Nullable DateTime featuredAt();
   public abstract @Nullable List<User> friends();
   public abstract Float fxRate();
@@ -81,6 +82,7 @@ public abstract class Project implements Parcelable, Relay {
     public abstract Builder currencySymbol(String __);
     public abstract Builder currentCurrency(String __);
     public abstract Builder currencyTrailingCode(boolean __);
+    public abstract Builder displayPrelaunch(boolean __);
     public abstract Builder deadline(DateTime __);
     public abstract Builder featuredAt(DateTime __);
     public abstract Builder friends(List<User> __);

--- a/app/src/main/java/com/kickstarter/models/Project.java
+++ b/app/src/main/java/com/kickstarter/models/Project.java
@@ -82,7 +82,7 @@ public abstract class Project implements Parcelable, Relay {
     public abstract Builder currencySymbol(String __);
     public abstract Builder currentCurrency(String __);
     public abstract Builder currencyTrailingCode(boolean __);
-    public abstract Builder displayPrelaunch(boolean __);
+    public abstract Builder displayPrelaunch(Boolean __);
     public abstract Builder deadline(DateTime __);
     public abstract Builder featuredAt(DateTime __);
     public abstract Builder friends(List<User> __);

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -373,13 +373,13 @@ interface ProjectViewModel {
                 .compose(errors())
 
             mappedProjectValues
-                .filter { BooleanUtils.isTrue(it.prelaunchActivated()) }
+                .filter { BooleanUtils.isTrue(it.displayPrelaunch()) }
                 .map { it.webProjectUrl() }
                 .compose(bindToLifecycle())
                 .subscribe(this.prelaunchUrl)
 
             val initialProject = mappedProjectValues
-                .filter { BooleanUtils.isFalse(it.prelaunchActivated()) }
+                .filter { BooleanUtils.isFalse(it.displayPrelaunch()) }
 
             // An observable of the ref tag stored in the cookie for the project. Can emit `null`.
             val cookieRefTag = initialProject


### PR DESCRIPTION
# 📲 What

Switch logic tied to `prelaunchActivated()` from the `User` payload to rely on `displayPrelaunch()` instead. 

# 🤔 Why

Currently, native is using the field `prelaunch_activated` to determine the display logic of prelaunch deeplinks. We want to change this logic to check `display_prelaunch` instead. 

The backend will be updating `prelaunch_activated` to actually return the correct `project.prelaunch_activated` value. This is also keeping parity with web as they are using this field. Because of this, any instances using prelaunch_activated for display logic will need to be updated to use display_prelaunch instead.

Relevant backend PR: https://github.com/kickstarter/kickstarter/pull/21408

# 🛠 How

- Update the `User` struct to grab `displayPrelaunch` value available from the API
- Switch instances of `prelaunchActivated()` to `displayPrelaunch()` so logic relys on this boolean
- Update the `ProjectFactory` method `prelaunchProject` to be set the `displayPrelaunch` value 

# 📋 QA

This change requires smoke and regression testing. 
- Find a project in prelaunch
- Open the deeplink on your mobile device
- Make sure the deeplink opens the project in the web browser on your device

# Story 📖

[NT-1821: Switch prelaunch display logic to use display_prelaunch field from v1 API](https://kickstarter.atlassian.net/browse/NT-1821)
