### PR TITLE
[no-jira]: Remove "suggested_no_reward_amount" experiment

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/models/OptimizelyExperiment.kt
+++ b/app/src/main/java/com/kickstarter/libs/models/OptimizelyExperiment.kt
@@ -4,8 +4,7 @@ class OptimizelyExperiment {
     enum class Key(val key: String) {
         PLEDGE_CTA_COPY("pledge_cta_copy"),
         CAMPAIGN_DETAILS("native_project_page_campaign_details"),
-        CREATOR_DETAILS("native_project_page_conversion_creator_details"),
-        SUGGESTED_NO_REWARD_AMOUNT("suggested_no_reward_amount")
+        CREATOR_DETAILS("native_project_page_conversion_creator_details")
     }
 
     enum class Variant(val rawValue: String?) {

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -6,9 +6,7 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUser
-import com.kickstarter.libs.models.OptimizelyExperiment
 import com.kickstarter.libs.utils.EventName
-import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.BackingFactory
 import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.mock.factories.ProjectDataFactory
@@ -929,56 +927,6 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
             .build()
         this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject), RewardFactory.noReward())
         this.titleIsGone.assertValue(false)
-        this.titleForReward.assertNoValues()
-        this.titleForNoReward.assertValue(R.string.You_pledged_without_a_reward)
-    }
-
-    @Test
-    fun testNoRewardSuggestedAmountExperimentVariant4() {
-        val environment = environment()
-            .toBuilder()
-            .optimizely(MockExperimentsClientType(OptimizelyExperiment.Variant.VARIANT_4))
-            .build()
-        setUpEnvironment(environment)
-
-        val noRewardBacking = BackingFactory.backing()
-            .toBuilder()
-            .reward(RewardFactory.noReward())
-            .rewardId(null)
-            .build()
-        val backedProject = ProjectFactory.backedProject()
-            .toBuilder()
-            .backing(noRewardBacking)
-            .build()
-        this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject), RewardFactory.noReward())
-
-        this.titleIsGone.assertValue(false)
-        this.minimumAmountTitle.assertValue("$50")
-        this.titleForReward.assertNoValues()
-        this.titleForNoReward.assertValue(R.string.You_pledged_without_a_reward)
-    }
-
-    @Test
-    fun testNoRewardSuggestedAmountExperimentVariant2() {
-        val environment = environment()
-            .toBuilder()
-            .optimizely(MockExperimentsClientType(OptimizelyExperiment.Variant.VARIANT_2))
-            .build()
-        setUpEnvironment(environment)
-
-        val noRewardBacking = BackingFactory.backing()
-            .toBuilder()
-            .reward(RewardFactory.noReward())
-            .rewardId(null)
-            .build()
-        val backedProject = ProjectFactory.backedProject()
-            .toBuilder()
-            .backing(noRewardBacking)
-            .build()
-        this.vm.inputs.configureWith(ProjectDataFactory.project(backedProject), RewardFactory.noReward())
-
-        this.titleIsGone.assertValue(false)
-        this.minimumAmountTitle.assertValue("$10")
         this.titleForReward.assertNoValues()
         this.titleForNoReward.assertValue(R.string.You_pledged_without_a_reward)
     }


### PR DESCRIPTION
# 📲 What

- Remove any code related to the "suggested_no_reward_amount" experiment

# 👀 See
- No user facing changes, the experiment has been off some time now.
<img width="1036" alt="Screen Shot 2021-09-22 at 10 34 30 AM" src="https://user-images.githubusercontent.com/4083656/134393318-61134a6b-a275-41aa-828e-bd65799c7a45.png">

|  |  |

# 📋 QA
- Pledge to a japaneese project with the reward no reward- the amount should be ¥100
- Pledge to a Hong Kong based project with reward no reward- the amount should be $10
- Pledge to a US based project with reward no reward- the amount should be $1
- Pledge to a EUR based project with reward no reward- the amount should be €1

