### PR TITLE
NT-1867: eliminate unnecessary identify calls

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
@@ -23,15 +23,22 @@ class LakeTrackingClient(
     currentConfig: CurrentConfigType,
     optimizely: ExperimentsClientType
 ) : TrackingClient(context, currentUser, build, currentConfig, optimizely) {
-    private var loggedInUser: User? = null
-    private var config: Config? = null
+    override fun type() = Type.LAKE
+    override var isInitialized: Boolean = true
+    override var config: Config? = null
+    override var loggedInUser: User? = null
 
     init {
-        // Cache the most recent config for default Lake properties.
-        this.currentConfig.observable().subscribe { c -> this.config = c }
-    }
+        this.currentUser.observable()
+                .subscribe {
+                    this.loggedInUser = it
+                }
 
-    override fun type() = Type.LAKE
+        this.currentConfig.observable()
+                .subscribe { c ->
+                    this.config = c
+                }
+    }
 
     @Throws(JSONException::class)
     override fun trackingData(eventName: String, newProperties: Map<String, Any?>) {

--- a/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
@@ -30,14 +30,14 @@ class LakeTrackingClient(
 
     init {
         this.currentUser.observable()
-                .subscribe {
-                    this.loggedInUser = it
-                }
+            .subscribe {
+                this.loggedInUser = it
+            }
 
         this.currentConfig.observable()
-                .subscribe { c ->
-                    this.config = c
-                }
+            .subscribe { c ->
+                this.config = c
+            }
     }
 
     @Throws(JSONException::class)

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -38,14 +38,14 @@ class SegmentTrackingClient(
             }
 
         this.currentUser.observable()
-                .distinctUntilChanged { prevUser, newUser ->
-                    updateUserAndCheckTraits(prevUser, newUser)
-                }
-                .filter { ObjectUtils.isNotNull(it) }
-                .map { requireNotNull(it) }
-                .subscribe {
-                    identify(it)
-                }
+            .distinctUntilChanged { prevUser, newUser ->
+                updateUserAndCheckTraits(prevUser, newUser)
+            }
+            .filter { ObjectUtils.isNotNull(it) }
+            .map { requireNotNull(it) }
+            .subscribe {
+                identify(it)
+            }
     }
 
     /**
@@ -59,7 +59,7 @@ class SegmentTrackingClient(
      * @return true in case traits remain the same
      *         false in case traits changed
      */
-    private fun updateUserAndCheckTraits(prevUser: User?, newUser: User?) :Boolean {
+    private fun updateUserAndCheckTraits(prevUser: User?, newUser: User?): Boolean {
         this.loggedInUser = newUser
         return prevUser?.getTraits() == newUser?.getTraits()
     }

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -28,7 +28,6 @@ class SegmentTrackingClient(
 
     init {
         this.currentConfig.observable()
-            .distinctUntilChanged()
             .subscribe {
                 // - Check the feature flag active, and initialize Segment client
                 this.config = it

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -21,12 +21,17 @@ class SegmentTrackingClient(
 ) : TrackingClient(context, currentUser, build, currentConfig, optimizely) {
 
     private var segmentClient: Analytics? = null
+    private var isInitialized = false
 
     init {
-        // - Check the feature flag active, and initialize Segment client
-        if (this.isEnabled()) {
-            initialize()
-        }
+        this.currentConfig.observable()
+                .distinctUntilChanged()
+                .subscribe {
+                    // - Check the feature flag active, and initialize Segment client
+                    if (this.isEnabled() && !isInitialized) {
+                        initialize()
+                    }
+                }
     }
 
     private fun initialize() {
@@ -49,6 +54,7 @@ class SegmentTrackingClient(
                 .logLevel(logLevel)
                 .build()
 
+            isInitialized = true
             Analytics.setSingletonInstance(segmentClient)
         }
     }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -31,24 +31,6 @@ abstract class TrackingClient(
     @set:Inject var optimizely: ExperimentsClientType
 ) : TrackingClientType() {
 
-    private var loggedInUser: User? = null
-    private var config: Config? = null
-
-    init {
-
-        this.currentUser.observable()
-            .distinctUntilChanged()
-            .subscribe { u ->
-                this.loggedInUser = u
-                this.loggedInUser?.let { identify(it) }
-            }
-
-        this.currentConfig.observable()
-            .subscribe { c ->
-                this.config = c
-            }
-    }
-
     override val isGooglePlayServicesAvailable: Boolean
         get() = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(this.context) == ConnectionResult.SUCCESS
 
@@ -78,7 +60,7 @@ abstract class TrackingClient(
 
     override fun isEnabled(): Boolean {
         return if (type() == Type.SEGMENT) {
-            config?.isFeatureFlagEnabled(SEGMENT_ENABLED.configFeatureName) ?: false
+            this.config?.isFeatureFlagEnabled(SEGMENT_ENABLED.configFeatureName) ?: false
         } else true
     }
 

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -12,8 +12,11 @@ abstract class TrackingClientType {
         SEGMENT("\uD83C\uDF81 Segment");
     }
 
+    protected abstract var config: Config?
     protected abstract val isGooglePlayServicesAvailable: Boolean
     protected abstract val isTalkBackOn: Boolean
+    protected abstract var isInitialized: Boolean
+    protected abstract var loggedInUser: User?
 
     abstract fun optimizely(): ExperimentsClientType?
     abstract fun loggedInUser(): User?

--- a/app/src/test/java/com/kickstarter/KSRobolectrictTestCase.kt
+++ b/app/src/test/java/com/kickstarter/KSRobolectrictTestCase.kt
@@ -15,6 +15,7 @@ import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.services.MockApiClient
 import com.kickstarter.mock.services.MockApolloClient
 import com.kickstarter.mock.services.MockWebClient
+import com.kickstarter.models.User
 import com.stripe.android.Stripe
 import junit.framework.TestCase
 import org.joda.time.DateTimeUtils
@@ -34,7 +35,7 @@ abstract class KSRobolectricTestCase : TestCase() {
     lateinit var experimentsTest: TestSubscriber<String>
     lateinit var lakeTest: TestSubscriber<String>
     lateinit var segmentTrack: TestSubscriber<String>
-    lateinit var segmentIdentify: TestSubscriber<Long>
+    lateinit var segmentIdentify: TestSubscriber<User>
 
     @Before
     @Throws(Exception::class)
@@ -101,7 +102,7 @@ abstract class KSRobolectricTestCase : TestCase() {
             mockCurrentConfig, TrackingClientType.Type.SEGMENT, experimentsClientType
         )
         segmentTrackingClient.eventNames.subscribe(segmentTrack)
-        segmentTrackingClient.identifiedId.subscribe(segmentIdentify)
+        segmentTrackingClient.identifiedUser.subscribe(segmentIdentify)
         return segmentTrackingClient
     }
 }

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -62,7 +62,7 @@ public final class MockTrackingClient extends TrackingClientType {
   }
 
   @Override
-  protected void setConfig(Config config) {
+  protected void setConfig(final Config config) {
     this.config = config;
   }
 
@@ -77,12 +77,12 @@ public final class MockTrackingClient extends TrackingClientType {
   }
 
   @Override
-  protected void setLoggedInUser(User loggedInUser) {
+  protected void setLoggedInUser(final User loggedInUser) {
     this.loggedInUser = loggedInUser;
   }
 
   @Override
-  protected void setInitialized(boolean isInitialized) {
+  protected void setInitialized(final boolean isInitialized) {
     this.isInitialized = isInitialized;
   }
 

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -24,6 +24,7 @@ public final class MockTrackingClient extends TrackingClientType {
   private final ExperimentsClientType optimizely;
   @Nullable private User loggedInUser;
   private Config config = ConfigFactory.config();
+  private Boolean isInitialized = false;
 
   public MockTrackingClient(final @NonNull CurrentUserType currentUser, final @NonNull CurrentConfigType currentConfig, final Type type, final @NonNull ExperimentsClientType optimizely) {
     this.type = type;
@@ -41,18 +42,48 @@ public final class MockTrackingClient extends TrackingClientType {
 
   @Override
   public void identify(final @NotNull User user) {
-    this.identifiedId.onNext(user.id());
+    this.identifiedUser.onNext(user);
   }
 
   @Override
   public void reset() {
     this.loggedInUser = null;
-    this.identifiedId.onNext(null);
+    this.identifiedUser.onNext(null);
   }
 
   @Override
   public boolean isEnabled() {
     return true;
+  }
+
+  @Override
+  protected Config getConfig() {
+    return this.config;
+  }
+
+  @Override
+  protected void setConfig(Config config) {
+    this.config = config;
+  }
+
+  @Override
+  protected boolean isInitialized() {
+    return true;
+  }
+
+  @Override
+  protected User getLoggedInUser() {
+    return this.loggedInUser;
+  }
+
+  @Override
+  protected void setLoggedInUser(User loggedInUser) {
+    this.loggedInUser = loggedInUser;
+  }
+
+  @Override
+  protected void setInitialized(boolean isInitialized) {
+    this.isInitialized = isInitialized;
   }
 
   public static class Event {
@@ -67,7 +98,7 @@ public final class MockTrackingClient extends TrackingClientType {
   private final @NonNull PublishSubject<Event> events = PublishSubject.create();
   public final @NonNull Observable<String> eventNames = this.events.map(e -> e.name);
   public final @NonNull Observable<Map<String, Object>> eventProperties = this.events.map(e -> e.properties);
-  public final @NonNull BehaviorSubject<Long> identifiedId = BehaviorSubject.create();
+  public final @NonNull BehaviorSubject<User> identifiedUser = BehaviorSubject.create();
 
   @Override
   public void track(final @NotNull String eventName, final @NotNull Map<String, ?> additionalProperties) {

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -63,13 +63,13 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         segment.trackAppOpen()
 
         this.segmentTrack.assertValue("App Open")
-        this.segmentIdentify.assertValue(user.id())
+        this.segmentIdentify.assertValue(user)
 
         assertSessionProperties(user)
         assertContextProperties()
@@ -82,7 +82,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         segment.trackAppOpen()
@@ -101,7 +101,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         segment.trackActivityFeedPageViewed()
@@ -124,13 +124,13 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         val projectData = ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended())
 
         segment.trackCampaignDetailsCTAClicked(projectData)
-        this.segmentIdentify.assertValue(user.id())
+        this.segmentIdentify.assertValue(user)
 
         assertSessionProperties(user)
         assertContextProperties()
@@ -148,7 +148,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         val params = DiscoveryParams
@@ -157,7 +157,7 @@ class SegmentTest : KSRobolectricTestCase() {
             .build()
 
         segment.trackExplorePageViewed(params)
-        this.segmentIdentify.assertValue(user.id())
+        this.segmentIdentify.assertValue(user)
 
         assertSessionProperties(user)
         assertContextProperties()
@@ -170,7 +170,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         val params = DiscoveryParams
@@ -179,7 +179,7 @@ class SegmentTest : KSRobolectricTestCase() {
             .build()
 
         segment.trackDiscoveryPageViewed(params)
-        this.segmentIdentify.assertValue(user.id())
+        this.segmentIdentify.assertValue(user)
 
         assertSessionProperties(user)
         assertContextProperties()
@@ -199,7 +199,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         val project = project().toBuilder().build()
@@ -232,7 +232,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         val project = project().toBuilder().build()
@@ -282,7 +282,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         val params = DiscoveryParams
@@ -329,7 +329,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         val projectData = ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended())
@@ -363,7 +363,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         val params = DiscoveryParams
@@ -402,7 +402,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         val params = DiscoveryParams
@@ -432,7 +432,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals(null, expectedProperties["discover_tag"])
         assertEquals(false, expectedProperties["discover_watched"])
 
-        this.segmentIdentify.assertValue(user.id())
+        this.segmentIdentify.assertValue(user)
     }
 
     @Test
@@ -441,7 +441,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         segment.trackDiscoverProjectCTAClicked()
@@ -463,7 +463,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         val params = DiscoveryParams
@@ -493,7 +493,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals(null, expectedProperties["discover_tag"])
         assertEquals(false, expectedProperties["discover_watched"])
 
-        this.segmentIdentify.assertValue(user.id())
+        this.segmentIdentify.assertValue(user)
     }
 
     @Test
@@ -502,7 +502,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         val params = DiscoveryParams
@@ -636,7 +636,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val client = client(user)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
-        client.identifiedId.subscribe(this.segmentIdentify)
+        client.identifiedUser.subscribe(this.segmentIdentify)
         val segment = AnalyticEvents(listOf(client))
 
         segment.trackProjectPageViewed(ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()), PledgeFlowContext.NEW_PLEDGE)
@@ -653,7 +653,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals(false, expectedProperties["project_user_is_project_creator"])
 
         this.segmentTrack.assertValues("Project Page Viewed")
-        this.segmentIdentify.assertValue(user.id())
+        this.segmentIdentify.assertValue(user)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ChangePasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ChangePasswordViewModelTest.kt
@@ -25,7 +25,7 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
     private val progressBarIsVisible = TestSubscriber<Boolean>()
     private val saveButtonIsEnabled = TestSubscriber<Boolean>()
     private val success = TestSubscriber<String>()
-    private val userId = TestSubscriber<Long?>()
+    private val currentUser = TestSubscriber<User?>()
 
     private fun setUpEnvironment(environment: Environment) {
         this.vm = ChangePasswordViewModel.ViewModel(environment)
@@ -148,7 +148,7 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.changePasswordClicked()
         this.error.assertValue("Oops")
 
-        userId.assertValue(user.id())
+        currentUser.assertValue(user)
     }
 
     @Test
@@ -185,7 +185,7 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.changePasswordClicked()
         this.success.assertValue("test@email.com")
 
-        userId.assertValues(user.id(), null)
+        currentUser.assertValues(user, null)
     }
 
     private fun getMockClientWithUser(user: User) = MockTrackingClient(
@@ -194,6 +194,6 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
         TrackingClientType.Type.SEGMENT,
         MockExperimentsClientType()
     ).apply {
-        this.identifiedId.subscribe(userId)
+        this.identifiedUser.subscribe(currentUser)
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/CreatePasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CreatePasswordViewModelTest.kt
@@ -26,7 +26,7 @@ class CreatePasswordViewModelTest : KSRobolectricTestCase() {
     private val progressBarIsVisible = TestSubscriber<Boolean>()
     private val saveButtonIsEnabled = TestSubscriber<Boolean>()
     private val success = TestSubscriber<String>()
-    private val userId = TestSubscriber<Long?>()
+    private val currentUser = TestSubscriber<User?>()
 
     private fun setUpEnvironment(environment: Environment) {
         this.vm = CreatePasswordViewModel.ViewModel(environment)
@@ -142,7 +142,7 @@ class CreatePasswordViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.createPasswordClicked()
         this.error.assertValue("Oops")
 
-        userId.assertValue(user.id())
+        currentUser.assertValue(user)
     }
 
     @Test
@@ -178,7 +178,7 @@ class CreatePasswordViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.createPasswordClicked()
         this.success.assertValue("test@emai")
 
-        userId.assertValues(user.id(), null)
+        currentUser.assertValues(user, null)
     }
 
     private fun getMockClientWithUser(user: User) = MockTrackingClient(
@@ -187,6 +187,6 @@ class CreatePasswordViewModelTest : KSRobolectricTestCase() {
         TrackingClientType.Type.SEGMENT,
         MockExperimentsClientType()
     ).apply {
-        this.identifiedId.subscribe(userId)
+        this.identifiedUser.subscribe(currentUser)
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/SettingsViewModelTest.kt
@@ -19,7 +19,7 @@ class SettingsViewModelTest : KSRobolectricTestCase() {
     private val currentUserTest = TestSubscriber<User>()
     private val logout = TestSubscriber<Void>()
     private val showConfirmLogoutPrompt = TestSubscriber<Boolean>()
-    private val userId = TestSubscriber<Long?>()
+    private val currentUser = TestSubscriber<User?>()
 
     private fun setUpEnvironment(user: User) {
         val currentUser = MockCurrentUser(user)
@@ -82,7 +82,7 @@ class SettingsViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.confirmLogoutClicked()
         this.logout.assertValue(null)
 
-        this.userId.assertValues(user.id(), null)
+        this.currentUser.assertValues(user, null)
     }
 
     private fun getMockClientWithUser(user: User) = MockTrackingClient(
@@ -91,6 +91,6 @@ class SettingsViewModelTest : KSRobolectricTestCase() {
         TrackingClientType.Type.SEGMENT,
         MockExperimentsClientType()
     ).apply {
-        this.identifiedId.subscribe(userId)
+        this.identifiedUser.subscribe(currentUser)
     }
 }


### PR DESCRIPTION
# 📲 What

- Removed from `TrackingClient.kt` internal variables `config` and `loggedInUser` those two properties have become class properties on `TrackingClientType.kt`
- `LakeTrackingClient.kt ` overrides  it's own `config` and `loggedInUser`
- `SegmentTrackingClient.kt ` overrides  it's own `config` and `loggedInUser`
- For `SegmentTrackingClient.kt` we update the current user only when some of the traits has change with method `updateUserAndCheckTraits`
- Avoid race condition for initializing Segment SDK, call initialize only when we have configuration available
- Added `isInitialized` state for Segment SDK
- Modified several tests

# 👀 See
- No visible changes on this PR. It's all around behaviour.

# 📋 QA
- Make sure when you come from background `identify` it's not called
- Make sure if you change some of your Opt-in preferences `identify` it's called
- Make sure if you change your password or email you are logged out of the app and no `identify` is called
- Make sure every time you log in `identify` is called 
- Race condition has been solved, all the events should get to Segment Dashboard

# Story 📖

[NT-1867](https://kickstarter.atlassian.net/browse/NT-1867)
