### PR TITLE
NT-1980: Add Cursor to each comment item

### DIFF
--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -250,7 +250,9 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                                 .map { project ->
 
                                     val comments = project?.comments()?.edges()?.map { edge ->
-                                        createCommentObject(edge?.node()?.fragments()?.comment())
+                                        createCommentObject(edge?.node()?.fragments()?.comment()).toBuilder()
+                                            .cursor(edge?.cursor())
+                                            .build()
                                     }
 
                                     CommentEnvelope.builder()


### PR DESCRIPTION
# 📲 What

Add Cursor to each comment item

# 🤔 Why

There is a cursor attached to every comment. This needed to implement pagination

# 🛠 How

- Set the cursor field with graphql node cursor
```
 createCommentObject(edge?.node()?.fragments()?.comment()).toBuilder()
                                            .cursor(edge?.cursor())
                                            .build()
```

# 👀 See

![cursor](https://user-images.githubusercontent.com/63934292/119670542-e125f180-be30-11eb-8a48-1f66d49c2afe.png)

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

Instructions for anyone to be able to QA this work.

# Story 📖

https://kickstarter.atlassian.net/browse/NT-1980
