### PR TITLE
PAY-2080: Retry pledge after error with PaymentSheet

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -224,7 +224,7 @@ dependencies {
     implementation "com.jakewharton.rxbinding:rxbinding-support-v4:$rx_binding_version"
     implementation "com.jakewharton.timber:timber:5.0.1"
     implementation 'com.optimizely.ab:android-sdk:3.13.2'
-    implementation 'com.stripe:stripe-android:20.14.0'
+    implementation 'com.stripe:stripe-android:20.16.1'
     final okhttp_version = '4.10.+'
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp_version"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttp_version"

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
@@ -285,6 +285,7 @@ fun Project.reduce(): Project {
         .currencySymbol(this.currencySymbol())
         .currencyTrailingCode(this.currencyTrailingCode())
         .isBacking(this.isBacking())
+        .backing(backing())
         .availableCardTypes(this.availableCardTypes())
         .category(this.category())
         .build()

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
@@ -262,3 +262,30 @@ fun Project.updateStartedProjectAndDiscoveryParamsList(
 
     return listOfProjects
 }
+
+/**
+ * Extension function that will return a reduced copy of the the target project, the fields available
+ * on the reduce copy are those ones required on the next Screens: BackingAddons, PledgeFragment, ThanksActivity
+ *
+ * The end goal is to reduce to the bare minimum the amount of memory required to be serialized on Intents
+ * when presenting screens in order to avoid `android.os.TransactionTooLargeException`
+ */
+fun Project.reduce(): Project {
+    return Project.Builder()
+        .id(this.id())
+        .slug(this.slug())
+        .name(this.name())
+        .location(this.location())
+        .deadline(this.deadline())
+        .staticUsdRate(this.staticUsdRate())
+        .fxRate(this.fxRate())
+        .country(this.country())
+        .currentCurrency(this.currentCurrency())
+        .currency(this.currency())
+        .currencySymbol(this.currencySymbol())
+        .currencyTrailingCode(this.currencyTrailingCode())
+        .isBacking(this.isBacking())
+        .availableCardTypes(this.availableCardTypes())
+        .category(this.category())
+        .build()
+}

--- a/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.kt
@@ -160,14 +160,14 @@ class ActivityFeedActivity : BaseActivity<ActivityFeedViewModel.ViewModel>() {
 
     private fun startProjectActivity(project: Project) {
         val intent = Intent().getProjectIntent(this)
-            .putExtra(IntentKey.PROJECT, project)
+            .putExtra(IntentKey.PROJECT_PARAM, project.slug())
             .putExtra(IntentKey.REF_TAG, RefTag.activity())
         startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 
     private fun startUpdateActivity(activity: Activity) {
         val intent = Intent(this, UpdateActivity::class.java)
-            .putExtra(IntentKey.PROJECT, activity.project())
+            .putExtra(IntentKey.PROJECT_PARAM, activity.project()?.slug())
             .putExtra(IntentKey.UPDATE, activity.update())
         startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -736,7 +736,6 @@ class ProjectPageActivity :
         val pledgeData = checkoutDatandProjectData.second
         val projectData = pledgeData.projectData()
         if (clearFragmentBackStack()) {
-            updateFragments(projectData)
             startActivity(
                 Intent(this, ThanksActivity::class.java)
                     .putExtra(IntentKey.PROJECT, projectData.project())

--- a/app/src/main/java/com/kickstarter/ui/activities/ThanksActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ThanksActivity.kt
@@ -144,7 +144,7 @@ class ThanksActivity : BaseActivity<ThanksViewModel.ViewModel>() {
 
     private fun startProjectActivity(projectAndRefTagAndIsFfEnabled: Pair<Project, RefTag>) {
         val intent = Intent().getProjectIntent(this)
-            .putExtra(IntentKey.PROJECT, projectAndRefTagAndIsFfEnabled.first)
+            .putExtra(IntentKey.PROJECT_PARAM, projectAndRefTagAndIsFfEnabled.first?.slug())
             .putExtra(IntentKey.REF_TAG, projectAndRefTagAndIsFfEnabled.second)
         startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }

--- a/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/DiscoveryFragment.kt
@@ -272,7 +272,7 @@ class DiscoveryFragment : BaseFragment<DiscoveryFragmentViewModel.ViewModel>() {
     private fun startProjectActivity(project: Project, refTag: RefTag) {
         context?.let {
             val intent = Intent().getProjectIntent(it)
-                .putExtra(IntentKey.PROJECT, project)
+                .putExtra(IntentKey.PROJECT_PARAM, project.slug())
                 .putExtra(IntentKey.REF_TAG, refTag)
             startActivity(intent)
             TransitionUtils.transition(it, TransitionUtils.slideInFromRight())

--- a/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/PledgeFragment.kt
@@ -721,7 +721,8 @@ class PledgeFragment :
             is PaymentSheetResult.Failed -> {
                 binding?.pledgeContent?.let { pledgeContent ->
                     context?.let {
-                        showErrorToast(it, pledgeContent, getString(R.string.general_error_something_wrong))
+                        val errorMessage = paymentSheetResult.error.localizedMessage ?: getString(R.string.general_error_something_wrong)
+                        showErrorToast(it, pledgeContent, errorMessage)
                     }
                 }
             }

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -16,8 +16,8 @@ import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
 import com.kickstarter.libs.utils.NumberUtils
 import com.kickstarter.libs.utils.RewardDecoration
 import com.kickstarter.libs.utils.ViewUtils
+import com.kickstarter.libs.utils.extensions.reduce
 import com.kickstarter.libs.utils.extensions.selectPledgeFragment
-import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.adapters.RewardsAdapter
 import com.kickstarter.ui.data.PledgeData
@@ -172,23 +172,7 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Rewa
     private fun showAddonsFragment(pledgeDataAndReason: Pair<PledgeData, PledgeReason>) {
         if (this.isVisible && this.parentFragmentManager.findFragmentByTag(BackingAddOnsFragment::class.java.simpleName) == null) {
 
-            val reducedProject = Project.Builder()
-                .id(pledgeDataAndReason.first.projectData().project().id())
-                .slug(pledgeDataAndReason.first.projectData().project().slug())
-                .name(pledgeDataAndReason.first.projectData().project().name())
-                .location(pledgeDataAndReason.first.projectData().project().location())
-                .deadline(pledgeDataAndReason.first.projectData().project().deadline())
-                .staticUsdRate(pledgeDataAndReason.first.projectData().project().staticUsdRate())
-                .fxRate(pledgeDataAndReason.first.projectData().project().fxRate())
-                .country(pledgeDataAndReason.first.projectData().project().country())
-                .currentCurrency(pledgeDataAndReason.first.projectData().project().currentCurrency())
-                .currency(pledgeDataAndReason.first.projectData().project().currency())
-                .currencySymbol(pledgeDataAndReason.first.projectData().project().currencySymbol())
-                .currencyTrailingCode(pledgeDataAndReason.first.projectData().project().currencyTrailingCode())
-                .isBacking(pledgeDataAndReason.first.projectData().project().isBacking())
-                .availableCardTypes(pledgeDataAndReason.first.projectData().project().availableCardTypes())
-                .category(pledgeDataAndReason.first.projectData().project().category())
-                .build()
+            val reducedProject = pledgeDataAndReason.first.projectData().project().reduce()
 
             val reducedProjectData = pledgeDataAndReason.first.projectData().toBuilder().project(reducedProject).build()
             val reducedPledgeData = pledgeDataAndReason.first.toBuilder().projectData(reducedProjectData).build()

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -17,6 +17,7 @@ import com.kickstarter.libs.utils.NumberUtils
 import com.kickstarter.libs.utils.RewardDecoration
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.selectPledgeFragment
+import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.adapters.RewardsAdapter
 import com.kickstarter.ui.data.PledgeData
@@ -170,7 +171,30 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Rewa
 
     private fun showAddonsFragment(pledgeDataAndReason: Pair<PledgeData, PledgeReason>) {
         if (this.isVisible && this.parentFragmentManager.findFragmentByTag(BackingAddOnsFragment::class.java.simpleName) == null) {
-            val addOnsFragment = BackingAddOnsFragment.newInstance(pledgeDataAndReason)
+
+            val reducedProject = Project.Builder()
+                .id(pledgeDataAndReason.first.projectData().project().id())
+                .slug(pledgeDataAndReason.first.projectData().project().slug())
+                .name(pledgeDataAndReason.first.projectData().project().name())
+                .location(pledgeDataAndReason.first.projectData().project().location())
+                .deadline(pledgeDataAndReason.first.projectData().project().deadline())
+                .staticUsdRate(pledgeDataAndReason.first.projectData().project().staticUsdRate())
+                .fxRate(pledgeDataAndReason.first.projectData().project().fxRate())
+                .country(pledgeDataAndReason.first.projectData().project().country())
+                .currentCurrency(pledgeDataAndReason.first.projectData().project().currentCurrency())
+                .currency(pledgeDataAndReason.first.projectData().project().currency())
+                .currencySymbol(pledgeDataAndReason.first.projectData().project().currencySymbol())
+                .currencyTrailingCode(pledgeDataAndReason.first.projectData().project().currencyTrailingCode())
+                .isBacking(pledgeDataAndReason.first.projectData().project().isBacking())
+                .availableCardTypes(pledgeDataAndReason.first.projectData().project().availableCardTypes())
+                .category(pledgeDataAndReason.first.projectData().project().category())
+                .build()
+
+            val reducedProjectData = pledgeDataAndReason.first.projectData().toBuilder().project(reducedProject).build()
+            val reducedPledgeData = pledgeDataAndReason.first.toBuilder().projectData(reducedProjectData).build()
+
+            val addOnsFragment = BackingAddOnsFragment.newInstance(Pair(reducedPledgeData, pledgeDataAndReason.second))
+
             this.parentFragmentManager.beginTransaction()
                 .setCustomAnimations(R.anim.slide_in_right, 0, 0, R.anim.slide_out_right)
                 .add(

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -1164,6 +1164,17 @@ interface PledgeFragmentViewModel {
                 .filter { ObjectUtils.isNotNull(it) }
                 .map { it as Pair<StoredCard, Int> }
 
+            // - When setupIntent finishes with error reload the payment methods
+            this.paymentSheetResult
+                .filter {
+                    it != PaymentSheetResult.Completed
+                }
+                .withLatestFrom(cardsAndProject) { _, cardsAndProject ->
+                    return@withLatestFrom cardsAndProject
+                }
+                .compose(bindToLifecycle())
+                .subscribe(this.cardsAndProject)
+
             this.cardSaved
                 .compose<Pair<StoredCard, Project>>(combineLatestPair(project))
                 .compose(bindToLifecycle())

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
@@ -8,6 +8,9 @@ import com.kickstarter.mock.factories.ConfigFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.Project
+import com.kickstarter.models.ProjectFaq
+import com.kickstarter.models.Reward
+import com.kickstarter.models.User
 import com.kickstarter.services.DiscoveryParams
 import org.joda.time.DateTime
 import org.junit.Test
@@ -348,5 +351,35 @@ class ProjectExtTest : KSRobolectricTestCase() {
         val secondProject = project
 
         assertTrue(project.deadline() == secondProject.deadline())
+    }
+
+    @Test
+    fun testReduce_project() {
+        val project = ProjectFactory.project()
+        val reducedProject = project.reduce()
+
+        assertEquals(project.id(), reducedProject.id())
+        assertEquals(project.name(), reducedProject.name())
+        assertEquals(project.slug(), reducedProject.slug())
+        assertEquals(project.location(), reducedProject.location())
+        assertEquals(project.deadline(), reducedProject.deadline())
+        assertEquals(project.staticUsdRate(), reducedProject.staticUsdRate())
+        assertEquals(project.fxRate(), reducedProject.fxRate())
+        assertEquals(project.country(), reducedProject.country())
+        assertEquals(project.currency(), reducedProject.currency())
+        assertEquals(project.currentCurrency(), reducedProject.currentCurrency())
+        assertEquals(project.currencySymbol(), reducedProject.currencySymbol())
+        assertEquals(project.currencyTrailingCode(), reducedProject.currencyTrailingCode())
+        assertEquals(project.currencyTrailingCode(), reducedProject.currencyTrailingCode())
+        assertEquals(project.isBacking(), reducedProject.isBacking())
+        assertEquals(project.availableCardTypes(), reducedProject.availableCardTypes())
+        assertEquals(project.category(), reducedProject.category())
+
+        assertEquals(reducedProject.rewards(), emptyList<Reward>()) // Default builder value
+        assertEquals(reducedProject.creator(), User.builder().build()) // Default builder value
+        assertEquals(reducedProject.video(), null) // Default builder value
+        assertEquals(reducedProject.projectFaqs(), emptyList<ProjectFaq>()) // Default builder value
+        assertEquals(reducedProject.photo(), null) // Default builder value
+        assertEquals(reducedProject.story(), "") // Default builder value
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -1678,8 +1678,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(true, false, false, true)
-        this.pledgeProgressIsGone.assertValues(false, false, true)
+        this.pledgeButtonIsEnabled.assertValues(true, false, true)
+        this.pledgeProgressIsGone.assertValues(false, true)
         this.showUpdatePaymentError.assertValueCount(1)
     }
 
@@ -1713,8 +1713,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(true, false, false, true)
-        this.pledgeProgressIsGone.assertValues(false, false, true)
+        this.pledgeButtonIsEnabled.assertValues(true, false, true)
+        this.pledgeProgressIsGone.assertValues(false, true)
         this.showUpdatePaymentError.assertValueCount(1)
 
         this.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
@@ -1743,9 +1743,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(true, false, false)
-        this.pledgeProgressIsGone.assertValues(false, false)
-        this.showUpdatePaymentSuccess.assertValueCount(2)
+        this.pledgeButtonIsEnabled.assertValues(true, false)
+        this.pledgeProgressIsGone.assertValues(false)
+        this.showUpdatePaymentSuccess.assertValueCount(1)
     }
 
     @Test
@@ -1800,9 +1800,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(true, false, false)
-        this.pledgeProgressIsGone.assertValues(false, false)
-        this.showUpdatePaymentSuccess.assertValueCount(2)
+        this.pledgeButtonIsEnabled.assertValues(true, false)
+        this.pledgeProgressIsGone.assertValues(false)
+        this.showUpdatePaymentSuccess.assertValueCount(1)
 
         this.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
     }
@@ -1835,20 +1835,20 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
 
         this.vm.inputs.pledgeButtonClicked()
-        this.pledgeButtonIsEnabled.assertValues(true, false, false)
-        this.pledgeProgressIsGone.assertValues(false, false)
+        this.pledgeButtonIsEnabled.assertValues(true, false)
+        this.pledgeProgressIsGone.assertValues(false)
         this.showSCAFlow.assertValueCount(1)
         this.showUpdatePaymentError.assertNoValues()
-        this.showUpdatePaymentSuccess.assertValueCount(1)
+        this.showUpdatePaymentSuccess.assertNoValues()
 
         this.vm.inputs.stripeSetupResultSuccessful(StripeIntentResult.Outcome.SUCCEEDED)
 
-        this.pledgeButtonIsEnabled.assertValues(true, false, false)
-        this.pledgeProgressIsGone.assertValues(false, false)
+        this.pledgeButtonIsEnabled.assertValues(true, false)
+        this.pledgeProgressIsGone.assertValues(false)
         this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
         this.showSCAFlow.assertValueCount(1)
         this.showUpdatePaymentError.assertNoValues()
-        this.showUpdatePaymentSuccess.assertValueCount(2)
+        this.showUpdatePaymentSuccess.assertValueCount(1)
     }
 
     @Test
@@ -1879,20 +1879,20 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
 
         this.vm.inputs.pledgeButtonClicked()
-        this.pledgeButtonIsEnabled.assertValues(true, false, false)
-        this.pledgeProgressIsGone.assertValues(false, false)
+        this.pledgeButtonIsEnabled.assertValues(true, false)
+        this.pledgeProgressIsGone.assertValues(false)
         this.showSCAFlow.assertValueCount(1)
         this.showUpdatePaymentError.assertNoValues()
-        this.showUpdatePaymentSuccess.assertValueCount(1)
+        this.showUpdatePaymentSuccess.assertNoValues()
 
         this.vm.inputs.stripeSetupResultSuccessful(StripeIntentResult.Outcome.FAILED)
 
-        this.pledgeButtonIsEnabled.assertValues(true, false, false, true)
-        this.pledgeProgressIsGone.assertValues(false, false, true)
+        this.pledgeButtonIsEnabled.assertValues(true, false, true)
+        this.pledgeProgressIsGone.assertValues(false, true)
         this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
         this.showSCAFlow.assertValueCount(1)
         this.showUpdatePaymentError.assertValueCount(1)
-        this.showUpdatePaymentSuccess.assertValueCount(1)
+        this.showUpdatePaymentSuccess.assertNoValues()
     }
 
     @Test
@@ -1923,20 +1923,20 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
 
         this.vm.inputs.pledgeButtonClicked()
-        this.pledgeButtonIsEnabled.assertValues(true, false, false)
-        this.pledgeProgressIsGone.assertValues(false, false)
+        this.pledgeButtonIsEnabled.assertValues(true, false)
+        this.pledgeProgressIsGone.assertValues(false)
         this.showSCAFlow.assertValueCount(1)
         this.showUpdatePaymentError.assertNoValues()
-        this.showUpdatePaymentSuccess.assertValueCount(1)
+        this.showUpdatePaymentSuccess.assertNoValues()
 
         this.vm.inputs.stripeSetupResultUnsuccessful(Exception("eek"))
 
-        this.pledgeButtonIsEnabled.assertValues(true, false, false, true)
-        this.pledgeProgressIsGone.assertValues(false, false, true)
+        this.pledgeButtonIsEnabled.assertValues(true, false, true)
+        this.pledgeProgressIsGone.assertValues(false, true)
         this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
         this.showSCAFlow.assertValueCount(1)
         this.showUpdatePaymentError.assertValueCount(1)
-        this.showUpdatePaymentSuccess.assertValueCount(1)
+        this.showUpdatePaymentSuccess.assertNoValues()
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -2320,12 +2320,12 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
 
+        this.pledgeButtonIsEnabled.assertValues(true)
         this.vm.inputs.pledgeButtonClicked()
 
         // Successfully pledging with a valid amount should show the thanks page
-        this.pledgeButtonIsEnabled.assertValues(true)
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
-        this.showPledgeSuccess.assertNoValues()
+        this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
 
         this.segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
@@ -2339,12 +2339,12 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
 
+        this.pledgeButtonIsEnabled.assertValues(true)
         this.vm.inputs.pledgeButtonClicked()
 
         // Successfully pledging with a valid amount should show the thanks page
-        this.pledgeButtonIsEnabled.assertValues(true)
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
-        this.showPledgeSuccess.assertNoValues()
+        this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
 
         this.segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
@@ -2363,12 +2363,12 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
 
-        this.vm.inputs.pledgeButtonClicked()
-
         // Successfully pledging with a valid amount should show the thanks page
-        this.pledgeButtonIsEnabled.assertValues(true)
+        this.pledgeButtonIsEnabled.assertValue(true)
+
+        this.vm.inputs.pledgeButtonClicked()
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
-        this.showPledgeSuccess.assertNoValues()
+        this.showPledgeSuccess.assertValueCount(1)
         this.showPledgeError.assertNoValues()
 
         this.segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
@@ -2430,10 +2430,10 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
 
+        this.pledgeButtonIsEnabled.assertValues(true)
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(true)
-        this.pledgeProgressIsGone.assertNoValues()
+        this.pledgeProgressIsGone.assertValue(false)
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertNoValues()
 
@@ -2473,8 +2473,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(true)
-        this.pledgeProgressIsGone.assertNoValues()
+        this.pledgeButtonIsEnabled.assertValues(true, false)
+        this.pledgeProgressIsGone.assertValue(false)
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertNoValues()
 
@@ -2514,10 +2514,10 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.showSelectedCard.assertValue(Pair(0, CardState.SELECTED))
 
+        this.pledgeButtonIsEnabled.assertValues(true)
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(true)
-        this.pledgeProgressIsGone.assertNoValues()
+        this.pledgeProgressIsGone.assertValue(false)
         this.showPledgeSuccess.assertNoValues()
         this.showPledgeError.assertNoValues()
 

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -1678,8 +1678,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(true, false, true)
-        this.pledgeProgressIsGone.assertValues(false, true)
+        this.pledgeButtonIsEnabled.assertValues(true, false, false, true)
+        this.pledgeProgressIsGone.assertValues(false, false, true)
         this.showUpdatePaymentError.assertValueCount(1)
     }
 
@@ -1713,8 +1713,8 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(true, false, true)
-        this.pledgeProgressIsGone.assertValues(false, true)
+        this.pledgeButtonIsEnabled.assertValues(true, false, false, true)
+        this.pledgeProgressIsGone.assertValues(false, false, true)
         this.showUpdatePaymentError.assertValueCount(1)
 
         this.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
@@ -1743,9 +1743,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(true, false)
-        this.pledgeProgressIsGone.assertValues(false)
-        this.showUpdatePaymentSuccess.assertValueCount(1)
+        this.pledgeButtonIsEnabled.assertValues(true, false, false)
+        this.pledgeProgressIsGone.assertValues(false, false)
+        this.showUpdatePaymentSuccess.assertValueCount(2)
     }
 
     @Test
@@ -1800,9 +1800,9 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(true, false)
-        this.pledgeProgressIsGone.assertValues(false)
-        this.showUpdatePaymentSuccess.assertValueCount(1)
+        this.pledgeButtonIsEnabled.assertValues(true, false, false)
+        this.pledgeProgressIsGone.assertValues(false, false)
+        this.showUpdatePaymentSuccess.assertValueCount(2)
 
         this.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
     }
@@ -1835,20 +1835,20 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
 
         this.vm.inputs.pledgeButtonClicked()
-        this.pledgeButtonIsEnabled.assertValues(true, false)
-        this.pledgeProgressIsGone.assertValue(false)
-        this.showSCAFlow.assertValueCount(1)
-        this.showUpdatePaymentError.assertNoValues()
-        this.showUpdatePaymentSuccess.assertNoValues()
-
-        this.vm.inputs.stripeSetupResultSuccessful(StripeIntentResult.Outcome.SUCCEEDED)
-
-        this.pledgeButtonIsEnabled.assertValues(true, false)
-        this.pledgeProgressIsGone.assertValue(false)
-        this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
+        this.pledgeButtonIsEnabled.assertValues(true, false, false)
+        this.pledgeProgressIsGone.assertValues(false, false)
         this.showSCAFlow.assertValueCount(1)
         this.showUpdatePaymentError.assertNoValues()
         this.showUpdatePaymentSuccess.assertValueCount(1)
+
+        this.vm.inputs.stripeSetupResultSuccessful(StripeIntentResult.Outcome.SUCCEEDED)
+
+        this.pledgeButtonIsEnabled.assertValues(true, false, false)
+        this.pledgeProgressIsGone.assertValues(false, false)
+        this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
+        this.showSCAFlow.assertValueCount(1)
+        this.showUpdatePaymentError.assertNoValues()
+        this.showUpdatePaymentSuccess.assertValueCount(2)
     }
 
     @Test
@@ -1879,20 +1879,20 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
 
         this.vm.inputs.pledgeButtonClicked()
-        this.pledgeButtonIsEnabled.assertValues(true, false)
-        this.pledgeProgressIsGone.assertValue(false)
+        this.pledgeButtonIsEnabled.assertValues(true, false, false)
+        this.pledgeProgressIsGone.assertValues(false, false)
         this.showSCAFlow.assertValueCount(1)
         this.showUpdatePaymentError.assertNoValues()
-        this.showUpdatePaymentSuccess.assertNoValues()
+        this.showUpdatePaymentSuccess.assertValueCount(1)
 
         this.vm.inputs.stripeSetupResultSuccessful(StripeIntentResult.Outcome.FAILED)
 
-        this.pledgeButtonIsEnabled.assertValues(true, false, true)
-        this.pledgeProgressIsGone.assertValues(false, true)
+        this.pledgeButtonIsEnabled.assertValues(true, false, false, true)
+        this.pledgeProgressIsGone.assertValues(false, false, true)
         this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
         this.showSCAFlow.assertValueCount(1)
         this.showUpdatePaymentError.assertValueCount(1)
-        this.showUpdatePaymentSuccess.assertNoValues()
+        this.showUpdatePaymentSuccess.assertValueCount(1)
     }
 
     @Test
@@ -1923,20 +1923,20 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
 
         this.vm.inputs.pledgeButtonClicked()
-        this.pledgeButtonIsEnabled.assertValues(true, false)
-        this.pledgeProgressIsGone.assertValues(false)
+        this.pledgeButtonIsEnabled.assertValues(true, false, false)
+        this.pledgeProgressIsGone.assertValues(false, false)
         this.showSCAFlow.assertValueCount(1)
         this.showUpdatePaymentError.assertNoValues()
-        this.showUpdatePaymentSuccess.assertNoValues()
+        this.showUpdatePaymentSuccess.assertValueCount(1)
 
         this.vm.inputs.stripeSetupResultUnsuccessful(Exception("eek"))
 
-        this.pledgeButtonIsEnabled.assertValues(true, false, true)
-        this.pledgeProgressIsGone.assertValues(false, true)
+        this.pledgeButtonIsEnabled.assertValues(true, false, false, true)
+        this.pledgeProgressIsGone.assertValues(false, false, true)
         this.showSelectedCard.assertValues(Pair(1, CardState.SELECTED), Pair(0, CardState.SELECTED))
         this.showSCAFlow.assertValueCount(1)
         this.showUpdatePaymentError.assertValueCount(1)
-        this.showUpdatePaymentSuccess.assertNoValues()
+        this.showUpdatePaymentSuccess.assertValueCount(1)
     }
 
     @Test
@@ -2392,10 +2392,10 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(true)
-        this.pledgeProgressIsGone.assertNoValues()
+        this.pledgeButtonIsEnabled.assertValues(true, false, true)
+        this.pledgeProgressIsGone.assertValueCount(2)
         this.showPledgeSuccess.assertNoValues()
-        this.showPledgeError.assertNoValues()
+        this.showPledgeError.assertValueCount(1)
 
         this.vm.inputs.onRiskManagementConfirmed()
 


### PR DESCRIPTION
# 📲 What
Several points in the PR: 
- 1 - Fix for crash with exception `Fatal Exception: java.lang.IllegalArgumentException: Invalid Setup Intent client secret: ...` discovered during QA party for Checkout flows with PaymentSheet. [Firebase report](https://console.firebase.google.com/u/1/project/android-internal-debug/crashlytics/app/android:com.kickstarter.kickstarter.internal.debug/issues/b2711e4d175f0a1b5a96b4e149dffb37)
Refined a bit the user facing error messages for this point with, instead of presenting the generic "Something went wrong" message, now the Stripe error localized message is displayed to the user.
- 2 - Discovered `TransactionTooLargeException` for certain projects when triggering 3DS flow after adding payment method using `PaymentSheet` [Firebase report](https://console.firebase.google.com/u/1/project/android-internal-debug/crashlytics/app/android:com.kickstarter.kickstarter.internal.debug/issues/68bb75bdb88c66f2b4fa785b47953d89)
- Updated Stripes library to latest version 


# 🛠 How
⚠️ (use debug build to have complete logs).
This section is gonna described mainly those steps to identify the root cause behind #2. In order to debug an identify the `TransactionTooLargeException` a key tool has been https://github.com/guardian/toolargetool, is a debug tool so no trace of it on the PR.

First taking a closer look into the logcat trace of the error, on the warnings you can see : 
![Screenshot 2022-11-24 at 9 30 24 AM](https://user-images.githubusercontent.com/4083656/204362177-a020a7fe-48bc-4718-ada0-1ac6b20b21c3.png)

This warning trace indicates fragments presented and their size, as you can see two of the are taking up much more memory than they should, and are considerably bigger that the rest one fragment with `[size=143456]` and `[size=431628]` those hexadecimals identifiers can be traced back to the KS fragments by filtering mode the onCreate logs (the screenshot is just to showcase how to filter in logcat, it does not match the with the execution of the previous exception)
![Screenshot 2022-11-28 at 11 19 16 AM](https://user-images.githubusercontent.com/4083656/204362681-14891d61-aabd-4647-83b4-40805fc28df2.png)

At this point the guilty intents have been identified in your trace and those two were `BackingAddOnsFragment` and `PledgeFragment`, the intents for launching those two fragments were taking more than 100KB each ...

Now if you add `toolargetool` to your build, and have breakpoints on those functions starting the  `BackingAddOnsFragment` and `PledgeFragment` you will be able to evaluate in real time the size of the intent by using toolargetool method `bundleBreakdown`

BEFORE: 140KB was the size for the the `BackingAddOnsFragment` bundle
![Screenshot 2022-11-28 at 11 47 25 AM](https://user-images.githubusercontent.com/4083656/204367895-09e8c552-6afb-4505-8fef-a33b1fe7bed6.png)

NOW: 3.6 is the size for the `BackingAddOnsFragment` bundle
![Screenshot 2022-11-28 at 11 41 59 AM](https://user-images.githubusercontent.com/4083656/204368052-fbc49f7c-7c08-4a92-87b4-a69fc251c4bb.png)

The solution has been reducing the project fields to only those mandatory to be able to operate the user journey from the moment a reward is picked, please take a look into `Project.reduce()` extension function to have more details about which ones are those mandatory fields.

Also taken the chance to review the RX subscriptions and tied those who weren't before to the lifecycle in all the user journey since the point a reward is picked, and reduced to only the `project.slug` the bundles for `ProjectActivity`, `UpdateActivity`.

# 👀 See

<img width="1759" alt="Screenshot 2022-11-28 at 12 00 11 PM" src="https://user-images.githubusercontent.com/4083656/204369824-f214c12e-f9be-44e3-9734-590620434cb8.png">


| Before 🐛 |

https://user-images.githubusercontent.com/4083656/204614086-778e7bc5-8cd4-49a6-acbb-e8e6e82f74a4.mp4



| After 🦋 |


https://user-images.githubusercontent.com/4083656/204614116-abe5d618-776a-45de-ba7b-1c69010b4f8b.mp4


|  |  |

# 📋 QA

For QA #1 : 
- Pledge to a project, adding a new payment method during checkout, introduce the payment details, and before hitting "Continue CTA" on the PaymentSheet turn on airplane mode, or loose connectivity, hit now the "Continue CTA" on the PaymentSheet. You should see an error message and the payment method not added to the UI. Once you recover  connectivity, you should be able to add the payment method again and pledge.
- Pledge to a project, adding a new payment method during checkout, a 3DS one, you can use for example `4000 0000 0000 3220`, once the 3DS flow is presented fail it, you should see a message like the screenshot below, and the payment method not visible on the UI. After that you should be able to pledge or add a new payment method as usual. 
![Screenshot 2022-11-28 at 1 59 19 PM](https://user-images.githubusercontent.com/4083656/204614908-dc3ffc1a-0e9f-4bbf-bd8e-999df7211309.png)

For QA #2 : 
- Go to the project https://staging.kickstarter.com/projects/patshand/destiny-ny-volume-six-volumes-1-6-available and try to pledge , adding a new payment method during checkout, a 3DS one, you can use for example `4000 0000 0000 3220`. You should be able to complete the 3DS challenge without any crash as shown on the AFTER video 

# Story 📖

[NTV-2080](https://kickstarter.atlassian.net/browse/PAY-2080)
