### PR TITLE
NT-953: Fetch a thread query

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.2'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.6.1'
     }
 }
 
@@ -105,7 +105,6 @@ android.applicationVariants.all { variant ->
 
 android {
     compileSdkVersion 30
-    buildToolsVersion '29.0.3'
 
     defaultConfig {
         applicationId "com.kickstarter"

--- a/app/src/main/graphql/replies.graphql
+++ b/app/src/main/graphql/replies.graphql
@@ -1,0 +1,16 @@
+query GetRepliesForComment($commentableId: ID!, $cursor: String) {
+    commentable: node(id: $commentableId) {
+        ... on Comment {
+            # TODO: By default I used a page size of 25 make sure that's correct
+            replies(last: 25, before: $cursor) {
+                totalCount
+                nodes {
+                    ...comment
+                }
+                pageInfo {
+                    ...pageInfo
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/graphql/replies.graphql
+++ b/app/src/main/graphql/replies.graphql
@@ -1,7 +1,8 @@
+# Example for a similar query on the backend https://github.com/kickstarter/kickstarter/blob/master/test/graph/query_types/commentable_type_test.rb
 query GetRepliesForComment($commentableId: ID!, $cursor: String) {
     commentable: node(id: $commentableId) {
         ... on Comment {
-            # TODO: By default I used a page size of 25 make sure that's correct
+            # TODO: By default a page size of 25 make sure that's correct
             replies(last: 25, before: $cursor) {
                 totalCount
                 nodes {

--- a/app/src/main/graphql/replies.graphql
+++ b/app/src/main/graphql/replies.graphql
@@ -1,9 +1,8 @@
 # Example for a similar query on the backend https://github.com/kickstarter/kickstarter/blob/master/test/graph/query_types/commentable_type_test.rb
-query GetRepliesForComment($commentableId: ID!, $cursor: String) {
+query GetRepliesForComment($commentableId: ID!, $cursor: String, $pageSize: Int) {
     commentable: node(id: $commentableId) {
         ... on Comment {
-            # TODO: By default a page size of 25 make sure that's correct
-            replies(last: 25, before: $cursor) {
+            replies(last: $pageSize, before: $cursor) {
                 totalCount
                 nodes {
                     ...comment

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -71,11 +71,7 @@ open class MockApolloClient : ApolloClientType {
         )
     }
 
-    override fun getCommentReplies(
-        commentId: String,
-        cursor: String,
-        pageSize: Int
-    ): Observable<CommentEnvelope> {
+    override fun getRepliesForComment(comment: Comment, cursor: String, pageSize: Int): Observable<CommentEnvelope> {
         return Observable.just(CommentEnvelopeFactory.emptyCommentsEnvelope())
     }
 

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -7,14 +7,7 @@ import UpdateUserCurrencyMutation
 import UpdateUserEmailMutation
 import UpdateUserPasswordMutation
 import UserPrivacyQuery
-import com.kickstarter.mock.factories.BackingFactory
-import com.kickstarter.mock.factories.CheckoutFactory
-import com.kickstarter.mock.factories.CommentFactory
-import com.kickstarter.mock.factories.CreatorDetailsFactory
-import com.kickstarter.mock.factories.ErroredBackingFactory
-import com.kickstarter.mock.factories.PageInfoEnvelopeFactory
-import com.kickstarter.mock.factories.RewardFactory
-import com.kickstarter.mock.factories.StoredCardFactory
+import com.kickstarter.mock.factories.*
 import com.kickstarter.models.Backing
 import com.kickstarter.models.Checkout
 import com.kickstarter.models.Comment
@@ -68,6 +61,14 @@ open class MockApolloClient : ApolloClientType {
                 .totalCount(1)
                 .build()
         )
+    }
+
+    override fun getCommentReplies(
+        commentId: String,
+        cursor: String,
+        pageSize: Int
+    ): Observable<CommentEnvelope> {
+        return Observable.just(CommentEnvelopeFactory.emptyCommentsEnvelope())
     }
 
     override fun createComment(comment: PostCommentData): Observable<Comment> {

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -7,7 +7,15 @@ import UpdateUserCurrencyMutation
 import UpdateUserEmailMutation
 import UpdateUserPasswordMutation
 import UserPrivacyQuery
-import com.kickstarter.mock.factories.*
+import com.kickstarter.mock.factories.BackingFactory
+import com.kickstarter.mock.factories.CheckoutFactory
+import com.kickstarter.mock.factories.CommentEnvelopeFactory
+import com.kickstarter.mock.factories.CommentFactory
+import com.kickstarter.mock.factories.CreatorDetailsFactory
+import com.kickstarter.mock.factories.ErroredBackingFactory
+import com.kickstarter.mock.factories.PageInfoEnvelopeFactory
+import com.kickstarter.mock.factories.RewardFactory
+import com.kickstarter.mock.factories.StoredCardFactory
 import com.kickstarter.models.Backing
 import com.kickstarter.models.Checkout
 import com.kickstarter.models.Comment

--- a/app/src/main/java/com/kickstarter/models/Comment.java
+++ b/app/src/main/java/com/kickstarter/models/Comment.java
@@ -11,7 +11,7 @@ import auto.parcel.AutoParcel;
 
 @AutoGson
 @AutoParcel
-public abstract class Comment implements Parcelable{
+public abstract class Comment implements Parcelable, Relay{
   public abstract User author();
   public abstract String body();
   public abstract DateTime createdAt();

--- a/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
+++ b/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
@@ -36,7 +36,7 @@ interface ApolloClientType {
 
     fun getProjectComments(slug: String, cursor: String?, limit: Int = 25): Observable<CommentEnvelope>
 
-    fun getCommentReplies(commentId: String, cursor: String, pageSize: Int = 25): Observable<CommentEnvelope>
+    fun getRepliesForComment(comment: Comment, cursor: String = "", pageSize: Int = 25): Observable<CommentEnvelope>
 
     fun createComment(comment: PostCommentData): Observable<Comment>
 

--- a/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
+++ b/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
@@ -36,6 +36,8 @@ interface ApolloClientType {
 
     fun getProjectComments(slug: String, cursor: String?, limit: Int = 25): Observable<CommentEnvelope>
 
+    fun getCommentReplies(commentId: String, cursor: String, pageSize: Int = 25): Observable<CommentEnvelope>
+
     fun createComment(comment: PostCommentData): Observable<Comment>
 
     fun createPassword(password: String, confirmPassword: String): Observable<CreatePasswordMutation.Data>

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -273,17 +273,13 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
         }.subscribeOn(Schedulers.io())
     }
 
-    override fun getCommentReplies(
-        commentId: String,
-        cursor: String,
-        pageSize: Int
-    ): Observable<CommentEnvelope> {
+    override fun getRepliesForComment(comment: Comment, cursor: String, pageSize: Int): Observable<CommentEnvelope> {
         return Observable.defer {
             val ps = PublishSubject.create<CommentEnvelope>()
 
             this.service.query(
                 GetRepliesForCommentQuery.builder()
-                    .commentableId(commentId)
+                    .commentableId(encodeRelayId(comment))
                     .cursor(cursor)
                     .pageSize(pageSize)
                     .build()
@@ -294,6 +290,9 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                     }
 
                     override fun onResponse(response: Response<GetRepliesForCommentQuery.Data>) {
+                        response.data?.let { data ->
+                            Observable.just(data.commentable())
+                        }
                     }
                 })
             return@defer ps

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -189,44 +189,6 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
         }
     }
 
-    private fun createCommentObject(commentFr: fragment.Comment?): Comment {
-
-        val badges: List<String>? = commentFr?.authorBadges()?.map { badge ->
-            badge?.rawValue() ?: ""
-        }
-
-        val author = User.builder()
-            .id(decodeRelayId(commentFr?.author()?.fragments()?.user()?.id()) ?: -1)
-            .name(commentFr?.author()?.fragments()?.user()?.name())
-            .avatar(
-                Avatar.builder()
-                    .medium(commentFr?.author()?.fragments()?.user()?.imageUrl())
-                    .build()
-            )
-            .build()
-
-        return Comment.builder()
-            .id(decodeRelayId(commentFr?.id()) ?: -1)
-            .author(author)
-            .repliesCount(commentFr?.replies()?.totalCount() ?: 0)
-            .body(commentFr?.body())
-            .authorBadges(badges)
-            .cursor("")
-            .createdAt(commentFr?.createdAt())
-            .deleted(commentFr?.deleted())
-            .parentId(decodeRelayId(commentFr?.parentId()) ?: -1)
-            .build()
-    }
-
-    private fun createPageInfoObject(pageFr: fragment.PageInfo?): PageInfoEnvelope {
-        return PageInfoEnvelope.builder()
-            .endCursor(pageFr?.endCursor() ?: "")
-            .hasNextPage(pageFr?.hasNextPage() ?: false)
-            .hasPreviousPage(pageFr?.hasPreviousPage() ?: false)
-            .startCursor(pageFr?.startCursor() ?: "")
-            .build()
-    }
-
     override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
         return Observable.defer {
             val ps = PublishSubject.create<CommentEnvelope>()
@@ -276,25 +238,27 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
     override fun getRepliesForComment(comment: Comment, cursor: String, pageSize: Int): Observable<CommentEnvelope> {
         return Observable.defer {
             val ps = PublishSubject.create<CommentEnvelope>()
-
             this.service.query(
                 GetRepliesForCommentQuery.builder()
                     .commentableId(encodeRelayId(comment))
                     .cursor(cursor)
                     .pageSize(pageSize)
                     .build()
-            )
-                .enqueue(object : ApolloCall.Callback<GetRepliesForCommentQuery.Data>() {
-                    override fun onFailure(e: ApolloException) {
-                        ps.onError(e)
-                    }
+            ).enqueue(object : ApolloCall.Callback<GetRepliesForCommentQuery.Data>() {
+                override fun onFailure(e: ApolloException) {
+                    ps.onError(e)
+                }
 
-                    override fun onResponse(response: Response<GetRepliesForCommentQuery.Data>) {
-                        response.data?.let { data ->
-                            Observable.just(data.commentable())
-                        }
+                override fun onResponse(response: Response<GetRepliesForCommentQuery.Data>) {
+                    response.data?.let { responseData ->
+                        Observable.just(createCommentEnvelop(responseData))
+                            .subscribe {
+                                ps.onNext(it)
+                                ps.onCompleted()
+                            }
                     }
-                })
+                }
+            })
             return@defer ps
         }.subscribeOn(Schedulers.io())
     }
@@ -785,6 +749,59 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
             return@defer ps
         }
     }
+}
+
+private fun createCommentObject(commentFr: fragment.Comment?): Comment {
+
+    val badges: List<String>? = commentFr?.authorBadges()?.map { badge ->
+        badge?.rawValue() ?: ""
+    }
+
+    val author = User.builder()
+        .id(decodeRelayId(commentFr?.author()?.fragments()?.user()?.id()) ?: -1)
+        .name(commentFr?.author()?.fragments()?.user()?.name())
+        .avatar(
+            Avatar.builder()
+                .medium(commentFr?.author()?.fragments()?.user()?.imageUrl())
+                .build()
+        )
+        .build()
+
+    return Comment.builder()
+        .id(decodeRelayId(commentFr?.id()) ?: -1)
+        .author(author)
+        .repliesCount(commentFr?.replies()?.totalCount() ?: 0)
+        .body(commentFr?.body())
+        .authorBadges(badges)
+        .cursor("")
+        .createdAt(commentFr?.createdAt())
+        .deleted(commentFr?.deleted())
+        .parentId(decodeRelayId(commentFr?.parentId()) ?: -1)
+        .build()
+}
+
+private fun createPageInfoObject(pageFr: fragment.PageInfo?): PageInfoEnvelope {
+    return PageInfoEnvelope.builder()
+        .endCursor(pageFr?.endCursor() ?: "")
+        .hasNextPage(pageFr?.hasNextPage() ?: false)
+        .hasPreviousPage(pageFr?.hasPreviousPage() ?: false)
+        .startCursor(pageFr?.startCursor() ?: "")
+        .build()
+}
+
+private fun createCommentEnvelop(responseData: GetRepliesForCommentQuery.Data): CommentEnvelope {
+    val replies = (responseData.commentable() as GetRepliesForCommentQuery.AsComment).replies()
+    val listOfComments = replies?.nodes()?.map { commentFragment ->
+        createCommentObject(commentFragment.fragments().comment())
+    } ?: emptyList()
+    val totalCount = replies?.totalCount() ?: 0
+    val pageInfo = createPageInfoObject(replies?.pageInfo()?.fragments()?.pageInfo())
+
+    return CommentEnvelope.builder()
+        .comments(listOfComments)
+        .pageInfoEnvelope(pageInfo)
+        .totalCount(totalCount)
+        .build()
 }
 
 private fun createBackingObject(backingGr: fragment.Backing?): Backing {

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -273,6 +273,33 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
         }.subscribeOn(Schedulers.io())
     }
 
+    override fun getCommentReplies(
+        commentId: String,
+        cursor: String,
+        pageSize: Int
+    ): Observable<CommentEnvelope> {
+        return Observable.defer {
+            val ps = PublishSubject.create<CommentEnvelope>()
+
+            this.service.query(
+                GetRepliesForCommentQuery.builder()
+                    .commentableId(commentId)
+                    .cursor(cursor)
+                    .pageSize(pageSize)
+                    .build()
+            )
+                .enqueue(object : ApolloCall.Callback<GetRepliesForCommentQuery.Data>() {
+                    override fun onFailure(e: ApolloException) {
+                        ps.onError(e)
+                    }
+
+                    override fun onResponse(response: Response<GetRepliesForCommentQuery.Data>) {
+                    }
+                })
+            return@defer ps
+        }.subscribeOn(Schedulers.io())
+    }
+
     override fun createComment(comment: PostCommentData): Observable<Comment> {
         return Observable.defer {
             val ps = PublishSubject.create<Comment>()

--- a/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
@@ -11,6 +11,7 @@ import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.ThreadActivity
 import rx.Observable
 import rx.subjects.BehaviorSubject
+import timber.log.Timber
 
 interface ThreadViewModel {
 
@@ -29,13 +30,17 @@ interface ThreadViewModel {
 
         private val rootComment = BehaviorSubject.create<Comment>()
         private val focusOnCompose = BehaviorSubject.create<Boolean>()
+
         val inputs = this
         val outputs = this
 
         init {
             getCommentFromIntent()
-                .compose(bindToLifecycle())
-                .subscribe(this.rootComment)
+
+            val comment = getCommentFromIntent()
+                .distinctUntilChanged()
+                .filter { ObjectUtils.isNotNull(it) }
+                .map { requireNotNull(it) }
 
             intent()
                 .map { it.getBooleanExtra(IntentKey.REPLY_EXPAND, false) }
@@ -43,19 +48,32 @@ interface ThreadViewModel {
                 .compose(bindToLifecycle())
                 .subscribe(this.focusOnCompose)
 
-            getCommentFromIntent()
+            val commentEnvelope = getCommentFromIntent()
                 .switchMap {
                     this.apolloClient.getRepliesForComment(it)
                 }
-                .filter { ObjectUtils.isNotNull(it) }
                 .share()
+
+            commentEnvelope
+                .compose(bindToLifecycle())
+                .subscribe {
+                    Timber.i(
+                        "******* Comment envelope with \n" +
+                            "totalComments:${it.totalCount} \n" +
+                            "commentsList: ${it.comments?.map { comment -> comment.body() + " |"}} \n" +
+                            "commentsListSize: ${it.comments?.size} \n" +
+                            "pageInfo: ${it.pageInfoEnvelope} ****"
+                    )
+                }
+
+            comment
+                .compose(bindToLifecycle())
+                .subscribe(this.rootComment)
         }
 
         private fun getCommentFromIntent() = intent()
             .map { it.getParcelableExtra(IntentKey.COMMENT) as Comment? }
-            .distinctUntilChanged()
-            .filter { ObjectUtils.isNotNull(it) }
-            .map { requireNotNull(it) }
+            .ofType(Comment::class.java)
 
         override fun getRootComment(): Observable<Comment> = this.rootComment
         override fun shouldFocusOnCompose(): Observable<Boolean> = this.focusOnCompose


### PR DESCRIPTION
# 📲 What

- Create new method for the GraphQL networking client able to fetch all the replies to a concrete comment

# 🤔 Why
- We will load the Thread screen with the list of replies to a concrete comment

# 🛠 How
- Added new `replies.graphql` file, note I'm reusing all the fragments previously created :) 
- `apolloClient` has a new method `getRepliesForComment` that executes previous mentioned query and retruns a `CommentEnvelope`
- On `ThreadViewModel` there is a subscription already working that fetches replies, for now it just displays on logcat the retrieved data
<img width="766" alt="Screen Shot 2021-05-28 at 3 47 38 PM" src="https://user-images.githubusercontent.com/4083656/120048513-26caf180-bfcc-11eb-8f23-e7bde4284a1f.png">


# 👀 See
- On Logcat you can see the CommentEnvelope Structure 
<img width="1184" alt="LogcatReplies" src="https://user-images.githubusercontent.com/4083656/120048543-3ea27580-bfcc-11eb-9449-0460030a5c81.png">

- it matches the comments on the web
![RepliesOnWeb](https://user-images.githubusercontent.com/4083656/120048706-ab1d7480-bfcc-11eb-9064-f89fc738e61a.png)


- You can also take a look on the networking profiler 
<img width="1562" alt="ProfilerResponse" src="https://user-images.githubusercontent.com/4083656/120048600-5f6acb00-bfcc-11eb-96f9-02ace7fdb2f6.png">
|  |  |

# 📋 QA
- Go to any comment with replies, and check logcat on your environment, you should see the message showing the comment envelope content

# Story 📖

[NT-1953](https://kickstarter.atlassian.net/browse/NT-1953)
