### PR TITLE
PAY-1571: Rewards Carousel can display localReceiptLocation UI

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.kt
@@ -94,8 +94,16 @@ object RewardUtils {
      */
     fun isShippable(reward: Reward): Boolean {
         val shippingType = reward.shippingType()
-        val noShippingTypes = reward.shippingPreferenceType() == Reward.ShippingPreference.NONE
+        val noShippingTypes = reward.shippingPreferenceType() == Reward.ShippingPreference.NONE ||
+            reward.shippingPreferenceType() == Reward.ShippingPreference.LOCAL
         return shippingType != null && !(Reward.SHIPPING_TYPE_NO_SHIPPING == shippingType || noShippingTypes)
+    }
+
+    fun isLocalPickup(reward: Reward): Boolean {
+        val isLocalPreference = reward.shippingPreferenceType() == Reward.ShippingPreference.LOCAL
+        val hasLocalLocation = reward.localReceiptLocation()?.displayableName()?.isNotEmpty() ?: false
+
+        return isLocalPreference && hasLocalLocation
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.kt
@@ -169,6 +169,16 @@ object RewardFactory {
             .build()
     }
 
+    fun localReceiptLocation(): Reward {
+        return reward().toBuilder()
+            .shippingType(Reward.SHIPPING_TYPE_LOCAL_PICKUP)
+            .shippingPreference(Reward.ShippingPreference.LOCAL.name)
+            .shippingPreferenceType(Reward.ShippingPreference.LOCAL)
+            .localReceiptLocation(LocationFactory.germany())
+            .estimatedDeliveryOn(null)
+            .build()
+    }
+
     @JvmStatic
     fun noReward(): Reward {
         return builder()

--- a/app/src/main/java/com/kickstarter/models/Reward.kt
+++ b/app/src/main/java/com/kickstarter/models/Reward.kt
@@ -44,7 +44,11 @@ class Reward private constructor(
     /**
      * this field will be available just for GraphQL, in V1 it would be empty
      */
-    private val shippingRules: List<ShippingRule>?
+    private val shippingRules: List<ShippingRule>?,
+    /**
+     * field reflecting the local pickup location, available only at GraphQL, in V1 it would be empty
+     */
+    private val localReceiptLocation: Location?
 ) : Parcelable, Relay {
     fun backersCount() = this.backersCount
     fun convertedMinimum() = this.convertedMinimum
@@ -70,6 +74,7 @@ class Reward private constructor(
     fun shippingRules() = this.shippingRules
     fun isAllGone() = remaining().isZero()
     fun isLimited() = limit() != null && !isAllGone()
+    fun localReceiptLocation() = this.localReceiptLocation
 
     @Parcelize
     data class Builder(
@@ -94,7 +99,8 @@ class Reward private constructor(
         private var startsAt: DateTime? = null,
         private var isAvailable: Boolean = false,
         private var shippingPreferenceType: ShippingPreference? = null,
-        private var shippingRules: List<ShippingRule>? = null
+        private var shippingRules: List<ShippingRule>? = null,
+        private var localReceiptLocation: Location? = null
     ) : Parcelable {
         fun backersCount(backersCount: Int?) = apply { this.backersCount = backersCount }
         fun convertedMinimum(convertedMinimum: Double?) = apply { this.convertedMinimum = convertedMinimum ?: 0.0 }
@@ -118,6 +124,7 @@ class Reward private constructor(
         fun shippingRules(shippingRules: List<ShippingRule>?) = apply { this.shippingRules = shippingRules }
         fun shippingPreferenceType(shippingPreferenceType: ShippingPreference?) = apply { this.shippingPreferenceType = shippingPreferenceType }
         fun isAvailable(isAvailable: Boolean?) = apply { this.isAvailable = isAvailable ?: false }
+        fun localReceiptLocation(localReceiptLocation: Location?) = apply { this.localReceiptLocation = localReceiptLocation }
         fun build() = Reward(
             backersCount = backersCount,
             convertedMinimum = convertedMinimum,
@@ -140,7 +147,8 @@ class Reward private constructor(
             hasAddons = hasAddons,
             shippingRules = shippingRules,
             shippingPreferenceType = shippingPreferenceType,
-            isAvailable = isAvailable
+            isAvailable = isAvailable,
+            localReceiptLocation = localReceiptLocation
         )
     }
 
@@ -151,6 +159,7 @@ class Reward private constructor(
         const val SHIPPING_TYPE_MULTIPLE_LOCATIONS = "multiple_locations"
         const val SHIPPING_TYPE_NO_SHIPPING = "no_shipping"
         const val SHIPPING_TYPE_SINGLE_LOCATION = "single_location"
+        const val SHIPPING_TYPE_LOCAL_PICKUP = "local"
     }
 
     fun toBuilder() = Builder(
@@ -175,7 +184,8 @@ class Reward private constructor(
         hasAddons = hasAddons,
         shippingRules = shippingRules,
         shippingPreferenceType = shippingPreferenceType,
-        isAvailable = isAvailable
+        isAvailable = isAvailable,
+        localReceiptLocation = localReceiptLocation
     )
 
     override fun equals(other: Any?): Boolean {
@@ -202,7 +212,8 @@ class Reward private constructor(
                 hasAddons() == other.hasAddons() &&
                 shippingRules() == other.shippingRules() &&
                 shippingPreferenceType() == other.shippingPreferenceType() &&
-                isAvailable() == other.isAvailable()
+                isAvailable() == other.isAvailable() &&
+                localReceiptLocation() == other.localReceiptLocation()
         }
         return equals
     }
@@ -227,6 +238,7 @@ class Reward private constructor(
         NOSHIPPING(
             SHIPPING_TYPE_NO_SHIPPING
         ),
+        LOCAL("local"),
         UNKNOWN("\$UNKNOWN");
     }
 }

--- a/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
@@ -126,6 +126,7 @@ fun rewardTransformer(
         ShippingPreference.NONE -> Reward.ShippingPreference.NONE
         ShippingPreference.RESTRICTED -> Reward.ShippingPreference.RESTRICTED
         ShippingPreference.UNRESTRICTED -> Reward.ShippingPreference.UNRESTRICTED
+        ShippingPreference.LOCAL -> Reward.ShippingPreference.LOCAL
         else -> Reward.ShippingPreference.UNKNOWN
     }
 
@@ -135,6 +136,8 @@ fun rewardTransformer(
     val shippingRules = shippingRulesExpanded.map {
         shippingRuleTransformer(it)
     }
+
+    val localReceiptLocation = locationTransformer(rewardGr.localReceiptLocation()?.fragments()?.location())
 
     return Reward.builder()
         .title(title)
@@ -157,6 +160,7 @@ fun rewardTransformer(
         .shippingRules(shippingRules)
         .isAvailable(available)
         .backersCount(backersCount)
+        .localReceiptLocation(localReceiptLocation)
         .build()
 }
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardViewHolder.kt
@@ -20,6 +20,7 @@ import com.kickstarter.libs.utils.TransitionUtils.slideInFromRight
 import com.kickstarter.libs.utils.TransitionUtils.transition
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.isTrue
+import com.kickstarter.libs.utils.extensions.setGone
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.IntentKey
@@ -27,6 +28,7 @@ import com.kickstarter.ui.activities.BackingActivity
 import com.kickstarter.ui.adapters.RewardItemsAdapter
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.RewardViewHolderViewModel
+import rx.android.schedulers.AndroidSchedulers
 
 class RewardViewHolder(private val binding: ItemRewardBinding, val delegate: Delegate?, private val inset: Boolean = false) : KSViewHolder(binding.root) {
 
@@ -103,8 +105,10 @@ class RewardViewHolder(private val binding: ItemRewardBinding, val delegate: Del
 
         this.viewModel.outputs.shippingSummaryIsGone()
             .compose(bindToLifecycle())
-            .compose(observeForUI())
-            .subscribe { ViewUtils.setGone(this.binding.rewardShippingSummary, it) }
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                this.binding.rewardShippingSummary.setGone(it)
+            }
 
         this.viewModel.outputs.minimumAmountTitle()
             .compose(bindToLifecycle())
@@ -202,6 +206,20 @@ class RewardViewHolder(private val binding: ItemRewardBinding, val delegate: Del
             .subscribe { isGone ->
                 if (!isGone) this.binding.rewardSelectedRewardTag.visibility = View.VISIBLE
                 else ViewUtils.setGone(this.binding.rewardSelectedRewardTag, true)
+            }
+
+        this.viewModel.outputs.localPickUpIsGone()
+            .compose(bindToLifecycle())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                this.binding.localPickupContainer.localPickupGroup.setGone(it)
+            }
+
+        this.viewModel.outputs.localPickUpName()
+            .compose(bindToLifecycle())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                this.binding.localPickupContainer.localPickupLocation.text = it
             }
     }
 

--- a/app/src/main/res/layout/add_on_card.xml
+++ b/app/src/main/res/layout/add_on_card.xml
@@ -104,6 +104,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/divider" />
 
+        <include
+            layout="@layout/reward_item_local_pickup"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="visible"
+            app:layout_constraintTop_toBottomOf="@id/items_container"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
         <LinearLayout
             android:id="@+id/pills_container"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_add_on.xml
+++ b/app/src/main/res/layout/item_add_on.xml
@@ -88,34 +88,14 @@
                     app:layout_constraintTop_toBottomOf="@id/add_on_items_container"
                     tools:text="@string/Pledge_any_amount_to_help_bring_this_project_to_life" />
 
-                <androidx.appcompat.widget.AppCompatTextView
-                    android:id="@+id/local_pickup_title"
-                    style="@style/RewardSectionTitle"
-                    android:text="@string/FPO_reward_location"
-                    android:layout_marginTop="@dimen/grid_5_half"
-                    app:layout_constraintTop_toBottomOf="@id/add_on_description_text_view"
-                    app:layout_constraintStart_toStartOf="parent" />
-
-                <androidx.appcompat.widget.AppCompatTextView
-                    android:id="@+id/local_pickup_location"
-                    style="@style/BodyPrimary"
-                    android:layout_height="wrap_content"
-                    android:layout_width="0dp"
-                    android:scrollHorizontally="true"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:layout_marginTop="@dimen/grid_2"
-                    app:layout_constraintTop_toBottomOf="@id/local_pickup_title"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    tools:text="Oakland, CA Plus a super long description here because we need to know how it is gonna behave "/>
-
-                <androidx.constraintlayout.widget.Group
-                    android:id="@+id/backing_group"
-                    android:layout_width="wrap_content"
+                <include
+                    layout="@layout/reward_item_local_pickup"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:visibility="visible"
-                    app:constraint_referenced_ids="local_pickup_title, local_pickup_location" />
+                    app:layout_constraintTop_toBottomOf="@id/add_on_description_text_view"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/item_add_on.xml
+++ b/app/src/main/res/layout/item_add_on.xml
@@ -88,6 +88,35 @@
                     app:layout_constraintTop_toBottomOf="@id/add_on_items_container"
                     tools:text="@string/Pledge_any_amount_to_help_bring_this_project_to_life" />
 
+                <androidx.appcompat.widget.AppCompatTextView
+                    android:id="@+id/local_pickup_title"
+                    style="@style/RewardSectionTitle"
+                    android:text="@string/FPO_reward_location"
+                    android:layout_marginTop="@dimen/grid_5_half"
+                    app:layout_constraintTop_toBottomOf="@id/add_on_description_text_view"
+                    app:layout_constraintStart_toStartOf="parent" />
+
+                <androidx.appcompat.widget.AppCompatTextView
+                    android:id="@+id/local_pickup_location"
+                    style="@style/BodyPrimary"
+                    android:layout_height="wrap_content"
+                    android:layout_width="0dp"
+                    android:scrollHorizontally="true"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:layout_marginTop="@dimen/grid_2"
+                    app:layout_constraintTop_toBottomOf="@id/local_pickup_title"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    tools:text="Oakland, CA Plus a super long description here because we need to know how it is gonna behave "/>
+
+                <androidx.constraintlayout.widget.Group
+                    android:id="@+id/backing_group"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:visibility="visible"
+                    app:constraint_referenced_ids="local_pickup_title, local_pickup_location" />
+
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.cardview.widget.CardView>
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -154,6 +154,12 @@
                 tools:text="December 2019" />
             </LinearLayout>
 
+            <include
+                layout="@layout/reward_item_local_pickup"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="visible" />
+
           <com.google.android.flexbox.FlexboxLayout
             android:id="@+id/reward_limit_container"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_reward.xml
+++ b/app/src/main/res/layout/item_reward.xml
@@ -155,6 +155,7 @@
             </LinearLayout>
 
             <include
+                android:id="@+id/local_pickup_container"
                 layout="@layout/reward_item_local_pickup"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/reward_item_local_pickup.xml
+++ b/app/src/main/res/layout/reward_item_local_pickup.xml
@@ -4,8 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:id="@+id/local_pickup_container">
+    android:layout_height="match_parent">
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/local_pickup_title"
@@ -30,7 +29,7 @@
         tools:text="Oakland, CA Plus a super long description here because we need to know how it is gonna behave "/>
 
     <androidx.constraintlayout.widget.Group
-        android:id="@+id/backing_group"
+        android:id="@+id/local_pickup_group"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"

--- a/app/src/main/res/layout/reward_item_local_pickup.xml
+++ b/app/src/main/res/layout/reward_item_local_pickup.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:id="@+id/local_pickup_container">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/local_pickup_title"
+        style="@style/RewardSectionTitle"
+        android:text="@string/FPO_reward_location"
+        android:layout_marginTop="@dimen/grid_5_half"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/local_pickup_location"
+        style="@style/BodyPrimary"
+        android:layout_height="wrap_content"
+        android:layout_width="0dp"
+        android:scrollHorizontally="true"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:layout_marginTop="@dimen/grid_1"
+        app:layout_constraintTop_toBottomOf="@id/local_pickup_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:text="Oakland, CA Plus a super long description here because we need to know how it is gonna behave "/>
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/backing_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:constraint_referenced_ids="local_pickup_title, local_pickup_location" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,5 +81,6 @@
 
   <!-- Campaign -->
   <string name="Story">Story</string>
+    <string name="FPO_reward_location">Reward location</string>
 
 </resources>

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardUtilsTest.kt
@@ -15,6 +15,7 @@ import com.kickstarter.libs.utils.RewardUtils.isExpired
 import com.kickstarter.libs.utils.RewardUtils.isItemized
 import com.kickstarter.libs.utils.RewardUtils.isLimitReached
 import com.kickstarter.libs.utils.RewardUtils.isLimited
+import com.kickstarter.libs.utils.RewardUtils.isLocalPickup
 import com.kickstarter.libs.utils.RewardUtils.isNoReward
 import com.kickstarter.libs.utils.RewardUtils.isReward
 import com.kickstarter.libs.utils.RewardUtils.isShippable
@@ -442,6 +443,13 @@ class RewardUtilsTest : KSRobolectricTestCase() {
         reward = RewardFactory.reward().toBuilder().endsAt(currentDate.toDateTime()).build()
         val timeInSecondsUntilDeadline = timeInSecondsUntilDeadline(reward)
         assertEquals(timeInSecondsUntilDeadline, 120)
+    }
+
+    @Test
+    fun testIsShippableRewardWithLocalPickupLocation() {
+        val reward = RewardFactory.localReceiptLocation()
+        assertFalse(isShippable(reward))
+        assertTrue(isLocalPickup(reward))
     }
 
     companion object {


### PR DESCRIPTION
# 📲 What

A new type of shipping preference has been added. Now a reward can be collected locally

# 🛠 How
- The reward model has been extended with a new optional Location field named `localReceiptLocation`
- A New shippingPreference type has been added `LOCAL`

# 👀 See

https://user-images.githubusercontent.com/4083656/165413650-55a43750-8453-472e-a78f-e1eedfddee79.mp4
<img width="997" alt="Screen Shot 2022-04-26 at 5 19 45 PM" src="https://user-images.githubusercontent.com/4083656/165413787-bde29c24-f10c-474c-a1d4-19d8d2225e6b.png">

|  |  |

# 📋 QA

- Load this project https://staging.kickstarter.com/projects/alexa-test-1/reclaimed-chocolate-reprinting?ref=nav_search&result=project&term=reclaimed
two of the rewards have `Reward Location` make sure you can see the UI displayed on each card on the rewards carousel with the feature flag active
- Load the same project with the feature flag disabled, the `Reward Location` section is not visible
- Load any other project, make sure the `Reward Location` is not visible

# Story 📖

[PAY-1571](https://kickstarter.atlassian.net/browse/PAY-1571)
