### PR TITLE
NTV-286  Upgrade PerimeterX SDK to latest version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -312,7 +312,7 @@ dependencies {
     implementation 'com.appboy:appboy-segment-integration:9.0.0'
 
     // Security
-    implementation 'com.perimeterx.sdk:msdk:1.13.1'
+    implementation 'com.perimeterx.sdk:msdk:1.16.2'
 
     // Picasso
     implementation 'com.squareup.picasso:picasso:2.71828'


### PR DESCRIPTION
# 📲 What
Upgrade PerimeterX SDK


# 🛠 How
Upgrade PerimeterX SDK from Android SDK/1.13.1 to 1.16.2.


# 📋 QA

PerimeterX keeps working as usual, you can look for `PerimeterXClient` on logcat

# Story 📖

https://kickstarter.atlassian.net/browse/NTV-286
