### PR TITLE
NTV-242: Remove deprecated FirebaseInstanceId.getInstance().id

### DIFF
--- a/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.kt
+++ b/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.kt
@@ -16,7 +16,6 @@ import androidx.work.BackoffPolicy
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
-import com.google.firebase.iid.FirebaseInstanceId
 import com.jakewharton.processphoenix.ProcessPhoenix
 import com.kickstarter.KSApplication
 import com.kickstarter.R
@@ -24,6 +23,7 @@ import com.kickstarter.databinding.InternalToolsLayoutBinding
 import com.kickstarter.libs.ApiEndpoint
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.Build
+import com.kickstarter.libs.FirebaseHelper
 import com.kickstarter.libs.Logout
 import com.kickstarter.libs.preferences.StringPreferenceType
 import com.kickstarter.libs.qualifiers.ApiEndpointPreference
@@ -217,7 +217,7 @@ class InternalToolsActivity : BaseActivity<InternalToolsViewModel>() {
         binding.apiEndpoint.text = apiEndpointPreference?.get()
         binding.buildDate.text = build?.buildDate()?.toString(DateTimeFormat.forPattern("MMM dd, yyyy h:mm:ss aa zzz"))
         binding.commitSha.text = build?.sha()
-        binding.deviceId.text = FirebaseInstanceId.getInstance().id
+        binding.deviceId.text = FirebaseHelper.identifier
         binding.variant.text = build?.variant()
         binding.versionCode.text = build?.versionCode().toString()
         binding.versionName.text = build?.versionName()

--- a/app/src/main/java/com/kickstarter/libs/FirebaseHelper.kt
+++ b/app/src/main/java/com/kickstarter/libs/FirebaseHelper.kt
@@ -1,0 +1,35 @@
+package com.kickstarter.libs
+
+import android.content.Context
+import com.google.firebase.FirebaseApp
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.installations.FirebaseInstallations
+import com.kickstarter.libs.utils.extensions.isKSApplication
+
+class FirebaseHelper(context: Context, callback: () -> Boolean) {
+
+    companion object {
+        @JvmStatic lateinit var identifier: String
+        // - Should be called just one time
+        @JvmStatic fun initialize(context: Context, callback: () -> Boolean): FirebaseHelper {
+            return FirebaseHelper(context, callback)
+        }
+    }
+
+    init {
+        if (context.isKSApplication()) {
+            if (FirebaseApp.getApps(context).isEmpty()) {
+                FirebaseApp.initializeApp(context)
+                FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(true)
+                FirebaseAnalytics.getInstance(context).setAnalyticsCollectionEnabled(true)
+                FirebaseInstallations.getInstance().id.addOnSuccessListener { s: String ->
+                    identifier = s
+                    callback()
+                }
+            }
+        } else {
+            identifier = "Test Id"
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/OptimizelyExperimentsClient.kt
@@ -1,7 +1,6 @@
 package com.kickstarter.libs
 
 import android.os.Build
-import com.google.firebase.iid.FirebaseInstanceId
 import com.kickstarter.BuildConfig
 import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.libs.models.OptimizelyExperiment
@@ -22,7 +21,7 @@ class OptimizelyExperimentsClient(private val optimizelyManager: OptimizelyManag
         optimizelyClient().track(eventKey, userId(), attributes(experimentData, this.optimizelyEnvironment))
     }
 
-    override fun userId(): String = FirebaseInstanceId.getInstance().id
+    override fun userId(): String = FirebaseHelper.identifier
 
     override fun enabledFeatures(user: User?): List<String> {
         return this.optimizelyClient().getEnabledFeatures(

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -8,7 +8,6 @@ import android.view.accessibility.AccessibilityManager
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.crashlytics.FirebaseCrashlytics
-import com.google.firebase.iid.FirebaseInstanceId
 import com.kickstarter.BuildConfig
 import com.kickstarter.R
 import com.kickstarter.libs.qualifiers.ApplicationContext
@@ -83,7 +82,7 @@ abstract class TrackingClient(
 
     override fun currentVariants(): Array<String>? = this.config?.currentVariants()
 
-    override fun deviceDistinctId(): String = FirebaseInstanceId.getInstance().id
+    override fun deviceDistinctId(): String = FirebaseHelper.identifier
 
     override fun deviceFormat(): String =
         if (this.context.resources.getBoolean(R.bool.isTablet)) "tablet"

--- a/app/src/main/java/com/kickstarter/libs/utils/ExperimentUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/ExperimentUtils.kt
@@ -1,6 +1,6 @@
 package com.kickstarter.libs.utils
 
-import com.google.firebase.iid.FirebaseInstanceId
+import com.kickstarter.libs.FirebaseHelper
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.models.OptimizelyEnvironment
 import com.kickstarter.models.User
@@ -32,7 +32,7 @@ object ExperimentUtils {
     private fun getInstanceId(environment: OptimizelyEnvironment) = when (environment) {
         OptimizelyEnvironment.DEVELOPMENT -> ""
         OptimizelyEnvironment.PRODUCTION -> null
-        OptimizelyEnvironment.STAGING -> FirebaseInstanceId.getInstance().id
+        OptimizelyEnvironment.STAGING -> FirebaseHelper.identifier
     }
 }
 

--- a/app/src/main/java/com/kickstarter/services/interceptors/ApiRequestInterceptor.kt
+++ b/app/src/main/java/com/kickstarter/services/interceptors/ApiRequestInterceptor.kt
@@ -1,9 +1,9 @@
 package com.kickstarter.services.interceptors
 
 import android.net.Uri
-import com.google.firebase.iid.FirebaseInstanceId
 import com.kickstarter.libs.Build
 import com.kickstarter.libs.CurrentUserType
+import com.kickstarter.libs.FirebaseHelper
 import com.kickstarter.libs.perimeterx.PerimeterXClientType
 import com.kickstarter.libs.utils.WebUtils.userAgent
 import com.kickstarter.libs.utils.extensions.isApiUri
@@ -38,7 +38,7 @@ class ApiRequestInterceptor(
 
         val builder: Request.Builder = initialRequest.newBuilder()
             .addHeader("Accept", "application/json")
-            .addHeader("Kickstarter-Android-App-UUID", FirebaseInstanceId.getInstance().id)
+            .addHeader("Kickstarter-Android-App-UUID", FirebaseHelper.identifier)
             .addHeader("User-Agent", userAgent(build))
 
         pxManager.addHeaderTo(builder)

--- a/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
+++ b/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
@@ -1,8 +1,8 @@
 package com.kickstarter.services.interceptors
 
-import com.google.firebase.iid.FirebaseInstanceId
 import com.kickstarter.libs.Build
 import com.kickstarter.libs.CurrentUserType
+import com.kickstarter.libs.FirebaseHelper
 import com.kickstarter.libs.perimeterx.PerimeterXClientType
 import com.kickstarter.libs.utils.WebUtils
 import okhttp3.Interceptor
@@ -30,7 +30,7 @@ class GraphQLInterceptor(
 
         builder.addHeader("User-Agent", WebUtils.userAgent(this.build))
             .addHeader("X-KICKSTARTER-CLIENT", this.clientId)
-            .addHeader("Kickstarter-Android-App-UUID", FirebaseInstanceId.getInstance().id)
+            .addHeader("Kickstarter-Android-App-UUID", FirebaseHelper.identifier)
 
         pxManager.addHeaderTo(builder)
 


### PR DESCRIPTION
# 📲 What

We get the Application identifier with a deprecated method
<img width="468" alt="Screen Shot 2021-10-14 at 11 17 10 AM" src="https://user-images.githubusercontent.com/4083656/137378138-ff826cfb-4ff9-48ee-8e4e-836397cc395c.png">
![Screen Shot 2021-10-14 at 11 21 52 AM](https://user-images.githubusercontent.com/4083656/137378154-8993fe70-cc9f-4918-89d9-c44fe01d730c.png)



# 🛠 How
`Firebase.getInstance.id:String `

has been has been substituted over 

```
 FirebaseInstallations.getInstance().id.addOnSuccessListener { s: String ->
                    identifier = s
                }
```
 

Firebase Documentation: 

https://firebase.google.com/docs/reference/android/com/google/firebase/installations/FirebaseInstallations

Android Best Practices around identifiers:

https://developer.android.com/training/articles/user-data-ids

 

**Developer Notes**

* All reference call for the firebase identifier and firebase initialization has been place behind a helper class FirebaseHelper.kt 

* FirebaseInstallations.getInstance().id is an async Task, once the task is resolved successfully the identifier is kept in memory. Should be called only once on Application created.

* All need to consult the identifier should be consumed via the identifier hold on the FirebaseHelper

|  |  |

# 📋 QA
- No user facing changes, you should be able to log-in, navigate, pledge as usual. Take a look in the internal tools screen the deviceId is showing, make sure activate/deactivate feature flags/ experiments with Optimizely keep working as usual.

# Story 📖

[NTV-242](https://kickstarter.atlassian.net/browse/NTV-242)
