### PR TITLE
NT-1910: UX – Not logged in / Not backer for Comment Composer

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -49,18 +49,18 @@ class CommentsActivity :
                 binding.commentComposer.setAvatarUrl(it)
             }
 
-        viewModel.outputs.enableCommentComposer()
+        viewModel.outputs.commentComposerStatus()
             .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
-                binding.commentComposer.showCommentComposerDisabledView(!it)
+                binding.commentComposer.setCommentComposerStatus(it)
             }
 
         viewModel.outputs.showCommentComposer()
             .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
-                binding.commentComposer.isVisible = true
+                binding.commentComposer.isVisible = it
             }
 
         viewModel.outputs.setEmptyState()

--- a/app/src/main/java/com/kickstarter/ui/views/CommentComposerView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/CommentComposerView.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import androidx.annotation.StringRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.withStyledAttributes
+import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import com.kickstarter.R
@@ -54,7 +55,7 @@ class CommentComposerView @JvmOverloads constructor(
                 setAvatarUrl(it)
             }
             getBoolean(R.styleable.CommentComposerView_composer_disabled, false).also {
-                showCommentComposerDisabledView(it)
+                showCommentComposerDisabledView()
             }
         }
     }
@@ -79,10 +80,32 @@ class CommentComposerView @JvmOverloads constructor(
         binding.commentTextComposer.hint = context.getString(hint)
     }
 
-    fun showCommentComposerDisabledView(isVisible: Boolean) {
-        binding.commentsDisableMsg.isVisible = isVisible
-        binding.commentTextGroup.isVisible = !isVisible
-        binding.commentActionButton.isVisible = !isVisible
+    fun setCommentComposerStatus(commentComposerStatus: CommentComposerStatus) {
+        when (commentComposerStatus) {
+            CommentComposerStatus.ENABLED -> showCommentComposerEnabledView()
+            CommentComposerStatus.DISABLED -> showCommentComposerDisabledView()
+            CommentComposerStatus.GONE -> hideCommentComposer()
+        }
+    }
+
+    fun showCommentComposerDisabledView() {
+        binding.separtor.isVisible = true
+        binding.commentsDisableMsg.isVisible = true
+        binding.commentTextGroup.isVisible = false
+        binding.commentActionButton.isVisible = false
+    }
+
+    fun showCommentComposerEnabledView() {
+        binding.separtor.isVisible = true
+        binding.commentsDisableMsg.isVisible = false
+        binding.commentTextGroup.isVisible = true
+        binding.commentActionButton.isVisible = true
+    }
+
+    fun hideCommentComposer() {
+        binding.commentsDisableMsg.isGone = true
+        binding.commentTextGroup.isGone = true
+        binding.commentActionButton.isGone = true
     }
 
     fun setCommentComposerActionClickListener(onCommentComposerViewClickedListener: OnCommentComposerViewClickedListener?) {
@@ -96,4 +119,10 @@ class CommentComposerView @JvmOverloads constructor(
 
 interface OnCommentComposerViewClickedListener {
     fun onClickActionListener(string: String)
+}
+
+enum class CommentComposerStatus(val commentComposerStatus: Int) {
+    ENABLED(0), // Visible and interactable
+    DISABLED(1), // Visible and not interactable
+    GONE(2) // Entire view is completely gone
 }

--- a/app/src/main/java/com/kickstarter/ui/views/CommentComposerView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/CommentComposerView.kt
@@ -88,21 +88,21 @@ class CommentComposerView @JvmOverloads constructor(
         }
     }
 
-    fun showCommentComposerDisabledView() {
+    private fun showCommentComposerDisabledView() {
         binding.separtor.isVisible = true
         binding.commentsDisableMsg.isVisible = true
         binding.commentTextGroup.isVisible = false
         binding.commentActionButton.isVisible = false
     }
 
-    fun showCommentComposerEnabledView() {
+    private fun showCommentComposerEnabledView() {
         binding.separtor.isVisible = true
         binding.commentsDisableMsg.isVisible = false
         binding.commentTextGroup.isVisible = true
         binding.commentActionButton.isVisible = true
     }
 
-    fun hideCommentComposer() {
+    private fun hideCommentComposer() {
         binding.commentsDisableMsg.isGone = true
         binding.commentTextGroup.isGone = true
         binding.commentActionButton.isGone = true

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -23,7 +23,7 @@ import com.kickstarter.services.mutations.PostCommentData
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.CommentsActivity
 import com.kickstarter.ui.data.CommentCardData
-import com.kickstarter.ui.data.ProjectData
+import com.kickstarter.ui.views.CommentComposerStatus
 import org.joda.time.DateTime
 import rx.Observable
 import rx.subjects.BehaviorSubject
@@ -39,9 +39,9 @@ interface CommentsViewModel {
 
     interface Outputs : PaginatedViewModelOutput<CommentCardData> {
         fun currentUserAvatar(): Observable<String?>
-        fun enableCommentComposer(): Observable<Boolean>
+        fun commentComposerStatus(): Observable<CommentComposerStatus>
         fun enableReplyButton(): Observable<Boolean>
-        fun showCommentComposer(): Observable<Void>
+        fun showCommentComposer(): Observable<Boolean>
         fun commentsList(): Observable<List<CommentCardData>>
         fun setEmptyState(): Observable<Boolean>
         fun insertComment(): Observable<CommentCardData>
@@ -60,8 +60,8 @@ interface CommentsViewModel {
         private val nextPage = PublishSubject.create<Void>()
 
         private val currentUserAvatar = BehaviorSubject.create<String?>()
-        private val enableCommentComposer = BehaviorSubject.create<Boolean>()
-        private val showCommentComposer = BehaviorSubject.create<Void>()
+        private val commentComposerStatus = BehaviorSubject.create<CommentComposerStatus>()
+        private val showCommentComposer = BehaviorSubject.create<Boolean>()
         private val commentsList = BehaviorSubject.create<List<CommentCardData>?>()
         private val disableReplyButton = BehaviorSubject.create<Boolean>()
 
@@ -92,15 +92,7 @@ interface CommentsViewModel {
             loggedInUser
                 .compose(bindToLifecycle())
                 .subscribe {
-                    showCommentComposer.onNext(null)
-                }
-
-            intent()
-                .map { it.getParcelableExtra(IntentKey.PROJECT_DATA) as ProjectData? }
-                .ofType(ProjectData::class.java)
-                .compose(bindToLifecycle())
-                .subscribe {
-                    enableCommentComposer.onNext(isProjectBackedOrUserIsCreator(Pair(it.project(), it.user())))
+                    showCommentComposer.onNext(true)
                 }
 
             val projectOrUpdate = intent()
@@ -125,16 +117,13 @@ interface CommentsViewModel {
             }.map { requireNotNull(it) }
                 .share()
 
-            Observable.combineLatest(
-                loggedInUser,
-                initialProject
-            ) { a: User?, b: Project ->
-                Pair.create(a, b)
-            }.compose(bindToLifecycle())
+            initialProject
+                .compose(combineLatestPair(currentUser.observable()))
+                .compose(bindToLifecycle())
                 .subscribe {
-                    it.second?.let { project ->
-                        enableCommentComposer.onNext(isProjectBackedOrUserIsCreator(Pair(project, it.first)))
-                    }
+                    val composerStatus = getCommentComposerStatus(Pair(it.first, it.second))
+                    showCommentComposer.onNext(composerStatus != CommentComposerStatus.GONE)
+                    commentComposerStatus.onNext(composerStatus)
                 }
 
             val projectSlug = initialProject
@@ -272,15 +261,19 @@ interface CommentsViewModel {
             }
         }
 
-        private fun isProjectBackedOrUserIsCreator(pair: Pair<Project, User?>) =
-            pair.first.isBacking || ProjectUtils.userIsCreator(pair.first, pair.second)
+        private fun getCommentComposerStatus(projectAndUser: Pair<Project, User?>) =
+            when {
+                projectAndUser.second == null -> CommentComposerStatus.GONE
+                projectAndUser.first.isBacking || ProjectUtils.userIsCreator(projectAndUser.first, projectAndUser.second) -> CommentComposerStatus.ENABLED
+                else -> CommentComposerStatus.DISABLED
+            }
 
         override fun refresh() = refresh.onNext(null)
         override fun nextPage() = nextPage.onNext(null)
 
         override fun currentUserAvatar(): Observable<String?> = currentUserAvatar
-        override fun enableCommentComposer(): Observable<Boolean> = enableCommentComposer
-        override fun showCommentComposer(): Observable<Void> = showCommentComposer
+        override fun commentComposerStatus(): Observable<CommentComposerStatus> = commentComposerStatus
+        override fun showCommentComposer(): Observable<Boolean> = showCommentComposer
         override fun commentsList(): Observable<List<CommentCardData>> = commentsList
         override fun enableReplyButton(): Observable<Boolean> = disableReplyButton
 

--- a/app/src/main/res/layout/activity_comments_layout.xml
+++ b/app/src/main/res/layout/activity_comments_layout.xml
@@ -74,6 +74,7 @@
                 tools:listitem="@layout/comment_card" />
 
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
         <ProgressBar
             android:id="@+id/comments_loading_indicator"
             android:layout_width="match_parent"
@@ -90,19 +91,5 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <View
-            android:id="@+id/separtor"
-            android:layout_width="0dp"
-            android:layout_height="1dp"
-            android:background="@color/kds_support_200"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/comment_composer" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
-
-
-

--- a/app/src/main/res/layout/comment_composer_view.xml
+++ b/app/src/main/res/layout/comment_composer_view.xml
@@ -5,23 +5,37 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/white"
-    android:padding="@dimen/grid_3">
+    android:background="@color/white">
+
+    <View
+        android:id="@+id/separtor"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:background="@color/kds_support_200"
+        android:layout_marginBottom="@dimen/grid_3"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView
         android:id="@+id/avatar"
         android:layout_width="@dimen/comments_feed_avatar_width"
         android:layout_height="@dimen/comments_feed_avatar_height"
         android:layout_alignParentStart="true"
+        app:layout_constraintTop_toBottomOf="@id/separtor"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        tools:ignore="ContentDescription" />
+        tools:ignore="ContentDescription"
+        android:layout_marginTop="@dimen/grid_3"
+        android:layout_marginStart="@dimen/grid_3"
+        android:layout_marginBottom="@dimen/grid_3"/>
 
     <View
         android:id="@+id/editTextTextBackground"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginStart="@dimen/grid_2"
+        android:layout_marginEnd="@dimen/grid_3"
         android:background="@drawable/border_rounded_soft_grey_50"
         app:layout_constraintBottom_toBottomOf="@+id/comment_text_composer"
         app:layout_constraintEnd_toEndOf="parent"
@@ -43,7 +57,8 @@
         android:enabled="false"
         android:text="@string/post"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="@id/comment_text_composer"
+        app:layout_constraintBottom_toBottomOf="@id/comment_text_composer"
         app:layout_constraintEnd_toEndOf="@+id/editTextTextBackground"
         app:layout_constraintStart_toEndOf="@+id/comment_text_composer" />
 
@@ -58,6 +73,9 @@
         style="@style/CommentsDisabledMessageTextView"
         android:text="@string/only_backers_can_leave_comments"
         android:visibility="gone"
+        android:layout_marginTop="@dimen/grid_3"
+        android:layout_marginStart="@dimen/grid_2"
+        android:layout_marginBottom="@dimen/grid_3"
         app:layout_constraintBottom_toBottomOf="@id/avatar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/avatar"

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -59,7 +59,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         // Start the view model with a backed project.
         vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
-        // The comment composer should be hidden and disabled to write comments as no user login -ed
+        // The comment composer should be hidden and disabled to write comments as no user logged-in
         showCommentComposer.assertValue(false)
         commentComposerStatus.assertValue(CommentComposerStatus.GONE)
     }
@@ -75,7 +75,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         // Start the view model with a backed project.
         vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
-        // The comment composer enabled to write comments
+        // The comment composer should show but in disabled state
         commentComposerStatus.assertValue(CommentComposerStatus.DISABLED)
         showCommentComposer.assertValues(true, true)
     }

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -15,6 +15,7 @@ import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope
 import com.kickstarter.services.mutations.PostCommentData
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.data.CommentCardData
+import com.kickstarter.ui.views.CommentComposerStatus
 import org.joda.time.DateTime
 import org.junit.Test
 import rx.Observable
@@ -23,8 +24,8 @@ import rx.subjects.BehaviorSubject
 
 class CommentsViewModelTest : KSRobolectricTestCase() {
     private val commentsList = TestSubscriber<List<CommentCardData>?>()
-    private val enableCommentComposer = TestSubscriber<Boolean>()
-    private val showCommentComposer = TestSubscriber<Void>()
+    private val commentComposerStatus = TestSubscriber<CommentComposerStatus>()
+    private val showCommentComposer = TestSubscriber<Boolean>()
     private val showEmptyState = TestSubscriber<Boolean>()
     private val isLoadingMoreItems = TestSubscriber<Boolean>()
     private val isRefreshing = TestSubscriber<Boolean>()
@@ -33,53 +34,54 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     private val commentPostedSubscriber = BehaviorSubject.create<CommentCardData>()
 
     @Test
-    fun testCommentsViewModel_showCommentComposer_isLogInUser() {
+    fun testCommentsViewModel_whenUserLoggedInAndBacking_shouldShowEnabledComposer() {
         val vm = CommentsViewModel.ViewModel(
             environment().toBuilder().currentUser(MockCurrentUser(UserFactory.user())).build()
         )
-        vm.outputs.enableCommentComposer().subscribe(enableCommentComposer)
+        vm.outputs.commentComposerStatus().subscribe(commentComposerStatus)
         vm.outputs.showCommentComposer().subscribe(showCommentComposer)
 
         // Start the view model with a backed project.
         vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
 
         // The comment composer should be shown to backer and enabled to write comments
-        enableCommentComposer.assertValue(true)
-        showCommentComposer.assertValueCount(1)
+        commentComposerStatus.assertValue(CommentComposerStatus.ENABLED)
+        showCommentComposer.assertValues(true, true)
     }
 
     @Test
-    fun testCommentsViewModel_showCommentComposer_isLogoutUser() {
-        val vm = CommentsViewModel.ViewModel(environment())
+    fun testCommentsViewModel_whenUserIsLoggedOut_composerShouldBeGone() {
+        val vm = CommentsViewModel.ViewModel(environment().toBuilder().build())
 
-        vm.outputs.enableCommentComposer().subscribe(enableCommentComposer)
+        vm.outputs.commentComposerStatus().subscribe(commentComposerStatus)
         vm.outputs.showCommentComposer().subscribe(showCommentComposer)
 
         // Start the view model with a backed project.
-        vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
+        vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
         // The comment composer should be hidden and disabled to write comments as no user login -ed
-        showCommentComposer.assertNoValues()
-        enableCommentComposer.assertNoValues()
+        showCommentComposer.assertValue(false)
+        commentComposerStatus.assertValue(CommentComposerStatus.GONE)
     }
 
     @Test
-    fun testCommentsViewModel_enableCommentComposer_isBacking() {
+    fun testCommentsViewModel_whenUserIsLoggedInNotBacking_shouldShowDisabledComposer() {
         val vm = CommentsViewModel.ViewModel(
             environment().toBuilder().currentUser(MockCurrentUser(UserFactory.user())).build()
         )
-        val enableCommentComposer = TestSubscriber<Boolean>()
-        vm.outputs.enableCommentComposer().subscribe(enableCommentComposer)
+        vm.outputs.commentComposerStatus().subscribe(commentComposerStatus)
+        vm.outputs.showCommentComposer().subscribe(showCommentComposer)
 
         // Start the view model with a backed project.
-        vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.backedProject()))
+        vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
 
         // The comment composer enabled to write comments
-        enableCommentComposer.assertValue(true)
+        commentComposerStatus.assertValue(CommentComposerStatus.DISABLED)
+        showCommentComposer.assertValues(true, true)
     }
 
     @Test
-    fun testCommentsViewModel_enableCommentComposer_isCreator() {
+    fun testCommentsViewModel_whenUserIsCreator_shouldShowEnabledComposer() {
         val currentUser = UserFactory.user().toBuilder().id(1234).build()
         val project = ProjectFactory.project()
             .toBuilder()
@@ -89,14 +91,16 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         val vm = CommentsViewModel.ViewModel(
             environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build()
         )
-        val enableCommentComposer = TestSubscriber<Boolean>()
-        vm.outputs.enableCommentComposer().subscribe(enableCommentComposer)
+
+        vm.outputs.commentComposerStatus().subscribe(commentComposerStatus)
+        vm.outputs.showCommentComposer().subscribe(showCommentComposer)
 
         // Start the view model with a project.
         vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
 
         // The comment composer enabled to write comments for creator
-        enableCommentComposer.assertValues(true)
+        showCommentComposer.assertValues(true, true)
+        commentComposerStatus.assertValues(CommentComposerStatus.ENABLED)
     }
 
     @Test
@@ -111,14 +115,16 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         val vm = CommentsViewModel.ViewModel(
             environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build()
         )
-        val enableCommentComposer = TestSubscriber<Boolean>()
-        vm.outputs.enableCommentComposer().subscribe(enableCommentComposer)
+
+        vm.outputs.commentComposerStatus().subscribe(commentComposerStatus)
+        vm.outputs.showCommentComposer().subscribe(showCommentComposer)
 
         // Start the view model with a project.
         vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
 
         // Comment composer should be disabled and shown the disabled msg if not backing and not creator.
-        enableCommentComposer.assertValue(false)
+        showCommentComposer.assertValues(true, true)
+        commentComposerStatus.assertValue(CommentComposerStatus.DISABLED)
     }
     @Test
     fun testCommentsViewModel_setCurrentUserAvatar() {


### PR DESCRIPTION
# 📲 What

This change handles the different states of the comment composer in relation to the user state i.e. logged out, not backing, etc.
Also had to update the UI to make the separator disappear as it was still appearing when the composer was gone. 

# 🤔 Why

There are three states -> `ENABLED, DISABLED, GONE`
- `GONE` -> The comment composer should be completely gone if the user is not logged in.
- `ENABLED` -> If the user is logged in and a backer, or is the creator, the comment composer is enabled.
- `DISABLED` -> If the user is logged in but not a backer, then the comment composer should be in the disabled state

# 🛠 How

Created an enum that holds these three states, and when the comment view model is initiated, it emits this state to the activity and the view responds accordingly. 

# 👀 See

Logged in: Backing and not backing
![Screenshot_1622673686](https://user-images.githubusercontent.com/19390326/120690863-c0cee600-c473-11eb-9679-4ebdd1cf1f86.png) ![Screenshot_1622673709](https://user-images.githubusercontent.com/19390326/120690866-c1677c80-c473-11eb-83d5-ffea328edd1e.png)

Logged out:
![Screenshot_1622673778](https://user-images.githubusercontent.com/19390326/120690868-c1677c80-c473-11eb-8e93-d58f71c73ef4.png)


# 📋 QA

Make sure you have a project that you are not backing, a project that you are backing, and a project that you created, and all projects must have comments. Test going to the comments directly from the project page, as well as from the updates page. Then test the different states listed below. 

🔴  = no comment composer
🟡  = comment composer disabled
🟢  = comment composer enabled

These are the different states to test:
Logged out = 🔴 
Logged in and not backing = 🟡 
Logged in and backing = 🟢 
Logged in and creator = 🟢 

# Story 📖

[NT-1910: UX – Not logged in / Not backer for Comment Composer](https://kickstarter.atlassian.net/browse/NT-1910)
