### PR TITLE
NTV-278: UI pre-load polish

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectOverviewFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectOverviewFragment.kt
@@ -1,8 +1,10 @@
 package com.kickstarter.ui.fragments.projectpage
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.text.Html
+import android.text.Html.FROM_HTML_MODE_LEGACY
 import android.text.SpannableString
 import android.text.TextUtils
 import android.util.Pair
@@ -432,7 +434,11 @@ class ProjectOverviewFragment : BaseFragment<ProjectOverviewViewModel.ViewModel>
     }
 
     private fun setBlurbTextViews(blurb: String) {
-        val blurbHtml = Html.fromHtml(TextUtils.htmlEncode(blurb))
+        val blurbHtml = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            Html.fromHtml(TextUtils.htmlEncode(blurb), FROM_HTML_MODE_LEGACY)
+        } else {
+            Html.fromHtml(TextUtils.htmlEncode(blurb))
+        }
         binding.blurb.text = blurbHtml
     }
 

--- a/app/src/main/res/layout/project_creator_dashboard_header.xml
+++ b/app/src/main/res/layout/project_creator_dashboard_header.xml
@@ -6,7 +6,8 @@
   android:layout_height="wrap_content"
   android:gravity="center"
   android:orientation="horizontal"
-  android:padding="@dimen/project_padding_x">
+  android:padding="@dimen/project_padding_x"
+  android:visibility="gone">
 
   <TextView
     android:id="@+id/project_launch_date"


### PR DESCRIPTION
# 📲 What
- Remove rectangle visible previous to the project finish loading.
- The rectangle is the button from the Creator Dashboard piece of UI, only should be visible when the creator of the project is loading the project. 

# 👀 See

| Before 🐛 | After 🦋 |
| 
<img width="488" alt="Screen Shot 2021-11-03 at 3 14 28 PM" src="https://user-images.githubusercontent.com/4083656/140201249-a80937a7-cb93-40b9-bc3a-74128f71aeea.png">

 | 
<img width="497" alt="Screen Shot 2021-11-03 at 3 15 17 PM" src="https://user-images.githubusercontent.com/4083656/140201008-9c26af22-ca3c-4fc0-8e98-d9eb3279ffbc.png">
 |
|  |  |

# 📋 QA

- Load a project, you'll see in the time before the data is collected and rendered the rectangle has disappeared.

# Story 📖

[NTV-278](https://kickstarter.atlassian.net/browse/NTV-278)
