### PR TITLE
NTV-289 :Remove old awareness component for experiment

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -622,6 +622,13 @@ class PledgeFragment :
             .subscribe {
                 showRiskMessageDialog()
             }
+
+        this.viewModel.outputs.changePledgeSectionAccountabilityFragmentVisiablity()
+            .compose(observeForUI())
+            .compose(bindToLifecycle())
+            .subscribe {
+                binding?.pledgeSectionAccountability?.root?.isGone = it
+            }
     }
 
     private fun showRiskMessageDialog() {

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -320,6 +320,8 @@ interface PledgeFragmentViewModel {
         fun pledgeAmountHeader(): Observable<CharSequence>
 
         fun changeCheckoutRiskMessageBottomSheetStatus(): Observable<Boolean>
+
+        fun changePledgeSectionAccountabilityFragmentVisiablity(): Observable<Boolean>
     }
 
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<PledgeFragment>(environment), Inputs, Outputs {
@@ -349,6 +351,7 @@ interface PledgeFragmentViewModel {
         private val additionalPledgeAmountIsGone = BehaviorSubject.create<Boolean>()
         private val baseUrlForTerms = BehaviorSubject.create<String>()
         private val changeCheckoutRiskMessageBottomSheetStatus = BehaviorSubject.create<Boolean>()
+        private val changePledgeSectionAccountabilityFragmentVisiablity = BehaviorSubject.create<Boolean>()
         private val cardsAndProject = BehaviorSubject.create<Pair<List<StoredCard>, Project>>()
         private val continueButtonIsEnabled = BehaviorSubject.create<Boolean>()
         private val continueButtonIsGone = BehaviorSubject.create<Boolean>()
@@ -1177,6 +1180,15 @@ interface PledgeFragmentViewModel {
                     this.changeCheckoutRiskMessageBottomSheetStatus.onNext(false)
                 }
 
+            experimentData
+                .map { this.optimizely.variant(OptimizelyExperiment.Key.NATIVE_RISK_MESSAGING, it) != OptimizelyExperiment.Variant.CONTROL }
+                .compose(combineLatestPair(pledgeReason))
+                .filter { it.second == PledgeReason.PLEDGE }
+                .compose(bindToLifecycle())
+                .subscribe {
+                    changePledgeSectionAccountabilityFragmentVisiablity.onNext(it.first)
+                }
+
             this.pledgeButtonClicked
                 .compose(combineLatestPair(experimentData))
                 .filter { this.optimizely.variant(OptimizelyExperiment.Key.NATIVE_RISK_MESSAGING, it.second) == OptimizelyExperiment.Variant.CONTROL }
@@ -1933,5 +1945,9 @@ interface PledgeFragmentViewModel {
         @NonNull
         override fun changeCheckoutRiskMessageBottomSheetStatus(): Observable<Boolean> = this
             .changeCheckoutRiskMessageBottomSheetStatus
+
+        @NonNull
+        override fun changePledgeSectionAccountabilityFragmentVisiablity(): Observable<Boolean> =
+            this.changePledgeSectionAccountabilityFragmentVisiablity
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -126,6 +126,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     private val bonusSummaryIsGone = TestSubscriber<Boolean>()
     private val shippingRule = TestSubscriber<ShippingRule>()
     private val changeCheckoutRiskMessageBottomSheetStatus = TestSubscriber<Boolean>()
+    private val changePledgeSectionAccountabilityFragmentVisiablity = TestSubscriber<Boolean>()
 
     private fun setUpEnvironment(
         environment: Environment,
@@ -199,6 +200,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.bonusSummaryIsGone().subscribe(this.bonusSummaryIsGone)
         this.vm.outputs.shippingRule().subscribe(this.shippingRule)
         this.vm.outputs.changeCheckoutRiskMessageBottomSheetStatus().subscribe(this.changeCheckoutRiskMessageBottomSheetStatus)
+        this.vm.outputs.changePledgeSectionAccountabilityFragmentVisiablity().subscribe(this.changePledgeSectionAccountabilityFragmentVisiablity)
 
         val projectData = project.backing()?.let {
             return@let ProjectData.builder()
@@ -1488,6 +1490,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.changeCheckoutRiskMessageBottomSheetStatus.assertValueCount(2)
         this.changeCheckoutRiskMessageBottomSheetStatus.assertValues(true, false)
+        this.changePledgeSectionAccountabilityFragmentVisiablity.assertValues(true)
     }
 
     @Test
@@ -1501,6 +1504,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.pledgeButtonClicked()
 
         this.changeCheckoutRiskMessageBottomSheetStatus.assertNoValues()
+        this.changePledgeSectionAccountabilityFragmentVisiablity.assertValues(false)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
Remove old awareness component from checkout page on variant

# 🤔 Why

Our experiment was slightly flawed from the very start, as we forgot to remove the old component from the checkout flow.

# 🛠 How
Run control side of the experiment and confirm the component is present
Run variant side of the experiment and confirm the component is gone



# 👀 See

https://user-images.githubusercontent.com/1075310/141837821-304c44b9-03ba-4d52-897a-cbabe6ef71a9.mp4


# 📋 QA

Add your user ID to the whitelist here: Native Risk Messaging Whitelist
Test both the control flow and the variant_1 flow by changing your group on the whitelist. control should not show dialog, variant_1 should show dialog


# Story 📖
https://kickstarter.atlassian.net/browse/NTV-289
