### PR TITLE
[no-jira]: Fix Hide backer tag when video clicked

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -345,6 +345,11 @@ class ProjectPageActivity :
             .compose(Transformers.observeForUI())
             .subscribe { viewModel.inputs.fullScreenVideoButtonClicked(it) }
 
+        binding.mediaHeader.outputs.playButtonClicks()
+            .compose(bindToLifecycle())
+            .compose(Transformers.observeForUI())
+            .subscribe { viewModel.inputs.onVideoPlayButtonClicked() }
+
         this.viewModel.outputs.onOpenVideoInFullScreen()
             .subscribeOn(Schedulers.io())
             .distinctUntilChanged()

--- a/app/src/main/java/com/kickstarter/ui/views/MediaHeader.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/MediaHeader.kt
@@ -139,6 +139,7 @@ class MediaHeader @JvmOverloads constructor(
             binding.videoPlayButtonOverlay.isGone = true
             binding.videoProjectView.isVisible = true
             binding.videoProjectView.setPlayerPlayWhenReadyFlag(true)
+            playButtonClicks.onNext(null)
         }
 
         binding.videoProjectView.setOnFullScreenClickedListener(object : OnFullScreenOpenedClickedListener {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
@@ -130,6 +130,8 @@ interface ProjectPageViewModel {
         fun tabSelected(position: Int)
 
         fun closeFullScreenVideo(seekPosition: Long)
+
+        fun onVideoPlayButtonClicked()
     }
 
     interface Outputs {
@@ -288,6 +290,7 @@ interface ProjectPageViewModel {
         private val updatePledgeClicked = PublishSubject.create<Void>()
         private val updatesTextViewClicked = PublishSubject.create<Void>()
         private val viewRewardsClicked = PublishSubject.create<Void>()
+        private val onVideoPlayButtonClicked = PublishSubject.create<Void>()
 
         private val backingDetailsIsVisible = BehaviorSubject.create<Boolean>()
         private val backingDetailsSubtitle = BehaviorSubject.create<Either<String, Int>?>()
@@ -941,6 +944,13 @@ interface ProjectPageViewModel {
                 .subscribe {
                     this.showUpdatePledge.onNext(it)
                 }
+
+            onVideoPlayButtonClicked
+                .distinctUntilChanged()
+                .compose(bindToLifecycle())
+                .subscribe {
+                    backingViewGroupIsVisible.onNext(false)
+                }
         }
 
         private fun getSelectedTabContextName(selectedTabIndex: Int): String = when (selectedTabIndex) {
@@ -1083,6 +1093,8 @@ interface ProjectPageViewModel {
         }
 
         override fun closeFullScreenVideo(position: Long) = closeFullScreenVideo.onNext(position)
+
+        override fun onVideoPlayButtonClicked() = onVideoPlayButtonClicked.onNext(null)
 
         override fun updateVideoCloseSeekPosition(): Observable< Long> =
             updateVideoCloseSeekPosition

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
@@ -275,6 +275,25 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testBackingViewGroup_whenPlayButtonClicked_shouldEmitFalse() {
+        val project = ProjectFactory.initialProject().toBuilder().isBacking(true).build()
+        val currentUser = MockCurrentUser()
+        val environment = environment()
+            .toBuilder()
+            .currentUser(currentUser)
+            .build()
+
+        requireNotNull(environment.currentConfig()).config(ConfigFactory.config())
+
+        setUpEnvironment(environment)
+
+        this.vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
+        this.vm.inputs.onVideoPlayButtonClicked()
+
+        backingViewGroupIsVisible.assertValues(true, false)
+    }
+
+    @Test
     fun testBackingViewGroup_whenNotBacking_shouldEmitFalse() {
         val project = ProjectFactory.initialProject().toBuilder().isBacking(false).build()
         val currentUser = MockCurrentUser()


### PR DESCRIPTION
# 📲 What

Hide backer tag when video clicked

# 🤔 Why

Update video for projects to play in the same screen

# 🛠 How
![image](https://user-images.githubusercontent.com/1075310/201139365-164498da-e624-424b-bbfe-a11c2efdbfde.png)


| Before 🐛 | 

https://user-images.githubusercontent.com/1075310/201140703-93ca2290-6d2d-41e3-b8d1-6e0af3f2b737.mp4


| After 🦋 |

https://user-images.githubusercontent.com/1075310/201140656-18bf85f7-ba7e-44a4-9917-876853102b49.mp4






# 📋 QA
Play a video on the backed project
