### PR TITLE
[no-jira]: remove redundant observable subscription

### DIFF
--- a/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClient.kt
@@ -772,11 +772,8 @@ class KSApolloClient(val service: ApolloClient) : ApolloClientType {
                                         it.fragments().shippingRule()
                                     } ?: emptyList()
 
-                            Observable.just(shippingRulesListTransformer(rulesExpanded))
-                                .subscribe {
-                                    ps.onNext(it)
-                                    ps.onCompleted()
-                                }
+                            ps.onNext(shippingRulesListTransformer(rulesExpanded))
+                            ps.onCompleted()
                         }
                     }
                 })


### PR DESCRIPTION
# 📲 What

remove redundant observable subscription
- Crash found on debug mode -> https://console.firebase.google.com/u/1/project/android-internal-debug/crashlytics/app/android:com.kickstarter.kickstarter.internal.debug/issues/b8212ae8eda97df540f406bc64f0206d?time=last-seven-days&sessionEventKey=62A0D052013F00013C299D0103B10107_1685371054770622520


# 👀 See
- No user facing changes
|  |  |

# 📋 QA
- Load addOns with world wide shipping base reward
- Load addOns with restricted shipping base reward

