### PR TITLE
NTV-350 :Add Save Project deep link

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -182,9 +182,22 @@
             android:parentActivityName=".ui.activities.DiscoveryActivity"
             android:theme="@style/ProjectActivity"
             android:screenOrientation="portrait"
+            android:exported="true"
             android:configChanges="screenSize|orientation"
             android:windowSoftInputMode="adjustResize"
-            tools:ignore="LockedOrientationActivity" />
+            tools:ignore="LockedOrientationActivity" >
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="*.kickstarter.com"
+                    android:pathPrefix="/projects/"
+                    android:scheme="ksr" />
+            </intent-filter>
+        </activity>
         <activity
             android:name=".ui.activities.ProjectNotificationSettingsActivity"
             android:parentActivityName=".ui.activities.SettingsActivity"

--- a/app/src/main/java/com/kickstarter/libs/utils/UrlUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/UrlUtils.kt
@@ -10,6 +10,7 @@ object UrlUtils {
 
     private const val KEY_REF = "ref"
     private const val KEY_COMMENT = "comment"
+    private const val KEY_SAVE = "save"
 
     fun appendPath(baseUrl: String, path: String): String {
         val uriBuilder = Uri.parse(baseUrl).buildUpon()
@@ -44,5 +45,9 @@ object UrlUtils {
 
     fun commentId(url: String): String? {
         return Uri.parse(url).getQueryParameter(KEY_COMMENT)
+    }
+
+    fun saveFlag(url: String): Boolean? {
+        return Uri.parse(url).getQueryParameter(KEY_SAVE)?.equals("true")
     }
 }

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/UriExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/UriExt.kt
@@ -135,6 +135,12 @@ fun Uri.isProjectCommentUri(webEndpoint: String): Boolean {
         .matches()
 }
 
+fun Uri.isProjectSaveUri(webEndpoint: String): Boolean {
+    return isKickstarterUri(webEndpoint) &&
+        PROJECT_PATTERN.matcher(path()).matches() &&
+        PROJECT_SAVE_QUERY_PATTERN.matcher(query()).matches()
+}
+
 fun Uri.isProjectUpdateCommentsUri(webEndpoint: String): Boolean {
     return isKickstarterUri(webEndpoint) && PROJECT_UPDATE_COMMENTS_PATTERN.matcher(path()).matches()
 }
@@ -210,6 +216,11 @@ private val PROJECT_REWARD_FULFILLMENT = Pattern.compile(
 // /projects/:creator_param/:project_param/comments
 private val PROJECT_COMMENTS_PATTERN = Pattern.compile(
     "\\A\\/projects(\\/[a-zA-Z0-9_-]+)?\\/[a-zA-Z0-9_-]+\\/comments\\z"
+)
+
+// save=true|false
+private val PROJECT_SAVE_QUERY_PATTERN = Pattern.compile(
+    "save(\\=[a-zA-Z]+)"
 )
 
 // /projects/:creator_param/:project_param/posts/:update_param/comments

--- a/app/src/main/java/com/kickstarter/ui/IntentKey.java
+++ b/app/src/main/java/com/kickstarter/ui/IntentKey.java
@@ -44,6 +44,8 @@ public final class IntentKey {
   public static final String REPLY_EXPAND = "com.kickstarter.kickstarter.intent_reply_expand";
   public static final String REPLY_SCROLL_BOTTOM = "com.kickstarter.kickstarter.intent_reply_scroll_bottom";
   public static final String DEEP_LINK_SCREEN_PROJECT_COMMENT = "com.kickstarter.kickstarter.deep_link_screen_project_comment";
+  public static final String DEEP_LINK_SCREEN_PROJECT_SAVE = "com.kickstarter.kickstarter.save";
+  public static final String SAVE_FLAG_VALUE = "com.kickstarter.kickstarter.intent_save_flag_value";
   public static final String DEEP_LINK_SCREEN_PROJECT_UPDATE = "com.kickstarter.kickstarter.deep_link_screen_project_update";
   public static final String DEEP_LINK_SCREEN_PROJECT_UPDATE_COMMENT = "com.kickstarter.kickstarter.deep_link_screen_project_update_comment";
   public static final String VIDEO_SEEK_POSITION = "com.kickstarter.kickstarter.intent_video_seek_position";

--- a/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.kt
@@ -10,6 +10,8 @@ import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ApplicationUtils
 import com.kickstarter.libs.utils.UrlUtils.commentId
 import com.kickstarter.libs.utils.UrlUtils.refTag
+import com.kickstarter.libs.utils.UrlUtils.saveFlag
+import com.kickstarter.libs.utils.extensions.getProjectIntent
 import com.kickstarter.libs.utils.extensions.path
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.viewmodels.DeepLinkViewModel
@@ -36,6 +38,11 @@ class DeepLinkActivity : BaseActivity<DeepLinkViewModel.ViewModel?>() {
             .compose(bindToLifecycle())
             .compose(Transformers.observeForUI())
             .subscribe { uri: Uri -> startProjectActivity(uri) }
+
+        viewModel.outputs.startProjectActivityToSave()
+            .compose(bindToLifecycle())
+            .compose(Transformers.observeForUI())
+            .subscribe { startProjectActivityForSave(it.first, it.second) }
 
         viewModel.outputs.startProjectActivityForComment()
             .compose(bindToLifecycle())
@@ -84,6 +91,19 @@ class DeepLinkActivity : BaseActivity<DeepLinkViewModel.ViewModel?>() {
 
     private fun startProjectActivity(uri: Uri) {
         startActivity(projectIntent(uri))
+        finish()
+    }
+
+    private fun startProjectActivityForSave(uri: Uri, isFfEnabled: Boolean) {
+        val projectIntent = Intent().getProjectIntent(this, isFfEnabled)
+            .setData(uri)
+            .putExtra(IntentKey.DEEP_LINK_SCREEN_PROJECT_SAVE, true)
+
+        saveFlag(uri.toString())?.let {
+            projectIntent.putExtra(IntentKey.SAVE_FLAG_VALUE, it)
+        }
+
+        startActivity(projectIntent)
         finish()
     }
 

--- a/app/src/main/java/com/kickstarter/ui/intentmappers/ProjectIntentMapper.kt
+++ b/app/src/main/java/com/kickstarter/ui/intentmappers/ProjectIntentMapper.kt
@@ -72,6 +72,13 @@ object ProjectIntentMapper {
     }
 
     /**
+     * Returns a [deepLinkSaveFlag] observable. If there is no deepLink Save Flag
+     */
+    fun deepLinkSaveFlag(intent: Intent): Observable<Boolean> {
+        return Observable.just(intent.getBooleanExtra(IntentKey.SAVE_FLAG_VALUE, false))
+    }
+
+    /**
      * Returns an observable of push notification envelopes from the intent data. This will emit only when the project
      * is launched from a push notification.
      */

--- a/app/src/main/java/com/kickstarter/ui/intentmappers/ProjectIntentMapper.kt
+++ b/app/src/main/java/com/kickstarter/ui/intentmappers/ProjectIntentMapper.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.utils.ObjectUtils
+import com.kickstarter.libs.utils.extensions.query
 import com.kickstarter.models.Project
 import com.kickstarter.services.ApiClientType
 import com.kickstarter.services.ApolloClientType
@@ -19,6 +20,10 @@ object ProjectIntentMapper {
     // /projects/param-1/param-2*
     val PROJECT_PATTERN =
         Pattern.compile("\\A\\/projects\\/([a-zA-Z0-9_-]+)(\\/([a-zA-Z0-9_-]+)).*")
+
+    private val PROJECT_SAVE_QUERY_PATTERN = Pattern.compile(
+        "save(\\=[a-zA-Z]+)"
+    )
 
     fun project(intent: Intent, apolloClient: ApolloClientType): Observable<Project> {
         val intentProject = projectFromIntent(intent)
@@ -119,5 +124,22 @@ object ProjectIntentMapper {
         return if (matcher.matches() && matcher.group(3) != null) {
             matcher.group(3)
         } else null
+    }
+
+    /**
+     * check the project save query from a uri. e.g.: A uri like `ksr://www.kickstarter.com/projects/1186238668/skull-graphic-tee?save=true`
+     * returns true or false
+     */
+    fun hasSaveQueryFromUri(uri: Uri?): Boolean {
+        if (uri == null) {
+            return false
+        }
+        val scheme = uri.scheme
+        if (!(scheme == SCHEME_KSR || scheme == SCHEME_HTTPS)) {
+            return false
+        }
+        val matcher = PROJECT_PATTERN.matcher(uri.path)
+        val query = PROJECT_SAVE_QUERY_PATTERN.matcher(uri.query()).matches()
+        return matcher.matches() && matcher.group(3) != null && query
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
@@ -401,6 +401,14 @@ interface ProjectPageViewModel {
             val refTag = intent()
                 .flatMap { ProjectIntentMapper.refTag(it) }
 
+            val saveFlag = intent()
+                .take(1)
+                .delay(3, TimeUnit.SECONDS, environment.scheduler()) // add delay to wait until activity subscribed to viewmodel
+                .filter {
+                    it.getBooleanExtra(IntentKey.DEEP_LINK_SCREEN_PROJECT_SAVE, false)
+                }
+                .flatMap { ProjectIntentMapper.deepLinkSaveFlag(it) }
+
             val loggedInUserOnHeartClick = this.currentUser.observable()
                 .compose<User>(takeWhen(this.heartButtonClicked))
                 .filter { u -> u != null }
@@ -463,14 +471,32 @@ interface ProjectPageViewModel {
                 }
                 .share()
 
+            val projectOnDeepLinkChangeSave = saveFlag
+                .compose(combineLatestPair(this.currentUser.observable()))
+                .filter { it.second != null }
+                .withLatestFrom(initialProject) { userAndFlag, p ->
+                    Pair(userAndFlag, p)
+                }
+                .take(1)
+                .filter {
+                    it.second.isStarred() != it.first.first
+                }.switchMap {
+                    if (it.first.first) {
+                        this.saveProject(it.second)
+                    } else {
+                        this.unSaveProject(it.second)
+                    }
+                }.share()
+
             val currentProject = Observable.merge(
                 initialProject,
                 refreshedProjectNotification.compose(values()),
                 projectOnUserChangeSave,
-                savedProjectOnLoginSuccess
+                savedProjectOnLoginSuccess,
+                projectOnDeepLinkChangeSave
             )
 
-            val projectSavedStatus = projectOnUserChangeSave.mergeWith(savedProjectOnLoginSuccess)
+            val projectSavedStatus = Observable.merge(projectOnUserChangeSave, savedProjectOnLoginSuccess, projectOnDeepLinkChangeSave)
 
             projectSavedStatus
                 .compose(bindToLifecycle())

--- a/app/src/test/java/com/kickstarter/services/UriExtTest.kt
+++ b/app/src/test/java/com/kickstarter/services/UriExtTest.kt
@@ -13,6 +13,7 @@ import com.kickstarter.libs.utils.extensions.isModalUri
 import com.kickstarter.libs.utils.extensions.isNewGuestCheckoutUri
 import com.kickstarter.libs.utils.extensions.isProjectCommentUri
 import com.kickstarter.libs.utils.extensions.isProjectPreviewUri
+import com.kickstarter.libs.utils.extensions.isProjectSaveUri
 import com.kickstarter.libs.utils.extensions.isProjectSurveyUri
 import com.kickstarter.libs.utils.extensions.isProjectUpdateCommentsUri
 import com.kickstarter.libs.utils.extensions.isProjectUpdateUri
@@ -152,6 +153,12 @@ class UriExtTest : KSRobolectricTestCase() {
         val updateCommentsUri = Uri.parse("https://www.ksr.com/projects/creator/project/posts/id/comments")
         assertTrue(updateCommentsUri.isProjectUpdateCommentsUri(webEndpoint))
         assertFalse(updatesUri.isProjectUpdateCommentsUri(webEndpoint))
+    }
+
+    @Test
+    fun testUri_isProjectSaveUri() {
+        val saveProjectUri = Uri.parse("https://www.ksr.com/projects/creator/project?save=true")
+        assertTrue(saveProjectUri.isProjectSaveUri(webEndpoint))
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/ui/intents/ProjectIntentMapperTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/intents/ProjectIntentMapperTest.kt
@@ -2,6 +2,7 @@ package com.kickstarter.ui.intents
 
 import android.content.Intent
 import android.net.Uri
+import androidx.core.net.toUri
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.RefTag
 import com.kickstarter.mock.factories.ProjectFactory
@@ -143,5 +144,11 @@ class ProjectIntentMapperTest : KSRobolectricTestCase() {
         val resultTest = TestSubscriber.create<PushNotificationEnvelope>()
         ProjectIntentMapper.pushNotificationEnvelope(intent).subscribe(resultTest)
         resultTest.assertNoValues()
+    }
+
+    @Test
+    fun testProjectHasSaveQueryFromUri() {
+        assertTrue(ProjectIntentMapper.hasSaveQueryFromUri("ksr://www.kickstarter.com/projects/1186238668/skull-graphic-tee?save=true".toUri()))
+        assertFalse(ProjectIntentMapper.hasSaveQueryFromUri("ksr://www.kickstarter.com/projects/1186238668/skull-graphic-tee".toUri()))
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.kt
@@ -2,9 +2,12 @@ package com.kickstarter.viewmodels
 
 import android.content.Intent
 import android.net.Uri
+import android.util.Pair
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUser
+import com.kickstarter.libs.models.OptimizelyFeature
+import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApiClient
@@ -24,6 +27,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
     private val startProjectActivityForCheckout = TestSubscriber<Uri>()
     private val startProjectActivityForComment = TestSubscriber<Uri>()
     private val startProjectActivityForUpdate = TestSubscriber<Uri>()
+    private val startProjectActivityToSave = TestSubscriber<Pair<Uri, Boolean>>()
     private val startProjectActivityForCommentToUpdate = TestSubscriber<Uri>()
     private val finishDeeplinkActivity = TestSubscriber<Void>()
 
@@ -36,6 +40,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         vm.outputs.startProjectActivityForComment().subscribe(startProjectActivityForComment)
         vm.outputs.startProjectActivityForUpdate().subscribe(startProjectActivityForUpdate)
         vm.outputs.startProjectActivityForCommentToUpdate().subscribe(startProjectActivityForCommentToUpdate)
+        vm.outputs.startProjectActivityToSave().subscribe(startProjectActivityToSave)
         vm.outputs.finishDeeplinkActivity().subscribe(finishDeeplinkActivity)
     }
 
@@ -48,6 +53,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         vm.outputs.startProjectActivityForComment().subscribe(startProjectActivityForComment)
         vm.outputs.startProjectActivityForUpdate().subscribe(startProjectActivityForUpdate)
         vm.outputs.startProjectActivityForCommentToUpdate().subscribe(startProjectActivityForCommentToUpdate)
+        vm.outputs.startProjectActivityToSave().subscribe(startProjectActivityToSave)
         vm.outputs.finishDeeplinkActivity().subscribe(finishDeeplinkActivity)
     }
 
@@ -62,6 +68,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startProjectActivity.assertNoValues()
         startProjectActivityForCheckout.assertNoValues()
         startProjectActivityForComment.assertNoValues()
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -75,6 +82,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startProjectActivity.assertNoValues()
         startProjectActivityForCheckout.assertNoValues()
         startProjectActivityForComment.assertNoValues()
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -88,6 +96,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startDiscoveryActivity.assertNoValues()
         startProjectActivityForComment.assertNoValues()
         startProjectActivityForCheckout.assertValue(Uri.parse(url))
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -101,6 +110,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startDiscoveryActivity.assertNoValues()
         startProjectActivityForCheckout.assertNoValues()
         startProjectActivityForComment.assertValue(Uri.parse(url))
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -116,6 +126,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         vm.intent(intentWithData(url))
         startBrowser.assertNoValues()
         startProjectActivityForComment.assertValue(Uri.parse(url))
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -130,6 +141,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startProjectActivityForCheckout.assertNoValues()
         startProjectActivityForComment.assertNoValues()
         startProjectActivityForUpdate.assertValue(Uri.parse(url))
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -145,6 +157,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         vm.intent(intentWithData(url))
         startBrowser.assertNoValues()
         startProjectActivityForUpdate.assertValue(Uri.parse(url))
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -159,6 +172,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startProjectActivityForCheckout.assertNoValues()
         startProjectActivityForUpdate.assertNoValues()
         startProjectActivityForCommentToUpdate.assertValue(Uri.parse(url))
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -175,6 +189,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startBrowser.assertNoValues()
         startProjectActivityForUpdate.assertNoValues()
         startProjectActivityForCommentToUpdate.assertValue(Uri.parse(url))
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -190,6 +205,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startDiscoveryActivity.assertNoValues()
         startProjectActivityForComment.assertNoValues()
         startProjectActivityForCheckout.assertValue(Uri.parse(expectedUrl))
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -203,6 +219,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startDiscoveryActivity.assertNoValues()
         startProjectActivityForComment.assertNoValues()
         startProjectActivityForCheckout.assertNoValues()
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -218,6 +235,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startDiscoveryActivity.assertNoValues()
         startProjectActivityForComment.assertNoValues()
         startProjectActivityForCheckout.assertNoValues()
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -230,6 +248,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startProjectActivity.assertNoValues()
         startProjectActivityForComment.assertNoValues()
         startProjectActivityForCheckout.assertNoValues()
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -245,6 +264,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         vm.intent(intentWithData(url))
         startBrowser.assertNoValues()
         finishDeeplinkActivity.assertValueCount(1)
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -260,6 +280,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         vm.intent(intentWithData(url))
         startBrowser.assertNoValues()
         finishDeeplinkActivity.assertValueCount(1)
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -273,6 +294,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         vm.intent(intentWithData(url))
         startBrowser.assertNoValues()
         finishDeeplinkActivity.assertNoValues()
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -298,6 +320,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startProjectActivityForCommentToUpdate.assertNoValues()
         startProjectActivityForUpdate.assertNoValues()
         finishDeeplinkActivity.assertValueCount(1)
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -323,6 +346,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startProjectActivityForCommentToUpdate.assertNoValues()
         startProjectActivityForUpdate.assertNoValues()
         finishDeeplinkActivity.assertValueCount(1)
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -346,6 +370,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
         startProjectActivityForCommentToUpdate.assertNoValues()
         startProjectActivityForUpdate.assertNoValues()
         finishDeeplinkActivity.assertValueCount(1)
+        startProjectActivityToSave.assertNoValues()
     }
 
     @Test
@@ -361,6 +386,37 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
             "https://clicks.kickstarter.com/f/a/Hs4EAU85CJvgLr-uBBByog~~/AAQRxQA~/RgRiXE13P0TUaHR0cHM6Ly93d3cua2lja3N0YXJ0ZXIuY29tL3Byb2plY3RzL21zdDNrL21ha2Vtb3JlbXN0M2s_cmVmPU5ld3NBcHIxNjIxLWVuLWdsb2JhbC1hbGwmdXRtX21lZGl1bT1lbWFpbC1tZ2ImdXRtX3NvdXJjZT1wd2xuZXdzbGV0dGVyJnV0bV9jYW1wYWlnbj1wcm9qZWN0c3dlbG92ZS0wNDE2MjAyMSZ1dG1fY29udGVudD1pbWFnZSZiYW5uZXI9ZmlsbS1uZXdzbGV0dGVyMDFXA3NwY0IKYHh3yHlgkYIOrFIYbGl6YmxhaXJAa2lja3N0YXJ0ZXIuY29tWAQAAABU"
         vm.intent(intentWithData(emails))
         startBrowser.assertValueCount(1)
+        startProjectActivityToSave.assertNoValues()
+    }
+
+    @Test
+    fun testProjectSaveLink_startsProjectPageActivity() {
+
+        val url =
+            "https://www.kickstarter.com/projects/smithsonian/smithsonian-anthology-of-hip-hop-and-rap?save=true"
+        val expectedUrl =
+            "$url&ref=android_deep_link"
+        val mockExperimentsClientType: MockExperimentsClientType =
+            object : MockExperimentsClientType() {
+                override fun isFeatureEnabled(feature: OptimizelyFeature.Key): Boolean {
+                    return true
+                }
+            }
+
+        val environment = environment()
+            .toBuilder()
+            .optimizely(mockExperimentsClientType)
+            .build()
+
+        setUpEnvironment(environment)
+
+        vm.intent(intentWithData(url))
+        startProjectActivityToSave.assertValue(Pair(Uri.parse(expectedUrl), true))
+        startDiscoveryActivity.assertNoValues()
+        startProjectActivity.assertNoValues()
+        startProjectActivityForCheckout.assertNoValues()
+        startProjectActivityForComment.assertNoValues()
+        startBrowser.assertNoValues()
     }
 
     private fun mockApiSetBacking(backing: Backing, completed: Boolean): MockApiClient {

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.util.Pair
+import androidx.core.net.toUri
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.libs.ActivityRequestCodes
@@ -1758,6 +1759,39 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
                 return Observable.just(refreshedProject)
             }
         }
+    }
+
+    @Test
+    fun testUIOutputs_whenSaveProjectFromDeepLinkURI_isSuccessful() {
+
+        val currentUser = MockCurrentUser()
+        val project = ProjectFactory.successfulProject()
+        val testScheduler = TestScheduler()
+
+        setUpEnvironment(
+            environment().toBuilder()
+                .currentUser(currentUser)
+                .apolloClient(object : MockApolloClient() {
+                    override fun getProject(param: String): Observable<Project> {
+                        return Observable.just(project)
+                    }
+                })
+                .scheduler(testScheduler).build()
+        )
+
+        // Start the view model with a project.
+        val intent = Intent().apply {
+            data = "ksr://www.kickstarter.com/projects/1186238668/skull-graphic-tee?save=true".toUri()
+        }
+        currentUser.refresh(UserFactory.user())
+        this.vm.intent(intent)
+
+        testScheduler.advanceTimeBy(3, TimeUnit.SECONDS)
+
+        // The project should be saved, and a save prompt should NOT be shown.
+        this.savedTest.assertValues(false, true)
+        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart)
+        this.showSavedPromptTest.assertValueCount(0)
     }
 
     private fun deepLinkIntent(): Intent {

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
@@ -410,6 +410,40 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testUIOutputs_whenSaveProjectFromDeepLink_isSuccessful() {
+
+        val currentUser = MockCurrentUser()
+        val project = ProjectFactory.successfulProject()
+        val testScheduler = TestScheduler()
+
+        setUpEnvironment(
+            environment().toBuilder()
+                .currentUser(currentUser)
+                .apolloClient(object : MockApolloClient() {
+                    override fun getProject(param: String): Observable<Project> {
+                        return Observable.just(project)
+                    }
+                })
+                .scheduler(testScheduler).build()
+        )
+
+        // Start the view model with a project.
+        val intent = deepLinkIntent().apply {
+            putExtra(IntentKey.DEEP_LINK_SCREEN_PROJECT_SAVE, true)
+            putExtra(IntentKey.SAVE_FLAG_VALUE, true)
+        }
+        currentUser.refresh(UserFactory.user())
+        this.vm.intent(intent)
+
+        testScheduler.advanceTimeBy(3, TimeUnit.SECONDS)
+
+        // The project should be saved, and a save prompt should NOT be shown.
+        this.savedTest.assertValues(false, true)
+        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart)
+        this.showSavedPromptTest.assertValueCount(0)
+    }
+
+    @Test
     fun testUIOutputs_whenFetchProjectFromDeepLink_isUnsuccessful() {
         var error = true
         val refreshedProject = ProjectFactory.project()

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectViewModelTest.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.util.Pair
+import androidx.core.net.toUri
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.libs.ActivityRequestCodes
@@ -1719,6 +1720,39 @@ class ProjectViewModelTest : KSRobolectricTestCase() {
         val intent = deepLinkIntent().apply {
             putExtra(IntentKey.DEEP_LINK_SCREEN_PROJECT_SAVE, true)
             putExtra(IntentKey.SAVE_FLAG_VALUE, true)
+        }
+        currentUser.refresh(UserFactory.user())
+        this.vm.intent(intent)
+
+        testScheduler.advanceTimeBy(3, TimeUnit.SECONDS)
+
+        // The project should be saved, and a save prompt should NOT be shown.
+        this.savedTest.assertValues(false, true)
+        this.heartDrawableId.assertValues(R.drawable.icon__heart_outline, R.drawable.icon__heart)
+        this.showSavedPromptTest.assertValueCount(0)
+    }
+
+    @Test
+    fun testUIOutputs_whenSaveProjectFromDeepLinkURI_isSuccessful() {
+
+        val currentUser = MockCurrentUser()
+        val project = ProjectFactory.successfulProject()
+        val testScheduler = TestScheduler()
+
+        setUpEnvironment(
+            environment().toBuilder()
+                .currentUser(currentUser)
+                .apolloClient(object : MockApolloClient() {
+                    override fun getProject(param: String): Observable<Project> {
+                        return Observable.just(project)
+                    }
+                })
+                .scheduler(testScheduler).build()
+        )
+
+        // Start the view model with a project.
+        val intent = Intent().apply {
+            data = "ksr://www.kickstarter.com/projects/1186238668/skull-graphic-tee?save=true".toUri()
         }
         currentUser.refresh(UserFactory.user())
         this.vm.intent(intent)


### PR DESCRIPTION
# 📲 What

enable saving a project through Braze interactions

# 🤔 Why
We can save a project from a Braze surface

# 🛠 How
1- handle URL deep linking in `ProjectViewModel` and `ProjectPageViewModel` in android manifest  
2-handle URL deep linking from deeplinking activity to `ProjectViewModel` and `ProjectPageViewModel` 

# 👀 See

https://user-images.githubusercontent.com/1075310/153472839-965aa8ba-2405-4964-bfd1-225640919320.mp4


# 📋 QA

Create a dummy in-app message on Braze and double-check if the project is added to saved projects user should be login
I tested using 
`adb shell am start -a android.intent.action.VIEW     -c android.intent.category.BROWSABLE     -d "ksr://staging.kickstarter.com/projects/fjorden/fjorden-iphone-photography-reinvented?save=false"`


# Story 📖

https://kickstarter.atlassian.net/browse/NTV-350
