### PR TITLE
NTV-277: Backer cannot comment on updates

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -461,6 +461,7 @@ interface CommentsViewModel {
             when {
                 projectAndUser.second == null -> CommentComposerStatus.GONE
                 projectAndUser.first.canComment() ?: false -> CommentComposerStatus.ENABLED
+                projectAndUser.first.isBacking -> CommentComposerStatus.ENABLED
                 else -> CommentComposerStatus.DISABLED
             }
 


### PR DESCRIPTION
# 📲 What

- Bring back the check around the current user being a backer

# 🤔 Why

- we recently added the field `canComment` to the project, it works perfectly for comments on a project. We did not had in mind though the comments on updates. 


# 👀 See


https://user-images.githubusercontent.com/4083656/140171554-a138ba0b-5871-430a-9299-02330d13b4d6.mp4

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

- Try to comment as a backer into a update from the project page
- Try to comment as a backer into a update from the activities page
- Check that you cannot comment on any update or project in which you are not backer

# Story 📖

[NTV-277](https://kickstarter.atlassian.net/browse/NTV-277)
