### PR TITLE
NT-2038: Cell UI for pagination error & NT-2039: Reload the errored page

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -16,6 +16,7 @@ import com.kickstarter.models.Comment
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.adapters.CommentsAdapter
 import com.kickstarter.ui.extensions.hideKeyboard
+import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.ui.viewholders.EmptyCommentsViewHolder
 import com.kickstarter.ui.views.OnCommentComposerViewClickedListener
 import com.kickstarter.viewmodels.CommentsViewModel
@@ -106,7 +107,7 @@ class CommentsActivity :
             .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
-                adapter.addErrorPaginationCell()
+                adapter.addErrorPaginationCell(it)
             }
 
         binding.commentComposer.setCommentComposerActionClickListener(object : OnCommentComposerViewClickedListener {
@@ -184,6 +185,12 @@ class CommentsActivity :
         }
         binding.commentsSwipeRefreshLayout.visibility = (!visibility).toVisibility()
         binding.noComments.visibility = visibility.toVisibility()
+    }
+
+    override fun retryCallback() {
+        // TODO: retry the same page https://kickstarter.atlassian.net/browse/NT-2039
+        // TODO: snackbar to help QA, should be deleted once NT-2039 is finished
+        this.showSnackbar(binding.commentsSwipeRefreshLayout, R.string.Couldnt_load_more_comments)
     }
 
     override fun emptyCommentsLoginClicked(viewHolder: EmptyCommentsViewHolder?) {

--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -16,7 +16,6 @@ import com.kickstarter.models.Comment
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.adapters.CommentsAdapter
 import com.kickstarter.ui.extensions.hideKeyboard
-import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.ui.viewholders.EmptyCommentsViewHolder
 import com.kickstarter.ui.views.OnCommentComposerViewClickedListener
 import com.kickstarter.viewmodels.CommentsViewModel
@@ -188,9 +187,7 @@ class CommentsActivity :
     }
 
     override fun retryCallback() {
-        // TODO: retry the same page https://kickstarter.atlassian.net/browse/NT-2039
-        // TODO: snackbar to help QA, should be deleted once NT-2039 is finished
-        this.showSnackbar(binding.commentsSwipeRefreshLayout, R.string.Couldnt_load_more_comments)
+        viewModel.inputs.nextPage()
     }
 
     override fun emptyCommentsLoginClicked(viewHolder: EmptyCommentsViewHolder?) {

--- a/app/src/main/java/com/kickstarter/ui/adapters/CommentsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/CommentsAdapter.kt
@@ -13,9 +13,10 @@ import com.kickstarter.ui.viewholders.CommentCardViewHolder
 import com.kickstarter.ui.viewholders.EmptyCommentsViewHolder
 import com.kickstarter.ui.viewholders.EmptyViewHolder
 import com.kickstarter.ui.viewholders.KSViewHolder
+import com.kickstarter.ui.viewholders.PaginationErrorViewHolder
 
 class CommentsAdapter(private val delegate: Delegate) : KSListAdapter() {
-    interface Delegate : EmptyCommentsViewHolder.Delegate, CommentCardViewHolder.Delegate
+    interface Delegate : EmptyCommentsViewHolder.Delegate, CommentCardViewHolder.Delegate, PaginationErrorViewHolder.ViewListener
 
     init {
         insertSection(SECTION_INITIAL_LOAD_ERROR, emptyList<Boolean>())
@@ -37,9 +38,9 @@ class CommentsAdapter(private val delegate: Delegate) : KSListAdapter() {
         submitList(items())
     }
 
-    fun addErrorPaginationCell() {
+    fun addErrorPaginationCell(shouldShowErrorCell: Boolean) {
         // - we want to display SECTION_COMMENTS & SECTION_ERROR_PAGINATING at the same time so we should not clean SECTION_COMMENTS
-        setSection(SECTION_ERROR_PAGINATING, listOf(true))
+        setSection(SECTION_ERROR_PAGINATING, listOf(shouldShowErrorCell))
         setSection(SECTION_INITIAL_LOAD_ERROR, emptyList<Boolean>())
         submitList(items())
     }
@@ -55,7 +56,7 @@ class CommentsAdapter(private val delegate: Delegate) : KSListAdapter() {
         return when (layout) {
             R.layout.item_comment_card -> CommentCardViewHolder(ItemCommentCardBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false), delegate)
             R.layout.comment_initial_load_error_layout -> EmptyViewHolder(CommentInitialLoadErrorLayoutBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false))
-            R.layout.item_error_pagination -> EmptyViewHolder(ItemErrorPaginationBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false))
+            R.layout.item_error_pagination -> PaginationErrorViewHolder(ItemErrorPaginationBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false), delegate)
             else -> EmptyViewHolder(EmptyViewBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false))
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/PaginationErrorViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/PaginationErrorViewHolder.kt
@@ -1,0 +1,38 @@
+package com.kickstarter.ui.viewholders
+
+import com.kickstarter.databinding.ItemErrorPaginationBinding
+import com.kickstarter.libs.rx.transformers.Transformers
+import com.kickstarter.libs.utils.extensions.toVisibility
+import com.kickstarter.viewmodels.PaginationErrorViewHolderViewModel
+
+@Suppress("UNCHECKED_CAST")
+class PaginationErrorViewHolder(
+    val binding: ItemErrorPaginationBinding,
+    private val viewListener: ViewListener
+) : KSViewHolder(binding.root) {
+
+    interface ViewListener {
+        fun retryCallback()
+    }
+
+    private val vm: PaginationErrorViewHolderViewModel.ViewModel = PaginationErrorViewHolderViewModel.ViewModel(environment())
+
+    init {
+        this.vm.outputs.isErrorPaginationVisible()
+            .compose(bindToLifecycle())
+            .compose(Transformers.observeForUI())
+            .subscribe {
+                binding.errorPaginationRetryButton.visibility = it.toVisibility()
+            }
+
+        binding.errorPaginationRetryButton.setOnClickListener {
+            viewListener.retryCallback()
+        }
+    }
+
+    override fun bindData(data: Any?) {
+        if (data is Boolean) {
+            this.vm.inputs.configureWith(data)
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/viewmodels/PaginationErrorViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PaginationErrorViewHolderViewModel.kt
@@ -1,0 +1,44 @@
+package com.kickstarter.viewmodels
+
+import com.kickstarter.libs.ActivityViewModel
+import com.kickstarter.libs.Environment
+import com.kickstarter.ui.viewholders.PaginationErrorViewHolder
+import rx.Observable
+import rx.subjects.BehaviorSubject
+
+interface PaginationErrorViewHolderViewModel {
+    interface Inputs {
+        /** Pair with the configuration for the feedback cell UI
+         * @param configureCellWith
+         * - true: Show Error Cell configuration
+         * - false: Hide Error Cell configuration
+         */
+        fun configureWith(configureCellWith: Boolean)
+    }
+
+    interface Outputs {
+        fun isErrorPaginationVisible(): Observable<Boolean>
+    }
+
+    class ViewModel(environment: Environment) : ActivityViewModel<PaginationErrorViewHolder>(environment), Inputs, Outputs {
+        private val isErrorPaginationVisible = BehaviorSubject.create<Boolean>()
+        private val initCellConfig = BehaviorSubject.create<Boolean>()
+
+        val inputs = this
+        val outputs = this
+
+        init {
+            this.initCellConfig
+                .compose(bindToLifecycle())
+                .subscribe {
+                    this.isErrorPaginationVisible.onNext(it)
+                }
+        }
+
+        // - Inputs
+        override fun configureWith(shouldShowErrorCell: Boolean) = this.initCellConfig.onNext(shouldShowErrorCell)
+
+        // - Outputs
+        override fun isErrorPaginationVisible(): Observable<Boolean> = this.isErrorPaginationVisible
+    }
+}

--- a/app/src/main/res/layout/item_error_pagination.xml
+++ b/app/src/main/res/layout/item_error_pagination.xml
@@ -2,16 +2,24 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:id="@+id/pagination_error_cell"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <androidx.appcompat.widget.AppCompatImageButton
-        android:id="@+id/pagination_error_component"
+    <androidx.appcompat.widget.AppCompatButton
         android:layout_width="match_parent"
-        android:layout_height="@dimen/grid_8"
-        android:background="@color/kds_alert"
-        android:animateLayoutChanges="true"
+        android:id="@+id/error_pagination_retry_button"
+        style="@style/CommentsRetryButton"
+        android:layout_height="@dimen/grid_9"
+        android:layout_marginStart="@dimen/grid_3"
+        android:layout_marginTop="@dimen/grid_2"
+        android:drawableStart="@drawable/ic_retry_send_comment"
+        android:text="@string/Couldnt_load_more_comments"
+        android:gravity="center_vertical"
+        android:visibility="gone"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,4 +93,5 @@
   <string name="view_replies">View replies</string>
   <string name="posting">Posting...</string>
   <string name="posted">Posted</string>
+    <string name="Couldnt_load_more_comments">Couldnt load more comments. Tap to retry</string>
 </resources>

--- a/app/src/test/java/com/kickstarter/viewmodels/PaginationErrorViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PaginationErrorViewHolderViewModelTest.kt
@@ -4,7 +4,7 @@ import com.kickstarter.KSRobolectricTestCase
 import org.junit.Test
 import rx.observers.TestSubscriber
 
-class PaginationErrorViewHolderViewModelTest: KSRobolectricTestCase(){
+class PaginationErrorViewHolderViewModelTest : KSRobolectricTestCase() {
     private lateinit var vm: PaginationErrorViewHolderViewModel.ViewModel
 
     private val isErrorCellVisible = TestSubscriber<Boolean>()

--- a/app/src/test/java/com/kickstarter/viewmodels/PaginationErrorViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PaginationErrorViewHolderViewModelTest.kt
@@ -1,0 +1,32 @@
+package com.kickstarter.viewmodels
+
+import com.kickstarter.KSRobolectricTestCase
+import org.junit.Test
+import rx.observers.TestSubscriber
+
+class PaginationErrorViewHolderViewModelTest: KSRobolectricTestCase(){
+    private lateinit var vm: PaginationErrorViewHolderViewModel.ViewModel
+
+    private val isErrorCellVisible = TestSubscriber<Boolean>()
+
+    private fun setupEnvironment() {
+        this.vm = PaginationErrorViewHolderViewModel.ViewModel(environment())
+        this.vm.outputs.isErrorPaginationVisible().subscribe(isErrorCellVisible)
+    }
+
+    @Test
+    fun isErrorCellUIVisible() {
+        setupEnvironment()
+
+        this.vm.inputs.configureWith(true)
+        this.isErrorCellVisible.assertValue(true)
+    }
+
+    @Test
+    fun isErrorCellUINotVisible() {
+        setupEnvironment()
+
+        this.vm.inputs.configureWith(false)
+        this.isErrorCellVisible.assertValue(false)
+    }
+}


### PR DESCRIPTION
# 📲 What

- Added pagination Error cell ViewHolder + ViewModel + ViewHolderViewModelTest
- Retry errorred page callback


# 👀 See

https://user-images.githubusercontent.com/4083656/121965519-fdc39400-cd21-11eb-94ce-f148689678a6.mp4




|  |  |

# 📋 QA
- Load a project with several comments -> Load coments screen - Lose conectivity -> scroll to the bottom -> once the loading indicator has finished you'll see a new cell on the bottom with the error displayed -> touch the cell or pull the bottom of the list -> recover conectivity ->  touch the cell or pull the bottom of the list -> you will see the next page loaded on the list and the error cell disappear 

# Story 📖

[NT-2019](https://kickstarter.atlassian.net/browse/NT-2019)
