### PR TITLE
NTV-277: Collaborator & Baker can comment on project updates and project

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -77,7 +77,6 @@ interface CommentsViewModel {
     class ViewModel(@NonNull val environment: Environment) : ActivityViewModel<CommentsActivity>(environment), Inputs, Outputs {
 
         private val currentUser: CurrentUserType = environment.currentUser()
-        private val client: ApiClientType = environment.apiClient()
         private val apolloClient: ApolloClientType = environment.apolloClient()
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -155,7 +154,7 @@ interface CommentsViewModel {
             }.flatMap {
                 it?.either<Observable<Project?>>(
                     { value: Project? -> Observable.just(value) },
-                    { u: Update? -> client.fetchProject(u?.projectId().toString()).compose(Transformers.neverError()) }
+                    { u: Update? -> apolloClient.getProject(u?.projectId().toString()).compose(Transformers.neverError()) }
                 )
             }.map {
                 requireNotNull(it)

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -18,7 +18,6 @@ import com.kickstarter.models.extensions.cardStatus
 import com.kickstarter.models.extensions.updateCanceledPledgeComment
 import com.kickstarter.models.extensions.updateCommentAfterSuccessfulPost
 import com.kickstarter.models.extensions.updateCommentFailedToPost
-import com.kickstarter.services.ApiClientType
 import com.kickstarter.services.ApolloClientType
 import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope
 import com.kickstarter.ui.IntentKey

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -461,7 +461,6 @@ interface CommentsViewModel {
             when {
                 projectAndUser.second == null -> CommentComposerStatus.GONE
                 projectAndUser.first.canComment() ?: false -> CommentComposerStatus.ENABLED
-                projectAndUser.first.isBacking -> CommentComposerStatus.ENABLED
                 else -> CommentComposerStatus.DISABLED
             }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -18,7 +18,6 @@ import com.kickstarter.models.extensions.cardStatus
 import com.kickstarter.models.extensions.updateCanceledPledgeComment
 import com.kickstarter.models.extensions.updateCommentAfterSuccessfulPost
 import com.kickstarter.models.extensions.updateCommentFailedToPost
-import com.kickstarter.services.ApiClientType
 import com.kickstarter.services.ApolloClientType
 import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope
 import com.kickstarter.ui.IntentKey
@@ -77,7 +76,6 @@ interface CommentsViewModel {
     class ViewModel(@NonNull val environment: Environment) : ActivityViewModel<CommentsActivity>(environment), Inputs, Outputs {
 
         private val currentUser: CurrentUserType = environment.currentUser()
-        private val client: ApiClientType = environment.apiClient()
         private val apolloClient: ApolloClientType = environment.apolloClient()
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -155,7 +153,7 @@ interface CommentsViewModel {
             }.flatMap {
                 it?.either<Observable<Project?>>(
                     { value: Project? -> Observable.just(value) },
-                    { u: Update? -> client.fetchProject(u?.projectId().toString()).compose(Transformers.neverError()) }
+                    { u: Update? -> apolloClient.getProject(u?.projectId().toString()).compose(Transformers.neverError()) }
                 )
             }.map {
                 requireNotNull(it)
@@ -461,7 +459,6 @@ interface CommentsViewModel {
             when {
                 projectAndUser.second == null -> CommentComposerStatus.GONE
                 projectAndUser.first.canComment() ?: false -> CommentComposerStatus.ENABLED
-                projectAndUser.first.isBacking -> CommentComposerStatus.ENABLED
                 else -> CommentComposerStatus.DISABLED
             }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -18,6 +18,7 @@ import com.kickstarter.models.extensions.cardStatus
 import com.kickstarter.models.extensions.updateCanceledPledgeComment
 import com.kickstarter.models.extensions.updateCommentAfterSuccessfulPost
 import com.kickstarter.models.extensions.updateCommentFailedToPost
+import com.kickstarter.services.ApiClientType
 import com.kickstarter.services.ApolloClientType
 import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope
 import com.kickstarter.ui.IntentKey
@@ -76,6 +77,7 @@ interface CommentsViewModel {
     class ViewModel(@NonNull val environment: Environment) : ActivityViewModel<CommentsActivity>(environment), Inputs, Outputs {
 
         private val currentUser: CurrentUserType = environment.currentUser()
+        private val client: ApiClientType = environment.apiClient()
         private val apolloClient: ApolloClientType = environment.apolloClient()
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -153,7 +155,7 @@ interface CommentsViewModel {
             }.flatMap {
                 it?.either<Observable<Project?>>(
                     { value: Project? -> Observable.just(value) },
-                    { u: Update? -> apolloClient.getProject(u?.projectId().toString()).compose(Transformers.neverError()) }
+                    { u: Update? -> client.fetchProject(u?.projectId().toString()).compose(Transformers.neverError()) }
                 )
             }.map {
                 requireNotNull(it)
@@ -459,6 +461,7 @@ interface CommentsViewModel {
             when {
                 projectAndUser.second == null -> CommentComposerStatus.GONE
                 projectAndUser.first.canComment() ?: false -> CommentComposerStatus.ENABLED
+                projectAndUser.first.isBacking -> CommentComposerStatus.ENABLED
                 else -> CommentComposerStatus.DISABLED
             }
 


### PR DESCRIPTION
# 📲 What

- A collaborator can comment on updates

# 🤔 Why

- Project was being fetch from V1 instead of graph, reason why the field `canComment` was not populated for updates

# 🛠 How

- Exchange the call to project from V1 to the GraphQL one

# 👀 See

https://user-images.githubusercontent.com/4083656/140186073-a534861a-d12a-49a0-8e21-f7fb77e67757.mp4


|  |  |

# 📋 QA

- Try to comment as a backer into an update from the project page
- Try to comment as a backer into an update from the activities page
- Try to comment as Collaborator into an update from the project page 
- Try to comment as Collaborator into a project from the project page
- Check that you cannot comment on any update or project in which you are not backer

# Story 📖

[Name of Trello Story](Trello link)
