### PR TITLE
NT-1852: Segment initialization moved to SegmentTrackingClient

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -86,8 +86,6 @@ import com.kickstarter.services.interceptors.KSRequestInterceptor;
 import com.kickstarter.services.interceptors.WebRequestInterceptor;
 import com.kickstarter.ui.SharedPreferenceKey;
 import com.optimizely.ab.android.sdk.OptimizelyManager;
-import com.segment.analytics.Analytics;
-import com.segment.analytics.android.integrations.appboy.AppboyIntegration;
 import com.stripe.android.Stripe;
 
 import org.joda.time.DateTime;
@@ -100,7 +98,6 @@ import javax.annotation.Nonnull;
 import javax.inject.Singleton;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.preference.PreferenceManager;
 import dagger.Module;
 import dagger.Provides;
@@ -176,33 +173,6 @@ public class ApplicationModule {
       .webClient(webClient)
       .webEndpoint(webEndpoint)
       .build();
-  }
-
-  @Provides
-  @Nullable
-  @Singleton
-  static Analytics provideSegment(final @NonNull Build build, final @ApplicationContext @NonNull Context context) {
-    String apiKey = "";
-
-    Analytics segmentClient = null;
-
-    if (build.isRelease() && Build.isExternal()) {
-      apiKey = Secrets.Segment.PRODUCTION;
-    }
-    if (build.isDebug() || Build.isInternal()) {
-      apiKey = Secrets.Segment.STAGING;
-    }
-
-    if (context instanceof KSApplication && !((KSApplication) context).isInUnitTests()) {
-      segmentClient = new Analytics.Builder(context, apiKey)
-              .use(AppboyIntegration.FACTORY)
-              .trackApplicationLifecycleEvents()
-              .build();
-
-      Analytics.setSingletonInstance(segmentClient);
-    }
-
-    return segmentClient;
   }
 
   @Provides
@@ -458,10 +428,9 @@ public class ApplicationModule {
           final @NonNull CurrentUserType currentUser,
           final @NonNull Build build,
           final @NonNull CurrentConfigType currentConfig,
-          final @NonNull ExperimentsClientType experimentsClientType,
-          final @Nullable Analytics segment) {
+          final @NonNull ExperimentsClientType experimentsClientType) {
     final LakeTrackingClient lakeTrackingClient = new LakeTrackingClient(context, currentUser, build, currentConfig, experimentsClientType);
-    final SegmentTrackingClient segmentTrackingClient = new SegmentTrackingClient(build, context, currentConfig, currentUser,  experimentsClientType, segment);
+    final SegmentTrackingClient segmentTrackingClient = new SegmentTrackingClient(build, context, currentConfig, currentUser,  experimentsClientType);
     final List<TrackingClientType> clients = Arrays.asList(lakeTrackingClient, segmentTrackingClient);
     return new AnalyticEvents(clients);
   }

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -1,27 +1,58 @@
 package com.kickstarter.libs
 
 import android.content.Context
+import com.kickstarter.libs.utils.Secrets
+import com.kickstarter.libs.utils.extensions.isKSApplication
 import com.kickstarter.models.User
 import com.segment.analytics.Analytics
 import com.segment.analytics.Properties
 import com.segment.analytics.Traits
+import com.segment.analytics.android.integrations.appboy.AppboyIntegration
 import timber.log.Timber
 
 class SegmentTrackingClient(
     build: Build,
-    context: Context,
+    private val context: Context,
     currentConfig: CurrentConfigType,
     currentUser: CurrentUserType,
     optimizely: ExperimentsClientType,
-    private val segmentAnalytics: Analytics?
 ) : TrackingClient(context, currentUser, build, currentConfig, optimizely) {
+
+    private var segmentClient: Analytics? = null
+
+    init {
+        // - Check the feature flag active, and initialize Segment client
+        if (this.isEnabled()) {
+            initialize()
+        }
+    }
+
+    private fun initialize() {
+        if (this.context.isKSApplication()) {
+            var apiKey = ""
+            if (build.isRelease && Build.isExternal()) {
+                apiKey = Secrets.Segment.PRODUCTION
+            }
+            if (build.isDebug || Build.isInternal()) {
+                apiKey = Secrets.Segment.STAGING
+            }
+
+            this.segmentClient = Analytics.Builder(context, apiKey)
+                // - This flag will activate sending information to Braze
+                .use(AppboyIntegration.FACTORY)
+                .trackApplicationLifecycleEvents()
+                .build()
+
+            Analytics.setSingletonInstance(segmentClient)
+        }
+    }
 
     /**
      * Perform the request to the Segment third party library
      * see https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#track
      */
     override fun trackingData(eventName: String, newProperties: Map<String, Any?>) {
-        segmentAnalytics?.let { segment ->
+        this.segmentClient?.let { segment ->
             segment.track(eventName, this.getProperties(newProperties))
         }
     }
@@ -48,10 +79,10 @@ class SegmentTrackingClient(
 
         if (this.build.isDebug && type() == Type.SEGMENT) {
             user.apply {
-                Timber.d("Queued ${type().tag} Identify userName: ${this.name()} userId: ${ this.id()}")
+                Timber.d("Queued ${type().tag} Identify userName: ${this.name()} userId: ${this.id()}")
             }
         }
-        segmentAnalytics?.let { segment ->
+        this.segmentClient?.let { segment ->
             segment.identify(user.id().toString(), getTraits(user), null)
         }
     }
@@ -65,7 +96,7 @@ class SegmentTrackingClient(
         if (this.build.isDebug) {
             Timber.d("Queued ${type().tag} Reset user after logout")
         }
-        segmentAnalytics?.reset()
+        this.segmentClient?.reset()
     }
 
     /**


### PR DESCRIPTION
# 📲 What

- Segment initialization moved to SegmentTrackingClient.kt

# 🤔 Why
- Isolate the initialization of the dependency in the Client we created for that purpose
- Now the lifecycle events we send to segment are also behind the feature flag.

# 🛠 How

- The initialization for segment has been moved to `SegmentTrackingClient` in that way we've completely isolated the dependency on it's client.
- `SegmentTrackingClient` has the method `isEnabled()` to check if the feature flag is active

# 📋 QA
- Check that if you have the feature flag off, no lifecycle event is sent to Segment.

# Story 📖

[NT-1852](https://kickstarter.atlassian.net/browse/NT-1852)
