### PR TITLE
NTV-637: Messages screen unable to load more messages

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/RecyclerViewPaginator.java
+++ b/app/src/main/java/com/kickstarter/libs/RecyclerViewPaginator.java
@@ -51,7 +51,6 @@ public final class RecyclerViewPaginator {
 
     final Observable<Pair<Integer, Integer>> lastVisibleAndCount = RxRecyclerView.scrollEvents(this.recyclerView)
       .filter(__ -> BoolenExtKt.isFalse(Secrets.IS_OSS))
-      .filter(__ -> this.recyclerView.canScrollVertically(DIRECTION_DOWN))
       .map(__ -> this.recyclerView.getLayoutManager())
       .ofType(LinearLayoutManager.class)
       .map(this::displayedItemFromLinearLayout)

--- a/app/src/main/java/com/kickstarter/libs/RecyclerViewPaginator.java
+++ b/app/src/main/java/com/kickstarter/libs/RecyclerViewPaginator.java
@@ -22,7 +22,6 @@ public final class RecyclerViewPaginator {
   private final @NonNull Action0 nextPage;
   private final Observable<Boolean> isLoading;
   private Subscription subscription;
-  private static final int DIRECTION_DOWN = 1;
   private Subscription retrySubscription;
   private final PublishSubject<Void> retryLoadingNextPageSubject =  PublishSubject.create();
 

--- a/app/src/main/res/layout/message_thread_view.xml
+++ b/app/src/main/res/layout/message_thread_view.xml
@@ -6,7 +6,7 @@
     android:paddingTop="@dimen/activity_horizontal_margin"
     android:paddingBottom="@dimen/activity_horizontal_margin"
     android:layout_width="match_parent"
-    android:layout_height="80dp">
+    android:layout_height="wrap_content">
 
     <ImageView
         android:id="@+id/participant_avatar_image_view"

--- a/app/src/main/res/layout/message_thread_view.xml
+++ b/app/src/main/res/layout/message_thread_view.xml
@@ -1,94 +1,90 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-  android:id="@+id/message_thread_container"
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
-  android:layout_width="match_parent"
-  android:layout_height="wrap_content"
-  android:focusable="true"
-  android:foreground="@drawable/click_indicator_light"
-  android:orientation="vertical">
-
-  <RelativeLayout
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/message_thread_container"
+    android:paddingTop="@dimen/activity_horizontal_margin"
+    android:paddingBottom="@dimen/activity_horizontal_margin"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_marginBottom="@dimen/activity_vertical_margin"
-    android:layout_marginEnd="@dimen/activity_horizontal_margin"
-    android:layout_marginStart="@dimen/activity_horizontal_margin"
-    android:layout_marginTop="@dimen/activity_vertical_margin"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintTop_toTopOf="parent">
+    android:layout_height="80dp">
 
     <ImageView
-      android:id="@+id/participant_avatar_image_view"
-      android:layout_width="@dimen/grid_5"
-      android:layout_height="@dimen/grid_5"
-      android:layout_alignParentStart="true"
-      android:layout_centerVertical="true"
-      tools:background="@color/accent"
-      tools:ignore="ContentDescription" />
+        android:id="@+id/participant_avatar_image_view"
+        android:layout_width="@dimen/grid_7"
+        android:layout_height="@dimen/grid_7"
+        android:layout_centerVertical="true"
+        android:layout_marginLeft="@dimen/grid_3"
+        android:layout_marginRight="@dimen/grid_3"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:background="@color/accent"
+        tools:ignore="ContentDescription" />
 
     <TextView
-      android:id="@+id/message_thread_date_text_view"
-      style="@style/Caption2Primary"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentEnd="true"
-      android:layout_alignParentTop="true"
-      tools:text="Yesterday" />
-
-    <LinearLayout
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginEnd="@dimen/grid_2"
-      android:layout_marginStart="@dimen/grid_2"
-      android:layout_toEndOf="@+id/participant_avatar_image_view"
-      android:layout_toStartOf="@+id/message_thread_date_text_view"
-      android:orientation="vertical">
-
-      <LinearLayout
-        android:layout_width="wrap_content"
+        android:id="@+id/participant_name_text_view"
+        style="@style/BodyPrimary"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/grid_1_half"
-        android:orientation="horizontal">
+        android:layout_marginEnd="@dimen/grid_1_half"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:lines="1"
+        tools:text="Somebody once told me that"
+        app:layout_constraintStart_toStartOf="@+id/guideline1"
+        app:layout_constraintEnd_toStartOf="@+id/message_thread_unread_count_text_view"
+        app:layout_constraintTop_toTopOf="parent"/>
 
-        <TextView
-          android:id="@+id/participant_name_text_view"
-          style="@style/BodyPrimary"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginEnd="@dimen/grid_1_half"
-          android:layout_weight="1"
-          android:ellipsize="end"
-          android:lines="1"
-          tools:text="Somebody once told me that" />
+    <TextView
+        android:id="@+id/message_thread_unread_count_text_view"
+        style="@style/Caption1Primary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/grid_1"
+        android:layout_weight="0"
+        android:textColor="@color/accent"
+        android:textStyle="bold"
+        tools:text="(2)"
+        app:layout_constraintStart_toEndOf="@+id/participant_name_text_view"
+        app:layout_constraintEnd_toStartOf="@+id/guideline2"
+        app:layout_constraintTop_toTopOf="parent"/>
 
-        <TextView
-          android:id="@+id/message_thread_unread_count_text_view"
-          style="@style/Caption1Primary"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginEnd="@dimen/grid_1"
-          android:layout_weight="0"
-          android:textColor="@color/accent"
-          android:textStyle="bold"
-          tools:text="(2)" />
-
-      </LinearLayout>
-
-      <TextView
+    <TextView
         android:id="@+id/message_thread_body_text_view"
         style="@style/FootnoteSecondary"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:ellipsize="end"
         android:importantForAccessibility="no"
         android:lines="1"
-        tools:text="Thanks for backing our project!" />
+        android:layout_marginTop="@dimen/grid_1"
+        tools:text="Thanks for backing our project!"
+        app:layout_constraintTop_toBottomOf="@+id/participant_name_text_view"
+        app:layout_constraintStart_toStartOf="@+id/guideline1"
+        app:layout_constraintEnd_toEndOf="@+id/guideline2" />
 
-    </LinearLayout>
+    <TextView
+        android:id="@+id/message_thread_date_text_view"
+        style="@style/Caption2Primary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="Yesterday"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        app:layout_constraintStart_toStartOf="@+id/guideline2"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 
-  </RelativeLayout>
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.18" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.82" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
# 📲 What

The messages screen was loading only the first batch of messages, never retrieving more.

# 🤔 Why

- It was a UI related problem, when the first batch of elements was not big enough to trigger scroll events on `RecyclerViewPaginator.java` it was imposible to trigger the next call page.

# 🛠 How

- `RecyclerViewPaginator.java` filter `canScrollVertically` removed, now relying only in the last item visible to call nextPage.
- Took the chance to change the `message_thread_view` to a flat hierarchy without relative|linearLayouts

# 👀 See

| Before 🐛 |


https://user-images.githubusercontent.com/4083656/206320598-8145e428-58dd-418b-b33b-b8ebcd5d2e2a.mp4



| After 🦋 |

- Tablet simulator


https://user-images.githubusercontent.com/4083656/206320515-665c3ca8-720c-4e1f-8ff7-0156e400f5f8.mp4

- Real phone device


https://user-images.githubusercontent.com/4083656/206320568-20104856-b965-4484-ab31-0742ca659361.mp4




|  |  |

# 📋 QA

- Go to your messages and scroll through several pages.
- `RecyclerViewPaginator.java` is used in all recyclerViews loading information from V1, check Discovery screen, Activity Feed screen to make sure no side effect raises.

# Story 📖

[NTV-637](https://kickstarter.atlassian.net/browse/NTV-637)
