### PR TITLE
PAY-1988:  Fixed 3DS validation error

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/PaymentMethodsSettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/PaymentMethodsSettingsActivity.kt
@@ -97,7 +97,7 @@ class PaymentMethodsSettingsActivity : AppCompatActivity() {
         )
 
         compositeDisposable.add(
-            this.viewModel.success()
+            this.viewModel.successDeleting()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { showSnackbar(binding.settingPaymentMethodsActivityToolbar.paymentMethodsToolbar, R.string.Got_it_your_changes_have_been_saved) }
@@ -122,6 +122,15 @@ class PaymentMethodsSettingsActivity : AppCompatActivity() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe {
                     showErrorSnackBar(binding.settingPaymentMethodsActivityToolbar.paymentMethodsToolbar, getString(R.string.general_error_something_wrong))
+                }
+        )
+
+        compositeDisposable.add(
+            this.viewModel.successSaving()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe {
+                    showSnackbar(binding.settingPaymentMethodsActivityToolbar.paymentMethodsToolbar, R.string.Got_it_your_changes_have_been_saved)
                 }
         )
     }
@@ -150,12 +159,13 @@ class PaymentMethodsSettingsActivity : AppCompatActivity() {
 
     private fun onPaymentOption(paymentOption: PaymentOption?) {
         paymentOption?.let {
-            this.viewModel.inputs.savePaymentOption()
             flowController.confirm()
+            this.viewModel.inputs.confirmedLoading(true)
         }
     }
 
     fun onPaymentSheetResult(paymentSheetResult: PaymentSheetResult) {
+        this.viewModel.inputs.confirmedLoading(false)
         when (paymentSheetResult) {
             is PaymentSheetResult.Canceled -> {
                 showErrorSnackBar(binding.paymentMethodsContent, getString(R.string.general_error_oops))
@@ -164,7 +174,7 @@ class PaymentMethodsSettingsActivity : AppCompatActivity() {
                 showErrorSnackBar(binding.paymentMethodsContent, getString(R.string.general_error_something_wrong))
             }
             is PaymentSheetResult.Completed -> {
-                showSnackbar(binding.settingPaymentMethodsActivityToolbar.paymentMethodsToolbar, R.string.Got_it_your_changes_have_been_saved)
+                this.viewModel.inputs.savePaymentOption()
             }
         }
     }

--- a/app/src/test/java/com/kickstarter/viewmodels/PaymentMethodsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PaymentMethodsViewModelTest.kt
@@ -38,7 +38,7 @@ class PaymentMethodsViewModelTest : KSRobolectricTestCase() {
         compositeDisposable.add(this.vm.outputs.dividerIsVisible().subscribe { this.dividerIsVisible.onNext(it) })
         compositeDisposable.add(this.vm.outputs.progressBarIsVisible().subscribe { this.progressBarIsVisible.onNext(it) })
         compositeDisposable.add(this.vm.outputs.showDeleteCardDialog().subscribe { this.showDeleteCardDialog.onNext(it) })
-        compositeDisposable.add(this.vm.outputs.success().subscribe { this.success.onNext(it) })
+        compositeDisposable.add(this.vm.outputs.successDeleting().subscribe { this.success.onNext(it) })
         compositeDisposable.add(this.vm.outputs.presentPaymentSheet().subscribe { this.presentPaymentSheet.onNext(it) })
         compositeDisposable.add(this.vm.outputs.showError().subscribe { this.showError.onNext(it) })
     }

--- a/app/src/test/java/com/kickstarter/viewmodels/PaymentMethodsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PaymentMethodsViewModelTest.kt
@@ -24,9 +24,10 @@ class PaymentMethodsViewModelTest : KSRobolectricTestCase() {
     private val error = TestSubscriber<String>()
     private val progressBarIsVisible = TestSubscriber<Boolean>()
     private val showDeleteCardDialog = TestSubscriber<Unit>()
-    private val success = TestSubscriber<String>()
+    private val successDeleting = TestSubscriber<String>()
     private val presentPaymentSheet = TestSubscriber<String>()
     private val showError = TestSubscriber<String>()
+    private val successSaving = TestSubscriber<String>()
     private val compositeDisposable = CompositeDisposable()
 
     private fun setUpEnvironment(environment: Environment) {
@@ -38,9 +39,10 @@ class PaymentMethodsViewModelTest : KSRobolectricTestCase() {
         compositeDisposable.add(this.vm.outputs.dividerIsVisible().subscribe { this.dividerIsVisible.onNext(it) })
         compositeDisposable.add(this.vm.outputs.progressBarIsVisible().subscribe { this.progressBarIsVisible.onNext(it) })
         compositeDisposable.add(this.vm.outputs.showDeleteCardDialog().subscribe { this.showDeleteCardDialog.onNext(it) })
-        compositeDisposable.add(this.vm.outputs.successDeleting().subscribe { this.success.onNext(it) })
+        compositeDisposable.add(this.vm.outputs.successDeleting().subscribe { this.successDeleting.onNext(it) })
         compositeDisposable.add(this.vm.outputs.presentPaymentSheet().subscribe { this.presentPaymentSheet.onNext(it) })
         compositeDisposable.add(this.vm.outputs.showError().subscribe { this.showError.onNext(it) })
+        compositeDisposable.add(this.vm.outputs.successSaving().subscribe { this.successSaving.onNext(it) })
     }
 
     @After
@@ -139,7 +141,7 @@ class PaymentMethodsViewModelTest : KSRobolectricTestCase() {
         this.cards.assertValueCount(1)
         this.vm.inputs.deleteCardClicked("id")
         this.vm.inputs.confirmDeleteCardClicked()
-        this.success.assertValueCount(1)
+        this.successDeleting.assertValueCount(1)
         this.cards.assertValueCount(2)
     }
 
@@ -222,6 +224,7 @@ class PaymentMethodsViewModelTest : KSRobolectricTestCase() {
         this.cards.assertValues(cardsList, cardsListUpdated)
         this.progressBarIsVisible.assertValues(false, true, false, true, false, true, false, true, false)
         this.showError.assertNoValues()
+        this.successSaving.assertValue(card.toString())
     }
 
     @Test
@@ -265,5 +268,6 @@ class PaymentMethodsViewModelTest : KSRobolectricTestCase() {
         this.cards.assertValues(cardsList)
         this.progressBarIsVisible.assertValues(false, true, false, true, false, true, false, true, false)
         this.showError.assertValues(errorString)
+        this.successSaving.assertNoValues()
     }
 }


### PR DESCRIPTION
# 📲 What

- Error during 3DS validation flow

# 🤔 Why

- `SavePaymentMethod` mutation was being called before the validation process was completed by the user, when receiving the user input through `onPaymentOption` there was no warrant for the 3DS validation process to be completed. To be completely sure the validation process is finalized `SavePaymentMethod` has being moved to `onPaymentSheetResult` ONLY when the result is completed.
- Added additional UI loading  starting from the moment where we have the payment method available, until some result is obtained from `onPaymentSheetResult`
- Differentiate between success state for deleting payment methods, and success state for saving payment method

# 👀 See
| Before 🐛 |
- Not saving the payment method, as it was attempting to save the payment methods once available, but not after having the complete Result

https://user-images.githubusercontent.com/4083656/193075692-b6c1f23d-13a2-4804-9e9c-5546c9ac4fbd.mp4




| After 🦋 |
- 3DS flow with success authentication, 3DS flow failing authentication


https://user-images.githubusercontent.com/4083656/193074473-15a1db57-ddfc-4911-9ede-93f8fc093e1f.mp4



| --- | --- |
|  |  |

# 📋 QA
- Try to add this payment method on user settings 4000002760003184 it always request 3DS validation, accept the validation, make sure the new payment method is added, and the black snackbar is presented
-  Try to add this payment method on user settings 4000002760003184 it always request 3DS validation, fail the validation, make sure no new payment methods is added and the red error snackbar is presented
- Add any other type of card nothing should have changed

# Story 📖

[PAY-1899](https://kickstarter.atlassian.net/browse/PAY-1988)
