### PR TITLE
[NT-2045] Identify when the Segment SDK is Initialized

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -142,6 +142,10 @@ open class SegmentTrackingClient(
 
             this.isInitialized = true
 
+            loggedInUser?.let {
+                identify(it)
+            }
+
             if (build.isDebug) {
                 Timber.d("${type().tag} client:$segmentClient isInitialized:$isInitialized")
                 Timber.d("${type().tag} currentThread: ${Thread.currentThread()}")


### PR DESCRIPTION
# 📲 What

Call the identify call when the Segment SDK is initialized and ready to receive an identify call. We noticed that when opening the app when the user is logged in, the app identifies the user before the SDK is initialized. This prevents the user from being identified. 

# 🛠 How

Add an additional identify call when the SDK initialization is completed. The trade off of the additional identify call is worth it for ensuring the user is identified. 

# 📋 QA

- [ ] Run the app with the user logged in and make sure the user is identified

[NT-2045](https://kickstarter.atlassian.net/browse/NT-2045)
