### PR TITLE
EP-462: Android QA 4/6 - Session Properties Fixes

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
@@ -57,7 +57,7 @@ interface ExperimentsClientType {
      * "session_variants_optimizely" : [ "Experiment1":"variant1",
      *                                   "Experiment2":"varian2"]
      */
-    fun getTrackingProperties(): Map<String, Array<Map<String, String>>>
+    fun getTrackingProperties(): Map<String, Array<String>>
 }
 
 const val EXPERIMENTS_CLIENT_READY = "experiments_client_ready"

--- a/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
@@ -54,8 +54,8 @@ interface ExperimentsClientType {
 
     /**
      * Map with all the experiments available to the app, with the corresponding variant:
-     * "session_variants_optimizely" : [ "Experiment[variant1]",
-     *                                   "Experiment[variant2]"]
+     * "session_variants_optimizely" : [ "Experiment1[variant1]",
+     *                                   "Experiment2[variant2]"]
      */
     fun getTrackingProperties(): Map<String, Array<String>>
 }

--- a/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/ExperimentsClientType.kt
@@ -54,8 +54,8 @@ interface ExperimentsClientType {
 
     /**
      * Map with all the experiments available to the app, with the corresponding variant:
-     * "session_variants_optimizely" : [ "Experiment1":"variant1",
-     *                                   "Experiment2":"varian2"]
+     * "session_variants_optimizely" : [ "Experiment[variant1]",
+     *                                   "Experiment[variant2]"]
      */
     fun getTrackingProperties(): Map<String, Array<String>>
 }

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
@@ -59,7 +59,7 @@ class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManag
 
         this.optimizelyClient().optimizelyConfig?.experimentsMap?.map { entry ->
             val variant: String = this.optimizelyClient().getVariation(entry.key, userId())?.let { it.key } ?: "unknown"
-            experimentsList.add("${entry.key}[${variant}]")
+            experimentsList.add("${entry.key}[$variant]")
         }
 
         properties["variants_optimizely"] = experimentsList.toTypedArray()

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
@@ -52,18 +52,32 @@ class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManag
     override fun trackingVariation(experimentKey: String, experimentData: ExperimentData): String? {
         return optimizelyClient().getVariation(experimentKey, userId(), attributes(experimentData, this.optimizelyEnvironment))?.key
     }
+//
+//    override fun getTrackingProperties(): Map<String, Array<Map<String, String>>> {
+//        val experimentsList = mutableListOf<Map<String, String>>()
+//        val properties = mutableMapOf<String, Array<Map<String, String>>>()
+//
+//        this.optimizelyClient().optimizelyConfig?.experimentsMap?.map { entry ->
+//            val variant: String = this.optimizelyClient().getVariation(entry.key, userId())?.let { it.key } ?: "unknown"
+//            experimentsList.add(mapOf(entry.key to variant))
+//        }
+//
+//        properties["variants_optimizely"] = experimentsList.toTypedArray()
+//
+//        return properties.toMap()
+//    }
 
-    override fun getTrackingProperties(): Map<String, Array<Map<String, String>>> {
-        val experimentsList = mutableListOf<Map<String, String>>()
-        val properties = mutableMapOf<String, Array<Map<String, String>>>()
+    override fun getTrackingProperties(): Map<String, Array<String>> {
+        val experimentsList = mutableListOf<String>()
+        val properties = mutableMapOf<String, Array<String>>()
 
         this.optimizelyClient().optimizelyConfig?.experimentsMap?.map { entry ->
             val variant: String = this.optimizelyClient().getVariation(entry.key, userId())?.let { it.key } ?: "unknown"
-            experimentsList.add(mapOf(entry.key to variant))
+            experimentsList.add("${entry.key}[${variant}]")
         }
 
         properties["variants_optimizely"] = experimentsList.toTypedArray()
 
-        return properties.toMap()
+        return properties
     }
 }

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
@@ -52,20 +52,6 @@ class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManag
     override fun trackingVariation(experimentKey: String, experimentData: ExperimentData): String? {
         return optimizelyClient().getVariation(experimentKey, userId(), attributes(experimentData, this.optimizelyEnvironment))?.key
     }
-//
-//    override fun getTrackingProperties(): Map<String, Array<Map<String, String>>> {
-//        val experimentsList = mutableListOf<Map<String, String>>()
-//        val properties = mutableMapOf<String, Array<Map<String, String>>>()
-//
-//        this.optimizelyClient().optimizelyConfig?.experimentsMap?.map { entry ->
-//            val variant: String = this.optimizelyClient().getVariation(entry.key, userId())?.let { it.key } ?: "unknown"
-//            experimentsList.add(mapOf(entry.key to variant))
-//        }
-//
-//        properties["variants_optimizely"] = experimentsList.toTypedArray()
-//
-//        return properties.toMap()
-//    }
 
     override fun getTrackingProperties(): Map<String, Array<String>> {
         val experimentsList = mutableListOf<String>()

--- a/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
+++ b/app/src/main/java/com/kickstarter/mock/MockExperimentsClientType.kt
@@ -59,5 +59,5 @@ open class MockExperimentsClientType(private val variant: OptimizelyExperiment.V
 
     override fun variant(experiment: OptimizelyExperiment.Key, experimentData: ExperimentData): OptimizelyExperiment.Variant = this.variant
 
-    override fun getTrackingProperties(): Map<String, Array<Map<String, String>>> = emptyMap()
+    override fun getTrackingProperties(): Map<String, Array<String>> = emptyMap()
 }

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -1067,15 +1067,14 @@ class SegmentTest : KSRobolectricTestCase() {
                 return listOf("optimizely_feature")
             }
 
-            override fun getTrackingProperties(): Map<String, Array<Map<String, String>>> {
+            override fun getTrackingProperties(): Map<String, Array<String>> {
                 return getOptimizelySession()
             }
         }
     )
 
-    private fun getOptimizelySession(): Map<String, Array<Map<String, String>>> {
-        val experiment1 = mapOf("suggested_no_reward_amount" to "variation_3")
-        val array = arrayOf(experiment1)
+    private fun getOptimizelySession(): Map<String, Array<String>> {
+        val array = arrayOf("suggested_no_reward_amount[variation_3]")
         return mapOf("variants_optimizely" to array)
     }
 


### PR DESCRIPTION
# 📲 What

The format with which we were sending `session_variants_optimizely` was incorrect. We want to send an array of strings formatted with the name of the optimizely experiment and the experiment group the user is in:
```
"suggested_no_reward_amount[control]"
```
# 🤔 Why

Segment integration/QA feedback

# 📋 QA

- Open kickstarter and make sure you are logged in
- Fire any event that include session properties
- Verify on segment that the raw json is formatted correctly (you have to be whitelisted in an optimizely experiment): 
![Screen Shot 2021-04-16 at 4 31 18 PM](https://user-images.githubusercontent.com/19390326/115082207-84e7bd80-9ed3-11eb-8f26-a7e3d920b80d.png)

# Story 📖

[EP-462: Android QA 4/6 - Session Properties Fixes](https://kickstarter.atlassian.net/browse/EP-462)
