### PR TITLE
NTV-610: OperatorObserveOn.java crash due BackpressureException

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -13,7 +13,6 @@ import com.kickstarter.R
 import com.kickstarter.databinding.FragmentBackingAddonsBinding
 import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
-import com.kickstarter.libs.utils.ObjectUtils
 import com.kickstarter.libs.utils.extensions.selectPledgeFragment
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
@@ -28,7 +27,6 @@ import com.kickstarter.ui.extensions.hideKeyboard
 import com.kickstarter.ui.viewholders.BackingAddOnViewHolder
 import com.kickstarter.viewmodels.BackingAddOnsFragmentViewModel
 import rx.android.schedulers.AndroidSchedulers
-import rx.schedulers.Schedulers
 import java.util.concurrent.TimeUnit
 
 @RequiresFragmentViewModel(BackingAddOnsFragmentViewModel.ViewModel::class)

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -28,6 +28,7 @@ import com.kickstarter.ui.extensions.hideKeyboard
 import com.kickstarter.ui.viewholders.BackingAddOnViewHolder
 import com.kickstarter.viewmodels.BackingAddOnsFragmentViewModel
 import rx.android.schedulers.AndroidSchedulers
+import rx.schedulers.Schedulers
 import java.util.concurrent.TimeUnit
 
 @RequiresFragmentViewModel(BackingAddOnsFragmentViewModel.ViewModel::class)
@@ -85,8 +86,8 @@ class BackingAddOnsFragment : BaseFragment<BackingAddOnsFragmentViewModel.ViewMo
 
         this.viewModel.outputs.totalSelectedAddOns()
             .compose(bindToLifecycle())
+            .onBackpressureBuffer()
             .observeOn(AndroidSchedulers.mainThread())
-            .filter { ObjectUtils.isNotNull(it) }
             .subscribe { total ->
                 binding?.fragmentBackingAddonsSectionFooterLayout?.backingAddonsFooterButton ?.text = selectProperString(total)
             }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingAddOnsFragmentViewModel.kt
@@ -23,7 +23,6 @@ import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.ui.fragments.BackingAddOnsFragment
 import com.kickstarter.viewmodels.usecases.ShowPledgeFragmentUseCase
 import rx.Observable
-import rx.schedulers.Schedulers
 import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
 import java.util.Locale
@@ -101,7 +100,7 @@ class BackingAddOnsFragmentViewModel {
         private val isEnabledCTAButton = BehaviorSubject.create<Boolean>()
 
         // - Current addOns selection
-        private val totalSelectedAddOns = PublishSubject.create<Int>()
+        private val totalSelectedAddOns = BehaviorSubject.create(0)
         private val quantityPerId = PublishSubject.create<Pair<Int, Long>>()
         private val currentSelection = BehaviorSubject.create(mutableMapOf<Long, Int>())
 


### PR DESCRIPTION
# 📲 What

Take a look to crashlytics, currently this is the top most crash: 

[https://console.firebase.google.com/u/1/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/5ba1ed9df8b88c29636d073b?versions=3.4.0 (2013150893)&time=last-seven-days&sessionEventKey=6318E1CB00420001277716B88A1FF104_1719151239564076462](https://console.firebase.google.com/u/1/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/5ba1ed9df8b88c29636d073b?versions=3.4.0%20(2013150893)&time=last-seven-days&sessionEventKey=6318E1CB00420001277716B88A1FF104_1719151239564076462)

# 🤔 Why
`rx.exceptions.MissingBackpressureException`
The exception is caused due to backpressure, it basically means the Observable source emits faster than the consumer consumes.

The long-term solution to avoid it will be 
->  1 Add pagination for AddOns screen
->  Migrating to RxJava2, that provides tools to better handle Backpressure strategies plus dispose of subscriptions. Here a detailed for the future architecture changes that will address this plan : [H2 2022 Android Tech Plan](https://kickstarter.atlassian.net/wiki/spaces/~420550558/pages/2028339209/H2+2022+Android+Tech+Plan) 

# 🛠 How
For a more short term workaround with the limited tools we have on the current RXJava 1.3.8 version the operator `.onBackpressureBuffer()` has been added before subscribing to the problematic observable.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | 

|After 🦋 |

https://user-images.githubusercontent.com/4083656/189253505-da6525d2-b4c2-465c-a07c-a61a3ecd78d0.mp4

|  |  |

# 📋 QA

Instructions for anyone to be able to QA this work.

# Story 📖

[Name of Trello Story](Trello link)
