### PR TITLE
NTV-189: Bug investigation

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.Pair
 import com.kickstarter.R
 import com.kickstarter.libs.KSString
-import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import org.joda.time.DateTime

--- a/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.kt
@@ -197,28 +197,4 @@ object RewardUtils {
             else -> floor(seconds / 60.0 / 60.0 / 24.0).toInt()
         }
     }
-
-    /**
-     * Returns the amount value for each variant, being Control the original value, and the minimum
-     * the minPledge defined by country
-     *
-     * @param variant the variant for which you want to get the value
-     * @param reward in case no known variant as save return use the current reward.minimum amount
-     * @param minPledge defined by country
-     *
-     * @return Double with the amount
-     */
-    fun rewardAmountByVariant(variant: OptimizelyExperiment.Variant?, reward: Reward, minPledge: Int): Double {
-        val value =
-            if (isNoReward(reward)) {
-                when (variant) {
-                    OptimizelyExperiment.Variant.CONTROL -> 1.0
-                    OptimizelyExperiment.Variant.VARIANT_2 -> 10.0
-                    OptimizelyExperiment.Variant.VARIANT_3 -> 20.0
-                    OptimizelyExperiment.Variant.VARIANT_4 -> 50.0
-                    else -> reward.minimum()
-                }
-            } else reward.minimum()
-        return if (value < minPledge) minPledge.toDouble() else value
-    }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -10,6 +10,7 @@ import com.kickstarter.libs.Environment
 import com.kickstarter.libs.FragmentViewModel
 import com.kickstarter.libs.NumberOptions
 import com.kickstarter.libs.models.Country
+import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
 import com.kickstarter.libs.rx.transformers.Transformers.errors
 import com.kickstarter.libs.rx.transformers.Transformers.ignoreValues
@@ -25,6 +26,7 @@ import com.kickstarter.libs.utils.ProjectUtils
 import com.kickstarter.libs.utils.ProjectViewUtils
 import com.kickstarter.libs.utils.RefTagUtils
 import com.kickstarter.libs.utils.RewardUtils
+import com.kickstarter.libs.utils.ExperimentData
 import com.kickstarter.models.Backing
 import com.kickstarter.models.Checkout
 import com.kickstarter.models.Project
@@ -598,9 +600,6 @@ interface PledgeFragmentViewModel {
                 .subscribe {
                     variantSuggestedAmount.onNext(it)
                 }
-
-            val fullProjectDataAndPledgeData = projectData
-                .compose<Pair<ProjectData, PledgeData>>(combineLatestPair(pledgeData))
 
             projectAndReward
                 .map { rewardTitle(it.first, it.second) }

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -20,13 +20,13 @@ import com.kickstarter.libs.rx.transformers.Transformers.values
 import com.kickstarter.libs.rx.transformers.Transformers.zipPair
 import com.kickstarter.libs.utils.BooleanUtils
 import com.kickstarter.libs.utils.DateTimeUtils
+import com.kickstarter.libs.utils.ExperimentData
 import com.kickstarter.libs.utils.NumberUtils
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.ProjectUtils
 import com.kickstarter.libs.utils.ProjectViewUtils
 import com.kickstarter.libs.utils.RefTagUtils
 import com.kickstarter.libs.utils.RewardUtils
-import com.kickstarter.libs.utils.ExperimentData
 import com.kickstarter.models.Backing
 import com.kickstarter.models.Checkout
 import com.kickstarter.models.Project

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.java
@@ -104,7 +104,7 @@ public interface ThanksViewModel {
         .take(1)
         .compose(bindToLifecycle());
 
-      final Observable<Category> rootCategory = project.flatMap(p -> rootCategory(p, this.apiClient));
+      final Observable<Category> rootCategory = project.switchMap(p -> rootCategory(p, this.apiClient));
 
       final Observable<Boolean> isGamesCategory = rootCategory
         .map(c -> "games".equals(c.slug()));
@@ -136,7 +136,7 @@ public interface ThanksViewModel {
       Observable.combineLatest(
         project,
         rootCategory,
-        project.flatMap(p -> this.relatedProjects(p, this.apiClient)),
+        project.switchMap(p -> this.relatedProjects(p, this.apiClient)),
         ThanksData::new
       )
         .compose(bindToLifecycle())

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.kt
@@ -5,7 +5,6 @@ import android.util.Pair
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.libs.KSString
-import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.utils.RewardUtils.deadlineCountdownDetail
 import com.kickstarter.libs.utils.RewardUtils.deadlineCountdownUnit
 import com.kickstarter.libs.utils.RewardUtils.deadlineCountdownValue
@@ -22,7 +21,6 @@ import com.kickstarter.libs.utils.RewardUtils.isShippable
 import com.kickstarter.libs.utils.RewardUtils.isTimeLimitedEnd
 import com.kickstarter.libs.utils.RewardUtils.isTimeLimitedStart
 import com.kickstarter.libs.utils.RewardUtils.isValidTimeRange
-import com.kickstarter.libs.utils.RewardUtils.rewardAmountByVariant
 import com.kickstarter.libs.utils.RewardUtils.shippingSummary
 import com.kickstarter.libs.utils.RewardUtils.timeInSecondsUntilDeadline
 import com.kickstarter.mock.factories.LocationFactory
@@ -413,16 +411,6 @@ class RewardUtilsTest : KSRobolectricTestCase() {
     @Test
     fun isValidTimeRage_whenStartNotLimited_returnsTrue() {
         assertEquals(true, isValidTimeRange(rewardWithAddons))
-    }
-
-    @Test
-    fun minimumRewardAmountByVariant() {
-        assertEquals(1.0, rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, noReward, 1))
-        assertEquals(10.0, rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_2, noReward, 1))
-        assertEquals(20.0, rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_3, noReward, 1))
-        assertEquals(50.0, rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward, 1))
-        assertEquals(10.0, rewardAmountByVariant(OptimizelyExperiment.Variant.CONTROL, noReward, 10))
-        assertEquals(100.0, rewardAmountByVariant(OptimizelyExperiment.Variant.VARIANT_4, noReward, 100))
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Reports from CS telling the bonus support is multiplied by 10 when trying to update pledge or fixing pledge.
We haven't been able to reproduce the issue but fixed on the way for that investigation other issues.
- - Update pledge with addOns and shipping 
- - Deleted old code related to an experiment with the minimum pledge
- - Exchenged `flatmap` over `switchmap` on Thanks Page.



# 🛠 How

More in-depth discussion of the change or implementation.

# 👀 See
- BOFORE: Pledge to a project with addons with shipping -> update pledge not working
![Screen Shot 2021-09-21 at 2 52 15 PM](https://user-images.githubusercontent.com/4083656/134253114-20150dcf-1ab1-4058-a740-21c23422f2f8.png)

- NOW: Pledge to a project with addons with shipping -> update pledge 


https://user-images.githubusercontent.com/4083656/134253919-f2821c2e-a86d-461b-acc4-2e4aa2b0b7b7.mp4



- Minimum pledge by country keeps working after refactor: Japan min pledge 

https://user-images.githubusercontent.com/4083656/134253331-e3eed125-44cc-4c21-abe7-0b51ac34a84b.mp4

|  |  |

# 📋 QA

- Pledge to a project with addOns and shipping, add bonus support to the pledge. 
- Update the payment method 
- Change rewards

# Story 📖

[Name of Trello Story](Trello link)
