### PR TITLE
NTV-602 && SD-1499: Crash when opening updates for concrete project

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
@@ -72,12 +72,10 @@ fun Intent.getCreatorBioWebViewActivityIntent(context: Context, project: Project
  * Return a Intent ready to launch the ProjectUpdates activity
  * @param context
  * @param projectAndData
- * @param comment -> to open the comments activity to a specific thread
  */
-fun Intent.getProjectUpdatesActivityIntent(context: Context, projectAndData: Pair<Project, ProjectData>): Intent {
+fun Intent.getProjectUpdatesActivityIntent(context: Context, projectAndData: ProjectData): Intent {
     return this.setClass(context, ProjectUpdatesActivity::class.java)
-        .putExtra(IntentKey.PROJECT, projectAndData.first)
-        .putExtra(IntentKey.PROJECT_DATA, projectAndData.second)
+        .putExtra(IntentKey.PROJECT_DATA, projectAndData)
 }
 
 /**

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -158,7 +158,7 @@ fun Activity.startUpdatesActivity(
  * the Transition occurs slide_in_right -> fade_out_slide_out_left
  * @param projectAndData
  */
-fun Activity.startProjectUpdatesActivity(projectAndData: Pair<Project, ProjectData>) {
+fun Activity.startProjectUpdatesActivity(projectAndData: ProjectData) {
     startActivity(Intent().getProjectUpdatesActivityIntent(this, projectAndData))
     overridePendingTransition(R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectOverviewFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectOverviewFragment.kt
@@ -319,7 +319,7 @@ class ProjectOverviewFragment : BaseFragment<ProjectOverviewViewModel.ViewModel>
             .compose(bindToLifecycle())
             .compose(Transformers.observeForUI())
             .subscribe {
-                activity?.startProjectUpdatesActivity(Pair(it.project(), it))
+                activity?.startProjectUpdatesActivity(it)
             }
 
         viewModel.outputs.startCreatorView()

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectUpdatesViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectUpdatesViewModel.kt
@@ -69,15 +69,13 @@ interface ProjectUpdatesViewModel {
             cookieManager = requireNotNull(environment.cookieManager())
             sharedPreferences = requireNotNull(environment.sharedPreferences())
 
-            val project = intent()
-                .map<Any?> { it.getParcelableExtra(IntentKey.PROJECT) }
-                .ofType(Project::class.java)
-                .take(1)
-
             val projectData = intent()
                 .map<Any?> { it.getParcelableExtra(IntentKey.PROJECT_DATA) }
                 .ofType(ProjectData::class.java)
                 .take(1)
+
+            val project = projectData
+                .map { it.project() }
 
             projectData
                 .map {

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/IntentExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/IntentExtTest.kt
@@ -67,9 +67,8 @@ class IntentExtTest : KSRobolectricTestCase() {
     @Test
     fun testGetProjectUpdatesIntent() {
         val projectData = ProjectDataFactory.project(ProjectFactory.project())
-        val intent = Intent().getProjectUpdatesActivityIntent(context(), Pair(projectData.project(), projectData))
+        val intent = Intent().getProjectUpdatesActivityIntent(context(), projectData)
         assertEquals(intent.component?.className, "com.kickstarter.ui.activities.ProjectUpdatesActivity")
-        assertEquals(intent.extras?.get(IntentKey.PROJECT), projectData.project())
         assertEquals(intent.extras?.get(IntentKey.PROJECT_DATA), projectData)
     }
 


### PR DESCRIPTION
# 📲 What
- Go to the project https://staging.kickstarter.com/projects/kimeramodels/tenebrae-fate-of-asteria
- Press Updates

# 🤔 Why
The intent generated is exceeding the limit of 1MB forcing the app to crash. Take a look to the android documentation :  [Parcelables and Bundles  |  Android Developers](https://developer.android.com/guide/components/activities/parcelables-and-bundles#sdbp)

By looking at logcat you can see the exception TransactionTooLargeException

```
08-22 13:00:22.436  1190  1370 W UsageStatsService: Unexpected activity event reported! (com.kickstarter.kickstarter.internal.debug/com.kickstarter.ui.activities.DiscoveryActivity event : 23 instanceId : 141828132)
08-22 13:00:22.436  1190  2519 E ActivityTaskManager: Transaction too large, intent: Intent { cmp=com.kickstarter.kickstarter.internal.debug/com.kickstarter.ui.activities.ProjectUpdatesActivity (has extras) }, extras size: 530736, icicle size: 0
08-22 13:00:22.437  1190  2519 E JavaBinder: !!! FAILED BINDER TRANSACTION !!!  (parcel size = 534448)
08-22 13:00:22.438  1190  2519 E ActivityTaskManager: Second failure launching com.kickstarter.kickstarter.internal.debug/com.kickstarter.ui.activities.ProjectUpdatesActivity, giving up
08-22 13:00:22.438  1190  2519 E ActivityTaskManager: android.os.TransactionTooLargeException: data parcel size 534448 bytes
08-22 13:00:22.438  1190  2519 E ActivityTaskManager:   at android.os.BinderProxy.transactNative(Native Method)
08-22 13:00:22.438  1190  2519 E ActivityTaskManager:   at android.os.BinderProxy.transact(BinderProxy.java:571)
```

# 🛠 How

The intent is serializing the project AND the projectData, being redundant information, by only passing projectData, the viewModel for the Updates screen will have access to the project as is the second field on projectData class.

The solution for this bug is a refactor to eliminate the data redundancy and generate an intent with size reduced in half.

# 👀 See
| Before 🐛 |

https://user-images.githubusercontent.com/4083656/186228291-501c56ae-728b-4d36-a659-6fa3e94939e6.mp4


| After 🦋 |


https://user-images.githubusercontent.com/4083656/186228317-f17648e4-ebb3-4013-87d1-3cfe418422e4.mp4



|  |  |

# 📋 QA

- Go to the project https://staging.kickstarter.com/projects/kimeramodels/tenebrae-fate-of-asteria
- Press Updates, should not suffer the crash

# Story 📖

[NTV-602](https://kickstarter.atlassian.net/browse/NTV-602)
[SD-1499](https://kickstarter.atlassian.net/browse/SD-1499)
