### PR TITLE
WEB-663 : [Android] Remove the ability to log in with Facebook

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
@@ -5,15 +5,8 @@ import android.content.Intent
 import android.util.Pair
 import com.kickstarter.models.Project
 import com.kickstarter.ui.IntentKey
-import com.kickstarter.ui.activities.CampaignDetailsActivity
-import com.kickstarter.ui.activities.CommentsActivity
-import com.kickstarter.ui.activities.CreatorBioActivity
-import com.kickstarter.ui.activities.CreatorDashboardActivity
-import com.kickstarter.ui.activities.ProjectPageActivity
-import com.kickstarter.ui.activities.ProjectUpdatesActivity
-import com.kickstarter.ui.activities.ResetPasswordActivity
-import com.kickstarter.ui.activities.UpdateActivity
-import com.kickstarter.ui.activities.VideoActivity
+import com.kickstarter.ui.activities.*
+import com.kickstarter.ui.data.LoginReason
 import com.kickstarter.ui.data.ProjectData
 
 fun Intent.getProjectIntent(context: Context): Intent {
@@ -142,6 +135,27 @@ fun Intent.getResetPasswordIntent(
     return this.setClass(context, ResetPasswordActivity::class.java).apply {
         this.putExtra(IntentKey.RESET_PASSWORD_FACEBOOK_LOGIN, isResetPasswordFacebook)
         // ForgetPassword
+        email?.let {
+            this.putExtra(IntentKey.EMAIL, it)
+        }
+    }
+}
+
+/**
+ * Return a Intent ready to launch the LoginActivity with extras:
+ * @param context
+ * @param isResetPasswordFacebook
+ * @param email ->  email for reset account
+ */
+fun Intent.getLoginActivityIntent(
+    context: Context,
+    email: String? = null,
+    loginReason: LoginReason? = null
+): Intent {
+    return this.setClass(context, LoginActivity::class.java).apply {
+        loginReason?.let {
+            this.putExtra(IntentKey.LOGIN_REASON, it)
+        }
         email?.let {
             this.putExtra(IntentKey.EMAIL, it)
         }

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
@@ -5,7 +5,16 @@ import android.content.Intent
 import android.util.Pair
 import com.kickstarter.models.Project
 import com.kickstarter.ui.IntentKey
-import com.kickstarter.ui.activities.*
+import com.kickstarter.ui.activities.CampaignDetailsActivity
+import com.kickstarter.ui.activities.CommentsActivity
+import com.kickstarter.ui.activities.CreatorBioActivity
+import com.kickstarter.ui.activities.CreatorDashboardActivity
+import com.kickstarter.ui.activities.LoginActivity
+import com.kickstarter.ui.activities.ProjectPageActivity
+import com.kickstarter.ui.activities.ProjectUpdatesActivity
+import com.kickstarter.ui.activities.ResetPasswordActivity
+import com.kickstarter.ui.activities.UpdateActivity
+import com.kickstarter.ui.activities.VideoActivity
 import com.kickstarter.ui.data.LoginReason
 import com.kickstarter.ui.data.ProjectData
 

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
@@ -11,6 +11,7 @@ import com.kickstarter.ui.activities.CreatorBioActivity
 import com.kickstarter.ui.activities.CreatorDashboardActivity
 import com.kickstarter.ui.activities.ProjectPageActivity
 import com.kickstarter.ui.activities.ProjectUpdatesActivity
+import com.kickstarter.ui.activities.ResetPasswordActivity
 import com.kickstarter.ui.activities.UpdateActivity
 import com.kickstarter.ui.activities.VideoActivity
 import com.kickstarter.ui.data.ProjectData
@@ -125,4 +126,24 @@ fun Intent.getVideoActivityIntent(
     return this.setClass(context, VideoActivity::class.java)
         .putExtra(IntentKey.VIDEO_URL_SOURCE, videoSource)
         .putExtra(IntentKey.VIDEO_SEEK_POSITION, videoSeekPosition)
+}
+
+/**
+ * Return a Intent ready to launch the ResetPasswordIntent with extras:
+ * @param context
+ * @param isResetPasswordFacebook
+ * @param email ->  email for reset account
+ */
+fun Intent.getResetPasswordIntent(
+    context: Context,
+    isResetPasswordFacebook: Boolean = false,
+    email: String? = null
+): Intent {
+    return this.setClass(context, ResetPasswordActivity::class.java).apply {
+        this.putExtra(IntentKey.RESET_PASSWORD_FACEBOOK_LOGIN, isResetPasswordFacebook)
+        // ForgetPassword
+        email?.let {
+            this.putExtra(IntentKey.EMAIL, it)
+        }
+    }
 }

--- a/app/src/main/java/com/kickstarter/ui/IntentKey.kt
+++ b/app/src/main/java/com/kickstarter/ui/IntentKey.kt
@@ -51,4 +51,5 @@ object IntentKey {
         "com.kickstarter.kickstarter.deep_link_screen_project_update_comment"
     const val VIDEO_SEEK_POSITION = "com.kickstarter.kickstarter.intent_video_seek_position"
     const val VIDEO_URL_SOURCE = "com.kickstarter.kickstarter.intent_video_SOURCE"
+    const val RESET_PASSWORD_FACEBOOK_LOGIN = "com.kickstarter.kickstarter.intent_reset_password_facebook"
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
@@ -167,14 +167,6 @@ class LoginActivity : BaseActivity<LoginViewModel.ViewModel>() {
     }
 
     private fun startResetPasswordActivity() {
-        val intent = if (environment().optimizely()?.isFeatureEnabled(OptimizelyFeature.Key.ANDROID_FACEBOOK_LOGIN_REMOVE) == true) {
-            Intent().getResetPasswordIntent(this, email = binding.loginFormView.email.text.toString())
-        } else {
-            Intent(this, ResetPasswordActivity::class.java)
-                .putExtra(IntentKey.EMAIL, binding.loginFormView.email.text.toString())
-        }
-        startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
-
         val intent = Intent().getResetPasswordIntent(this, email = binding.loginFormView.email.text.toString())
         startActivityForResult(intent, ActivityRequestCodes.RESET_FLOW)
         overridePendingTransition(R.anim.slide_in_right, R.anim.fade_out_slide_out_left)

--- a/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
@@ -9,7 +9,6 @@ import com.kickstarter.databinding.LoginLayoutBinding
 import com.kickstarter.libs.ActivityRequestCodes
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.KSString
-import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.ObjectUtils
@@ -104,7 +103,7 @@ class LoginActivity : BaseActivity<LoginViewModel.ViewModel>() {
 
         binding.loginFormView.forgotYourPasswordTextView.setOnClickListener {
             startResetPasswordActivity()
-               }
+        }
 
         binding.loginFormView.loginButton.setOnClickListener {
             this.viewModel.inputs.loginClick()

--- a/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
@@ -9,11 +9,13 @@ import com.kickstarter.databinding.LoginLayoutBinding
 import com.kickstarter.libs.ActivityRequestCodes
 import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.KSString
+import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft
 import com.kickstarter.libs.utils.ViewUtils
+import com.kickstarter.libs.utils.extensions.getResetPasswordIntent
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.extensions.hideKeyboard
 import com.kickstarter.ui.extensions.onChange
@@ -101,8 +103,12 @@ class LoginActivity : BaseActivity<LoginViewModel.ViewModel>() {
             .subscribe({ this.setLoginButtonEnabled(it) })
 
         binding.loginFormView.forgotYourPasswordTextView.setOnClickListener {
-            val intent = Intent(this, ResetPasswordActivity::class.java)
-                .putExtra(IntentKey.EMAIL, binding.loginFormView.email.text.toString())
+            val intent = if (environment().optimizely()?.isFeatureEnabled(OptimizelyFeature.Key.ANDROID_FACEBOOK_LOGIN_REMOVE) == true) {
+                Intent().getResetPasswordIntent(this, email = binding.loginFormView.email.text.toString())
+            } else {
+                Intent(this, ResetPasswordActivity::class.java)
+                    .putExtra(IntentKey.EMAIL, binding.loginFormView.email.text.toString())
+            }
             startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
         }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/LoginToutActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/LoginToutActivity.kt
@@ -9,10 +9,12 @@ import com.kickstarter.R
 import com.kickstarter.databinding.LoginToutLayoutBinding
 import com.kickstarter.libs.ActivityRequestCodes
 import com.kickstarter.libs.BaseActivity
+import com.kickstarter.libs.KSString
 import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
+import com.kickstarter.libs.utils.extensions.getResetPasswordIntent
 import com.kickstarter.services.apiresponses.ErrorEnvelope.FacebookUser
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.HelpActivity.Terms
@@ -26,11 +28,13 @@ import rx.android.schedulers.AndroidSchedulers
 class LoginToutActivity : BaseActivity<LoginToutViewModel.ViewModel>() {
 
     private lateinit var binding: LoginToutLayoutBinding
+    private lateinit var ksString: KSString
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = LoginToutLayoutBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        this.ksString = requireNotNull(environment().ksString())
         binding.loginToolbar.loginToolbar.title = getString(R.string.login_tout_navbar_title)
 
         viewModel.outputs.finishWithSuccessfulResult()
@@ -79,6 +83,14 @@ class LoginToutActivity : BaseActivity<LoginToutViewModel.ViewModel>() {
             .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { ViewUtils.showDialog(this, getString(R.string.login_tout_navbar_title), it) }
+
+        viewModel.outputs.startResetPasswordActivity()
+            .compose(bindToLifecycle())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                val intent = Intent().getResetPasswordIntent(this, isResetPasswordFacebook = true)
+                startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
+            }
 
         binding.facebookLoginButton.setOnClickListener {
             facebookLoginClick()

--- a/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
@@ -3,6 +3,7 @@ package com.kickstarter.ui.activities
 import android.content.Intent
 import android.os.Bundle
 import android.util.Pair
+import androidx.core.view.isVisible
 import com.kickstarter.R
 import com.kickstarter.databinding.ResetPasswordLayoutBinding
 import com.kickstarter.libs.BaseActivity
@@ -32,12 +33,12 @@ class ResetPasswordActivity : BaseActivity<ResetPasswordViewModel.ViewModel>() {
 
         setContentView(binding.root)
 
-        binding.resetPasswordToolbar.loginToolbar.setTitle(getString(this.forgotPasswordString))
-
-        this.viewModel.outputs.resetSuccess()
+        this.viewModel.outputs.resetLoginPasswordSuccess()
             .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe { onResetSuccess() }
+            .subscribe {
+                onResetSuccess()
+            }
 
         this.viewModel.outputs.isFormSubmitting()
             .compose(bindToLifecycle())
@@ -63,6 +64,25 @@ class ResetPasswordActivity : BaseActivity<ResetPasswordViewModel.ViewModel>() {
             .compose(Transformers.observeForUI())
             .subscribe {
                 binding.resetPasswordFormView.email.setText(it)
+            }
+
+        this.viewModel.outputs.resetPasswordScreenStatus()
+            .compose(bindToLifecycle())
+            .compose(Transformers.observeForUI())
+            .subscribe {
+                binding.resetPasswordToolbar.loginToolbar.setTitle(getString(it.title))
+                it.hint?.let { hint ->
+                    binding.resetPasswordHint.setText(hint)
+                    binding.resetPasswordHint.isVisible = true
+                }
+            }
+
+        this.viewModel.outputs.resetFacebookLoginPasswordSuccess()
+            .compose(bindToLifecycle())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                setFormEnabled(false)
+                finish()
             }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ResetPasswordActivity.kt
@@ -11,7 +11,7 @@ import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.TransitionUtils.slideInFromLeft
 import com.kickstarter.libs.utils.ViewUtils
-import com.kickstarter.ui.IntentKey
+import com.kickstarter.libs.utils.extensions.getLoginActivityIntent
 import com.kickstarter.ui.data.LoginReason
 import com.kickstarter.ui.extensions.onChange
 import com.kickstarter.ui.extensions.text
@@ -81,8 +81,7 @@ class ResetPasswordActivity : BaseActivity<ResetPasswordViewModel.ViewModel>() {
             .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
-                setFormEnabled(false)
-                finish()
+                navigateToLoginActivity()
             }
     }
 
@@ -92,13 +91,18 @@ class ResetPasswordActivity : BaseActivity<ResetPasswordViewModel.ViewModel>() {
 
     private fun onResetSuccess() {
         setFormEnabled(false)
-        val intent = Intent(this, LoginActivity::class.java)
-            .putExtra(IntentKey.EMAIL, binding.resetPasswordFormView.email.text())
-            .putExtra(IntentKey.LOGIN_REASON, LoginReason.RESET_PASSWORD)
+        val intent =
+            Intent().getLoginActivityIntent(this, binding.resetPasswordFormView.email.text(), LoginReason.RESET_PASSWORD)
         setResult(RESULT_OK, intent)
         finish()
     }
 
+    private fun navigateToLoginActivity() {
+        setFormEnabled(false)
+        val intent = Intent().getLoginActivityIntent(this, binding.resetPasswordFormView.email.text(), LoginReason.RESET_PASSWORD)
+        startActivityWithTransition(intent, R.anim.fade_in_slide_in_left, R.anim.slide_out_right)
+        finish()
+    }
     private fun setFormEnabled(isEnabled: Boolean) {
         binding.resetPasswordFormView.resetPasswordButton.isEnabled = isEnabled
     }

--- a/app/src/main/java/com/kickstarter/ui/data/ResetPasswordScreenState.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/ResetPasswordScreenState.kt
@@ -8,7 +8,7 @@ enum class ResetPasswordScreenState(
     @StringRes val hint: Int?
 ) {
     ResetPassword(
-        title = R.string.FPO_reset_your_password_title,
+        title = R.string.FPO_reset_your_password,
         hint = R.string.FPO_reset_your_password_hint
     ),
     ForgetPassword(

--- a/app/src/main/java/com/kickstarter/ui/data/ResetPasswordScreenState.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/ResetPasswordScreenState.kt
@@ -1,0 +1,18 @@
+package com.kickstarter.ui.data
+
+import androidx.annotation.StringRes
+import com.kickstarter.R
+
+enum class ResetPasswordScreenState(
+    @StringRes val title: Int,
+    @StringRes val hint: Int?
+) {
+    ResetPassword(
+        title = R.string.FPO_reset_your_password_title,
+        hint = R.string.FPO_reset_your_password_hint
+    ),
+    ForgetPassword(
+        title = R.string.forgot_password_title,
+        hint = null
+    )
+}

--- a/app/src/main/res/layout/reset_password_layout.xml
+++ b/app/src/main/res/layout/reset_password_layout.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView
   xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   android:gravity="center_horizontal"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
@@ -14,6 +15,20 @@
     <include
         android:id="@+id/reset_password_toolbar"
         layout="@layout/login_toolbar" />
+
+    <TextView
+        android:id="@+id/reset_password_hint"
+        style="@style/CalloutPrimaryMaison"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/grid_4"
+        android:layout_marginTop="@dimen/grid_2"
+        android:layout_marginBottom="@dimen/grid_5"
+        android:layout_marginRight="@dimen/grid_4"
+        android:gravity="center|start"
+        android:visibility="gone"
+        tools:text="@string/FPO_reset_your_password_hint"
+        tools:visibility="visible" />
 
     <include
         android:id="@+id/reset_password_form_view"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,4 +82,7 @@
   <!-- Campaign -->
   <string name="Story">Story</string>
 
+  <!-- facebook remove -->
+  <string name="FPO_reset_your_password_title">Reset your password</string>
+  <string name="FPO_reset_your_password_hint">FPO We’ve discontinued logging in through Facebook.  To access your Kickstarter account, enter the email associated to your Facebook account and we’ll send you a link to reset your password.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,9 @@
   <string name="Story">Story</string>
 
   <!-- facebook remove -->
-  <string name="FPO_reset_your_password_title">Reset your password</string>
+  <string name="FPO_reset_your_password">Reset your password</string>
   <string name="FPO_reset_your_password_hint">FPO We’ve discontinued logging in through Facebook.  To access your Kickstarter account, enter the email associated to your Facebook account and we’ll send you a link to reset your password.</string>
+  <string name="FPO_reset_your_password_dialog_msg">FPO: We can no longer log you in through Facebook. Please log in with your Kickstarter password, or set a new password with your Facebook email.</string>
+  <string name="FPO_login_with_kickstarter">Log in</string>
+  <string name="FPO_Set_new_password">Set new password</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -572,6 +572,10 @@
     <item name="android:fontFamily">@string/font_family_maison_neue_book</item>
   </style>
 
+  <style name="CalloutPrimaryMaison" parent="CalloutPrimary">
+    <item name="android:fontFamily">@string/font_family_maison_neue_book</item>
+  </style>
+
   <style name="Warning" parent="TextPrimary">
     <item name="android:layout_marginTop">@dimen/grid_1</item>
     <item name="android:layout_marginBottom">@dimen/grid_2</item>

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/IntentExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/IntentExtTest.kt
@@ -6,6 +6,7 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.mock.factories.ProjectDataFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.ui.IntentKey
+import com.kickstarter.ui.data.LoginReason
 import org.junit.Test
 
 class IntentExtTest : KSRobolectricTestCase() {
@@ -112,5 +113,22 @@ class IntentExtTest : KSRobolectricTestCase() {
         assertEquals(intent2.component?.className, "com.kickstarter.ui.activities.ResetPasswordActivity")
         assertEquals(intent2.extras?.get(IntentKey.EMAIL), "test@kickstarter.com")
         assertEquals(intent2.extras?.get(IntentKey.RESET_PASSWORD_FACEBOOK_LOGIN), false)
+    }
+
+    @Test
+    fun testLoginActivityIntent() {
+        val intent = Intent().getLoginActivityIntent(context())
+        assertEquals(intent.component?.className, "com.kickstarter.ui.activities.LoginActivity")
+        assertEquals(intent.extras?.get(IntentKey.EMAIL), null)
+
+        val intent1 = Intent().getLoginActivityIntent(context(), loginReason = LoginReason.RESET_PASSWORD)
+        assertEquals(intent1.component?.className, "com.kickstarter.ui.activities.LoginActivity")
+        assertEquals(intent1.extras?.get(IntentKey.EMAIL), null)
+        assertEquals(intent1.extras?.get(IntentKey.LOGIN_REASON), LoginReason.RESET_PASSWORD)
+
+        val intent2 = Intent().getLoginActivityIntent(context(), email = "test@kickstarter.com")
+        assertEquals(intent2.component?.className, "com.kickstarter.ui.activities.LoginActivity")
+        assertEquals(intent2.extras?.get(IntentKey.EMAIL), "test@kickstarter.com")
+        assertEquals(intent2.extras?.get(IntentKey.LOGIN_REASON), null)
     }
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/IntentExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/IntentExtTest.kt
@@ -96,4 +96,17 @@ class IntentExtTest : KSRobolectricTestCase() {
         assertEquals(intent.extras?.get(IntentKey.IS_UPDATE_COMMENT), isCommentForUpdate)
         assertEquals(intent.extras?.get(IntentKey.COMMENT), comment)
     }
+
+    @Test
+    fun testResetPasswordIntent() {
+        val intent = Intent().getResetPasswordIntent(context(), true)
+        assertEquals(intent.component?.className, "com.kickstarter.ui.activities.ResetPasswordActivity")
+        assertEquals(intent.extras?.get(IntentKey.EMAIL), null)
+        assertEquals(intent.extras?.get(IntentKey.RESET_PASSWORD_FACEBOOK_LOGIN), true)
+
+        val intent2 = Intent().getResetPasswordIntent(context(), email = "test@kickstarter.com")
+        assertEquals(intent2.component?.className, "com.kickstarter.ui.activities.ResetPasswordActivity")
+        assertEquals(intent2.extras?.get(IntentKey.EMAIL), "test@kickstarter.com")
+        assertEquals(intent2.extras?.get(IntentKey.RESET_PASSWORD_FACEBOOK_LOGIN), false)
+    }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.kt
@@ -4,7 +4,9 @@ import android.content.Intent
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUser
+import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.utils.EventName
+import com.kickstarter.mock.MockExperimentsClientType
 import com.kickstarter.mock.services.MockApiClient
 import com.kickstarter.models.User
 import com.kickstarter.services.apiresponses.AccessTokenEnvelope
@@ -24,6 +26,7 @@ class LoginToutViewModelTest : KSRobolectricTestCase() {
     private val startSignupActivity = TestSubscriber<Void>()
     private val currentUser = TestSubscriber<User?>()
     private val showDisclaimerActivity = TestSubscriber<DisclaimerItems>()
+    private val startResetPasswordActivity = TestSubscriber<Void>()
 
     private fun setUpEnvironment(environment: Environment, loginReason: LoginReason) {
         vm = LoginToutViewModel.ViewModel(environment)
@@ -31,6 +34,7 @@ class LoginToutViewModelTest : KSRobolectricTestCase() {
         vm.loginError.subscribe(loginError)
         vm.outputs.startSignupActivity().subscribe(startSignupActivity)
         vm.outputs.startLoginActivity().subscribe(startLoginActivity)
+        vm.outputs.startResetPasswordActivity().subscribe(startResetPasswordActivity)
         vm.outputs.showDisclaimerActivity().subscribe(showDisclaimerActivity)
         environment.currentUser()?.observable()?.subscribe(currentUser)
         vm.intent(Intent().putExtra(IntentKey.LOGIN_REASON, loginReason))
@@ -80,6 +84,36 @@ class LoginToutViewModelTest : KSRobolectricTestCase() {
         this.currentUser.assertValueCount(1)
         finishWithSuccessfulResult.assertValueCount(1)
         segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
+    }
+
+    @Test
+    fun facebookLoginWithFeatureFlag_Enabled() {
+        val currentUser = MockCurrentUser()
+        val mockExperimentsClientType: MockExperimentsClientType =
+            object : MockExperimentsClientType() {
+                override fun isFeatureEnabled(feature: OptimizelyFeature.Key): Boolean {
+                    return true
+                }
+            }
+
+        val environment = environment()
+            .toBuilder()
+            .currentUser(currentUser)
+            .optimizely(mockExperimentsClientType)
+            .build()
+        setUpEnvironment(environment, LoginReason.DEFAULT)
+
+        this.currentUser.assertValuesAndClear(null)
+
+        vm.inputs.facebookLoginClick(
+            null,
+            listOf("public_profile", "user_friends", "email")
+        )
+
+        startResetPasswordActivity.assertValueCount(1)
+        finishWithSuccessfulResult.assertNoValues()
+
+        segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.kt
@@ -133,8 +133,6 @@ class LoginToutViewModelTest : KSRobolectricTestCase() {
         startLoginActivity.assertNoValues()
         startResetPasswordActivity.assertValueCount(1)
         segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
-
-
     }
 
     @Test
@@ -180,9 +178,6 @@ class LoginToutViewModelTest : KSRobolectricTestCase() {
 
         startResetPasswordActivity.assertNoValues()
         startLoginActivity.assertValueCount(1)
-        segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
-
-
     }
 
     @Test


### PR DESCRIPTION
# 📲 What
[Android] ask user to reset password with facebook login error  
https://www.figma.com/file/lmJlSlEk5Wp7BfxCVtKplU/Deprecrating-FB-Authentication?node-id=192%3A2368
# 🤔 Why

Facebook login completely unavailable due to revoked API, user clicks FB CTA

# 🛠 How
Check under feature flag with facebook login error to show dialog to user to reset password or login normally 
![image](https://user-images.githubusercontent.com/1075310/184010716-c72e7297-6d8e-4598-a55b-ed06ab2c76b4.png)


# 👀 See

https://user-images.githubusercontent.com/1075310/184010350-04676813-27d4-4e77-bbcb-a27e47bbdbce.mp4


# 📋 QA

Test on staging as we already have facebook error and feature flag enabled to work as demo 
Test production with normal flow login with facebook 

# Story 📖
https://kickstarter.atlassian.net/browse/WEB-663