### PR TITLE
NTV-296: Feature flag fro Story Tab

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/models/OptimizelyFeature.kt
+++ b/app/src/main/java/com/kickstarter/libs/models/OptimizelyFeature.kt
@@ -3,6 +3,7 @@ package com.kickstarter.libs.models
 class OptimizelyFeature {
     enum class Key(val key: String) {
         LIGHTS_ON("android_lights_on"),
-        PROJECT_PAGE_V2("android_project_page_v2")
+        PROJECT_PAGE_V2("android_project_page_v2"),
+        ANDROID_STORY_TAB("android_story_tab")
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -18,7 +18,6 @@ import androidx.annotation.MenuRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
-import androidx.core.view.isGone
 import androidx.fragment.app.FragmentManager
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
@@ -35,7 +34,6 @@ import com.kickstarter.libs.ProjectPagerTabs
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ApplicationUtils
-import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.toVisibility
 import com.kickstarter.models.Project
@@ -76,12 +74,10 @@ class ProjectPageActivity :
     private val animDuration = 200L
     private lateinit var binding: ActivityProjectPageBinding
 
-    private val pagerAdapterMap = mutableMapOf(
-        ProjectPagerTabs.OVERVIEW to true,
-        ProjectPagerTabs.CAMPAIGN to true,
-        ProjectPagerTabs.FAQS to true,
-        ProjectPagerTabs.RISKS to true,
-        ProjectPagerTabs.ENVIRONMENTAL_COMMITMENT to false
+    private val pagerAdapterList = mutableListOf(
+        ProjectPagerTabs.OVERVIEW,
+        ProjectPagerTabs.FAQS,
+        ProjectPagerTabs.RISKS,
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -93,7 +89,7 @@ class ProjectPageActivity :
         // Do not configure the pager at other lifecycle events apart from OnCreate
         if (savedInstanceState == null) {
             // - Configure pager on load, otherwise the first fragment on the pager gets no data
-            configurePager()
+            configurePager(pagerAdapterList)
         }
 
         val viewTreeObserver = binding.pledgeContainerLayout.pledgeContainerRoot.viewTreeObserver
@@ -128,17 +124,17 @@ class ProjectPageActivity :
                 (binding.projectPager.adapter as ProjectPagerAdapter).updatedWithProjectData(it)
             }
 
-        this.viewModel.outputs.updateEnvCommitmentsTabVisibility()
-            .filter { ObjectUtils.isNotNull(it) }
-            .map { requireNotNull(it) }
-            .distinctUntilChanged()
+        this.viewModel.outputs.updateTabs()
             .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe { isGone ->
-                if (!isGone) {
-                    pagerAdapterMap[ProjectPagerTabs.ENVIRONMENTAL_COMMITMENT] = !isGone
+            .subscribe { updateTabs ->
+                if (updateTabs.first) {
+                    pagerAdapterList.add(ProjectPagerTabs.CAMPAIGN.ordinal, ProjectPagerTabs.CAMPAIGN)
                 }
-                configurePager()
+                if (updateTabs.second) {
+                    pagerAdapterList.add(ProjectPagerTabs.ENVIRONMENTAL_COMMITMENT)
+                }
+                configurePager(pagerAdapterList)
             }
 
         this.viewModel.outputs.backingDetailsSubtitle()
@@ -360,14 +356,14 @@ class ProjectPageActivity :
         }
     }
 
-    private fun configurePager() {
+    private fun configurePager(pagerList: List<ProjectPagerTabs>) {
         val viewPager = binding.projectPager
         val tabLayout = binding.projectDetailTabs
 
-        viewPager.adapter = ProjectPagerAdapter(supportFragmentManager, pagerAdapterMap, lifecycle)
+        viewPager.adapter = ProjectPagerAdapter(supportFragmentManager, pagerList, lifecycle)
 
         TabLayoutMediator(tabLayout, viewPager) { tab, position ->
-            tab.text = getTabTitle(position)
+            tab.text = getTabTitle(position, pagerList)
         }.attach()
 
         tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
@@ -386,12 +382,6 @@ class ProjectPageActivity :
                 // Handle tab unselect
             }
         })
-
-        pagerAdapterMap.forEach { entry ->
-            binding.projectDetailTabs.getTabAt(
-                entry.key.ordinal
-            )?.view?.isGone = !entry.value
-        }
     }
 
     override fun onResume() {
@@ -460,13 +450,12 @@ class ProjectPageActivity :
         return Pair.create(R.anim.fade_in_slide_in_left, R.anim.slide_out_right)
     }
 
-    private fun getTabTitle(position: Int) = when (position) {
-        ProjectPagerTabs.OVERVIEW.ordinal -> getString(R.string.Overview)
-        ProjectPagerTabs.CAMPAIGN.ordinal -> getString(R.string.Campaign)
-        ProjectPagerTabs.FAQS.ordinal -> getString(R.string.Faq)
-        ProjectPagerTabs.RISKS.ordinal -> getString(R.string.Risks)
-        ProjectPagerTabs.ENVIRONMENTAL_COMMITMENT.ordinal -> getString(R.string.Environmental_commitments)
-        else -> ""
+    private fun getTabTitle(position: Int, pagerList: List<ProjectPagerTabs>) = when (pagerList[position]) {
+        ProjectPagerTabs.OVERVIEW -> getString(R.string.Overview)
+        ProjectPagerTabs.CAMPAIGN -> getString(R.string.Campaign)
+        ProjectPagerTabs.FAQS -> getString(R.string.Faq)
+        ProjectPagerTabs.RISKS -> getString(R.string.Risks)
+        ProjectPagerTabs.ENVIRONMENTAL_COMMITMENT -> getString(R.string.Environmental_commitments)
     }
 
     private fun animateScrimVisibility(show: Boolean) {
@@ -626,24 +615,24 @@ class ProjectPageActivity :
         }
 
         binding.pledgeContainerLayout.pledgeToolbar.setOnMenuItemClickListener {
-            when {
-                it.itemId == R.id.update_pledge -> {
+            when (it.itemId) {
+                R.id.update_pledge -> {
                     this.viewModel.inputs.updatePledgeClicked()
                     true
                 }
-                it.itemId == R.id.rewards -> {
+                R.id.rewards -> {
                     this.viewModel.inputs.viewRewardsClicked()
                     true
                 }
-                it.itemId == R.id.update_payment -> {
+                R.id.update_payment -> {
                     this.viewModel.inputs.updatePaymentClicked()
                     true
                 }
-                it.itemId == R.id.cancel_pledge -> {
+                R.id.cancel_pledge -> {
                     this.viewModel.inputs.cancelPledgeClicked()
                     true
                 }
-                it.itemId == R.id.contact_creator -> {
+                R.id.contact_creator -> {
                     this.viewModel.inputs.contactCreatorClicked()
                     true
                 }
@@ -789,8 +778,8 @@ class ProjectPageActivity :
             val rewardsFragment = rewardsFragment()
             val backingFragment = backingFragment()
             if (rewardsFragment != null && backingFragment != null) {
-                when {
-                    supportFragmentManager.backStackEntryCount == 0 -> when {
+                when (supportFragmentManager.backStackEntryCount) {
+                    0 -> when {
                         projectData.project().isBacking() -> if (!rewardsFragment.isHidden) {
                             supportFragmentManager.beginTransaction()
                                 .show(backingFragment)

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -76,17 +76,12 @@ class ProjectPageActivity :
     private val animDuration = 200L
     private lateinit var binding: ActivityProjectPageBinding
 
-    private var pagerAdapterMap = mutableMapOf(
+    private val pagerAdapterMap = mutableMapOf(
         ProjectPagerTabs.OVERVIEW to true,
         ProjectPagerTabs.CAMPAIGN to true,
         ProjectPagerTabs.FAQS to true,
         ProjectPagerTabs.RISKS to true,
         ProjectPagerTabs.ENVIRONMENTAL_COMMITMENT to false
-    )
-
-    private var pagerAdapter = ProjectPagerAdapter(
-        supportFragmentManager, pagerAdapterMap,
-        lifecycle
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -130,7 +125,7 @@ class ProjectPageActivity :
             .subscribe {
                 // - Every time the ProjectData gets updated
                 // - the fragments on the viewPager are updated as well
-                pagerAdapter.updatedWithProjectData(it)
+                (binding.projectPager.adapter as ProjectPagerAdapter).updatedWithProjectData(it)
             }
 
         this.viewModel.outputs.updateEnvCommitmentsTabVisibility()
@@ -373,9 +368,7 @@ class ProjectPageActivity :
         val viewPager = binding.projectPager
         val tabLayout = binding.projectDetailTabs
 
-        pagerAdapter = ProjectPagerAdapter(supportFragmentManager, pagerAdapterMap, lifecycle)
-
-        viewPager.adapter = pagerAdapter
+        viewPager.adapter = ProjectPagerAdapter(supportFragmentManager, pagerAdapterMap, lifecycle)
 
         TabLayoutMediator(tabLayout, viewPager) { tab, position ->
             tab.text = getTabTitle(position)

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -135,10 +135,6 @@ class ProjectPageActivity :
             .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { isGone ->
-                binding.projectDetailTabs.getTabAt(
-                    ProjectPagerTabs.ENVIRONMENTAL_COMMITMENT
-                        .ordinal
-                )?.view?.isGone = isGone
                 if (!isGone) {
                     pagerAdapterMap[ProjectPagerTabs.ENVIRONMENTAL_COMMITMENT] = !isGone
                 }
@@ -390,6 +386,12 @@ class ProjectPageActivity :
                 // Handle tab unselect
             }
         })
+
+        pagerAdapterMap.forEach { entry ->
+            binding.projectDetailTabs.getTabAt(
+                entry.key.ordinal
+            )?.view?.isGone = !entry.value
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/kickstarter/ui/adapters/ProjectPagerAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/ProjectPagerAdapter.kt
@@ -15,26 +15,25 @@ import com.kickstarter.ui.fragments.projectpage.ProjectRiskFragment
 
 class ProjectPagerAdapter(
     private val fragmentManager: FragmentManager,
-    private val pagerAdapterMap: MutableMap<ProjectPagerTabs, Boolean>,
+    private val pagerAdapterList: List<ProjectPagerTabs>,
     lifecycle: Lifecycle
 ) :
     FragmentStateAdapter(fragmentManager, lifecycle) {
 
-    override fun getItemCount(): Int = pagerAdapterMap.count { it.value }
+    override fun getItemCount(): Int = pagerAdapterList.size
 
     override fun createFragment(position: Int): Fragment {
-        return when {
-            position == ProjectPagerTabs.OVERVIEW.ordinal && pagerAdapterMap[ProjectPagerTabs.OVERVIEW] == true ->
+        return when (pagerAdapterList[position]) {
+            ProjectPagerTabs.OVERVIEW ->
                 ProjectOverviewFragment.newInstance(position)
-            position == ProjectPagerTabs.FAQS.ordinal && pagerAdapterMap[ProjectPagerTabs.FAQS] == true ->
+            ProjectPagerTabs.FAQS ->
                 FrequentlyAskedQuestionFragment.newInstance(position)
-            position == ProjectPagerTabs.CAMPAIGN.ordinal && pagerAdapterMap[ProjectPagerTabs.CAMPAIGN] == true ->
+            ProjectPagerTabs.CAMPAIGN ->
                 ProjectCampaignFragment.newInstance(position)
-            position == ProjectPagerTabs.RISKS.ordinal && pagerAdapterMap[ProjectPagerTabs.RISKS] == true ->
+            ProjectPagerTabs.RISKS ->
                 ProjectRiskFragment.newInstance(position)
-            position == ProjectPagerTabs.ENVIRONMENTAL_COMMITMENT.ordinal && pagerAdapterMap[ProjectPagerTabs.ENVIRONMENTAL_COMMITMENT] == true ->
+            ProjectPagerTabs.ENVIRONMENTAL_COMMITMENT ->
                 ProjectEnvironmentalCommitmentsFragment.newInstance(position)
-            else -> ProjectOverviewFragment.newInstance(position)
         }
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
@@ -15,6 +15,7 @@ import com.kickstarter.libs.KSCurrency
 import com.kickstarter.libs.ProjectPagerTabs
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.models.OptimizelyExperiment
+import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
 import com.kickstarter.libs.rx.transformers.Transformers.errors
 import com.kickstarter.libs.rx.transformers.Transformers.ignoreValues
@@ -45,7 +46,6 @@ import com.kickstarter.models.Backing
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.User
-import com.kickstarter.services.ApiClientType
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.ProjectPageActivity
 import com.kickstarter.ui.data.CheckoutData
@@ -245,7 +245,8 @@ interface ProjectPageViewModel {
         /** Emits when the backing view group should be gone. */
         fun backingViewGroupIsVisible(): Observable<Boolean>
 
-        fun updateEnvCommitmentsTabVisibility(): Observable<Boolean>
+        /** Will emmit the need to show/hide the Campaign Tab and the Environmental Tab. */
+        fun updateTabs(): Observable<Pair<Boolean, Boolean>>
 
         fun hideVideoPlayer(): Observable<Boolean>
     }
@@ -254,7 +255,7 @@ interface ProjectPageViewModel {
         ActivityViewModel<ProjectPageActivity>(environment),
         Inputs,
         Outputs {
-        private val client: ApiClientType = environment.apiClient()
+
         private val cookieManager: CookieManager = environment.cookieManager()
         private val currentUser: CurrentUserType = environment.currentUser()
         private val ksCurrency: KSCurrency = environment.ksCurrency()
@@ -325,7 +326,7 @@ interface ProjectPageViewModel {
         private val projectPhoto = PublishSubject.create<String>()
         private val playButtonIsVisible = PublishSubject.create<Boolean>()
         private val backingViewGroupIsVisible = PublishSubject.create<Boolean>()
-        private val updateEnvCommitmentsTabVisibility = PublishSubject.create<Boolean>()
+        private val updateTabs = PublishSubject.create<Pair<Boolean, Boolean>>()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -485,10 +486,13 @@ interface ProjectPageViewModel {
             }
 
             currentProjectData
+                .distinctUntilChanged()
                 .compose(bindToLifecycle())
                 .subscribe {
                     this.projectData.onNext(it)
-                    this.updateEnvCommitmentsTabVisibility.onNext(it.project().envCommitments()?.isNullOrEmpty())
+                    val showEnvironmentalTab = it.project().envCommitments()?.isNotEmpty() ?: false
+                    val showCampaignTab = this.optimizely.isFeatureEnabled(OptimizelyFeature.Key.ANDROID_STORY_TAB)
+                    this.updateTabs.onNext(Pair(showCampaignTab, showEnvironmentalTab))
                 }
 
             currentProject
@@ -1115,8 +1119,7 @@ interface ProjectPageViewModel {
         override fun startVideoActivity(): Observable<Project> = this.startVideoActivity
 
         @NonNull
-        override fun updateEnvCommitmentsTabVisibility(): Observable<Boolean> = this
-            .updateEnvCommitmentsTabVisibility
+        override fun updateTabs(): Observable<Pair<Boolean, Boolean>> = this.updateTabs
 
         @NonNull
         override fun hideVideoPlayer(): Observable<Boolean> = this.hideVideoPlayer

--- a/app/src/main/res/layout/activity_project_page.xml
+++ b/app/src/main/res/layout/activity_project_page.xml
@@ -168,26 +168,6 @@
             app:tabIndicatorColor="@color/kds_trust_500"
             app:tabMaxWidth="0dp"
             app:tabMode="scrollable">
-
-            <com.google.android.material.tabs.TabItem
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/Overview" />
-
-            <com.google.android.material.tabs.TabItem
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/Campaign" />
-
-            <com.google.android.material.tabs.TabItem
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/Faq" />
-
-            <com.google.android.material.tabs.TabItem
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/Environmental_commitments" />
         </com.google.android.material.tabs.TabLayout>
 
         <androidx.viewpager2.widget.ViewPager2

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
@@ -11,6 +11,7 @@ import com.kickstarter.libs.Either
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUser
 import com.kickstarter.libs.models.OptimizelyExperiment
+import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.BackingFactory
@@ -289,6 +290,55 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
 
         this.updateTabs.assertValue(Pair(false, true))
     }
+
+    @Test
+    fun testUIOutputs_whenFetchProjectWithEnvCommitmentAndStoryTabFFDisabled() {
+        val initialProject = ProjectFactory.project()
+        val refreshedProject = ProjectFactory.project()
+        val mockExperimentsClientType: MockExperimentsClientType =
+            object : MockExperimentsClientType() {
+                override fun isFeatureEnabled(feature: OptimizelyFeature.Key): Boolean {
+                    return false
+                }
+            }
+
+        val environment = environment()
+            .toBuilder()
+            .optimizely(mockExperimentsClientType)
+            .apolloClient(apiClientWithSuccessFetchingProject(refreshedProject))
+            .build()
+
+        setUpEnvironment(environment)
+
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, initialProject))
+
+        this.updateTabs.assertValue(Pair(false, true))
+    }
+
+    @Test
+    fun testUIOutputs_whenFetchProjectWithEnvCommitmentAndStoryTabFFEnabled() {
+        val initialProject = ProjectFactory.project()
+        val refreshedProject = ProjectFactory.project()
+        val mockExperimentsClientType: MockExperimentsClientType =
+            object : MockExperimentsClientType() {
+                override fun isFeatureEnabled(feature: OptimizelyFeature.Key): Boolean {
+                    return true
+                }
+            }
+
+        val environment = environment()
+            .toBuilder()
+            .optimizely(mockExperimentsClientType)
+            .apolloClient(apiClientWithSuccessFetchingProject(refreshedProject))
+            .build()
+
+        setUpEnvironment(environment)
+
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, initialProject))
+
+        this.updateTabs.assertValue(Pair(true, true))
+    }
+
     @Test
     fun testUIOutputs_whenFetchProjectFromIntent_isUnsuccessful() {
         var error = true

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
@@ -69,21 +69,19 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
     private val showShareSheet = TestSubscriber<Pair<String, String>>()
     private val showUpdatePledge = TestSubscriber<Pair<PledgeData, PledgeReason>>()
     private val showUpdatePledgeSuccess = TestSubscriber<Void>()
-    private val startCampaignWebViewActivity = TestSubscriber<ProjectData>()
     private val startRootCommentsActivity = TestSubscriber<Pair<Project, ProjectData>>()
     private val startRootCommentsForCommentsThreadActivity = TestSubscriber<Pair<String, Pair<Project, ProjectData>>>()
     private val startProjectUpdateActivity = TestSubscriber< Pair<Pair<String, Boolean>, Pair<Project, ProjectData>>>()
     private val startProjectUpdateToRepliesDeepLinkActivity = TestSubscriber<Pair<Pair<String, String>, Pair<Project, ProjectData>>>()
     private val startLoginToutActivity = TestSubscriber<Void>()
     private val startMessagesActivity = TestSubscriber<Project>()
-    private val startProjectUpdatesActivity = TestSubscriber<Pair<Project, ProjectData>>()
     private val startThanksActivity = TestSubscriber<Pair<CheckoutData, PledgeData>>()
     private val startVideoActivity = TestSubscriber<Project>()
     private val updateFragments = TestSubscriber<ProjectData>()
     private val projectPhoto = TestSubscriber<String>()
     private val playButtonIsVisible = TestSubscriber<Boolean>()
     private val backingViewGroupIsVisible = TestSubscriber<Boolean>()
-    private val updateEnvCommitmentsTabVisibility = TestSubscriber<Boolean>()
+    private val updateTabs = TestSubscriber<Pair<Boolean, Boolean>>()
     private val hideVideoPlayer = TestSubscriber<Boolean>()
 
     private fun setUpEnvironment(environment: Environment) {
@@ -124,7 +122,7 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.updateFragments().subscribe(this.updateFragments)
         this.vm.outputs.startRootCommentsForCommentsThreadActivity().subscribe(this.startRootCommentsForCommentsThreadActivity)
         this.vm.outputs.startProjectUpdateToRepliesDeepLinkActivity().subscribe(this.startProjectUpdateToRepliesDeepLinkActivity)
-        this.vm.outputs.updateEnvCommitmentsTabVisibility().subscribe(this.updateEnvCommitmentsTabVisibility)
+        this.vm.outputs.updateTabs().subscribe(this.updateTabs)
         this.vm.outputs.projectPhoto().subscribe(this.projectPhoto)
         this.vm.outputs.playButtonIsVisible().subscribe(this.playButtonIsVisible)
         this.vm.outputs.backingViewGroupIsVisible().subscribe(this.backingViewGroupIsVisible)
@@ -273,7 +271,7 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, initialProject))
 
-        this.updateEnvCommitmentsTabVisibility.assertValues(true)
+        this.updateTabs.assertValue(Pair(false, false))
     }
 
     @Test
@@ -289,7 +287,7 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
 
         this.vm.intent(Intent().putExtra(IntentKey.PROJECT, initialProject))
 
-        this.updateEnvCommitmentsTabVisibility.assertValues(false)
+        this.updateTabs.assertValue(Pair(false, true))
     }
     @Test
     fun testUIOutputs_whenFetchProjectFromIntent_isUnsuccessful() {


### PR DESCRIPTION
# 📲 What

- Added feature flag to show/hide the campaign tab.
- Small refactor, in how we show/hide tabs, group together when to update tabs to reduce the number of times the pager needs to be configured.


# 👀 See
- Feature Flag Enable, on the video you can see a project without environmental commitments, and a project with environmental commitments: 

https://user-images.githubusercontent.com/4083656/152074346-8f6b0577-d2f0-4d69-9569-0aa46b2d26d0.mp4




- Feature Flag Disabled, on the video you can see a project without environmental commitments, and a project with environmental commitments:

https://user-images.githubusercontent.com/4083656/152074051-a99eae48-e5f0-45e2-b3cd-69dd5dd79110.mp4



|  |  |

# 📋 QA
- Check when there is "Environmental Commitments" the tab shows
- Use optimizely dashboard to activate/deactivate the feature flag on stagin, and check the tab shows/hide on the app

# Story 📖

[NTV-296](https://kickstarter.atlassian.net/browse/NTV-296)
