### PR TITLE
NTV-603: Mark as received UI inconsistent behaviour

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardUtils.kt
@@ -81,8 +81,10 @@ object RewardUtils {
     /**
      * Returns `true` if the reward is considered the 'non-reward' option, i.e. the reward is the option
      * backers select when they want to pledge to a project without selecting a particular reward.
+     * reward.id == 0L -> in case the data was obtained from API V1
+     * reward.id == null -> in case the data was obtained from API GraphQL
      */
-    fun isNoReward(reward: Reward) = reward.id() == 0L
+    fun isNoReward(reward: Reward) = reward.id() == 0L || reward.id() == null
 
     /**
      * Returns `true` if the reward is a specific reward for a project, i.e. it is not the 'no-reward' option.

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -162,7 +162,7 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>() {
             .compose(bindToLifecycle())
             .compose(Transformers.observeForUI())
             .subscribe {
-                binding?.receivedSectionLayout?.root?.setGone(it)
+                binding?.receivedSectionLayout?.receivedSectionLayoutContainer?.setGone(it)
             }
 
         this.viewModel.outputs.receivedSectionCreatorIsGone()
@@ -222,7 +222,6 @@ class BackingFragment : BaseFragment<BackingFragmentViewModel.ViewModel>() {
             .compose(Transformers.observeForUI())
             .subscribe {
                 binding?.pledgeDetailsLabel?.text = getString(R.string.Pledge_details)
-                binding?.receivedSectionLayout?.root?.setGone(true)
                 binding?.deliveryDisclaimerSection?.root?.setGone(it)
                 binding?.estimatedDeliveryLabel2?.setGone(true)
             }

--- a/app/src/main/res/layout/fragment_backing_section_reward_delivery.xml
+++ b/app/src/main/res/layout/fragment_backing_section_reward_delivery.xml
@@ -6,6 +6,7 @@
     android:layout_marginStart="@dimen/grid_3"
     android:layout_marginEnd="@dimen/grid_3"
     android:background="@drawable/rect_trans_rounded"
+    android:id="@+id/received_section_layout_container"
     app:cardElevation="0dp">
 
     <TextView

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -481,15 +481,28 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testNotifyDelegateToRefreshProject() {
+        val backing = BackingFactory.backing()
+            .toBuilder()
+            .status(Backing.STATUS_COLLECTED)
+            .build()
+        val project = ProjectFactory.backedProject()
+            .toBuilder()
+            .backing(backing)
+            .build()
+        val projectData = ProjectDataFactory.project(project).toBuilder()
+            .backing(backing)
+            .build()
+
         val environment = environment()
             .toBuilder()
-            .apolloClient(mockApolloClientForBacking(BackingFactory.backing()))
+            .apolloClient(mockApolloClientForBacking(backing))
             .build()
         setUpEnvironment(environment)
-        this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.backedProject()))
+        this.vm.inputs.configureWith(projectData)
 
         this.vm.inputs.refreshProject()
         this.notifyDelegateToRefreshProject.assertValueCount(1)
+        this.receivedSectionIsGone.assertValues(false)
     }
 
     @Test
@@ -970,9 +983,11 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testReceivedSectionIsGone_whenBackingIsCollectedNoCreator_actualReward() {
+        val reward = RewardFactory.reward()
         val backing = BackingFactory.backing()
             .toBuilder()
-            .rewardId(3L)
+            .reward(reward)
+            .rewardId(reward.id())
             .status(Backing.STATUS_COLLECTED)
             .build()
 
@@ -990,6 +1005,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testReceivedSectionIsGone_whenBackingIsCollectedAndUserIsCreator_actualReward() {
         val user = UserFactory.creator()
+        val reward = RewardFactory.reward()
 
         val project = ProjectFactory.backedProject()
             .toBuilder()
@@ -999,7 +1015,8 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         val backing = BackingFactory.backing()
             .toBuilder()
             .project(project)
-            .rewardId(3L)
+            .reward(reward)
+            .rewardId(reward.id())
             .status(Backing.STATUS_COLLECTED)
             .build()
 
@@ -1020,10 +1037,12 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testReceivedSectionIsGone_whenBackingIsCollectedNoCreator_noReward() {
+        val reward = RewardFactory.noReward()
         val backing = BackingFactory.backing()
             .toBuilder()
             .backer(UserFactory.user())
-            .rewardId(null)
+            .reward(reward)
+            .rewardId(reward.id())
             .status(Backing.STATUS_COLLECTED)
             .build()
 


### PR DESCRIPTION
# 📲 What
- load  manage your pledge screen for a reward that has an estimated delivery date, and is shippable. If you reload the screen, the mark as received UI disappears. Now it has a consistent behaviour.

# 🤔 Why
- A reward "no reward" is considered as such when the ID == 0 , but only for graphQL API, when the request is made to V1 API the entire the consideration of reward no reward within the backing object is reward == null && rewardId == null
- The input data to the screen has two entry points for the reward:
- - ProjectData -> baking -> reward
- - ProjectData -> Project -> backing -> reward
When hitting refresh the observable for showing the "Mark as received UI" was not emiting properly, now obtained both rewards if available and merged on a single observable.

# 👀 See
| Before 🐛 | 

https://user-images.githubusercontent.com/4083656/187496002-9d6df6f0-1785-4105-bed7-9a8ce1a7528b.mp4


| After 🦋 |

https://user-images.githubusercontent.com/4083656/187496028-f2616604-2946-414b-9fc2-a4d665848542.mp4

|  |  |

# 📋 QA

- Go to your profile
- Search for a project that is completed, and a backed reward shippable
- Load manage your pledge screen

# Story 📖

[SD-1527](https://kickstarter.atlassian.net/browse/SD-1527)
[NTV-603](https://kickstarter.atlassian.net/browse/NTV-603)
