### PR TITLE
NTV-141 :  New comments disappearing on pagination

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -506,6 +506,7 @@ interface CommentsViewModel {
                 }.compose(bindToLifecycle())
                 .subscribe {
                     this.newlyPostedCommentsList.clear()
+                    println("newlyPostedCommentsList size with refresh ${newlyPostedCommentsList.size}")
                 }
 
             this.internalError

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -123,6 +123,7 @@ interface CommentsViewModel {
 
         private var openedThreadActivityFromDeepLink = false
 
+        private val newlyPostedCommentsList = mutableListOf<CommentCardData>()
         init {
 
             this.currentUserStream.observable()
@@ -249,7 +250,6 @@ interface CommentsViewModel {
                 }
 
             this.insertNewCommentToList
-                .distinctUntilChanged()
                 .withLatestFrom(this.currentUserStream.loggedInUser()) {
                         comment, user ->
                     Pair(comment, user)
@@ -273,13 +273,20 @@ interface CommentsViewModel {
                             .build()
                     )
                 }
-                .doOnNext { scrollToTop.onNext(true) }
+                .distinctUntilChanged { prev, curr ->
+                    prev.first.first.second.equals(curr.first.first.second)
+                }
+                .doOnNext {
+                    this.scrollToTop.onNext(true)
+                }
                 .withLatestFrom(this.commentsList) { it, list ->
                     list.toMutableList().apply {
                         add(0, it.second)
+                        newlyPostedCommentsList.add(0, it.second)
                     }.toList()
                 }.compose(bindToLifecycle())
                 .subscribe {
+
                     commentsList.onNext(it)
                 }
 
@@ -364,11 +371,17 @@ interface CommentsViewModel {
             this.commentsList
                 .compose(takePairWhen(this.commentToRefresh))
                 .map {
-                    it.second.first.updateCommentAfterSuccessfulPost(it.first, it.second.second)
+                    val mappedList = it.second.first.updateCommentAfterSuccessfulPost(it.first, it.second.second)
+                    updateNewlyPostedCommentWithNewStatus(mappedList[it.second.second])
+                    mappedList
                 }
                 .distinctUntilChanged()
+                .doOnNext {
+                    this.scrollToTop.onNext(false)
+                }
                 .compose(bindToLifecycle())
                 .subscribe {
+
                     this.commentsList.onNext(it)
                 }
 
@@ -383,7 +396,9 @@ interface CommentsViewModel {
             this.commentsList
                 .compose(takePairWhen(this.failedCommentCardToRefresh))
                 .map {
-                    it.second.first.updateCommentFailedToPost(it.first, it.second.second)
+                    val mappedList = it.second.first.updateCommentFailedToPost(it.first, it.second.second)
+                    updateNewlyPostedCommentWithNewStatus(mappedList[it.second.second])
+                    mappedList
                 }
                 .distinctUntilChanged()
                 .compose(bindToLifecycle())
@@ -401,6 +416,16 @@ interface CommentsViewModel {
                 .subscribe {
                     this.commentsList.onNext(it)
                 }
+        }
+
+        private fun updateNewlyPostedCommentWithNewStatus(
+            updatedComment: CommentCardData
+        ) {
+            this.newlyPostedCommentsList.indexOfFirst { item ->
+                item.commentableId == updatedComment.commentableId
+            }.also { index ->
+                newlyPostedCommentsList[index] = updatedComment
+            }
         }
 
         private fun trackRootCommentPageViewEvent(it: Pair<Project, Update?>) {
@@ -445,6 +470,13 @@ interface CommentsViewModel {
 
             apolloPaginate.paginatedData()
                 ?.share()
+                ?.map {
+                    if (this.newlyPostedCommentsList.isNotEmpty()) {
+                        this.newlyPostedCommentsList + it
+                    } else {
+                        it
+                    }
+                }
                 ?.subscribe {
                     this.commentsList.onNext(it)
                 }
@@ -471,6 +503,9 @@ interface CommentsViewModel {
             this.refresh
                 .doOnNext {
                     this.isRefreshing.onNext(true)
+                }.compose(bindToLifecycle())
+                .subscribe {
+                    this.newlyPostedCommentsList.clear()
                 }
 
             this.internalError

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -2,6 +2,7 @@ package com.kickstarter.viewmodels
 
 import android.util.Pair
 import androidx.annotation.NonNull
+import androidx.annotation.VisibleForTesting
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Either
 import com.kickstarter.libs.Environment
@@ -123,7 +124,8 @@ interface CommentsViewModel {
 
         private var openedThreadActivityFromDeepLink = false
 
-        private val newlyPostedCommentsList = mutableListOf<CommentCardData>()
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        val newlyPostedCommentsList = mutableListOf<CommentCardData>()
         init {
 
             this.currentUserStream.observable()
@@ -280,13 +282,12 @@ interface CommentsViewModel {
                     this.scrollToTop.onNext(true)
                 }
                 .withLatestFrom(this.commentsList) { it, list ->
+                    newlyPostedCommentsList.add(0, it.second)
                     list.toMutableList().apply {
                         add(0, it.second)
-                        newlyPostedCommentsList.add(0, it.second)
                     }.toList()
                 }.compose(bindToLifecycle())
                 .subscribe {
-
                     commentsList.onNext(it)
                 }
 
@@ -381,7 +382,6 @@ interface CommentsViewModel {
                 }
                 .compose(bindToLifecycle())
                 .subscribe {
-
                     this.commentsList.onNext(it)
                 }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -506,7 +506,6 @@ interface CommentsViewModel {
                 }.compose(bindToLifecycle())
                 .subscribe {
                     this.newlyPostedCommentsList.clear()
-                    println("newlyPostedCommentsList size with refresh ${newlyPostedCommentsList.size}")
                 }
 
             this.internalError

--- a/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
@@ -2,6 +2,7 @@ package com.kickstarter.viewmodels
 
 import android.util.Pair
 import androidx.annotation.NonNull
+import androidx.annotation.VisibleForTesting
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.loadmore.ApolloPaginate
@@ -112,6 +113,8 @@ interface ThreadViewModel {
         private val initialError = BehaviorSubject.create<Throwable>()
         private val paginationError = BehaviorSubject.create<Throwable>()
 
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        val newlyPostedCommentsList = mutableListOf<CommentCardData>()
         init {
 
             val commentData = getCommentCardDataFromIntent()
@@ -171,6 +174,7 @@ interface ThreadViewModel {
                 .withLatestFrom(this.onCommentReplies) { reply, pair ->
                     Pair(
                         pair.first.toMutableList().apply {
+                            newlyPostedCommentsList.add(0, reply)
                             /** bind new reply at the top of list to as list is reversed  **/
                             add(0, reply)
                         }.toList(),
@@ -256,7 +260,9 @@ interface ThreadViewModel {
             this.onCommentReplies
                 .compose(Transformers.combineLatestPair(this.failedCommentCardToRefresh))
                 .map {
-                    Pair(it.second.first.updateCommentFailedToPost(it.first.first, it.second.second), it.first.second)
+                    val mappedList = it.second.first.updateCommentFailedToPost(it.first.first, it.second.second)
+                    updateNewlyPostedCommentWithNewStatus(mappedList[it.second.second])
+                    Pair(mappedList, it.first.second)
                 }
                 .distinctUntilChanged()
                 .compose(bindToLifecycle())
@@ -283,7 +289,9 @@ interface ThreadViewModel {
             this.onCommentReplies
                 .compose(Transformers.combineLatestPair(this.successfullyPostedCommentCardToRefresh))
                 .map {
-                    Pair(it.second.first.updateCommentAfterSuccessfulPost(it.first.first, it.second.second), it.first.second)
+                    val mappedList = it.second.first.updateCommentAfterSuccessfulPost(it.first.first, it.second.second)
+                    updateNewlyPostedCommentWithNewStatus(mappedList[it.second.second])
+                    Pair(mappedList, it.first.second)
                 }
                 .distinctUntilChanged()
                 .compose(bindToLifecycle())
@@ -330,6 +338,16 @@ interface ThreadViewModel {
                 }
         }
 
+        private fun updateNewlyPostedCommentWithNewStatus(
+            updatedComment: CommentCardData
+        ) {
+            this.newlyPostedCommentsList.indexOfFirst { item ->
+                item.commentableId == updatedComment.commentableId
+            }.also { index ->
+                newlyPostedCommentsList[index] = updatedComment
+            }
+        }
+
         private fun loadCommentListFromProjectOrUpdate(comment: Observable<Comment>) {
             val startOverWith =
                 Observable.merge(
@@ -368,9 +386,17 @@ interface ThreadViewModel {
             apolloPaginate
                 .paginatedData()
                 ?.map { it.reversed() }
+                ?.map {
+                    if (this.newlyPostedCommentsList.isNotEmpty()) {
+                        this.newlyPostedCommentsList + it
+                    } else {
+                        it
+                    }
+                }
                 ?.compose(Transformers.combineLatestPair(this.hasPreviousElements))
                 ?.distinctUntilChanged()
                 ?.share()
+
                 ?.subscribe {
                     this.onCommentReplies.onNext(it)
                 }

--- a/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
@@ -386,17 +386,16 @@ interface ThreadViewModel {
             apolloPaginate
                 .paginatedData()
                 ?.map { it.reversed() }
+                ?.compose(Transformers.combineLatestPair(this.hasPreviousElements))
+                ?.distinctUntilChanged()
+                ?.share()
                 ?.map {
                     if (this.newlyPostedRepliesList.isNotEmpty()) {
-                        this.newlyPostedRepliesList + it
+                        Pair(this.newlyPostedRepliesList + it.first, it.second)
                     } else {
                         it
                     }
                 }
-                ?.compose(Transformers.combineLatestPair(this.hasPreviousElements))
-                ?.distinctUntilChanged()
-                ?.share()
-
                 ?.subscribe {
                     this.onCommentReplies.onNext(it)
                 }

--- a/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThreadViewModel.kt
@@ -114,7 +114,7 @@ interface ThreadViewModel {
         private val paginationError = BehaviorSubject.create<Throwable>()
 
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-        val newlyPostedCommentsList = mutableListOf<CommentCardData>()
+        val newlyPostedRepliesList = mutableListOf<CommentCardData>()
         init {
 
             val commentData = getCommentCardDataFromIntent()
@@ -174,7 +174,7 @@ interface ThreadViewModel {
                 .withLatestFrom(this.onCommentReplies) { reply, pair ->
                     Pair(
                         pair.first.toMutableList().apply {
-                            newlyPostedCommentsList.add(0, reply)
+                            newlyPostedRepliesList.add(0, reply)
                             /** bind new reply at the top of list to as list is reversed  **/
                             add(0, reply)
                         }.toList(),
@@ -341,10 +341,10 @@ interface ThreadViewModel {
         private fun updateNewlyPostedCommentWithNewStatus(
             updatedComment: CommentCardData
         ) {
-            this.newlyPostedCommentsList.indexOfFirst { item ->
+            this.newlyPostedRepliesList.indexOfFirst { item ->
                 item.commentableId == updatedComment.commentableId
             }.also { index ->
-                newlyPostedCommentsList[index] = updatedComment
+                newlyPostedRepliesList[index] = updatedComment
             }
         }
 
@@ -387,8 +387,8 @@ interface ThreadViewModel {
                 .paginatedData()
                 ?.map { it.reversed() }
                 ?.map {
-                    if (this.newlyPostedCommentsList.isNotEmpty()) {
-                        this.newlyPostedCommentsList + it
+                    if (this.newlyPostedRepliesList.isNotEmpty()) {
+                        this.newlyPostedRepliesList + it
                     } else {
                         it
                     }

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -372,8 +372,8 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     }
 
     /*
-* test Pagination
-*/
+    * test Pagination
+    */
     @Test
     fun testCommentsViewModel_ProjectLoadingMore_AndInsertNewComment() {
         val currentUser = UserFactory.user()

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -397,6 +397,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         // post a comment
         vm.inputs.insertNewCommentToList(commentCardData.comment?.body()!!, createdAt)
+        assertEquals(1, vm.newlyPostedCommentsList.size)
         assertEquals(2, commentsList.value?.size)
         assertEquals(CommentFactory.comment(), commentsList.value?.last()?.comment)
     }
@@ -525,7 +526,10 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         // - New posted comment with status "TRYING_TO_POST"
         vm.inputs.insertNewCommentToList(newPostedComment.body(), DateTime.now())
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
+
+        assertEquals(1, vm.newlyPostedCommentsList.size)
         commentsList.assertValueCount(2)
+
         vm.outputs.commentsList().take(1).subscribe {
             val newList = it
             assertTrue(newList.size == 3)
@@ -624,7 +628,11 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         // - New posted comment with status "TRYING_TO_POST"
         vm.inputs.insertNewCommentToList(newPostedComment.body(), DateTime.now())
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
+
+        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(CommentCardStatus.TRYING_TO_POST.commentCardStatus, vm.newlyPostedCommentsList[0].commentCardState)
         commentsList.assertValueCount(2)
+
         vm.outputs.commentsList().take(1).subscribe {
             val newList = it
             assertTrue(newList.size == 3)
@@ -651,6 +659,12 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
         this.hasPendingComments.assertValues(Pair(false, false), Pair(true, false), Pair(false, false))
         segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
+
+        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(
+            CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus,
+            vm.newlyPostedCommentsList[0].commentCardState
+        )
 
         vm.onResumeActivity()
         segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
@@ -747,6 +761,12 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
         this.hasPendingComments.assertValues(Pair(false, true), Pair(true, true), Pair(false, true))
         segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
+
+        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(
+            CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus,
+            vm.newlyPostedCommentsList[0].commentCardState
+        )
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
@@ -6,7 +6,12 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUser
 import com.kickstarter.libs.utils.EventName
-import com.kickstarter.mock.factories.*
+import com.kickstarter.mock.factories.AvatarFactory
+import com.kickstarter.mock.factories.CommentCardDataFactory
+import com.kickstarter.mock.factories.CommentEnvelopeFactory
+import com.kickstarter.mock.factories.CommentFactory
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClient
 import com.kickstarter.models.Comment
 import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope

--- a/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
@@ -275,7 +275,7 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
 
         val onRepliesResult = onReplies.value
 
-        assertEquals(true,onRepliesResult?.second)
+        assertEquals(true, onRepliesResult?.second)
         assertEquals(replies.comments?.size, onRepliesResult?.first?.size)
         assertEquals(true, onRepliesResult?.second)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
@@ -6,12 +6,7 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUser
 import com.kickstarter.libs.utils.EventName
-import com.kickstarter.mock.factories.AvatarFactory
-import com.kickstarter.mock.factories.CommentCardDataFactory
-import com.kickstarter.mock.factories.CommentEnvelopeFactory
-import com.kickstarter.mock.factories.CommentFactory
-import com.kickstarter.mock.factories.ProjectFactory
-import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.mock.factories.*
 import com.kickstarter.mock.services.MockApolloClient
 import com.kickstarter.models.Comment
 import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope
@@ -297,6 +292,73 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         openCommentGuideLines.assertValueCount(1)
     }
 
+    /*
+    * test Pagination
+    */
+    @Test
+    fun testThreadViewModel_ProjectLoadingMore_AndInsertNewReplay() {
+        val currentUser = UserFactory.user()
+            .toBuilder()
+            .id(1)
+            .avatar(AvatarFactory.avatar())
+            .build()
+
+        val createdAt = DateTime.now()
+
+        var firstCall = true
+
+        val testScheduler = TestScheduler()
+
+        val comment1 = CommentFactory.commentToPostWithUser(currentUser).toBuilder().id(1).body("comment1").build()
+        val comment2 = CommentFactory.commentToPostWithUser(currentUser).toBuilder().id(2).body("comment2").build()
+        val newPostedComment = CommentFactory.commentToPostWithUser(currentUser).toBuilder().id(3).body("comment3").build()
+
+        val commentEnvelope = CommentEnvelopeFactory.commentsEnvelope().toBuilder()
+            .comments(listOf(comment1, comment2))
+            .build()
+
+        val env = environment().toBuilder().currentUser(MockCurrentUser(currentUser))
+            .apolloClient(object : MockApolloClient() {
+
+                override fun getRepliesForComment(
+                    comment: Comment,
+                    cursor: String?,
+                    pageSize: Int
+                ): Observable<CommentEnvelope> {
+                    return if (firstCall)
+                        Observable.just(commentEnvelope)
+                    else
+                        Observable.just(CommentEnvelopeFactory.emptyCommentsEnvelope())
+                }
+            })
+            .scheduler(testScheduler).build()
+
+        val onReplies = BehaviorSubject.create<Pair<List<CommentCardData>, Boolean>>()
+        val vm = ThreadViewModel.ViewModel(env)
+        vm.intent(Intent().putExtra(IntentKey.COMMENT_CARD_DATA, CommentCardDataFactory.commentCardData()))
+        vm.outputs.onCommentReplies().subscribe(onReplies)
+
+        assertEquals(2, onReplies.value?.first?.size)
+
+        // post a comment
+        vm.inputs.insertNewReplyToList(newPostedComment.body(), DateTime.now())
+
+        assertEquals(3, onReplies.value?.first?.size)
+        assertEquals(1, vm.newlyPostedCommentsList.size)
+
+        firstCall = false
+        // get the next page which is end of page
+        vm.inputs.nextPage()
+
+        vm.outputs.onCommentReplies().take(0).subscribe {
+            assertEquals(2, it.first.size)
+            assertEquals(CommentFactory.comment(), it.first.last()?.comment)
+        }
+
+        assertEquals(3, onReplies.value?.first?.size)
+        assertEquals(1, vm.newlyPostedCommentsList.size)
+    }
+
     @Test
     fun testComments_UpdateCommentStateAfterPost() {
         val currentUser = UserFactory.user()
@@ -365,6 +427,9 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         vm.inputs.insertNewReplyToList(newPostedComment.body(), DateTime.now())
         testScheduler.advanceTimeBy(3, TimeUnit.SECONDS)
         onReplies.assertValueCount(2)
+        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(CommentCardStatus.TRYING_TO_POST.commentCardStatus, vm.newlyPostedCommentsList[0].commentCardState)
+
         vm.outputs.onCommentReplies().take(0).subscribe {
             val newList = it.first
             assertTrue(newList.size == 3)
@@ -396,6 +461,8 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
             assertTrue(newList[2].commentCardState == commentCardData2.commentCardState)
         }
         segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
+        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus, vm.newlyPostedCommentsList[0].commentCardState)
     }
 
     @Test
@@ -472,6 +539,8 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         vm.inputs.insertNewReplyToList(newPostedComment.body(), DateTime.now())
         testScheduler.advanceTimeBy(3, TimeUnit.SECONDS)
         onReplies.assertValueCount(2)
+        assertEquals(1, vm.newlyPostedCommentsList.size)
+
         vm.outputs.onCommentReplies().take(0).subscribe {
             val newList = it.first
             assertTrue(newList.size == 3)
@@ -489,7 +558,13 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         vm.inputs.refreshCommentCardInCaseFailedPosted(newPostedComment, 0)
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
 
+        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(
+            CommentCardStatus.FAILED_TO_SEND_COMMENT.commentCardStatus,
+            vm.newlyPostedCommentsList[0].commentCardState
+        )
         onReplies.assertValueCount(3)
+        assertEquals(1, vm.newlyPostedCommentsList.size)
         vm.outputs.onCommentReplies().take(0).subscribe {
             val newList = it.first
             assertTrue(newList.size == 3)
@@ -520,6 +595,12 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
             assertTrue(newList[2].commentCardState == commentCardData2.commentCardState)
         }
         segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
+
+        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(
+            CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus,
+            vm.newlyPostedCommentsList[0].commentCardState
+        )
     }
 
     @Test
@@ -611,6 +692,9 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         vm.inputs.insertNewReplyToList(newPostedComment.body(), DateTime.now())
         testScheduler.advanceTimeBy(3, TimeUnit.SECONDS)
         onReplies.assertValueCount(2)
+        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(CommentCardStatus.TRYING_TO_POST.commentCardStatus, vm.newlyPostedCommentsList[0].commentCardState)
+
         vm.outputs.onCommentReplies().take(0).subscribe {
             val newList = it.first
             assertTrue(newList.size == 3)

--- a/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
@@ -344,7 +344,7 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         vm.inputs.insertNewReplyToList(newPostedComment.body(), DateTime.now())
 
         assertEquals(3, onReplies.value?.first?.size)
-        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(1, vm.newlyPostedRepliesList.size)
 
         firstCall = false
         // get the next page which is end of page
@@ -356,7 +356,7 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         }
 
         assertEquals(3, onReplies.value?.first?.size)
-        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(1, vm.newlyPostedRepliesList.size)
     }
 
     @Test
@@ -427,8 +427,8 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         vm.inputs.insertNewReplyToList(newPostedComment.body(), DateTime.now())
         testScheduler.advanceTimeBy(3, TimeUnit.SECONDS)
         onReplies.assertValueCount(2)
-        assertEquals(1, vm.newlyPostedCommentsList.size)
-        assertEquals(CommentCardStatus.TRYING_TO_POST.commentCardStatus, vm.newlyPostedCommentsList[0].commentCardState)
+        assertEquals(1, vm.newlyPostedRepliesList.size)
+        assertEquals(CommentCardStatus.TRYING_TO_POST.commentCardStatus, vm.newlyPostedRepliesList[0].commentCardState)
 
         vm.outputs.onCommentReplies().take(0).subscribe {
             val newList = it.first
@@ -461,8 +461,8 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
             assertTrue(newList[2].commentCardState == commentCardData2.commentCardState)
         }
         segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
-        assertEquals(1, vm.newlyPostedCommentsList.size)
-        assertEquals(CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus, vm.newlyPostedCommentsList[0].commentCardState)
+        assertEquals(1, vm.newlyPostedRepliesList.size)
+        assertEquals(CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus, vm.newlyPostedRepliesList[0].commentCardState)
     }
 
     @Test
@@ -539,7 +539,7 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         vm.inputs.insertNewReplyToList(newPostedComment.body(), DateTime.now())
         testScheduler.advanceTimeBy(3, TimeUnit.SECONDS)
         onReplies.assertValueCount(2)
-        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(1, vm.newlyPostedRepliesList.size)
 
         vm.outputs.onCommentReplies().take(0).subscribe {
             val newList = it.first
@@ -558,13 +558,13 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         vm.inputs.refreshCommentCardInCaseFailedPosted(newPostedComment, 0)
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
 
-        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(1, vm.newlyPostedRepliesList.size)
         assertEquals(
             CommentCardStatus.FAILED_TO_SEND_COMMENT.commentCardStatus,
-            vm.newlyPostedCommentsList[0].commentCardState
+            vm.newlyPostedRepliesList[0].commentCardState
         )
         onReplies.assertValueCount(3)
-        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(1, vm.newlyPostedRepliesList.size)
         vm.outputs.onCommentReplies().take(0).subscribe {
             val newList = it.first
             assertTrue(newList.size == 3)
@@ -596,10 +596,10 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         }
         segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
 
-        assertEquals(1, vm.newlyPostedCommentsList.size)
+        assertEquals(1, vm.newlyPostedRepliesList.size)
         assertEquals(
             CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus,
-            vm.newlyPostedCommentsList[0].commentCardState
+            vm.newlyPostedRepliesList[0].commentCardState
         )
     }
 
@@ -692,8 +692,8 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         vm.inputs.insertNewReplyToList(newPostedComment.body(), DateTime.now())
         testScheduler.advanceTimeBy(3, TimeUnit.SECONDS)
         onReplies.assertValueCount(2)
-        assertEquals(1, vm.newlyPostedCommentsList.size)
-        assertEquals(CommentCardStatus.TRYING_TO_POST.commentCardStatus, vm.newlyPostedCommentsList[0].commentCardState)
+        assertEquals(1, vm.newlyPostedRepliesList.size)
+        assertEquals(CommentCardStatus.TRYING_TO_POST.commentCardStatus, vm.newlyPostedRepliesList[0].commentCardState)
 
         vm.outputs.onCommentReplies().take(0).subscribe {
             val newList = it.first

--- a/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
@@ -275,6 +275,7 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
 
         val onRepliesResult = onReplies.value
 
+        assertEquals(true,onRepliesResult?.second)
         assertEquals(replies.comments?.size, onRepliesResult?.first?.size)
         assertEquals(true, onRepliesResult?.second)
 


### PR DESCRIPTION
# 📲 What
 newly posted comments as soon as we load more pages of comments /Replies disappear 
  newly posted comments as soon as Pull to refresh duplicated

# 🤔 Why
Fix comments issue

# 🛠 How
Add a list of newly posted comments and append to the pagination source 

# 👀 See
Before 

Uploading device-2022-11-28-215421.mp4…


After 
https://user-images.githubusercontent.com/1075310/204365417-b34cfbd3-b643-44a2-bf12-c2764f7cb51f.mp4



# 📋 QA
1. Go to a project comments / Replies screen
2. Post a comment
3. Scroll down until more comments are loaded
4. Scroll back up and look for your latest comment
5. Pull to refresh


# Story 📖
https://kickstarter.atlassian.net/browse/NTV-141
