### PR TITLE
NTV-622: Internal builds not being generated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,9 @@ jobs:
       - run: ./gradlew checkstyle
       - run: ./gradlew ktlint
       - run: ./gradlew lintExternalRelease
-      - run: ./gradlew testExternalRelease -PdisablePreDex
+      - run: ./gradlew jacocoExternalReleaseReport -PdisablePreDex # jacoco executes internally testExternalRelease
       - codecov/upload:
-          file:  app/build/reports/jacoco/jacocoInternalDebugReport/jacocoInternalDebugReport.xml
+          file:  app/build/reports/jacoco/jacocoExternalReleaseReport/jacocoExternalReleaseReport.xml
       - store_artifacts:
           path: app/build/reports
           destination: reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ base_job: &base_job
   executor:
     name: android/android-machine
     resource-class: xlarge
-    tag: 2022.09.2
+    tag: 2022.09
   working_directory: '~/project'
   environment:
     TERM: dumb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ base_job: &base_job
   executor:
     name: android/android-machine
     resource-class: xlarge
-    tag: 2022.09
+    tag: 2022.08.1
   working_directory: '~/project'
   environment:
     TERM: dumb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 base_job: &base_job
   executor:
-      name: android/android-machine
-      resource-class: xlarge
+    name: android/android-machine
+    resource-class: xlarge
+    tag: 2022.09.2
   working_directory: '~/project'
   environment:
     TERM: dumb
@@ -10,8 +11,8 @@ base_job: &base_job
 
 version: 2.1
 orbs:
-  codecov: codecov/codecov@1.1.5
-  android: circleci/android@1.0.3
+  codecov: codecov/codecov@3.2.3
+  android: circleci/android@2.1.2
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
       - run: ./gradlew ktlint
       - run: ./gradlew lintExternalRelease
       - run: ./gradlew testExternalRelease -PdisablePreDex
-      - run: ./gradlew app:jacocoInternalDebug --stacktrace
       - codecov/upload:
           file:  app/build/reports/jacoco/jacocoInternalDebugReport/jacocoInternalDebugReport.xml
       - store_artifacts:

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/IntentExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/IntentExtTest.kt
@@ -13,7 +13,7 @@ class IntentExtTest : KSRobolectricTestCase() {
 
     @Test
     fun testGetProjectIntent_whenFeatureFlagTrue_shouldReturnProjectPageActivity() {
-        assertEquals(Intent().getProjectIntent(context()).component?.className, "com.kickstarter.ui.activities.ProjectPage")
+        assertEquals(Intent().getProjectIntent(context()).component?.className, "com.kickstarter.ui.activities.ProjectPageActivity")
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/IntentExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/IntentExtTest.kt
@@ -13,7 +13,7 @@ class IntentExtTest : KSRobolectricTestCase() {
 
     @Test
     fun testGetProjectIntent_whenFeatureFlagTrue_shouldReturnProjectPageActivity() {
-        assertEquals(Intent().getProjectIntent(context()).component?.className, "com.kickstarter.ui.activities.ProjectPageActivity")
+        assertEquals(Intent().getProjectIntent(context()).component?.className, "com.kickstarter.ui.activities.ProjectPage")
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Take a look into the internal pipelines -> https://app.circleci.com/pipelines/github/kickstarter/android-private
Take a look into the external pipelines (Open source repository) -> https://app.circleci.com/pipelines/github/kickstarter/android-oss

The internal ones where failing due to a time out on the code coverage generation 


# 🛠 How
- Updated the orbs for `Android` and `codecov`
- Deleted redundant step for testing, executing `jacocoExternalReleaseReport` set will call internally `testExternalRelease`

# 👀 See
- Internal branch successfully running all the stepsthat previously failed -> https://app.circleci.com/pipelines/github/kickstarter/android-private/772/workflows/20c45591-46ac-41d3-804c-a7da6d93b3d6/jobs/8145
|  |  |

# 📋 QA

- Nothing to QA, it's CI integration step, once this PR is merged the internal builds should run perfectly, but in case you wanna test it checkout this branch, raname it to 'internal' and push to the private repository, it will trigger the job for generating internal builds 

# Story 📖

[NTV-622](https://kickstarter.atlassian.net/browse/NTV-622)
