### PR TITLE
NTV-391 :  PerimeterX double value on header

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/perimeterx/PerimeterXClient.kt
@@ -60,6 +60,7 @@ open class PerimeterXClient(private val build: Build) : PerimeterXClientType {
         val headers = httpHeaders()?.toMap() ?: emptyMap()
 
         headers.forEach { (key, value) ->
+            builder?.removeHeader(key)
             builder?.addHeader(key, value)
         }
 


### PR DESCRIPTION
# 📲 What

 the header for PerimerterX has a duplicated value

# 🛠 How
remove the header before adding it 

# 👀 See
Before 


![Screen Shot 2022-12-01 at 7 11 21 PM](https://user-images.githubusercontent.com/1075310/205116606-e99d6d26-89ab-4191-965d-7491c317c6f3.png)
After
![Screen Shot 2022-12-01 at 7 05 07 PM](https://user-images.githubusercontent.com/1075310/205116570-63dded2b-6aca-47d0-8d11-1fa1dea7a049.png)


# 📋 QA

Check the networking profiler request 
# Story 📖

https://kickstarter.atlassian.net/browse/NTV-391
