### PR TITLE
[NT-2079] Fix Crash on CommentsActivity

### DIFF
--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -807,7 +807,7 @@ private fun createCommentObject(commentFr: fragment.Comment?): Comment {
 
     val author = User.builder()
         .id(decodeRelayId(commentFr?.author()?.fragments()?.user()?.id()) ?: -1)
-        .name(commentFr?.author()?.fragments()?.user()?.name())
+        .name(commentFr?.author()?.fragments()?.user()?.name() ?: "")
         .avatar(
             Avatar.builder()
                 .medium(commentFr?.author()?.fragments()?.user()?.imageUrl())


### PR DESCRIPTION
# 📲 What

Firebase shows an increased number of crashes on the `OnSubscribeMap.java`. Looking into the logs, the issues is due to an error for a null name. All of the crashes are on the comments activity. 

`com.kickstarter.services.KSApolloClientKt.createCommentObject (KSApolloClient.kt:816)`

At this line, we are building a user object from the comment fragment, however we are not checking if the author is null. If it is the name will be null and would crash the app on the comments activity

# 🛠 How

The fix is to simply check if the name of the author is null before building the user object.

# 📋 QA

- In the code, change line 810 in `KSApolloClient.kt` to `.name(null)` 
- This will force it to crash since a user's name should never be null
- Next change line 810 to `name(null) ?: "")`
- This should prevent the crash, and this emulates what is happening in the actual implementation if the name is null


# Story 📖

[NT-2079](https://kickstarter.atlassian.net/browse/NT-2079)
