### PR TITLE
NTV-412: Hide old campaign links

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectOverviewFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectOverviewFragment.kt
@@ -343,6 +343,14 @@ class ProjectOverviewFragment : BaseFragment<ProjectOverviewViewModel.ViewModel>
                 activity?.startCampaignWebViewActivity(it)
             }
 
+        viewModel.outputs.hideOldCampaignLink()
+            .compose(bindToLifecycle())
+            .compose(Transformers.observeForUI())
+            .subscribe {
+                binding.readMoreCampaignLink.setGone(it)
+                binding.projectCreatorInfoLayout.campaign.setGone(it)
+            }
+
         binding.projectCreatorDashboardHeader.projectDashboardButton.setOnClickListener {
             this.viewModel.inputs.creatorDashboardClicked()
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectOverviewViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectOverviewViewModel.kt
@@ -9,6 +9,7 @@ import com.kickstarter.libs.FragmentViewModel
 import com.kickstarter.libs.KSCurrency
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.models.OptimizelyExperiment
+import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.DateTimeUtils
 import com.kickstarter.libs.utils.ExperimentData
@@ -181,6 +182,7 @@ interface ProjectOverviewViewModel {
         fun startUpdatesView(): Observable<ProjectData>
         fun startCampaignView(): Observable<ProjectData>
         fun startCreatorDashboardView(): Observable<ProjectData>
+        fun hideOldCampaignLink(): Observable<Boolean>
     }
 
     class ViewModel(environment: Environment) : FragmentViewModel<ProjectOverviewFragment?>(environment), Inputs, Outputs {
@@ -247,6 +249,7 @@ interface ProjectOverviewViewModel {
         private val startUpdatesView: Observable<ProjectData>
         private val startCampaignView: Observable<ProjectData>
         private val creatorDashBoardView: Observable<ProjectData>
+        private val hideOldCampaignLink: Observable<Boolean>
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -451,7 +454,13 @@ interface ProjectOverviewViewModel {
             return this.creatorDashBoardView
         }
 
+        override fun hideOldCampaignLink(): Observable<Boolean> {
+            return hideOldCampaignLink
+        }
+
         init {
+            hideOldCampaignLink = Observable.just(optimizely.isFeatureEnabled(OptimizelyFeature.Key.ANDROID_STORY_TAB))
+
             val project = projectData
                 .distinctUntilChanged()
                 .map { it.project() }

--- a/app/src/main/res/layout/fragment_project_overview.xml
+++ b/app/src/main/res/layout/fragment_project_overview.xml
@@ -166,6 +166,7 @@
                 tools:text="Description about this project." />
 
             <LinearLayout
+                android:id="@+id/readMoreCampaignLink"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/grid_3"


### PR DESCRIPTION
# 📲 What

- If campaign tab is visible, hide the access to the old campaign webview activity

# 👀 See

| Before 🐛 | After 🦋 |
<img width="1001" alt="links" src="https://user-images.githubusercontent.com/4083656/155235992-e7870895-caa2-4676-985d-dc38de880a59.png">

|  |  |

# 📋 QA

- Check with the FF on, you cannot access the old campaign webview activity
- Check with the FF off, you can access the old campaign webview activity
- 
# Story 📖

[NTV-412](https://kickstarter.atlassian.net/browse/NTV-412)
