### PR TITLE
NT-1853: Removed Feature Flag for Braze

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -173,8 +173,8 @@ public class ApplicationModule {
   @Provides
   @Nonnull
   @Singleton
-  static RemotePushClientType provideBrazeClient(final @NonNull Build build, final @ApplicationContext @NonNull Context context, final @NonNull CurrentConfigType currentConfig) {
-    return new BrazeClient(context, build, currentConfig);
+  static RemotePushClientType provideBrazeClient(final @NonNull Build build, final @ApplicationContext @NonNull Context context) {
+    return new BrazeClient(context, build);
   }
 
   @Provides

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -136,7 +136,7 @@ open class SegmentTrackingClient(
                 AppboyIntegration.FACTORY.key(),
                 Analytics.Callback<Any?> {
                     if (build.isDebug) Timber.d("${type().tag} Integration with ${AppboyIntegration.FACTORY} finalized")
-                    BrazeClient.setInAppCustomListener(this.currentUser, this.currentConfig, this.build)
+                    BrazeClient.setInAppCustomListener(this.currentUser, this.build)
                 }
             )
 

--- a/app/src/main/java/com/kickstarter/libs/braze/BrazeClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/braze/BrazeClient.kt
@@ -11,12 +11,8 @@ import com.appboy.support.AppboyLogger
 import com.appboy.ui.inappmessage.AppboyInAppMessageManager
 import com.google.firebase.messaging.RemoteMessage
 import com.kickstarter.libs.Build
-import com.kickstarter.libs.Config
-import com.kickstarter.libs.CurrentConfigType
 import com.kickstarter.libs.CurrentUserType
-import com.kickstarter.libs.utils.ConfigFeatureName
 import com.kickstarter.libs.utils.Secrets
-import com.kickstarter.libs.utils.extensions.isFeatureFlagEnabled
 import com.kickstarter.libs.utils.extensions.isKSApplication
 import com.kickstarter.libs.utils.extensions.registerActivityLifecycleCallbacks
 
@@ -76,39 +72,16 @@ interface RemotePushClientType {
  * Braze client SDK wrapper class.
  * @param context It needs the application context to be initialized,
  * @param build the type of build will determine the IdSender from Firebase and the logs mode
- * @param configuration current configuration, it will be used mainly to check feature flag enable/disable
  */
 open class BrazeClient(
     private val context: Context,
-    private val build: Build,
-    private val configuration: CurrentConfigType
+    private val build: Build
 ) : RemotePushClientType {
 
-    private var config: Config? = null
     private var initialized = false
 
     override val isInitialized: Boolean
         get() = initialized
-
-    init {
-        this.configuration.observable()
-            .distinctUntilChanged()
-            .subscribe { c ->
-                // - Cache the most recent config
-                this.config = c
-                initialize()
-            }
-    }
-
-    /**
-     * - Do not initialize Braze SDK until the current configuration is loaded
-     * and it has not previously being initialized
-     */
-    private fun initialize() {
-        if (isSDKEnabled() && this.context.isKSApplication() && !this.isInitialized) {
-            this.init()
-        }
-    }
 
     override fun init() {
         if (isSDKEnabled() && !this.initialized) {

--- a/app/src/main/java/com/kickstarter/libs/braze/BrazeClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/braze/BrazeClient.kt
@@ -129,8 +129,7 @@ open class BrazeClient(
         }
     }
 
-    override fun isSDKEnabled(): Boolean =
-        config?.isFeatureFlagEnabled(ConfigFeatureName.BRAZE_ENABLED.configFeatureName) ?: false
+    override fun isSDKEnabled(): Boolean = true
 
     override fun getIdSender(): String {
         var senderId = ""
@@ -175,8 +174,8 @@ open class BrazeClient(
      * on the `onIntegrationReady` callback
      */
     companion object {
-        fun setInAppCustomListener(currentUser: CurrentUserType, currentConfig: CurrentConfigType, build: Build) {
-            AppboyInAppMessageManager.getInstance().setCustomInAppMessageManagerListener(InAppCustomListener(currentUser, currentConfig, build))
+        fun setInAppCustomListener(currentUser: CurrentUserType, build: Build) {
+            AppboyInAppMessageManager.getInstance().setCustomInAppMessageManagerListener(InAppCustomListener(currentUser, build))
         }
     }
 }

--- a/app/src/main/java/com/kickstarter/libs/braze/InAppCustomListener.kt
+++ b/app/src/main/java/com/kickstarter/libs/braze/InAppCustomListener.kt
@@ -4,7 +4,6 @@ import com.appboy.models.IInAppMessage
 import com.appboy.ui.inappmessage.InAppMessageOperation
 import com.appboy.ui.inappmessage.listeners.AppboyDefaultInAppMessageManagerListener
 import com.kickstarter.libs.Build
-import com.kickstarter.libs.CurrentConfigType
 import com.kickstarter.libs.CurrentUserType
 import timber.log.Timber
 
@@ -16,7 +15,6 @@ import timber.log.Timber
  */
 class InAppCustomListener(
     loggedInUser: CurrentUserType,
-    config: CurrentConfigType,
     private val build: Build
 ) : AppboyDefaultInAppMessageManagerListener() {
 
@@ -24,7 +22,7 @@ class InAppCustomListener(
 
     init {
         if (build.isDebug) Timber.d("${this.javaClass.canonicalName} Init block custom listener")
-        handler = InAppCustomListenerHandler(loggedInUser, config)
+        handler = InAppCustomListenerHandler(loggedInUser)
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/libs/braze/InAppCustomListenerHandler.kt
+++ b/app/src/main/java/com/kickstarter/libs/braze/InAppCustomListenerHandler.kt
@@ -1,27 +1,14 @@
 package com.kickstarter.libs.braze
 
-import com.kickstarter.libs.Config
-import com.kickstarter.libs.CurrentConfigType
 import com.kickstarter.libs.CurrentUserType
-import com.kickstarter.libs.utils.ConfigFeatureName
-import com.kickstarter.libs.utils.extensions.isFeatureFlagEnabled
 import com.kickstarter.models.User
-import rx.schedulers.Schedulers
 
 class InAppCustomListenerHandler(
-    private val currentUser: CurrentUserType,
-    private val currentConfig: CurrentConfigType
+    private val currentUser: CurrentUserType
 ) {
-
-    private var config: Config? = null
     private var loggedInUser: User? = null
 
     init {
-        this.currentConfig.observable()
-            .subscribeOn(Schedulers.io())
-            .subscribe {
-                this.config = it
-            }
 
         this.currentUser.observable()
             .distinctUntilChanged()
@@ -31,16 +18,11 @@ class InAppCustomListenerHandler(
     }
 
     /**
-     * In case the user is logged in, and the
-     * feature flag is active
+     * In case the user is logged in
      * @return true
      *
-     * In case no user logged in or the feature flag not active
-     * feature
+     * In case no user logged in
      * @return false
      */
-    fun shouldShowMessage() =
-        if (this.config != null && this.loggedInUser != null) {
-            this.config?.isFeatureFlagEnabled(ConfigFeatureName.BRAZE_ENABLED.configFeatureName) ?: false
-        } else false
+    fun shouldShowMessage() = this.loggedInUser != null
 }

--- a/app/src/main/java/com/kickstarter/libs/utils/ConfigFeatureName.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/ConfigFeatureName.kt
@@ -17,11 +17,5 @@ enum class ConfigFeatureName(val configFeatureName: String) {
      * Internal name for "android_segment"
      * @{link https://github.com/kickstarter/kickstarter/blob/e9c61ea9f1e4817bb64560db7c32f3b9704cdc60/config/features.yml#L219}
      */
-    SEGMENT_ENABLED("android_segment"),
-
-    /**
-     * Internal name for "android_braze"
-     * @{link https://github.com/kickstarter/kickstarter/blob/c623c063c08e4264fbda750b243b0ef0c91fd637/config/features.yml#L224}
-     */
-    BRAZE_ENABLED("android_braze")
+    SEGMENT_ENABLED("android_segment")
 }

--- a/app/src/test/java/com/kickstarter/libs/BrazeClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/BrazeClientTest.kt
@@ -7,9 +7,6 @@ import android.os.Bundle
 import com.google.firebase.messaging.RemoteMessage
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.braze.BrazeClient
-import com.kickstarter.libs.utils.ConfigFeatureName
-import com.kickstarter.mock.MockCurrentConfig
-import com.kickstarter.mock.factories.ConfigFactory
 import org.junit.Test
 
 const val mockSenderId = "MockSender"
@@ -25,9 +22,8 @@ class BrazeClientTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testInitialize_whenEnabledFeatureFlag() {
-        val mockConfig = mockCurrentConfig(enabledFeatureFlag = true)
-        val mockClient = MockBrazeClient(build, context, mockConfig)
+    fun testInitialize() {
+        val mockClient = MockBrazeClient(build, context)
 
         mockClient.init()
         assertTrue(mockClient.isSDKEnabled())
@@ -37,20 +33,8 @@ class BrazeClientTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testInitialize_whenDisabledFeatureFlag() {
-        val mockConfig = mockCurrentConfig(enabledFeatureFlag = false)
-        val mockClient = MockBrazeClient(build, context, mockConfig)
-
-        mockClient.init()
-        assertFalse(mockClient.isSDKEnabled())
-        assertEquals(mockSenderId, mockClient.getIdSender())
-        assertFalse(mockClient.isInitialized)
-    }
-
-    @Test
-    fun testHandleMessageNotBraze_whenEnabledFeatureFlag() {
-        val mockConfig = mockCurrentConfig(enabledFeatureFlag = true)
-        val mockClient = MockBrazeClient(build, context, mockConfig)
+    fun testHandleMessageNotBraze() {
+        val mockClient = MockBrazeClient(build, context)
 
         mockClient.init()
         assertTrue(mockClient.isSDKEnabled())
@@ -60,35 +44,12 @@ class BrazeClientTest : KSRobolectricTestCase() {
 
         val message: RemoteMessage = RemoteMessage(Bundle())
         assertFalse(mockClient.handleRemoteMessages(context, message))
-    }
-
-    @Test
-    fun testHandleMessageNotBraze_whenDisabledFeatureFlag() {
-        val mockConfig = mockCurrentConfig(enabledFeatureFlag = false)
-        val mockClient = MockBrazeClient(build, context, mockConfig)
-
-        mockClient.init()
-        assertFalse(mockClient.isSDKEnabled())
-        assertEquals(mockSenderId, mockClient.getIdSender())
-        assertNotNull(mockClient.getLifeCycleCallbacks())
-
-        val message: RemoteMessage = RemoteMessage(Bundle())
-        assertFalse(mockClient.handleRemoteMessages(context, message))
-    }
-
-    private fun mockCurrentConfig(enabledFeatureFlag: Boolean) = MockCurrentConfig().apply {
-        var config =
-            if (enabledFeatureFlag)
-                ConfigFactory.configWithFeatureEnabled(ConfigFeatureName.BRAZE_ENABLED.configFeatureName)
-            else ConfigFactory.configWithFeatureDisabled(ConfigFeatureName.BRAZE_ENABLED.configFeatureName)
-        config(config)
     }
 
     class MockBrazeClient(
         private val build: Build,
-        private val context: Context,
-        private val config: CurrentConfigType
-    ) : BrazeClient(build = build, context = context, configuration = config) {
+        private val context: Context
+    ) : BrazeClient(build = build, context = context) {
         private var initialized = false
 
         override val isInitialized: Boolean

--- a/app/src/test/java/com/kickstarter/libs/InAppCustomListenerHandlerTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/InAppCustomListenerHandlerTest.kt
@@ -4,9 +4,6 @@ import com.appboy.ui.inappmessage.InAppMessageOperation
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.braze.InAppCustomListener
 import com.kickstarter.libs.braze.InAppCustomListenerHandler
-import com.kickstarter.libs.utils.ConfigFeatureName
-import com.kickstarter.mock.MockCurrentConfig
-import com.kickstarter.mock.factories.ConfigFactory
 import com.kickstarter.mock.factories.UserFactory
 import org.junit.Test
 
@@ -23,11 +20,7 @@ class InAppCustomListenerHandlerTest : KSRobolectricTestCase() {
     fun testMessageShouldShow_True() {
         val user = UserFactory.user()
         val mockUser = MockCurrentUser(user)
-        val mockConfig = MockCurrentConfig().apply {
-            val config = ConfigFactory.configWithFeatureEnabled(ConfigFeatureName.BRAZE_ENABLED.configFeatureName)
-            config(config)
-        }
-        val handler = InAppCustomListenerHandler(mockUser, mockConfig)
+        val handler = InAppCustomListenerHandler(mockUser)
 
         Thread.sleep(100) // wait a bit until InAppCustomListenerHandler.init block executed
         assertTrue(handler.shouldShowMessage())
@@ -35,12 +28,8 @@ class InAppCustomListenerHandlerTest : KSRobolectricTestCase() {
 
     @Test
     fun testMessageShouldShow_False() {
-        val mockUser = MockCurrentUser()
-        val mockConfig = MockCurrentConfig().apply {
-            val config = ConfigFactory.configWithFeatureDisabled(ConfigFeatureName.BRAZE_ENABLED.configFeatureName)
-            config(config)
-        }
-        val handler = InAppCustomListenerHandler(mockUser, mockConfig)
+        val mockUser = MockCurrentUser() // - no user logged in
+        val handler = InAppCustomListenerHandler(mockUser)
 
         Thread.sleep(100) // wait a bit until InAppCustomListenerHandler.init block executed
         assertFalse(handler.shouldShowMessage())
@@ -50,11 +39,7 @@ class InAppCustomListenerHandlerTest : KSRobolectricTestCase() {
     fun testInAppCustomListener_DisplayNow() {
         val user = UserFactory.user()
         val mockUser = MockCurrentUser(user)
-        val mockConfig = MockCurrentConfig().apply {
-            val config = ConfigFactory.configWithFeatureEnabled(ConfigFeatureName.BRAZE_ENABLED.configFeatureName)
-            config(config)
-        }
-        val listener = InAppCustomListener(mockUser, mockConfig, build)
+        val listener = InAppCustomListener(mockUser, build)
 
         Thread.sleep(100) // wait a bit until InAppCustomListener.init block executed
         assertTrue(listener.beforeInAppMessageDisplayed(null) == InAppMessageOperation.DISPLAY_NOW)
@@ -62,13 +47,8 @@ class InAppCustomListenerHandlerTest : KSRobolectricTestCase() {
 
     @Test
     fun testInAppCustomListener_Discard() {
-        val user = UserFactory.user()
-        val mockUser = MockCurrentUser(user)
-        val mockConfig = MockCurrentConfig().apply {
-            val config = ConfigFactory.configWithFeatureDisabled(ConfigFeatureName.BRAZE_ENABLED.configFeatureName)
-            config(config)
-        }
-        val listener = InAppCustomListener(mockUser, mockConfig, build)
+        val mockUser = MockCurrentUser() // - no user logged in
+        val listener = InAppCustomListener(mockUser, build)
 
         Thread.sleep(100) // wait a bit until InAppCustomListener.init block executed
         assertTrue(listener.beforeInAppMessageDisplayed(null) == InAppMessageOperation.DISCARD)


### PR DESCRIPTION
# 📲 What

- Remove Feature Flag for Braze

# 🛠 How
- Config object removed as dependency on `BrazeClient`,  `InAppCustomListener`, `InAppCustomListenerHandler`
- Any check related with the Feature Flag now is always true or directly removed
- Updated/removed unit tests around feature flag being enabled or disabled

# 📋 QA
- Make sure Braze client is always initialized when loading the app, you can take a look in logcat a search for `AppBoy` logs

# Story 📖

[NT-1853](https://kickstarter.atlassian.net/browse/NT-1853)
