### PR TITLE
[no-jira]: percentage funded

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -28,6 +28,9 @@ fragment projectCard on Project {
     goal {
         ... amount
     }
+    pledged {
+        ... amount
+    }
     id
     isWatched
     launchedAt

--- a/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
@@ -434,6 +434,7 @@ fun projectTransformer(projectFragment: ProjectCard?): Project {
     val friends =
         projectFragment?.friends()?.nodes()?.map { userTransformer(it.fragments().user()) }
             ?: emptyList()
+    val pledged = projectFragment?.pledged()?.fragments()?.amount()?.amount()?.toDouble() ?: 0.0
     val fxRate = projectFragment?.fxRate()?.toFloat()
     val deadline = projectFragment?.deadlineAt()
     val goal = projectFragment?.goal()?.fragments()?.amount()?.amount()?.toDouble() ?: 0.0
@@ -471,6 +472,7 @@ fun projectTransformer(projectFragment: ProjectCard?): Project {
         .friends(friends)
         .fxRate(fxRate)
         .deadline(deadline)
+        .pledged(pledged)
         .goal(goal)
         .id(id)
         .isBacking(isBacking)


### PR DESCRIPTION
# 📲 What

- The percentage was missing after the migration to GraphQL

# 🤔 Why

- `percentage` field was not queried


# 👀 See
| Before 🐛 | A
<img width="1082" alt="Screen Shot 2022-02-03 at 3 56 39 PM" src="https://user-images.githubusercontent.com/4083656/152449238-98ca4d28-6a84-40a0-ae87-581aa0ad9127.png">
fter 🦋 |

|  |  |

# 📋 QA

- Check the percentage and progress bar are loading correctly

