### PR TITLE
NTV-271:Parser – Fix video element

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/htmlparser/ElementExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/ElementExt.kt
@@ -35,6 +35,11 @@ fun Element.isImageStructure(): Boolean {
     return !isTemplateDiv.isNullOrEmpty()
 }
 
+fun Element.parseVideoElement(): String {
+    val sourceUrls = this.children().mapNotNull { it.attr("src") }
+    return sourceUrls.firstOrNull { it.contains("high") } ?: sourceUrls.first()
+}
+
 fun Element.parseImageElement(): ImageViewElement {
     var src = ""
     var caption: String? = null

--- a/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLModels.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLModels.kt
@@ -4,7 +4,7 @@ import org.jsoup.nodes.Element
 
 interface ViewElement
 
-data class VideoViewElement(val sourceUrls: List<String>) : ViewElement
+data class VideoViewElement(val sourceUrls: String) : ViewElement
 data class TextViewElement(var components: List<TextComponent>) : ViewElement {
     val attributedText: String
         get() {

--- a/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLParser.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLParser.kt
@@ -33,7 +33,10 @@ class HTMLParser {
                 }
                 ViewElementType.VIDEO -> {
                     val sourceUrls = element.children().mapNotNull { it.attr("src") }
-                    val videoViewElement = VideoViewElement(ArrayList(sourceUrls))
+
+                    val videoViewElement = VideoViewElement(
+                        sourceUrls.firstOrNull { it.contains("high") } ?: sourceUrls.first()
+                    )
                     viewElements.add(videoViewElement)
                 }
                 ViewElementType.EXTERNAL_SOURCES -> {

--- a/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLParser.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLParser.kt
@@ -32,11 +32,7 @@ class HTMLParser {
                     return@forEach
                 }
                 ViewElementType.VIDEO -> {
-                    val sourceUrls = element.children().mapNotNull { it.attr("src") }
-
-                    val videoViewElement = VideoViewElement(
-                        sourceUrls.firstOrNull { it.contains("high") } ?: sourceUrls.first()
-                    )
+                    val videoViewElement = VideoViewElement(element.parseVideoElement())
                     viewElements.add(videoViewElement)
                 }
                 ViewElementType.EXTERNAL_SOURCES -> {

--- a/app/src/test/java/com/kickstarter/libs/htmlparser/HTMLParserTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/htmlparser/HTMLParserTest.kt
@@ -211,4 +211,38 @@ class HTMLParserTest {
         assert(textElement.components[0].text == "This is a headline")
         assert(textElement.components[0].styles[0] == TextComponent.TextStyleType.HEADER)
     }
+
+    @Test
+    fun parseVideoElement() {
+        val highURL = "https://v.kickstarter.com/1638357287_13f84af2b93199f2f08d64f29bb5849c4ccc9ae7/assets/034/747/335/b060e1907417e761401ac958a6df9cd7_h264_high.mp4"
+        val baseURL = "https://v.kickstarter" +
+            ".com/1638357287_13f84af2b93199f2f08d64f29bb5849c4ccc9ae7/assets/034/747/335/b060e1907417e761401ac958a6df9cd7_h264_base.mp4"
+
+        val html = "<video class=\"landscape\" preload=\"none\">\n" +
+            "<source src=$highURL type=\"video/mp4; codecs=&quot;avc1.64001E, mp4a.40.2&quot;\">\n" +
+            "<source src=$baseURL type=\"video/mp4; codecs=&quot;avc1.42E01E, mp4a.40.2&quot;\">\n" +
+            "You'll need an HTML5 capable browser to see this content.\n" +
+            "</video>"
+        val listOfElements = HTMLParser().parse(html)
+        assert(listOfElements.size == 1)
+
+        val videoViewElement: VideoViewElement = listOfElements.last() as VideoViewElement
+        TestCase.assertEquals(videoViewElement.sourceUrls, highURL)
+    }
+
+    @Test
+    fun parseVideoElementWithOneSource() {
+        val baseURL = "https://v.kickstarter" +
+            ".com/1638357287_13f84af2b93199f2f08d64f29bb5849c4ccc9ae7/assets/034/747/335/b060e1907417e761401ac958a6df9cd7_h264_base.mp4"
+
+        val html = "<video class=\"landscape\" preload=\"none\">\n" +
+            "<source src=$baseURL type=\"video/mp4; codecs=&quot;avc1.42E01E, mp4a.40.2&quot;\">\n" +
+            "You'll need an HTML5 capable browser to see this content.\n" +
+            "</video>"
+        val listOfElements = HTMLParser().parse(html)
+        assert(listOfElements.size == 1)
+
+        val videoViewElement: VideoViewElement = listOfElements.last() as VideoViewElement
+        TestCase.assertEquals(videoViewElement.sourceUrls, baseURL)
+    }
 }


### PR DESCRIPTION
# 📲 What
modify the parser to return a VideoViewElement(url:String) instead of VideoViewElement(list:ArrayList)

# 🛠 How
we use the high URL else use the first URL 

![Screen Shot 2021-11-29 at 1 28 01 PM](https://user-images.githubusercontent.com/1075310/143860404-3cde99f9-f445-49c0-a001-2544acd4452a.png)

# 👀 See
![Screen Shot 2021-11-29 at 1 28 39 PM](https://user-images.githubusercontent.com/1075310/143860342-a911be78-cc06-40fc-9fd5-0ebcc037d243.png)

# 📋 QA
Check parser and test class

https://kickstarter.atlassian.net/browse/NTV-271
