### PR TITLE
NTV-10: Add deep link to comment thread

### DIFF
--- a/app/src/main/graphql/replies.graphql
+++ b/app/src/main/graphql/replies.graphql
@@ -14,3 +14,12 @@ query GetRepliesForComment($commentableId: ID!, $cursor: String, $pageSize: Int)
         }
     }
 }
+
+query GetComment($commentableId: ID!) {
+    commentable: node(id: $commentableId) {
+        ... on Comment {
+            ...comment
+
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/libs/utils/UrlUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/UrlUtils.kt
@@ -9,6 +9,7 @@ import com.kickstarter.R
 object UrlUtils {
 
     private const val KEY_REF = "ref"
+    private const val KEY_COMMENT = "comment"
 
     fun appendPath(baseUrl: String, path: String): String {
         val uriBuilder = Uri.parse(baseUrl).buildUpon()
@@ -39,5 +40,9 @@ object UrlUtils {
 
     fun refTag(url: String): String? {
         return Uri.parse(url).getQueryParameter(KEY_REF)
+    }
+
+    fun commentId(url: String): String? {
+        return Uri.parse(url).getQueryParameter(KEY_COMMENT)
     }
 }

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -92,6 +92,10 @@ open class MockApolloClient : ApolloClientType {
         return Observable.just(CommentEnvelopeFactory.emptyCommentsEnvelope())
     }
 
+    override fun getComment(commentableId: String): Observable<Comment> {
+        return Observable.just(CommentFactory.comment())
+    }
+
     override fun createComment(comment: PostCommentData): Observable<Comment> {
         return Observable.just(CommentFactory.comment())
     }

--- a/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
+++ b/app/src/main/java/com/kickstarter/services/ApolloClientType.kt
@@ -40,6 +40,8 @@ interface ApolloClientType {
 
     fun getRepliesForComment(comment: Comment, cursor: String? = null, pageSize: Int = REPLIES_PAGE_SIZE): Observable<CommentEnvelope>
 
+    fun getComment(commentableId: String): Observable<Comment>
+
     fun createComment(comment: PostCommentData): Observable<Comment>
 
     fun createPassword(password: String, confirmPassword: String): Observable<CreatePasswordMutation.Data>

--- a/app/src/main/java/com/kickstarter/ui/IntentKey.java
+++ b/app/src/main/java/com/kickstarter/ui/IntentKey.java
@@ -42,6 +42,7 @@ public final class IntentKey {
   public static final String COMMENT = "com.kickstarter.kickstarter.intent_comment";
   public static final String COMMENT_CARD_DATA = "com.kickstarter.kickstarter.intent_comment_card_data";
   public static final String REPLY_EXPAND = "com.kickstarter.kickstarter.intent_reply_expand";
+  public static final String REPLY_SCROLL_BOTTOM = "com.kickstarter.kickstarter.intent_reply_scroll_bottom";
   public static final String DEEP_LINK_SCREEN_PROJECT_COMMENT = "com.kickstarter.kickstarter.deep_link_screen_project_comment";
   public static final String DEEP_LINK_SCREEN_PROJECT_UPDATE = "com.kickstarter.kickstarter.deep_link_screen_project_update";
   public static final String DEEP_LINK_SCREEN_PROJECT_UPDATE_COMMENT = "com.kickstarter.kickstarter.deep_link_screen_project_update_comment";

--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -221,6 +221,13 @@ class CommentsActivity :
             .subscribe {
                 startThreadActivity(it.first, it.second)
             }
+
+        viewModel.outputs.startThreadActivityFromDeepLink()
+            .compose(bindToLifecycle())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                startThreadActivityFromDeepLink(it)
+            }
     }
 
     fun postComment(comment: String) {
@@ -290,6 +297,19 @@ class CommentsActivity :
         val threadIntent = Intent(this, ThreadActivity::class.java).apply {
             putExtra(IntentKey.COMMENT_CARD_DATA, commentData)
             putExtra(IntentKey.REPLY_EXPAND, openKeyboard)
+        }
+
+        startActivity(threadIntent)
+        this.let {
+            TransitionUtils.transition(it, TransitionUtils.slideInFromRight())
+        }
+    }
+
+    private fun startThreadActivityFromDeepLink(commentData: CommentCardData) {
+        val threadIntent = Intent(this, ThreadActivity::class.java).apply {
+            putExtra(IntentKey.COMMENT_CARD_DATA, commentData)
+            putExtra(IntentKey.REPLY_EXPAND, false)
+            putExtra(IntentKey.REPLY_SCROLL_BOTTOM, true)
         }
 
         startActivity(threadIntent)

--- a/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.kt
@@ -8,6 +8,7 @@ import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ApplicationUtils
+import com.kickstarter.libs.utils.UrlUtils.commentId
 import com.kickstarter.libs.utils.UrlUtils.refTag
 import com.kickstarter.libs.utils.extensions.path
 import com.kickstarter.ui.IntentKey
@@ -89,6 +90,11 @@ class DeepLinkActivity : BaseActivity<DeepLinkViewModel.ViewModel?>() {
     private fun startProjectActivityForComment(uri: Uri) {
         val projectIntent = projectIntent(uri)
             .putExtra(IntentKey.DEEP_LINK_SCREEN_PROJECT_COMMENT, true)
+
+        commentId(uri.toString())?.let {
+            projectIntent.putExtra(IntentKey.COMMENT, it)
+        }
+
         startActivity(projectIntent)
         finish()
     }
@@ -99,6 +105,11 @@ class DeepLinkActivity : BaseActivity<DeepLinkViewModel.ViewModel?>() {
         val projectIntent = projectIntent(uri)
             .putExtra(IntentKey.DEEP_LINK_SCREEN_PROJECT_UPDATE, path[path.lastIndex - 1])
             .putExtra(IntentKey.DEEP_LINK_SCREEN_PROJECT_UPDATE_COMMENT, true)
+
+        commentId(uri.toString())?.let {
+            projectIntent.putExtra(IntentKey.COMMENT, it)
+        }
+
         startActivity(projectIntent)
         finish()
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectActivity.kt
@@ -246,11 +246,25 @@ class ProjectActivity :
                 this.startRootCommentsActivity(it)
             }
 
+        this.viewModel.outputs.startRootCommentsForCommentsThreadActivity()
+            .compose(bindToLifecycle())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                this.startRootCommentsForCommentsThreadActivity(it)
+            }
+
         this.viewModel.outputs.startProjectUpdateActivity()
             .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
                 this.startProjectUpdateActivity(it)
+            }
+
+        this.viewModel.outputs.startProjectUpdateToRepliesDeepLinkActivity()
+            .compose(bindToLifecycle())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                this.startProjectUpdateToRepliesDeepLinkActivity(it)
             }
 
         this.viewModel.outputs.startCreatorBioWebViewActivity()
@@ -663,11 +677,33 @@ class ProjectActivity :
         startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 
+    private fun startProjectUpdateToRepliesDeepLinkActivity(projectAndData: Pair<Pair<String, String>, Pair<Project, ProjectData>>) {
+        val intent = Intent(this, UpdateActivity::class.java)
+            .putExtra(IntentKey.PROJECT, projectAndData.second.first)
+            .putExtra(IntentKey.UPDATE_POST_ID, projectAndData.first.first)
+            .putExtra(IntentKey.IS_UPDATE_COMMENT, projectAndData.first.second.isNotEmpty())
+            .putExtra(IntentKey.COMMENT, projectAndData.first.second)
+        startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
+    }
+
     private fun startRootCommentsActivity(projectAndData: Pair<Project, ProjectData>) {
         startActivity(
             Intent(this, CommentsActivity::class.java)
                 .putExtra(IntentKey.PROJECT, projectAndData.first)
                 .putExtra(IntentKey.PROJECT_DATA, projectAndData.second)
+        )
+
+        this.let {
+            TransitionUtils.transition(it, TransitionUtils.slideInFromRight())
+        }
+    }
+
+    private fun startRootCommentsForCommentsThreadActivity(pair: Pair<String, Pair<Project, ProjectData>>) {
+        startActivity(
+            Intent(this, CommentsActivity::class.java)
+                .putExtra(IntentKey.PROJECT, pair.second.first)
+                .putExtra(IntentKey.PROJECT_DATA, pair.second.second)
+                .putExtra(IntentKey.COMMENT, pair.first)
         )
 
         this.let {

--- a/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.kt
@@ -74,11 +74,27 @@ class UpdateActivity : BaseActivity<UpdateViewModel.ViewModel?>(), KSWebView.Del
                 viewModel.inputs.goToCommentsActivity()
             }
 
+        viewModel.outputs.deedLinkToThreadActivity()
+            .filter { it.second == true }
+            .map { it.first }
+            .compose(bindToLifecycle())
+            .compose(observeForUI())
+            .subscribe {
+                viewModel.inputs.goToCommentsActivityToDeepLinkThreadActivity(it)
+            }
+
         viewModel.outputs.startRootCommentsActivity()
             .compose(bindToLifecycle())
             .compose(observeForUI())
             .subscribe { update ->
                 startRootCommentsActivity(update)
+            }
+
+        viewModel.outputs.startRootCommentsActivityToDeepLinkThreadActivity()
+            .compose(bindToLifecycle())
+            .compose(observeForUI())
+            .subscribe {
+                startRootCommentsActivityToDeepLinkThreadActivity(it)
             }
 
         viewModel.outputs.startProjectActivity()
@@ -153,6 +169,14 @@ class UpdateActivity : BaseActivity<UpdateViewModel.ViewModel?>(), KSWebView.Del
     private fun startRootCommentsActivity(update: Update) {
         val intent = Intent(this, CommentsActivity::class.java)
             .putExtra(IntentKey.UPDATE, update)
+        startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
+    }
+
+    private fun startRootCommentsActivityToDeepLinkThreadActivity(data: Pair<String, Update>) {
+        val intent = Intent(this, CommentsActivity::class.java)
+            .putExtra(IntentKey.UPDATE, data.first)
+            .putExtra(IntentKey.COMMENT, data.second)
+
         startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.kt
@@ -174,8 +174,8 @@ class UpdateActivity : BaseActivity<UpdateViewModel.ViewModel?>(), KSWebView.Del
 
     private fun startRootCommentsActivityToDeepLinkThreadActivity(data: Pair<String, Update>) {
         val intent = Intent(this, CommentsActivity::class.java)
-            .putExtra(IntentKey.UPDATE, data.first)
-            .putExtra(IntentKey.COMMENT, data.second)
+            .putExtra(IntentKey.COMMENT, data.first)
+            .putExtra(IntentKey.UPDATE, data.second)
 
         startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.kt
@@ -74,7 +74,7 @@ class UpdateActivity : BaseActivity<UpdateViewModel.ViewModel?>(), KSWebView.Del
                 viewModel.inputs.goToCommentsActivity()
             }
 
-        viewModel.outputs.deedLinkToThreadActivity()
+        viewModel.outputs.deepLinkToThreadActivity()
             .filter { it.second == true }
             .map { it.first }
             .compose(bindToLifecycle())

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -63,6 +63,7 @@ interface CommentsViewModel {
         fun paginateCommentsError(): Observable<Throwable>
         fun pullToRefreshError(): Observable<Throwable>
         fun startThreadActivity(): Observable<Pair<CommentCardData, Boolean>>
+        fun startThreadActivityFromDeepLink(): Observable<CommentCardData>
         fun hasPendingComments(): Observable<Pair<Boolean, Boolean>>
 
         /** Emits a boolean indicating whether comments are being fetched from the API.  */
@@ -107,6 +108,7 @@ interface CommentsViewModel {
         private val displayPaginationError = BehaviorSubject.create<Boolean>()
         private val commentToRefresh = PublishSubject.create<Pair<Comment, Int>>()
         private val startThreadActivity = BehaviorSubject.create<Pair<CommentCardData, Boolean>>()
+        private val startThreadActivityFromDeepLink = BehaviorSubject.create<CommentCardData>()
         private val hasPendingComments = BehaviorSubject.create<Pair<Boolean, Boolean>>()
 
         // - Error observables to handle the 3 different use cases
@@ -182,12 +184,15 @@ interface CommentsViewModel {
             loadCommentListFromProjectOrUpdate(projectOrUpdateComment)
 
             val deepLinkCommentableId =
-                intent().filter { it.getStringExtra(IntentKey.COMMENT)?.isNotEmpty() }
-                    .map { requireNotNull(it.getStringExtra(IntentKey.COMMENT)) }
+                intent().filter {
+                    it.getStringExtra(IntentKey.COMMENT)?.isNotEmpty()
+                }.map { requireNotNull(it.getStringExtra(IntentKey.COMMENT)) }
 
-            deepLinkCommentableId.switchMap {
-                return@switchMap apolloClient.getComment(it)
-            }.compose(Transformers.neverError())
+            deepLinkCommentableId
+                .compose(Transformers.takeWhen(projectOrUpdateComment))
+                .switchMap {
+                    return@switchMap apolloClient.getComment(it)
+                }.compose(Transformers.neverError())
                 .compose(combineLatestPair(deepLinkCommentableId))
                 .map {
                     CommentCardData.builder()
@@ -198,11 +203,8 @@ interface CommentsViewModel {
                         .build()
                 }.compose(bindToLifecycle())
                 .subscribe {
-                    this.startThreadActivity.onNext(
-                        Pair(
-                            it,
-                            false
-                        )
+                    this.startThreadActivityFromDeepLink.onNext(
+                        it
                     )
                 }
 
@@ -498,6 +500,8 @@ interface CommentsViewModel {
         override fun setEmptyState(): Observable<Boolean> = setEmptyState
 
         override fun startThreadActivity(): Observable<Pair<CommentCardData, Boolean>> = this.startThreadActivity
+        override fun startThreadActivityFromDeepLink(): Observable<CommentCardData> = this.startThreadActivityFromDeepLink
+
         override fun isFetchingComments(): Observable<Boolean> = this.isFetchingComments
 
         override fun hasPendingComments(): Observable<Pair<Boolean, Boolean>> = this.hasPendingComments

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -202,11 +202,7 @@ interface CommentsViewModel {
                         .commentableId(it.second)
                         .build()
                 }.compose(bindToLifecycle())
-                .subscribe {
-                    this.startThreadActivityFromDeepLink.onNext(
-                        it
-                    )
-                }
+                .subscribe { this.startThreadActivityFromDeepLink.onNext(it) }
 
             this.insertNewCommentToList
                 .distinctUntilChanged()

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectViewModel.kt
@@ -577,9 +577,7 @@ interface ProjectViewModel {
                     Pair(updateId, project)
                 }
                 .compose(bindToLifecycle())
-                .subscribe {
-                    this.startProjectUpdateToRepliesDeepLinkActivity.onNext(it)
-                }
+                .subscribe { this.startProjectUpdateToRepliesDeepLinkActivity.onNext(it) }
 
             currentProject
                 .compose<Project>(takeWhen(this.creatorDashboardButtonClicked))

--- a/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
@@ -290,6 +290,16 @@ interface ThreadViewModel {
             this.backPressed
                 .compose(bindToLifecycle())
                 .subscribe { this.closeThreadActivity.onNext(it) }
+
+            intent()
+                .map { it.getBooleanExtra(IntentKey.REPLY_SCROLL_BOTTOM, false) }
+                .filter { it }
+                .compose(Transformers.takeWhen(this.onCommentReplies))
+                .distinctUntilChanged()
+                .compose(bindToLifecycle())
+                .subscribe {
+                    scrollToBottom.onNext(null)
+                }
         }
 
         private fun loadCommentListFromProjectOrUpdate(comment: Observable<Comment>) {

--- a/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
@@ -247,9 +247,7 @@ interface ThreadViewModel {
                 }
                 .distinctUntilChanged()
                 .compose(bindToLifecycle())
-                .subscribe {
-                    this.onCommentReplies.onNext(it)
-                }
+                .subscribe { this.onCommentReplies.onNext(it) }
 
             // - Update internal mutable list with the latest state after successful response
             this.onCommentReplies

--- a/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.kt
@@ -107,7 +107,7 @@ interface UpdateViewModel {
                 .map { it.getParcelableExtra(IntentKey.UPDATE) as? Update? }
 
             intent()
-                .filter { it.hasExtra(IntentKey.IS_UPDATE_COMMENT) && !it.hasExtra(IntentKey.IS_UPDATE_COMMENT) }
+                .filter { it.hasExtra(IntentKey.IS_UPDATE_COMMENT) && !it.hasExtra(IntentKey.COMMENT) }
                 .map {
                     it.getBooleanExtra(IntentKey.IS_UPDATE_COMMENT, false)
                 }

--- a/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.kt
@@ -111,9 +111,7 @@ interface UpdateViewModel {
                 .map {
                     it.getBooleanExtra(IntentKey.IS_UPDATE_COMMENT, false)
                 }
-                .subscribe {
-                    this.deepLinkToRootComment.onNext(it)
-                }
+                .subscribe { this.deepLinkToRootComment.onNext(it) }
 
             intent()
                 .filter { it.hasExtra(IntentKey.COMMENT) && it.getStringExtra(IntentKey.COMMENT)?.isNotEmpty() ?: false }

--- a/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.kt
@@ -107,6 +107,7 @@ interface UpdateViewModel {
                 .map { it.getParcelableExtra(IntentKey.UPDATE) as? Update? }
 
             intent()
+                .filter { it.hasExtra(IntentKey.IS_UPDATE_COMMENT) && !it.hasExtra(IntentKey.IS_UPDATE_COMMENT) }
                 .map {
                     it.getBooleanExtra(IntentKey.IS_UPDATE_COMMENT, false)
                 }

--- a/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.kt
@@ -59,7 +59,7 @@ interface UpdateViewModel {
         fun startRootCommentsActivity(): Observable<Update>
 
         /** Emits an update to start the comments activity with.  */
-        fun deedLinkToThreadActivity(): Observable<Pair<String, Boolean>>
+        fun deepLinkToThreadActivity(): Observable<Pair<String, Boolean>>
 
         /** Emits a Uri and a ref tag to start the project activity with.  */
         fun startProjectActivity(): Observable<Pair<Uri, RefTag>>
@@ -93,8 +93,8 @@ interface UpdateViewModel {
         private val startProjectActivity = PublishSubject.create<Pair<Uri, RefTag>>()
         private val updateSequence = BehaviorSubject.create<String>()
         private val webViewUrl = BehaviorSubject.create<String>()
-        private val deedLinkToRootComment = BehaviorSubject.create<Boolean>()
-        private val deedLinkToThreadActivity = BehaviorSubject.create<Pair<String, Boolean>>()
+        private val deepLinkToRootComment = BehaviorSubject.create<Boolean>()
+        private val deepLinkToThreadActivity = BehaviorSubject.create<Pair<String, Boolean>>()
 
         @JvmField
         val inputs: Inputs = this
@@ -112,7 +112,7 @@ interface UpdateViewModel {
                     it.getBooleanExtra(IntentKey.IS_UPDATE_COMMENT, false)
                 }
                 .subscribe {
-                    this.deedLinkToRootComment.onNext(it)
+                    this.deepLinkToRootComment.onNext(it)
                 }
 
             intent()
@@ -124,7 +124,7 @@ interface UpdateViewModel {
                     )
                 }
                 .subscribe {
-                    this.deedLinkToThreadActivity.onNext(it)
+                    this.deepLinkToThreadActivity.onNext(it)
                 }
 
             val project = intent()
@@ -200,7 +200,7 @@ interface UpdateViewModel {
                 .compose(bindToLifecycle())
                 .subscribe {
                     startRootCommentsActivity.onNext(it)
-                    deedLinkToRootComment.onNext(false)
+                    deepLinkToRootComment.onNext(false)
                 }
 
             goToCommentsActivityToDeepLinkThreadActivity
@@ -212,7 +212,7 @@ interface UpdateViewModel {
                 .compose(bindToLifecycle())
                 .subscribe {
                     startRootCommentsActivityToDeepLinkThreadActivity.onNext(it)
-                    deedLinkToThreadActivity.onNext(Pair(it.first, false))
+                    deepLinkToThreadActivity.onNext(Pair(it.first, false))
                 }
 
             currentUpdate
@@ -287,7 +287,7 @@ interface UpdateViewModel {
 
         override fun startRootCommentsActivity(): Observable<Update> = startRootCommentsActivity
 
-        override fun deedLinkToThreadActivity(): Observable<Pair<String, Boolean>> = deedLinkToThreadActivity
+        override fun deepLinkToThreadActivity(): Observable<Pair<String, Boolean>> = deepLinkToThreadActivity
 
         override fun startProjectActivity(): Observable<Pair<Uri, RefTag>> = startProjectActivity
 
@@ -297,6 +297,6 @@ interface UpdateViewModel {
 
         override fun webViewUrl(): Observable<String> = webViewUrl
 
-        override fun hasCommentsDeepLinks(): Observable<Boolean> = deedLinkToRootComment
+        override fun hasCommentsDeepLinks(): Observable<Boolean> = deepLinkToRootComment
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/UpdateViewModel.kt
@@ -115,7 +115,7 @@ interface UpdateViewModel {
                 }
 
             intent()
-                .filter { it.getStringExtra(IntentKey.COMMENT)?.isNotEmpty() }
+                .filter { it.hasExtra(IntentKey.COMMENT) && it.getStringExtra(IntentKey.COMMENT)?.isNotEmpty() ?: false }
                 .map {
                     Pair(
                         requireNotNull(it.getStringExtra(IntentKey.COMMENT)),

--- a/app/src/test/java/com/kickstarter/viewmodels/UpdateViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/UpdateViewModelTest.java
@@ -332,7 +332,7 @@ public final class UpdateViewModelTest extends KSRobolectricTestCase {
 
     // Initial update index url emits.
     webViewUrl.assertValues(update.urls().web().update());
-    deedLinkToThreadActivity.assertValue(Pair.create(commentableId,true));
+    deedLinkToThreadActivity.assertValue(Pair.create(commentableId, true));
 
     vm.inputs.goToCommentsActivityToDeepLinkThreadActivity(commentableId);
 
@@ -340,7 +340,7 @@ public final class UpdateViewModelTest extends KSRobolectricTestCase {
     testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
 
 
-    startRootCommentsActivityToDeepLinkThreadActivity.assertValue(Pair.create(commentableId,update));
+    startRootCommentsActivityToDeepLinkThreadActivity.assertValue(Pair.create(commentableId, update));
     startRootCommentsActivityToDeepLinkThreadActivity.assertValueCount(1);
   }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/UpdateViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/UpdateViewModelTest.java
@@ -270,8 +270,8 @@ public final class UpdateViewModelTest extends KSRobolectricTestCase {
     final TestSubscriber<String> webViewUrl = new TestSubscriber<>();
     vm.outputs.webViewUrl().subscribe(webViewUrl);
 
-    final TestSubscriber<Boolean> deedLinkToRootComment = new TestSubscriber<>();
-    vm.hasCommentsDeepLinks().subscribe(deedLinkToRootComment);
+    final TestSubscriber<Boolean> deepLinkToRootComment = new TestSubscriber<>();
+    vm.hasCommentsDeepLinks().subscribe(deepLinkToRootComment);
 
     // Start the intent with a project and update.
     vm.intent(new Intent()
@@ -282,7 +282,7 @@ public final class UpdateViewModelTest extends KSRobolectricTestCase {
 
     // Initial update index url emits.
     webViewUrl.assertValues(update.urls().web().update());
-    deedLinkToRootComment.assertValue(true);
+    deepLinkToRootComment.assertValue(true);
 
     vm.inputs.goToCommentsActivity();
 
@@ -319,8 +319,8 @@ public final class UpdateViewModelTest extends KSRobolectricTestCase {
     final TestSubscriber<String> webViewUrl = new TestSubscriber<>();
     vm.outputs.webViewUrl().subscribe(webViewUrl);
 
-    final TestSubscriber<Pair<String, Boolean>> deedLinkToThreadActivity = new TestSubscriber<>();
-    vm.deedLinkToThreadActivity().subscribe(deedLinkToThreadActivity);
+    final TestSubscriber<Pair<String, Boolean>> deepLinkToThreadActivity = new TestSubscriber<>();
+    vm.deepLinkToThreadActivity().subscribe(deepLinkToThreadActivity);
 
     // Start the intent with a project and update.
     vm.intent(new Intent()
@@ -332,7 +332,7 @@ public final class UpdateViewModelTest extends KSRobolectricTestCase {
 
     // Initial update index url emits.
     webViewUrl.assertValues(update.urls().web().update());
-    deedLinkToThreadActivity.assertValue(Pair.create(commentableId, true));
+    deepLinkToThreadActivity.assertValue(Pair.create(commentableId, true));
 
     vm.inputs.goToCommentsActivityToDeepLinkThreadActivity(commentableId);
 

--- a/app/src/test/java/com/kickstarter/viewmodels/UpdateViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/UpdateViewModelTest.java
@@ -293,4 +293,54 @@ public final class UpdateViewModelTest extends KSRobolectricTestCase {
     startRootCommentsActivity.assertValue(update);
     startRootCommentsActivity.assertValueCount(1);
   }
+
+  @Test
+  public void testUpdateViewModel_DeepLinkCommentThread() {
+    final String postId = "3254626";
+    final String commentableId = "Q29tbWVudC0zMzU2MTY4Ng";
+    final Update update = UpdateFactory.update();
+
+    final ApiClientType apiClient = new MockApiClient() {
+      @Override
+      public @NonNull Observable<Update> fetchUpdate(final @NonNull String projectParam, final @NonNull String updateParam) {
+        return Observable.just(update);
+      }
+    };
+
+    final TestScheduler testScheduler = new TestScheduler();
+
+    final Environment environment = environment().toBuilder().apiClient(apiClient).scheduler(testScheduler).build();
+
+    final UpdateViewModel.ViewModel vm = new UpdateViewModel.ViewModel(environment);
+
+    final TestSubscriber<Pair<String, Update>> startRootCommentsActivityToDeepLinkThreadActivity = new TestSubscriber<>();
+    vm.outputs.startRootCommentsActivityToDeepLinkThreadActivity().subscribe(startRootCommentsActivityToDeepLinkThreadActivity);
+
+    final TestSubscriber<String> webViewUrl = new TestSubscriber<>();
+    vm.outputs.webViewUrl().subscribe(webViewUrl);
+
+    final TestSubscriber<Pair<String, Boolean>> deedLinkToThreadActivity = new TestSubscriber<>();
+    vm.deedLinkToThreadActivity().subscribe(deedLinkToThreadActivity);
+
+    // Start the intent with a project and update.
+    vm.intent(new Intent()
+            .putExtra(IntentKey.PROJECT, ProjectFactory.project())
+            .putExtra(IntentKey.UPDATE_POST_ID, postId)
+            .putExtra(IntentKey.IS_UPDATE_COMMENT, true)
+            .putExtra(IntentKey.COMMENT, commentableId)
+    );
+
+    // Initial update index url emits.
+    webViewUrl.assertValues(update.urls().web().update());
+    deedLinkToThreadActivity.assertValue(Pair.create(commentableId,true));
+
+    vm.inputs.goToCommentsActivityToDeepLinkThreadActivity(commentableId);
+
+
+    testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
+
+
+    startRootCommentsActivityToDeepLinkThreadActivity.assertValue(Pair.create(commentableId,update));
+    startRootCommentsActivityToDeepLinkThreadActivity.assertValueCount(1);
+  }
 }


### PR DESCRIPTION
# 📲 What

Add deep-link to Thread activity comments

# 🤔 Why

So users can access the project thread activity from a shared link

# 🛠 How
Deep Link to thread activity by sending a commendable_id
Check type of project screen Comment/Update

Set intent with commendable_id to open update activity Or CommentActivity
LoadComment from Graph-ql
Fire to. open the Thread activity from Comment activity 

# 👀 See

https://user-images.githubusercontent.com/1075310/132056437-1e840ac7-6a20-4e9f-b7e6-5a22b7bbb9d8.mp4


https://user-images.githubusercontent.com/1075310/132056553-92d0532b-9d15-485b-82d1-64d51a59b1d7.mp4





# 📋 QA
Run branch on the device 
open Link [ https://www.kickstarter.com/projects/fjorden/fjorden-iphone-photography-reinvented/posts/3254626/comments?comment=Q29tbWVudC0zMzU2MTY4Ng%3D%3D]From device 
and use the previous command with any of those url's ie:

```
adb shell am start -a android.intent.action.VIEW \
    -c android.intent.category.BROWSABLE \
    -d " https://www.kickstarter.com/projects/fjorden/fjorden-iphone-photography-reinvented/posts/3254626/comments?comment=Q29tbWVudC0zMzU2MTY4Ng%3D%3D"
```

Run branch on the device 
open Link [ https://www.kickstarter.com/projects/fjorden/fjorden-iphone-photography-reinvented/comments?comment=Q29tbWVudC0zMzY0OTg0MQ%3D%3D]From device 
and use the previous command with any of those url's ie:

```
adb shell am start -a android.intent.action.VIEW \
    -c android.intent.category.BROWSABLE \
    -d "  https://www.kickstarter.com/projects/fjorden/fjorden-iphone-photography-reinvented/comments?comment=Q29tbWVudC0zMzY0OTg0MQ%3D%3D"
```
# Story 📖
https://kickstarter.atlassian.net/browse/NTV-10