### PR TITLE
NTV-301: Remove gray line above images

### DIFF
--- a/app/src/main/res/layout/view_element_image_from_html.xml
+++ b/app/src/main/res/layout/view_element_image_from_html.xml
@@ -11,6 +11,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/grid_3"
+        android:outlineProvider="none"
         android:contentDescription="@null"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
# 📲 What

Gray line was appearing above images rendered from the html parser. This fix removes that line. 

# 🛠 How

Added an attribute to the image view

# 👀 See
Before and After
![Screenshot_20211208-114932](https://user-images.githubusercontent.com/19390326/145255639-ec079ab3-b5ad-43e8-9c2b-f9e33601ebd9.png) ![Screenshot_20211208-115721](https://user-images.githubusercontent.com/19390326/145255651-20d43291-3804-42d4-ba73-0636e8b595f7.png)


# 📋 QA

Visit any project with images and there shouldn't be a gray line.

# Story 📖

[NTV-301: Remove gray line above images](https://kickstarter.atlassian.net/browse/NTV-301)
