### PR TITLE
NT-2028: Navigation – Back button should slide view out

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -2,6 +2,7 @@ package com.kickstarter.ui.activities
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Pair
 import android.view.View
 import androidx.core.view.isVisible
 import com.kickstarter.R
@@ -11,6 +12,7 @@ import com.kickstarter.libs.RecyclerViewPaginator
 import com.kickstarter.libs.SwipeRefresher
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.utils.ApplicationUtils
+import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.UrlUtils
 import com.kickstarter.libs.utils.extensions.toVisibility
 import com.kickstarter.models.Comment
@@ -223,11 +225,14 @@ class CommentsActivity :
             putExtra(IntentKey.REPLY_EXPAND, openKeyboard)
         }
 
-        startActivityWithTransition(
-            threadIntent,
-            R.anim.slide_in_right,
-            R.anim.fade_out_slide_out_left
-        )
+        startActivity(threadIntent)
+        this.let {
+            TransitionUtils.transition(it, TransitionUtils.slideInFromRight())
+        }
+    }
+
+    override fun exitTransition(): Pair<Int, Int>? {
+        return Pair.create(R.anim.fade_in_slide_in_left, R.anim.slide_out_right)
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -30,6 +30,7 @@ import com.kickstarter.libs.MessagePreviousScreenType
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ApplicationUtils
+import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.models.Project
 import com.kickstarter.models.StoredCard
@@ -673,13 +674,15 @@ class ProjectActivity :
     }
 
     private fun startRootCommentsActivity(projectAndData: Pair<Project, ProjectData>) {
-        startActivityWithTransition(
+        startActivity(
             Intent(this, CommentsActivity::class.java)
                 .putExtra(IntentKey.PROJECT, projectAndData.first)
-                .putExtra(IntentKey.PROJECT_DATA, projectAndData.second),
-            R.anim.slide_in_right,
-            R.anim.fade_out_slide_out_left
+                .putExtra(IntentKey.PROJECT_DATA, projectAndData.second)
         )
+
+        this.let {
+            TransitionUtils.transition(it, TransitionUtils.slideInFromRight())
+        }
     }
 
     private fun startShareIntent(projectNameAndShareUrl: Pair<String, String>) {

--- a/app/src/main/java/com/kickstarter/ui/activities/ThreadActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ThreadActivity.kt
@@ -1,7 +1,9 @@
 package com.kickstarter.ui.activities
 
 import android.os.Bundle
+import android.util.Pair
 import androidx.core.view.isVisible
+import com.kickstarter.R
 import com.kickstarter.databinding.ActivityThreadLayoutBinding
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.KSString
@@ -98,6 +100,10 @@ class ThreadActivity :
         binding.commentsCardView.setCommentPostTime(DateTimeUtils.relative(this, ksString, comment.createdAt()))
         binding.commentsCardView.setCommentUserName(comment.author().name())
         binding.commentsCardView.setAvatarUrl(comment.author().avatar().medium())
+    }
+
+    override fun exitTransition(): Pair<Int, Int>? {
+        return Pair.create(R.anim.fade_in_slide_in_left, R.anim.slide_out_right)
     }
 
     override fun onRetryViewClicked(comment: Comment) {


### PR DESCRIPTION
# 📲 What

Navigation – Back button should slide view out

# 🤔 Why

Some background context on why the change is needed.

# 🛠 How

- Changed transision on startActivity

# 👀 See

- Navigate to any backed project
- Select comments
- Navigate to replies
- Navigate back to comments, afterwards to project. You should see the transitions

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

Instructions for anyone to be able to QA this work.

# Story 📖

https://kickstarter.atlassian.net/browse/NT-2028
