### PR TITLE
NTV-183: Fix discovery crash when changing sort after choosing category

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
@@ -268,9 +268,17 @@ interface DiscoveryViewModel {
             val paramsFromIntent = intent()
                 .flatMap { DiscoveryIntentMapper.params(it, apiClient) }
 
+            val pagerSelectedPage = pagerSetPrimaryPage.distinctUntilChanged()
+
             val drawerParamsClicked = childFilterRowClick
                 .mergeWith(topFilterRowClick)
-                .map { it.params() }
+                .withLatestFrom(
+                    pagerSelectedPage.map { DiscoveryUtils.sortFromPosition(it) }
+                ) { drawerClickParams, currentParams ->
+                    if (drawerClickParams.params().sort() == null)
+                        drawerClickParams.params().toBuilder().sort(currentParams).build()
+                    else drawerClickParams.params()
+                }
 
             // Merge various param data sources.
             val params = Observable.merge(
@@ -278,8 +286,6 @@ interface DiscoveryViewModel {
                 paramsFromIntent,
                 drawerParamsClicked
             )
-
-            val pagerSelectedPage = pagerSetPrimaryPage.distinctUntilChanged()
 
             val sortToTabOpen = Observable.merge(
                 pagerSelectedPage.map { DiscoveryUtils.sortFromPosition(it) },

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.java
@@ -297,9 +297,9 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
       DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).build(),
       DiscoveryParams.builder().sort(DiscoveryParams.Sort.POPULAR).build(),
       DiscoveryParams.builder().sort(DiscoveryParams.Sort.POPULAR).category(CategoryFactory.artCategory()).build(),
-      DiscoveryParams.builder().category(CategoryFactory.artCategory()).build()
+      DiscoveryParams.builder().category(CategoryFactory.artCategory()).sort(DiscoveryParams.Sort.POPULAR).build()
     );
-    this.updatePage.assertValues(0, 0, 1, 1, 0);
+    this.updatePage.assertValues(0, 0, 1, 1, 1);
 
     // Select MAGIC sort position.
     this.vm.getInputs().discoveryPagerAdapterSetPrimaryPage(Mockito.mock(DiscoveryPagerAdapter.class), 0);
@@ -310,10 +310,10 @@ public class DiscoveryViewModelTest extends KSRobolectricTestCase {
       DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).build(),
       DiscoveryParams.builder().sort(DiscoveryParams.Sort.POPULAR).build(),
       DiscoveryParams.builder().sort(DiscoveryParams.Sort.POPULAR).category(CategoryFactory.artCategory()).build(),
-      DiscoveryParams.builder().category(CategoryFactory.artCategory()).build(),
+      DiscoveryParams.builder().category(CategoryFactory.artCategory()).sort(DiscoveryParams.Sort.POPULAR).build(),
       DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).category(CategoryFactory.artCategory()).build()
     );
-    this.updatePage.assertValues(0, 0, 1, 1, 0, 0);
+    this.updatePage.assertValues(0, 0, 1, 1, 1, 0);
 
     // Simulate rotating the device and hitting initial getInputs() again.
     this.vm.getOutputs().updateParamsForPage().subscribe(this.rotatedUpdateParams);


### PR DESCRIPTION
# 📲 What

After introducing the new deeplinking logic to the discovery screen, we ran into a crash that was happening when choosing a category from the navigation drawer, and then selecting a sort different sort. This crash was happening if you followed these steps right after app bootstrap. 

# 🤔 Why

**TLDR; We updated the discovery params sent with navigation drawer clicks to take the current sort if the sort is null. This sometimes null sort was causing a crash when trying to be sent to our analytics client. Below is an in-depth and possibly unnecessary explanation, feel free to skip 😅** 

A discovery params object holds all of the configurations for the discovery screen (which sort the user is on, category, collections, etc). Everytime the user interacts with the screen, we send a new discovery params object to the view model. The streams take this data and update the screen accordingly. However, because this is updated in several places throughout the activity and viewmodel, maintaining all of the different edge cases while introducing new logic can be tricky. 

This specific crash was being caused when the user taps a category from the navigation drawer, and the sort passed down with it was null. Tapping a category sends a new discovery params object to the view model that sometimes does not contain a sort type. This null sort was accounted for previously by ALWAYS setting the current discovery params (no matter what their source was) with the current sort. However, we needed to tweak this logic when deeplinking to a specific sort was introduced, as the deeplinked sort was being overridden with the current sort, and hence would not change sort tabs. 

At first, we removed this logic completely, but when trying to pass the current sort to the segment analytic event after tapping a drawer item, it was null and caused this crash. So instead, since we still needed this logic sometimes, but it no longer applied to ALL discovery params, we extrapolated it to the specific use case of the discovery params sent with the navigation drawer clicks.

# 🛠 How

Update discovery params from drawer clicks with the current sort if sort passed down is empty:
<img width="559" alt="Screen Shot 2021-09-16 at 1 55 08 PM" src="https://user-images.githubusercontent.com/19390326/133661283-2ade9a76-7d83-492b-ba74-5e6fe9b765af.png">

# 📋 QA

- Switching tabs while on a category should not cause a crash
- Switching categories while on a sort should not revert it to magic (so if you're on popular and switch categories to art, you should still be on popular)
- Make sure all deeplinks work properly

# Story 📖

[NTV-183: 💥 – Explore with category/subcategory + sorting](https://kickstarter.atlassian.net/browse/NTV-183)
