### PR TITLE
NT-2180: Empty state showing when pull to refresh

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/loadmore/ApolloPaginate.kt
+++ b/app/src/main/java/com/kickstarter/libs/loadmore/ApolloPaginate.kt
@@ -225,7 +225,6 @@ class ApolloPaginate<Data, Envelope : ApolloEnvelope, Params>(
             .map(this.pageTransformation)
             .takeUntil { data: List<Data> -> data.isEmpty() }
             .doOnSubscribe { _isFetching.onNext(true) }
-            //.doOnUnsubscribe { _isFetching.onNext(false) }
             .doAfterTerminate {
                 _isFetching.onNext(false)
             }

--- a/app/src/main/java/com/kickstarter/libs/loadmore/ApolloPaginate.kt
+++ b/app/src/main/java/com/kickstarter/libs/loadmore/ApolloPaginate.kt
@@ -225,6 +225,7 @@ class ApolloPaginate<Data, Envelope : ApolloEnvelope, Params>(
             .map(this.pageTransformation)
             .takeUntil { data: List<Data> -> data.isEmpty() }
             .doOnSubscribe { _isFetching.onNext(true) }
+            //.doOnUnsubscribe { _isFetching.onNext(false) }
             .doAfterTerminate {
                 _isFetching.onNext(false)
             }

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -174,7 +174,7 @@ interface CommentsViewHolderViewModel {
 
             this.internalError
                 .distinctUntilChanged()
-                .withLatestFrom(commentData) { error, data -> Pair(error, data)}
+                .withLatestFrom(commentData) { error, data -> Pair(error, data) }
                 .compose(bindToLifecycle())
                 .delay(1, TimeUnit.SECONDS, environment.scheduler())
                 .subscribe {

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -145,13 +145,14 @@ interface CommentsViewHolderViewModel {
 
         init {
 
-            val comment = Observable.merge(this.commentInput.map { it.comment }, postedSuccessfully)
+            val comment = Observable.merge(this.commentInput.distinctUntilChanged().map { it.comment }, postedSuccessfully)
                 .filter { ObjectUtils.isNotNull(it) }
                 .map { requireNotNull(it) }
 
             configureCommentCardWithComment(comment)
 
             val commentCardStatus = this.commentInput
+                .distinctUntilChanged()
                 .filter { ObjectUtils.isNotNull(it) }
                 .map {
                     val commentCardState = cardStatus(it)
@@ -172,7 +173,8 @@ interface CommentsViewHolderViewModel {
             postComment(commentData, internalError, environment)
 
             this.internalError
-                .compose(combineLatestPair(commentData))
+                .distinctUntilChanged()
+                .withLatestFrom(commentData) { error, data -> Pair(error, data)}
                 .compose(bindToLifecycle())
                 .delay(1, TimeUnit.SECONDS, environment.scheduler())
                 .subscribe {

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -173,8 +173,8 @@ interface CommentsViewHolderViewModel {
             postComment(commentData, internalError, environment)
 
             this.internalError
+                .compose(combineLatestPair(commentData))
                 .distinctUntilChanged()
-                .withLatestFrom(commentData) { error, data -> Pair(error, data) }
                 .compose(bindToLifecycle())
                 .delay(1, TimeUnit.SECONDS, environment.scheduler())
                 .subscribe {

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -418,7 +418,7 @@ interface CommentsViewModel {
                     .commentCardState(comment.cardStatus())
                     .commentableId(it.first.commentableId)
                     .build()
-            }?: emptyList()
+            } ?: emptyList()
 
         private fun buildCommentBody(it: Pair<User, Pair<String, DateTime>>): Comment {
             return Comment.builder()

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -339,7 +339,7 @@ interface CommentsViewModel {
                     .loadWithParams {
                         loadWithProjectOrUpdateComments(Observable.just(it.first), it.second)
                     }
-                    .clearWhenStartingOver(true)
+                    .clearWhenStartingOver(false)
                     .build()
 
             apolloPaginate.isFetching()
@@ -347,12 +347,9 @@ interface CommentsViewModel {
                 .subscribe(this.isFetchingComments)
 
             apolloPaginate.paginatedData()
-                ?.compose(combineLatestPair(this.isFetchingComments))
-                ?.filter { !it.second }
-                ?.distinctUntilChanged()
                 ?.share()
                 ?.subscribe {
-                    this.commentsList.onNext(it.first)
+                    this.commentsList.onNext(it)
                 }
 
             this.internalError
@@ -421,7 +418,7 @@ interface CommentsViewModel {
                     .commentCardState(comment.cardStatus())
                     .commentableId(it.first.commentableId)
                     .build()
-            }
+            }?: emptyList()
 
         private fun buildCommentBody(it: Pair<User, Pair<String, DateTime>>): Comment {
             return Comment.builder()


### PR DESCRIPTION
# 📲 What
- Fixed duplicated comments when errored comments present on the list
- Fixed empty state showing when pull to refresh

# 👀 See

https://user-images.githubusercontent.com/4083656/129404038-7243b848-b10e-482b-829e-b373dc3ba636.mp4


|  |  |

# 📋 QA

Steps to reproduce: 
1- Go to a project comments

2 - Pull to refresh

**BEFORE**
Notice how the empty screen shows up while loading

**NOW**
Empty state do not show while loading

# Story 📖

[NT-2180](https://kickstarter.atlassian.net/browse/NT-2180)
