### PR TITLE
WEB-875: [Android] Show dialog on bootstrap when preference has not been set

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/SharedPreferenceKey.kt
+++ b/app/src/main/java/com/kickstarter/ui/SharedPreferenceKey.kt
@@ -11,4 +11,5 @@ object SharedPreferenceKey {
     const val USER = "user"
     const val FEATURE_FLAG = "feature_flags"
     const val HAS_SEEN_NOTIF_PERMISSIONS = "has_seen_notif_permissions"
+    const val CONSENT_MANAGEMENT_PREFERENCE = "consent_management_preference"
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
@@ -30,6 +30,7 @@ import com.kickstarter.ui.adapters.DiscoveryPagerAdapter
 import com.kickstarter.ui.data.LoginReason
 import com.kickstarter.ui.extensions.showErrorSnackBar
 import com.kickstarter.ui.extensions.showSuccessSnackBar
+import com.kickstarter.ui.fragments.ConsentManagementDialogFragment
 import com.kickstarter.ui.fragments.DiscoveryFragment
 import com.kickstarter.ui.fragments.DiscoveryFragment.Companion.newInstance
 import com.kickstarter.viewmodels.DiscoveryViewModel
@@ -43,6 +44,7 @@ class DiscoveryActivity : BaseActivity<DiscoveryViewModel.ViewModel>() {
     private lateinit var drawerAdapter: DiscoveryDrawerAdapter
     private lateinit var drawerLayoutManager: LinearLayoutManager
     private lateinit var pagerAdapter: DiscoveryPagerAdapter
+    private lateinit var consentManagementDialogFragment: ConsentManagementDialogFragment
     private var internalTools: InternalToolsType? = null
     private lateinit var binding: DiscoveryLayoutBinding
 
@@ -109,6 +111,15 @@ class DiscoveryActivity : BaseActivity<DiscoveryViewModel.ViewModel>() {
             .subscribe {
                 requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                 viewModel.inputs.hasSeenNotificationsPermission(true)
+            }
+
+        viewModel.outputs.showConsentManagementDialog()
+            .distinctUntilChanged()
+            .delay(2000, TimeUnit.MILLISECONDS)
+            .subscribe {
+                consentManagementDialogFragment = ConsentManagementDialogFragment()
+                consentManagementDialogFragment.isCancelable = false
+                consentManagementDialogFragment.show(supportFragmentManager, "consentManagementDialogFragment")
             }
 
         viewModel.outputs.clearPages()

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
@@ -2,7 +2,6 @@ package com.kickstarter.viewmodels
 
 import android.content.Intent
 import android.net.Uri
-import android.util.Log
 import android.util.Pair
 import com.google.common.collect.Iterables.filter
 import com.kickstarter.R
@@ -36,10 +35,10 @@ import com.kickstarter.ui.viewholders.discoverydrawer.LoggedInViewHolder
 import com.kickstarter.ui.viewholders.discoverydrawer.LoggedOutViewHolder
 import com.kickstarter.ui.viewholders.discoverydrawer.ParentFilterViewHolder
 import com.kickstarter.ui.viewholders.discoverydrawer.TopFilterViewHolder
-import java.util.Locale.filter
 import rx.Observable
 import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
+import java.util.Locale.filter
 
 interface DiscoveryViewModel {
     interface Inputs : DiscoveryDrawerAdapter.Delegate, DiscoveryPagerAdapter.Delegate {

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
@@ -2,10 +2,13 @@ package com.kickstarter.viewmodels
 
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import android.util.Pair
+import com.google.common.collect.Iterables.filter
 import com.kickstarter.R
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.DiscoveryUtils
 import com.kickstarter.libs.utils.ObjectUtils
@@ -21,6 +24,7 @@ import com.kickstarter.models.User
 import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.services.apiresponses.ErrorEnvelope
 import com.kickstarter.services.apiresponses.InternalBuildEnvelope
+import com.kickstarter.ui.SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE
 import com.kickstarter.ui.SharedPreferenceKey.HAS_SEEN_NOTIF_PERMISSIONS
 import com.kickstarter.ui.activities.DiscoveryActivity
 import com.kickstarter.ui.adapters.DiscoveryDrawerAdapter
@@ -32,6 +36,7 @@ import com.kickstarter.ui.viewholders.discoverydrawer.LoggedInViewHolder
 import com.kickstarter.ui.viewholders.discoverydrawer.LoggedOutViewHolder
 import com.kickstarter.ui.viewholders.discoverydrawer.ParentFilterViewHolder
 import com.kickstarter.ui.viewholders.discoverydrawer.TopFilterViewHolder
+import java.util.Locale.filter
 import rx.Observable
 import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
@@ -109,6 +114,9 @@ interface DiscoveryViewModel {
         /** Emits if the user should be shown the notification permission request  */
         fun showNotifPermissionsRequest(): Observable<Void?>
 
+        /** Emits if the user should be shown the consent management dialog  */
+        fun showConsentManagementDialog(): Observable<Void?>
+
         /** Emits the error message from verify endpoint  */
         fun showErrorMessage(): Observable<String?>
     }
@@ -124,6 +132,7 @@ interface DiscoveryViewModel {
         private val currentConfigType = requireNotNull(environment.currentConfig())
         private val sharedPreferences = requireNotNull(environment.sharedPreferences())
         private val webClient = requireNotNull(environment.webClient())
+        private val optimizely = environment.optimizely()
 
         private fun currentDrawerMenuIcon(user: User?): Int {
             if (ObjectUtils.isNull(user)) {
@@ -152,6 +161,7 @@ interface DiscoveryViewModel {
         private val parentFilterRowClick = PublishSubject.create<NavigationDrawerData.Section.Row>()
         private val profileClick = PublishSubject.create<Void?>()
         private val showNotifPermissionRequest = BehaviorSubject.create<Void?>()
+        private val showConsentManagementDialog = BehaviorSubject.create<Void?>()
         private val settingsClick = PublishSubject.create<Void?>()
         private val sortClicked = PublishSubject.create<Int>()
         private val hasSeenNotificationsPermission = PublishSubject.create<Boolean>()
@@ -248,6 +258,12 @@ interface DiscoveryViewModel {
             hasSeenNotificationsPermission
                 .compose(bindToLifecycle())
                 .subscribe { sharedPreferences.edit().putBoolean(HAS_SEEN_NOTIF_PERMISSIONS, it).apply() }
+
+            Observable.just(sharedPreferences.contains(CONSENT_MANAGEMENT_PREFERENCE))
+                .filter { !it }
+                .filter { this.optimizely?.isFeatureEnabled(OptimizelyFeature.Key.ANDROID_CONSENT_MANAGEMENT) }
+                .compose(bindToLifecycle())
+                .subscribe { showConsentManagementDialog.onNext(null) }
 
             val paramsFromIntent = intent()
                 .flatMap { DiscoveryIntentMapper.params(it, apiClient, apolloClient) }
@@ -452,5 +468,6 @@ interface DiscoveryViewModel {
         override fun showSuccessMessage(): Observable<String> { return successMessage }
         override fun showErrorMessage(): Observable<String?> { return messageError }
         override fun showNotifPermissionsRequest(): Observable<Void?> { return showNotifPermissionRequest }
+        override fun showConsentManagementDialog(): Observable<Void?> { return showConsentManagementDialog }
     }
 }


### PR DESCRIPTION
# 📲 What

Show the consent management dialog on bootstrap when a user has not set consent preferences. 

# 🤔 Why

Consent management

# 🛠 How
We show the dialog if:
- There is no consent preference saved in shared preferences
- The feature flag is on for the user 
![Screen Shot 2023-01-10 at 6 30 46 PM](https://user-images.githubusercontent.com/19390326/211621470-46b8f8e2-f41c-47dd-abec-4ffc5fa10c14.png)

The consent preference cannot be dismissed unless a user selects allow or deny

# 👀 See

![Screenshot_20230109-155856](https://user-images.githubusercontent.com/19390326/211621861-88c986af-e8fc-445d-a92e-a974501af7e8.png)

# 📋 QA

- Make sure you are on staging
- Open app, dialog should appear on bootstrap

# Story 📖

[WEB-875: [Android] Show dialog on bootstrap when preference has not been set]( https://kickstarter.atlassian.net/browse/WEB-875)
