### PR TITLE
NTV-395: UI – Out of place image captions

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/ImageElementViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/ImageElementViewHolder.kt
@@ -11,7 +11,6 @@ import timber.log.Timber
 class ImageElementViewHolder(
     val binding: ViewElementImageFromHtmlBinding
 ) : KSViewHolder(binding.root) {
-    // TODO: attach ViewModel if necessary
     private val imageView = binding.imageView
 
     private fun configure(element: ImageViewElement) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/ImageElementViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/ImageElementViewHolder.kt
@@ -6,6 +6,7 @@ import com.kickstarter.libs.htmlparser.ImageViewElement
 import com.kickstarter.libs.utils.ApplicationUtils
 import com.kickstarter.ui.viewholders.KSViewHolder
 import com.kickstarter.ui.views.OnImageWithCaptionClickedListener
+import timber.log.Timber
 
 class ImageElementViewHolder(
     val binding: ViewElementImageFromHtmlBinding
@@ -33,7 +34,10 @@ class ImageElementViewHolder(
 
     override fun bindData(data: Any?) {
         (data as? ImageViewElement).apply {
-            this?.let { configure(it) }
+            this?.let {
+                configure(it)
+                Timber.d("${this.javaClass.canonicalName} with ImageViewElement: $it")
+            }
         }
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/ImageElementViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/ImageElementViewHolder.kt
@@ -6,7 +6,6 @@ import com.kickstarter.libs.htmlparser.ImageViewElement
 import com.kickstarter.libs.utils.ApplicationUtils
 import com.kickstarter.ui.viewholders.KSViewHolder
 import com.kickstarter.ui.views.OnImageWithCaptionClickedListener
-import timber.log.Timber
 
 class ImageElementViewHolder(
     val binding: ViewElementImageFromHtmlBinding
@@ -35,7 +34,6 @@ class ImageElementViewHolder(
         (data as? ImageViewElement).apply {
             this?.let {
                 configure(it)
-                Timber.d("${this.javaClass.canonicalName} with ImageViewElement: $it")
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/views/ImageWithCaptionView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/ImageWithCaptionView.kt
@@ -60,7 +60,7 @@ class ImageWithCaptionView @JvmOverloads constructor(
                     isUnderlineText = true
                 )
             }
-        }
+        } else binding.imageCaptionTextView.isVisible = false
     }
 
     fun setLinkOnImage(href: String?) {


### PR DESCRIPTION
# 📲 What

- You could see captions on images where there were really not caption on the original HTMl, or even see them appear after scrolling up and down

# 🤔 Why

- When the cell was recycled with a new Image element, the caption UI piece was not updated therefore showing caption data if the previous loaded image element had it.

# 🛠 How

- Clear the caption text

# 👀 See
* Before Video: You can see wild captions appear on images that should not have them

https://user-images.githubusercontent.com/4083656/153964256-f050f45b-8174-44d8-85a2-357f53772c19.mp4

* After Video: No wild captions anymore


https://user-images.githubusercontent.com/4083656/153964280-7b5358be-0630-48a2-8f4d-ac249fe93b78.mp4



|  |  |

# 📋 QA

- Load [this project](https://www.kickstarter.com/projects/tanyassmith/make-100-intentscents) and pay close attention to the caption on images, you can compare with the website to make sure no caption is visible out of place 

# Story 📖

[NTV-395](https://kickstarter.atlassian.net/browse/NTV-395)
