### PR TITLE
NTV-535: Fix crashes

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -799,7 +799,7 @@ class ProjectPageActivity :
         try {
             // - Every time the ProjectData gets updated
             // - the fragments on the viewPager are updated as well
-            (binding.projectPager.adapter as ProjectPagerAdapter).updatedWithProjectData(projectData)
+            (binding.projectPager.adapter as? ProjectPagerAdapter)?.updatedWithProjectData(projectData)
 
             val rewardsFragment = rewardsFragment()
             val backingFragment = backingFragment()

--- a/app/src/main/java/com/kickstarter/ui/intentmappers/DiscoveryIntentMapper.kt
+++ b/app/src/main/java/com/kickstarter/ui/intentmappers/DiscoveryIntentMapper.kt
@@ -74,10 +74,10 @@ object DiscoveryIntentMapper {
         if (categoryParam != null) {
             paramBuilders.add(
                 apolloClient.fetchCategory(categoryParam)
+                    .compose(Transformers.neverError())
                     .filter { ObjectUtils.isNotNull(it) }
                     .map { requireNotNull(it) }
                     .map { DiscoveryParams.builder().category(it) }
-                    .compose(Transformers.neverError())
             )
         }
 
@@ -86,8 +86,8 @@ object DiscoveryIntentMapper {
             paramBuilders.add(
                 client
                     .fetchLocation(locationParam)
-                    .map { DiscoveryParams.builder().location(it) }
                     .compose(Transformers.neverError())
+                    .map { DiscoveryParams.builder().location(it) }
             )
         }
         paramBuilders.add(Observable.just(params.toBuilder()))

--- a/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.java
+++ b/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.java
@@ -5,6 +5,7 @@ import com.kickstarter.libs.ApiPaginator;
 import com.kickstarter.libs.CurrentUserType;
 import com.kickstarter.libs.Environment;
 import com.kickstarter.libs.ExperimentsClientType;
+import com.kickstarter.libs.rx.transformers.Transformers;
 import com.kickstarter.libs.utils.EventContextValues;
 import com.kickstarter.libs.utils.extensions.IntExtKt;
 import com.kickstarter.models.Activity;
@@ -152,7 +153,7 @@ public interface ActivityFeedViewModel {
         .startOverWith(this.refresh)
         .envelopeToListOfData(ActivityEnvelope::activities)
         .envelopeToMoreUrl(env -> env.urls().api().moreActivities())
-        .loadWithParams(__ -> this.apiClient.fetchActivities())
+        .loadWithParams(__ -> this.apiClient.fetchActivities().compose(Transformers.neverError()))
         .loadWithPaginationPath(this.apiClient::fetchActivitiesWithPaginationPath)
         .build();
 

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.kt
@@ -472,7 +472,7 @@ interface DiscoveryFragmentViewModel {
             return apolloClient.getProjects(
                 discoveryParamsStringPair.first,
                 discoveryParamsStringPair.second
-            )
+            ).compose(Transformers.neverError())
         }
 
         private fun activityHasNotBeenSeen(activity: Activity?): Boolean {
@@ -481,6 +481,7 @@ interface DiscoveryFragmentViewModel {
 
         private fun fetchActivity(): Observable<Activity?> {
             return apiClient.fetchActivities(1)
+                .compose(Transformers.neverError())
                 .distinctUntilChanged()
                 .map { it.activities() }
                 .map { it.firstOrNull() }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.kt
@@ -481,7 +481,6 @@ interface DiscoveryFragmentViewModel {
 
         private fun fetchActivity(): Observable<Activity?> {
             return apiClient.fetchActivities(1)
-                .compose(Transformers.neverError())
                 .distinctUntilChanged()
                 .map { it.activities() }
                 .map { it.firstOrNull() }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
@@ -215,7 +215,7 @@ interface DiscoveryViewModel {
             val verification = uriFromVerification
                 .map { it.getTokenFromQueryParams() }
                 .filter { ObjectUtils.isNotNull(it) }
-                .switchMap { apiClient.verifyEmail(it) }
+                .switchMap { apiClient.verifyEmail(it).compose(Transformers.neverError()) }
                 .materialize()
                 .share()
                 .distinctUntilChanged()

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
@@ -215,7 +215,7 @@ interface DiscoveryViewModel {
             val verification = uriFromVerification
                 .map { it.getTokenFromQueryParams() }
                 .filter { ObjectUtils.isNotNull(it) }
-                .switchMap { apiClient.verifyEmail(it).compose(Transformers.neverError()) }
+                .switchMap { apiClient.verifyEmail(it) }
                 .materialize()
                 .share()
                 .distinctUntilChanged()

--- a/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.kt
@@ -127,8 +127,8 @@ interface ProfileViewModel {
                 .nextPage(this.nextPage)
                 .envelopeToListOfData { it.projects() }
                 .envelopeToMoreUrl { env -> env.urls()?.api()?.moreProjects() }
-                .loadWithParams { this.client.fetchProjects(params) }
-                .loadWithPaginationPath { this.client.fetchProjects(it) }
+                .loadWithParams { this.client.fetchProjects(params).compose(neverError()) }
+                .loadWithPaginationPath { this.client.fetchProjects(it).compose(neverError()) }
                 .build()
 
             paginator.isFetching

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.kt
@@ -118,7 +118,9 @@ interface ThanksViewModel {
             val rootCategory = project
                 .switchMap {
                     rootCategory(it, apolloClient)
-                }.filter {
+                }
+                .compose(Transformers.neverError())
+                .filter {
                     ObjectUtils.isNotNull(it)
                 }.map { requireNotNull(it) }
 
@@ -402,7 +404,7 @@ interface ThanksViewModel {
                         Observable.just(category)
                     }
                     else -> {
-                        client.fetchCategory(category.rootId().toString()).compose(Transformers.neverError())
+                        client.fetchCategory(category.rootId().toString())
                     }
                 }
             }

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.kt
@@ -402,7 +402,7 @@ interface ThanksViewModel {
                         Observable.just(category)
                     }
                     else -> {
-                        client.fetchCategory(category.rootId().toString())
+                        client.fetchCategory(category.rootId().toString()).compose(Transformers.neverError())
                     }
                 }
             }

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -30,6 +30,8 @@ android.applicationVariants.all { variant ->
                          '**/*Subcomponent$Builder.class',
                          '**/*Module_*Factory.class',
                          '**/KSApplication.*',
+                         '**/libs/utils/ApplicationLifecycleUtil.*',
+                         '**/libs/utils/ApplicationUtils.*',
                          '**/ApplicationModule.*',
                          '**/*Activity*.*',
                          '**/*Fragment*.*',


### PR DESCRIPTION
# 📲 What

Investigate all the early network related crashes, and look for those network calls without error handling, or using deprecated transformers.

# 👀 See
- No user facing changes
|  |  |

# 📋 QA
- Turn off any connectivity you might have and launch the app on discovery screen, activity screen and any project screen.

# Story 📖

[NTV-535](https://kickstarter.atlassian.net/browse/NTV-535)
