### PR TITLE
PAY-2100: Compose spike

### DIFF
--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectRiskViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectRiskViewModelTest.kt
@@ -4,22 +4,34 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.mock.factories.ProjectDataFactory
 import com.kickstarter.mock.factories.ProjectFactory
-import com.kickstarter.viewmodels.projectpage.ProjectRiskViewModel
+import com.kickstarter.viewmodels.projectpage.ProjectRiskViewModel.ProjectRiskViewModel
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subscribers.TestSubscriber
+import org.junit.After
 import org.junit.Test
-import rx.observers.TestSubscriber
 
 class ProjectRiskViewModelTest : KSRobolectricTestCase() {
 
-    private lateinit var vm: ProjectRiskViewModel.ViewModel
+    private lateinit var vm: ProjectRiskViewModel
 
     private val projectRisks = TestSubscriber.create<String>()
     private val openLearnAboutAccountabilityOnKickstarter = TestSubscriber.create<String>()
+    private val disposables = CompositeDisposable()
 
     private fun setUpEnvironment(environment: Environment) {
-        this.vm = ProjectRiskViewModel.ViewModel(environment)
+        this.vm = ProjectRiskViewModel(environment)
 
-        this.vm.outputs.projectRisks().subscribe(this.projectRisks)
-        this.vm.outputs.openLearnAboutAccountabilityOnKickstarter().subscribe(this.openLearnAboutAccountabilityOnKickstarter)
+        disposables.add(this.vm.outputs.projectRisks().subscribe { this.projectRisks.onNext(it) })
+        disposables.add(
+            this.vm.outputs.openLearnAboutAccountabilityOnKickstarter().subscribe {
+                this.openLearnAboutAccountabilityOnKickstarter.onNext(it)
+            }
+        )
+    }
+
+    @After
+    fun cleanUp() {
+        disposables.clear()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

The `ProjectRiskFragment` UI has been targeted as the first one to be migrated to Compose, but in order to be able to successfully do so a few steps are required prior to it:

- Adopt `ViewModel` -> https://developer.android.com/topic/libraries/architecture/viewmodel
- Upgrade to RxJava 2.2 
- Remove inheritance from `BaseFragment` and `FragmentViewModel`

# 🤔 Why

Engineering plan detailing how and why to tackle the previous 3 points https://kickstarter.atlassian.net/wiki/spaces/~420550558/pages/2028339209/H2+2022+Android+Tech+Plan


# 👀 See
 No user facing changes, it should all look prior to these changes

https://user-images.githubusercontent.com/4083656/208513618-068300c9-867b-4cdf-8cca-d37ed92e509e.mp4




|  |  |

# 📋 QA

- Load several projects and go to the risks tab


# Story 📖

[PAY-2100](https://kickstarter.atlassian.net/browse/PAY-2100)
