### PR TITLE
Filter the null value for project when clicked heart button

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -34,6 +34,7 @@ import com.kickstarter.libs.ProjectPagerTabs
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ApplicationUtils
+import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.toVisibility
 import com.kickstarter.models.Project
@@ -129,6 +130,8 @@ class ProjectPageActivity :
             }
 
         this.viewModel.outputs.updateEnvCommitmentsTabVisibility()
+            .filter { ObjectUtils.isNotNull(it) }
+            .map { requireNotNull(it) }
             .distinctUntilChanged()
             .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())


### PR DESCRIPTION
# 📲 What

Fix the crash when clicking the heart icon on the project page 

# 🤔 Why

we call that service to save the project and update the UI with returned project object  which  has a different structure than the original graph-ql  as environment Commits  return null

# 🛠 How
Filter value that is not null

# 👀 See
https://user-images.githubusercontent.com/1075310/139472003-85b58454-5b42-48ba-8a85-7a662b5cd234.mp4

# 📋 QA

Open project page with tabs and click Heart ❤️  icon



