### PR TITLE
NT-1984: Feature flags for threads

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/models/OptimizelyFeature.kt
+++ b/app/src/main/java/com/kickstarter/libs/models/OptimizelyFeature.kt
@@ -3,6 +3,7 @@ package com.kickstarter.libs.models
 class OptimizelyFeature {
     enum class Key(val key: String) {
         LIGHTS_ON("android_lights_on"),
-        COMMENT_THREADING("android_comment_threading")
+        COMMENT_THREADING("android_comment_threading"),
+        COMMENT_ENABLE_THREADS("android_comment_enable_threads"),
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/ThreadActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ThreadActivity.kt
@@ -47,7 +47,7 @@ class ThreadActivity : BaseActivity<ThreadViewModel.ViewModel>() {
     private fun configureRootCommentView(comment: Comment) {
         binding.commentsCardView.setCommentUserName(comment.author().name())
         binding.commentsCardView.setCommentBody(comment.body())
-        binding.commentsCardView.hideReplyViewGroup()
+        binding.commentsCardView.hideReplyButton()
         binding.commentsCardView.setCommentPostTime(DateTimeUtils.relative(this, ksString, comment.createdAt()))
         binding.commentsCardView.setCommentUserName(comment.author().name())
         binding.commentsCardView.setAvatarUrl(comment.author().avatar().medium())

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
@@ -52,15 +52,20 @@ class CommentCardViewHolder(
             .compose(Transformers.observeForUI())
             .subscribe { binding.commentsCardView.setCommentCardStatus(it) }
 
-        this.vm.outputs.isCommentActionGroupVisible()
+        this.vm.outputs.isReplyButtonVisible()
             .compose(bindToLifecycle())
             .compose(Transformers.observeForUI())
-            .subscribe { binding.commentsCardView.setCommentActionGroupVisibility(it) }
+            .subscribe { binding.commentsCardView.setReplyButtonVisibility(it) }
 
         this.vm.outputs.commentPostTime()
             .compose(bindToLifecycle())
             .compose(Transformers.observeForUI())
             .subscribe { binding.commentsCardView.setCommentPostTime(DateTimeUtils.relative(context(), ksString, it)) }
+
+        this.vm.outputs.isCommentEnableThreads()
+            .compose(bindToLifecycle())
+            .compose(Transformers.observeForUI())
+            .subscribe { binding.commentsCardView}
 
         this.vm.outputs.openCommentGuideLines()
             .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
@@ -65,7 +65,7 @@ class CommentCardViewHolder(
         this.vm.outputs.isCommentEnableThreads()
             .compose(bindToLifecycle())
             .compose(Transformers.observeForUI())
-            .subscribe { binding.commentsCardView}
+            .subscribe { binding.commentsCardView.setCommentEnabledThreads(it) }
 
         this.vm.outputs.openCommentGuideLines()
             .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
@@ -135,8 +135,8 @@ class CommentCard @JvmOverloads constructor(
 
     private fun shouldShowReplyButton(cardCommentStatus: CommentCardStatus) =
         cardCommentStatus == CommentCardStatus.COMMENT_WITH_REPLIES ||
-        cardCommentStatus == CommentCardStatus.COMMENT_WITHOUT_REPLIES ||
-        cardCommentStatus == CommentCardStatus.FAILED_TO_SEND_COMMENT
+            cardCommentStatus == CommentCardStatus.COMMENT_WITHOUT_REPLIES ||
+            cardCommentStatus == CommentCardStatus.FAILED_TO_SEND_COMMENT
 
     /*
      * To display replies count
@@ -146,7 +146,7 @@ class CommentCard @JvmOverloads constructor(
         setViewRepliesVisibility(replies > 0)
     }
 
-    fun setViewRepliesVisibility(isViewRepliesVisible: Boolean){
+    fun setViewRepliesVisibility(isViewRepliesVisible: Boolean) {
         binding.replies.isVisible = isViewRepliesVisible && isCommentEnabledThreads
     }
 

--- a/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
@@ -85,7 +85,7 @@ class CommentCard @JvmOverloads constructor(
                 setCommentUserName(it)
             }
 
-            getBoolean(R.styleable.CommentCardView_is_comment_action_group_visible, true)?.also {
+            getBoolean(R.styleable.CommentCardView_is_comment_reply_button_visible, true)?.also {
                 setReplyButtonVisibility(it)
             }
 

--- a/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
@@ -104,7 +104,7 @@ class CommentCard @JvmOverloads constructor(
     }
 
     fun setReplyButtonVisibility(isGroupVisible: Boolean) {
-        binding.replyButton.isVisible = isGroupVisible && isCommentEnabledThreads
+        binding.replyButton.isVisible = isGroupVisible && this.isCommentEnabledThreads
     }
 
     fun setCommentCardStatus(cardCommentStatus: CommentCardStatus) {
@@ -122,7 +122,7 @@ class CommentCard @JvmOverloads constructor(
         }
 
         binding.retryButton.isVisible =
-            cardCommentStatus == CommentCardStatus.FAILED_TO_SEND_COMMENT && isCommentEnabledThreads
+            cardCommentStatus == CommentCardStatus.FAILED_TO_SEND_COMMENT
 
         val commentBodyTextColor = if (cardCommentStatus == CommentCardStatus.FAILED_TO_SEND_COMMENT) {
             R.color.soft_grey_disable

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -245,6 +245,6 @@ interface CommentsViewHolderViewModel {
 
         override fun viewCommentReplies(): Observable<Comment> = this.viewCommentReplies
 
-        override fun isCommentEnableThreads(): Observable<Boolean> =  this.isCommentEnableThreads
+        override fun isCommentEnableThreads(): Observable<Boolean> = this.isCommentEnableThreads
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -190,6 +190,7 @@ interface CommentsViewHolderViewModel {
          * or the current user is the creator of the project
          *  @param commentCardData
          *  @param featureFlagActive
+         *  @param user
          *
          *  @return
          *  true -> if current user is backer and the feature flag is active

--- a/app/src/main/res/layout/comment_card.xml
+++ b/app/src/main/res/layout/comment_card.xml
@@ -55,7 +55,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 
-
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/reply_button"
         style="@style/CommentsReplayButton"
@@ -66,16 +65,6 @@
         app:layout_constraintBottom_toTopOf="@+id/separtor"
         app:layout_constraintStart_toStartOf="@id/avatar"
         app:layout_constraintTop_toBottomOf="@id/replies" />
-
-    <androidx.appcompat.widget.AppCompatImageButton
-        android:id="@+id/flag_button"
-        style="@style/CommentsReplayButton"
-        android:src="@drawable/ic_flag"
-        android:layout_marginTop="@dimen/grid_3"
-        app:layout_goneMarginTop="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/separtor"
-        app:layout_constraintEnd_toEndOf="@id/comment_body"
-        app:layout_constraintTop_toBottomOf="@id/replies"/>
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/retry_button"
@@ -113,17 +102,11 @@
         app:layout_constraintStart_toStartOf="parent" />
 
     <androidx.constraintlayout.widget.Group
-        android:id="@+id/comment_action_group"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:constraint_referenced_ids="reply_button,flag_button" />
-
-    <androidx.constraintlayout.widget.Group
         android:id="@+id/reply_message_group"
         android:layout_width="wrap_content"
         android:visibility="gone"
         android:layout_height="wrap_content"
+        tools:visibility="visible"
         app:constraint_referenced_ids="flagged_message,info_button" />
 
     <androidx.constraintlayout.widget.Group
@@ -131,5 +114,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
+        tools:visibility="visible"
         app:constraint_referenced_ids="flagged_message,info_button" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -21,6 +21,6 @@
     <attr name="comment_card_message" format="string" />
     <attr name="comment_card_replies" format="integer" />
     <attr name="comment_card_avatar_url" format="string" />
-    <attr name="is_comment_action_group_visible" format="boolean" />
+    <attr name="is_comment_reply_button_visible" format="boolean" />
   </declare-styleable>
 </resources>

--- a/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
@@ -113,7 +113,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         assertFalse(commentDeletedMessageGroup.isVisible)
         assertFalse(retryButton.isVisible)
     }
-    
+
     @Test
     fun testVisibilityFeatureFlagOff() {
         commentCard.setCommentEnabledThreads(false)

--- a/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
@@ -19,7 +19,7 @@ class CommentCardTest : KSRobolectricTestCase() {
     private lateinit var commentDeletedMessageGroup: Group
     private lateinit var commentBody: AppCompatTextView
     private lateinit var replyButton: AppCompatButton
-    private lateinit var repliesContainer: View
+    private lateinit var repliesButton: AppCompatTextView
     private lateinit var retryButton: AppCompatButton
 
     @Before
@@ -31,7 +31,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         commentDeletedMessageGroup = commentCard.findViewById(R.id.comment_deleted_message_group)
         replyButton = commentCard.findViewById(R.id.reply_button)
         retryButton = commentCard.findViewById(R.id.retry_button)
-        repliesContainer = commentCard.findViewById(R.id.replies)
+        repliesButton = commentCard.findViewById(R.id.replies)
 
         // - Specify Feature Flag enabled
         commentCard.setCommentEnabledThreads(true)
@@ -96,17 +96,19 @@ class CommentCardTest : KSRobolectricTestCase() {
         commentCard.setCommentReplies(1)
         assertTrue(commentBody.isVisible)
         assertTrue(replyButton.isVisible)
-        assertTrue(repliesContainer.isVisible)
+        assertTrue(repliesButton.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
         assertFalse(retryButton.isVisible)
     }
 
     @Test
     fun testCommentViewReplyStatus_No_Replies() {
+        commentCard.setCommentEnabledThreads(true)
         commentCard.setCommentReplies(0)
+
         assertTrue(commentBody.isVisible)
         assertTrue(replyButton.isVisible)
-        assertFalse(repliesContainer.isVisible)
+        assertFalse(repliesButton.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
         assertFalse(retryButton.isVisible)
     }
@@ -118,7 +120,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         commentCard.setCommentReplies(10)
         assertTrue(commentBody.isVisible)
         assertFalse(replyButton.isVisible)
-        assertFalse(repliesContainer.isVisible)
+        assertFalse(repliesButton.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
         assertFalse(retryButton.isVisible)
     }

--- a/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
@@ -18,7 +18,7 @@ class CommentCardTest : KSRobolectricTestCase() {
     private lateinit var commentCard: CommentCard
     private lateinit var commentDeletedMessageGroup: Group
     private lateinit var commentBody: AppCompatTextView
-    private lateinit var commentActionGroup: Group
+    private lateinit var replyButton: AppCompatButton
     private lateinit var repliesContainer: View
     private lateinit var retryButton: AppCompatButton
 
@@ -29,9 +29,12 @@ class CommentCardTest : KSRobolectricTestCase() {
             .findViewById(R.id.comments_card_view)
         commentBody = commentCard.findViewById(R.id.comment_body)
         commentDeletedMessageGroup = commentCard.findViewById(R.id.comment_deleted_message_group)
-        commentActionGroup = commentCard.findViewById(R.id.comment_action_group)
+        replyButton = commentCard.findViewById(R.id.reply_button)
         retryButton = commentCard.findViewById(R.id.retry_button)
         repliesContainer = commentCard.findViewById(R.id.replies)
+
+        // - Specify Feature Flag enabled
+        commentCard.setCommentEnabledThreads(true)
     }
 
     @Test
@@ -39,7 +42,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         commentCard.setCommentCardStatus(CommentCardStatus.DELETED_COMMENT)
         assertFalse(commentBody.isVisible)
         assertFalse(retryButton.isVisible)
-        assertFalse(commentActionGroup.isVisible)
+        assertFalse(replyButton.isVisible)
         assertTrue(commentDeletedMessageGroup.isVisible)
     }
 
@@ -48,7 +51,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         commentCard.setCommentCardStatus(CommentCardStatus.FAILED_TO_SEND_COMMENT)
         assertTrue(commentBody.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
-        assertTrue(commentActionGroup.isVisible)
+        assertTrue(replyButton.isVisible)
         assertTrue(retryButton.isVisible)
     }
 
@@ -56,7 +59,7 @@ class CommentCardTest : KSRobolectricTestCase() {
     fun testCommentWithoutReplyStatus() {
         commentCard.setCommentCardStatus(CommentCardStatus.COMMENT_WITHOUT_REPLIES)
         assertTrue(commentBody.isVisible)
-        assertTrue(commentActionGroup.isVisible)
+        assertTrue(replyButton.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
         assertFalse(retryButton.isVisible)
     }
@@ -65,7 +68,7 @@ class CommentCardTest : KSRobolectricTestCase() {
     fun testCommentWithReplyStatus() {
         commentCard.setCommentCardStatus(CommentCardStatus.COMMENT_WITH_REPLIES)
         assertTrue(commentBody.isVisible)
-        assertTrue(commentActionGroup.isVisible)
+        assertTrue(replyButton.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
         assertFalse(retryButton.isVisible)
     }
@@ -74,7 +77,7 @@ class CommentCardTest : KSRobolectricTestCase() {
     fun setCommentActionGroupVisibility_whenFalse_setToInvisible() {
         commentCard.setReplyButtonVisibility(false)
         assertTrue(commentBody.isVisible)
-        assertFalse(commentActionGroup.isVisible)
+        assertFalse(replyButton.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
         assertFalse(retryButton.isVisible)
     }
@@ -83,7 +86,7 @@ class CommentCardTest : KSRobolectricTestCase() {
     fun setCommentActionGroupVisibility_whenTrue_setToInvisible() {
         commentCard.setReplyButtonVisibility(true)
         assertTrue(commentBody.isVisible)
-        assertTrue(commentActionGroup.isVisible)
+        assertTrue(replyButton.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
         assertFalse(retryButton.isVisible)
     }
@@ -92,7 +95,7 @@ class CommentCardTest : KSRobolectricTestCase() {
     fun testCommentViewReplyStatus_With_Replies() {
         commentCard.setCommentReplies(1)
         assertTrue(commentBody.isVisible)
-        assertTrue(commentActionGroup.isVisible)
+        assertTrue(replyButton.isVisible)
         assertTrue(repliesContainer.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
         assertFalse(retryButton.isVisible)
@@ -102,7 +105,19 @@ class CommentCardTest : KSRobolectricTestCase() {
     fun testCommentViewReplyStatus_No_Replies() {
         commentCard.setCommentReplies(0)
         assertTrue(commentBody.isVisible)
-        assertTrue(commentActionGroup.isVisible)
+        assertTrue(replyButton.isVisible)
+        assertFalse(repliesContainer.isVisible)
+        assertFalse(commentDeletedMessageGroup.isVisible)
+        assertFalse(retryButton.isVisible)
+    }
+    
+    @Test
+    fun testVisibilityFeatureFlagOff() {
+        commentCard.setCommentEnabledThreads(false)
+
+        commentCard.setCommentReplies(10)
+        assertTrue(commentBody.isVisible)
+        assertFalse(replyButton.isVisible)
         assertFalse(repliesContainer.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
         assertFalse(retryButton.isVisible)

--- a/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
@@ -72,7 +72,7 @@ class CommentCardTest : KSRobolectricTestCase() {
 
     @Test
     fun setCommentActionGroupVisibility_whenFalse_setToInvisible() {
-        commentCard.setCommentActionGroupVisibility(false)
+        commentCard.setReplyButtonVisibility(false)
         assertTrue(commentBody.isVisible)
         assertFalse(commentActionGroup.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
@@ -81,7 +81,7 @@ class CommentCardTest : KSRobolectricTestCase() {
 
     @Test
     fun setCommentActionGroupVisibility_whenTrue_setToInvisible() {
-        commentCard.setCommentActionGroupVisibility(true)
+        commentCard.setReplyButtonVisibility(true)
         assertTrue(commentBody.isVisible)
         assertTrue(commentActionGroup.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)

--- a/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
@@ -1,7 +1,6 @@
 package com.kickstarter.ui.view
 
 import android.view.LayoutInflater
-import android.view.View
 import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -27,14 +26,14 @@ class CommentCardTest : KSRobolectricTestCase() {
     override fun setUp() {
         commentCard = (LayoutInflater.from(context()).inflate(R.layout.item_comment_card, null) as ConstraintLayout)
             .findViewById(R.id.comments_card_view)
+        // - Specify Feature Flag enabled
+        commentCard.setCommentEnabledThreads(true)
+
         commentBody = commentCard.findViewById(R.id.comment_body)
         commentDeletedMessageGroup = commentCard.findViewById(R.id.comment_deleted_message_group)
         replyButton = commentCard.findViewById(R.id.reply_button)
         retryButton = commentCard.findViewById(R.id.retry_button)
         repliesButton = commentCard.findViewById(R.id.replies)
-
-        // - Specify Feature Flag enabled
-        commentCard.setCommentEnabledThreads(true)
     }
 
     @Test
@@ -94,6 +93,8 @@ class CommentCardTest : KSRobolectricTestCase() {
     @Test
     fun testCommentViewReplyStatus_With_Replies() {
         commentCard.setCommentReplies(1)
+        commentCard.setCommentCardStatus(CommentCardStatus.COMMENT_WITH_REPLIES)
+
         assertTrue(commentBody.isVisible)
         assertTrue(replyButton.isVisible)
         assertTrue(repliesButton.isVisible)
@@ -103,8 +104,8 @@ class CommentCardTest : KSRobolectricTestCase() {
 
     @Test
     fun testCommentViewReplyStatus_No_Replies() {
-        commentCard.setCommentEnabledThreads(true)
         commentCard.setCommentReplies(0)
+        commentCard.setCommentCardStatus(CommentCardStatus.COMMENT_WITHOUT_REPLIES)
 
         assertTrue(commentBody.isVisible)
         assertTrue(replyButton.isVisible)
@@ -118,6 +119,8 @@ class CommentCardTest : KSRobolectricTestCase() {
         commentCard.setCommentEnabledThreads(false)
 
         commentCard.setCommentReplies(10)
+        commentCard.setCommentCardStatus(CommentCardStatus.COMMENT_WITH_REPLIES)
+
         assertTrue(commentBody.isVisible)
         assertFalse(replyButton.isVisible)
         assertFalse(repliesButton.isVisible)

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
@@ -167,7 +167,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testCommentreplyButtonVisibility_whenUserLoggedInAndProjectBacked_shouldSendTrue() {
+    fun testCommentReplyButtonVisibility_whenUserLoggedInAndProjectBackedFFOn_shouldSendTrue() {
         val environment = optimizelyFeatureFlagOn().toBuilder()
             .currentUser(MockCurrentUser(UserFactory.user()))
             .build()
@@ -179,7 +179,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testCommentreplyButtonVisibility_whenUserLoggedInAndProjectBacked_FeatureFlagOff() {
+    fun testCommentReplyButtonVisibility_whenUserLoggedInAndProjectBackedFFOff_shouldSendFalse() {
         val environment = optimizelyFeatureFlagOff().toBuilder()
             .currentUser(MockCurrentUser(UserFactory.user()))
             .build()
@@ -192,8 +192,11 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testCommentreplyButtonVisibility_whenUserLoggedInAndProjectNotBacked_shouldSendFalse() {
-        setUpEnvironment(environment().toBuilder().currentUser(MockCurrentUser(UserFactory.user())).build())
+    fun testCommentReplyButtonVisibility_whenUserLoggedInAndProjectNotBackedFFOff_shouldSendFalse() {
+        val environment = optimizelyFeatureFlagOff().toBuilder()
+            .currentUser(MockCurrentUser(UserFactory.user()))
+            .build()
+        setUpEnvironment(environment)
         val comment = CommentFactory.comment()
         val commentCardData = CommentCardData.builder().comment(comment).project(ProjectFactory.project()).build()
         this.vm.inputs.configureWith(commentCardData)
@@ -201,8 +204,65 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testCommentreplyButtonVisibility_whenUserNotLoggedIn_shouldSendFalse() {
-        setUpEnvironment(environment())
+    fun testCommentReplyButtonVisibility_whenUserLoggedInAndProjectNotBackedFFOn_shouldSendFalse() {
+        val environment = optimizelyFeatureFlagOn().toBuilder()
+            .currentUser(MockCurrentUser(UserFactory.user()))
+            .build()
+        setUpEnvironment(environment)
+        val comment = CommentFactory.comment()
+        val commentCardData = CommentCardData.builder().comment(comment).project(ProjectFactory.project()).build()
+        this.vm.inputs.configureWith(commentCardData)
+        this.isReplyButtonVisible.assertValue(false)
+    }
+
+    @Test
+    fun testCommentReplyButtonVisibility_whenProjectNotBackedAndUserIsCreatorFFOn_shouldSendTrue() {
+        val user = UserFactory.creator().toBuilder().id(2).build()
+
+        val environment = optimizelyFeatureFlagOn().toBuilder()
+            .currentUser(MockCurrentUser(user))
+            .build()
+        setUpEnvironment(environment)
+
+        val comment = CommentFactory.comment()
+        val commentCardData = CommentCardData.builder().comment(comment).project(ProjectFactory.project().toBuilder().creator(user).build()).build()
+        this.vm.inputs.configureWith(commentCardData)
+        this.isReplyButtonVisible.assertValue(true)
+    }
+
+    @Test
+    fun testCommentReplyButtonVisibility_whenProjectNotBackedAndUserIsCreatorFFOff_shouldSendFalse() {
+        val user = UserFactory.creator().toBuilder().id(2).build()
+
+        val environment = optimizelyFeatureFlagOff().toBuilder()
+            .currentUser(MockCurrentUser(user))
+            .build()
+        setUpEnvironment(environment)
+
+        val comment = CommentFactory.comment()
+        val commentCardData = CommentCardData.builder().comment(comment).project(ProjectFactory.project().toBuilder().creator(user).build()).build()
+        this.vm.inputs.configureWith(commentCardData)
+        this.isReplyButtonVisible.assertValue(false)
+    }
+
+    @Test
+    fun testCommentReplyButtonVisibility_whenUserNotLoggedInFFOn_shouldSendFalse() {
+        val environment = optimizelyFeatureFlagOn().toBuilder()
+            .build()
+        setUpEnvironment(environment)
+
+        val comment = CommentFactory.comment()
+        val commentCardData = CommentCardData.builder().comment(comment).project(ProjectFactory.project()).build()
+        this.vm.inputs.configureWith(commentCardData)
+        this.isReplyButtonVisible.assertValue(false)
+    }
+
+    @Test
+    fun testCommentReplyButtonVisibility_whenUserNotLoggedInFFOff_shouldSendFalse() {
+        val environment = optimizelyFeatureFlagOff().toBuilder()
+            .build()
+        setUpEnvironment(environment)
+
         val comment = CommentFactory.comment()
         val commentCardData = CommentCardData.builder().comment(comment).project(ProjectFactory.project()).build()
         this.vm.inputs.configureWith(commentCardData)

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
@@ -3,6 +3,7 @@ package com.kickstarter.viewmodels
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUser
+import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.AvatarFactory
 import com.kickstarter.mock.factories.CommentFactory
 import com.kickstarter.mock.factories.ProjectFactory
@@ -23,7 +24,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
     private val commentAuthorAvatarUrl = TestSubscriber<String>()
     private val commentMessageBody = TestSubscriber<String>()
     private val commentPostTime = TestSubscriber<DateTime>()
-    private val isActionGroupVisible = TestSubscriber<Boolean>()
+    private val isReplyButtonVisible = TestSubscriber<Boolean>()
     private val openCommentGuideLines = TestSubscriber<Comment>()
     private val retrySendComment = TestSubscriber<Comment>()
     private val replyToComment = TestSubscriber<Comment>()
@@ -38,7 +39,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.commentAuthorAvatarUrl().subscribe(this.commentAuthorAvatarUrl)
         this.vm.outputs.commentMessageBody().subscribe(this.commentMessageBody)
         this.vm.outputs.commentPostTime().subscribe(this.commentPostTime)
-        this.vm.outputs.isReplyButtonVisible().subscribe(this.isActionGroupVisible)
+        this.vm.outputs.isReplyButtonVisible().subscribe(this.isReplyButtonVisible)
         this.vm.outputs.openCommentGuideLines().subscribe(this.openCommentGuideLines)
         this.vm.outputs.retrySendComment().subscribe(this.retrySendComment)
         this.vm.outputs.replyToComment().subscribe(this.replyToComment)
@@ -166,40 +167,46 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testCommentActionGroupVisibility_whenUserLoggedInAndProjectBacked_shouldSendTrue() {
-        setUpEnvironment(environment().toBuilder().currentUser(MockCurrentUser(UserFactory.user())).build())
+    fun testCommentreplyButtonVisibility_whenUserLoggedInAndProjectBacked_shouldSendTrue() {
+        val environment = optimizelyFeatureFlagOn().toBuilder()
+            .currentUser(MockCurrentUser(UserFactory.user()))
+            .build()
+        setUpEnvironment(environment)
         val comment = CommentFactory.comment()
         val commentCardData = CommentCardData.builder().comment(comment).project(ProjectFactory.backedProject()).build()
         this.vm.inputs.configureWith(commentCardData)
-        this.isActionGroupVisible.assertValue(true)
+        this.isReplyButtonVisible.assertValue(true)
     }
 
     @Test
-    fun testCommentActionGroupVisibility_whenUserLoggedInAndProjectNotBacked_shouldSendFalse() {
+    fun testCommentreplyButtonVisibility_whenUserLoggedInAndProjectBacked_FeatureFlagOff() {
+        val environment = optimizelyFeatureFlagOff().toBuilder()
+            .currentUser(MockCurrentUser(UserFactory.user()))
+            .build()
+        setUpEnvironment(environment)
+        val comment = CommentFactory.comment()
+        val commentCardData = CommentCardData.builder().comment(comment).project(ProjectFactory.backedProject()).build()
+
+        this.vm.inputs.configureWith(commentCardData)
+        this.isReplyButtonVisible.assertValue(false)
+    }
+
+    @Test
+    fun testCommentreplyButtonVisibility_whenUserLoggedInAndProjectNotBacked_shouldSendFalse() {
         setUpEnvironment(environment().toBuilder().currentUser(MockCurrentUser(UserFactory.user())).build())
         val comment = CommentFactory.comment()
         val commentCardData = CommentCardData.builder().comment(comment).project(ProjectFactory.project()).build()
         this.vm.inputs.configureWith(commentCardData)
-        this.isActionGroupVisible.assertValue(false)
+        this.isReplyButtonVisible.assertValue(false)
     }
 
     @Test
-    fun testCommentActionGroupVisibility_whenUserNotLoggedIn_shouldSendFalse() {
+    fun testCommentreplyButtonVisibility_whenUserNotLoggedIn_shouldSendFalse() {
         setUpEnvironment(environment())
         val comment = CommentFactory.comment()
         val commentCardData = CommentCardData.builder().comment(comment).project(ProjectFactory.project()).build()
         this.vm.inputs.configureWith(commentCardData)
-        this.isActionGroupVisible.assertValue(false)
-    }
-
-    @Test
-    fun testCommentActionGroupVisibility_whenProjectNotBackedAndUserIsCreator_shouldSendTrue() {
-        val user = UserFactory.creator().toBuilder().id(2).build()
-        setUpEnvironment(environment().toBuilder().currentUser(MockCurrentUser(user)).build())
-        val comment = CommentFactory.comment()
-        val commentCardData = CommentCardData.builder().comment(comment).project(ProjectFactory.project().toBuilder().creator(user).build()).build()
-        this.vm.inputs.configureWith(commentCardData)
-        this.isActionGroupVisible.assertValue(true)
+        this.isReplyButtonVisible.assertValue(false)
     }
 
     @Test
@@ -210,4 +217,12 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(commentData)
         this.repliesCount.assertValue(comment.repliesCount())
     }
+
+    private fun optimizelyFeatureFlagOn() = environment().toBuilder()
+        .optimizely(MockExperimentsClientType(true))
+        .build()
+
+    private fun optimizelyFeatureFlagOff() = environment().toBuilder()
+        .optimizely(MockExperimentsClientType(false))
+        .build()
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
@@ -38,7 +38,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.commentAuthorAvatarUrl().subscribe(this.commentAuthorAvatarUrl)
         this.vm.outputs.commentMessageBody().subscribe(this.commentMessageBody)
         this.vm.outputs.commentPostTime().subscribe(this.commentPostTime)
-        this.vm.outputs.isCommentActionGroupVisible().subscribe(this.isActionGroupVisible)
+        this.vm.outputs.isReplyButtonVisible().subscribe(this.isActionGroupVisible)
         this.vm.outputs.openCommentGuideLines().subscribe(this.openCommentGuideLines)
         this.vm.outputs.retrySendComment().subscribe(this.retrySendComment)
         this.vm.outputs.replyToComment().subscribe(this.replyToComment)


### PR DESCRIPTION
# 📲 What

- New feature flag added that `hides View replies/Reply buttons`
- The Flag button has been removed
- Feature flag added to optimizely

# 🛠 How
- `CommentCard.kt` will be aware of the feature flag state via a new output from the viewmodel `isCommentEnableThreads`
- All the visibility updates will happend internally on `CommentCard`



# 👀 See
- New optimizely Feature Flag
![Screen Shot 2021-06-03 at 2 35 26 PM](https://user-images.githubusercontent.com/4083656/120715138-08a43c00-c479-11eb-896d-937ded7de6a1.png)

- Backer with feature flag off: reply and view replies buttons are gone
https://user-images.githubusercontent.com/4083656/120713432-bc57fc80-c476-11eb-8e24-6ceb533c805b.mp4

- Backer with feature flag on: reply and view replies buttons are visible and active
https://user-images.githubusercontent.com/4083656/120713769-36888100-c477-11eb-8978-bee459714c44.mp4

- No Backer with feature flag off: view replies buttons is gone
https://user-images.githubusercontent.com/4083656/120714369-f5dd3780-c477-11eb-81d8-e289f1146a90.mp4

- No Backer with feature flag on: view replies buttons is visible and active
https://user-images.githubusercontent.com/4083656/120714568-39d03c80-c478-11eb-8589-1a89b3fe3cdf.mp4


|  |  |

# 📋 QA
- With the feature flag on, make sure as baker you can reply and see replies
- With the feature flag off, make sure as baker you cannot see the reply button nor the view replies button
- With the feature flag on, make sure as NO baker you can see the view replies button and it's active
- With the feature flag off, make sure as NO baker you cannot see the view replies button

# Story 📖

[NT-1984](https://kickstarter.atlassian.net/browse/NT-1984)
