### PR TITLE
NT-2001 :UX – Show pending dialog

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -173,7 +173,11 @@ class CommentsActivity :
     }
 
     override fun back() {
-        viewModel.inputs.checkIfThereAnyPendingComments(true)
+        if (binding.commentComposer.isCommentComposerEmpty() == true) {
+            viewModel.inputs.checkIfThereAnyPendingComments(true)
+        } else {
+            handleBackAction(true)
+        }
     }
 
     private fun closeCommentsActivity() {

--- a/app/src/main/java/com/kickstarter/ui/activities/ThreadActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ThreadActivity.kt
@@ -201,7 +201,11 @@ class ThreadActivity :
     }
 
     override fun back() {
-        viewModel.inputs.checkIfThereAnyPendingComments()
+        if (binding.replyComposer.isCommentComposerEmpty() == true) {
+            viewModel.inputs.checkIfThereAnyPendingComments()
+        } else {
+            handleBackAction()
+        }
     }
 
     private fun closeCommentsActivity() {

--- a/app/src/main/java/com/kickstarter/ui/views/CommentComposerView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/CommentComposerView.kt
@@ -65,6 +65,8 @@ class CommentComposerView @JvmOverloads constructor(
         binding.commentActionButton.isGone = it
     }
 
+    fun isCommentComposerEmpty(): Boolean? = binding.commentTextComposer.text?.isNullOrEmpty()
+
     fun clearCommentComposer() {
         binding.commentTextComposer.text?.clear()
     }


### PR DESCRIPTION
# 📲 What

show the confirmation dialog when the user tries to leave the screen with something written in the comment composer.
![image](https://user-images.githubusercontent.com/1075310/126644124-b6c7ff32-40a9-445a-a0a2-25c0fa4bd3d6.png)

# 🤔 Why

So we show a dialog in case there is a text in comment composer in comment or replies activity

# 🛠 How
![image](https://user-images.githubusercontent.com/1075310/126643624-9541d87e-0779-468f-807c-d6606a700554.png)

![image](https://user-images.githubusercontent.com/1075310/126643407-66af7548-648a-47be-b320-df44ec696418.png)


# 👀 See

https://user-images.githubusercontent.com/1075310/126643807-38b9ec09-f285-45d2-9a2b-ef683725dfe7.mp4


# 📋 QA

1. Open Comment and thread Activity
2. Write a comment in the composer 
3. Press back 

# Story 📖
https://kickstarter.atlassian.net/browse/NT-2001

