### PR TITLE
NT-2029:UX – Add delay to "Posting..." error state

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -247,8 +247,8 @@ interface CommentsViewHolderViewModel {
             Observable
                 .combineLatest(onRetryViewClicked, commentData) { _, newData ->
                     return@combineLatest executePostCommentMutation(newData)
+                        .delay(1, TimeUnit.SECONDS)
                 }
-                .delay(1, TimeUnit.SECONDS)
                 .switchMap {
                     it
                 }.doOnNext {

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -19,7 +19,6 @@ import com.kickstarter.ui.viewholders.CommentCardViewHolder
 import com.kickstarter.ui.views.CommentCardStatus
 import org.joda.time.DateTime
 import rx.Observable
-import rx.android.schedulers.AndroidSchedulers
 import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
 import java.util.concurrent.TimeUnit
@@ -84,8 +83,6 @@ interface CommentsViewHolderViewModel {
 
         /** Emits the current [OptimizelyFeature.Key.COMMENT_ENABLE_THREADS] status to the CommentCard UI*/
         fun isCommentEnableThreads(): Observable<Boolean>
-
-        fun internalError(): Observable<Throwable>
     }
 
     class ViewModel(environment: Environment) : ActivityViewModel<CommentCardViewHolder>(environment), Inputs, Outputs {
@@ -145,8 +142,7 @@ interface CommentsViewHolderViewModel {
 
             this.internalError
                 .compose(bindToLifecycle())
-                .observeOn(AndroidSchedulers.mainThread())
-                .delay(1, TimeUnit.SECONDS)
+                .delay(1, TimeUnit.SECONDS, environment.scheduler())
                 .subscribe {
                     this.commentCardStatus.onNext(CommentCardStatus.FAILED_TO_SEND_COMMENT)
                 }
@@ -390,7 +386,5 @@ interface CommentsViewHolderViewModel {
         override fun viewCommentReplies(): Observable<Comment> = this.viewCommentReplies
 
         override fun isCommentEnableThreads(): Observable<Boolean> = this.isCommentEnableThreads
-
-        override fun internalError(): Observable<Throwable> = this.internalError
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -19,6 +19,7 @@ import com.kickstarter.ui.viewholders.CommentCardViewHolder
 import com.kickstarter.ui.views.CommentCardStatus
 import org.joda.time.DateTime
 import rx.Observable
+import rx.android.schedulers.AndroidSchedulers
 import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
 import java.util.concurrent.TimeUnit
@@ -83,6 +84,8 @@ interface CommentsViewHolderViewModel {
 
         /** Emits the current [OptimizelyFeature.Key.COMMENT_ENABLE_THREADS] status to the CommentCard UI*/
         fun isCommentEnableThreads(): Observable<Boolean>
+
+        fun internalError(): Observable<Throwable>
     }
 
     class ViewModel(environment: Environment) : ActivityViewModel<CommentCardViewHolder>(environment), Inputs, Outputs {
@@ -106,6 +109,7 @@ interface CommentsViewHolderViewModel {
         private val flagComment = PublishSubject.create<Comment>()
         private val viewCommentReplies = PublishSubject.create<Comment>()
         private val isCommentEnableThreads = PublishSubject.create<Boolean>()
+        private val internalError = BehaviorSubject.create<Throwable>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -138,7 +142,15 @@ interface CommentsViewHolderViewModel {
                 .map {
                     Pair(requireNotNull(it.first.comment?.body()), requireNotNull(it.first.project))
                 }
-            postComment(commentData)
+
+            this.internalError
+                .compose(bindToLifecycle())
+                .observeOn(AndroidSchedulers.mainThread())
+                .delay(1, TimeUnit.SECONDS)
+                .subscribe {
+                    this.commentCardStatus.onNext(CommentCardStatus.FAILED_TO_SEND_COMMENT)
+                }
+            postComment(commentData, internalError)
         }
 
         /**
@@ -217,10 +229,12 @@ interface CommentsViewHolderViewModel {
 
             comment
                 .compose(takeWhen(this.onRetryViewClicked))
+                .doOnNext {
+                    this.commentCardStatus.onNext(CommentCardStatus.RE_TRYING_TO_POST)
+                }
                 .compose(bindToLifecycle())
                 .subscribe {
                     this.retrySendComment.onNext(it)
-                    this.commentCardStatus.onNext(CommentCardStatus.RE_TRYING_TO_POST)
                 }
 
             comment
@@ -233,9 +247,9 @@ interface CommentsViewHolderViewModel {
          * Handles the logic for posting comments (new ones, and the retry attempts)
          * @param commentData will emmit only in case we need to post a new comment
          */
-        private fun postComment(commentData: Observable<Pair<String, Project>>) {
+        private fun postComment(commentData: Observable<Pair<String, Project>>, errorObservable: BehaviorSubject<Throwable>) {
             commentData
-                .map { executePostCommentMutation(it) }
+                .map { executePostCommentMutation(it, errorObservable) }
                 .switchMap {
                     it
                 }
@@ -246,10 +260,8 @@ interface CommentsViewHolderViewModel {
 
             Observable
                 .combineLatest(onRetryViewClicked, commentData) { _, newData ->
-                    return@combineLatest executePostCommentMutation(newData)
-                        .delay(1, TimeUnit.SECONDS)
-                }
-                .switchMap {
+                    return@combineLatest executePostCommentMutation(newData, errorObservable)
+                }.switchMap {
                     it
                 }.doOnNext {
                     this.commentCardStatus.onNext(CommentCardStatus.POSTING_COMMENT_COMPLETED_SUCCESSFULLY)
@@ -290,7 +302,7 @@ interface CommentsViewHolderViewModel {
          * // TODO: we will need the entire comment plus very important the [parentId]
          * @return Observable<Comment>
          */
-        private fun executePostCommentMutation(commentData: Pair<String, Project>) =
+        private fun executePostCommentMutation(commentData: Pair<String, Project>, errorObservable: BehaviorSubject<Throwable>) =
             this.apolloClient.createComment(
                 PostCommentData(
                     project = commentData.second,
@@ -299,7 +311,7 @@ interface CommentsViewHolderViewModel {
                     parentId = null
                 )
             ).doOnError {
-                this.commentCardStatus.onNext(CommentCardStatus.FAILED_TO_SEND_COMMENT)
+                errorObservable.onNext(it)
             }
                 .onErrorResumeNext(Observable.empty())
 
@@ -378,5 +390,7 @@ interface CommentsViewHolderViewModel {
         override fun viewCommentReplies(): Observable<Comment> = this.viewCommentReplies
 
         override fun isCommentEnableThreads(): Observable<Boolean> = this.isCommentEnableThreads
+
+        override fun internalError(): Observable<Throwable> = this.internalError
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -248,6 +248,7 @@ interface CommentsViewHolderViewModel {
                 .combineLatest(onRetryViewClicked, commentData) { _, newData ->
                     return@combineLatest executePostCommentMutation(newData)
                 }
+                .delay(1, TimeUnit.SECONDS)
                 .switchMap {
                     it
                 }.doOnNext {

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
@@ -17,6 +17,8 @@ import org.joda.time.DateTime
 import org.junit.Test
 import rx.Observable
 import rx.observers.TestSubscriber
+import rx.schedulers.TestScheduler
+import java.util.concurrent.TimeUnit
 
 class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
 
@@ -33,7 +35,8 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
     private val replyToComment = TestSubscriber<Comment>()
     private val flagComment = TestSubscriber<Comment>()
     private val repliesCount = TestSubscriber<Int>()
-    private val newCommentBind = TestSubscriber<CommentCardData>()
+    private val internalError = TestSubscriber<Throwable>()
+    private val testScheduler = TestScheduler()
 
     private val createdAt = DateTime.now()
     private val currentUser = UserFactory.user().toBuilder().id(1).avatar(
@@ -54,6 +57,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.replyToComment().subscribe(this.replyToComment)
         this.vm.outputs.flagComment().subscribe(this.flagComment)
         this.vm.outputs.commentRepliesCount().subscribe(this.repliesCount)
+        this.vm.outputs.internalError().subscribe(this.internalError)
     }
 
     @Test
@@ -302,6 +306,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
                 return Observable.error(Throwable())
             }
         })
+            .scheduler(testScheduler)
             .currentUser(MockCurrentUser(currentUser))
             .build()
 
@@ -315,25 +320,33 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
             .build()
 
         this.vm.inputs.configureWith(commentCardData)
+        testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
+
         this.vm.inputs.onRetryViewClicked()
 
         this.retrySendComment.assertValue(comment)
+
+        testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
+
+        this.retrySendComment.assertValue(comment)
+
+        this.internalError.assertValueCount(2)
+
         this.commentCardStatus.assertValues(
             CommentCardStatus.TRYING_TO_POST,
-            CommentCardStatus.FAILED_TO_SEND_COMMENT,
-            CommentCardStatus.RE_TRYING_TO_POST,
-            CommentCardStatus.FAILED_TO_SEND_COMMENT,
+            CommentCardStatus.RE_TRYING_TO_POST
         )
 
         this.vm.inputs.onRetryViewClicked()
 
+        testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
+
+        this.internalError.assertValueCount(3)
+
         this.commentCardStatus.assertValues(
             CommentCardStatus.TRYING_TO_POST,
-            CommentCardStatus.FAILED_TO_SEND_COMMENT,
             CommentCardStatus.RE_TRYING_TO_POST,
-            CommentCardStatus.FAILED_TO_SEND_COMMENT,
             CommentCardStatus.RE_TRYING_TO_POST,
-            CommentCardStatus.FAILED_TO_SEND_COMMENT
         )
     }
 
@@ -423,13 +436,16 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testSendCommentFailedAndPressRetry() {
         val currentUser = UserFactory.user().toBuilder().id(1).build()
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+
+        val env = environment().toBuilder()
+                .apolloClient(object : MockApolloClient() {
             override fun createComment(comment: PostCommentData): Observable<Comment> {
                 return Observable.error(Throwable())
             }
-        })
+        }).scheduler(testScheduler)
             .currentUser(MockCurrentUser(currentUser))
             .build()
+
         setUpEnvironment(env)
 
         val comment = CommentFactory.commentToPostWithUser(currentUser)
@@ -440,14 +456,17 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
             .build()
 
         this.vm.inputs.configureWith(commentCardData)
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
+
         this.vm.inputs.onRetryViewClicked()
+        testScheduler.advanceTimeBy(3, TimeUnit.SECONDS)
 
         this.retrySendComment.assertValue(comment)
+
+        this.internalError.assertValueCount(2)
         this.commentCardStatus.assertValues(
             CommentCardStatus.TRYING_TO_POST,
-            CommentCardStatus.FAILED_TO_SEND_COMMENT,
-            CommentCardStatus.RE_TRYING_TO_POST,
-            CommentCardStatus.FAILED_TO_SEND_COMMENT
+            CommentCardStatus.RE_TRYING_TO_POST
         )
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
@@ -438,11 +438,11 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
         val currentUser = UserFactory.user().toBuilder().id(1).build()
 
         val env = environment().toBuilder()
-                .apolloClient(object : MockApolloClient() {
-            override fun createComment(comment: PostCommentData): Observable<Comment> {
-                return Observable.error(Throwable())
-            }
-        }).scheduler(testScheduler)
+            .apolloClient(object : MockApolloClient() {
+                override fun createComment(comment: PostCommentData): Observable<Comment> {
+                    return Observable.error(Throwable())
+                }
+            }).scheduler(testScheduler)
             .currentUser(MockCurrentUser(currentUser))
             .build()
 


### PR DESCRIPTION
# 📲 What

Add 1 second delay before transitioning from Posting… back to any state

# 🤔 Why

apply the delay to any transition

# 🛠 How

adding delay before retrying so Posting state can be visiable 

# 👀 See


https://user-images.githubusercontent.com/1075310/121569293-eda96d00-ca20-11eb-943d-2857d4224149.mp4


# 📋 QA

- Add new comments, pull to refresh
- try to post without connection, you'll see the error states, 
- Retry makes sure to see "posting..." state 
- then get back connectivity and retry


# Story 📖

https://kickstarter.atlassian.net/browse/NT-2029