### PR TITLE
NT-1965:UX – Show not-a-backer-anymore comments

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -92,6 +92,7 @@ fragment comment on Comment {
     body
     deleted
     parentId
+    authorCanceledPledge
     replies {
         totalCount
     }

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/CommentListExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/CommentListExt.kt
@@ -2,8 +2,9 @@ package com.kickstarter.libs.utils.extensions
 
 import com.kickstarter.models.Comment
 import com.kickstarter.models.Project
+import com.kickstarter.models.extensions.cardStatus
 import com.kickstarter.ui.data.CommentCardData
 
 fun List<Comment>.toCommentCardList(project: Project?): List<CommentCardData> = this.map { comment: Comment ->
-    CommentCardData.builder().comment(comment).project(project).build()
+    CommentCardData.builder().comment(comment).commentCardState(comment.cardStatus()).project(project).build()
 }

--- a/app/src/main/java/com/kickstarter/mock/factories/CommentCardDataFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CommentCardDataFactory.kt
@@ -13,6 +13,7 @@ class CommentCardDataFactory {
         fun commentCardData(): CommentCardData = CommentCardData.builder()
             .comment(CommentFactory.comment())
             .project(ProjectFactory.project())
+            .commentCardState(0)
             .commentableId(null)
             .build()
     }

--- a/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CommentFactory.kt
@@ -21,6 +21,22 @@ class CommentFactory {
                 .cursor("")
                 .authorBadges(listOf())
                 .deleted(false)
+                .authorCanceledPledge(false)
+                .createdAt(DateTime.now())
+                .build()
+        }
+
+        fun commentWithCanceledPledgeAuthor(user: User): Comment {
+            return Comment.builder()
+                .id(-1)
+                .author(user)
+                .body("Some text here")
+                .parentId(-1)
+                .repliesCount(0)
+                .cursor("")
+                .authorBadges(listOf())
+                .deleted(false)
+                .authorCanceledPledge(true)
                 .createdAt(DateTime.now())
                 .build()
         }
@@ -44,6 +60,7 @@ class CommentFactory {
                 .repliesCount(repliesCount)
                 .cursor("")
                 .authorBadges(listOf())
+                .authorCanceledPledge(false)
                 .deleted(isDelete)
                 .createdAt(DateTime.parse("2021-01-01T00:00:00Z"))
                 .body(body)
@@ -58,6 +75,7 @@ class CommentFactory {
                 .createdAt(createdAt)
                 .cursor("")
                 .deleted(false)
+                .authorCanceledPledge(false)
                 .id(-1)
                 .repliesCount(0)
                 .author(
@@ -80,6 +98,7 @@ class CommentFactory {
                 .deleted(false)
                 .id(-1)
                 .repliesCount(0)
+                .authorCanceledPledge(false)
                 .author(
                     UserFactory.user()
                         .toBuilder()
@@ -101,6 +120,29 @@ class CommentFactory {
                     .cursor("")
                     .deleted(isDelete)
                     .id(-1)
+                    .repliesCount(repliesCount)
+                    .author(currentUser)
+                    .authorCanceledPledge(false)
+                    .build(),
+                0,
+                project.id().toString(),
+                project
+
+            )
+        }
+
+        fun liveCanceledPledgeCommentCardData(comment: String = "Some Comment", createdAt: DateTime, currentUser: User, isDelete: Boolean = false, repliesCount: Int = 0): CommentCardData {
+            val project = ProjectFactory.project().toBuilder().creator(UserFactory.creator().toBuilder().id(278438049).build()).build()
+            return CommentCardData(
+                Comment.builder()
+                    .body(comment)
+                    .parentId(-1)
+                    .authorBadges(listOf())
+                    .createdAt(createdAt)
+                    .cursor("")
+                    .deleted(isDelete)
+                    .id(-1)
+                    .authorCanceledPledge(true)
                     .repliesCount(repliesCount)
                     .author(currentUser)
                     .build(),

--- a/app/src/main/java/com/kickstarter/models/Comment.java
+++ b/app/src/main/java/com/kickstarter/models/Comment.java
@@ -16,6 +16,7 @@ public abstract class Comment implements Parcelable, Relay{
   public abstract String body();
   public abstract DateTime createdAt();
   public abstract Boolean deleted();
+  public abstract Boolean authorCanceledPledge();
   public abstract String cursor();
   public abstract Integer repliesCount();
   public abstract List<String> authorBadges();
@@ -31,6 +32,7 @@ public abstract class Comment implements Parcelable, Relay{
     public abstract Builder body(String __);
     public abstract Builder createdAt(DateTime __);
     public abstract Builder deleted(Boolean __);
+    public abstract Builder authorCanceledPledge(Boolean __);
     public abstract Builder id(long __);
     public abstract Builder parentId(long __);
     public abstract Comment build();
@@ -53,6 +55,7 @@ public abstract class Comment implements Parcelable, Relay{
               Objects.equals(this.author(), other.author()) &&
               Objects.equals(this.cursor(), other.cursor()) &&
               Objects.equals(this.deleted(), other.deleted()) &&
+              Objects.equals(this.authorCanceledPledge(), other.authorCanceledPledge()) &&
               Objects.equals(this.createdAt(), other.createdAt()) &&
               Objects.equals(this.parentId(), other.parentId());
     }

--- a/app/src/main/java/com/kickstarter/models/extensions/CommentExt.kt
+++ b/app/src/main/java/com/kickstarter/models/extensions/CommentExt.kt
@@ -68,7 +68,7 @@ fun Comment.updateCanceledPledgeComment(
 ): List<CommentCardData> {
 
     val position = listOfComments.indexOfFirst { commentCardData ->
-        commentCardData.commentCardState == CommentCardStatus.CANCELED_PLEDGE_MSG.commentCardStatus &&
+        commentCardData.commentCardState == CommentCardStatus.CANCELED_PLEDGE_MESSAGE.commentCardStatus &&
             commentCardData.comment?.body() == this.body() &&
             commentCardData.comment?.author()?.id() == this.author().id()
     }
@@ -87,7 +87,7 @@ fun Comment.updateCanceledPledgeComment(
 
 fun Comment.cardStatus() = when {
     this.deleted() ?: false -> CommentCardStatus.DELETED_COMMENT
-    this.authorCanceledPledge() ?: false -> CommentCardStatus.CANCELED_PLEDGE_MSG
+    this.authorCanceledPledge() ?: false -> CommentCardStatus.CANCELED_PLEDGE_MESSAGE
     this.repliesCount() ?: 0 != 0 -> CommentCardStatus.COMMENT_WITH_REPLIES
     else -> CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS
 }.commentCardStatus

--- a/app/src/main/java/com/kickstarter/models/extensions/CommentExt.kt
+++ b/app/src/main/java/com/kickstarter/models/extensions/CommentExt.kt
@@ -58,3 +58,36 @@ fun Comment.updateCommentFailedToPost(
 
     return listOfComments
 }
+
+/**
+ * Update the internal persisted list of comments with the failed response
+ * from calling the Post Mutation
+ */
+fun Comment.updateCanceledPledgeComment(
+    listOfComments: List<CommentCardData>
+): List<CommentCardData> {
+
+    val position = listOfComments.indexOfFirst { commentCardData ->
+        commentCardData.commentCardState == CommentCardStatus.CANCELED_PLEDGE_MSG.commentCardStatus &&
+            commentCardData.comment?.body() == this.body() &&
+            commentCardData.comment?.author()?.id() == this.author().id()
+    }
+
+    if (position >= 0 && position < listOfComments.size) {
+        return listOfComments.toMutableList().apply {
+            this[position] = listOfComments[position].toBuilder()
+                .commentCardState(CommentCardStatus.CANCELED_PLEDGE_COMMENT.commentCardStatus)
+                .comment(this@updateCanceledPledgeComment)
+                .build()
+        }
+    }
+
+    return listOfComments
+}
+
+fun Comment.cardStatus() = when {
+    this.deleted() ?: false -> CommentCardStatus.DELETED_COMMENT
+    this.authorCanceledPledge() ?: false -> CommentCardStatus.CANCELED_PLEDGE_MSG
+    this.repliesCount() ?: 0 != 0 -> CommentCardStatus.COMMENT_WITH_REPLIES
+    else -> CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS
+}.commentCardStatus

--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -824,6 +824,7 @@ private fun createCommentObject(commentFr: fragment.Comment?): Comment {
         .cursor("")
         .createdAt(commentFr?.createdAt())
         .deleted(commentFr?.deleted())
+        .authorCanceledPledge(commentFr?.authorCanceledPledge())
         .parentId(decodeRelayId(commentFr?.parentId()) ?: -1)
         .build()
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -150,7 +150,7 @@ class CommentsActivity :
         this.showAlertDialog(
             getString(R.string.Your_comment_wasnt_posted),
             getString(R.string.You_will_lose_the_comment),
-            getString(R.string.cancel),
+            getString(R.string.Cancel),
             getString(R.string.leave_page),
             false,
             positiveAction = {
@@ -257,6 +257,10 @@ class CommentsActivity :
 
     override fun onCommentPostedFailed(comment: Comment) {
         viewModel.inputs.refreshCommentCardInCaseFailedPosted(comment)
+    }
+
+    override fun onShowCommentClicked(comment: Comment) {
+        viewModel.inputs.onShowCanceledPledgeComment(comment)
     }
 
     override fun onCommentRepliesClicked(comment: Comment) {

--- a/app/src/main/java/com/kickstarter/ui/activities/ThreadActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ThreadActivity.kt
@@ -189,7 +189,7 @@ class ThreadActivity :
         this.showAlertDialog(
             getString(R.string.Your_comment_wasnt_posted),
             getString(R.string.You_will_lose_the_comment),
-            getString(R.string.cancel),
+            getString(R.string.Cancel),
             getString(R.string.leave_page),
             false,
             positiveAction = {
@@ -258,6 +258,10 @@ class ThreadActivity :
 
     override fun retryCallback() {
         viewModel.inputs.reloadRepliesPage()
+    }
+
+    override fun onShowCommentClicked(comment: Comment) {
+        viewModel.inputs.onShowCanceledPledgeComment(comment)
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/kickstarter/ui/adapters/RootCommentAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/RootCommentAdapter.kt
@@ -5,14 +5,14 @@ import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import com.kickstarter.R
 import com.kickstarter.databinding.ItemRootCommentCardBinding
-import com.kickstarter.models.Comment
+import com.kickstarter.ui.data.CommentCardData
 import com.kickstarter.ui.viewholders.KSViewHolder
 import com.kickstarter.ui.viewholders.RootCommentViewHolder
 
 /** Replies Root comment cell adapter **/
 class RootCommentAdapter : KSListAdapter() {
 
-    fun updateRootCommentCell(rootComment: Comment) {
+    fun updateRootCommentCell(rootComment: CommentCardData) {
         addSection(listOf(rootComment))
         submitList(items())
     }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/CommentCardViewHolder.kt
@@ -25,6 +25,7 @@ class CommentCardViewHolder(
         fun onCommentRepliesClicked(comment: Comment)
         fun onCommentPostedSuccessFully(comment: Comment)
         fun onCommentPostedFailed(comment: Comment)
+        fun onShowCommentClicked(comment: Comment)
     }
 
     private val vm: CommentsViewHolderViewModel.ViewModel = CommentsViewHolderViewModel.ViewModel(environment())
@@ -102,6 +103,11 @@ class CommentCardViewHolder(
             .compose(Transformers.observeForUI())
             .subscribe { this.delegate.onFlagButtonClicked(it) }
 
+        this.vm.outputs.showCanceledComment()
+            .compose(bindToLifecycle())
+            .compose(Transformers.observeForUI())
+            .subscribe { this.delegate.onShowCommentClicked(it) }
+
         this.vm.outputs.isSuccessfullyPosted()
             .compose(bindToLifecycle())
             .compose(Transformers.observeForUI())
@@ -132,11 +138,20 @@ class CommentCardViewHolder(
             override fun onCommentGuideLinesClicked(view: View) {
                 vm.inputs.onCommentGuideLinesClicked()
             }
+
+            override fun onShowCommentClicked(view: View) {
+                vm.inputs.onShowCommentClicked()
+            }
         })
 
         binding.commentsCardView.setFlaggedMessage(
             context().getString(R.string.This_comment_has_been_removed_by_Kickstarter) +
                 context().getString(R.string.Learn_more_about_comment_guidelines)
+        )
+
+        binding.commentsCardView.setCancelPledgeMessage(
+            context().getString(R.string.this_person_canceled_pledge) +
+                context().getString(R.string.show_comment)
         )
 
         if (isReply) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RootCommentViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RootCommentViewHolder.kt
@@ -1,9 +1,13 @@
 package com.kickstarter.ui.viewholders
 
+import android.view.View
+import com.kickstarter.R
 import com.kickstarter.databinding.ItemRootCommentCardBinding
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.DateTimeUtils
-import com.kickstarter.models.Comment
+import com.kickstarter.ui.data.CommentCardData
+import com.kickstarter.ui.views.CommentCardStatus
+import com.kickstarter.ui.views.OnCommentCardClickedListener
 import com.kickstarter.viewmodels.RootCommentViewHolderViewModel
 
 @Suppress("UNCHECKED_CAST")
@@ -13,23 +17,62 @@ class RootCommentViewHolder(
 
     private val vm: RootCommentViewHolderViewModel.ViewModel = RootCommentViewHolderViewModel.ViewModel(environment())
     private val ksString = environment().ksString()
-
     init {
         this.vm.outputs.bindRootComment()
             .compose(bindToLifecycle())
             .compose(Transformers.observeForUI())
-            .subscribe { comment ->
-                binding.commentsCardView.setCommentUserName(comment.author().name())
-                binding.commentsCardView.setCommentBody(comment.body())
-                binding.commentsCardView.hideReplyButton()
-                binding.commentsCardView.setCommentPostTime(DateTimeUtils.relative(context(), ksString, comment.createdAt()))
-                binding.commentsCardView.setCommentUserName(comment.author().name())
-                binding.commentsCardView.setAvatarUrl(comment.author().avatar().medium())
+            .subscribe { commentCardData ->
+                CommentCardStatus.values().firstOrNull { commentCardData.commentCardState == it.commentCardStatus }?.let {
+                    if (it == CommentCardStatus.CANCELED_PLEDGE_MESSAGE) {
+                        binding.commentsCardView.setCommentCardStatus(it)
+                        binding.commentsCardView.setCancelPledgeMessage(
+                            context().getString(R.string.this_person_canceled_pledge) +
+                                context().getString(R.string.show_comment)
+                        )
+                        binding.commentsCardView.setCommentCardClickedListener(object :
+                                OnCommentCardClickedListener {
+                                override fun onRetryViewClicked(view: View) {
+                                }
+
+                                override fun onReplyButtonClicked(view: View) {
+                                }
+
+                                override fun onFlagButtonClicked(view: View) {
+                                }
+
+                                override fun onViewRepliesButtonClicked(view: View) {
+                                }
+
+                                override fun onCommentGuideLinesClicked(view: View) {
+                                }
+
+                                override fun onShowCommentClicked(view: View) {
+                                    vm.inputs.onShowCanceledPledgeRootCommentClicked()
+                                }
+                            })
+                    }
+                }
+
+                commentCardData?.comment?.let { comment ->
+                    binding.commentsCardView.setCommentUserName(comment.author().name())
+                    binding.commentsCardView.setCommentBody(comment.body())
+                    binding.commentsCardView.hideReplyButton()
+                    binding.commentsCardView.setCommentPostTime(DateTimeUtils.relative(context(), ksString, comment.createdAt()))
+                    binding.commentsCardView.setCommentUserName(comment.author().name())
+                    binding.commentsCardView.setAvatarUrl(comment.author().avatar().medium())
+                }
+            }
+
+        this.vm.outputs.showCanceledPledgeRootComment()
+            .compose(bindToLifecycle())
+            .compose(Transformers.observeForUI())
+            .subscribe {
+                binding.commentsCardView.setCommentCardStatus(it)
             }
     }
 
     override fun bindData(data: Any?) {
-        if (data is Comment) {
+        if (data is CommentCardData) {
             this.vm.inputs.configureWith(data)
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
@@ -67,6 +67,21 @@ class CommentCard @JvmOverloads constructor(
         )
     }
 
+    private fun bindCancelPledgeMessage() {
+        binding.canceledPledgeMessage.parseHtmlTag()
+        binding.canceledPledgeMessage.makeLinks(
+            Pair(
+                context.resources.getString(R.string.show_comment),
+                OnClickListener {
+                    onCommentCardClickedListener?.onShowCommentClicked(it)
+                },
+
+            ),
+            linkColor = R.color.kds_create_500,
+            isUnderlineText = false
+        )
+    }
+
     private fun obtainStyledAttributes(context: Context, attrs: AttributeSet?, defStyleAttr: Int) {
         context.withStyledAttributes(
             set = attrs,
@@ -120,14 +135,18 @@ class CommentCard @JvmOverloads constructor(
             cardCommentStatus == CommentCardStatus.FAILED_TO_SEND_COMMENT ||
             cardCommentStatus == CommentCardStatus.RE_TRYING_TO_POST ||
             cardCommentStatus == CommentCardStatus.POSTING_COMMENT_COMPLETED_SUCCESSFULLY ||
-            cardCommentStatus == CommentCardStatus.TRYING_TO_POST
+            cardCommentStatus == CommentCardStatus.TRYING_TO_POST ||
+            cardCommentStatus == CommentCardStatus.CANCELED_PLEDGE_COMMENT
 
-        if (cardCommentStatus == CommentCardStatus.DELETED_COMMENT) {
+        if (cardCommentStatus == CommentCardStatus.DELETED_COMMENT || cardCommentStatus == CommentCardStatus.CANCELED_PLEDGE_MSG) {
             binding.commentBody.isInvisible = true
         }
 
         binding.commentDeletedMessageGroup.isVisible =
             cardCommentStatus == CommentCardStatus.DELETED_COMMENT
+
+        binding.canceledPledgeMessage.isVisible =
+            cardCommentStatus == CommentCardStatus.CANCELED_PLEDGE_MSG
 
         if (shouldShowReplyButton(cardCommentStatus)) {
             setReplyButtonVisibility(true)
@@ -198,6 +217,11 @@ class CommentCard @JvmOverloads constructor(
         bindFlaggedMessage()
     }
 
+    fun setCancelPledgeMessage(message: String) {
+        binding.canceledPledgeMessage.text = message
+        bindCancelPledgeMessage()
+    }
+
     fun setCommentCardClickedListener(onCommentCardClickedListener: OnCommentCardClickedListener?) {
         this.onCommentCardClickedListener = onCommentCardClickedListener
     }
@@ -213,6 +237,7 @@ interface OnCommentCardClickedListener {
     fun onFlagButtonClicked(view: View)
     fun onViewRepliesButtonClicked(view: View)
     fun onCommentGuideLinesClicked(view: View)
+    fun onShowCommentClicked(view: View)
 }
 
 enum class CommentCardStatus(val commentCardStatus: Int) {
@@ -222,5 +247,7 @@ enum class CommentCardStatus(val commentCardStatus: Int) {
     DELETED_COMMENT(3), // Deleted comment
     RE_TRYING_TO_POST(4), // trying to post comment
     POSTING_COMMENT_COMPLETED_SUCCESSFULLY(5), // trying to post comment,
-    TRYING_TO_POST(6), // comments without reply view
+    TRYING_TO_POST(6), // comments without reply view,
+    CANCELED_PLEDGE_MSG(7),
+    CANCELED_PLEDGE_COMMENT(8),
 }

--- a/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/CommentCard.kt
@@ -138,7 +138,7 @@ class CommentCard @JvmOverloads constructor(
             cardCommentStatus == CommentCardStatus.TRYING_TO_POST ||
             cardCommentStatus == CommentCardStatus.CANCELED_PLEDGE_COMMENT
 
-        if (cardCommentStatus == CommentCardStatus.DELETED_COMMENT || cardCommentStatus == CommentCardStatus.CANCELED_PLEDGE_MSG) {
+        if (cardCommentStatus == CommentCardStatus.DELETED_COMMENT || cardCommentStatus == CommentCardStatus.CANCELED_PLEDGE_MESSAGE) {
             binding.commentBody.isInvisible = true
         }
 
@@ -146,7 +146,7 @@ class CommentCard @JvmOverloads constructor(
             cardCommentStatus == CommentCardStatus.DELETED_COMMENT
 
         binding.canceledPledgeMessage.isVisible =
-            cardCommentStatus == CommentCardStatus.CANCELED_PLEDGE_MSG
+            cardCommentStatus == CommentCardStatus.CANCELED_PLEDGE_MESSAGE
 
         if (shouldShowReplyButton(cardCommentStatus)) {
             setReplyButtonVisibility(true)
@@ -248,6 +248,6 @@ enum class CommentCardStatus(val commentCardStatus: Int) {
     RE_TRYING_TO_POST(4), // trying to post comment
     POSTING_COMMENT_COMPLETED_SUCCESSFULLY(5), // trying to post comment,
     TRYING_TO_POST(6), // comments without reply view,
-    CANCELED_PLEDGE_MSG(7),
+    CANCELED_PLEDGE_MESSAGE(7),
     CANCELED_PLEDGE_COMMENT(8),
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -43,6 +43,9 @@ interface CommentsViewHolderViewModel {
 
         /** Configure the view model with the [Comment]. */
         fun configureWith(commentCardData: CommentCardData)
+
+        /** Show cancelled comment pledge */
+        fun onShowCommentClicked()
     }
 
     interface Outputs {
@@ -93,6 +96,9 @@ interface CommentsViewHolderViewModel {
 
         /** Emits when the execution of the post mutation is error, it will be used to update the main list state for this comment**/
         fun isFailedToPost(): Observable<Comment>
+
+        /** Emits the current [Comment] when show comment for canceled pledge. */
+        fun showCanceledComment(): Observable<Comment>
     }
 
     class ViewModel(environment: Environment) :
@@ -103,6 +109,7 @@ interface CommentsViewHolderViewModel {
         private val onReplyButtonClicked = PublishSubject.create<Void>()
         private val onFlagButtonClicked = PublishSubject.create<Void>()
         private val onViewCommentRepliesButtonClicked = PublishSubject.create<Void>()
+        private val onShowCommentClicked = PublishSubject.create<Void>()
 
         private val commentCardStatus = BehaviorSubject.create<CommentCardStatus>()
         private val isReplyButtonVisible = BehaviorSubject.create<Boolean>()
@@ -120,6 +127,7 @@ interface CommentsViewHolderViewModel {
         private val internalError = BehaviorSubject.create<Throwable>()
         private val postedSuccessfully = BehaviorSubject.create<Comment>()
         private val failedToPosted = BehaviorSubject.create<Comment>()
+        private val showCanceledComment = PublishSubject.create<Comment>()
 
         private val isCommentReply = BehaviorSubject.create<Void>()
 
@@ -267,6 +275,11 @@ interface CommentsViewHolderViewModel {
                 .compose(takeWhen(this.onFlagButtonClicked))
                 .compose(bindToLifecycle())
                 .subscribe(this.flagComment)
+
+            comment
+                .compose(takeWhen(this.onShowCommentClicked))
+                .compose(bindToLifecycle())
+                .subscribe(this.showCanceledComment)
         }
 
         /**
@@ -394,12 +407,20 @@ interface CommentsViewHolderViewModel {
          */
         private fun cardStatus(commentCardData: CommentCardData) = when {
             commentCardData.comment?.deleted() ?: false -> CommentCardStatus.DELETED_COMMENT
+            commentCardData.comment?.authorCanceledPledge() ?: false -> checkCanceledPledgeCommentStatus(commentCardData)
             (commentCardData.comment?.repliesCount() ?: 0 != 0) -> CommentCardStatus.COMMENT_WITH_REPLIES
-            else -> CommentCardStatus.values()
-                .firstOrNull { it.commentCardStatus == commentCardData.commentCardState }
+            else -> CommentCardStatus.values().firstOrNull {
+                it.commentCardStatus == commentCardData.commentCardState
+            }
         }.also {
             this.isCommentEnableThreads.onNext(optimizely.isFeatureEnabled(OptimizelyFeature.Key.COMMENT_ENABLE_THREADS))
         }
+
+        private fun checkCanceledPledgeCommentStatus(commentCardData: CommentCardData): CommentCardStatus =
+            if (commentCardData.commentCardState != CommentCardStatus.CANCELED_PLEDGE_COMMENT.commentCardStatus)
+                CommentCardStatus.CANCELED_PLEDGE_MSG
+            else
+                CommentCardStatus.CANCELED_PLEDGE_COMMENT
 
         override fun configureWith(commentCardData: CommentCardData) =
             this.commentInput.onNext(commentCardData)
@@ -414,6 +435,8 @@ interface CommentsViewHolderViewModel {
             this.onViewCommentRepliesButtonClicked.onNext(null)
 
         override fun onFlagButtonClicked() = this.onFlagButtonClicked.onNext(null)
+
+        override fun onShowCommentClicked() = this.onShowCommentClicked.onNext(null)
 
         override fun commentCardStatus(): Observable<CommentCardStatus> = this.commentCardStatus
 
@@ -446,5 +469,7 @@ interface CommentsViewHolderViewModel {
         override fun isSuccessfullyPosted(): Observable<Comment> = this.postedSuccessfully
 
         override fun isFailedToPost(): Observable<Comment> = this.failedToPosted
+
+        override fun showCanceledComment(): Observable<Comment> = this.showCanceledComment
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -418,7 +418,7 @@ interface CommentsViewHolderViewModel {
 
         private fun checkCanceledPledgeCommentStatus(commentCardData: CommentCardData): CommentCardStatus =
             if (commentCardData.commentCardState != CommentCardStatus.CANCELED_PLEDGE_COMMENT.commentCardStatus)
-                CommentCardStatus.CANCELED_PLEDGE_MSG
+                CommentCardStatus.CANCELED_PLEDGE_MESSAGE
             else
                 CommentCardStatus.CANCELED_PLEDGE_COMMENT
 

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -251,15 +251,16 @@ interface CommentsViewModel {
                 .compose(bindToLifecycle())
                 .subscribe { this.closeCommentsPage.onNext(it) }
 
-            this.onReplyClicked
-                .compose(combineLatestPair(commentsList))
+            commentsList
+                .compose(takePairWhen(onReplyClicked))
                 .compose(bindToLifecycle())
                 .subscribe { pair ->
-                    val cardData = pair.second.first { it.comment?.id() == pair.first.first.id() }
+
+                    val cardData = pair.first.first { it.comment?.id() == pair.second.first.id() }
                     this.startThreadActivity.onNext(
                         Pair(
                             cardData,
-                            pair.first.second
+                            pair.second.second
                         )
                     )
                 }
@@ -423,6 +424,7 @@ interface CommentsViewModel {
                 .cursor("")
                 .deleted(false)
                 .id(-1)
+                .authorCanceledPledge(false)
                 .repliesCount(0)
                 .author(it.first)
                 .build()

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -252,17 +252,14 @@ interface CommentsViewModel {
                 .subscribe { this.closeCommentsPage.onNext(it) }
 
             this.onReplyClicked
-                .compose(combineLatestPair(initialProject))
+                .compose(combineLatestPair(commentsList))
                 .compose(bindToLifecycle())
-                .subscribe {
+                .subscribe { pair ->
+                    val cardData = pair.second.first { it.comment?.id() == pair.first.first.id() }
                     this.startThreadActivity.onNext(
                         Pair(
-                            CommentCardData.builder()
-                                .comment(it.first.first)
-                                .commentableId(commentableId)
-                                .project(it.second)
-                                .build(),
-                            it.first.second
+                            cardData,
+                            pair.first.second
                         )
                     )
                 }

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -15,6 +15,8 @@ import com.kickstarter.models.Comment
 import com.kickstarter.models.Project
 import com.kickstarter.models.Update
 import com.kickstarter.models.User
+import com.kickstarter.models.extensions.cardStatus
+import com.kickstarter.models.extensions.updateCanceledPledgeComment
 import com.kickstarter.models.extensions.updateCommentAfterSuccessfulPost
 import com.kickstarter.models.extensions.updateCommentFailedToPost
 import com.kickstarter.services.ApiClientType
@@ -44,6 +46,7 @@ interface CommentsViewModel {
         /** Will be called with the successful response when calling the `postComment` Mutation **/
         fun refreshComment(comment: Comment)
         fun refreshCommentCardInCaseFailedPosted(comment: Comment)
+        fun onShowCanceledPledgeComment(comment: Comment)
     }
 
     interface Outputs {
@@ -83,6 +86,7 @@ interface CommentsViewModel {
         private val onReplyClicked = PublishSubject.create<Pair<Comment, Boolean>>()
         private val checkIfThereAnyPendingComments = PublishSubject.create<Boolean>()
         private val failedCommentCardToRefresh = PublishSubject.create<Comment>()
+        private val showCanceledPledgeComment = PublishSubject.create<Comment>()
 
         private val closeCommentsPage = BehaviorSubject.create<Void>()
         private val currentUserAvatar = BehaviorSubject.create<String?>()
@@ -293,6 +297,17 @@ interface CommentsViewModel {
                 .subscribe {
                     this.commentsList.onNext(it)
                 }
+
+            this.commentsList
+                .compose(takePairWhen(this.showCanceledPledgeComment))
+                .map {
+                    it.second.updateCanceledPledgeComment(it.first)
+                }
+                .distinctUntilChanged()
+                .compose(bindToLifecycle())
+                .subscribe {
+                    this.commentsList.onNext(it)
+                }
         }
 
         private fun loadCommentListFromProjectOrUpdate(projectOrUpdate: Observable<Pair<Project, Update?>>) {
@@ -397,6 +412,7 @@ interface CommentsViewModel {
                 CommentCardData.builder()
                     .comment(comment)
                     .project(it.second)
+                    .commentCardState(comment.cardStatus())
                     .commentableId(it.first.commentableId)
                     .build()
             }
@@ -433,6 +449,8 @@ interface CommentsViewModel {
         override fun checkIfThereAnyPendingComments(isBackAction: Boolean) = checkIfThereAnyPendingComments.onNext(isBackAction)
         override fun refreshCommentCardInCaseFailedPosted(comment: Comment) =
             this.failedCommentCardToRefresh.onNext(comment)
+        override fun onShowCanceledPledgeComment(comment: Comment) =
+            this.showCanceledPledgeComment.onNext(comment)
         // - Outputs
         override fun closeCommentsPage(): Observable<Void> = closeCommentsPage
         override fun currentUserAvatar(): Observable<String?> = currentUserAvatar

--- a/app/src/main/java/com/kickstarter/viewmodels/RootCommentViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RootCommentViewHolderViewModel.kt
@@ -2,39 +2,53 @@ package com.kickstarter.viewmodels
 
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
-import com.kickstarter.models.Comment
+import com.kickstarter.libs.rx.transformers.Transformers
+import com.kickstarter.ui.data.CommentCardData
 import com.kickstarter.ui.viewholders.RootCommentViewHolder
+import com.kickstarter.ui.views.CommentCardStatus
 import rx.Observable
 import rx.subjects.BehaviorSubject
+import rx.subjects.PublishSubject
 
 interface RootCommentViewHolderViewModel {
     interface Inputs {
-        fun configureWith(configureCellWith: Comment)
+        fun configureWith(configureCellWith: CommentCardData)
+        fun onShowCanceledPledgeRootCommentClicked()
     }
 
     interface Outputs {
-        fun bindRootComment(): Observable<Comment>
+        fun bindRootComment(): Observable<CommentCardData>
+        fun showCanceledPledgeRootComment(): Observable<CommentCardStatus>
     }
 
     class ViewModel(environment: Environment) : ActivityViewModel<RootCommentViewHolder>(environment), Inputs, Outputs {
-        private val bindRootComment = BehaviorSubject.create<Comment>()
-        private val initCellConfig = BehaviorSubject.create<Comment>()
+        private val initCellConfig = BehaviorSubject.create<CommentCardData>()
+        private val onShowCanceledPledgeRootCommentClicked = PublishSubject.create<Void>()
 
+        private val bindRootComment = BehaviorSubject.create<CommentCardData>()
+        private val showCanceledPledgeRootComment = PublishSubject.create<CommentCardStatus>()
         val inputs = this
         val outputs = this
 
         init {
-            this.initCellConfig
-                .compose(bindToLifecycle())
+            val commentCardData = this.initCellConfig
+            commentCardData.compose(bindToLifecycle())
                 .subscribe {
                     this.bindRootComment.onNext(it)
                 }
+
+            commentCardData
+                .map { requireNotNull(it.comment) }
+                .compose(Transformers.takeWhen(this.onShowCanceledPledgeRootCommentClicked))
+                .compose(bindToLifecycle())
+                .subscribe { this.showCanceledPledgeRootComment.onNext(CommentCardStatus.CANCELED_PLEDGE_COMMENT) }
         }
 
         // - Inputs
-        override fun configureWith(comment: Comment) = this.initCellConfig.onNext(comment)
-
+        override fun configureWith(comment: CommentCardData) = this.initCellConfig.onNext(comment)
+        override fun onShowCanceledPledgeRootCommentClicked() = this.onShowCanceledPledgeRootCommentClicked.onNext(null)
         // - Outputs
-        override fun bindRootComment(): Observable<Comment> = this.bindRootComment
+        override fun bindRootComment(): Observable<CommentCardData> = this.bindRootComment
+        override fun showCanceledPledgeRootComment(): Observable<CommentCardStatus> = this.showCanceledPledgeRootComment
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
@@ -375,6 +375,7 @@ interface ThreadViewModel {
                 .deleted(false)
                 .id(-1)
                 .repliesCount(0)
+                .authorCanceledPledge(false)
                 .author(it.first.second)
                 .build()
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
@@ -44,7 +44,7 @@ interface ThreadViewModel {
 
     interface Outputs {
         /** The anchored root comment */
-        fun getRootComment(): Observable<Comment>
+        fun getRootComment(): Observable<CommentCardData>
 
         /** get comment replies **/
         fun onCommentReplies(): Observable<Pair<List<CommentCardData>, Boolean>>
@@ -86,7 +86,7 @@ interface ThreadViewModel {
         private val backPressed = PublishSubject.create<Void>()
         private val showCanceledPledgeComment = PublishSubject.create<Comment>()
 
-        private val rootComment = BehaviorSubject.create<Comment>()
+        private val rootComment = BehaviorSubject.create<CommentCardData>()
         private val focusOnCompose = BehaviorSubject.create<Boolean>()
         private val currentUserAvatar = BehaviorSubject.create<String?>()
         private val replyComposerStatus = BehaviorSubject.create<CommentComposerStatus>()
@@ -180,7 +180,7 @@ interface ThreadViewModel {
             commentData
                 .compose(bindToLifecycle())
                 .subscribe {
-                    this.rootComment.onNext(it.comment)
+                    this.rootComment.onNext(it)
                 }
 
             val loggedInUser = this.currentUser.loggedInUser()
@@ -401,7 +401,7 @@ interface ThreadViewModel {
         override fun refreshCommentCardInCaseSuccessPosted(comment: Comment) =
             this.successfullyPostedCommentCardToRefresh.onNext(comment)
 
-        override fun getRootComment(): Observable<Comment> = this.rootComment
+        override fun getRootComment(): Observable<CommentCardData> = this.rootComment
         override fun onCommentReplies(): Observable<Pair<List<CommentCardData>, Boolean>> =
             this.onCommentReplies
 

--- a/app/src/main/res/layout/comment_card.xml
+++ b/app/src/main/res/layout/comment_card.xml
@@ -54,6 +54,7 @@
         android:text="@string/View_replies"
         app:layout_constraintBottom_toTopOf="@+id/reply_button"
         app:layout_goneMarginBottom="@dimen/grid_3"
+        android:layout_marginTop="@dimen/grid_3_half"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 
@@ -129,6 +130,17 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/info_button"
         app:layout_constraintTop_toBottomOf="@id/avatar"/>
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/canceled_pledge_message"
+        style="@style/CommentCardFlaggedMessage"
+        android:text="@string/this_person_canceled_pledge"
+        android:visibility="gone"
+        android:paddingBottom="@dimen/grid_7_half"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/avatar"
+        app:layout_constraintTop_toBottomOf="@id/avatar"
+        tools:visibility="visible" />
 
     <View
         android:id="@+id/separtor"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
   <!-- Replies Screen -->
   <string name="Your_comment_wasnt_posted">Your comment wasn\'t posted</string>
   <string name="You_will_lose_the_comment">You\'ll lose the comment if you leave this page.</string>
-  <string name="cancel">Cancel</string>
   <string name="leave_page">Leave page</string>
+  <string name="this_person_canceled_pledge">This person has canceled their pledge. </string>
+  <string name="show_comment">Show comment</string>
 </resources>

--- a/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
@@ -24,6 +24,7 @@ class CommentCardTest : KSRobolectricTestCase() {
     private lateinit var retryButton: View
     private lateinit var postingButton: AppCompatButton
     private lateinit var postedButton: AppCompatButton
+    private lateinit var showCanceledPledgeComment: AppCompatTextView
 
     @Before
     @Throws(Exception::class)
@@ -40,6 +41,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         repliesButton = commentCard.findViewById(R.id.replies)
         postingButton = commentCard.findViewById(R.id.posting_button)
         postedButton = commentCard.findViewById(R.id.posted_button)
+        showCanceledPledgeComment = commentCard.findViewById(R.id.canceled_pledge_message)
     }
 
     @Test
@@ -51,6 +53,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         assertTrue(commentDeletedMessageGroup.isVisible)
         assertFalse(postedButton.isVisible)
         assertFalse(postingButton.isVisible)
+        assertFalse(showCanceledPledgeComment.isVisible)
     }
 
     @Test
@@ -62,6 +65,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         assertTrue(retryButton.isVisible)
         assertFalse(postedButton.isVisible)
         assertFalse(postingButton.isVisible)
+        assertFalse(showCanceledPledgeComment.isVisible)
     }
 
     @Test
@@ -84,6 +88,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         assertFalse(retryButton.isVisible)
         assertFalse(postedButton.isVisible)
         assertFalse(postingButton.isVisible)
+        assertFalse(showCanceledPledgeComment.isVisible)
     }
 
     @Test
@@ -95,6 +100,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         assertFalse(retryButton.isVisible)
         assertFalse(postedButton.isVisible)
         assertFalse(postingButton.isVisible)
+        assertFalse(showCanceledPledgeComment.isVisible)
     }
 
     @Test
@@ -120,6 +126,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         assertFalse(retryButton.isVisible)
         assertFalse(postedButton.isVisible)
         assertFalse(postingButton.isVisible)
+        assertFalse(showCanceledPledgeComment.isVisible)
     }
 
     @Test
@@ -134,6 +141,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         assertFalse(retryButton.isVisible)
         assertFalse(postedButton.isVisible)
         assertFalse(postingButton.isVisible)
+        assertFalse(showCanceledPledgeComment.isVisible)
     }
 
     @Test
@@ -148,6 +156,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         assertFalse(repliesButton.isVisible)
         assertFalse(commentDeletedMessageGroup.isVisible)
         assertFalse(retryButton.isVisible)
+        assertFalse(showCanceledPledgeComment.isVisible)
     }
     @Test
     fun testTryingToPostCommentStatus() {
@@ -158,6 +167,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         assertFalse(retryButton.isVisible)
         assertFalse(postedButton.isVisible)
         assertTrue(postingButton.isVisible)
+        assertFalse(showCanceledPledgeComment.isVisible)
     }
 
     @Test
@@ -168,6 +178,32 @@ class CommentCardTest : KSRobolectricTestCase() {
         assertFalse(replyButton.isVisible)
         assertFalse(retryButton.isVisible)
         assertTrue(postedButton.isVisible)
+        assertFalse(postingButton.isVisible)
+        assertFalse(postingButton.isVisible)
+        assertFalse(showCanceledPledgeComment.isVisible)
+    }
+
+    @Test
+    fun testShowCanceledPledgeCommentStatus() {
+        commentCard.setCommentCardStatus(CommentCardStatus.CANCELED_PLEDGE_COMMENT)
+        assertTrue(commentBody.isVisible)
+        assertFalse(commentDeletedMessageGroup.isVisible)
+        assertFalse(replyButton.isVisible)
+        assertFalse(retryButton.isVisible)
+        assertFalse(postedButton.isVisible)
+        assertFalse(postingButton.isVisible)
+        assertFalse(showCanceledPledgeComment.isVisible)
+    }
+    
+    @Test
+    fun testshowCanceledPledgeMessageStatus() {
+        commentCard.setCommentCardStatus(CommentCardStatus.CANCELED_PLEDGE_MESSAGE)
+        assertFalse(commentBody.isVisible)
+        assertTrue(showCanceledPledgeComment.isVisible)
+        assertFalse(commentDeletedMessageGroup.isVisible)
+        assertFalse(replyButton.isVisible)
+        assertFalse(retryButton.isVisible)
+        assertFalse(postedButton.isVisible)
         assertFalse(postingButton.isVisible)
     }
 }

--- a/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/view/CommentCardTest.kt
@@ -194,7 +194,7 @@ class CommentCardTest : KSRobolectricTestCase() {
         assertFalse(postingButton.isVisible)
         assertFalse(showCanceledPledgeComment.isVisible)
     }
-    
+
     @Test
     fun testshowCanceledPledgeMessageStatus() {
         commentCard.setCommentCardStatus(CommentCardStatus.CANCELED_PLEDGE_MESSAGE)

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
@@ -610,4 +610,18 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
 
         this.commentSuccessfullyPosted.assertValue(reply)
     }
+
+    @Test
+    fun testAuthorCanceledPledgeComment() {
+        setUpEnvironment(environment())
+        val commentCardData = CommentFactory.liveCanceledPledgeCommentCardData(createdAt = createdAt, currentUser = currentUser)
+
+        this.vm.inputs.configureWith(commentCardData)
+
+        this.commentCardStatus.assertValue(CommentCardStatus.CANCELED_PLEDGE_MESSAGE)
+
+        this.vm.inputs.configureWith(commentCardData.toBuilder().commentCardState(CommentCardStatus.CANCELED_PLEDGE_COMMENT.commentCardStatus).build())
+
+        this.commentCardStatus.assertValues(CommentCardStatus.CANCELED_PLEDGE_MESSAGE, CommentCardStatus.CANCELED_PLEDGE_COMMENT)
+    }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -410,23 +410,30 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .avatar(AvatarFactory.avatar())
             .build()
 
-        val createdAt = DateTime.now()
+        val comment1 = CommentFactory.commentToPostWithUser(currentUser).toBuilder().id(1).body("comment1").build()
+        
+        val commentEnvelope = CommentEnvelopeFactory.commentsEnvelope().toBuilder()
+            .comments(listOf(comment1))
+            .build()
 
-        val vm = CommentsViewModel.ViewModel(
-            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build()
-        )
-        val comment = CommentFactory.liveComment(createdAt = createdAt)
-        val project = ProjectFactory.project()
-        vm.outputs.startThreadActivity().subscribe(startThreadActivity)
-        vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
-
+        val testScheduler = TestScheduler()
+        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+                return Observable.just(commentEnvelope)
+            }
+        })
+            .currentUser(MockCurrentUser(currentUser))
+            .scheduler(testScheduler)
+            .build()
+        
+        val vm = CommentsViewModel.ViewModel(env)
         // Start the view model with a project.
 
-        vm.inputs.onReplyClicked(comment, true)
-
-        assertEquals(startThreadActivity.value.first.project, project)
-        assertEquals(startThreadActivity.value.first.comment, comment)
-        assertTrue(startThreadActivity.value.second)
+        vm.inputs.onReplyClicked(comment1, true)
+        vm.outputs.startThreadActivity().take(0).subscribe {
+            assertEquals(it.first.comment, comment1)
+            assertTrue(it.second)
+        }
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -12,7 +12,6 @@ import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.UpdateFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClient
-import com.kickstarter.models.Comment
 import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.data.CommentCardData
@@ -40,7 +39,6 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     private val openCommentGuideLines = TestSubscriber<Void>()
     private val startThreadActivity = BehaviorSubject.create<Pair<CommentCardData, Boolean>>()
     private val hasPendingComments = TestSubscriber<Pair<Boolean, Boolean>>()
-    private val shouldShowPaginationErrorUI = TestSubscriber<Comment>()
 
     @Test
     fun testCommentsViewModel_whenUserLoggedInAndBacking_shouldShowEnabledComposer() {

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -411,7 +411,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .build()
 
         val comment1 = CommentFactory.commentToPostWithUser(currentUser).toBuilder().id(1).body("comment1").build()
-        
+
         val commentEnvelope = CommentEnvelopeFactory.commentsEnvelope().toBuilder()
             .comments(listOf(comment1))
             .build()
@@ -425,7 +425,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .currentUser(MockCurrentUser(currentUser))
             .scheduler(testScheduler)
             .build()
-        
+
         val vm = CommentsViewModel.ViewModel(env)
         // Start the view model with a project.
 

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -12,6 +12,7 @@ import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.UpdateFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClient
+import com.kickstarter.models.Comment
 import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.data.CommentCardData
@@ -39,6 +40,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     private val openCommentGuideLines = TestSubscriber<Void>()
     private val startThreadActivity = BehaviorSubject.create<Pair<CommentCardData, Boolean>>()
     private val hasPendingComments = TestSubscriber<Pair<Boolean, Boolean>>()
+    private val shouldShowPaginationErrorUI = TestSubscriber<Comment>()
 
     @Test
     fun testCommentsViewModel_whenUserLoggedInAndBacking_shouldShowEnabledComposer() {
@@ -704,5 +706,58 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         vm.inputs.checkIfThereAnyPendingComments(true)
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
         this.hasPendingComments.assertValues(Pair(false, true), Pair(true, true), Pair(false, true))
+    }
+
+    @Test
+    fun testComments_onShowCanceledPledgeComment() {
+        val currentUser = UserFactory.user()
+            .toBuilder()
+            .id(1)
+            .build()
+
+        val comment1 = CommentFactory.commentWithCanceledPledgeAuthor(currentUser).toBuilder().id(1).body("comment1").build()
+
+        val commentEnvelope = CommentEnvelopeFactory.commentsEnvelope().toBuilder()
+            .comments(listOf(comment1))
+            .build()
+
+        val testScheduler = TestScheduler()
+        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+                return Observable.just(commentEnvelope)
+            }
+        })
+            .currentUser(MockCurrentUser(currentUser))
+            .scheduler(testScheduler)
+            .build()
+
+        val commentCardData1 = CommentCardData.builder()
+            .comment(comment1)
+            .commentCardState(CommentCardStatus.CANCELED_PLEDGE_MESSAGE.commentCardStatus)
+            .build()
+
+        val commentCardData2 = CommentCardData.builder()
+            .comment(comment1)
+            .commentCardState(CommentCardStatus.CANCELED_PLEDGE_COMMENT.commentCardStatus)
+            .build()
+
+        val vm = CommentsViewModel.ViewModel(env)
+        vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.project()))
+        vm.outputs.commentsList().subscribe(commentsList)
+
+        commentsList.assertValueCount(1)
+        vm.outputs.commentsList().take(0).subscribe {
+            val newList = it
+            assertTrue(newList[0].comment?.body() == commentCardData1.comment?.body())
+            assertTrue(newList[0].commentCardState == commentCardData1.commentCardState)
+        }
+
+        vm.inputs.onShowCanceledPledgeComment(comment1)
+
+        vm.outputs.commentsList().take(1).subscribe {
+            val newList = it
+            assertTrue(newList[0].comment?.body() == commentCardData2.comment?.body())
+            assertTrue(newList[0].commentCardState == commentCardData2.commentCardState)
+        }
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/RootCommentViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RootCommentViewHolderViewModelTest.kt
@@ -2,25 +2,48 @@ package com.kickstarter.viewmodels
 
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.mock.factories.CommentFactory
-import com.kickstarter.models.Comment
+import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.ui.data.CommentCardData
+import com.kickstarter.ui.views.CommentCardStatus
 import org.junit.Test
 import rx.observers.TestSubscriber
 
 class RootCommentViewHolderViewModelTest : KSRobolectricTestCase() {
     private lateinit var vm: RootCommentViewHolderViewModel.ViewModel
 
-    private val bindRootComment = TestSubscriber<Comment>()
+    private val bindRootComment = TestSubscriber<CommentCardData>()
+    private val showCanceledPledgeRootCommentClicked = TestSubscriber<CommentCardStatus>()
 
     private fun setupEnvironment() {
         this.vm = RootCommentViewHolderViewModel.ViewModel(environment())
+
         this.vm.outputs.bindRootComment().subscribe(bindRootComment)
+        this.vm.outputs.showCanceledPledgeRootComment().subscribe(showCanceledPledgeRootCommentClicked)
     }
 
     @Test
-    fun bindRootCommentTest() {
+    fun bindCanceledRootCommentTest() {
         setupEnvironment()
-        val comment = CommentFactory.comment()
-        this.vm.inputs.configureWith(comment)
-        this.bindRootComment.assertValue(comment)
+        val currentUser = UserFactory.user()
+            .toBuilder()
+            .id(1)
+            .build()
+
+        val comment = CommentFactory.commentWithCanceledPledgeAuthor(currentUser).toBuilder().id(1).body("comment1").build()
+        val commentCardData1 = CommentCardData.builder()
+            .comment(comment)
+            .commentCardState(CommentCardStatus.CANCELED_PLEDGE_MESSAGE.commentCardStatus)
+            .build()
+
+        this.vm.inputs.configureWith(commentCardData1)
+
+        vm.outputs.bindRootComment().take(0).subscribe {
+            assertTrue(it.comment?.body() == commentCardData1.comment?.body())
+            assertTrue(it.commentCardState == commentCardData1.commentCardState)
+        }
+
+        this.vm.inputs.onShowCanceledPledgeRootCommentClicked()
+
+        this.showCanceledPledgeRootCommentClicked.assertValue(CommentCardStatus.CANCELED_PLEDGE_COMMENT)
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
@@ -61,7 +61,7 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
 
         val commentCardData = CommentCardDataFactory.commentCardData()
 
-        this.vm.intent(Intent().putExtra(IntentKey.COMMENT_CARD_DATA, CommentCardDataFactory.commentCardData()))
+        this.vm.intent(Intent().putExtra(IntentKey.COMMENT_CARD_DATA, commentCardData))
         getComment.assertValue(commentCardData)
 
         this.vm.intent(Intent().putExtra("Some other Key", commentCardData))

--- a/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
@@ -648,4 +648,64 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
         this.hasPendingComments.assertValues(false, true, true)
     }
+
+    @Test
+    fun testComments_onShowCanceledPledgeComment() {
+        val currentUser = UserFactory.user()
+            .toBuilder()
+            .id(1)
+            .build()
+
+        val comment1 = CommentFactory.commentWithCanceledPledgeAuthor(currentUser).toBuilder().id(1).body("comment1").build()
+
+        val commentEnvelope = CommentEnvelopeFactory.commentsEnvelope().toBuilder()
+            .comments(listOf(comment1))
+            .build()
+
+        val testScheduler = TestScheduler()
+
+        val env = environment().toBuilder()
+            .apolloClient(object : MockApolloClient() {
+                override fun getRepliesForComment(
+                    comment: Comment,
+                    cursor: String?,
+                    pageSize: Int
+                ): Observable<CommentEnvelope> {
+                    return Observable.just(commentEnvelope)
+                }
+            })
+            .currentUser(MockCurrentUser(currentUser))
+            .scheduler(testScheduler)
+            .build()
+
+        val commentCardData1 = CommentCardData.builder()
+            .comment(comment1)
+            .commentCardState(CommentCardStatus.CANCELED_PLEDGE_MESSAGE.commentCardStatus)
+            .build()
+
+        val commentCardData2 = CommentCardData.builder()
+            .comment(comment1)
+            .commentCardState(CommentCardStatus.CANCELED_PLEDGE_COMMENT.commentCardStatus)
+            .build()
+
+        val vm = ThreadViewModel.ViewModel(env)
+        // Start the view model with a backed project and comment.
+        vm.intent(Intent().putExtra(IntentKey.COMMENT_CARD_DATA, CommentCardDataFactory.commentCardData()))
+        vm.outputs.onCommentReplies().subscribe(onReplies)
+
+        onReplies.assertValueCount(1)
+        vm.outputs.onCommentReplies().take(0).subscribe {
+            val newList = it.first
+            assertTrue(newList[0].comment?.body() == commentCardData1.comment?.body())
+            assertTrue(newList[0].commentCardState == commentCardData1.commentCardState)
+        }
+
+        vm.inputs.onShowCanceledPledgeComment(comment1)
+
+        vm.outputs.onCommentReplies().take(1).subscribe {
+            val newList = it.first
+            assertTrue(newList[0].comment?.body() == commentCardData2.comment?.body())
+            assertTrue(newList[0].commentCardState == commentCardData2.commentCardState)
+        }
+    }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit
 class ThreadViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var vm: ThreadViewModel.ViewModel
-    private val getComment = TestSubscriber<Comment>()
+    private val getComment = TestSubscriber<CommentCardData>()
     private val focusCompose = TestSubscriber<Boolean>()
     private val onReplies = TestSubscriber<Pair<List<CommentCardData>, Boolean>>()
 
@@ -62,10 +62,10 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         val commentCardData = CommentCardDataFactory.commentCardData()
 
         this.vm.intent(Intent().putExtra(IntentKey.COMMENT_CARD_DATA, CommentCardDataFactory.commentCardData()))
-        getComment.assertValue(commentCardData.comment)
+        getComment.assertValue(commentCardData)
 
         this.vm.intent(Intent().putExtra("Some other Key", commentCardData))
-        getComment.assertValue(commentCardData.comment)
+        getComment.assertValue(commentCardData)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Comments from users who have cancelled their pledge should be hidden at first.

# 🤔 Why

To mark the canceled pledge users comments

# 🛠 How

- Add flagged to cancled pledge 
- ![image](https://user-images.githubusercontent.com/1075310/126830975-1023b5b1-add0-460f-84dc-1f526e340480.png)

- Add new status to Comment card
- ![image](https://user-images.githubusercontent.com/1075310/126831046-c16882ea-a628-4660-ae2c-fa1a4b03affa.png)

- Handle new UI for Show canceled comment 
- Handle on show comment in comment and thread activity 
- Handle Root comment and pass status to thread Activity 


# 👀 See

https://user-images.githubusercontent.com/1075310/126831207-1d562fcd-e077-40ee-9d4e-9250eb56e727.mp4



# 📋 QA

Check Project "Keep Moms in the Game "

# Story 📖

https://kickstarter.atlassian.net/browse/NT-1965
