### PR TITLE
PAY-2077: Updating amount using input text on update pledge flow did not enabled button

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentLegacyViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentLegacyViewModel.kt
@@ -1670,7 +1670,7 @@ interface PledgeFragmentLegacyViewModel {
 
             if (pReason == PledgeReason.PLEDGE) updated = true
             else if (pReason == PledgeReason.UPDATE_PLEDGE) {
-                updated = (bHasChanged && aUpdated) || shippingUpdated
+                updated = (bHasChanged || aUpdated) || shippingUpdated
             }
 
             return updated

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -1731,7 +1731,7 @@ interface PledgeFragmentViewModel {
 
             if (pReason == PledgeReason.PLEDGE) updated = true
             else if (pReason == PledgeReason.UPDATE_PLEDGE) {
-                updated = (bHasChanged && aUpdated) || shippingUpdated
+                updated = (bHasChanged || aUpdated) || shippingUpdated
             }
 
             return updated

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentLegacyViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentLegacyViewModelTest.kt
@@ -1947,7 +1947,7 @@ class PledgeFragmentLegacyViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.increasePledgeButtonClicked()
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(false, false, true)
+        this.pledgeButtonIsEnabled.assertValues(false, true, false, true)
         this.pledgeProgressIsGone.assertValues(false, true)
         this.showUpdatePledgeError.assertValueCount(1)
     }
@@ -2057,7 +2057,7 @@ class PledgeFragmentLegacyViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.increasePledgeButtonClicked()
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(false, false)
+        this.pledgeButtonIsEnabled.assertValues(false, true, false)
         this.pledgeProgressIsGone.assertValue(false)
     }
 
@@ -3056,6 +3056,7 @@ class PledgeFragmentLegacyViewModelTest : KSRobolectricTestCase() {
             )
             .reward(reward)
             .rewardId(reward.id())
+            .amount(reward.convertedMinimum())
             .build()
         val backedProject = ProjectFactory.backedProject()
             .toBuilder()

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -2018,7 +2018,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.increasePledgeButtonClicked()
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(false, false, true)
+        this.pledgeButtonIsEnabled.assertValues(false, true, false, true)
         this.pledgeProgressIsGone.assertValues(false, true)
         this.showUpdatePledgeError.assertValueCount(1)
     }
@@ -2128,7 +2128,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.increasePledgeButtonClicked()
         this.vm.inputs.pledgeButtonClicked()
 
-        this.pledgeButtonIsEnabled.assertValues(false, false)
+        this.pledgeButtonIsEnabled.assertValues(false, true, false)
         this.pledgeProgressIsGone.assertValue(false)
     }
 
@@ -3167,6 +3167,7 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
             )
             .reward(reward)
             .rewardId(reward.id())
+            .amount(reward.convertedMinimum())
             .build()
         val backedProject = ProjectFactory.backedProject()
             .toBuilder()


### PR DESCRIPTION
# 📲 What

Updating amount using input text on update pledge flow did not enabled the continue button.


# 👀 See

| Before 🐛 |

https://user-images.githubusercontent.com/4083656/204927340-d1a4bbb2-5e02-46f1-9ee5-a97928d5799e.mp4




|After 🦋 |

https://user-images.githubusercontent.com/4083656/204927349-f068208c-bafe-4b54-8468-d731ec4eac8d.mp4




|  |  |

# 📋 QA

- Update a pledge, update the bonus amount using only the text field, not the steppers

# Story 📖

[PAY-2077](https://kickstarter.atlassian.net/browse/PAY-2077)
