### PR TITLE
NTV-318: Update dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -196,27 +196,27 @@ repositories {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'androidx.annotation:annotation:1.2.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.browser:browser:1.3.0'
+    implementation 'androidx.annotation:annotation:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation 'androidx.browser:browser:1.4.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'androidx.work:work-runtime-ktx:2.7.0-alpha05'
+    implementation 'androidx.work:work-runtime-ktx:2.7.1'
     implementation 'com.android.support.constraint:constraint-layout:2.0.4'
     implementation 'com.apollographql.apollo:apollo-runtime:2.5.10'
     implementation 'com.facebook.android:facebook-android-sdk:12.0.1'
     implementation 'com.google.android.play:core-ktx:1.8.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
     final auto_parcel_version = "0.3.1"
     implementation "com.github.frankiesardo:auto-parcel:$auto_parcel_version"
     kapt "com.github.frankiesardo:auto-parcel-processor:$auto_parcel_version"
     implementation "com.google.android.gms:play-services-wallet:18.1.3"
-    implementation "com.google.android.exoplayer:exoplayer:2.15.1"
+    implementation "com.google.android.exoplayer:exoplayer:2.16.1"
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
-    implementation 'com.google.android.material:material:1.5.0-alpha02'
-    final dagger_version = "2.39"
+    implementation 'com.google.android.material:material:1.6.0-alpha01'
+    final dagger_version = "2.40"
     implementation "com.google.dagger:dagger:$dagger_version"
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
     implementation "com.jakewharton:process-phoenix:2.0.0"
@@ -254,7 +254,7 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:2.71828'
 
     // Firebase
-    implementation platform('com.google.firebase:firebase-bom:28.4.2')
+    implementation platform('com.google.firebase:firebase-bom:29.0.2')
     implementation 'com.google.firebase:firebase-crashlytics'
     implementation 'com.google.firebase:firebase-analytics-ktx'
     implementation 'com.google.firebase:firebase-perf-ktx'
@@ -267,7 +267,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.6.1"
     testImplementation "org.robolectric:shadows-multidex:4.6.1"
     testImplementation "androidx.test:core:1.4.0"
-    androidTestImplementation 'androidx.annotation:annotation:1.2.0'
+    androidTestImplementation 'androidx.annotation:annotation:1.3.0'
 
     def espresso = '3.4.0'
     androidTestImplementation ('androidx.test.espresso:espresso-contrib:' + espresso) {

--- a/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
@@ -16,10 +16,12 @@ import kotlin.math.absoluteValue
 
 fun decodeRelayId(encodedRelayId: String?): Long? {
     return try {
-        String(Base64Utils.decode(encodedRelayId), Charset.defaultCharset())
-            .replaceBeforeLast("-", "", "")
-            .toLong()
-            .absoluteValue
+        encodedRelayId?.let {
+            String(Base64Utils.decode(it), Charset.defaultCharset())
+                .replaceBeforeLast("-", "", "")
+                .toLong()
+                .absoluteValue
+        }
     } catch (e: Exception) {
         null
     }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.4'
-        classpath 'com.google.gms:google-services:4.3.5'
+        classpath 'com.google.gms:google-services:4.3.10'
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.firebase:perf-plugin:1.3.5'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.0'
+    ext.kotlin_version = '1.5.21'
     ext.jacoco_version = '0.8.7'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.3.10'
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        // updating performance plugin causes the jacoco plugin for code coverage to drop to 0 for some unknown reason
         classpath 'com.google.firebase:perf-plugin:1.3.5'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.21'
+    ext.kotlin_version = '1.6.0'
     ext.jacoco_version = '0.8.7'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath 'com.google.gms:google-services:4.3.5'
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
# 📲 What

- Updated dependencies and gradle plugin
- ℹ️ Found the depency causing jacoco to drop coverange to 0%, the Firebase performance monitor, further investigation will occur on that end but for now do not update the firebase performance plugin just yet
- Those dependencies introducing braking changes have their own Jira task assigned.

|  |  |

# 📋 QA

- Everything keeps working as usual. You can try to pledge a project, review some old backings ... 

# Story 📖

[NTV-318](https://kickstarter.atlassian.net/browse/NTV-318)
