### PR TITLE
NTV-542: Update Exoplayer dependency to 2.17.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -209,7 +209,7 @@ dependencies {
     final auto_parcel_version = "0.3.1"
     implementation "com.github.frankiesardo:auto-parcel:$auto_parcel_version"
     kapt "com.github.frankiesardo:auto-parcel-processor:$auto_parcel_version"
-    implementation "com.google.android.exoplayer:exoplayer:2.16.1"
+    implementation "com.google.android.exoplayer:exoplayer:2.17.1"
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
     implementation 'com.google.android.material:material:1.5.0'
     final dagger_version = "2.41"

--- a/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import com.google.android.exoplayer2.C
+import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.source.MediaSource
@@ -135,9 +136,9 @@ class VideoActivity : BaseActivity<VideoViewModel.ViewModel>() {
         val fileType = Util.inferContentType(videoUri)
 
         return if (fileType == C.TYPE_HLS) {
-            HlsMediaSource.Factory(dataSourceFactory).createMediaSource(videoUri)
+            HlsMediaSource.Factory(dataSourceFactory).createMediaSource(MediaItem.fromUri(videoUri))
         } else {
-            ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(videoUri)
+            ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(MediaItem.fromUri(videoUri))
         }
     }
 
@@ -154,7 +155,7 @@ class VideoActivity : BaseActivity<VideoViewModel.ViewModel>() {
         }
     }
 
-    private val eventListener: Player.EventListener = object : Player.EventListener {
+    private val eventListener: Player.Listener = object : Player.Listener {
         override fun onPlayerStateChanged(playWhenReady: Boolean, playbackState: Int) {
             onStateChanged(playbackState)
         }


### PR DESCRIPTION
# 📲 What

Update exoplayer dependency and fix any breaking changes.

# 👀 See

No user facing changes. 

# 📋 QA

Make sure videos are working correctly

# Story 📖

[NTV-542: Update Exoplayer dependency to 2.17.1](https://kickstarter.atlassian.net/browse/NTV-542)
