### PR TITLE
NTV-360: Zoom on campaign images

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -268,6 +268,9 @@ dependencies {
     implementation 'com.google.firebase:firebase-inappmessaging-display'
     implementation 'com.google.firebase:firebase-perf'
 
+    // Zoom on Images
+    implementation 'io.github.aghajari:ZoomHelper:1.1.0'
+
     // Testing
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-core:4.0.0"

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -19,6 +19,7 @@ import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentManager
+import com.aghajari.zoomhelper.ZoomHelper
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import com.google.firebase.crashlytics.FirebaseCrashlytics
@@ -402,6 +403,10 @@ class ProjectPageActivity :
     }
 
     override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
+        event?.let {
+            ZoomHelper.getInstance().dispatchTouchEvent(it, this)
+        }
+
         if (event?.action == MotionEvent.ACTION_DOWN) {
             val view = currentFocus
             if (view is EditText || view?.parent is CardInputWidget) {

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -2,23 +2,52 @@ package com.kickstarter.ui.extensions
 
 import android.content.Context
 import android.widget.ImageView
+import androidx.appcompat.widget.AppCompatImageView
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.kickstarter.R
 import com.kickstarter.libs.transformations.CircleTransformation
 import com.kickstarter.libs.utils.extensions.isKSApplication
+import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
 
 fun ImageView.loadCircleImage(url: String?) {
     url?.let {
+        val target = this
         Picasso.get().load(it)
             .transform(CircleTransformation())
-            .into(this)
+            .into(
+                this,
+                object : Callback {
+                    override fun onSuccess() {
+                    }
+
+                    override fun onError(e: Exception?) {
+                        target.setImageResource(R.drawable.image_placeholder)
+                    }
+                }
+            )
     }
 }
 
-fun ImageView.loadImage(url: String?, context: Context) {
+fun ImageView.loadImage(url: String?, context: Context, imageViewPlaceholder: AppCompatImageView? = null) {
+    val target = this
     if (context.applicationContext.isKSApplication()) {
-        Picasso.get().load(url).into(this)
+        Picasso.get().load(url).into(
+            this,
+            object : Callback {
+                override fun onSuccess() {
+                    imageViewPlaceholder?.background = target.background
+                }
+
+                override fun onError(e: Exception?) {
+                    target.setImageResource(R.drawable.image_placeholder)
+                }
+            }
+        )
+        imageViewPlaceholder?.let {
+            Picasso.get().load(url).into(it)
+        }
     } else {
         this.setImageResource(R.drawable.image_placeholder)
     }
@@ -28,6 +57,8 @@ fun ImageView.loadGifImage(url: String?, context: Context) {
     if (context.applicationContext.isKSApplication()) {
         Glide.with(context)
             .asGif()
+            .error(R.drawable.image_placeholder)
+            .diskCacheStrategy(DiskCacheStrategy.ALL)
             .load(url)
             .into(this)
     } else {

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -17,17 +17,7 @@ fun ImageView.loadCircleImage(url: String?) {
         val target = this
         Picasso.get().load(it)
             .transform(CircleTransformation())
-            .into(
-                this,
-                object : Callback {
-                    override fun onSuccess() {
-                    }
-
-                    override fun onError(e: Exception?) {
-                        target.setImageResource(R.drawable.image_placeholder)
-                    }
-                }
-            )
+            .into(this)
     }
 }
 
@@ -42,13 +32,11 @@ fun ImageView.loadImage(url: String?, context: Context, imageViewPlaceholder: Ap
                 }
 
                 override fun onError(e: Exception?) {
-                    target.setImageResource(R.drawable.image_placeholder)
                 }
             }
         )
     } else {
         this.setImageResource(R.drawable.image_placeholder)
-        imageViewPlaceholder?.setImageBitmap(target.drawable.toBitmap())
     }
 }
 

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -43,11 +43,13 @@ fun ImageView.loadImage(url: String?, context: Context, imageViewPlaceholder: Ap
 
                 override fun onError(e: Exception?) {
                     target.setImageResource(R.drawable.image_placeholder)
+                    imageViewPlaceholder?.setImageBitmap(target.drawable.toBitmap())
                 }
             }
         )
     } else {
         this.setImageResource(R.drawable.image_placeholder)
+        imageViewPlaceholder?.setImageBitmap(target.drawable.toBitmap())
     }
 }
 

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -43,7 +43,6 @@ fun ImageView.loadImage(url: String?, context: Context, imageViewPlaceholder: Ap
 
                 override fun onError(e: Exception?) {
                     target.setImageResource(R.drawable.image_placeholder)
-                    imageViewPlaceholder?.setImageBitmap(target.drawable.toBitmap())
                 }
             }
         )

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -3,6 +3,7 @@ package com.kickstarter.ui.extensions
 import android.content.Context
 import android.widget.ImageView
 import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.graphics.drawable.toBitmap
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.kickstarter.R
@@ -10,6 +11,7 @@ import com.kickstarter.libs.transformations.CircleTransformation
 import com.kickstarter.libs.utils.extensions.isKSApplication
 import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
+
 
 fun ImageView.loadCircleImage(url: String?) {
     url?.let {
@@ -37,7 +39,7 @@ fun ImageView.loadImage(url: String?, context: Context, imageViewPlaceholder: Ap
             this,
             object : Callback {
                 override fun onSuccess() {
-                    imageViewPlaceholder?.background = target.background
+                    imageViewPlaceholder?.setImageBitmap(target.drawable.toBitmap())
                 }
 
                 override fun onError(e: Exception?) {
@@ -45,9 +47,6 @@ fun ImageView.loadImage(url: String?, context: Context, imageViewPlaceholder: Ap
                 }
             }
         )
-        imageViewPlaceholder?.let {
-            Picasso.get().load(url).into(it)
-        }
     } else {
         this.setImageResource(R.drawable.image_placeholder)
     }

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -12,7 +12,6 @@ import com.kickstarter.libs.utils.extensions.isKSApplication
 import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
 
-
 fun ImageView.loadCircleImage(url: String?) {
     url?.let {
         val target = this

--- a/app/src/main/java/com/kickstarter/ui/views/ImageWithCaptionView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/ImageWithCaptionView.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.ui.views
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -7,6 +8,7 @@ import android.view.View
 import android.view.View.OnClickListener
 import androidx.cardview.widget.CardView
 import androidx.core.view.isVisible
+import com.aghajari.zoomhelper.ZoomHelper
 import com.kickstarter.R
 import com.kickstarter.databinding.ViewImageWithCaptionBinding
 import com.kickstarter.libs.utils.extensions.isGif
@@ -14,6 +16,7 @@ import com.kickstarter.ui.extensions.loadGifImage
 import com.kickstarter.ui.extensions.loadImage
 import com.kickstarter.ui.extensions.makeLinks
 
+@SuppressLint("ClickableViewAccessibility")
 class ImageWithCaptionView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -26,6 +29,10 @@ class ImageWithCaptionView @JvmOverloads constructor(
             LayoutInflater.from(context),
             this, true
         )
+
+    init {
+        ZoomHelper.addZoomableView(binding.imageView)
+    }
 
     fun setImage(src: String) {
         if (src.isGif()) {

--- a/app/src/main/java/com/kickstarter/ui/views/ImageWithCaptionView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/ImageWithCaptionView.kt
@@ -30,15 +30,13 @@ class ImageWithCaptionView @JvmOverloads constructor(
             this, true
         )
 
-    init {
-        ZoomHelper.addZoomableView(binding.imageView)
-    }
-
     fun setImage(src: String) {
         if (src.isGif()) {
             binding.imageView.loadGifImage(src, context)
         } else {
-            binding.imageView.loadImage(src, context)
+            binding.imageView.loadImage(src, context, binding.imageViewPlaceholder)
+            ZoomHelper.addZoomableView(binding.imageView)
+            ZoomHelper.removeZoomableView(binding.imageViewPlaceholder)
         }
     }
 

--- a/app/src/main/res/layout/view_image_with_caption.xml
+++ b/app/src/main/res/layout/view_image_with_caption.xml
@@ -27,6 +27,13 @@
         app:layout_constraintTop_toTopOf="parent"
         android:contentDescription="@null" />
 
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="image_view_placeholder,image_view" />
+
     <androidx.appcompat.widget.AppCompatTextView
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -39,6 +46,6 @@
         android:textIsSelectable="true"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/image_view_placeholder" />
+        app:layout_constraintTop_toBottomOf="@+id/barrier" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_image_with_caption.xml
+++ b/app/src/main/res/layout/view_image_with_caption.xml
@@ -1,15 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/image_with_caption_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/image_view_placeholder"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        android:contentDescription="@null"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/image_view"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
+        android:src="@drawable/image_placeholder"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
@@ -27,6 +39,6 @@
         android:textIsSelectable="true"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/image_view" />
+        app:layout_constraintTop_toBottomOf="@+id/image_view_placeholder" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.0'
+        classpath 'com.android.tools.build:gradle:7.1.1'
         classpath 'com.google.gms:google-services:4.3.10'
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
# 📲 What

- Zoomimg images on campaign tab

# 🛠 How
- Added new dependency
- Added placeholder below the zooming image, as it was causing jumps up and down when resizing the image out of the layout.

# 👀 See

https://user-images.githubusercontent.com/4083656/153312882-2de2be8e-acfd-4618-942b-40b645ae4f2c.mp4


|  |  |

# 📋 QA

- Go into any campaign and zoom some of the images.

# Story 📖

[NTV-360](https://kickstarter.atlassian.net/browse/NTV-360)
