### PR TITLE
NTV-587: Segment event for campaign tab

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
@@ -20,6 +20,7 @@ import com.kickstarter.libs.rx.transformers.Transformers.takePairWhen
 import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
 import com.kickstarter.libs.rx.transformers.Transformers.values
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName.PROJECT
+import com.kickstarter.libs.utils.EventContextValues.ContextSectionName.CAMPAIGN
 import com.kickstarter.libs.utils.EventContextValues.ContextSectionName.ENVIRONMENT
 import com.kickstarter.libs.utils.EventContextValues.ContextSectionName.FAQS
 import com.kickstarter.libs.utils.EventContextValues.ContextSectionName.OVERVIEW
@@ -920,7 +921,7 @@ interface ProjectPageViewModel {
 
         private fun getSelectedTabContextName(selectedTabIndex: Int): String = when (selectedTabIndex) {
             ProjectPagerTabs.OVERVIEW.ordinal -> OVERVIEW.contextName
-            // ProjectPagerTabs.CAMPAIGN.ordinal -> STORY.contextName
+            ProjectPagerTabs.CAMPAIGN.ordinal -> CAMPAIGN.contextName
             ProjectPagerTabs.FAQS.ordinal -> FAQS.contextName
             ProjectPagerTabs.RISKS.ordinal -> RISKS.contextName
             ProjectPagerTabs.ENVIRONMENTAL_COMMITMENT.ordinal -> ENVIRONMENT.contextName


### PR DESCRIPTION
# 📲 What

- When the user hits the `Campaign` tab, an analytic events should be sent to segment with the format: 
Event type: Page Viewed
context_page: project
context_section: campaign

# 🛠 How
- The code was already in place, sending incorrect `context_section`

# 👀 See
- Logcat screenshot
<img width="1714" alt="Screen Shot 2022-07-25 at 10 09 44 AM" src="https://user-images.githubusercontent.com/4083656/180836609-daa14c48-502c-4b0b-b1f5-35f47a6dd88c.png">

- Segment debugger
<img width="523" alt="Screen Shot 2022-07-25 at 10 13 25 AM" src="https://user-images.githubusercontent.com/4083656/180836582-f3866c99-8f90-4aec-ac7d-7a35b5fb48f6.png">

|  |  |

# 📋 QA
- Take a look in logcat when hitting the campaign tab, make sure the event is triggered with the correct properties.
- Take a look at Segment debugger, event should be there.

# Story 📖

[NTV-587](https://kickstarter.atlassian.net/browse/NTV-587)
