### PR TITLE
NTV-363: Hide collection option Social

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/DiscoveryParamsExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/DiscoveryParamsExt.kt
@@ -197,7 +197,7 @@ private fun topSections(user: User?): List<NavigationDrawerData.Section> {
 
     if (userIsLoggedIn) {
         filters.add(DiscoveryParams.builder().starred(1).build())
-        /*if (user?.social()?.isTrue() == true) {
+        /*if (user?.social()?.isTrue() == true) { //TODO: Bring back once social is available on graphql
             filters.add(DiscoveryParams.builder().social(1).build())
         }*/
     }

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/DiscoveryParamsExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/DiscoveryParamsExt.kt
@@ -197,9 +197,9 @@ private fun topSections(user: User?): List<NavigationDrawerData.Section> {
 
     if (userIsLoggedIn) {
         filters.add(DiscoveryParams.builder().starred(1).build())
-        if (user?.social()?.isTrue() == true) {
+        /*if (user?.social()?.isTrue() == true) {
             filters.add(DiscoveryParams.builder().social(1).build())
-        }
+        }*/
     }
 
     return Observable.from(filters)

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -60,7 +60,35 @@ open class MockApolloClient : ApolloClientType {
     }
 
     override fun getProjects(discoveryParams: DiscoveryParams, cursor: String?): Observable<DiscoverEnvelope> {
-        return Observable.just(DiscoverEnvelopeFactory.discoverEnvelope(emptyList()))
+        return Observable.just(
+            DiscoverEnvelope
+                .builder()
+                .projects(
+                    listOf(
+                        ProjectFactory.project(),
+                        ProjectFactory.allTheWayProject(),
+                        ProjectFactory.successfulProject()
+                    )
+                )
+                .urls(
+                    DiscoverEnvelope.UrlsEnvelope
+                        .builder()
+                        .api(
+                            DiscoverEnvelope.UrlsEnvelope.ApiEnvelope
+                                .builder()
+                                .moreProjects("http://more.projects.please")
+                                .build()
+                        )
+                        .build()
+                )
+                .stats(
+                    DiscoverEnvelope.StatsEnvelope
+                        .builder()
+                        .count(10)
+                        .build()
+                )
+                .build()
+        )
     }
 
     override fun getProjects(isMember: Boolean): Observable<DiscoverEnvelope> {

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -9,6 +9,7 @@ import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.ExperimentsClientType;
 import com.kickstarter.libs.FragmentViewModel;
 import com.kickstarter.libs.RefTag;
+import com.kickstarter.libs.loadmore.ApolloPaginate;
 import com.kickstarter.libs.models.OptimizelyFeature;
 import com.kickstarter.libs.preferences.IntPreferenceType;
 import com.kickstarter.libs.utils.EventContextValues;
@@ -151,26 +152,13 @@ public interface DiscoveryFragmentViewModel {
         selectedParams.compose(takeWhen(this.refresh))
       );
 
-      // TODO: fetch projects and paginate from GraphQL
-      /*final ApolloPaginate<Project, DiscoverEnvelope, DiscoveryParams> paginator;
+      final ApolloPaginate<Project, DiscoverEnvelope, DiscoveryParams> paginator;
       paginator = ApolloPaginate.<Project, DiscoverEnvelope, DiscoveryParams>builder()
           .nextPage(this.nextPage)
           .distinctUntilChanged(true)
           .startOverWith(startOverWith)
           .envelopeToListOfData(DiscoverEnvelope::projects)
           .loadWithParams(this::makeCallWithParams)
-          .clearWhenStartingOver(false)
-          .concater(ListUtils::concatDistinct)
-          .build();*/
-
-      final ApiPaginator<Project, DiscoverEnvelope, DiscoveryParams> paginator =
-        ApiPaginator.<Project, DiscoverEnvelope, DiscoveryParams>builder()
-          .nextPage(this.nextPage)
-          .startOverWith(startOverWith)
-          .envelopeToListOfData(DiscoverEnvelope::projects)
-          .envelopeToMoreUrl(env -> env.urls().api().moreProjects())
-          .loadWithParams(this.apiClient::fetchProjects)
-          .loadWithPaginationPath(this.apiClient::fetchProjects)
           .clearWhenStartingOver(false)
           .concater(ListUtils::concatDistinct)
           .build();

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.java
@@ -3,7 +3,6 @@ package com.kickstarter.viewmodels;
 import android.content.SharedPreferences;
 import android.util.Pair;
 
-import com.kickstarter.libs.ApiPaginator;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.ExperimentsClientType;

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/DiscoveryParamsExtKtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/DiscoveryParamsExtKtTest.kt
@@ -115,7 +115,7 @@ class DiscoveryParamsExtKtTest : KSRobolectricTestCase() {
             null,
             UserFactory.socialUser()
         )
-        assertEquals(8, data.sections().size)
+        assertEquals(7, data.sections().size)
         assertEquals(1, data.sections()[0].rows().size)
         assertEquals(1, data.sections()[1].rows().size)
         assertEquals(1, data.sections()[2].rows().size)
@@ -123,7 +123,6 @@ class DiscoveryParamsExtKtTest : KSRobolectricTestCase() {
         assertEquals(1, data.sections()[4].rows().size)
         assertEquals(1, data.sections()[5].rows().size)
         assertEquals(1, data.sections()[6].rows().size)
-        assertEquals(1, data.sections()[7].rows().size)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.java
@@ -19,10 +19,12 @@ import com.kickstarter.mock.factories.DiscoverEnvelopeFactory;
 import com.kickstarter.mock.factories.ProjectFactory;
 import com.kickstarter.mock.factories.UserFactory;
 import com.kickstarter.mock.services.MockApiClient;
+import com.kickstarter.mock.services.MockApolloClient;
 import com.kickstarter.models.Activity;
 import com.kickstarter.models.Project;
 import com.kickstarter.models.User;
 import com.kickstarter.services.ApiClientType;
+import com.kickstarter.services.ApolloClientType;
 import com.kickstarter.services.DiscoveryParams;
 import com.kickstarter.services.apiresponses.ActivityEnvelope;
 import com.kickstarter.services.apiresponses.DiscoverEnvelope;
@@ -266,7 +268,7 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
     final CurrentUserType currentUser = new MockCurrentUser();
 
     final Environment environment = environment().toBuilder()
-      .apiClient(new MockApiClient())
+      .apolloClient(new MockApolloClient())
       .currentUser(currentUser)
       .build();
 
@@ -296,19 +298,19 @@ public class DiscoveryFragmentViewModelTest extends KSRobolectricTestCase {
   @Test
   public void testShouldShowEmptySavedView_isTrue_whenUserHasNoSavedProjects() {
     final CurrentUserType currentUser = new MockCurrentUser();
-    final ApiClientType apiClient = new MockApiClient() {
+    final ApolloClientType apiClient = new MockApolloClient() {
       @Override
-      public @NonNull Observable<DiscoverEnvelope> fetchProjects(final @NonNull DiscoveryParams params) {
+      public @NonNull Observable<DiscoverEnvelope> getProjects(final @NonNull DiscoveryParams params, final String cursor) {
         if (params.isSavedProjects()) {
           return Observable.just(DiscoverEnvelopeFactory.discoverEnvelope(new ArrayList<>()));
         } else {
-          return super.fetchProjects(params);
+          return super.getProjects(params, cursor);
         }
       }
     };
 
     final Environment environment = environment().toBuilder()
-      .apiClient(apiClient)
+      .apolloClient(apiClient)
       .currentUser(currentUser)
       .build();
 


### PR DESCRIPTION
# 📲 What
- Hide from the drawer menu the options for `Backed by people you follow` until further notice.
- Exchanged V1 call to fetch projects over GraphQL

# 🤔 Why
- GraphQL migration.
- Reduce the network bandwidth the app consumes.

# 👀 See
- On this video the projects are loaded calling GraphQL

https://user-images.githubusercontent.com/4083656/151246645-5520fcbd-18e4-4a81-a2b8-5e9dbad089f6.mp4




- Drawer menu option deleted for `Backer by people you follow`
<img width="951" alt="Screen Shot 2022-01-26 at 12 58 33 PM" src="https://user-images.githubusercontent.com/4083656/151246119-39eaf5e9-22f7-4d16-8f71-952121fea8b1.png">


| Before 🐛 | After 🦋 |
| --- | --- |

- In this screenshot you can see the difference in between V1 vs GraphQL when fetching all project with sort `Magic`, in terms of size and latency
<img width="1761" alt="V1-vs-GraphQL" src="https://user-images.githubusercontent.com/4083656/151245744-75ab6571-cdc2-4abe-b850-5aab060ea813.png">


|  |  |

# 📋 QA

- launch the app without being logged, navigate a bit over the sorting tabs, and the drawer options.
- log in, navigate over every option on the drawer, and every sorting option 
- log in as creator, navigate over every option on the drawer, and every sorting option 

# Story 📖

[NTV-363](https://kickstarter.atlassian.net/browse/NTV-363)
