### PR TITLE
EP-485:Android QA: Project Properties Currency

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -224,13 +224,13 @@ object AnalyticEventsUtils {
             put("creator_uid", project.creator().id().toString())
             put("currency", project.currency())
             put("current_pledge_amount", project.pledged())
-            put("current_amount_pledged_usd", project.pledged() * project.staticUsdRate())
+            put("current_amount_pledged_usd", (project.pledged() * project.usdExchangeRate()).round())
             project.deadline()?.let { deadline ->
                 put("deadline", deadline)
             }
             put("duration", ProjectUtils.timeInDaysOfDuration(project).toFloat().roundToInt())
             put("goal", project.goal())
-            put("goal_usd", project.goal() * project.staticUsdRate())
+            put("goal_usd", (project.goal() * project.usdExchangeRate()).round())
             put("has_video", project.video() != null)
             put("hours_remaining", ceil((ProjectUtils.timeInSecondsUntilDeadline(project) / 60.0f / 60.0f).toDouble()).toInt())
             put("is_repeat_creator", IntegerUtils.intValueOrZero(project.creator().createdProjectsCount()) >= 2)

--- a/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
+++ b/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.java
@@ -58,6 +58,7 @@ public final class ProjectFactory {
       .staffPick(false)
       .state(Project.STATE_LIVE)
       .staticUsdRate(1.0f)
+      .usdExchangeRate(1.0f)
       .slug(slug)
       .updatedAt(DateTime.now())
       .urls(Project.Urls.builder().web(web).build())
@@ -378,6 +379,7 @@ public final class ProjectFactory {
       .currencySymbol("$")
       .currency("CAD")
       .staticUsdRate(0.75f)
+      .usdExchangeRate(0.75f)
       .fxRate(0.75f)
       .build();
   }
@@ -394,6 +396,7 @@ public final class ProjectFactory {
       .currencySymbol("$")
       .currency("CAD")
       .staticUsdRate(0.75f)
+      .usdExchangeRate(0.75f)
       .fxRate(.75f)
       .build();
   }
@@ -412,6 +415,7 @@ public final class ProjectFactory {
       .currency("MXN")
       .location(LocationFactory.mexico())
       .staticUsdRate(0.75f)
+      .usdExchangeRate(0.75f)
       .fxRate(0.75f)
       .build();
   }
@@ -428,6 +432,7 @@ public final class ProjectFactory {
       .currencySymbol("£")
       .currency("GBP")
       .staticUsdRate(1.5f)
+      .usdExchangeRate(0.75f)
       .fxRate(1.5f)
       .build();
   }

--- a/app/src/main/java/com/kickstarter/models/Project.java
+++ b/app/src/main/java/com/kickstarter/models/Project.java
@@ -60,6 +60,7 @@ public abstract class Project implements Parcelable, Relay {
   public abstract @State String state();
   public abstract @Nullable DateTime stateChangedAt();
   public abstract Float staticUsdRate();
+  public abstract Float usdExchangeRate();
   public abstract @Nullable Integer unreadMessagesCount();
   public abstract @Nullable Integer unseenActivityCount();
   public abstract @Nullable Integer updatesCount();
@@ -103,6 +104,7 @@ public abstract class Project implements Parcelable, Relay {
     public abstract Builder slug(String __);
     public abstract Builder staffPick(Boolean __);
     public abstract Builder staticUsdRate(Float __);
+    public abstract Builder usdExchangeRate(Float __);
     public abstract Builder state(@State String __);
     public abstract Builder stateChangedAt(DateTime __);
     public abstract Builder unreadMessagesCount(Integer __);


### PR DESCRIPTION
# 📲 What

Fix  `project_current_amount_pledged_usd` and `project_goal_usd` to match web 

# 🤔 Why

Segment integration/QA feedback

# 🛠 How
add the `usdExchangeRate` the same one that backend use 
![image](https://user-images.githubusercontent.com/1075310/115409452-1025c380-a1f2-11eb-9d00-fdbddb89614f.png)
![image](https://user-images.githubusercontent.com/1075310/115409601-3186af80-a1f2-11eb-91c0-4ca76abd8a6e.png)


# 👀 See

![Screen Shot 2021-04-19 at 11 21 04 PM](https://user-images.githubusercontent.com/1075310/115410052-9b06be00-a1f2-11eb-9233-2c79ba826af6.png)



# 📋 QA
1. open project that the currency is not in usd"SOLIDTEKNICS 100% Australian Made Iron Cookware"

# Story 📖

[https://kickstarter.atlassian.net/browse/EP-485]
