### PR TITLE
NTV-438: Deprecate autoparcel for checkout

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/factories/CheckoutBackingFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CheckoutBackingFactory.kt
@@ -2,13 +2,12 @@ package com.kickstarter.mock.factories
 
 import com.kickstarter.models.Checkout
 
-class CheckoutBackingFactory private constructor() {
-    companion object {
-        fun requiresAction(requiresAction: Boolean): Checkout.Backing {
-            return Checkout.Backing.builder()
-                .clientSecret(if (requiresAction) "boop" else null)
-                .requiresAction(requiresAction)
-                .build()
-        }
+object CheckoutBackingFactory {
+    @JvmStatic
+    fun requiresAction(requiresAction: Boolean): Checkout.Backing {
+        return Checkout.Backing.builder()
+            .clientSecret(if (requiresAction) "boop" else null)
+            .requiresAction(requiresAction)
+            .build()
     }
 }

--- a/app/src/main/java/com/kickstarter/mock/factories/CheckoutFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/CheckoutFactory.kt
@@ -2,13 +2,12 @@ package com.kickstarter.mock.factories
 
 import com.kickstarter.models.Checkout
 
-class CheckoutFactory private constructor() {
-    companion object {
-        fun requiresAction(requiresAction: Boolean): Checkout {
-            return Checkout.builder()
-                .id(IdFactory.id().toLong())
-                .backing(CheckoutBackingFactory.requiresAction(requiresAction))
-                .build()
-        }
+object CheckoutFactory {
+    @JvmStatic
+    fun requiresAction(requiresAction: Boolean): Checkout {
+        return Checkout.builder()
+            .id(IdFactory.id().toLong())
+            .backing(CheckoutBackingFactory.requiresAction(requiresAction))
+            .build()
     }
 }

--- a/app/src/main/java/com/kickstarter/models/Checkout.kt
+++ b/app/src/main/java/com/kickstarter/models/Checkout.kt
@@ -76,7 +76,7 @@ class Checkout private constructor(
         fun toBuilder() = Builder(
             clientSecret = clientSecret,
             requiresAction = requiresAction
-         
+
         )
 
         companion object {

--- a/app/src/main/java/com/kickstarter/models/Checkout.kt
+++ b/app/src/main/java/com/kickstarter/models/Checkout.kt
@@ -1,49 +1,87 @@
 package com.kickstarter.models
 
 import android.os.Parcelable
-import auto.parcel.AutoParcel
+import kotlinx.parcelize.Parcelize
 
-@AutoParcel
-abstract class Checkout : Parcelable {
-    abstract fun id(): Long?
-    abstract fun backing(): Backing
+@Parcelize
+class Checkout private constructor(
+    private val id: Long?,
+    private val backing: Backing,
+) : Parcelable {
+    fun id() = this.id
+    fun backing() = this.backing
 
-    @AutoParcel.Builder
-    abstract class Builder {
-        abstract fun id(id: Long?): Builder
-        abstract fun backing(backing: Backing): Builder
-        abstract fun build(): Checkout
+    @Parcelize
+    data class Builder(
+        private var id: Long? = null,
+        private var backing: Backing = Backing.builder().build()
+    ) : Parcelable {
+        fun id(id: Long?) = apply { this.id = id }
+        fun backing(backing: Backing) = apply { this.backing = backing }
+        fun build() = Checkout(
+            id = id,
+            backing = backing
+        )
     }
 
-    abstract fun toBuilder(): Builder
+    fun toBuilder() = Builder(
+        id = id,
+        backing = backing
+    )
 
     companion object {
-
-        fun builder(): Builder {
-            return AutoParcel_Checkout.Builder()
-        }
+        @JvmStatic
+        fun builder() = Builder()
     }
 
-    @AutoParcel
-    abstract class Backing : Parcelable {
+    override fun equals(obj: Any?): Boolean {
+        var equals = super.equals(obj)
+        if (obj is Checkout) {
+            equals = id() == obj.id() &&
+                backing() == obj.backing()
+        }
+        return equals
+    }
 
-        abstract fun clientSecret(): String?
-        abstract fun requiresAction(): Boolean
+    @Parcelize
+    data class Backing private constructor(
+        private val clientSecret: String?,
+        private val requiresAction: Boolean,
+    ) : Parcelable {
 
-        @AutoParcel.Builder
-        abstract class Builder {
-            abstract fun clientSecret(secret: String?): Builder
-            abstract fun requiresAction(requiresAction: Boolean): Builder
-            abstract fun build(): Backing
+        fun clientSecret() = this.clientSecret
+        fun requiresAction() = this.requiresAction
+
+        @Parcelize
+        data class Builder(
+            private var clientSecret: String? = null,
+            private var requiresAction: Boolean = false,
+        ) : Parcelable {
+            fun clientSecret(clientSecret: String?) = apply { this.clientSecret = clientSecret }
+            fun requiresAction(requiresAction: Boolean) = apply { this.requiresAction = requiresAction }
+            fun build() = Backing(
+                clientSecret = clientSecret,
+                requiresAction = requiresAction
+            )
         }
 
-        abstract fun toBuilder(): Builder
+        override fun equals(obj: Any?): Boolean {
+            var equals = super.equals(obj)
+            if (obj is Backing) {
+                equals = clientSecret() == obj.clientSecret() &&
+                    requiresAction() == obj.requiresAction()
+            }
+            return equals
+        }
+        fun toBuilder() = Builder(
+            clientSecret = clientSecret,
+            requiresAction = requiresAction
+         
+        )
 
         companion object {
-
-            fun builder(): Builder {
-                return AutoParcel_Checkout_Backing.Builder()
-            }
+            @JvmStatic
+            fun builder() = Builder()
         }
     }
 }

--- a/app/src/main/java/com/kickstarter/models/SurveyResponse.kt
+++ b/app/src/main/java/com/kickstarter/models/SurveyResponse.kt
@@ -19,7 +19,7 @@ class SurveyResponse private constructor(
 
     @Parcelize
     data class Builder(
-        private var answeredAt: DateTime? = DateTime.now(),
+        private var answeredAt: DateTime? = null,
         private var id: Long = 0L,
         private var project: Project? = null,
         private var urls: Urls? = null

--- a/app/src/test/java/com/kickstarter/models/CheckoutTest.kt
+++ b/app/src/test/java/com/kickstarter/models/CheckoutTest.kt
@@ -34,7 +34,7 @@ class CheckoutTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testSurvey_equalFalse() {
+    fun testCheckout_equalFalse() {
         val checkout = Checkout.builder().build()
         val checkout2 = Checkout.builder().backing(CheckoutBackingFactory.requiresAction(true)).build()
         val checkout3 = Checkout.builder().id(5678L).build()
@@ -45,7 +45,7 @@ class CheckoutTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testSurvey_equalTrue() {
+    fun testCheckout_equalTrue() {
         val checkout1 = Checkout.builder().build()
         val checkout2 = Checkout.builder().build()
 

--- a/app/src/test/java/com/kickstarter/models/CheckoutTest.kt
+++ b/app/src/test/java/com/kickstarter/models/CheckoutTest.kt
@@ -1,0 +1,54 @@
+package com.kickstarter.models
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.mock.factories.CheckoutBackingFactory
+import org.junit.Test
+
+class CheckoutTest : KSRobolectricTestCase() {
+
+    @Test
+    fun testDefaultInit() {
+        val backing = Checkout.Backing.builder()
+            .requiresAction(true)
+            .build()
+
+        val checkout = Checkout.builder()
+            .id(1234L)
+            .backing(backing)
+            .build()
+
+        assertEquals(checkout.id(), 1234L)
+        assertEquals(checkout.backing(), backing)
+        assertEquals(backing.requiresAction(), true)
+        assertEquals(backing.clientSecret(), null)
+    }
+
+    @Test
+    fun testDefaultWebInit() {
+
+        val backing = Checkout.Backing.builder().build().toBuilder().requiresAction(false).build()
+        assertFalse(backing.requiresAction())
+
+        val checkout = Checkout.builder().build().toBuilder().backing(backing).build()
+        assertEquals(checkout.backing(), backing)
+    }
+
+    @Test
+    fun testSurvey_equalFalse() {
+        val checkout = Checkout.builder().build()
+        val checkout2 = Checkout.builder().backing(CheckoutBackingFactory.requiresAction(true)).build()
+        val checkout3 = Checkout.builder().id(5678L).build()
+       
+        assertFalse(checkout == checkout2)
+        assertFalse(checkout == checkout3)
+        assertFalse(checkout3 == checkout2)
+    }
+
+    @Test
+    fun testSurvey_equalTrue() {
+        val checkout1 = Checkout.builder().build()
+        val checkout2 = Checkout.builder().build()
+
+        assertEquals(checkout1, checkout2)
+    }
+}

--- a/app/src/test/java/com/kickstarter/models/CheckoutTest.kt
+++ b/app/src/test/java/com/kickstarter/models/CheckoutTest.kt
@@ -2,6 +2,7 @@ package com.kickstarter.models
 
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.mock.factories.CheckoutBackingFactory
+import com.kickstarter.mock.factories.CheckoutFactory
 import org.junit.Test
 
 class CheckoutTest : KSRobolectricTestCase() {
@@ -35,10 +36,10 @@ class CheckoutTest : KSRobolectricTestCase() {
 
     @Test
     fun testCheckout_equalFalse() {
-        val checkout = Checkout.builder().build()
+        val checkout = CheckoutFactory.requiresAction(false)
         val checkout2 = Checkout.builder().backing(CheckoutBackingFactory.requiresAction(true)).build()
         val checkout3 = Checkout.builder().id(5678L).build()
-       
+
         assertFalse(checkout == checkout2)
         assertFalse(checkout == checkout3)
         assertFalse(checkout3 == checkout2)


### PR DESCRIPTION
# 📲 What

- Migrated to kotlin
- Adopt @Parcelize 

# 🤔 Why
- Remove all references to the AutoParcel library in Models, eventually, we will be able to remove that dependency.

# 👀 See


https://user-images.githubusercontent.com/1075310/160469127-30603321-b6cf-4979-8b3d-ca570229f089.mp4



# 📋 QA
test backing project 


# Story 📖
https://kickstarter.atlassian.net/browse/NTV-438
