### PR TITLE
Fix "Reply" copy

### DIFF
--- a/app/src/main/res/layout/comment_card.xml
+++ b/app/src/main/res/layout/comment_card.xml
@@ -59,9 +59,9 @@
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/reply_button"
-        style="@style/CommentsReplayButton"
+        style="@style/CommentsReplyButton"
         android:drawableStart="@drawable/ic_arrow_reply"
-        android:text="@string/Replay"
+        android:text="@string/general_navigation_buttons_reply"
         android:layout_marginTop="@dimen/grid_3"
         app:layout_goneMarginTop="@dimen/grid_none"
         android:layout_marginStart="@dimen/grid_none"
@@ -72,7 +72,7 @@
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/retry_button"
-        style="@style/CommentsReplayButton"
+        style="@style/CommentsReplyButton"
         android:layout_marginStart="@dimen/grid_none"
         android:layout_marginTop="@dimen/grid_0"
         app:layout_constraintTop_toBottomOf="@id/replies"
@@ -93,7 +93,7 @@
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/posting_button"
-        style="@style/CommentsReplayButton"
+        style="@style/CommentsReplyButton"
         android:drawableTint="@color/kds_support_400"
         android:drawableStart="@drawable/ic_retry_send_comment"
         android:text="@string/Posting"
@@ -105,7 +105,7 @@
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/posted_button"
-        style="@style/CommentsReplayButton"
+        style="@style/CommentsReplyButton"
         android:textColor="@color/kds_create_700"
         android:drawableStart="@drawable/ic_posted_check"
         android:text="@string/Posted"
@@ -117,7 +117,7 @@
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/info_button"
-        style="@style/CommentsReplayButton"
+        style="@style/CommentsReplyButton"
         android:src="@drawable/ic_info"
         app:layout_constraintTop_toTopOf="@+id/flagged_message"
         app:layout_constraintStart_toStartOf="@id/avatar"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -911,7 +911,7 @@
     <item name="android:background">@android:color/transparent</item>
   </style>
 
-  <style name="CommentsReplayButton" parent="CommentsCardButton">
+  <style name="CommentsReplyButton" parent="CommentsCardButton">
     <item name="android:textAllCaps">false</item>
     <item name="android:layout_width">0dp</item>
     <item name="android:layout_marginEnd">@dimen/grid_3</item>
@@ -931,7 +931,7 @@
     <item name="android:letterSpacing">0.01</item>
   </style>
 
-  <style name="CommentsRetryButton" parent="CommentsReplayButton">
+  <style name="CommentsRetryButton" parent="CommentsReplyButton">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:textColor">@color/retry_color</item>
   </style>


### PR DESCRIPTION
# 📲 What

We were displaying the wrong copy for the "Reply" button on the comment card. This updates to use the correct string.

# 👀 See

English and Spanish translations for reply, as examples:

![Screenshot_1623862463](https://user-images.githubusercontent.com/19390326/122261497-77828b80-cea2-11eb-9667-320ac9030970.png) ![Screenshot_1623862500](https://user-images.githubusercontent.com/19390326/122261498-77828b80-cea2-11eb-932d-fcd6680ada3a.png)

# 📋 QA

Go to the comments page on a project you have backed and check to make sure the Reply button is spelled correctly. Change device language to another language (Spanish or german for example) and recheck the comments page to make sure the correct translation is being used. 
