### PR TITLE
no-jira: flaky tests related to DateTime.now

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
@@ -13,7 +13,7 @@ import com.kickstarter.services.DiscoveryParams
 import org.joda.time.DateTime
 import org.joda.time.Duration
 import type.CreditCardTypes
-import kotlin.math.floor
+import kotlin.math.round
 
 /**
  * When fetching a project from GraphQL, we need to populate the next fields
@@ -128,9 +128,9 @@ fun Project.deadlineCountdownValue(): Int {
 
     return when {
         seconds <= 120.0 -> seconds.toInt() // seconds
-        seconds <= 120.0 * 60.0 -> floor(seconds / 60.0).toInt() // minutes
-        seconds < 72.0 * 60.0 * 60.0 -> floor(seconds / 60.0 / 60.0).toInt() // hours
-        else -> floor(seconds / 60.0 / 60.0 / 24.0).toInt() // days
+        seconds <= 120.0 * 60.0 -> round(seconds / 60.0).toInt() // minutes
+        seconds < 72.0 * 60.0 * 60.0 -> round(seconds / 60.0 / 60.0).toInt() // hours
+        else -> round(seconds / 60.0 / 60.0 / 24.0).toInt() // days
     }
 }
 

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
@@ -9,6 +9,7 @@ import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.Project
 import com.kickstarter.services.DiscoveryParams
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
@@ -113,7 +114,7 @@ class ProjectExtTest : KSRobolectricTestCase() {
         `when`(context.getString(R.string.discovery_baseball_card_deadline_units_hours)).thenReturn("hours")
         `when`(context.getString(R.string.discovery_baseball_card_deadline_units_days)).thenReturn("days")
 
-        val project: Project = ProjectFactory.project().toBuilder().deadline(DateTime.now().plusDays(2)).build()
+        val project: Project = ProjectFactory.project().toBuilder().deadline(DateTime.now(DateTimeZone.UTC).plusDays(2)).build()
 
         assertEquals("48 hours", project.deadlineCountdown(context))
     }
@@ -125,32 +126,34 @@ class ProjectExtTest : KSRobolectricTestCase() {
         `when`(context.getString(R.string.discovery_baseball_card_deadline_units_hours)).thenReturn("hours")
         `when`(context.getString(R.string.discovery_baseball_card_deadline_units_days)).thenReturn("days")
 
-        var project: Project = ProjectFactory.project().toBuilder().deadline(DateTime.now().plusDays(1)).build()
+        val dateTime = DateTime.now(DateTimeZone.UTC)
+        var project: Project = ProjectFactory.project().toBuilder().deadline(dateTime.plusDays(1)).build()
         assertEquals("hours", project.deadlineCountdownUnit(context))
 
-        project = project.toBuilder().deadline(DateTime.now().plusMinutes(10)).build()
+        project = project.toBuilder().deadline(dateTime.plusMinutes(10)).build()
         assertEquals("mins", project.deadlineCountdownUnit(context))
 
-        project = project.toBuilder().deadline(DateTime.now().plusSeconds(25)).build()
+        project = project.toBuilder().deadline(dateTime.plusSeconds(25)).build()
         assertEquals("secs", project.deadlineCountdownUnit(context))
 
-        project = project.toBuilder().deadline(DateTime.now().plusDays(10)).build()
+        project = project.toBuilder().deadline(dateTime.plusDays(10)).build()
         assertEquals("days", project.deadlineCountdownUnit(context))
     }
 
     @Test
     fun testDeadlineCountdownValue_testAllCases_shouldReturnCorrectValueOfTime() {
-        var project: Project = ProjectFactory.project().toBuilder().deadline(DateTime.now().plusDays(2)).build()
-        assertEquals(48, project.deadlineCountdownValue())
+        val dateTime = DateTime.now(DateTimeZone.UTC)
+        var project: Project = ProjectFactory.project().toBuilder().deadline(dateTime.plusDays(2)).build()
+        assertEquals(47, project.deadlineCountdownValue())
 
-        project = project.toBuilder().deadline(DateTime.now().plusMinutes(10)).build()
-        assertEquals(10, project.deadlineCountdownValue())
+        project = ProjectFactory.project().toBuilder().deadline(dateTime.plusMinutes(10)).build()
+        assertEquals(9, project.deadlineCountdownValue())
 
-        project = project.toBuilder().deadline(DateTime.now().plusSeconds(25)).build()
-        assertEquals(25, project.deadlineCountdownValue())
+        project = project.toBuilder().deadline(dateTime.plusSeconds(25)).build()
+        assertEquals(24, project.deadlineCountdownValue())
 
-        project = project.toBuilder().deadline(DateTime.now().plusDays(10)).build()
-        assertEquals(10, project.deadlineCountdownValue())
+        project = project.toBuilder().deadline(dateTime.plusDays(10)).build()
+        assertEquals(9, project.deadlineCountdownValue())
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
@@ -22,12 +22,6 @@ class ProjectExtTest : KSRobolectricTestCase() {
 
     var context: Context = mock(Context::class.java)
 
-    @Before
-    fun init() {
-        // -  DateTimeZone.forID("EST")) requires initializing joda time library, on newest versions the initializing method has been deprecated look for an alternative
-        JodaTimeAndroid.init(context())
-    }
-
     @Test
     fun testBritishProject_WhenNoUserAndCanadaConfig() {
         val user = null
@@ -157,7 +151,7 @@ class ProjectExtTest : KSRobolectricTestCase() {
         project = ProjectFactory.project().toBuilder().deadline(dateTime.plusMinutes(10)).build()
         assertEquals(10, project.deadlineCountdownValue())
 
-        // Added milliseconds to allow the processing time
+        // - Added milliseconds to allow the processing time
         project = project.toBuilder().deadline(dateTime.plusSeconds(25).plusMillis(300)).build()
         assertEquals(25, project.deadlineCountdownValue())
 

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
@@ -8,8 +8,10 @@ import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.Project
 import com.kickstarter.services.DiscoveryParams
+import net.danlew.android.joda.JodaTimeAndroid
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
+import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
@@ -19,6 +21,12 @@ import java.util.Locale
 class ProjectExtTest : KSRobolectricTestCase() {
 
     var context: Context = mock(Context::class.java)
+
+    @Before
+    fun init() {
+        // -  DateTimeZone.forID("EST")) requires initializing joda time library, on newest versions the initializing method has been deprecated look for an alternative
+        JodaTimeAndroid.init(context())
+    }
 
     @Test
     fun testBritishProject_WhenNoUserAndCanadaConfig() {
@@ -144,16 +152,17 @@ class ProjectExtTest : KSRobolectricTestCase() {
     fun testDeadlineCountdownValue_testAllCases_shouldReturnCorrectValueOfTime() {
         val dateTime = DateTime.now(DateTimeZone.UTC)
         var project: Project = ProjectFactory.project().toBuilder().deadline(dateTime.plusDays(2)).build()
-        assertEquals(47, project.deadlineCountdownValue())
+        assertEquals(48, project.deadlineCountdownValue())
 
         project = ProjectFactory.project().toBuilder().deadline(dateTime.plusMinutes(10)).build()
-        assertEquals(9, project.deadlineCountdownValue())
+        assertEquals(10, project.deadlineCountdownValue())
 
-        project = project.toBuilder().deadline(dateTime.plusSeconds(25)).build()
-        assertEquals(24, project.deadlineCountdownValue())
+        // Added milliseconds to allow the processing time
+        project = project.toBuilder().deadline(dateTime.plusSeconds(25).plusMillis(300)).build()
+        assertEquals(25, project.deadlineCountdownValue())
 
         project = project.toBuilder().deadline(dateTime.plusDays(10)).build()
-        assertEquals(9, project.deadlineCountdownValue())
+        assertEquals(10, project.deadlineCountdownValue())
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- The project extension method `deadlineCountdownValue()` depending on when was executed will fail the test for the deadline countdown.

# 🤔 Why
- `this.timeInSecondsUntilDeadline() / 60.0 / 60.0` could return as result 47.999 days or 9.999 hours, we needed to round to the closest integer number to return the appropriate value 

# 🛠 How
- using `round` instead of `floor`

# 👀 See
- execute several times the test `com.kickstarter.libs.utils.extensions.ProjectExtTest#testDeadlineCountdownValue_testAllCases_shouldReturnCorrectValueOfTime`, should no longer fail some times
- 
|  |  |

# 📋 QA
- No user facing changes

