### PR TITLE
NTV-291: Add Youtube fullscreen support

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/adapters/projectcampaign/ViewElementAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/projectcampaign/ViewElementAdapter.kt
@@ -25,7 +25,10 @@ import com.kickstarter.ui.viewholders.projectcampaign.VideoElementViewHolder
 /**
  * Adapter Specific to hold a list of ViewElements from the HTML Parser
  */
-class ViewElementAdapter(val requireActivity: FragmentActivity) : RecyclerView
+class ViewElementAdapter(
+    val requireActivity: FragmentActivity,
+    private val fullScreenDelegate: FullScreenDelegate
+) : RecyclerView
 .Adapter<RecyclerView
     .ViewHolder>() {
 
@@ -137,6 +140,7 @@ class ViewElementAdapter(val requireActivity: FragmentActivity) : RecyclerView
                         viewGroup,
                         false
                     ),
+                    fullScreenDelegate,
                     requireActivity
                 )
             }
@@ -150,6 +154,7 @@ class ViewElementAdapter(val requireActivity: FragmentActivity) : RecyclerView
                         viewGroup,
                         false
                     ),
+                    fullScreenDelegate,
                     requireActivity
                 )
             }
@@ -217,5 +222,9 @@ class ViewElementAdapter(val requireActivity: FragmentActivity) : RecyclerView
 
     fun releasePlayersOnPause() {
         VideoElementViewHolder.releasePlayersOnPause()
+    }
+
+    interface FullScreenDelegate {
+        fun onFullScreenClosed(index: Int)
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/ExternalViewViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/ExternalViewViewHolder.kt
@@ -4,11 +4,13 @@ import android.annotation.SuppressLint
 import androidx.fragment.app.FragmentActivity
 import com.kickstarter.databinding.ViewElementExternalSourceFromHtmlBinding
 import com.kickstarter.libs.htmlparser.ExternalSourceViewElement
+import com.kickstarter.ui.adapters.projectcampaign.ViewElementAdapter
 import com.kickstarter.ui.viewholders.KSViewHolder
 import com.kickstarter.ui.views.WebChromeVideoFullScreenClient
 
 class ExternalViewViewHolder(
     val binding: ViewElementExternalSourceFromHtmlBinding,
+    private val fullScreenDelegate: ViewElementAdapter.FullScreenDelegate,
     val requireActivity: FragmentActivity
 ) : KSViewHolder(binding.root) {
     private val webView = binding.externalSourceWebView
@@ -22,7 +24,10 @@ class ExternalViewViewHolder(
     @SuppressLint("SetJavaScriptEnabled")
     private fun setupWebView() {
         webView.settings.javaScriptEnabled = true
-        webView.webChromeClient = WebChromeVideoFullScreenClient(requireActivity)
+        webView.webChromeClient = WebChromeVideoFullScreenClient(
+            requireActivity,
+            fullScreenDelegate, absoluteAdapterPosition
+        )
     }
 
     override fun bindData(data: Any?) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/VideoElementViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/VideoElementViewHolder.kt
@@ -24,11 +24,13 @@ import com.kickstarter.databinding.ViewElementVideoFromHtmlBinding
 import com.kickstarter.libs.Build
 import com.kickstarter.libs.htmlparser.VideoViewElement
 import com.kickstarter.libs.utils.WebUtils
+import com.kickstarter.ui.adapters.projectcampaign.ViewElementAdapter
 import com.kickstarter.ui.extensions.loadImage
 import com.kickstarter.ui.viewholders.KSViewHolder
 
 class VideoElementViewHolder(
     val binding: ViewElementVideoFromHtmlBinding,
+    private val fullScreenDelegate: ViewElementAdapter.FullScreenDelegate,
     val requireActivity: FragmentActivity
 ) : KSViewHolder(binding.root) {
 
@@ -189,6 +191,7 @@ class VideoElementViewHolder(
                 R.drawable.ic_fullscreen_open
             )
         )
+        fullScreenDelegate.onFullScreenClosed(absoluteAdapterPosition)
     }
 
     fun releasePlayer(index: Int) {

--- a/app/src/main/java/com/kickstarter/ui/views/WebChromeVideoFullScreenClient.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/WebChromeVideoFullScreenClient.kt
@@ -7,8 +7,13 @@ import android.view.View
 import android.webkit.WebChromeClient
 import android.widget.FrameLayout
 import androidx.fragment.app.FragmentActivity
+import com.kickstarter.ui.adapters.projectcampaign.ViewElementAdapter
 
-class WebChromeVideoFullScreenClient(val requireActivity: FragmentActivity) : WebChromeClient() {
+class WebChromeVideoFullScreenClient(
+    val requireActivity: FragmentActivity,
+    private val fullScreenDelegate: ViewElementAdapter.FullScreenDelegate? = null,
+    private val elementIndex: Int? = null
+) : WebChromeClient() {
 
     private var customView: View? = null
     private var customViewCallback: CustomViewCallback? = null
@@ -31,6 +36,7 @@ class WebChromeVideoFullScreenClient(val requireActivity: FragmentActivity) : We
         requireActivity.requestedOrientation = originalOrientation
         customViewCallback?.onCustomViewHidden()
         customViewCallback = null
+        elementIndex?.let { fullScreenDelegate?.onFullScreenClosed(it) }
     }
 
     override fun onShowCustomView(paramView: View, paramCustomViewCallback: CustomViewCallback) {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectCampaignViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectCampaignViewModel.kt
@@ -15,11 +15,13 @@ class ProjectCampaignViewModel {
     interface Inputs {
         /** Configure with current [ProjectData]. */
         fun configureWith(projectData: ProjectData)
+        fun scrollToVideoPosition(position: Int)
     }
 
     interface Outputs {
         /** Emits in a list format the DOM elements  */
         fun storyViewElements(): Observable<List<ViewElement>>
+        fun onScrollToVideoPosition(): Observable<Int>
     }
 
     class ViewModel(@NonNull val environment: Environment) : FragmentViewModel<ProjectOverviewFragment>(environment), Inputs, Outputs {
@@ -29,6 +31,9 @@ class ProjectCampaignViewModel {
         private val htmlParser = HTMLParser()
         private val projectDataInput = BehaviorSubject.create<ProjectData>()
         private val storyViewElementsList: Observable<List<ViewElement>>
+
+        private val scrollToVideoPosition = BehaviorSubject.create<Int>()
+        private val onScrollToVideoPosition = BehaviorSubject.create<Int>()
 
         init {
             val project = projectDataInput
@@ -41,12 +46,20 @@ class ProjectCampaignViewModel {
                 .filter { ObjectUtils.isNotNull(it.story()) }
                 .map { requireNotNull(it.story()) }
                 .map { htmlParser.parse(it) }
+
+            scrollToVideoPosition
+                .compose(bindToLifecycle())
+                .subscribe {
+                    onScrollToVideoPosition.onNext(it)
+                }
         }
 
         // - Inputs
         override fun configureWith(projectData: ProjectData) =
             this.projectDataInput.onNext(projectData)
+        override fun scrollToVideoPosition(position: Int) = scrollToVideoPosition.onNext(position)
 
         override fun storyViewElements(): Observable<List<ViewElement>> = storyViewElementsList
+        override fun onScrollToVideoPosition(): Observable<Int> = onScrollToVideoPosition
     }
 }

--- a/app/src/main/res/layout/fragment_project_campaign.xml
+++ b/app/src/main/res/layout/fragment_project_campaign.xml
@@ -3,15 +3,16 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/project_campaign"
-    android:layout_marginBottom="@dimen/grid_7"
+    android:layout_marginBottom="@dimen/grid_9"
+    android:layout_marginTop="@dimen/grid_3"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/project_campaign_view_list_items"
         android:layout_width="0dp"
-        android:paddingTop="@dimen/grid_3"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/grid_3"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_project_campaign.xml
+++ b/app/src/main/res/layout/fragment_project_campaign.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/project_campaign"
+    android:layout_marginBottom="@dimen/grid_7"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -11,7 +12,6 @@
         android:layout_width="0dp"
         android:paddingTop="@dimen/grid_3"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/grid_7"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
# 📲 What
when exiting fullscreen we go back to the top of the campaign tab, we can prevent this and keep the previous position

# 🛠 How
Add a delegate to fire callback when the fullscreen closed and smooth scroll to the video position 

# 👀 See
https://user-images.githubusercontent.com/1075310/145255706-42b95cbe-518d-4ebd-a522-8ea5901a6ffa.mp4

# 📋 QA
open Projects with videos or youtube and check fullscreen 
"HipLok" and "Organicar"

# Story 📖
(https://kickstarter.atlassian.net/browse/NTV-291)
