### PR TITLE
Segment not sending events ghost

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,8 @@ android.applicationVariants.all { variant ->
                          '**/Dagger*Subcomponent*.class',
                          '**/*Subcomponent$Builder.class',
                          '**/*Module_*Factory.class',
+                         '**/KSApplication.*',
+                         '**/ApplicationModule.*',
                          '**/*Activity*.*',
                          '**/*Fragment*.*',
                          '**/*ViewHolder*.*',

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -421,6 +421,17 @@ public class ApplicationModule {
   }
 
   @Provides
+  @Singleton
+  SegmentTrackingClient provideSegmentTrackingClient(
+          final @ApplicationContext @NonNull Context context,
+          final @NonNull CurrentUserType currentUser,
+          final @NonNull Build build,
+          final @NonNull CurrentConfigType currentConfig,
+          final @NonNull ExperimentsClientType experimentsClientType) {
+    return new SegmentTrackingClient(build, context, currentConfig, currentUser,  experimentsClientType);
+  }
+
+  @Provides
   @LakeTracker
   @Singleton
   static AnalyticEvents provideAnalytics(
@@ -428,10 +439,10 @@ public class ApplicationModule {
           final @NonNull CurrentUserType currentUser,
           final @NonNull Build build,
           final @NonNull CurrentConfigType currentConfig,
-          final @NonNull ExperimentsClientType experimentsClientType) {
+          final @NonNull ExperimentsClientType experimentsClientType,
+          final @NonNull SegmentTrackingClient segmentClient) {
     final LakeTrackingClient lakeTrackingClient = new LakeTrackingClient(context, currentUser, build, currentConfig, experimentsClientType);
-    final SegmentTrackingClient segmentTrackingClient = new SegmentTrackingClient(build, context, currentConfig, currentUser,  experimentsClientType);
-    final List<TrackingClientType> clients = Arrays.asList(lakeTrackingClient, segmentTrackingClient);
+    final List<TrackingClientType> clients = Arrays.asList(lakeTrackingClient, segmentClient);
     return new AnalyticEvents(clients);
   }
 

--- a/app/src/main/java/com/kickstarter/KSApplication.java
+++ b/app/src/main/java/com/kickstarter/KSApplication.java
@@ -8,6 +8,7 @@ import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.kickstarter.libs.ApiEndpoint;
 import com.kickstarter.libs.PushNotifications;
+import com.kickstarter.libs.SegmentTrackingClient;
 import com.kickstarter.libs.braze.RemotePushClientType;
 import com.kickstarter.libs.utils.ApplicationLifecycleUtil;
 import com.kickstarter.libs.utils.Secrets;
@@ -32,6 +33,7 @@ public class KSApplication extends MultiDexApplication {
   @Inject protected CookieManager cookieManager;
   @Inject protected PushNotifications pushNotifications;
   @Inject protected RemotePushClientType remotePushClientType;
+  @Inject protected SegmentTrackingClient segmentTrackingClient;
 
   @Override
   @CallSuper
@@ -68,6 +70,11 @@ public class KSApplication extends MultiDexApplication {
     final ApplicationLifecycleUtil appUtil = new ApplicationLifecycleUtil(this);
     registerActivityLifecycleCallbacks(appUtil);
     registerComponentCallbacks(appUtil);
+
+    // - Initialize Segment SDK
+    if (this.segmentTrackingClient != null) {
+      this.segmentTrackingClient.initialize();
+    }
 
     // - Register lifecycle callback for Braze
     this.remotePushClientType.registerActivityLifecycleCallbacks(this);

--- a/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/LakeTrackingClient.kt
@@ -28,6 +28,10 @@ class LakeTrackingClient(
     override var config: Config? = null
     override var loggedInUser: User? = null
 
+    override fun initialize() {
+        // DO nothing
+    }
+
     init {
         this.currentUser.observable()
             .subscribe {

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -40,7 +40,7 @@ open class SegmentTrackingClient(
                     privateInitializer()
 
                     if (build.isDebug) {
-                        Timber.d("${type().tag} isCalledFromOnCreate:${calledFromOnCreate} withConfig:${config}")
+                        Timber.d("${type().tag} isCalledFromOnCreate:$calledFromOnCreate withConfig:$config")
                         Timber.d("${type().tag} currentThread: ${Thread.currentThread()}")
                     }
                 }
@@ -99,12 +99,11 @@ open class SegmentTrackingClient(
             }
 
             val segmentClient = Analytics.Builder(context, apiKey)
-                    // - This flag will activate sending information to Braze
-                    .use(AppboyIntegration.FACTORY)
-                    .trackApplicationLifecycleEvents()
-                    .logLevel(logLevel)
-                    .build()
-
+                // - This flag will activate sending information to Braze
+                .use(AppboyIntegration.FACTORY)
+                .trackApplicationLifecycleEvents()
+                .logLevel(logLevel)
+                .build()
 
             Analytics.setSingletonInstance(segmentClient)
             this.isInitialized = true

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -76,8 +76,7 @@ class SegmentTrackingClient(
                 apiKey = Secrets.Segment.STAGING
                 logLevel = Analytics.LogLevel.VERBOSE
             }
-
-            Timber.d("${type().tag} initializing isSDKEnabled:${this.isEnabled()}")
+            
             val segmentClient = Analytics.Builder(context, apiKey)
                         // - This flag will activate sending information to Braze
                         .use(AppboyIntegration.FACTORY)

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -15,7 +15,7 @@ import com.segment.analytics.android.integrations.appboy.AppboyIntegration
 import rx.subjects.BehaviorSubject
 import timber.log.Timber
 
-class SegmentTrackingClient(
+open class SegmentTrackingClient(
     build: Build,
     private val context: Context,
     currentConfig: CurrentConfigType,

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -76,13 +76,13 @@ class SegmentTrackingClient(
                 apiKey = Secrets.Segment.STAGING
                 logLevel = Analytics.LogLevel.VERBOSE
             }
-            
+
             val segmentClient = Analytics.Builder(context, apiKey)
-                        // - This flag will activate sending information to Braze
-                        .use(AppboyIntegration.FACTORY)
-                        .trackApplicationLifecycleEvents()
-                        .logLevel(logLevel)
-                        .build()
+                // - This flag will activate sending information to Braze
+                .use(AppboyIntegration.FACTORY)
+                .trackApplicationLifecycleEvents()
+                .logLevel(logLevel)
+                .build()
 
             Analytics.setSingletonInstance(segmentClient)
             this.isInitialized = true

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -9,7 +9,7 @@ import java.util.Locale
 abstract class TrackingClientType {
     enum class Type(val tag: String) {
         LAKE("💧 Lake"),
-        SEGMENT("\uD83C\uDF81 Segment");
+        SEGMENT("\uD83C\uDF81 Segment Analytics");
     }
 
     protected abstract var config: Config?
@@ -48,6 +48,15 @@ abstract class TrackingClientType {
      * is enabled to send data
      */
     abstract fun isEnabled(): Boolean
+
+    /**
+     * Will call initialize for the clients, method useful
+     * if the initialization needs to be tied to some concrete moment
+     * on the Application lifecycle and not by the Dagger injection
+     *
+     * for Segment should be called on Application.OnCreate
+     */
+    abstract fun initialize()
 
     fun track(eventName: String) {
         track(eventName, HashMap())

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.java
@@ -68,7 +68,7 @@ public final class MockTrackingClient extends TrackingClientType {
 
   @Override
   protected boolean isInitialized() {
-    return true;
+    return this.isInitialized;
   }
 
   @Override
@@ -84,6 +84,11 @@ public final class MockTrackingClient extends TrackingClientType {
   @Override
   protected void setInitialized(final boolean isInitialized) {
     this.isInitialized = isInitialized;
+  }
+
+  @Override
+  public void initialize() {
+    this.isInitialized = true;
   }
 
   public static class Event {


### PR DESCRIPTION
# 📲 What

- Segment SDK needs to be initialized on the `OnCreate` method on Application lifecycle AND on the mainThread. otherwise the client disappear on random occasions. 
- Static call to Segment methods via `Analytics.with(context)` instead of using the client.
- Basically the client disappear randomly, that happend when the initialization took place on another thread different from the main thread. 

# 🤔 Why
- We make a networking call to fetch the feature flags (we change threads basically), so we need to be sure to initialize ONCE we have the configuration ready AND the initialization takes place on the main thread.

# 🛠 How
- `SegmentTrackingClient` now has it's own provider on the `AppModule` for injecting the wrapper client.
- New `initialize` method has been added on `TrackingClientType` that method is only useful for now for the `SegmentTrackingClient` 
- We call `initialize` for segment on `OnCreate`
- The subscription for the current configuration needs to be done on the main thread.

# 👀 See
- No user facing changes
|  |  |

# 📋 QA
- Look at the logcat, start the app and kill it several times. You should always see the logs from the queue uploading like in this screenshoot, unless feature flag disabled of course.
![Screen Shot 2021-04-29 at 4 22 35 PM](https://user-images.githubusercontent.com/4083656/116629928-2f65d480-a907-11eb-9bbc-98ffb81e1f73.png)


