### PR TITLE
NT-2099:Crash when we create new comment and Press reply button

### DIFF
--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -838,7 +838,7 @@ private fun createPageInfoObject(pageFr: fragment.PageInfo?): PageInfoEnvelope {
 }
 
 private fun createCommentEnvelop(responseData: GetRepliesForCommentQuery.Data): CommentEnvelope {
-    val replies = (responseData.commentable() as GetRepliesForCommentQuery.AsComment).replies()
+    val replies = (responseData.commentable() as? GetRepliesForCommentQuery.AsComment)?.replies()
     val listOfComments = replies?.nodes()?.map { commentFragment ->
         createCommentObject(commentFragment.fragments().comment())
     } ?: emptyList()

--- a/app/src/main/java/com/kickstarter/ui/adapters/RepliesAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/RepliesAdapter.kt
@@ -28,7 +28,7 @@ class RepliesAdapter(private val delegate: Delegate) : KSListAdapter() {
         insertSection(SECTION_ROOT_COMMENT, emptyList<Comment>())
     }
 
-    fun takeData(replies: List<CommentCardData>, shouldViewMoreRepliesCell: Boolean,) {
+    fun takeData(replies: List<CommentCardData>, shouldViewMoreRepliesCell: Boolean) {
         if (replies.isNotEmpty()) {
             setSection(SECTION_COMMENTS, replies)
             setSection(SECTION_SHOW_MORE_REPLIES_PAGINATING, listOf(shouldViewMoreRepliesCell))

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -367,8 +367,7 @@ interface CommentsViewHolderViewModel {
                 (it.isBacking || ProjectUtils.userIsCreator(it, user)) && featureFlagActive &&
                     (
                         commentCardData.commentCardState == CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus ||
-                            commentCardData.commentCardState == CommentCardStatus.COMMENT_WITH_REPLIES.commentCardStatus ||
-                            commentCardData.commentCardState == CommentCardStatus.TRYING_TO_POST.commentCardStatus
+                            commentCardData.commentCardState == CommentCardStatus.COMMENT_WITH_REPLIES.commentCardStatus
                         ) &&
                     (commentCardData.comment?.parentId() ?: -1) < 0
             } ?: false


### PR DESCRIPTION
# 📲 What

Crash when we create a new comment and Press the reply button

# 🤔 Why

when we create a new comment and press reply we got crash as the comment wasn't posted  and doesn't have id

# 🛠 How

The replay button is visible after a comment posted successfully 
![image](https://user-images.githubusercontent.com/1075310/124661757-39c4c180-dea8-11eb-951d-77c1db051ae2.png)

# 👀 See

https://user-images.githubusercontent.com/1075310/124662572-544b6a80-dea9-11eb-884a-e8a610fa4c33.mp4
https://user-images.githubusercontent.com/1075310/124662856-a2f90480-dea9-11eb-8ba1-7984c27029d4.mp4


# 📋 QA
1- Post a new comment  and click reply
2- Post a new comment  in offline mode and  then retry after posting click reply
3- add the first comment 

# Story 📖
https://kickstarter.atlassian.net/browse/NT-2099
