### PR TITLE
NTV-41: Add deeplink for discovery with collections

### DIFF
--- a/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
+++ b/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
@@ -8,7 +8,6 @@ import android.os.Parcelable;
 import com.kickstarter.R;
 import com.kickstarter.libs.KSString;
 import com.kickstarter.libs.qualifiers.AutoGson;
-import com.kickstarter.libs.utils.BooleanUtils;
 import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.libs.utils.extensions.UriExt;
 import com.kickstarter.models.Category;
@@ -207,9 +206,8 @@ public abstract class DiscoveryParams implements Parcelable {
 
     final Boolean recommended = uri.getBooleanQueryParameter("recommended", false);
     if (recommended) {
-    builder = builder.recommended(recommended);
+      builder = builder.recommended(recommended);
     }
-
 
     final Integer social = ObjectUtils.toInteger(uri.getQueryParameter("social"));
     if (social != null) {

--- a/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
+++ b/app/src/main/java/com/kickstarter/services/DiscoveryParams.java
@@ -8,6 +8,7 @@ import android.os.Parcelable;
 import com.kickstarter.R;
 import com.kickstarter.libs.KSString;
 import com.kickstarter.libs.qualifiers.AutoGson;
+import com.kickstarter.libs.utils.BooleanUtils;
 import com.kickstarter.libs.utils.ObjectUtils;
 import com.kickstarter.libs.utils.extensions.UriExt;
 import com.kickstarter.models.Category;
@@ -204,18 +205,19 @@ public abstract class DiscoveryParams implements Parcelable {
       builder = builder.pledged(pledged);
     }
 
-    final Boolean recommended = ObjectUtils.toBoolean(uri.getQueryParameter("recommended"));
-    if (recommended != null) {
-      builder = builder.recommended(recommended);
+    final Boolean recommended = uri.getBooleanQueryParameter("recommended", false);
+    if (recommended) {
+    builder = builder.recommended(recommended);
     }
+
 
     final Integer social = ObjectUtils.toInteger(uri.getQueryParameter("social"));
     if (social != null) {
       builder = builder.social(social);
     }
 
-    final Boolean staffPicks = ObjectUtils.toBoolean(uri.getQueryParameter("staff_picks"));
-    if (staffPicks != null) {
+    final Boolean staffPicks = uri.getBooleanQueryParameter("staff_picks", false);
+    if (staffPicks) {
       builder = builder.staffPicks(staffPicks);
     }
 

--- a/app/src/test/java/com/kickstarter/services/DiscoveryParamsTest.java
+++ b/app/src/test/java/com/kickstarter/services/DiscoveryParamsTest.java
@@ -75,6 +75,29 @@ public final class DiscoveryParamsTest extends KSRobolectricTestCase {
   }
 
   @Test
+  public void testFromUri_collections() {
+    final DiscoveryParams staffPicksParams = DiscoveryParams.builder().staffPicks(true).build();
+
+    final Uri staffPicksUri = Uri.parse("https://www.kickstarter.com/discover/advanced?staff_picks=1");
+    assertEquals(staffPicksParams, DiscoveryParams.fromUri(staffPicksUri));
+
+    final DiscoveryParams recommendedParams = DiscoveryParams.builder().recommended(true).build();
+
+    final Uri recommendedUri = Uri.parse("https://www.kickstarter.com/discover/advanced?recommended=1");
+    assertEquals(recommendedParams, DiscoveryParams.fromUri(recommendedUri));
+
+    final DiscoveryParams starredParams = DiscoveryParams.builder().starred(1).build();
+
+    final Uri starredUri = Uri.parse("https://www.kickstarter.com/discover/advanced?starred=1");
+    assertEquals(starredParams, DiscoveryParams.fromUri(starredUri));
+
+    final DiscoveryParams socialParams = DiscoveryParams.builder().social(1).build();
+
+    final Uri socialUri = Uri.parse("https://www.kickstarter.com/discover/advanced?social=1");
+    assertEquals(socialParams, DiscoveryParams.fromUri(socialUri));
+  }
+
+  @Test
   public void testFromUri_customScopes() {
     final DiscoveryParams endingSoonParams = DiscoveryParams.builder().sort(DiscoveryParams.Sort.ENDING_SOON).build();
     final Uri endingSoonUri = Uri.parse("https://www.kickstarter.com/discover/ending-soon");


### PR DESCRIPTION
# 📲 What

We can now deeplink into the discovery activity with a sort parameter.

# 🤔 Why

Updated the DiscoveryParams fromUri() method to check for the collections parameter being set to true or false. 

# 🛠 How

It seems that in the past we had urls where the query param would be true instead of 1, so  I updated the existing functionality to account for both instances. 

# 👀 See
(I'm not following anyone so the social deeplink comes up blank 😅 )

https://user-images.githubusercontent.com/19390326/132756051-de59ceca-ef6f-476a-af45-b2d1502f263e.mp4

# 📋 QA

Thoroughly test all discovery deeplinks

# Story 📖

[NTV-41: Handle collections](https://kickstarter.atlassian.net/browse/NTV-24)
