### PR TITLE
NTV-361: Fix flaky tests related to datetime

### DIFF
--- a/app/src/test/java/com/kickstarter/models/MessageTest.kt
+++ b/app/src/test/java/com/kickstarter/models/MessageTest.kt
@@ -9,11 +9,12 @@ class MessageTest : TestCase() {
 
     @Test
     fun testDefaultInit() {
-        val message = Message.builder().createdAt(DateTime.now()).build()
+        val dateTime : DateTime = DateTime.now().plusMillis(300)
+        val message = Message.builder().createdAt(dateTime).build()
 
         assertTrue(message.id() == 0L)
         assertTrue(message.body() == "")
-        assertTrue(message.createdAt() == DateTime.now())
+        assertTrue(message.createdAt() == dateTime)
         assertTrue(message.recipient() == User.builder().build())
         assertTrue(message.sender() == User.builder().build())
     }
@@ -21,9 +22,9 @@ class MessageTest : TestCase() {
     @Test
     fun testMessage_equalFalse() {
         val message = Message.builder().build()
-        val message2 = Message.builder().body("body2").createdAt(DateTime.now()).id(1234L).sender(User.builder().build()).build()
-        val message3 = Message.builder().body("body3").createdAt(DateTime.now().plusDays(1)).id(5678L).sender(UserFactory.creator()).build()
-        val message4 = Message.builder().body("body4").createdAt(DateTime.now().plusDays(3)).id(1234L).recipient(UserFactory.germanUser()).sender(UserFactory.creator()).build()
+        val message2 = Message.builder().body("body2").createdAt(DateTime.now().plusMillis(300)).id(1234L).sender(User.builder().build()).build()
+        val message3 = Message.builder().body("body3").createdAt(DateTime.now().plusDays(1).plusMillis(300)).id(5678L).sender(UserFactory.creator()).build()
+        val message4 = Message.builder().body("body4").createdAt(DateTime.now().plusDays(3).plusMillis(300)).id(1234L).recipient(UserFactory.germanUser()).sender(UserFactory.creator()).build()
 
         assertFalse(message == message2)
         assertFalse(message == message3)
@@ -35,7 +36,7 @@ class MessageTest : TestCase() {
 
     @Test
     fun testMessage_equalTrue() {
-        val message1 = Message.builder().body("body2").createdAt(DateTime.now()).id(1234L).sender(User.builder().build()).build()
+        val message1 = Message.builder().body("body2").createdAt(DateTime.now().plusMillis(300)).id(1234L).sender(User.builder().build()).build()
         val message2 = message1.toBuilder().body("body2").build()
 
         assertTrue(message1 == message2)


### PR DESCRIPTION
# 📲 What

Added miliseconds to date time in unit tests to fix flakey test. 

# 📋 QA

- Run `MessageTest` a few times, ensure it is not failing sometimes 

# Story 📖

[NTV-361: Fix flaky tests related to datetime](https://kickstarter.atlassian.net/browse/WEB-361)
