### PR TITLE
NT-2037: Pagination Error Cell displayed at the same time as the comments cells 

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.ui.activities
 
 import android.content.Intent
+import android.opengl.Visibility
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
@@ -21,7 +22,6 @@ import com.kickstarter.viewmodels.CommentsViewModel
 import org.joda.time.DateTime
 import rx.android.schedulers.AndroidSchedulers
 import java.util.concurrent.TimeUnit
-
 
 @RequiresActivityViewModel(CommentsViewModel.ViewModel::class)
 class CommentsActivity :
@@ -100,6 +100,7 @@ class CommentsActivity :
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
                 adapter.addErrorPaginationCell()
+                binding.commentsRecyclerView.smoothScrollToPosition(adapter.itemCount)
             }
 
         binding.commentComposer.setCommentComposerActionClickListener(object : OnCommentComposerViewClickedListener {

--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -100,7 +100,6 @@ class CommentsActivity :
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
                 adapter.addErrorPaginationCell()
-                binding.commentsRecyclerView.smoothScrollToPosition(adapter.itemCount)
             }
 
         binding.commentComposer.setCommentComposerActionClickListener(object : OnCommentComposerViewClickedListener {

--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -1,14 +1,9 @@
 package com.kickstarter.ui.activities
 
-import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.view.isVisible
-import androidx.transition.ChangeBounds
-import androidx.transition.TransitionManager
 import com.kickstarter.R
 import com.kickstarter.databinding.ActivityCommentsLayoutBinding
 import com.kickstarter.libs.BaseActivity
@@ -23,7 +18,6 @@ import com.kickstarter.ui.extensions.hideKeyboard
 import com.kickstarter.ui.viewholders.EmptyCommentsViewHolder
 import com.kickstarter.ui.views.OnCommentComposerViewClickedListener
 import com.kickstarter.viewmodels.CommentsViewModel
-import kotlinx.android.synthetic.main.fragment_pledge_section_header_reward_sumary.*
 import org.joda.time.DateTime
 import rx.android.schedulers.AndroidSchedulers
 import java.util.concurrent.TimeUnit
@@ -105,16 +99,7 @@ class CommentsActivity :
             .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
-                val alphaValue = if (it) 1.0f else 0.0f
-                binding.paginationErrorComponent.animate()
-                    .alpha(alphaValue)
-                    .setDuration(300)
-                    .setListener(object : AnimatorListenerAdapter() {
-                        override fun onAnimationEnd(animation: Animator) {
-                            super.onAnimationEnd(animation)
-                            binding.paginationErrorComponent.visibility = if (it) View.VISIBLE else View.GONE
-                        }
-                    })
+                adapter.addErrorPaginationCell()
             }
 
         binding.commentComposer.setCommentComposerActionClickListener(object : OnCommentComposerViewClickedListener {

--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -1,7 +1,6 @@
 package com.kickstarter.ui.activities
 
 import android.content.Intent
-import android.opengl.Visibility
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible

--- a/app/src/main/java/com/kickstarter/ui/adapters/CommentsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/CommentsAdapter.kt
@@ -8,7 +8,10 @@ import com.kickstarter.databinding.EmptyViewBinding
 import com.kickstarter.databinding.ItemCommentCardBinding
 import com.kickstarter.databinding.ItemErrorPaginationBinding
 import com.kickstarter.ui.data.CommentCardData
-import com.kickstarter.ui.viewholders.*
+import com.kickstarter.ui.viewholders.CommentCardViewHolder
+import com.kickstarter.ui.viewholders.EmptyCommentsViewHolder
+import com.kickstarter.ui.viewholders.EmptyViewHolder
+import com.kickstarter.ui.viewholders.KSViewHolder
 
 class CommentsAdapter(private val delegate: Delegate) : KSListAdapter() {
     interface Delegate : EmptyCommentsViewHolder.Delegate, CommentCardViewHolder.Delegate

--- a/app/src/main/java/com/kickstarter/ui/adapters/CommentsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/CommentsAdapter.kt
@@ -4,27 +4,49 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import com.kickstarter.R
+import com.kickstarter.databinding.EmptyViewBinding
 import com.kickstarter.databinding.ItemCommentCardBinding
+import com.kickstarter.databinding.ItemErrorPaginationBinding
 import com.kickstarter.ui.data.CommentCardData
-import com.kickstarter.ui.viewholders.CommentCardViewHolder
-import com.kickstarter.ui.viewholders.EmptyCommentsViewHolder
-import com.kickstarter.ui.viewholders.KSViewHolder
+import com.kickstarter.ui.viewholders.*
 
 class CommentsAdapter(private val delegate: Delegate) : KSListAdapter() {
     interface Delegate : EmptyCommentsViewHolder.Delegate, CommentCardViewHolder.Delegate
 
-    @LayoutRes
-    override fun layout(sectionRow: SectionRow): Int {
-        return R.layout.item_comment_card
+    init {
+        insertSection(SECTION_COMENTS, emptyList<CommentCardData>())
+        insertSection(SECCTION_ERROR_PAGINATING, emptyList<Throwable>())
+    }
+
+    override fun layout(sectionRow: SectionRow): Int = when (sectionRow.section()) {
+        SECTION_COMENTS -> R.layout.item_comment_card
+        SECCTION_ERROR_PAGINATING -> R.layout.item_error_pagination
+        else -> 0
     }
 
     fun takeData(comments: List<CommentCardData>) {
-        clearSections()
-        addSection(comments)
+        setSection(SECTION_COMENTS, comments)
+        // - Clean every section different from the comments section if adding more comments
+        setSection(SECCTION_ERROR_PAGINATING, emptyList<Boolean>())
+        submitList(items())
+    }
+
+    fun addErrorPaginationCell() {
+        // - adding 1 element no clearing previous sections
+        setSection(SECCTION_ERROR_PAGINATING, listOf(true))
         submitList(items())
     }
 
     override fun viewHolder(@LayoutRes layout: Int, viewGroup: ViewGroup): KSViewHolder {
-        return CommentCardViewHolder(ItemCommentCardBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false), delegate)
+        return when (layout) {
+            R.layout.item_comment_card -> CommentCardViewHolder(ItemCommentCardBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false), delegate)
+            R.layout.item_error_pagination -> EmptyViewHolder(ItemErrorPaginationBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false))
+            else -> EmptyViewHolder(EmptyViewBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false))
+        }
+    }
+
+    companion object {
+        private const val SECTION_COMENTS = 0
+        private const val SECCTION_ERROR_PAGINATING = 1
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -196,10 +196,9 @@ interface CommentsViewModel {
                     Timber.d("************ On initializing error")
                 }
 
-            // TODO showcasing pagination error subscriptionto be completed on : https://kickstarter.atlassian.net/browse/NT-2019
             this.paginationError
+                .compose(bindToLifecycle())
                 .subscribe {
-                    this.isLoadingMoreItems.onNext(false)
                     this.displayPaginationError.onNext(true)
                 }
 
@@ -222,7 +221,6 @@ interface CommentsViewModel {
                 .compose(Transformers.takeWhen(this.nextPage))
                 .doOnNext {
                     this.isLoadingMoreItems.onNext(true)
-                    this.displayPaginationError.onNext(false)
                 }
                 .switchMap { getProjectComments(Observable.just(it), this.paginationError) }
                 .compose(bindToLifecycle())
@@ -255,6 +253,7 @@ interface CommentsViewModel {
             return@switchMap apolloClient.getProjectComments(it.slug() ?: "", lastCommentCursor)
         }.doOnError {
             errorObservable.onNext(it)
+            this.isLoadingMoreItems.onNext(false)
         }
             .onErrorResumeNext(Observable.empty())
             .filter { ObjectUtils.isNotNull(it) }

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -188,7 +188,7 @@ interface CommentsViewModel {
 
             // TODO showcasing subscription to initialization to be completed on : https://kickstarter.atlassian.net/browse/NT-1951
             this.internalError
-                .withLatestFrom(this.commentsList) { error, commentList -> Pair(error, commentList) }
+                .compose(combineLatestPair(commentsList))
                 .filter { it.second.isEmpty() }
                 .map { it.first }
                 .subscribe {

--- a/app/src/main/res/layout/activity_comments_layout.xml
+++ b/app/src/main/res/layout/activity_comments_layout.xml
@@ -40,6 +40,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:focusable="true"
+        android:background="@color/comment_background"
         tools:context="com.kickstarter.ui.activities.CommentsActivity"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         android:orientation="vertical">
@@ -60,7 +61,7 @@
             android:id="@+id/comments_swipe_refresh_layout"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toTopOf="@+id/comment_composer"
+            app:layout_constraintBottom_toTopOf="@+id/pagination_error_component"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
@@ -72,13 +73,23 @@
                 android:background="@color/kds_white"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 tools:listitem="@layout/comment_card" />
-
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/pagination_error_component"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/grid_8"
+            android:background="@color/kds_alert"
+            android:visibility="gone"
+            android:animateLayoutChanges="true"
+            app:layout_constraintTop_toBottomOf="@id/comments_swipe_refresh_layout"
+            app:layout_constraintBottom_toTopOf="@id/comment_composer"/>
 
         <ProgressBar
             android:id="@+id/comments_loading_indicator"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@+id/comment_composer"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
@@ -91,6 +102,5 @@
             app:composer_action_button_gone="true"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_comments_layout.xml
+++ b/app/src/main/res/layout/activity_comments_layout.xml
@@ -61,7 +61,7 @@
             android:id="@+id/comments_swipe_refresh_layout"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toTopOf="@+id/pagination_error_component"
+            app:layout_constraintBottom_toTopOf="@+id/comment_composer"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
@@ -74,16 +74,6 @@
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 tools:listitem="@layout/comment_card" />
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
-
-        <androidx.appcompat.widget.AppCompatImageButton
-            android:id="@+id/pagination_error_component"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/grid_8"
-            android:background="@color/kds_alert"
-            android:visibility="gone"
-            android:animateLayoutChanges="true"
-            app:layout_constraintTop_toBottomOf="@id/comments_swipe_refresh_layout"
-            app:layout_constraintBottom_toTopOf="@id/comment_composer"/>
 
         <ProgressBar
             android:id="@+id/comments_loading_indicator"

--- a/app/src/main/res/layout/item_error_pagination.xml
+++ b/app/src/main/res/layout/item_error_pagination.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.appcompat.widget.AppCompatImageButton
+        android:id="@+id/pagination_error_component"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/grid_8"
+        android:background="@color/kds_alert"
+        android:animateLayoutChanges="true"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -34,6 +34,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     private val pullToRefreshError = TestSubscriber.create<Throwable>()
     private val initialLoadError = TestSubscriber.create<Throwable>()
     private val paginationError = TestSubscriber.create<Throwable>()
+    private val shouldShowPaginatedCell = TestSubscriber.create<Boolean>()
     private val openCommentGuideLines = TestSubscriber<Void>()
 
     @Test
@@ -263,6 +264,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         vm.outputs.pullToRefreshError().subscribe(pullToRefreshError)
         vm.outputs.initialLoadCommentsError().subscribe(initialLoadError)
         vm.outputs.paginateCommentsError().subscribe(paginationError)
+        vm.outputs.shouldShowPaginationErrorUI().subscribe(shouldShowPaginatedCell)
 
         // Start the view model with a project.
         vm.inputs.refresh()
@@ -274,6 +276,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         pullToRefreshError.assertValueCount(1)
         initialLoadError.assertValueCount(0)
         paginationError.assertNoValues()
+        shouldShowPaginatedCell.assertNoValues()
     }
 
     @Test
@@ -295,6 +298,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         vm.outputs.isLoadingMoreItems().subscribe(isLoadingMoreItems)
         vm.outputs.commentsList().subscribe(commentsList)
         vm.outputs.paginateCommentsError().subscribe(paginationError)
+        vm.outputs.shouldShowPaginationErrorUI().subscribe(shouldShowPaginatedCell)
 
         enablePagination.assertValues(true)
 
@@ -305,6 +309,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         enablePagination.assertValues(true)
         commentsList.assertValueCount(1)
         paginationError.assertValueCount(1)
+        shouldShowPaginatedCell.assertValue(true)
     }
 
     /*


### PR DESCRIPTION
# 📲 What

- Subtask to add the new cell to handle the pagination error state
- ⚠️  the actual UI for the cell will come on next PR's this is just displaying two types of cell within the same RecyclerView and tidying up together the pagination errors logic.

# 🤔 Why
- Error when pagination designs required a a new cell within the actual recyclerview

# 👀 See

![errorCellScreenShoot](https://user-images.githubusercontent.com/4083656/121607603-2cc9c500-ca05-11eb-9172-9b2a77eb3adc.png)

https://user-images.githubusercontent.com/4083656/121607613-32bfa600-ca05-11eb-8ace-7e1ba5b75586.mp4


|  |  |

# 📋 QA
- Load comments for a project with many comments, turn off you connection, scroll to the bottom and try to paginate, you'll see the placeholder error cell appearing.
- recover connectivity, try to scroll again, the cell will disappear and you will see more comments added to the list.

# Story 📖

[NT-2037](https://kickstarter.atlassian.net/browse/NT-2037)
