### PR TITLE
PAY-1931: Upgrade stripe SDK to latest version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,12 +40,12 @@ if (file('signing.gradle').exists()) {
 
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.kickstarter"
         minSdkVersion 23
-        targetSdkVersion 31
+        targetSdkVersion 32
         testApplicationId "com.kickstarter.internal.debug.test"
         testInstrumentationRunner "com.kickstarter.screenshoot.testing.KSScreenShotTestRunner"
 
@@ -217,7 +217,7 @@ dependencies {
     implementation "com.jakewharton.rxbinding:rxbinding-support-v4:$rx_binding_version"
     implementation "com.jakewharton.timber:timber:5.0.1"
     implementation 'com.optimizely.ab:android-sdk:3.13.2'
-    implementation 'com.stripe:stripe-android:20.5.0'
+    implementation 'com.stripe:stripe-android:20.11.0'
     final okhttp_version = '4.10.+'
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp_version"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttp_version"


### PR DESCRIPTION
# 📲 What

Stipes SDK upgrade

# 🤔 Why

- Previous version had a bug for validating postal code

# 🛠 How

- Targeted API 32 (stripe's restriction)
- Updates to latest stripe version

# 👀 See

- pledge 

https://user-images.githubusercontent.com/4083656/187749061-12ec5bf7-2687-4bc2-a25e-ca4532837f5d.mp4

- Validate postal code with paymentsheet, update pledge (update pledge currently works with previously added payment methods, not yet with the added via PaymentSheet)

https://user-images.githubusercontent.com/4083656/187749262-c3f3b02b-7f5f-420f-9766-98009f09908a.mp4


|  |  |

# 📋 QA

- Pledge
- Add payment methods
- Update pledge

# Story 📖

[PAY-1931](https://kickstarter.atlassian.net/browse/PAY-1931)
