### PR TITLE
[no-jira]: Update segment version + flush queue with 1 event on staging

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -313,7 +313,7 @@ dependencies {
     implementation "org.jsoup:jsoup:1.12.1"
 
     // Analytics Segment-Braze
-    implementation 'com.segment.analytics.android:analytics:4.9.0'
+    implementation 'com.segment.analytics.android:analytics:4.9.4'
     implementation 'com.appboy:appboy-segment-integration:7.0.0'
 
     // Security

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -97,23 +97,36 @@ open class SegmentTrackingClient(
         if (this.context.isKSApplication() && !this.isInitialized && this.isEnabled()) {
             var apiKey = ""
             var logLevel = Analytics.LogLevel.NONE
+            var segmentClient: Analytics
 
             if (build.isRelease && Build.isExternal()) {
                 apiKey = Secrets.Segment.PRODUCTION
             }
+
             if (build.isDebug || Build.isInternal()) {
                 apiKey = Secrets.Segment.STAGING
                 logLevel = Analytics.LogLevel.VERBOSE
-            }
 
-            val segmentClient = Analytics.Builder(context, apiKey)
-                // - This flag will activate sending information to Braze
-                .use(AppboyIntegration.FACTORY)
-                .trackApplicationLifecycleEvents()
-                .logLevel(logLevel)
-                // - Set middleware for Braze destination
-                .useDestinationMiddleware(AppboyIntegration.FACTORY.key(), getMiddleware())
-                .build()
+                segmentClient = Analytics.Builder(context, apiKey)
+                    // - This flag will activate sending information to Braze
+                    .use(AppboyIntegration.FACTORY)
+                    .trackApplicationLifecycleEvents()
+                    .flushQueueSize(1)
+                    .logLevel(logLevel)
+                    // - Set middleware for Braze destination
+                    .useDestinationMiddleware(AppboyIntegration.FACTORY.key(), getMiddleware())
+                    .build()
+
+            } else {
+                segmentClient = Analytics.Builder(context, apiKey)
+                    // - This flag will activate sending information to Braze
+                    .use(AppboyIntegration.FACTORY)
+                    .trackApplicationLifecycleEvents()
+                    .logLevel(logLevel)
+                    // - Set middleware for Braze destination
+                    .useDestinationMiddleware(AppboyIntegration.FACTORY.key(), getMiddleware())
+                    .build()
+            }
 
             Analytics.setSingletonInstance(segmentClient)
             this.isInitialized = true

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -116,7 +116,6 @@ open class SegmentTrackingClient(
                     // - Set middleware for Braze destination
                     .useDestinationMiddleware(AppboyIntegration.FACTORY.key(), getMiddleware())
                     .build()
-
             } else {
                 segmentClient = Analytics.Builder(context, apiKey)
                     // - This flag will activate sending information to Braze


### PR DESCRIPTION
# 📲 What

- Update segment version + flush queue with 1 event on staging

# 🤔 Why

- We are trying to solve some timestamp issues going on. See -> https://github.com/segmentio/analytics-android/issues/757 and it seems it might be solve on the latest Segment SDK version.

# 🛠 How

- Updated version from 4.9.0 to 4.9.4
- Added `.flushQueueSize(1)` when instanciating Segment client on testing builds.

# 👀 See
- no user facing changes
- 
|  |  |

