### PR TITLE
NTV-414: /v1/activities was called from the app several times

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,8 +21,7 @@
 
     <application
         android:name=".KSApplication"
-        android:allowBackup="true"
-        android:fullBackupContent="@xml/full_backup_content"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher"


### PR DESCRIPTION
# 📲 What

- Removed allow backup from manifest
- Avoid using Transformers.neverError() operator
- Exchange flatmap over switchmap
- Added unit testing around failed calls to `fetchActivities` to make sure the networking request occurs only once

# 🤔 Why
- Take a look into [this datadog query](https://app.datadoghq.com/logs?cols=host%2Cservice%2C%40network.client.ip&event&from_ts=1645033326959&index=&live=false&messageDisplay=inline&query=%40http.url_details.path%3A%5C%2Fv1%5C%2Factivities+status%3Awarn+source%3Afastly&stream_sort=desc&to_ts=1645638126959&viz=stream), you'll see way too many calls from the same IP, with milliseconds of difference. 

|  |  |

# 📋 QA
- Not a simple way to reproduce it, as you need to get 401, 429 errors when calling `fetchActivities`, but test all keeps working as usual on the `Activity screen` and the `Discovery Card displaying the activity while you were gone` UI works as usual.
- If you do get a 401, 429 errors make sure the network call is not spamming our backend. 

# Story 📖

[NTV-414](https://kickstarter.atlassian.net/browse/NTV-414)
