### PR TITLE
EP-483: Checkout Amount Total Property

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -351,7 +351,7 @@ public class ApplicationModule {
   @NonNull
   static HttpLoggingInterceptor provideHttpLoggingInterceptor() {
     final HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
-    interceptor.setLevel(HttpLoggingInterceptor.Level.HEADERS);
+    interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
     return interceptor;
   }
 

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -351,7 +351,7 @@ public class ApplicationModule {
   @NonNull
   static HttpLoggingInterceptor provideHttpLoggingInterceptor() {
     final HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
-    interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+    interceptor.setLevel(HttpLoggingInterceptor.Level.HEADERS);
     return interceptor;
   }
 

--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -35,10 +35,10 @@ object AnalyticEventsUtils {
     fun checkoutProperties(checkoutData: CheckoutData, pledgeData: PledgeData, prefix: String = "checkout_"): Map<String, Any> {
         val project = pledgeData.projectData().project()
         val properties = HashMap<String, Any>().apply {
-            put("amount", checkoutData.amount())
+            put("amount", checkoutData.amount().round())
             checkoutData.id()?.let { put("id", it.toString()) }
             put("payment_type", checkoutData.paymentType().rawValue().toLowerCase(Locale.getDefault()))
-            put("amount_total_usd", checkoutData.totalAmount(project.staticUsdRate()))
+            put("amount_total_usd", checkoutData.totalAmount(project.staticUsdRate()).round())
             put("shipping_amount", checkoutData.shippingAmount())
             put("shipping_amount_usd", checkoutData.shippingAmount(project.staticUsdRate()).round())
             put("bonus_amount", checkoutData.bonus())
@@ -54,11 +54,10 @@ object AnalyticEventsUtils {
     @JvmOverloads
     fun checkoutProperties(checkoutData: CheckoutData, project: Project, addOns: List<Reward>?, prefix: String = "checkout_"): Map<String, Any> {
         val properties = HashMap<String, Any>().apply {
-            put("amount", checkoutData.amount())
-            put("checkout_amount", checkoutData.totalAmount(project.staticUsdRate()))
+            put("amount", checkoutData.amount().round())
             checkoutData.id()?.let { put("id", it.toString()) }
             put("payment_type", checkoutData.paymentType().rawValue().toLowerCase(Locale.getDefault()))
-            put("amount_total_usd", checkoutData.totalAmount(project.staticUsdRate()))
+            put("amount_total_usd", checkoutData.totalAmount(project.staticUsdRate()).round())
             put("shipping_amount", checkoutData.shippingAmount())
             put("shipping_amount_usd", checkoutData.shippingAmount(project.staticUsdRate()).round())
             put("bonus_amount", checkoutData.bonus())

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/CheckoutDataExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/CheckoutDataExt.kt
@@ -23,7 +23,7 @@ fun CheckoutData.totalAmount() = this.amount() + this.shippingAmount()
  *
  * @return Double
  */
-fun CheckoutData.totalAmount(usdRate: Float) = this.totalAmount() * usdRate
+fun CheckoutData.totalAmount(usdRate: Float) = this.amount() * usdRate
 
 /**
  * Returns the bonus amount added to the pledge

--- a/app/src/test/java/com/kickstarter/libs/LakeTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/LakeTest.kt
@@ -491,7 +491,7 @@ class LakeTest : KSRobolectricTestCase() {
         val expectedProperties = this.propertiesTest.value
         assertEquals(30.0, expectedProperties["checkout_amount"])
         assertEquals("credit_card", expectedProperties["checkout_payment_type"])
-        assertEquals(50.0, expectedProperties["checkout_amount_total_usd"])
+        assertEquals(30.0, expectedProperties["checkout_amount_total_usd"])
         assertEquals(20.0, expectedProperties["checkout_shipping_amount"])
     }
 

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -712,7 +712,7 @@ class SegmentTest : KSRobolectricTestCase() {
         // - we test asserting this properties all methods in SharedFunctions.kt
         assertEquals(10.0, expectedProperties["checkout_amount"])
         assertEquals("credit_card", expectedProperties["checkout_payment_type"])
-        assertEquals(30.0, expectedProperties["checkout_amount_total_usd"])
+        assertEquals(10.0, expectedProperties["checkout_amount_total_usd"])
         assertEquals(20.0, expectedProperties["checkout_shipping_amount_usd"])
         assertEquals(5, expectedProperties["checkout_add_ons_count_total"])
         assertEquals(2, expectedProperties["checkout_add_ons_count_unique"])
@@ -1083,7 +1083,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val expectedProperties = this.propertiesTest.value
         assertEquals(30.0, expectedProperties["checkout_amount"])
         assertEquals("credit_card", expectedProperties["checkout_payment_type"])
-        assertEquals(50.0, expectedProperties["checkout_amount_total_usd"])
+        assertEquals(30.0, expectedProperties["checkout_amount_total_usd"])
         assertEquals(20.0, expectedProperties["checkout_shipping_amount"])
         assertEquals(20.0, expectedProperties["checkout_shipping_amount_usd"])
         assertEquals(0, expectedProperties["checkout_add_ons_count_total"])


### PR DESCRIPTION
# 📲 What

Android QA: Checkout Amount Total Property

# 🤔 Why

The total amount of my checkout was $602 AUD. Web correctly converted that to 459.51, but Android is sending 555.3922764062881. I don’t know how this is being calculated on Android, but it should be the total pledge amount at checkout, converted to USD from the project currency. 

Should also be a decimal, not a float.

# 🛠 How

- Changed 
``` fun CheckoutData.totalAmount(usdRate: Float) = this.totalAmount() * usdRate ```
 to 
``` fun CheckoutData.totalAmount(usdRate: Float) = this.amount() * usdRate ```

This is because ``` this.amount() ``` is already ``` pledgeAmount + addOns + shippingAmount + bonus ```. 

- Rounded up to 2dp decimal 
```
 put("amount", checkoutData.amount().round()) 
 put("amount_total_usd", checkoutData.totalAmount(project.staticUsdRate()).round())
```

- Adjusted segment tests cases


# 👀 See

<img width="462" alt="checkoutAmount" src="https://user-images.githubusercontent.com/63934292/115053121-ae561880-9ed6-11eb-949d-2b4f71b98bc9.png">


| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA



# Story 📖

https://kickstarter.atlassian.net/browse/EP-483
