### PR TITLE
NT-2091: Remove duplicated Postal code field

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/NewCardFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/NewCardFragment.kt
@@ -171,6 +171,7 @@ class NewCardFragment : BaseFragment<NewCardFragmentViewModel.ViewModel>() {
         card_input_widget.clearFocus()
         cardholder_name.onFocusChangeListener = cardFocusChangeListener
         postal_code.onFocusChangeListener = cardFocusChangeListener
+        card_input_widget.postalCodeEnabled = false
         card_input_widget.setCardNumberTextWatcher(cardNumberWatcher)
         card_input_widget.setCvcNumberTextWatcher(cardValidityWatcher)
         card_input_widget.setExpiryDateTextWatcher(cardValidityWatcher)


### PR DESCRIPTION
# 📲 What
- The postal code in the stripe `CardInputWidget` was showing the Postal code, and our own input for postal code was shown as well at the same time.
- 
# 🛠 How
- Disabled postal code field on the `CardInputWidget` configuration

# 👀 See
| Before 🐛 |
<img width="368" alt="2PC" src="https://user-images.githubusercontent.com/4083656/125126417-ede46900-e0af-11eb-92fb-c3c7a5e84ce7.png">
| After 🦋 |


https://user-images.githubusercontent.com/4083656/125126764-6cd9a180-e0b0-11eb-8c95-3e904fde3c18.mp4


|  |  |

# 📋 QA
- Try to add a new payment method, you should see only one Postal code field 
- be able to successfully pledge to a project.

# Story 📖

[NT-2091](https://kickstarter.atlassian.net/browse/NT-2091)
