### PR TITLE
NTV-269 :Parser – Handle external sources

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLModels.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLModels.kt
@@ -45,10 +45,15 @@ data class EmbeddedLinkViewElement(
 
 open class ImageViewElement(open val src: String) : ViewElement
 
+data class ExternalSourceViewElement(
+    val htmlContent: String
+) : ViewElement
+
 enum class ViewElementType(val tag: String?) {
     IMAGE("img"),
     TEXT(null),
     VIDEO("video"),
+    EXTERNAL_SOURCES("iframe"),
     EMBEDDED_LINK(null),
     OEMBED(null),
     UNKNOWN(null);
@@ -70,6 +75,8 @@ enum class ViewElementType(val tag: String?) {
                 return IMAGE
             } else if (tag == VIDEO.tag) {
                 return VIDEO
+            } else if (tag == EXTERNAL_SOURCES.tag) {
+                return EXTERNAL_SOURCES
             }
             return UNKNOWN
         }

--- a/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLModels.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLModels.kt
@@ -62,11 +62,12 @@ enum class ViewElementType(val tag: String?) {
         fun initialize(element: Element): ViewElementType {
             val tag = element.tag().name
             if (tag == "div") {
-                if (element.children()[0].tag().name == EXTERNAL_SOURCES.tag) {
-                    return EXTERNAL_SOURCES
-                }
+
                 for (attribute in element.attributes()) {
                     if (attribute.key == "class" && attribute.value == "template oembed") {
+                        if (element.children()[0].tag().name == EXTERNAL_SOURCES.tag) {
+                            return EXTERNAL_SOURCES
+                        }
                         return OEMBED
                     }
                 }

--- a/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLModels.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLModels.kt
@@ -62,6 +62,9 @@ enum class ViewElementType(val tag: String?) {
         fun initialize(element: Element): ViewElementType {
             val tag = element.tag().name
             if (tag == "div") {
+                if (element.children()[0].tag().name == EXTERNAL_SOURCES.tag) {
+                    return EXTERNAL_SOURCES
+                }
                 for (attribute in element.attributes()) {
                     if (attribute.key == "class" && attribute.value == "template oembed") {
                         return OEMBED
@@ -75,8 +78,6 @@ enum class ViewElementType(val tag: String?) {
                 return IMAGE
             } else if (tag == VIDEO.tag) {
                 return VIDEO
-            } else if (tag == EXTERNAL_SOURCES.tag) {
-                return EXTERNAL_SOURCES
             }
             return UNKNOWN
         }

--- a/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLParser.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLParser.kt
@@ -41,7 +41,7 @@ class HTMLParser {
                     (element.attributes().firstOrNull { it.key == "href" })?.value?.let { href ->
                         val imageElements = element.getElementsByTag("img")
                         for (imageElement in imageElements) {
-                            imageElement.attributes()["src"].let { sourceUrl ->
+                            imageElement.attributes()["src"]?.let { sourceUrl ->
                                 viewElements.add(EmbeddedLinkViewElement(href, sourceUrl, caption))
                             }
                         }

--- a/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLParser.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLParser.kt
@@ -41,7 +41,7 @@ class HTMLParser {
                     (element.attributes().firstOrNull { it.key == "href" })?.value?.let { href ->
                         val imageElements = element.getElementsByTag("img")
                         for (imageElement in imageElements) {
-                            imageElement.attributes()["src"]?.let { sourceUrl ->
+                            imageElement.attributes()["src"].let { sourceUrl ->
                                 viewElements.add(EmbeddedLinkViewElement(href, sourceUrl, caption))
                             }
                         }
@@ -53,7 +53,6 @@ class HTMLParser {
                     viewElements.add(videoViewElement)
                 }
                 ViewElementType.EXTERNAL_SOURCES -> {
-
                     val sourceUrls = element.html()
                     val externalSourceViewElement = ExternalSourceViewElement(sourceUrls)
                     viewElements.add(externalSourceViewElement)

--- a/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLParser.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLParser.kt
@@ -53,7 +53,8 @@ class HTMLParser {
                     viewElements.add(videoViewElement)
                 }
                 ViewElementType.EXTERNAL_SOURCES -> {
-                    val sourceUrls = element.toString()
+
+                    val sourceUrls = element.html()
                     val externalSourceViewElement = ExternalSourceViewElement(sourceUrls)
                     viewElements.add(externalSourceViewElement)
                 }

--- a/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLParser.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLParser.kt
@@ -41,7 +41,7 @@ class HTMLParser {
                     (element.attributes().firstOrNull { it.key == "href" })?.value?.let { href ->
                         val imageElements = element.getElementsByTag("img")
                         for (imageElement in imageElements) {
-                            imageElement.attributes()["src"]?.let { sourceUrl ->
+                            imageElement.attributes()["src"].let { sourceUrl ->
                                 viewElements.add(EmbeddedLinkViewElement(href, sourceUrl, caption))
                             }
                         }
@@ -51,6 +51,11 @@ class HTMLParser {
                     val sourceUrls = element.attributes().mapNotNull { if (it.key == "data-href") it.value else null }
                     val videoViewElement = VideoViewElement(ArrayList(sourceUrls))
                     viewElements.add(videoViewElement)
+                }
+                ViewElementType.EXTERNAL_SOURCES -> {
+                    val sourceUrls = element.toString()
+                    val externalSourceViewElement = ExternalSourceViewElement(sourceUrls)
+                    viewElements.add(externalSourceViewElement)
                 }
                 ViewElementType.UNKNOWN -> {
                     print("UNKNOWN ELEMENT")

--- a/app/src/main/java/com/kickstarter/ui/adapters/projectcampaign/ViewElementAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/projectcampaign/ViewElementAdapter.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.kickstarter.databinding.EmptyViewBinding
 import com.kickstarter.databinding.ViewElementImageFromHtmlBinding
 import com.kickstarter.databinding.ViewElementTextFromHtmlBinding
-import com.kickstarter.libs.htmlparser.EmbeddedLinkViewElement
+import com.kickstarter.libs.htmlparser.ExternalSourceViewElement
 import com.kickstarter.libs.htmlparser.ImageViewElement
 import com.kickstarter.libs.htmlparser.TextViewElement
 import com.kickstarter.libs.htmlparser.VideoViewElement
@@ -51,8 +51,8 @@ class ViewElementAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                 else false
             }
 
-            (oldItem as? EmbeddedLinkViewElement)?.let {
-                val isSameType = newItem is EmbeddedLinkViewElement
+            (oldItem as? ExternalSourceViewElement)?.let {
+                val isSameType = newItem is ExternalSourceViewElement
                 return if (isSameType) newItem == oldItem
                 else false
             }
@@ -86,7 +86,7 @@ class ViewElementAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             return ElementViewHolderType.VIDEO.ordinal
         }
 
-        (element as? EmbeddedLinkViewElement)?.let {
+        (element as? ExternalSourceViewElement)?.let {
             return ElementViewHolderType.EMBEDDED.ordinal
         }
 

--- a/app/src/main/java/com/kickstarter/ui/adapters/projectcampaign/ViewElementAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/projectcampaign/ViewElementAdapter.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.kickstarter.databinding.EmptyViewBinding
 import com.kickstarter.databinding.ViewElementImageFromHtmlBinding
 import com.kickstarter.databinding.ViewElementTextFromHtmlBinding
-import com.kickstarter.libs.htmlparser.ExternalSourceViewElement
+import com.kickstarter.libs.htmlparser.EmbeddedLinkViewElement
 import com.kickstarter.libs.htmlparser.ImageViewElement
 import com.kickstarter.libs.htmlparser.TextViewElement
 import com.kickstarter.libs.htmlparser.VideoViewElement
@@ -51,8 +51,8 @@ class ViewElementAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                 else false
             }
 
-            (oldItem as? ExternalSourceViewElement)?.let {
-                val isSameType = newItem is ExternalSourceViewElement
+            (oldItem as? EmbeddedLinkViewElement)?.let {
+                val isSameType = newItem is EmbeddedLinkViewElement
                 return if (isSameType) newItem == oldItem
                 else false
             }
@@ -86,7 +86,7 @@ class ViewElementAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             return ElementViewHolderType.VIDEO.ordinal
         }
 
-        (element as? ExternalSourceViewElement)?.let {
+        (element as? EmbeddedLinkViewElement)?.let {
             return ElementViewHolderType.EMBEDDED.ordinal
         }
 

--- a/app/src/test/java/com/kickstarter/libs/htmlparser/HTMLParserTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/htmlparser/HTMLParserTest.kt
@@ -9,33 +9,37 @@ class HTMLParserTest {
     @Test
     fun testParseExternalSourceElement() {
 
-        val linksArray = arrayOf("https://www.youtube.com/embed/3u7EIiohs6U?feature=oembed&wmode=transparent",
+        val linksArray = arrayOf(
+            "https://www.youtube.com/embed/3u7EIiohs6U?feature=oembed&wmode=transparent",
             "https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F1088168317&show_artwork=true&maxwidth=560",
-            "https://open.spotify.com/embed/track/31H5dHBR7g381udIzXSKIE?si=62607f8611e74f0d&utm_source=oembed")
-        
+            "https://open.spotify.com/embed/track/31H5dHBR7g381udIzXSKIE?si=62607f8611e74f0d&utm_source=oembed"
+        )
+
         val htmlString = "<div class=\"template oembed\" contenteditable=\"false\" " +
-                "data-href=\"https://www.youtube.com/watch?v=3u7EIiohs6U\"> <iframe width=\"356\"" +
-                " height=\"200\" src=\"${linksArray[0]}\" frameborder=\"0\" " +
-                "allow=\"accelerometer;autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" " +
-                "allowfullscreen ></iframe> </div> <div class=\"template oembed\" " +
-                "contenteditable=\"false\" data-href=\"https://soundcloud" +
-                ".com/jamesblakeofficial/say-what-you-will\"> <iframe width=\"560\" " +
-                "height=\"400\" scrolling=\"no\" frameborder=\"no\" " +
-                "src=\"${linksArray[1]}}\"></iframe> </div> " +
-                "<div class=\"template oembed\" contenteditable=\"false\" " +
-                "data-href=\"https://open.spotify.com/track/31H5dHBR7g381udIzXSKIE?si=62607f8611e74f0d\">" +
-                " <iframe width=\"100%\" height=\"80\" title=\"Spotify Embed: Famous Last Words\" frameborder=\"0\"" +
-                " allowfullscreen allow=\"autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture\" src=\"${linksArray[2]}\" ></iframe> </div>"
+            "data-href=\"https://www.youtube.com/watch?v=3u7EIiohs6U\"> <iframe width=\"356\"" +
+            " height=\"200\" src=\"${linksArray[0]}\" frameborder=\"0\" " +
+            "allow=\"accelerometer;autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" " +
+            "allowfullscreen ></iframe> </div> <div class=\"template oembed\" " +
+            "contenteditable=\"false\" data-href=\"https://soundcloud" +
+            ".com/jamesblakeofficial/say-what-you-will\"> <iframe width=\"560\" " +
+            "height=\"400\" scrolling=\"no\" frameborder=\"no\" " +
+            "src=\"${linksArray[1]}}\"></iframe> </div> " +
+            "<div class=\"template oembed\" contenteditable=\"false\" " +
+            "data-href=\"https://open.spotify.com/track/31H5dHBR7g381udIzXSKIE?si=62607f8611e74f0d\">" +
+            " <iframe width=\"100%\" height=\"80\" title=\"Spotify Embed: Famous Last Words\" frameborder=\"0\"" +
+            " allowfullscreen allow=\"autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture\" src=\"${linksArray[2]}\" ></iframe> </div>"
 
         val listViewElements = HTMLParser().parse(htmlString)
-        
+
         TestCase.assertEquals(3, listViewElements.size)
 
         listViewElements.map {
             it as? ExternalSourceViewElement
         }.forEachIndexed { index, item ->
-            TestCase.assertTrue(item?.htmlContent?.contains(URI.create(linksArray[index]).host)
-                ?: false)
+            TestCase.assertTrue(
+                item?.htmlContent?.contains(URI.create(linksArray[index]).host)
+                    ?: false
+            )
         }
     }
 }

--- a/app/src/test/java/com/kickstarter/libs/htmlparser/HTMLParserTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/htmlparser/HTMLParserTest.kt
@@ -1,0 +1,41 @@
+package com.kickstarter.libs.htmlparser
+
+import junit.framework.TestCase
+import org.junit.Test
+import java.net.URI
+
+class HTMLParserTest {
+
+    @Test
+    fun testParseExternalSourceElement() {
+
+        val linksArray = arrayOf("https://www.youtube.com/embed/3u7EIiohs6U?feature=oembed&wmode=transparent",
+            "https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F1088168317&show_artwork=true&maxwidth=560",
+            "https://open.spotify.com/embed/track/31H5dHBR7g381udIzXSKIE?si=62607f8611e74f0d&utm_source=oembed")
+        
+        val htmlString = "<div class=\"template oembed\" contenteditable=\"false\" " +
+                "data-href=\"https://www.youtube.com/watch?v=3u7EIiohs6U\"> <iframe width=\"356\"" +
+                " height=\"200\" src=\"${linksArray[0]}\" frameborder=\"0\" " +
+                "allow=\"accelerometer;autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" " +
+                "allowfullscreen ></iframe> </div> <div class=\"template oembed\" " +
+                "contenteditable=\"false\" data-href=\"https://soundcloud" +
+                ".com/jamesblakeofficial/say-what-you-will\"> <iframe width=\"560\" " +
+                "height=\"400\" scrolling=\"no\" frameborder=\"no\" " +
+                "src=\"${linksArray[1]}}\"></iframe> </div> " +
+                "<div class=\"template oembed\" contenteditable=\"false\" " +
+                "data-href=\"https://open.spotify.com/track/31H5dHBR7g381udIzXSKIE?si=62607f8611e74f0d\">" +
+                " <iframe width=\"100%\" height=\"80\" title=\"Spotify Embed: Famous Last Words\" frameborder=\"0\"" +
+                " allowfullscreen allow=\"autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture\" src=\"${linksArray[2]}\" ></iframe> </div>"
+
+        val listViewElements = HTMLParser().parse(htmlString)
+        
+        TestCase.assertEquals(3, listViewElements.size)
+
+        listViewElements.map {
+            it as? ExternalSourceViewElement
+        }.forEachIndexed { index, item ->
+            TestCase.assertTrue(item?.htmlContent?.contains(URI.create(linksArray[index]).host)
+                ?: false)
+        }
+    }
+}


### PR DESCRIPTION
# 📲 What

Detect iframes for Youtube videos or audio media

# 🤔 Why

Add to Html parser Youtube videos or audio media

# 🛠 How
Detect the div that has external sources `iframe`
![image](https://user-images.githubusercontent.com/1075310/140173634-539f6743-fc73-492d-9ea1-fc97dcf7938d.png)


# 👀 See

Added unit testing for html 


# Story 📖

https://kickstarter.atlassian.net/browse/NTV-269
