### PR TITLE
NT-2067: 3DS card crash with SCA flow

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -80,6 +80,7 @@ import com.kickstarter.services.interceptors.KSRequestInterceptor;
 import com.kickstarter.services.interceptors.WebRequestInterceptor;
 import com.kickstarter.ui.SharedPreferenceKey;
 import com.optimizely.ab.android.sdk.OptimizelyManager;
+import com.stripe.android.PaymentConfiguration;
 import com.stripe.android.Stripe;
 
 import org.joda.time.DateTime;
@@ -596,6 +597,9 @@ public class ApplicationModule {
     final String stripePublishableKey = apiEndpoint == ApiEndpoint.PRODUCTION
       ? Secrets.StripePublishableKey.PRODUCTION
       : Secrets.StripePublishableKey.STAGING;
+    PaymentConfiguration.init(
+            context,
+            stripePublishableKey);
     return new Stripe(context, stripePublishableKey);
   }
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -418,7 +418,7 @@ class PledgeFragment : BaseFragment<PledgeFragmentViewModel.ViewModel>(), Reward
         this.viewModel.outputs.showSCAFlow()
             .compose(bindToLifecycle())
             .compose(observeForUI())
-            .subscribe { this.viewModel.environment.stripe().authenticateSetup(this, it) }
+            .subscribe { this.viewModel.environment.stripe().handleNextActionForSetupIntent(this, it) }
 
         this.viewModel.outputs.showPledgeError()
             .compose(bindToLifecycle())


### PR DESCRIPTION
# 📲 What

Test a 3D Secure card with Strong Customer Authentication

# 🤔 Why
- Updated to the latest version of Stripe SDK

# 🛠 How
- Updated deprecated method `authenticateSetup` over `handleNextActionForSetupIntent`
- Added initialization for PaymentConfiguration at the same level we initialize stripe SDK

# 👀 See

https://user-images.githubusercontent.com/4083656/124675147-f3a03b80-de70-11eb-88a0-ce726a1dfd5b.mp4


|  |  |

# 📋 QA
- On the video I pledged with the card with number `4000002500003155`
- Pledge to a project using one of these test cards -> [Regulatory Cards](https://stripe.com/docs/testing#regulatory-cards)

# Story 📖

[NT-2067](https://kickstarter.atlassian.net/browse/NT-2067)
