### PR TITLE
[no-jira]: Block Project page rotation to portrait

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -181,8 +181,10 @@
             android:name=".ui.activities.ProjectPageActivity"
             android:parentActivityName=".ui.activities.DiscoveryActivity"
             android:theme="@style/ProjectActivity"
+            android:screenOrientation="portrait"
             android:configChanges="screenSize|orientation"
-            android:windowSoftInputMode="adjustResize" />
+            android:windowSoftInputMode="adjustResize"
+            tools:ignore="LockedOrientationActivity" />
         <activity
             android:name=".ui.activities.ProjectNotificationSettingsActivity"
             android:parentActivityName=".ui.activities.SettingsActivity"

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -816,6 +816,12 @@ class ProjectPageActivity :
         }
     }
 
+    override fun onDestroy() {
+        binding.projectPager.adapter = null
+        this.viewModel = null
+        super.onDestroy()
+    }
+
     private fun updateManagePledgeMenu(@MenuRes menu: Int?) {
         menu?.let {
             binding.pledgeContainerLayout.pledgeToolbar.inflateMenu(it)


### PR DESCRIPTION
# 📲 What

- Block the project page rotation for the project screen.
- Only screens allowed to go landscape now with the project are videos on full screen.

|  |  |

# 📋 QA

- Try to play a video from a campaign in the video player on landscape, make sure when you close the full screen video, the advance playing the video is correct-
- Try the same use case for the youtube iframes.

