### PR TITLE
NTV-493: Deprecate Autoparcel for PledgeData.kt

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/data/PledgeData.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/PledgeData.kt
@@ -1,35 +1,70 @@
 package com.kickstarter.ui.data
 
 import android.os.Parcelable
-import auto.parcel.AutoParcel
 import com.kickstarter.models.Reward
 import com.kickstarter.models.ShippingRule
+import kotlinx.parcelize.Parcelize
 
-@AutoParcel
-abstract class PledgeData : Parcelable {
-    abstract fun pledgeFlowContext(): PledgeFlowContext
-    abstract fun projectData(): ProjectData
-    abstract fun addOns(): List<Reward>?
-    abstract fun shippingRule(): ShippingRule?
-    abstract fun reward(): Reward
+@Parcelize
+class PledgeData private constructor(
+    private val pledgeFlowContext: PledgeFlowContext,
+    private val projectData: ProjectData,
+    private val addOns: List<Reward>?,
+    private val shippingRule: ShippingRule?,
+    private val reward: Reward
+) : Parcelable {
+    fun pledgeFlowContext() = this.pledgeFlowContext
+    fun projectData() = this.projectData
+    fun addOns() = this.addOns
+    fun shippingRule() = this.shippingRule
+    fun reward() = this.reward
 
-    @AutoParcel.Builder
-    abstract class Builder {
-        abstract fun pledgeFlowContext(pledgeFlowContext: PledgeFlowContext): Builder
-        abstract fun projectData(projectData: ProjectData): Builder
-        abstract fun reward(reward: Reward): Builder
-        abstract fun addOns(rewards: List<Reward>): Builder
-        abstract fun shippingRule(shippingRule: ShippingRule): Builder
-        abstract fun build(): PledgeData
+    @Parcelize
+    data class Builder(
+        private var pledgeFlowContext: PledgeFlowContext = PledgeFlowContext.MANAGE_REWARD,
+        private var projectData: ProjectData = ProjectData.builder().build(),
+        private var addOns: List<Reward>? = null,
+        private var shippingRule: ShippingRule? = null,
+        private var reward: Reward = Reward.builder().build()
+    ) : Parcelable {
+        fun pledgeFlowContext(pledgeFlowContext: PledgeFlowContext) = apply { this.pledgeFlowContext = pledgeFlowContext }
+        fun projectData(projectData: ProjectData) = apply { this.projectData = projectData }
+        fun reward(reward: Reward) = apply { this.reward = reward }
+        fun addOns(addOns: List<Reward>) = apply { this.addOns = addOns }
+        fun shippingRule(shippingRule: ShippingRule) = apply { this.shippingRule = shippingRule }
+        fun build() = PledgeData(
+            pledgeFlowContext = pledgeFlowContext,
+            projectData = projectData,
+            reward = reward,
+            addOns = addOns,
+            shippingRule = shippingRule
+        )
     }
 
-    abstract fun toBuilder(): Builder
+    fun toBuilder() = Builder(
+        pledgeFlowContext = pledgeFlowContext,
+        projectData = projectData,
+        reward = reward,
+        addOns = addOns,
+        shippingRule = shippingRule
+    )
+
+    override fun equals(other: Any?): Boolean {
+        var equals = super.equals(other)
+        if (other is PledgeData) {
+            equals = pledgeFlowContext() == other.pledgeFlowContext() &&
+                projectData() == other.projectData() &&
+                reward() == other.reward() &&
+                addOns() == other.addOns() &&
+                shippingRule() == other.shippingRule()
+        }
+        return equals
+    }
 
     companion object {
 
-        fun builder(): Builder {
-            return AutoParcel_PledgeData.Builder()
-        }
+        @JvmStatic
+        fun builder() = Builder()
 
         fun with(pledgeFlowContext: PledgeFlowContext, projectData: ProjectData, reward: Reward, addOns: List<Reward>? = null, shippingRule: ShippingRule? = null) =
             addOns?.let { addOns ->

--- a/app/src/test/java/com/kickstarter/models/PledgeDataTest.kt
+++ b/app/src/test/java/com/kickstarter/models/PledgeDataTest.kt
@@ -1,0 +1,99 @@
+package com.kickstarter.models
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.mock.factories.ProjectDataFactory
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.ui.data.PledgeData
+import com.kickstarter.ui.data.PledgeFlowContext
+import org.junit.Test
+
+class PledgeDataTest : KSRobolectricTestCase() {
+    @Test
+    fun testDefaultInit() {
+        val project = ProjectFactory.project()
+        val projectData = ProjectDataFactory.project(project)
+        val reward = Reward.builder().build()
+        val addOns = listOf(reward)
+
+        val pledgeData = PledgeData.builder()
+            .pledgeFlowContext(PledgeFlowContext.MANAGE_REWARD)
+            .projectData(projectData)
+            .reward(reward)
+            .addOns(addOns)
+            .build()
+
+        assertEquals(pledgeData.pledgeFlowContext(), PledgeFlowContext.MANAGE_REWARD)
+        assertEquals(pledgeData.reward(), reward)
+        assertEquals(pledgeData.projectData(), projectData)
+        assertEquals(pledgeData.shippingRule(), null)
+        assertEquals(pledgeData.addOns(), addOns)
+    }
+
+    @Test
+    fun testPledgeData_equalFalse() {
+        val project = ProjectFactory.project()
+        val projectData = ProjectDataFactory.project(project)
+        val reward: Reward = Reward.builder().build()
+
+        val pledgeData = PledgeData.builder().build()
+        val pledgeData2 = PledgeData.builder()
+            .pledgeFlowContext(PledgeFlowContext.MANAGE_REWARD)
+            .projectData(projectData)
+            .reward(reward)
+            .addOns(listOf(reward))
+            .build()
+        val pledgeData3 = PledgeData.builder()
+            .pledgeFlowContext(PledgeFlowContext.FIX_ERRORED_PLEDGE)
+            .projectData(projectData)
+            .build()
+        
+        val pledgeData4 = PledgeData.builder()
+            .pledgeFlowContext(PledgeFlowContext.MANAGE_REWARD)
+            .projectData(projectData)
+            .reward(reward)
+            .build()
+        assertFalse(pledgeData == pledgeData2)
+        assertFalse(pledgeData == pledgeData3)
+        assertFalse(pledgeData == pledgeData4)
+
+        assertFalse(pledgeData3 == pledgeData2)
+        assertFalse(pledgeData3 == pledgeData4)
+    }
+
+    @Test
+    fun testPledgeData_equalTrue() {
+        val pledgeData1 = PledgeData.builder().build()
+        val pledgeData2 = PledgeData.builder().build()
+
+        assertEquals(pledgeData1, pledgeData2)
+    }
+
+    @Test
+    fun testPledgeDataToBuilder() {
+        val reward: Reward = Reward.builder().build()
+        val pledgeData = PledgeData.builder().build().toBuilder()
+            .reward(reward).build()
+
+        assertEquals(pledgeData.reward(), reward)
+    }
+    @Test
+    fun testPledgeDataWith() {
+        val project = ProjectFactory.project()
+        val projectData = ProjectDataFactory.project(project)
+        val reward = Reward.builder().build()
+        val addOns = listOf(reward)
+
+        val pledgeData = PledgeData.with(
+            pledgeFlowContext = PledgeFlowContext.MANAGE_REWARD,
+            projectData = projectData,
+            reward = reward,
+            addOns = addOns
+        ) 
+
+        assertEquals(pledgeData.pledgeFlowContext(), PledgeFlowContext.MANAGE_REWARD)
+        assertEquals(pledgeData.reward(), reward)
+        assertEquals(pledgeData.projectData(), projectData)
+        assertEquals(pledgeData.shippingRule(), null)
+        assertEquals(pledgeData.addOns(), addOns)
+    }
+}


### PR DESCRIPTION
# 📲 What

- Migrated to kotlin
- Adopt @Parcelize 

# 🤔 Why
- Remove all references to the AutoParcel library in Models, eventually, we will be able to remove that dependency.

# 👀 See

<img width="566" alt="Screen Shot 2022-04-18 at 5 14 57 PM" src="https://user-images.githubusercontent.com/1075310/163830065-9255d820-6394-47c6-9d3a-9ce7db0bfff6.png">


# 📋 QA
test pledge data parameter with  segment events 

# Story 📖
https://kickstarter.atlassian.net/browse/NTV-493
