### PR TITLE
no-jira: one more flacky test related to DateTime.now()

### DIFF
--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
@@ -113,7 +113,8 @@ class ProjectExtTest : KSRobolectricTestCase() {
         `when`(context.getString(R.string.discovery_baseball_card_deadline_units_hours)).thenReturn("hours")
         `when`(context.getString(R.string.discovery_baseball_card_deadline_units_days)).thenReturn("days")
 
-        val project: Project = ProjectFactory.project().toBuilder().deadline(DateTime.now().plusDays(2)).build()
+        // - Added milliseconds to allow processing times
+        val project: Project = ProjectFactory.project().toBuilder().deadline(DateTime.now().plusDays(2).plusMillis(300)).build()
 
         assertEquals("48 hours", project.deadlineCountdown(context))
     }


### PR DESCRIPTION
# 📲 What

The test `testDeadlineCountdown_shouldReturnCorrectString` failed from time to time 


# 🛠 How

- Added a few milliseconds to allow processing time 

# 👀 See
- No user facing changes
|  |  |

# 📋 QA

- Execute several times the test `testDeadlineCountdown_shouldReturnCorrectString` should never fail

