### PR TITLE
no-jira: flaky tests related to DateTime.now

### DIFF
--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
@@ -140,16 +140,20 @@ class ProjectExtTest : KSRobolectricTestCase() {
 
     @Test
     fun testDeadlineCountdownValue_testAllCases_shouldReturnCorrectValueOfTime() {
-        var project: Project = ProjectFactory.project().toBuilder().deadline(DateTime.now().plusDays(2)).build()
+        // - Added milliseconds to allow processing times
+        var project: Project = ProjectFactory.project().toBuilder().deadline(DateTime.now().plusDays(2).plusMillis(300)).build()
         assertEquals(48, project.deadlineCountdownValue())
 
-        project = project.toBuilder().deadline(DateTime.now().plusMinutes(10)).build()
+        // - Added milliseconds to allow processing times
+        project = project.toBuilder().deadline(DateTime.now().plusMinutes(10).plusMillis(300)).build()
         assertEquals(10, project.deadlineCountdownValue())
 
-        project = project.toBuilder().deadline(DateTime.now().plusSeconds(25)).build()
+        // - Added milliseconds to allow processing times
+        project = project.toBuilder().deadline(DateTime.now().plusSeconds(25).plusMillis(300)).build()
         assertEquals(25, project.deadlineCountdownValue())
 
-        project = project.toBuilder().deadline(DateTime.now().plusDays(10)).build()
+        // - Added milliseconds to allow processing times
+        project = project.toBuilder().deadline(DateTime.now().plusDays(10).plusMillis(300)).build()
         assertEquals(10, project.deadlineCountdownValue())
     }
 


### PR DESCRIPTION
# 📲 What

- The project extension method `deadlineCountdownValue()` depending on when was executed will fail the test for the deadline countdown.

# 🤔 Why
- added some extra milliseconds to the tests to allow processing time


# 👀 See
- execute several times the test `com.kickstarter.libs.utils.extensions.ProjectExtTest#testDeadlineCountdownValue_testAllCases_shouldReturnCorrectValueOfTime`, should no longer fail some times
- 
|  |  |

# 📋 QA
- No user facing changes