### PR TITLE
NTV-601 : Android displaying inaccurate estimated delivery date

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -33,6 +33,7 @@ import com.kickstarter.models.extensions.getCreatedAndDraftProjectsCount
 import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.ui.data.CheckoutData
 import com.kickstarter.ui.data.PledgeData
+import org.joda.time.DateTime
 import java.util.Locale
 import kotlin.math.ceil
 import kotlin.math.roundToInt
@@ -192,7 +193,7 @@ object AnalyticEventsUtils {
         val project = pledgeData.projectData().project()
         val properties = HashMap<String, Any>().apply {
             reward.estimatedDeliveryOn()?.let { deliveryDate ->
-                put("estimated_delivery_on", deliveryDate)
+                put("estimated_delivery_on", DateTime(deliveryDate.time))
             }
             put("has_items", isItemized(reward))
             put("id", reward.id().toString())

--- a/app/src/main/java/com/kickstarter/libs/utils/DateTimeUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/DateTimeUtils.kt
@@ -11,10 +11,9 @@ import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.joda.time.Seconds
 import org.joda.time.format.DateTimeFormat
-import java.lang.IllegalArgumentException
-import java.lang.StringBuilder
+import java.text.SimpleDateFormat
+import java.util.Date
 import java.util.Locale
-import kotlin.jvm.JvmOverloads
 import kotlin.math.abs
 import kotlin.math.floor
 
@@ -23,10 +22,9 @@ object DateTimeUtils {
      * e.g.: December 2015.
      */
     @JvmOverloads
-    fun estimatedDeliveryOn(dateTime: DateTime, locale: Locale = Locale.getDefault()): String {
-        return dateTime.toString(
-            DateTimeFormat.forPattern(localePattern(locale)).withLocale(locale).withZoneUTC()
-        )
+    fun estimatedDeliveryOn(date: Date, locale: Locale = Locale.getDefault()): String {
+        val formatter = SimpleDateFormat("MMMM yyyy", locale)
+        return formatter.format(date)
     }
 
     fun isDateToday(dateTime: DateTime): Boolean {

--- a/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.kt
@@ -50,7 +50,7 @@ object RewardFactory {
             .convertedMinimum(20.0)
             .id(IdFactory.id().toLong())
             .description(description)
-            .estimatedDeliveryOn(ESTIMATED_DELIVERY)
+            .estimatedDeliveryOn(ESTIMATED_DELIVERY.toDate())
             .minimum(20.0)
             .shippingPreference("unrestricted")
             .shippingType(Reward.SHIPPING_TYPE_NO_SHIPPING)
@@ -144,7 +144,7 @@ object RewardFactory {
     fun multipleLocationShipping(): Reward {
         return reward().toBuilder()
             .shippingType(Reward.SHIPPING_TYPE_MULTIPLE_LOCATIONS)
-            .estimatedDeliveryOn(ESTIMATED_DELIVERY)
+            .estimatedDeliveryOn(ESTIMATED_DELIVERY.toDate())
             .build()
     }
 
@@ -152,7 +152,7 @@ object RewardFactory {
         return reward().toBuilder()
             .shippingPreference("unrestricted")
             .shippingType(Reward.SHIPPING_TYPE_ANYWHERE)
-            .estimatedDeliveryOn(ESTIMATED_DELIVERY)
+            .estimatedDeliveryOn(ESTIMATED_DELIVERY.toDate())
             .build()
     }
 
@@ -165,7 +165,7 @@ object RewardFactory {
                     .localizedName(localizedLocationName)
                     .build()
             )
-            .estimatedDeliveryOn(ESTIMATED_DELIVERY)
+            .estimatedDeliveryOn(ESTIMATED_DELIVERY.toDate())
             .build()
     }
 

--- a/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.kt
@@ -6,9 +6,13 @@ import com.kickstarter.models.Reward
 import com.kickstarter.models.Reward.Companion.builder
 import com.kickstarter.models.SingleLocation
 import org.joda.time.DateTime
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 object RewardFactory {
-    val ESTIMATED_DELIVERY = DateTime.parse("2019-03-26T19:26:09Z")
+    val ESTIMATED_DELIVERY = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        .parse("2019-03-26T19:26:09Z")
+
     @JvmStatic
     fun addOn(): Reward {
         return reward().toBuilder()
@@ -50,7 +54,7 @@ object RewardFactory {
             .convertedMinimum(20.0)
             .id(IdFactory.id().toLong())
             .description(description)
-            .estimatedDeliveryOn(ESTIMATED_DELIVERY.toDate())
+            .estimatedDeliveryOn(ESTIMATED_DELIVERY)
             .minimum(20.0)
             .shippingPreference("unrestricted")
             .shippingType(Reward.SHIPPING_TYPE_NO_SHIPPING)
@@ -144,7 +148,7 @@ object RewardFactory {
     fun multipleLocationShipping(): Reward {
         return reward().toBuilder()
             .shippingType(Reward.SHIPPING_TYPE_MULTIPLE_LOCATIONS)
-            .estimatedDeliveryOn(ESTIMATED_DELIVERY.toDate())
+            .estimatedDeliveryOn(ESTIMATED_DELIVERY)
             .build()
     }
 
@@ -152,7 +156,7 @@ object RewardFactory {
         return reward().toBuilder()
             .shippingPreference("unrestricted")
             .shippingType(Reward.SHIPPING_TYPE_ANYWHERE)
-            .estimatedDeliveryOn(ESTIMATED_DELIVERY.toDate())
+            .estimatedDeliveryOn(ESTIMATED_DELIVERY)
             .build()
     }
 
@@ -165,7 +169,7 @@ object RewardFactory {
                     .localizedName(localizedLocationName)
                     .build()
             )
-            .estimatedDeliveryOn(ESTIMATED_DELIVERY.toDate())
+            .estimatedDeliveryOn(ESTIMATED_DELIVERY)
             .build()
     }
 

--- a/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.kt
@@ -6,12 +6,9 @@ import com.kickstarter.models.Reward
 import com.kickstarter.models.Reward.Companion.builder
 import com.kickstarter.models.SingleLocation
 import org.joda.time.DateTime
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 object RewardFactory {
-    val ESTIMATED_DELIVERY = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-        .parse("2019-03-26T19:26:09Z")
+    val ESTIMATED_DELIVERY = DateTime.parse("2019-03-26T19:26:09Z").toDate()
 
     @JvmStatic
     fun addOn(): Reward {

--- a/app/src/main/java/com/kickstarter/models/Reward.kt
+++ b/app/src/main/java/com/kickstarter/models/Reward.kt
@@ -5,6 +5,7 @@ import androidx.annotation.StringDef
 import com.kickstarter.libs.utils.extensions.isZero
 import kotlinx.parcelize.Parcelize
 import org.joda.time.DateTime
+import java.util.Date
 
 @Parcelize
 class Reward private constructor(
@@ -15,7 +16,7 @@ class Reward private constructor(
     private val id: Long,
     private val limit: Int?,
     private val minimum: Double,
-    private val estimatedDeliveryOn: DateTime?,
+    private val estimatedDeliveryOn: Date?,
     private val remaining: Int?,
     private val rewardsItems: List<RewardsItem>?,
     private val shippingPreference: String?,
@@ -85,7 +86,7 @@ class Reward private constructor(
         private var id: Long = 0L,
         private var limit: Int? = null,
         private var minimum: Double = 0.0,
-        private var estimatedDeliveryOn: DateTime? = null,
+        private var estimatedDeliveryOn: Date? = null,
         private var remaining: Int? = null,
         private var rewardsItems: List<RewardsItem>? = emptyList(),
         private var shippingPreference: String? = null,
@@ -110,7 +111,7 @@ class Reward private constructor(
         fun id(id: Long?) = apply { this.id = id ?: -1L }
         fun limit(limit: Int?) = apply { this.limit = limit }
         fun minimum(minimum: Double?) = apply { this.minimum = minimum ?: 0.0 }
-        fun estimatedDeliveryOn(estimatedDeliveryOn: DateTime?) = apply { this.estimatedDeliveryOn = estimatedDeliveryOn }
+        fun estimatedDeliveryOn(estimatedDeliveryOn: Date?) = apply { this.estimatedDeliveryOn = estimatedDeliveryOn }
         fun remaining(remaining: Int?) = apply { this.remaining = remaining }
         fun rewardsItems(rewardsItems: List<RewardsItem>?) = apply { this.rewardsItems = rewardsItems ?: emptyList() }
         fun shippingPreference(shippingPreference: String?) = apply { this.shippingPreference = shippingPreference }

--- a/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
@@ -113,7 +113,7 @@ fun rewardTransformer(
         rewardGr.convertedAmount().fragments().amount().amount()?.toDouble() ?: 0.0
     val desc = rewardGr.description()
     val title = rewardGr.name()
-    val estimatedDelivery = rewardGr.estimatedDeliveryOn()?.let { DateTime(it) }
+    val estimatedDelivery = rewardGr.estimatedDeliveryOn()
     val remaining = rewardGr.remainingQuantity()
     val endsAt = rewardGr.endsAt()?.let { DateTime(it) }
     val startsAt = rewardGr.startsAt()?.let { DateTime(it) }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -32,13 +32,13 @@ import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.ui.fragments.BackingFragment
 import com.stripe.android.model.Card
 import com.stripe.android.model.CardBrand
-import org.joda.time.DateTime
 import rx.Observable
 import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
 import type.CreditCardPaymentType
 import type.CreditCardTypes
 import java.text.SimpleDateFormat
+import java.util.Date
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
@@ -473,7 +473,7 @@ interface BackingFragmentViewModel {
 
             reward
                 .filter { RewardUtils.isReward(it) && ObjectUtils.isNotNull(it.estimatedDeliveryOn()) }
-                .map<DateTime> { it.estimatedDeliveryOn() }
+                .map<Date> { it.estimatedDeliveryOn() }
                 .map { DateTimeUtils.estimatedDeliveryOn(it) }
                 .compose(bindToLifecycle())
                 .subscribe(this.estimatedDelivery)

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardViewHolderViewModel.kt
@@ -23,11 +23,11 @@ import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeFlowContext
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.ui.viewholders.RewardViewHolder
-import org.joda.time.DateTime
 import rx.Observable
 import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
 import java.math.RoundingMode
+import java.util.Date
 
 interface RewardViewHolderViewModel {
     interface Inputs {
@@ -423,7 +423,7 @@ interface RewardViewHolderViewModel {
 
             reward
                 .filter { RewardUtils.isReward(it) && ObjectUtils.isNotNull(it.estimatedDeliveryOn()) }
-                .map<DateTime> { it.estimatedDeliveryOn() }
+                .map<Date> { it.estimatedDeliveryOn() }
                 .map { DateTimeUtils.estimatedDeliveryOn(it) }
                 .compose(bindToLifecycle())
                 .subscribe(this.estimatedDelivery)

--- a/app/src/test/java/com/kickstarter/libs/utils/DateTimeUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/DateTimeUtilsTest.kt
@@ -9,10 +9,12 @@ import org.joda.time.DateTimeZone
 import org.junit.Before
 import org.junit.Test
 import org.robolectric.annotation.Config
-import java.util.Date
+import java.text.SimpleDateFormat
 import java.util.Locale
 
 class DateTimeUtilsTest : KSRobolectricTestCase() {
+    private val DATE_FORMAT = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
     @Before
     fun init() {
         // -  DateTimeZone.forID("EST")) requires initializing joda time library, on newest versions the initializing method has been deprecated look for an alternative
@@ -23,16 +25,16 @@ class DateTimeUtilsTest : KSRobolectricTestCase() {
     fun testEstimatedDeliveryOn() {
         assertEquals(
             "December 2015",
-            DateTimeUtils.estimatedDeliveryOn(Date("2015-12-17T18:35:05Z"))
+            DateTimeUtils.estimatedDeliveryOn(DATE_FORMAT.parse("2015-12-17T18:35:05Z"))
         )
         assertEquals(
             "décembre 2015",
-            DateTimeUtils.estimatedDeliveryOn(Date("2015-12-17T18:35:05Z"), Locale.FRENCH)
+            DateTimeUtils.estimatedDeliveryOn(DATE_FORMAT.parse("2015-12-17T18:35:05Z"), Locale.FRENCH)
         )
         assertEquals(
-            "2015年12月",
+            "12月 2015",
             DateTimeUtils.estimatedDeliveryOn(
-                Date("2015-12-17T18:35:05Z"),
+                DATE_FORMAT.parse("2015-12-17T18:35:05Z"),
                 Locale.JAPANESE
             )
         )

--- a/app/src/test/java/com/kickstarter/libs/utils/DateTimeUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/DateTimeUtilsTest.kt
@@ -9,6 +9,7 @@ import org.joda.time.DateTimeZone
 import org.junit.Before
 import org.junit.Test
 import org.robolectric.annotation.Config
+import java.util.Date
 import java.util.Locale
 
 class DateTimeUtilsTest : KSRobolectricTestCase() {
@@ -22,16 +23,16 @@ class DateTimeUtilsTest : KSRobolectricTestCase() {
     fun testEstimatedDeliveryOn() {
         assertEquals(
             "December 2015",
-            DateTimeUtils.estimatedDeliveryOn(DateTime.parse("2015-12-17T18:35:05Z"))
+            DateTimeUtils.estimatedDeliveryOn(Date("2015-12-17T18:35:05Z"))
         )
         assertEquals(
             "décembre 2015",
-            DateTimeUtils.estimatedDeliveryOn(DateTime.parse("2015-12-17T18:35:05Z"), Locale.FRENCH)
+            DateTimeUtils.estimatedDeliveryOn(Date("2015-12-17T18:35:05Z"), Locale.FRENCH)
         )
         assertEquals(
             "2015年12月",
             DateTimeUtils.estimatedDeliveryOn(
-                DateTime.parse("2015-12-17T18:35:05Z"),
+                Date("2015-12-17T18:35:05Z"),
                 Locale.JAPANESE
             )
         )

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -20,7 +20,8 @@ import org.joda.time.DateTime
 import org.junit.Test
 import rx.observers.TestSubscriber
 import java.math.RoundingMode
-import java.util.Date
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
@@ -55,6 +56,8 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
     private val selectedRewardTagIsGone = TestSubscriber<Boolean>()
     private val localPickUpIsGone = TestSubscriber<Boolean>()
     private val localPickUpName = TestSubscriber<String>()
+
+    private val DATE_FORMAT = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
 
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = RewardViewHolderViewModel.ViewModel(environment)
@@ -644,7 +647,7 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
         val reward = RewardFactory.reward()
             .toBuilder()
-            .estimatedDeliveryOn(Date("2019-09-11T20:12:47+00:00"))
+            .estimatedDeliveryOn(DATE_FORMAT.parse(("2019-09-11T20:12:47+00:00")))
             .build()
         this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.project()), reward)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardViewHolderViewModelTest.kt
@@ -20,6 +20,7 @@ import org.joda.time.DateTime
 import org.junit.Test
 import rx.observers.TestSubscriber
 import java.math.RoundingMode
+import java.util.Date
 
 class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
@@ -643,7 +644,7 @@ class RewardViewHolderViewModelTest : KSRobolectricTestCase() {
 
         val reward = RewardFactory.reward()
             .toBuilder()
-            .estimatedDeliveryOn(DateTime.parse("2019-09-11T20:12:47+00:00"))
+            .estimatedDeliveryOn(Date("2019-09-11T20:12:47+00:00"))
             .build()
         this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.project()), reward)
 


### PR DESCRIPTION
# 📲 What

For this project, the estimated delivery date is different between  Android and web

# 🤔 Why
User report the estimated delivery date is different between  Android and web

# 🛠 How
as `estimatedDeliveryOn` date is formatted without the time change the android uses the date object replacing DateTime and removes the timezone to fix the issue for `estimatedDeliveryOn` 
<img width="663" alt="image" src="https://user-images.githubusercontent.com/1075310/204811121-55894e6a-660f-4b93-a9f0-3b87e4776041.png">


# 👀 See



| Before 🐛 |

https://user-images.githubusercontent.com/1075310/204814377-032da11c-73b4-4dc2-9375-dae32e757ba1.mp4

| After 🦋 |
 

https://user-images.githubusercontent.com/1075310/204814115-733d629a-e783-4ff0-818a-7c4963087c9e.mp4





# 📋 QA
Open projects [https://www.kickstarter.com/projects/alstup/the-first-connected-round-counter-and-timer-in-the-world](https://www.kickstarter.com/projects/alstup/the-first-connected-round-counter-and-timer-in-the-world) on web and android and validate rewards `estimatedDeliveryOn` date

Check segment parameter 
![image](https://user-images.githubusercontent.com/1075310/204875923-6275fced-2c67-456d-ad0a-8359fad472ff.png)

![Screenshot_20221130_232358](https://user-images.githubusercontent.com/1075310/204911078-d18835ca-3186-4955-8346-fc0b561f66b5.png)


![image](https://user-images.githubusercontent.com/1075310/204910812-eb835a4a-7975-4381-b1a0-39e67a25e3b7.png)

# Story 📖

https://kickstarter.atlassian.net/browse/NTV-601