### PR TITLE
Nt-2068: Fix update payment fails on pledges with addons, and no rewards

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -204,6 +204,9 @@ interface PledgeFragmentViewModel {
         /** Emits the shipping amount of the selected shipping rule. */
         fun shippingAmount(): Observable<CharSequence>
 
+        /** Emits the shipping rule. */
+        fun shippingRule(): Observable<ShippingRule>
+
         /** Emits a pair of list of shipping rules to be selected and the project. */
         fun shippingRulesAndProject(): Observable<Pair<List<ShippingRule>, Project>>
 
@@ -498,7 +501,7 @@ interface PledgeFragmentViewModel {
                 .map { it.first }
 
             val backingShippingRuleUpdatePayment = backingWhenPledgeReasonUpdatePayment
-                .filter { it.reward()?.let { reward -> !RewardUtils.isNoReward(reward) } }
+                .filter { it.reward()?.let { reward -> !RewardUtils.isNoReward(reward) } ?: false }
                 .compose<Pair<Backing, PledgeData>>(combineLatestPair(pledgeData))
                 .map { requireNotNull(it.first.locationId()) }
                 .compose<Pair<Long, List<ShippingRule>>>(combineLatestPair(shippingRules))
@@ -1876,5 +1879,8 @@ interface PledgeFragmentViewModel {
 
         @NonNull
         override fun pledgeAmountHeader(): Observable<CharSequence> = this.pledgeAmountHeader
+
+        @NonNull
+        override fun shippingRule(): Observable<ShippingRule> = this.shippingRule
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -51,7 +51,7 @@ import rx.subjects.PublishSubject
 import type.CreditCardPaymentType
 import java.math.RoundingMode
 import java.net.CookieManager
- import kotlin.math.max
+import kotlin.math.max
 
 interface PledgeFragmentViewModel {
     interface Inputs {
@@ -494,11 +494,11 @@ interface PledgeFragmentViewModel {
 
             val backingWhenPledgeReasonUpdatePayment = backing
                 .compose<Pair<Backing, PledgeReason>>(combineLatestPair(pledgeReason))
-                .filter{ PledgeReason.UPDATE_PAYMENT == it.second }
+                .filter { PledgeReason.UPDATE_PAYMENT == it.second }
                 .map { it.first }
 
             val backingShippingRuleUpdatePayment = backingWhenPledgeReasonUpdatePayment
-                .filter{ it.reward()?.let { reward -> !RewardUtils.isNoReward(reward) } }
+                .filter { it.reward()?.let { reward -> !RewardUtils.isNoReward(reward) } }
                 .compose<Pair<Backing, PledgeData>>(combineLatestPair(pledgeData))
                 .map { requireNotNull(it.first.locationId()) }
                 .compose<Pair<Long, List<ShippingRule>>>(combineLatestPair(shippingRules))
@@ -843,7 +843,7 @@ interface PledgeFragmentViewModel {
 
             // - Calculate total for Reward || Rewards + AddOns with Shipping location
             val totalWShipping = Observable.combineLatest(isRewardWithShipping, pledgeAmountHeader, shippingAmount, this.bonusAmount, pledgeReason) {
-                    _, pAmount, shippingAmount, bAmount, pReason ->
+                _, pAmount, shippingAmount, bAmount, pReason ->
                 return@combineLatest getAmount(pAmount, shippingAmount, bAmount, pReason)
             }
                 .distinctUntilChanged()

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -52,6 +52,7 @@ import org.joda.time.DateTime
 import org.junit.Test
 import rx.Observable
 import rx.observers.TestSubscriber
+import rx.subjects.BehaviorSubject
 import java.math.RoundingMode
 import java.net.CookieManager
 import java.util.Collections
@@ -122,6 +123,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val shippingRuleStaticIsGone = TestSubscriber<Boolean>()
     private val bonusSectionIsGone = TestSubscriber<Boolean>()
     private val bonusSummaryIsGone = TestSubscriber<Boolean>()
+    private val shippingRule = TestSubscriber<ShippingRule>()
+
 
     private fun setUpEnvironment(
         environment: Environment,
@@ -193,6 +196,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.shippingRuleStaticIsGone().subscribe(this.shippingRuleStaticIsGone)
         this.vm.outputs.isBonusSupportSectionGone().subscribe(this.bonusSectionIsGone)
         this.vm.outputs.bonusSummaryIsGone().subscribe(this.bonusSummaryIsGone)
+        this.vm.outputs.shippingRule().subscribe(this.shippingRule)
 
         val projectData = project.backing()?.let {
             return@let ProjectData.builder()
@@ -1197,6 +1201,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         val backing = BackingFactory.backing()
             .toBuilder()
             .amount(30.0)
+            .locationId(ShippingRuleFactory.usShippingRule().location().id())
             .shippingAmount(10f)
             .reward(reward)
             .rewardId(reward.id())
@@ -1210,6 +1215,51 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PAYMENT)
 
         this.shippingSummaryAmount.assertValue(expectedCurrency(environment, backedProject, 10.0))
+    }
+
+    @Test
+    fun testUpdatePayment_whenAddonsWithRewardAndShipping_shouldEmitShippingRule() {
+        val reward = RewardFactory.rewardWithShipping()
+        val backing = BackingFactory.backing()
+            .toBuilder()
+            .addOns(listOf(RewardFactory.addOnMultiple()))
+            .amount(30.0)
+            .locationId(ShippingRuleFactory.usShippingRule().location().id())
+            .shippingAmount(10f)
+            .reward(reward)
+            .rewardId(reward.id())
+            .build()
+        val backedProject = ProjectFactory.backedProject()
+            .toBuilder()
+            .backing(backing)
+            .build()
+
+        val environment = environment()
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PAYMENT)
+
+        this.shippingRule.assertValue(ShippingRuleFactory.usShippingRule())
+    }
+
+    @Test
+    fun testUpdatePayment_whenNoReward_shouldNotEmitShippingRule() {
+        val reward = RewardFactory.noReward()
+        val backing = BackingFactory.backing()
+            .toBuilder()
+            .amount(30.0)
+            .locationId(ShippingRuleFactory.usShippingRule().location().id())
+            .shippingAmount(10f)
+            .reward(RewardFactory.noReward())
+            .rewardId(0)
+            .build()
+        val backedProject = ProjectFactory.backedProject()
+            .toBuilder()
+            .backing(backing)
+            .build()
+
+        val environment = environment()
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.UPDATE_PAYMENT)
+
+        this.shippingRule.assertNoValues()
     }
 
     @Test
@@ -1316,7 +1366,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testShowNewCardFragment_whenUpdatingPaymentMethod() {
-        val backedProject = ProjectFactory.backedProject()
+        val backedProject = ProjectFactory.backedProjectWithNoReward()
         setUpEnvironment(environmentForLoggedInUser(UserFactory.user()), RewardFactory.noReward(), backedProject, PledgeReason.UPDATE_PAYMENT)
 
         this.vm.inputs.newCardButtonClicked()

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -52,7 +52,6 @@ import org.joda.time.DateTime
 import org.junit.Test
 import rx.Observable
 import rx.observers.TestSubscriber
-import rx.subjects.BehaviorSubject
 import java.math.RoundingMode
 import java.net.CookieManager
 import java.util.Collections
@@ -124,7 +123,6 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val bonusSectionIsGone = TestSubscriber<Boolean>()
     private val bonusSummaryIsGone = TestSubscriber<Boolean>()
     private val shippingRule = TestSubscriber<ShippingRule>()
-
 
     private fun setUpEnvironment(
         environment: Environment,


### PR DESCRIPTION
# 📲 What

- Users were unable to update payment when a reward had addons
- Also found that updating the payment was crashing on pledges with no rewards
- Added functionality that fixes both of these use cases 

# 🤔 Why

- The "Confirm" button being enabled is tied to a few different streams, one of which is `totalIsValid`. Up the line, this stream is tied to the shippingRule. For some reason, when a project had addons, we were not emitting a shipping rule, and therefore we were not emitting a total. Down the line, this meant that totalIsValid was never evaluated, and therefore the button never enabled. 
- This functionality is specific to backings with addons, but it seems that this use case is for rewards before the user backs the project. 
- This functionality was also causing a crash when updating the payment of a pledge with no reward, because this functionality was requiring the location id to not be null. If there is a pledge with no reward, there is no need for a shipping id 😅 

# 🛠 How

<img width="693" alt="Screen Shot 2021-08-23 at 12 14 21 PM" src="https://user-images.githubusercontent.com/19390326/130482638-086407cf-0ed9-4d8d-bf49-4db0c3646e52.png">

# 👀 See
Before: User would not see total and the confirm button would be disabled

After: User can see their total, and confirm button is enabled:
![Screenshot_1629735822](https://user-images.githubusercontent.com/19390326/130482965-3db65110-6f72-425d-8c07-102d7c4d0d84.png) ![Screenshot_1629735879](https://user-images.githubusercontent.com/19390326/130482967-79bcd0c4-7711-484e-b32a-8f831ae438ea.png)

# 📋 QA

This should be very thoroughly QAed, as there are many many many use-cases:
- Pledge with addons
- Pledge without addons
- Pledge with no reward
- Digital pledge with addons
- Digital pledge without addons
- There might be more 😅 

# Story 📖

[NT-2068: Manage Pledge – Unable to change payment method](https://kickstarter.atlassian.net/browse/NT-2068)
[NT-2195: Manage Pledge - Update payment on pledge with no reward crashes](https://kickstarter.atlassian.net/browse/NT-2195)
