### PR TITLE
NTV-359: Fix pledge with Reward+AddOns that are shippable

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -478,6 +478,7 @@ interface PledgeFragmentViewModel {
 
             val pledgeReason = arguments()
                 .map { it.getSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON) as PledgeReason }
+                .distinctUntilChanged()
 
             val updatingPayment = pledgeReason
                 .map { it == PledgeReason.UPDATE_PAYMENT || it == PledgeReason.FIX_PLEDGE }
@@ -807,7 +808,7 @@ interface PledgeFragmentViewModel {
                 .filter { ObjectUtils.isNotNull(it) }
                 .map { requireNotNull(it) }
                 .compose<Pair<ShippingRule, PledgeReason>>(combineLatestPair(pledgeReason))
-                .filter { it.second == PledgeReason.PLEDGE || it.second == PledgeReason.UPDATE_REWARD }
+                .filter { it.second == PledgeReason.PLEDGE || it.second == PledgeReason.UPDATE_REWARD || it.second == PledgeReason.FIX_PLEDGE }
                 .map { it.first }
                 .compose<Pair<ShippingRule, Project>>(combineLatestPair(project))
                 .compose(bindToLifecycle())
@@ -855,9 +856,11 @@ interface PledgeFragmentViewModel {
 
             val isRewardWithShipping = this.selectedReward
                 .filter { RewardUtils.isShippable(it) }
+                .distinctUntilChanged()
 
             val isDigitalRw = this.selectedReward
                 .filter { RewardUtils.isDigital(it) }
+                .distinctUntilChanged()
 
             // - Calculate total for Reward || Rewards + AddOns with Shipping location
             val totalWShipping = Observable.combineLatest(isRewardWithShipping, pledgeAmountHeader, shippingAmount, this.bonusAmount, pledgeReason) {

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -823,6 +823,30 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testPledgeSummaryAmount_whenFixingPaymentMethod_whenRewardAddOnShipping() {
+        val testData = setUpBackedRewardWithAddOnsAndShippingTestData()
+        val backedProject = testData.project
+        val reward = testData.reward
+
+        val environment = environment()
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.FIX_PLEDGE)
+
+        this.totalAmount.assertValue(expectedCurrency(environment, backedProject, 40.0))
+    }
+
+    @Test
+    fun testPledgeSummaryAmount_whenFixingPaymentMethod_whenRewardAddOnShippingBonusAmount() {
+        val testData = setUpBackedRewardWithAddOnsAndShippingAndBonusAmountTestData()
+        val backedProject = testData.project
+        val reward = testData.reward
+
+        val environment = environment()
+        setUpEnvironment(environment, reward, backedProject, PledgeReason.FIX_PLEDGE)
+
+        this.totalAmount.assertValue(expectedCurrency(environment, backedProject, 42.0))
+    }
+
+    @Test
     fun testTotalAmount_whenUpdatingPledge() {
         val testData = setUpBackedShippableRewardTestData()
         val backedProject = testData.project
@@ -2767,6 +2791,70 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
             .build()
 
         return TestData(shippableReward, backedProject, backing, shippingRulesEnvelope, storedCards)
+    }
+
+    private fun setUpBackedRewardWithAddOnsAndShippingAndBonusAmountTestData(): TestData {
+        val backingCard = StoredCardFactory.visa()
+        val reward = RewardFactory.rewardWithShipping()
+        val addOns = RewardFactory.rewardWithShipping()
+        val bAmount = 2.0
+        val storedCards = listOf(StoredCardFactory.discoverCard(), backingCard, StoredCardFactory.visa())
+        val backing = BackingFactory.backing()
+            .toBuilder()
+            .paymentSource(
+                PaymentSourceFactory.visa()
+                    .toBuilder()
+                    .id(backingCard.id())
+                    .build()
+            )
+            .bonusAmount(bAmount)
+            .reward(reward)
+            .rewardId(reward.id())
+            .addOns(listOf(addOns))
+            .build()
+
+        val backedProject = ProjectFactory.backedProject()
+            .toBuilder()
+            .backing(backing)
+            .build()
+
+        val shippingRulesEnvelope = ShippingRulesEnvelopeFactory.shippingRules()
+            .toBuilder()
+            .shippingRules(listOf(ShippingRuleFactory.usShippingRule(), ShippingRuleFactory.germanyShippingRule(), ShippingRuleFactory.mexicoShippingRule()))
+            .build()
+
+        return TestData(reward, backedProject, backing, shippingRulesEnvelope, storedCards)
+    }
+
+    private fun setUpBackedRewardWithAddOnsAndShippingTestData(): TestData {
+        val backingCard = StoredCardFactory.visa()
+        val reward = RewardFactory.rewardWithShipping()
+        val addOns = RewardFactory.rewardWithShipping()
+        val storedCards = listOf(StoredCardFactory.discoverCard(), backingCard, StoredCardFactory.visa())
+        val backing = BackingFactory.backing()
+            .toBuilder()
+            .paymentSource(
+                PaymentSourceFactory.visa()
+                    .toBuilder()
+                    .id(backingCard.id())
+                    .build()
+            )
+            .reward(reward)
+            .rewardId(reward.id())
+            .addOns(listOf(addOns))
+            .build()
+
+        val backedProject = ProjectFactory.backedProject()
+            .toBuilder()
+            .backing(backing)
+            .build()
+
+        val shippingRulesEnvelope = ShippingRulesEnvelopeFactory.shippingRules()
+            .toBuilder()
+            .shippingRules(listOf(ShippingRuleFactory.usShippingRule(), ShippingRuleFactory.germanyShippingRule(), ShippingRuleFactory.mexicoShippingRule()))
+            .build()
+
+        return TestData(reward, backedProject, backing, shippingRulesEnvelope, storedCards)
     }
 
     private fun setUpBackedNoRewardTestData(): TestData {


### PR DESCRIPTION
# 📲 What

- Could not fix a pledge, when the pledge contained a reward + addOns and they were shippable.

# 👀 See
| Before 🐛 | After 🦋 |
<img width="1083" alt="Fix-Pledge" src="https://user-images.githubusercontent.com/4083656/150871962-efb8bc76-12ff-41d1-95fd-d5a50d915678.png">

| --- | --- |
|  |  |

# Story 📖
[NTV-359](https://kickstarter.atlassian.net/browse/NTV-359)
