### PR TITLE
NTV-492 :Deprecate Autoparcel for EmailVerificationEnvelope.kt

### DIFF
--- a/app/src/main/java/com/kickstarter/services/apiresponses/EmailVerificationEnvelope.kt
+++ b/app/src/main/java/com/kickstarter/services/apiresponses/EmailVerificationEnvelope.kt
@@ -1,34 +1,45 @@
 package com.kickstarter.services.apiresponses
 
 import android.os.Parcelable
-import auto.parcel.AutoParcel
-import com.kickstarter.libs.qualifiers.AutoGson
+import kotlinx.parcelize.Parcelize
 
-@AutoGson
-@AutoParcel
-abstract class EmailVerificationEnvelope : Parcelable {
-    abstract fun message(): String
-    abstract fun code(): Int
+@Parcelize
+class EmailVerificationEnvelope private constructor(
+    private val message: String,
+    private val code: Int
+) : Parcelable {
+    fun message() = this.message
+    fun code() = this.code
 
-    @AutoParcel.Builder
-    abstract class Builder {
-        abstract fun message(message: String): Builder
-        abstract fun code(code: Int): Builder
-        abstract fun build(): EmailVerificationEnvelope
+    @Parcelize
+    data class Builder(
+        private var message: String = "",
+        private var code: Int = 0
+    ) : Parcelable {
+        fun message(message: String) = apply { this.message = message }
+        fun code(code: Int) = apply { this.code = code }
+        fun build() = EmailVerificationEnvelope(
+            message = message,
+            code = code
+        )
     }
 
-    @Override
+    fun toBuilder() = Builder(
+        message = message,
+        code = code
+    )
+
     override fun equals(other: Any?): Boolean {
-        return if (other is EmailVerificationEnvelope) {
-            other.code() == this.code() && other.message() == this.message()
-        } else super.equals(other)
+        var equals = super.equals(other)
+        if (other is EmailVerificationEnvelope) {
+            equals = other.code() == this.code() && 
+                other.message() == this.message()
+        }
+        return equals
     }
-
-    abstract fun toBuilder(): Builder
 
     companion object {
-        fun builder(): Builder {
-            return AutoParcel_EmailVerificationEnvelope.Builder()
-        }
+        @JvmStatic
+        fun builder() = Builder()
     }
 }

--- a/app/src/main/java/com/kickstarter/services/apiresponses/EmailVerificationEnvelope.kt
+++ b/app/src/main/java/com/kickstarter/services/apiresponses/EmailVerificationEnvelope.kt
@@ -32,8 +32,7 @@ class EmailVerificationEnvelope private constructor(
     override fun equals(other: Any?): Boolean {
         var equals = super.equals(other)
         if (other is EmailVerificationEnvelope) {
-            equals = other.code() == this.code() && 
-                other.message() == this.message()
+            equals = other.code() == this.code() && other.message() == this.message()
         }
         return equals
     }

--- a/app/src/test/java/com/kickstarter/models/EmailVerificationEnvelopeTest.kt
+++ b/app/src/test/java/com/kickstarter/models/EmailVerificationEnvelopeTest.kt
@@ -1,0 +1,53 @@
+package com.kickstarter.models
+
+import com.kickstarter.services.apiresponses.EmailVerificationEnvelope
+import junit.framework.TestCase
+import org.junit.Test
+
+class EmailVerificationEnvelopeTest : TestCase() {
+
+    @Test
+    fun testDefaultInit() {
+        val message = "test"
+      
+        val emailVerificationEnvelope = EmailVerificationEnvelope.builder()
+            .message(message)
+            .code(1)
+            .build()
+
+        assertEquals(emailVerificationEnvelope.message(), message)
+        
+        assertEquals(emailVerificationEnvelope.code(), 1)
+    }
+
+    @Test
+    fun testEmailVerificationEnvelope_equalFalse() {
+        val message = "test"
+        val emailVerificationEnvelope = EmailVerificationEnvelope.builder().build()
+        val emailVerificationEnvelope2 =
+            EmailVerificationEnvelope.builder().message(message).build()
+        val emailVerificationEnvelope3 = EmailVerificationEnvelope.builder().code(3).build()
+
+        assertFalse(emailVerificationEnvelope == emailVerificationEnvelope2)
+        assertFalse(emailVerificationEnvelope == emailVerificationEnvelope3)
+
+        assertFalse(emailVerificationEnvelope3 == emailVerificationEnvelope2)
+    }
+
+    @Test
+    fun testEmailVerificationEnvelope_equalTrue() {
+        val emailVerificationEnvelope1 = EmailVerificationEnvelope.builder().build()
+        val emailVerificationEnvelope2 = EmailVerificationEnvelope.builder().build()
+
+        assertEquals(emailVerificationEnvelope1, emailVerificationEnvelope2)
+    }
+
+    @Test
+    fun testEmailVerificationEnvelopeToBuilder() {
+        val message = "test"
+        val emailVerificationEnvelope = EmailVerificationEnvelope.builder().build().toBuilder()
+            .message(message).build()
+
+        assertEquals(emailVerificationEnvelope.message(), message)
+    }
+}

--- a/app/src/test/java/com/kickstarter/models/EmailVerificationEnvelopeTest.kt
+++ b/app/src/test/java/com/kickstarter/models/EmailVerificationEnvelopeTest.kt
@@ -9,14 +9,14 @@ class EmailVerificationEnvelopeTest : TestCase() {
     @Test
     fun testDefaultInit() {
         val message = "test"
-      
+
         val emailVerificationEnvelope = EmailVerificationEnvelope.builder()
             .message(message)
             .code(1)
             .build()
 
         assertEquals(emailVerificationEnvelope.message(), message)
-        
+
         assertEquals(emailVerificationEnvelope.code(), 1)
     }
 


### PR DESCRIPTION
# 📲 What

- Migrated to kotlin
- Adopt @Parcelize 

# 🤔 Why
- Remove all references to the AutoParcel library in Models, eventually, we will be able to remove that dependency.


# 📋 QA
Test Email Verification


# Story 📖
https://kickstarter.atlassian.net/browse/NTV-492
