### PR TITLE
Add .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,6 @@ jobs:
       - run: ./gradlew ktlint
       - run: ./gradlew lintExternalRelease
       - run:
-          command: ./gradlew testExternalRelease -PdisablePreDex
-          no_output_timeout: 30m
-      - run:
           command: ./gradlew jacocoExternalDebugReport -PdisablePreDex
           no_output_timeout: 30m
       - store_artifacts:


### PR DESCRIPTION
# 📲 What

- Temporary removal as we figure out the jacoco `Out of memory` issue
- ℹ️ the ideal scenario will be run only `jacocoExternalReleaseReport`, as jacoco task internally executes `testExternalRelease`