### PR TITLE
NTV-423: bug fixing on Campaign tabg

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/adapters/projectcampaign/ViewElementAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/projectcampaign/ViewElementAdapter.kt
@@ -200,6 +200,10 @@ class ViewElementAdapter(
         (holder as? VideoElementViewHolder)?.let { videoElementViewHolder ->
             videoElementViewHolder.releasePlayer(index = videoElementViewHolder.bindingAdapterPosition)
         }
+        (holder as? ImageElementViewHolder)?.let {
+            it.binding.imageView.setImage("")
+            it.binding.imageView.setCaption("")
+        }
 
         super.onViewRecycled(holder)
     }

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -3,7 +3,6 @@ package com.kickstarter.ui.extensions
 import android.content.Context
 import android.widget.ImageView
 import androidx.appcompat.widget.AppCompatImageView
-import androidx.core.graphics.drawable.toBitmap
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.kickstarter.R

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -13,7 +13,6 @@ import com.squareup.picasso.Picasso
 
 fun ImageView.loadCircleImage(url: String?) {
     url?.let {
-        val target = this
         Picasso.get().load(it)
             .transform(CircleTransformation())
             .into(this)

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -28,7 +28,7 @@ fun ImageView.loadImage(url: String?, context: Context, imageViewPlaceholder: Ap
             this,
             object : Callback {
                 override fun onSuccess() {
-                    imageViewPlaceholder?.setImageBitmap(target.drawable.toBitmap())
+                    imageViewPlaceholder?.setImageDrawable(target.drawable)
                 }
 
                 override fun onError(e: Exception?) {
@@ -44,7 +44,6 @@ fun ImageView.loadGifImage(url: String?, context: Context) {
     if (context.applicationContext.isKSApplication()) {
         Glide.with(context)
             .asGif()
-            .error(R.drawable.image_placeholder)
             .diskCacheStrategy(DiskCacheStrategy.ALL)
             .load(url)
             .into(this)

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectCampaignFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectCampaignFragment.kt
@@ -52,7 +52,8 @@ class ProjectCampaignFragment :
         super.onViewCreated(view, savedInstanceState)
         viewElementAdapter = ViewElementAdapter(requireActivity(), this)
         val headerElementAdapter = HeaderElementAdapter()
-        binding?.projectCampaignViewListItems?.itemAnimator?.changeDuration = 0
+
+        binding?.projectCampaignViewListItems?.itemAnimator = null
         binding?.projectCampaignViewListItems?.layoutManager = LinearLayoutManager(context)
         binding?.projectCampaignViewListItems?.adapter = ConcatAdapter(
             headerElementAdapter,
@@ -70,6 +71,7 @@ class ProjectCampaignFragment :
             .subscribe {
                 viewElementAdapter?.submitList(it)
             }
+
         this.viewModel.outputs.onScrollToVideoPosition()
             .subscribeOn(Schedulers.io())
             .distinctUntilChanged()

--- a/app/src/main/java/com/kickstarter/ui/views/ImageWithCaptionView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/ImageWithCaptionView.kt
@@ -31,12 +31,16 @@ class ImageWithCaptionView @JvmOverloads constructor(
         )
 
     fun setImage(src: String) {
-        if (src.isGif()) {
-            binding.imageView.loadGifImage(src, context)
+        if (src.isEmpty() || src.isBlank()) {
+            binding.imageView.setImageDrawable(null)
         } else {
-            binding.imageView.loadImage(src, context, binding.imageViewPlaceholder)
-            ZoomHelper.addZoomableView(binding.imageView)
-            ZoomHelper.removeZoomableView(binding.imageViewPlaceholder)
+            if (src.isGif()) {
+                binding.imageView.loadGifImage(src, context)
+            } else {
+                binding.imageView.loadImage(src, context, binding.imageViewPlaceholder)
+                ZoomHelper.addZoomableView(binding.imageView)
+                ZoomHelper.removeZoomableView(binding.imageViewPlaceholder)
+            }
         }
     }
 

--- a/app/src/main/res/layout/view_image_with_caption.xml
+++ b/app/src/main/res/layout/view_image_with_caption.xml
@@ -21,7 +21,6 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
-        android:src="@drawable/image_placeholder"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
# 📲 What
- Sometimes you could see image placeholder on top of the images available to pinch and zoom
![image](https://user-images.githubusercontent.com/4083656/157126447-b5b2c59a-c121-46d7-9e08-1d09897781e6.png)

- Campaign tab name replicated on the rest of the tabs
![Screen Shot 2022-03-07 at 2 12 37 PM](https://user-images.githubusercontent.com/4083656/157126606-1a44933c-2056-4948-955f-1da414570c0b.png)


# 🛠 How
- The images able to pinch and zoom had the same image below it to keep the structure of the content when doing the pinch  and zoom, the placeholder was loaded with the same drawable as the top image exchanged `setImageBitmap(target.drawable.toBitmap())` over `.setImageDrawable(target.drawable)` in order to avoid the `.toBitmap` transformation
- When a cell from the recyclerview is recycled clean the previous image 

# 📋 QA

- Load many campaigns, you should not see the placeholder image on top anymore. 
- Make sure you don't see the repeated Campaign name on the tabs

# Story 📖

[NTV-423](https://kickstarter.atlassian.net/browse/NTV-423)
