### PR TITLE
NTV-238: projectData emitted several times with different values on "EnvironmentalCommitment"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
             at: ~/project
       - android/create-avd:
           avd-name: Emulator
-          system-image: system-images;android-31;google_apis;x86
+          system-image: system-images;android-30;google_apis;x86
           install: true
       - run:
           name: Configure screen size and dpi for Screenshot test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
             at: ~/project
       - android/create-avd:
           avd-name: Emulator
-          system-image: system-images;android-30;google_apis;x86
+          system-image: system-images;android-31;google_apis;x86
           install: true
       - run:
           name: Configure screen size and dpi for Screenshot test
@@ -81,6 +81,8 @@ jobs:
           additional-args: -skin 1080x2220
           post-emulator-launch-assemble-command: ""
           run-logcat: true
+          no-window: true
+          restore-gradle-cache-prefix: v1a
       - android/wait-for-emulator
       - run:
           name: Config Emulator for Screenshot test

--- a/app/src/main/java/com/kickstarter/ui/intentmappers/ProjectIntentMapper.java
+++ b/app/src/main/java/com/kickstarter/ui/intentmappers/ProjectIntentMapper.java
@@ -29,18 +29,10 @@ public final class ProjectIntentMapper {
   public static @NonNull Observable<Project> project(final @NonNull Intent intent, final @NonNull ApolloClientType apolloClient) {
 
     final Project intentProject = projectFromIntent(intent);
-    final Observable<Project> projectFromParceledProject = intentProject == null ? Observable.empty() : Observable.just(intentProject)
-            .flatMap(apolloClient::getProject)
-            .startWith(intentProject)
-            .retry(3);
 
-    final Observable<Project> projectFromParceledParam = Observable.just(paramFromIntent(intent))
-            .filter(ObjectUtils::isNotNull)
-            .flatMap(apolloClient::getProject)
-            .retry(3);
+    final String projectSlug = intentProject != null ? intentProject.slug() : paramFromIntent(intent);
 
-    return projectFromParceledProject
-            .mergeWith(projectFromParceledParam);
+    return apolloClient.getProject(projectSlug).retry(3);
   }
 
   /**

--- a/app/src/test/java/com/kickstarter/ui/intents/ProjectIntentMapperTest.java
+++ b/app/src/test/java/com/kickstarter/ui/intents/ProjectIntentMapperTest.java
@@ -62,7 +62,7 @@ public final class ProjectIntentMapperTest extends KSRobolectricTestCase {
     ProjectIntentMapper.project(intent, new MockApolloClient())
             .subscribe(resultTest);
 
-    resultTest.assertValueCount(2);
+    resultTest.assertValueCount(1);
   }
 
   @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
@@ -316,7 +316,7 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
 
         // The project should be saved, and a star prompt should be shown.
         this.savedTest.assertValues(false, true)
-        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart_outline, R.drawable.icon__heart)
+        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart)
         this.showSavedPromptTest.assertValueCount(1)
 
         this.segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
@@ -298,14 +298,14 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.halfWayProject()))
 
         this.savedTest.assertValues(false)
-        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart_outline)
+        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline)
 
         // Try starring while logged out
         this.vm.inputs.heartButtonClicked()
 
         // The project shouldn't be saved, and a login prompt should be shown.
         this.savedTest.assertValues(false)
-        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart_outline)
+        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline)
         this.showSavedPromptTest.assertValueCount(0)
         this.startLoginToutActivity.assertValueCount(1)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
@@ -171,9 +171,9 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, initialProject))
 
-        this.pledgeActionButtonContainerIsGone.assertValues(true)
+        this.pledgeActionButtonContainerIsGone.assertNoValues()
         this.prelaunchUrl.assertNoValues()
-        this.projectData.assertValues(ProjectDataFactory.project(initialProject))
+        this.projectData.assertNoValues()
         this.reloadProjectContainerIsGone.assertValue(false)
         this.reloadProgressBarIsGone.assertValues(false, true)
         this.updateFragments.assertNoValues()
@@ -184,8 +184,6 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
         this.pledgeActionButtonContainerIsGone.assertValues(true, false)
         this.prelaunchUrl.assertNoValues()
         this.projectData.assertValues(
-            ProjectDataFactory.project(initialProject),
-            ProjectDataFactory.project(initialProject),
             ProjectDataFactory.project(refreshedProject)
         )
         this.reloadProjectContainerIsGone.assertValues(false, true, true)
@@ -380,7 +378,7 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
 
         // The project should be saved, and a save prompt should NOT be shown.
         this.savedTest.assertValues(false, true)
-        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart_outline, R.drawable.icon__heart)
+        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart)
         this.showSavedPromptTest.assertValueCount(0)
     }
 
@@ -405,7 +403,7 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
 
         // The project should be saved, and a save prompt should NOT be shown.
         this.savedTest.assertValues(false, true)
-        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart_outline, R.drawable.icon__heart)
+        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart)
         this.showSavedPromptTest.assertValueCount(0)
     }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -170,9 +170,9 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, initialProject))
 
-        this.pledgeActionButtonContainerIsGone.assertValues(true)
+        this.pledgeActionButtonContainerIsGone.assertNoValues()
         this.prelaunchUrl.assertNoValues()
-        this.projectData.assertValues(ProjectDataFactory.project(initialProject))
+        this.projectData.assertNoValues()
         this.reloadProjectContainerIsGone.assertValue(false)
         this.reloadProgressBarIsGone.assertValues(false, true)
         this.updateFragments.assertNoValues()
@@ -183,8 +183,6 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.pledgeActionButtonContainerIsGone.assertValues(true, false)
         this.prelaunchUrl.assertNoValues()
         this.projectData.assertValues(
-            ProjectDataFactory.project(initialProject),
-            ProjectDataFactory.project(initialProject),
             ProjectDataFactory.project(refreshedProject)
         )
         this.reloadProjectContainerIsGone.assertValues(false, true, true)
@@ -299,14 +297,14 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, ProjectFactory.halfWayProject()))
 
         this.savedTest.assertValues(false)
-        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart_outline)
+        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline)
 
         // Try starring while logged out
         this.vm.inputs.heartButtonClicked()
 
         // The project shouldn't be saved, and a login prompt should be shown.
         this.savedTest.assertValues(false)
-        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart_outline)
+        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline)
         this.showSavedPromptTest.assertValueCount(0)
         this.startLoginToutActivity.assertValueCount(1)
 
@@ -317,7 +315,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         // The project should be saved, and a star prompt should be shown.
         this.savedTest.assertValues(false, true)
-        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart_outline, R.drawable.icon__heart)
+        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart)
         this.showSavedPromptTest.assertValueCount(1)
 
         this.segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
@@ -379,7 +377,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         // The project should be saved, and a save prompt should NOT be shown.
         this.savedTest.assertValues(false, true)
-        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart_outline, R.drawable.icon__heart)
+        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart)
         this.showSavedPromptTest.assertValueCount(0)
     }
 
@@ -404,7 +402,7 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
 
         // The project should be saved, and a save prompt should NOT be shown.
         this.savedTest.assertValues(false, true)
-        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart_outline, R.drawable.icon__heart)
+        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart)
         this.showSavedPromptTest.assertValueCount(0)
     }
 


### PR DESCRIPTION
# 📲 What

- Reduce number of emissions for the initial project, to emit ONLY after the network call is successful.
- Fixed snapshot tests 
- Modified Unit test the reflect the reduced number of emissions

# 🤔 Why
- The tab/fragment for EnvironmentalCommitment on the navigation selector needs to be hidden when empty, we were getting false negative emissions
- Snapshot tests were having issues

# 👀 See
- No user facing changes
|  |  |

# 📋 QA
- Load the project page as usual
- All test passing again

# Story 📖

[NTV-238](https://kickstarter.atlassian.net/browse/NTV-238)
