### PR TITLE
NT-1923: remove jcenter()

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -261,6 +261,8 @@ apollo {
 }
 
 repositories {
+    // This is the only reference we cannot remove yet as it has not been migrated to mavenCentral() or google()
+    // see - https://github.com/google/flexbox-layout/issues/566
     jcenter()
     maven {
         url 'https://maven.google.com'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -242,7 +242,9 @@ android {
 buildscript {
     repositories {
         google()
-        jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.apollographql.apollo:apollo-gradle-plugin:2.3.0'
@@ -294,7 +296,7 @@ dependencies {
     implementation "com.jakewharton.rxbinding:rxbinding-recyclerview-v7:$rx_binding_version"
     implementation "com.jakewharton.rxbinding:rxbinding-support-v4:$rx_binding_version"
     implementation "com.jakewharton.timber:timber:3.0.1"
-    implementation 'com.optimizely.ab:android-sdk:3.5.1'
+    implementation 'com.optimizely.ab:android-sdk:3.10.1'
     implementation 'com.qualtrics:digital:1.3'
     implementation "com.stripe:stripe-android:12.0.1"
     final okhttp_version = "4.8.+"

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ buildscript {
     ext.jacoco_version = '0.8.5'
 
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
-        maven { url 'https://dl.bintray.com/apollographql/android/' }
         maven { url 'https://s3-us-west-2.amazonaws.com/si-mobile-sdks/android/' }
-        maven { url 'http://dl.bintray.com/optimizely/optimizely' }
         maven { url 'http://appboy.github.io/appboy-android-sdk/sdk' }
         maven { url 'http://appboy.github.io/appboy-segment-android/sdk' }
         maven { url 'https://perimeterx.jfrog.io/artifactory/px-Android-SDK/' }


### PR DESCRIPTION
# 📲 What
- We need to remove all possible references to bintray and jcenter() repositories 

# 🤔 Why

- see -> https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
- ⚠️  one last dependency still needs jcenter() as it has not been moved yet to mavencentral() or google() `implementation 'com.google.android:flexbox:1.1.0'`  see the issue open https://github.com/google/flexbox-layout/issues/566

# 👀 See
- No use facing changes
|  |  |

# 📋 QA
- The app compiles 

# Story 📖

[NT-1923](https://kickstarter.atlassian.net/browse/NT-1923)
