### PR TITLE
NT-1977: UX – Not logged in / not backer for Comment Card

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
@@ -73,7 +73,7 @@ class CommentFactory {
                     )
                     .build(),
                 0,
-                    ProjectFactory.project().toBuilder().creator(UserFactory.creator().toBuilder().id(278438049).build()).build()
+                ProjectFactory.project().toBuilder().creator(UserFactory.creator().toBuilder().id(278438049).build()).build()
 
             )
         }

--- a/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
@@ -2,6 +2,7 @@ package com.kickstarter.mock.factories
 
 import com.kickstarter.models.Avatar
 import com.kickstarter.models.Comment
+import com.kickstarter.ui.data.CommentCardData
 import org.joda.time.DateTime
 
 class CommentFactory {
@@ -50,6 +51,31 @@ class CommentFactory {
                         .build()
                 )
                 .build()
+        }
+
+        fun liveCommentCardData(comment: String = "Some Comment", createdAt: DateTime): CommentCardData {
+            return CommentCardData(
+                    Comment.builder()
+                            .body(comment)
+                            .parentId(-1)
+                            .authorBadges(listOf())
+                            .createdAt(createdAt)
+                            .cursor("")
+                            .deleted(false)
+                            .id(-1)
+                            .repliesCount(0)
+                            .author(
+                                    UserFactory.user()
+                                            .toBuilder()
+                                            .id(1)
+                                            .avatar(AvatarFactory.avatar())
+                                            .build()
+                            )
+                            .build(),
+                    0,
+                    null
+
+            )
         }
     }
 }

--- a/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
@@ -2,6 +2,7 @@ package com.kickstarter.mock.factories
 
 import com.kickstarter.models.Avatar
 import com.kickstarter.models.Comment
+import com.kickstarter.models.User
 import com.kickstarter.ui.data.CommentCardData
 import org.joda.time.DateTime
 
@@ -53,25 +54,19 @@ class CommentFactory {
                 .build()
         }
 
-        fun liveCommentCardData(comment: String = "Some Comment", createdAt: DateTime): CommentCardData {
+        fun liveCommentCardData(comment: String = "Some Comment", createdAt: DateTime, currentUser: User): CommentCardData {
             return CommentCardData(
-                Comment.builder()
-                    .body(comment)
-                    .parentId(-1)
-                    .authorBadges(listOf())
-                    .createdAt(createdAt)
-                    .cursor("")
-                    .deleted(false)
-                    .id(-1)
-                    .repliesCount(0)
-                    .author(
-                        UserFactory.user()
-                            .toBuilder()
-                            .id(1)
-                            .avatar(AvatarFactory.avatar())
-                            .build()
-                    )
-                    .build(),
+                    Comment.builder()
+                            .body(comment)
+                            .parentId(-1)
+                            .authorBadges(listOf())
+                            .createdAt(createdAt)
+                            .cursor("")
+                            .deleted(false)
+                            .id(-1)
+                            .repliesCount(0)
+                            .author(currentUser)
+                            .build(),
                 0,
                 ProjectFactory.project().toBuilder().creator(UserFactory.creator().toBuilder().id(278438049).build()).build()
 

--- a/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
@@ -55,25 +55,25 @@ class CommentFactory {
 
         fun liveCommentCardData(comment: String = "Some Comment", createdAt: DateTime): CommentCardData {
             return CommentCardData(
-                    Comment.builder()
-                            .body(comment)
-                            .parentId(-1)
-                            .authorBadges(listOf())
-                            .createdAt(createdAt)
-                            .cursor("")
-                            .deleted(false)
-                            .id(-1)
-                            .repliesCount(0)
-                            .author(
-                                    UserFactory.user()
-                                            .toBuilder()
-                                            .id(1)
-                                            .avatar(AvatarFactory.avatar())
-                                            .build()
-                            )
-                            .build(),
-                    0,
-                    null
+                Comment.builder()
+                    .body(comment)
+                    .parentId(-1)
+                    .authorBadges(listOf())
+                    .createdAt(createdAt)
+                    .cursor("")
+                    .deleted(false)
+                    .id(-1)
+                    .repliesCount(0)
+                    .author(
+                        UserFactory.user()
+                            .toBuilder()
+                            .id(1)
+                            .avatar(AvatarFactory.avatar())
+                            .build()
+                    )
+                    .build(),
+                0,
+                null
 
             )
         }

--- a/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
@@ -56,17 +56,17 @@ class CommentFactory {
 
         fun liveCommentCardData(comment: String = "Some Comment", createdAt: DateTime, currentUser: User): CommentCardData {
             return CommentCardData(
-                    Comment.builder()
-                            .body(comment)
-                            .parentId(-1)
-                            .authorBadges(listOf())
-                            .createdAt(createdAt)
-                            .cursor("")
-                            .deleted(false)
-                            .id(-1)
-                            .repliesCount(0)
-                            .author(currentUser)
-                            .build(),
+                Comment.builder()
+                    .body(comment)
+                    .parentId(-1)
+                    .authorBadges(listOf())
+                    .createdAt(createdAt)
+                    .cursor("")
+                    .deleted(false)
+                    .id(-1)
+                    .repliesCount(0)
+                    .author(currentUser)
+                    .build(),
                 0,
                 ProjectFactory.project().toBuilder().creator(UserFactory.creator().toBuilder().id(278438049).build()).build()
 

--- a/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
@@ -73,7 +73,7 @@ class CommentFactory {
                     )
                     .build(),
                 0,
-                null
+                    ProjectFactory.project().toBuilder().creator(UserFactory.creator().toBuilder().id(278438049).build()).build()
 
             )
         }

--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -43,7 +43,7 @@ class CommentsActivity :
             .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
-                binding.commentComposer.isDisabledViewVisible(!it)
+                binding.commentComposer.showCommentComposerDisabledView(!it)
             }
 
         viewModel.outputs.showCommentComposer()

--- a/app/src/main/java/com/kickstarter/ui/adapters/CommentsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/CommentsAdapter.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import com.kickstarter.R
 import com.kickstarter.databinding.ItemCommentCardBinding
-import com.kickstarter.models.Comment
 import com.kickstarter.ui.data.CommentCardData
 import com.kickstarter.ui.viewholders.CommentCardViewHolder
 import com.kickstarter.ui.viewholders.EmptyCommentsViewHolder

--- a/app/src/main/java/com/kickstarter/ui/adapters/CommentsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/CommentsAdapter.kt
@@ -6,6 +6,7 @@ import androidx.annotation.LayoutRes
 import com.kickstarter.R
 import com.kickstarter.databinding.ItemCommentCardBinding
 import com.kickstarter.models.Comment
+import com.kickstarter.ui.data.CommentCardData
 import com.kickstarter.ui.viewholders.CommentCardViewHolder
 import com.kickstarter.ui.viewholders.EmptyCommentsViewHolder
 import com.kickstarter.ui.viewholders.KSViewHolder
@@ -21,7 +22,7 @@ class CommentsAdapter(private val delegate: Delegate) : KSAdapter() {
         return R.layout.item_comment_card
     }
 
-    fun takeData(comments: List<Comment>) {
+    fun takeData(comments: List<CommentCardData>) {
         setSection(SECTION_COMMENTS_VIEW, comments)
 
         notifyDataSetChanged()

--- a/app/src/main/java/com/kickstarter/ui/data/CommentCardData.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/CommentCardData.kt
@@ -7,22 +7,21 @@ import kotlinx.android.parcel.Parcelize
 
 @Parcelize
 class CommentCardData(
-        val comment: Comment?,
-        val commentCardState: Int,
-        val project: Project?
+    val comment: Comment?,
+    val commentCardState: Int,
+    val project: Project?
 ) : Parcelable {
 
     @Parcelize
     data class Builder(
-            var comment: Comment? = null,
-            var commentCardState: Int = 0,
-            var project: Project? = null
+        var comment: Comment? = null,
+        var commentCardState: Int = 0,
+        var project: Project? = null
     ) : Parcelable {
         fun comment(comment: Comment?) = apply { this.comment = comment }
         fun commentCardState(commentCardState: Int) = apply { this.commentCardState = commentCardState }
         fun project(project: Project?) = apply { this.project = project }
         fun build() = CommentCardData(comment, commentCardState, project)
-
     }
 
     companion object {
@@ -30,5 +29,4 @@ class CommentCardData(
     }
 
     fun toBuilder() = CommentCardData.Builder(this.comment, this.commentCardState, this.project)
-
 }

--- a/app/src/main/java/com/kickstarter/ui/data/CommentCardData.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/CommentCardData.kt
@@ -1,0 +1,34 @@
+package com.kickstarter.ui.data
+
+import android.os.Parcelable
+import com.kickstarter.models.Comment
+import com.kickstarter.models.Project
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+class CommentCardData(
+        val comment: Comment?,
+        val commentCardState: Int,
+        val project: Project?
+) : Parcelable {
+
+    @Parcelize
+    data class Builder(
+            var comment: Comment? = null,
+            var commentCardState: Int = 0,
+            var project: Project? = null
+    ) : Parcelable {
+        fun comment(comment: Comment?) = apply { this.comment = comment }
+        fun commentCardState(commentCardState: Int) = apply { this.commentCardState = commentCardState }
+        fun project(project: Project?) = apply { this.project = project }
+        fun build() = CommentCardData(comment, commentCardState, project)
+
+    }
+
+    companion object {
+        fun builder() = CommentCardData.Builder()
+    }
+
+    fun toBuilder() = CommentCardData.Builder(this.comment, this.commentCardState, this.project)
+
+}

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
@@ -5,6 +5,7 @@ import com.kickstarter.databinding.ItemCommentCardBinding
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.DateTimeUtils
 import com.kickstarter.models.Comment
+import com.kickstarter.ui.data.CommentCardData
 import com.kickstarter.ui.views.OnCommentCardClickedListener
 import com.kickstarter.viewmodels.CommentsViewHolderViewModel
 
@@ -44,6 +45,11 @@ class CommentCardViewHolder(
             .compose(bindToLifecycle())
             .compose(Transformers.observeForUI())
             .subscribe { binding.commentsCardView.setCommentCardStatus(it) }
+
+        this.vm.outputs.isActionGroupVisible()
+                .compose(bindToLifecycle())
+                .compose(Transformers.observeForUI())
+                .subscribe{ binding.commentsCardView.setActionGroupVisibility(it)}
 
         this.vm.outputs.commentPostTime()
             .compose(bindToLifecycle())
@@ -90,6 +96,6 @@ class CommentCardViewHolder(
     }
 
     override fun bindData(data: Any?) {
-        this.vm.inputs.configureWith(data as Comment)
+        this.vm.inputs.configureWith(data as CommentCardData)
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
@@ -49,7 +49,7 @@ class CommentCardViewHolder(
         this.vm.outputs.isCommentActionGroupVisible()
             .compose(bindToLifecycle())
             .compose(Transformers.observeForUI())
-            .subscribe{ binding.commentsCardView.setCommentActionGroupVisibility(it)}
+            .subscribe { binding.commentsCardView.setCommentActionGroupVisibility(it) }
 
         this.vm.outputs.commentPostTime()
             .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
@@ -46,10 +46,10 @@ class CommentCardViewHolder(
             .compose(Transformers.observeForUI())
             .subscribe { binding.commentsCardView.setCommentCardStatus(it) }
 
-        this.vm.outputs.isActionGroupVisible()
+        this.vm.outputs.isCommentActionGroupVisible()
                 .compose(bindToLifecycle())
                 .compose(Transformers.observeForUI())
-                .subscribe{ binding.commentsCardView.setActionGroupVisibility(it)}
+                .subscribe{ binding.commentsCardView.setCommentActionGroupVisibility(it)}
 
         this.vm.outputs.commentPostTime()
             .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
@@ -47,9 +47,9 @@ class CommentCardViewHolder(
             .subscribe { binding.commentsCardView.setCommentCardStatus(it) }
 
         this.vm.outputs.isCommentActionGroupVisible()
-                .compose(bindToLifecycle())
-                .compose(Transformers.observeForUI())
-                .subscribe{ binding.commentsCardView.setCommentActionGroupVisibility(it)}
+            .compose(bindToLifecycle())
+            .compose(Transformers.observeForUI())
+            .subscribe{ binding.commentsCardView.setCommentActionGroupVisibility(it)}
 
         this.vm.outputs.commentPostTime()
             .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
@@ -101,8 +101,8 @@ class CommentCard @JvmOverloads constructor(
         binding.commentDeletedMessageGroup.isVisible =
             cardCommentStatus == CommentCardStatus.DELETED_COMMENT
 
-        binding.commentBody.isVisible = cardCommentStatus == CommentCardStatus.COMMENT_WITH_REPLY ||
-            cardCommentStatus == CommentCardStatus.COMMENT_WITHOUT_REPLY
+        binding.commentBody.isVisible = cardCommentStatus == CommentCardStatus.COMMENT_WITH_REPLIES ||
+            cardCommentStatus == CommentCardStatus.COMMENT_WITHOUT_REPLIES
 
         binding.retryButton.isVisible =
             cardCommentStatus == CommentCardStatus.FAILED_TO_SEND_COMMENT
@@ -145,8 +145,8 @@ interface OnCommentCardClickedListener {
 }
 
 enum class CommentCardStatus(val commentCardStatus: Int) {
-    COMMENT_WITHOUT_REPLY(0), // comments without reply view
-    COMMENT_WITH_REPLY(1), // comments with reply view
+    COMMENT_WITHOUT_REPLIES(0), // comments without reply view
+    COMMENT_WITH_REPLIES(1), // comments with reply view
     FAILED_TO_SEND_COMMENT(2), // pending comment
     DELETED_COMMENT(3) // Deleted comment
 }

--- a/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
@@ -78,6 +78,11 @@ class CommentCard @JvmOverloads constructor(
             getString(R.styleable.CommentCardView_comment_card_user_name)?.also {
                 setCommentUserName(it)
             }
+
+            getBoolean(R.styleable.CommentCardView_is_comment_action_group_visible, true)?.also {
+                setActionGroupVisibility(it)
+            }
+
             getInt(R.styleable.CommentCardView_comment_card_status, 0).also { attrValue ->
                 CommentCardStatus.values().firstOrNull {
                     it.commentCardStatus == attrValue
@@ -88,15 +93,16 @@ class CommentCard @JvmOverloads constructor(
         }
     }
 
+    fun setActionGroupVisibility(isGroupVisble: Boolean) {
+        binding.commentActionGroup.isVisible = isGroupVisble
+    }
+
     fun setCommentCardStatus(cardCommentStatus: CommentCardStatus) {
         binding.commentDeletedMessageGroup.isVisible =
             cardCommentStatus == CommentCardStatus.DELETED_COMMENT
 
-        binding.commentBody.isVisible = cardCommentStatus == CommentCardStatus.COMMENT_WITH_REPLAY ||
-            cardCommentStatus == CommentCardStatus.COMMENT_WITHOUT_REPLAY
-
-        binding.commentActionGroup.isVisible = cardCommentStatus == CommentCardStatus.COMMENT_WITH_REPLAY ||
-            cardCommentStatus == CommentCardStatus.COMMENT_WITHOUT_REPLAY
+        binding.commentBody.isVisible = cardCommentStatus == CommentCardStatus.COMMENT_WITH_REPLY ||
+            cardCommentStatus == CommentCardStatus.COMMENT_WITHOUT_REPLY
 
         binding.retryButton.isVisible =
             cardCommentStatus == CommentCardStatus.FAILED_TO_SEND_COMMENT
@@ -139,8 +145,8 @@ interface OnCommentCardClickedListener {
 }
 
 enum class CommentCardStatus(val commentCardStatus: Int) {
-    COMMENT_WITHOUT_REPLAY(0), // comments without replay view
-    COMMENT_WITH_REPLAY(1), // comments with replay view
+    COMMENT_WITHOUT_REPLY(0), // comments without reply view
+    COMMENT_WITH_REPLY(1), // comments with reply view
     FAILED_TO_SEND_COMMENT(2), // pending comment
     DELETED_COMMENT(3) // Deleted comment
 }

--- a/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
@@ -80,7 +80,7 @@ class CommentCard @JvmOverloads constructor(
             }
 
             getBoolean(R.styleable.CommentCardView_is_comment_action_group_visible, true)?.also {
-                setActionGroupVisibility(it)
+                setCommentActionGroupVisibility(it)
             }
 
             getInt(R.styleable.CommentCardView_comment_card_status, 0).also { attrValue ->
@@ -93,7 +93,7 @@ class CommentCard @JvmOverloads constructor(
         }
     }
 
-    fun setActionGroupVisibility(isGroupVisble: Boolean) {
+    fun setCommentActionGroupVisibility(isGroupVisble: Boolean) {
         binding.commentActionGroup.isVisible = isGroupVisble
     }
 

--- a/app/src/main/java/com/kickstarter/ui/views/CommentComposerView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/CommentComposerView.kt
@@ -54,7 +54,7 @@ class CommentComposerView @JvmOverloads constructor(
                 setAvatarUrl(it)
             }
             getBoolean(R.styleable.CommentComposerView_composer_disabled, false).also {
-                isDisabledViewVisible(it)
+                showCommentComposerDisabledView(it)
             }
         }
     }
@@ -75,7 +75,7 @@ class CommentComposerView @JvmOverloads constructor(
         binding.commentTextComposer.hint = context.getString(hint)
     }
 
-    fun isDisabledViewVisible(isVisible: Boolean) {
+    fun showCommentComposerDisabledView(isVisible: Boolean) {
         binding.commentsDisableMsg.isVisible = isVisible
         binding.commentTextGroup.isVisible = !isVisible
         binding.commentActionButton.isVisible = !isVisible

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -51,7 +51,7 @@ interface CommentsViewHolderViewModel {
         fun commentPostTime(): Observable<DateTime>
 
         /** Emits the visibility of the comment card action group */
-        fun isActionGroupVisible(): Observable<Boolean>
+        fun isCommentActionGroupVisible(): Observable<Boolean>
 
         /** Emits the current [Comment] when Comment GuideLines clicked.. */
         fun openCommentGuideLines(): Observable<Comment>
@@ -74,7 +74,7 @@ interface CommentsViewHolderViewModel {
         private val onFlagButtonClicked = PublishSubject.create<Void>()
 
         private val commentCardStatus = BehaviorSubject.create<CommentCardStatus>()
-        private val isActionGroupVisible = BehaviorSubject.create<Boolean>()
+        private val isCommentActionGroupVisible = BehaviorSubject.create<Boolean>()
         private val commentAuthorName = BehaviorSubject.create<String>()
         private val commentAuthorAvatarUrl = BehaviorSubject.create<String>()
         private val commentMessageBody = BehaviorSubject.create<String>()
@@ -109,7 +109,7 @@ interface CommentsViewHolderViewModel {
                             project: Project -> project.isBacking ||
                             ProjectUtils.userIsCreator(project, it.second)
                         } ?: false
-                        this.isActionGroupVisible.onNext(isActionGroupVisibile)
+                        this.isCommentActionGroupVisible.onNext(isActionGroupVisibile)
                     }
 
             val comment = this.commentInput
@@ -181,7 +181,7 @@ interface CommentsViewHolderViewModel {
 
         override fun commentPostTime(): Observable<DateTime> = this.commentPostTime
 
-        override fun isActionGroupVisible(): Observable<Boolean> = this.isActionGroupVisible
+        override fun isCommentActionGroupVisible(): Observable<Boolean> = this.isCommentActionGroupVisible
 
         override fun openCommentGuideLines(): Observable<Comment> = openCommentGuideLines
 

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -101,7 +101,7 @@ interface CommentsViewHolderViewModel {
 
             val comment = this.commentInput
                 .map { it.comment }
-                .map{requireNotNull(it)}
+                .map { requireNotNull(it) }
 
             comment
                 .map { it.author()?.name() }
@@ -149,9 +149,9 @@ interface CommentsViewHolderViewModel {
         }
 
         private fun isActionGroupVisible(commentCardData: CommentCardData, user: User?) =
-                commentCardData.project?.let {
-                    it.isBacking || ProjectUtils.userIsCreator(it, user)
-                } ?: false
+            commentCardData.project?.let {
+                it.isBacking || ProjectUtils.userIsCreator(it, user)
+            } ?: false
 
         private fun cardStatus(comment: Comment?) = when {
             comment?.deleted() ?: false -> CommentCardStatus.DELETED_COMMENT

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -2,8 +2,13 @@ package com.kickstarter.viewmodels
 
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
+import com.kickstarter.libs.utils.ObjectUtils
+import com.kickstarter.libs.utils.ProjectUtils
 import com.kickstarter.models.Comment
+import com.kickstarter.models.Project
+import com.kickstarter.ui.data.CommentCardData
 import com.kickstarter.ui.viewholders.CommentCardViewHolder
 import com.kickstarter.ui.views.CommentCardStatus
 import org.joda.time.DateTime
@@ -26,7 +31,7 @@ interface CommentsViewHolderViewModel {
         fun onFlagButtonClicked()
 
         /** Configure the view model with the [Comment]. */
-        fun configureWith(comment: Comment)
+        fun configureWith(commentCardData: CommentCardData)
     }
 
     interface Outputs {
@@ -45,6 +50,9 @@ interface CommentsViewHolderViewModel {
         /** Emits the comment post time */
         fun commentPostTime(): Observable<DateTime>
 
+        /** Emits the visibility of the comment card action group */
+        fun isActionGroupVisible(): Observable<Boolean>
+
         /** Emits the current [Comment] when Comment GuideLines clicked.. */
         fun openCommentGuideLines(): Observable<Comment>
 
@@ -59,13 +67,14 @@ interface CommentsViewHolderViewModel {
     }
 
     class ViewModel(environment: Environment) : ActivityViewModel<CommentCardViewHolder>(environment), Inputs, Outputs {
-        private val commentInput = PublishSubject.create<Comment>()
+        private val commentInput = PublishSubject.create<CommentCardData>()
         private val onCommentGuideLinesClicked = PublishSubject.create<Void>()
         private val onRetryViewClicked = PublishSubject.create<Void>()
         private val onReplyButtonClicked = PublishSubject.create<Void>()
         private val onFlagButtonClicked = PublishSubject.create<Void>()
 
         private val commentCardStatus = BehaviorSubject.create<CommentCardStatus>()
+        private val isActionGroupVisible = BehaviorSubject.create<Boolean>()
         private val commentAuthorName = BehaviorSubject.create<String>()
         private val commentAuthorAvatarUrl = BehaviorSubject.create<String>()
         private val commentMessageBody = BehaviorSubject.create<String>()
@@ -80,58 +89,79 @@ interface CommentsViewHolderViewModel {
 
         init {
             this.commentInput
+                    .map { it.comment }
+                    .filter { ObjectUtils.isNotNull(it) }
                 .compose(bindToLifecycle())
                 .subscribe {
                     val cardStatus = when {
-                        it.deleted() -> CommentCardStatus.DELETED_COMMENT
-                        (it.repliesCount() != 0) -> CommentCardStatus.COMMENT_WITH_REPLAY
-                        else -> CommentCardStatus.COMMENT_WITHOUT_REPLAY
+                        it?.deleted() ?: false -> CommentCardStatus.DELETED_COMMENT
+                        (it?.repliesCount() ?: false != 0) -> CommentCardStatus.COMMENT_WITH_REPLY
+                        else -> CommentCardStatus.COMMENT_WITHOUT_REPLY
                     }
                     this.commentCardStatus.onNext(cardStatus)
                 }
 
             this.commentInput
-                .map { it.author().name() }
+                    .compose(Transformers.combineLatestPair(environment.currentUser().observable()))
+                    .compose(bindToLifecycle())
+                    .subscribe {
+                        val isActionGroupVisibile = it.first.project?.let {
+                            project: Project -> project.isBacking ||
+                            ProjectUtils.userIsCreator(project, it.second)
+                        } ?: false
+                        this.isActionGroupVisible.onNext(isActionGroupVisibile)
+                    }
+
+            val comment = this.commentInput
+                    .map { it.comment }
+                    .map{requireNotNull(it)}
+
+            comment
+                .map { it.author()?.name() }
+                .filter { ObjectUtils.isNotNull(it) }
                 .compose(bindToLifecycle())
                 .subscribe(this.commentAuthorName)
 
-            this.commentInput
-                .map { it.author().avatar().medium() }
-                .compose(bindToLifecycle())
+            comment
+                .map { it.author()?.avatar()?.medium() }
+                    .filter { ObjectUtils.isNotNull(it) }
+                    .compose(bindToLifecycle())
                 .subscribe(this.commentAuthorAvatarUrl)
 
-            this.commentInput
+            comment
                 .map { it.body() }
-                .compose(bindToLifecycle())
+                    .filter { ObjectUtils.isNotNull(it) }
+                    .compose(bindToLifecycle())
                 .subscribe(this.commentMessageBody)
 
-            this.commentInput
+            comment
                 .map { it.createdAt() }
-                .compose(bindToLifecycle())
+                    .filter { ObjectUtils.isNotNull(it) }
+                    .compose(bindToLifecycle())
                 .subscribe(this.commentPostTime)
 
-            this.commentInput
+            comment
                 .compose(takeWhen(this.onCommentGuideLinesClicked))
                 .compose(bindToLifecycle())
                 .subscribe(this.openCommentGuideLines)
 
-            this.commentInput
+            comment
                 .compose(takeWhen(this.onReplyButtonClicked))
                 .compose(bindToLifecycle())
                 .subscribe(this.replyToComment)
 
-            this.commentInput
+            comment
                 .compose(takeWhen(this.onRetryViewClicked))
                 .compose(bindToLifecycle())
                 .subscribe(this.retrySendComment)
 
-            this.commentInput
+            comment
                 .compose(takeWhen(this.onFlagButtonClicked))
                 .compose(bindToLifecycle())
                 .subscribe(this.flagComment)
         }
 
-        override fun configureWith(comment: Comment) = this.commentInput.onNext(comment)
+        override fun configureWith(commentCardData: CommentCardData) = this.commentInput.onNext(commentCardData)
 
         override fun onCommentGuideLinesClicked() = this.onCommentGuideLinesClicked.onNext(null)
 
@@ -150,6 +180,8 @@ interface CommentsViewHolderViewModel {
         override fun commentMessageBody(): Observable<String> = this.commentMessageBody
 
         override fun commentPostTime(): Observable<DateTime> = this.commentPostTime
+
+        override fun isActionGroupVisible(): Observable<Boolean> = this.isActionGroupVisible
 
         override fun openCommentGuideLines(): Observable<Comment> = openCommentGuideLines
 

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -101,6 +101,7 @@ interface CommentsViewHolderViewModel {
 
             val comment = this.commentInput
                 .map { it.comment }
+                .filter { ObjectUtils.isNotNull(it) }
                 .map { requireNotNull(it) }
 
             comment

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -123,7 +123,8 @@ interface CommentsViewModel {
                 .compose<Pair<CommentEnvelope, Project?>>(combineLatestPair(initialProject))
                 .map<Pair<List<CommentCardData>, Int>> {
                     val commentCardDataList: List<CommentCardData>? = it.first.comments?.map {
-                        comment: Comment -> CommentCardData.builder().comment(comment).project(it.second).build()
+                        comment: Comment ->
+                        CommentCardData.builder().comment(comment).project(it.second).build()
                     }
                     Pair.create(commentCardDataList, it.first.totalCount)
                 }

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -230,12 +230,10 @@ interface CommentsViewModel {
                 )
         }
 
-        private fun mapToCommentCardDataList(it: Pair<CommentEnvelope, Project?>): Pair<List<CommentCardData>, Int>? {
-            val commentCardDataList: List<CommentCardData>? = it.first.comments?.map { comment: Comment ->
+        private fun mapToCommentCardDataList(it: Pair<CommentEnvelope, Project?>) =
+            it.first.comments?.map { comment: Comment ->
                 CommentCardData.builder().comment(comment).project(it.second).build()
             }
-            return Pair.create(commentCardDataList, it.first.totalCount)
-        }
 
         private fun buildCommentBody(it: Pair<User, Pair<String, DateTime>>): Comment? {
             return Comment.builder()
@@ -269,9 +267,7 @@ interface CommentsViewModel {
                 }
                     .filter { ObjectUtils.isNotNull(it) }
                     .compose<Pair<CommentEnvelope, Project?>>(combineLatestPair(initialProject))
-                    .map {
-                        mapToCommentCardDataList(it)
-                    }
+                    .map { Pair(mapToCommentCardDataList(it), it.first.totalCount) }
             }
         }
 

--- a/app/src/main/res/layout/activity_comments_layout.xml
+++ b/app/src/main/res/layout/activity_comments_layout.xml
@@ -82,6 +82,14 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 
+        <com.kickstarter.ui.views.CommentComposerView
+            android:id="@+id/comment_composer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:composer_disabled="false"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
         <View
             android:id="@+id/separtor"
             android:layout_width="0dp"
@@ -90,14 +98,6 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@+id/comment_composer" />
-
-        <com.kickstarter.ui.views.CommentComposerView
-            android:id="@+id/comment_composer"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:composer_disabled="false"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -20,5 +20,6 @@
     <attr name="comment_card_post_time" format="string" />
     <attr name="comment_card_message" format="string" />
     <attr name="comment_card_avatar_url" format="string" />
+    <attr name="is_comment_action_group_visible" format="boolean" />
   </declare-styleable>
 </resources>

--- a/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
@@ -69,7 +69,7 @@ class CommentCardTest : KSRobolectricTestCase() {
 
     @Test
     fun setCommentActionGroupVisibility_whenFalse_setToInvisible() {
-        commentCard.setActionGroupVisibility(false)
+        commentCard.setCommentActionGroupVisibility(false)
         assertTrue(commentBody.isVisible)
         assertFalse(commentActionGroup.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
@@ -78,7 +78,7 @@ class CommentCardTest : KSRobolectricTestCase() {
 
     @Test
     fun setCommentActionGroupVisibility_whenTrue_setToInvisible() {
-        commentCard.setActionGroupVisibility(true)
+        commentCard.setCommentActionGroupVisibility(true)
         assertTrue(commentBody.isVisible)
         assertTrue(commentActionGroup.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)

--- a/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
@@ -51,7 +51,7 @@ class CommentCardTest : KSRobolectricTestCase() {
 
     @Test
     fun testCommentWithoutReplyStatus() {
-        commentCard.setCommentCardStatus(CommentCardStatus.COMMENT_WITHOUT_REPLY)
+        commentCard.setCommentCardStatus(CommentCardStatus.COMMENT_WITHOUT_REPLIES)
         assertTrue(commentBody.isVisible)
         assertTrue(commentActionGroup.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
@@ -60,7 +60,7 @@ class CommentCardTest : KSRobolectricTestCase() {
 
     @Test
     fun testCommentWithReplyStatus() {
-        commentCard.setCommentCardStatus(CommentCardStatus.COMMENT_WITH_REPLY)
+        commentCard.setCommentCardStatus(CommentCardStatus.COMMENT_WITH_REPLIES)
         assertTrue(commentBody.isVisible)
         assertTrue(commentActionGroup.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)

--- a/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
@@ -36,7 +36,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         commentCard.setCommentCardStatus(CommentCardStatus.DELETED_COMMENT)
         assertFalse(commentBody.isVisible)
         assertFalse(retryButton.isVisible)
-        assertFalse(commentActionGroup.isVisible)
+        assertTrue(commentActionGroup.isVisible)
         assertTrue(commentDeletedMessageGroup.isVisible)
     }
 
@@ -45,13 +45,13 @@ class CommentCardTest : KSRobolectricTestCase() {
         commentCard.setCommentCardStatus(CommentCardStatus.FAILED_TO_SEND_COMMENT)
         assertFalse(commentBody.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
-        assertFalse(commentActionGroup.isVisible)
+        assertTrue(commentActionGroup.isVisible)
         assertTrue(retryButton.isVisible)
     }
 
     @Test
     fun testCommentWithoutReplyStatus() {
-        commentCard.setCommentCardStatus(CommentCardStatus.COMMENT_WITHOUT_REPLAY)
+        commentCard.setCommentCardStatus(CommentCardStatus.COMMENT_WITHOUT_REPLY)
         assertTrue(commentBody.isVisible)
         assertTrue(commentActionGroup.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
@@ -60,7 +60,25 @@ class CommentCardTest : KSRobolectricTestCase() {
 
     @Test
     fun testCommentWithReplyStatus() {
-        commentCard.setCommentCardStatus(CommentCardStatus.COMMENT_WITH_REPLAY)
+        commentCard.setCommentCardStatus(CommentCardStatus.COMMENT_WITH_REPLY)
+        assertTrue(commentBody.isVisible)
+        assertTrue(commentActionGroup.isVisible)
+        assertFalse(commentDeletedMessageGroup.isVisible)
+        assertFalse(retryButton.isVisible)
+    }
+
+    @Test
+    fun setCommentActionGroupVisibility_whenFalse_setToInvisible() {
+        commentCard.setActionGroupVisibility(false)
+        assertTrue(commentBody.isVisible)
+        assertFalse(commentActionGroup.isVisible)
+        assertFalse(commentDeletedMessageGroup.isVisible)
+        assertFalse(retryButton.isVisible)
+    }
+
+    @Test
+    fun setCommentActionGroupVisibility_whenTrue_setToInvisible() {
+        commentCard.setActionGroupVisibility(true)
         assertTrue(commentBody.isVisible)
         assertTrue(commentActionGroup.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
@@ -100,7 +100,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(commentCardData)
 
         this.commentAuthorAvatarUrl.assertValue(userAvatar.medium())
-        this.commentCardStatus.assertValue(CommentCardStatus.COMMENT_WITHOUT_REPLY)
+        this.commentCardStatus.assertValue(CommentCardStatus.COMMENT_WITHOUT_REPLIES)
     }
 
     @Test
@@ -111,7 +111,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(commentCardData)
 
         this.commentAuthorName.assertValue(comment.author().name())
-        this.commentCardStatus.assertValue(CommentCardStatus.COMMENT_WITHOUT_REPLY)
+        this.commentCardStatus.assertValue(CommentCardStatus.COMMENT_WITHOUT_REPLIES)
     }
 
     @Test
@@ -122,7 +122,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(commentCardData)
 
         this.commentMessageBody.assertValue(comment.body())
-        this.commentCardStatus.assertValue(CommentCardStatus.COMMENT_WITHOUT_REPLY)
+        this.commentCardStatus.assertValue(CommentCardStatus.COMMENT_WITHOUT_REPLIES)
     }
 
     @Test
@@ -151,7 +151,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
         val comment = CommentFactory.comment()
         val commentCardData = CommentCardData.builder().comment(comment).build()
         this.vm.inputs.configureWith(commentCardData)
-        this.commentCardStatus.assertValue(CommentCardStatus.COMMENT_WITHOUT_REPLY)
+        this.commentCardStatus.assertValue(CommentCardStatus.COMMENT_WITHOUT_REPLIES)
     }
 
     @Test
@@ -160,7 +160,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
         val updatedComment = CommentFactory.comment(repliesCount = 10)
         val commentCardData = CommentCardData.builder().comment(updatedComment).build()
         this.vm.inputs.configureWith(commentCardData)
-        this.commentCardStatus.assertValue(CommentCardStatus.COMMENT_WITH_REPLY)
+        this.commentCardStatus.assertValue(CommentCardStatus.COMMENT_WITH_REPLIES)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
@@ -199,5 +199,4 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(commentCardData)
         this.isActionGroupVisible.assertValue(true)
     }
-
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
@@ -37,7 +37,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.commentAuthorAvatarUrl().subscribe(this.commentAuthorAvatarUrl)
         this.vm.outputs.commentMessageBody().subscribe(this.commentMessageBody)
         this.vm.outputs.commentPostTime().subscribe(this.commentPostTime)
-        this.vm.outputs.isActionGroupVisible().subscribe(this.isActionGroupVisible)
+        this.vm.outputs.isCommentActionGroupVisible().subscribe(this.isActionGroupVisible)
         this.vm.outputs.openCommentGuideLines().subscribe(this.openCommentGuideLines)
         this.vm.outputs.retrySendComment().subscribe(this.retrySendComment)
         this.vm.outputs.replyToComment().subscribe(this.replyToComment)

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -29,8 +29,8 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     private val isLoadingMoreItems = TestSubscriber<Boolean>()
     private val isRefreshing = TestSubscriber<Boolean>()
     private val enablePagination = TestSubscriber<Boolean>()
-    private val commentSubscriber = TestSubscriber<CommentCardData>()
-    private val commentPostedSubscriber = TestSubscriber<CommentCardData>()
+    private val commentSubscriber = BehaviorSubject.create<CommentCardData>()
+    private val commentPostedSubscriber = BehaviorSubject.create<CommentCardData>()
 
     @Test
     fun testCommentsViewModel_showCommentComposer_isLogInUser() {
@@ -287,8 +287,8 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         // post a comment
         vm.inputs.postComment("Some Comment", createdAt)
 
-        commentPostedSubscriber.assertValue(CommentFactory.liveCommentCardData(createdAt = createdAt))
-        commentSubscriber.assertValue(CommentFactory.liveCommentCardData(createdAt = createdAt))
+        assertEquals(CommentFactory.liveCommentCardData(createdAt = createdAt, currentUser = currentUser).comment, commentPostedSubscriber.value.comment)
+        assertEquals(CommentFactory.liveCommentCardData(createdAt = createdAt, currentUser = currentUser).comment, commentSubscriber.value.comment)
     }
 
     @Test
@@ -318,7 +318,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         // post a comment
         vm.inputs.postComment("Some Comment", createdAt)
 
-        commentPostedSubscriber.assertValue(CommentFactory.liveCommentCardData(createdAt = createdAt))
-        commentSubscriber.assertValue(CommentFactory.liveCommentCardData(createdAt = createdAt))
+        assertEquals(CommentFactory.liveCommentCardData(createdAt = createdAt, currentUser = currentUser).comment, commentPostedSubscriber.value.comment)
+        assertEquals(CommentFactory.liveCommentCardData(createdAt = createdAt, currentUser = currentUser).comment, commentSubscriber.value.comment)
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -36,9 +36,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testCommentsViewModel_showCommentComposer_isLogoutUser() {
-        val vm = CommentsViewModel.ViewModel(
-            environment().toBuilder().build()
-        )
+        val vm = CommentsViewModel.ViewModel(environment())
 
         vm.outputs.enableCommentComposer().subscribe(enableCommentComposer)
         vm.outputs.showCommentComposer().subscribe(showCommentComposer)

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -3,7 +3,12 @@ package com.kickstarter.viewmodels
 import android.content.Intent
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.MockCurrentUser
-import com.kickstarter.mock.factories.*
+import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.mock.factories.AvatarFactory
+import com.kickstarter.mock.factories.UpdateFactory
+import com.kickstarter.mock.factories.CommentEnvelopeFactory
+import com.kickstarter.mock.factories.CommentFactory
 import com.kickstarter.mock.services.MockApolloClient
 import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope
 import com.kickstarter.ui.IntentKey

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -3,13 +3,14 @@ package com.kickstarter.viewmodels
 import android.content.Intent
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.MockCurrentUser
-import com.kickstarter.mock.factories.UserFactory
-import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.AvatarFactory
-import com.kickstarter.mock.factories.UpdateFactory
 import com.kickstarter.mock.factories.CommentEnvelopeFactory
 import com.kickstarter.mock.factories.CommentFactory
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.mock.factories.UpdateFactory
+import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClient
+import com.kickstarter.models.Comment
 import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope
 import com.kickstarter.services.mutations.PostCommentData
 import com.kickstarter.ui.IntentKey
@@ -286,8 +287,8 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         // post a comment
         vm.inputs.postComment("Some Comment", createdAt)
 
-        commentPostedSubscriber.assertValue(CommentFactory.liveComment(createdAt = createdAt))
-        commentSubscriber.assertValue(CommentFactory.liveComment(createdAt = createdAt))
+        commentPostedSubscriber.assertValue(CommentFactory.liveCommentCardData(createdAt = createdAt))
+        commentSubscriber.assertValue(CommentFactory.liveCommentCardData(createdAt = createdAt))
     }
 
     @Test
@@ -317,7 +318,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         // post a comment
         vm.inputs.postComment("Some Comment", createdAt)
 
-        commentPostedSubscriber.assertValue(CommentFactory.liveComment(createdAt = createdAt))
-        commentSubscriber.assertValue(CommentFactory.liveComment(createdAt = createdAt))
+        commentPostedSubscriber.assertValue(CommentFactory.liveCommentCardData(createdAt = createdAt))
+        commentSubscriber.assertValue(CommentFactory.liveCommentCardData(createdAt = createdAt))
     }
 }


### PR DESCRIPTION
# 📲 What

We want to disable the reply/comment card action buttons in different user states i.e. logged in or out, backing or not backing, etc.
I also renamed a few variables to be clearer and extracted some functionality into individual methods, for readability and all that good stuff 😄 

# 🤔 Why

- The reply option should only show if the user is logged in and has backed the project, or if they are the project creator. 
- A user should not be able to reply to projects if they are not logged in, or if they are logged in but have not backed the project or they are not the creator. 

# 🛠 How

- Created a new `CommentCardData` model that holds the `comment`, the `project` the comment is from, and the state of the card (for future use when replying, errored, etc).
- We then transform the list of comments returned in the network call to a list of `CommentCardData`, which is passed to the adapter and eventually the `CommentsViewHolderViewModel`
- The `CommentsViewHolderViewModel` view model then performs a check when initialized that returns true or false depending on if the user should see the reply button. This boolean is passed to the `CommentViewModel`, which toggles the visibility of the action group on the comment card, which holds the reply button as well as the flag comment button.

# 👀 See

No reply/action buttons: Logged out and logged in and NOT backing, respectively:
![Screenshot_1622590680](https://user-images.githubusercontent.com/19390326/120403679-af21fd00-c312-11eb-9171-4e07534e55ae.png) ![Screenshot_1622591284](https://user-images.githubusercontent.com/19390326/120403680-af21fd00-c312-11eb-8fe9-528ab5d71ff7.png) 

Reply/Action buttons visible: Logged in and backing
![Screenshot_1622591300](https://user-images.githubusercontent.com/19390326/120403681-af21fd00-c312-11eb-916d-65746a2fa7bb.png)

# 📋 QA
Make sure you have a project that you are not backing, a project that you are backing, and a project that you created, and all projects must have comments. Then test the different states listed below.

⛔ = no reply or action buttons
✅  = reply and action buttons visible

These are the different states to test:
Logged out = ⛔
Logged in and not backing = ⛔ 
Logged in and backing = ✅ 
Logged in and creator = ✅ 

# Story 📖

[NT-1977: UX – Not logged in / not backer for Comment Card](https://kickstarter.atlassian.net/browse/NT-1977)
