### PR TITLE
EP-466:  context_page = other

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -1323,7 +1323,7 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         fun track(eventName: String, additionalProperties: Map<String, Any>) {
             val properties = hashMapOf<String, Any>()
             properties.putAll(additionalProperties)
-            if(!properties.containsKey(CONTEXT_PAGE.contextName))
+            if (!properties.containsKey(CONTEXT_PAGE.contextName))
                 properties[CONTEXT_PAGE.contextName] = EventContextValues.ContextPageName.OTHER.contextName
 
             clients.forEach { client ->

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -335,6 +335,14 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
     }
 
     /**
+     * Sends data to the client when the signup page is viewed.
+     */
+    fun trackSignUpPageViewedForTest() {
+        val props: HashMap<String, Any> = HashMap()
+        client.track(PAGE_VIEWED.eventName, props)
+    }
+
+    /**
      * Sends data to the client when the login/sign-up page is viewed.
      */
     fun trackLoginOrSignUpPagedViewed() {
@@ -1313,8 +1321,13 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         }
 
         fun track(eventName: String, additionalProperties: Map<String, Any>) {
+            val properties = hashMapOf<String, Any>()
+            properties.putAll(additionalProperties)
+            if(!properties.containsKey(CONTEXT_PAGE.contextName))
+                properties[CONTEXT_PAGE.contextName] = EventContextValues.ContextPageName.OTHER.contextName
+
             clients.forEach { client ->
-                client?.track(eventName, additionalProperties)
+                client?.track(eventName, properties)
             }
         }
 

--- a/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
@@ -79,7 +79,8 @@ class EventContextValues {
         UPDATE_PLEDGE("update_pledge"),
         LOGIN("log_in"),
         MANAGE_PLEDGE("manage_pledge"),
-        TWO_FACTOR_AUTH("two_factor_auth")
+        TWO_FACTOR_AUTH("two_factor_auth"),
+        OTHER("other")
     }
 
     /**

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -7,6 +7,7 @@ import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_CTA
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_LOCATION
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_PAGE
 import com.kickstarter.libs.utils.ContextPropertyKeyName.CONTEXT_TYPE
+import com.kickstarter.libs.utils.EventContextValues
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.ACTIVITY_FEED
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.LOGIN
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.LOGIN_SIGN_UP
@@ -114,6 +115,41 @@ class SegmentTest : KSRobolectricTestCase() {
         segment.trackAppOpen()
 
         this.segmentTrack.assertValue("App Open")
+
+        assertSessionProperties(null)
+        assertContextProperties()
+    }
+
+    @Test
+    fun testDefaultProperties_WithContextPage() {
+        val client = client(null)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackSignUpPageViewed()
+
+        val expectedProperties = propertiesTest.value
+        assertEquals(SIGN_UP.contextName, expectedProperties[CONTEXT_PAGE.contextName])
+
+        assertSessionProperties(null)
+        assertContextProperties()
+    }
+
+    /*
+    context_page should be set to other for page without context page set
+     */
+    @Test
+    fun testDefaultProperties_WithoutContextPage() {
+        val client = client(null)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackSignUpPageViewedForTest()
+
+        val expectedProperties = propertiesTest.value
+        assertEquals(EventContextValues.ContextPageName.OTHER.contextName, expectedProperties[CONTEXT_PAGE.contextName])
 
         assertSessionProperties(null)
         assertContextProperties()

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -137,7 +137,7 @@ class SegmentTest : KSRobolectricTestCase() {
     }
 
     /*
-     context_page should be set to other for page without context page
+     context_page should be set to other for properties without context page
      */
     @Test
     fun testProperties_WithoutContextPage() {

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -121,7 +121,7 @@ class SegmentTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testDefaultProperties_WithContextPage() {
+    fun testProperties_WithContextPage() {
         val client = client(null)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)
@@ -137,10 +137,10 @@ class SegmentTest : KSRobolectricTestCase() {
     }
 
     /*
-    context_page should be set to other for page without context page set
+     context_page should be set to other for page without context page
      */
     @Test
-    fun testDefaultProperties_WithoutContextPage() {
+    fun testProperties_WithoutContextPage() {
         val client = client(null)
         client.eventNames.subscribe(this.segmentTrack)
         client.eventProperties.subscribe(this.propertiesTest)


### PR DESCRIPTION
# 📲 What

Android: context_page = other

# 🤔 Why

Automatically send the value context_page = other for all events that occur on pages we haven’t named yet? This is particularly relevant for some Phase 2 events.

# 🛠 How

- Refactored ``` client.track ``` method to set ``` context_page ``` to ``` other ``` for properties without ``` context_page ``` set

```
fun track(eventName: String, additionalProperties: Map<String, Any>) {
            val properties = hashMapOf<String, Any>()
            properties.putAll(additionalProperties)
            if (!properties.containsKey(CONTEXT_PAGE.contextName))
                properties[CONTEXT_PAGE.contextName] = EventContextValues.ContextPageName.OTHER.contextName

            clients.forEach { client ->
                client?.track(eventName, properties)
            }
        }

```

- Added unit tests to test for properties  with and without ``` context_page ```

```

 @Test
    fun testProperties_WithContextPage() {
        val client = client(null)
        client.eventNames.subscribe(this.segmentTrack)
        client.eventProperties.subscribe(this.propertiesTest)
        val segment = AnalyticEvents(listOf(client))

        segment.trackSignUpPageViewed()

        val expectedProperties = propertiesTest.value
        assertEquals(SIGN_UP.contextName, expectedProperties[CONTEXT_PAGE.contextName])

        assertSessionProperties(null)
        assertContextProperties()
    }

```

```

 /*
     context_page should be set to other for properties without context page
     */
    @Test
    fun testProperties_WithoutContextPage() {
        val client = client(null)
        client.eventNames.subscribe(this.segmentTrack)
        client.eventProperties.subscribe(this.propertiesTest)
        val segment = AnalyticEvents(listOf(client))

        segment.trackSignUpPageViewedForTest()

        val expectedProperties = propertiesTest.value
        assertEquals(EventContextValues.ContextPageName.OTHER.contextName, expectedProperties[CONTEXT_PAGE.contextName])

        assertSessionProperties(null)
        assertContextProperties()
    }

```

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

- On the discovery page, click on any project.
- Events name ``` Project Page Viewed ``` with ``` context_page = other ```  and ``` CTA Clicked ``` with ``` context_page = discover  ``` should be registered on segment console.

<img width="722" alt="other" src="https://user-images.githubusercontent.com/63934292/116802344-f2b5fb00-ab09-11eb-9108-edfcf1617b66.png">

<img width="725" alt="context_page" src="https://user-images.githubusercontent.com/63934292/116802408-4e808400-ab0a-11eb-8c0b-72e9e29502f3.png">



# Story 📖

https://kickstarter.atlassian.net/browse/EP-466
