### PR TITLE
WEB-878: [Android] Save consent preference on user interaction with dialog

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
@@ -5,6 +5,7 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.drawable.Animatable
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.GravityCompat
@@ -115,7 +116,7 @@ class DiscoveryActivity : BaseActivity<DiscoveryViewModel.ViewModel>() {
 
         viewModel.outputs.showConsentManagementDialog()
             .distinctUntilChanged()
-            .delay(2000, TimeUnit.MILLISECONDS)
+//            .delay(2000, TimeUnit.MILLISECONDS)
             .subscribe {
                 consentManagementDialogFragment = ConsentManagementDialogFragment()
                 consentManagementDialogFragment.isCancelable = false

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
@@ -5,7 +5,6 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.drawable.Animatable
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.GravityCompat

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
@@ -115,7 +115,6 @@ class DiscoveryActivity : BaseActivity<DiscoveryViewModel.ViewModel>() {
 
         viewModel.outputs.showConsentManagementDialog()
             .distinctUntilChanged()
-//            .delay(2000, TimeUnit.MILLISECONDS)
             .subscribe {
                 consentManagementDialogFragment = ConsentManagementDialogFragment()
                 consentManagementDialogFragment.isCancelable = false

--- a/app/src/main/java/com/kickstarter/ui/fragments/ConsentManagementDialogFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/ConsentManagementDialogFragment.kt
@@ -3,19 +3,35 @@ package com.kickstarter.ui.fragments
 import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
 import com.kickstarter.R
+import com.kickstarter.libs.utils.extensions.getEnvironment
+import com.kickstarter.viewmodels.ConsentManagementDialogFragmentViewModel
 
 class ConsentManagementDialogFragment : DialogFragment() {
 
+    private lateinit var viewModelFactory: ConsentManagementDialogFragmentViewModel.Factory
+    private val viewModel: ConsentManagementDialogFragmentViewModel.ConsentManagementDialogFragmentViewModel by viewModels { viewModelFactory }
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        this.context?.getEnvironment()?.let { env ->
+            viewModelFactory = ConsentManagementDialogFragmentViewModel.Factory(env)
+        }
+
+        Log.d("leigh", "onCreateDialog: did this work?")
         return activity?.let {
-            val builder = AlertDialog.Builder(it)
-            builder.setTitle(R.string.FPO_allow_app_to_track)
-            builder.setMessage(R.string.FPO_Allow_Kickstarter_to_track_analytics_to_provide_a_more_personalized_experience)
-                .setPositiveButton(R.string.FPO_allow) { dialog, id -> }
-                .setNegativeButton(R.string.FPO_deny) { dialog, id -> }
-            builder.create()
-        } ?: throw IllegalStateException("Activity cannot be null")
-    }
+                val builder = AlertDialog.Builder(it)
+                builder.setTitle(R.string.FPO_allow_app_to_track)
+                builder.setMessage(R.string.FPO_Allow_Kickstarter_to_track_analytics_to_provide_a_more_personalized_experience)
+                    .setPositiveButton(R.string.FPO_allow) { dialog, id ->
+                        this.viewModel.inputs.onAllow()
+                    }
+                    .setNegativeButton(R.string.FPO_deny) { dialog, id ->
+                        this.viewModel.inputs.onDeny()
+                    }
+                builder.create()
+            } ?: throw IllegalStateException("Activity cannot be null")
+        }
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/ConsentManagementDialogFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/ConsentManagementDialogFragment.kt
@@ -3,7 +3,6 @@ package com.kickstarter.ui.fragments
 import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
-import android.util.Log
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.kickstarter.R
@@ -20,16 +19,15 @@ class ConsentManagementDialogFragment : DialogFragment() {
             viewModelFactory = ConsentManagementDialogFragmentViewModel.Factory(env)
         }
 
-        Log.d("leigh", "onCreateDialog: did this work?")
         return activity?.let {
                 val builder = AlertDialog.Builder(it)
                 builder.setTitle(R.string.FPO_allow_app_to_track)
                 builder.setMessage(R.string.FPO_Allow_Kickstarter_to_track_analytics_to_provide_a_more_personalized_experience)
                     .setPositiveButton(R.string.FPO_allow) { dialog, id ->
-                        this.viewModel.inputs.onAllow()
+                        this.viewModel.inputs.userConsentPreference(true)
                     }
                     .setNegativeButton(R.string.FPO_deny) { dialog, id ->
-                        this.viewModel.inputs.onDeny()
+                        this.viewModel.inputs.userConsentPreference(false)
                     }
                 builder.create()
             } ?: throw IllegalStateException("Activity cannot be null")

--- a/app/src/main/java/com/kickstarter/ui/fragments/ConsentManagementDialogFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/ConsentManagementDialogFragment.kt
@@ -20,16 +20,16 @@ class ConsentManagementDialogFragment : DialogFragment() {
         }
 
         return activity?.let {
-                val builder = AlertDialog.Builder(it)
-                builder.setTitle(R.string.FPO_allow_app_to_track)
-                builder.setMessage(R.string.FPO_Allow_Kickstarter_to_track_analytics_to_provide_a_more_personalized_experience)
-                    .setPositiveButton(R.string.FPO_allow) { dialog, id ->
-                        this.viewModel.inputs.userConsentPreference(true)
-                    }
-                    .setNegativeButton(R.string.FPO_deny) { dialog, id ->
-                        this.viewModel.inputs.userConsentPreference(false)
-                    }
-                builder.create()
-            } ?: throw IllegalStateException("Activity cannot be null")
-        }
+            val builder = AlertDialog.Builder(it)
+            builder.setTitle(R.string.FPO_allow_app_to_track)
+            builder.setMessage(R.string.FPO_Allow_Kickstarter_to_track_analytics_to_provide_a_more_personalized_experience)
+                .setPositiveButton(R.string.FPO_allow) { dialog, id ->
+                    this.viewModel.inputs.userConsentPreference(true)
+                }
+                .setNegativeButton(R.string.FPO_deny) { dialog, id ->
+                    this.viewModel.inputs.userConsentPreference(false)
+                }
+            builder.create()
+        } ?: throw IllegalStateException("Activity cannot be null")
+    }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModel.kt
@@ -1,0 +1,53 @@
+package com.kickstarter.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.kickstarter.libs.Environment
+import com.kickstarter.ui.SharedPreferenceKey
+import rx.subjects.BehaviorSubject
+
+interface ConsentManagementDialogFragmentViewModel {
+
+    interface Inputs {
+        fun onAllow()
+        fun onDeny()
+    }
+
+    interface Outputs {}
+
+    class ConsentManagementDialogFragmentViewModel(environment: Environment) : ViewModel(), Inputs, Outputs {
+        val inputs: Inputs = this
+        val outputs: Outputs = this
+
+        private val onUserTapsAllow = BehaviorSubject.create<Void>()
+        private val onUserTapsDeny = BehaviorSubject.create<Void>()
+
+        private val sharedPreferences = requireNotNull(environment.sharedPreferences())
+
+        init {
+            onUserTapsAllow
+                .subscribe {
+                    sharedPreferences.edit().putBoolean(SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE, true).apply()
+                }
+
+            onUserTapsDeny
+                .subscribe {
+                    sharedPreferences.edit().putBoolean(SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE, false).apply()
+                }
+        }
+
+        override fun onAllow() {
+            this.onUserTapsAllow.onNext(null)
+        }
+
+        override fun onDeny() {
+            this.onUserTapsDeny.onNext(null)
+        }
+    }
+
+    class Factory(private val environment: Environment) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return ConsentManagementDialogFragmentViewModel(environment) as T
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModel.kt
@@ -9,7 +9,7 @@ import rx.subjects.BehaviorSubject
 interface ConsentManagementDialogFragmentViewModel {
 
     interface Inputs {
-        /** The consent preference of the user represented as a boolean. True if they allow consent, false if they deny consent */
+        /** The consent preference of the user represented as a [Boolean] value. True if they allow consent, false if they deny consent. */
         fun userConsentPreference(consentPreference: Boolean)
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModel.kt
@@ -9,39 +9,29 @@ import rx.subjects.BehaviorSubject
 interface ConsentManagementDialogFragmentViewModel {
 
     interface Inputs {
-        fun onAllow()
-        fun onDeny()
+        /** The consent preference of the user represented as a boolean. True if they allow consent, false if they deny consent */
+        fun userConsentPreference(consentPreference: Boolean)
     }
 
-    interface Outputs {}
+    interface Outputs
 
     class ConsentManagementDialogFragmentViewModel(environment: Environment) : ViewModel(), Inputs, Outputs {
         val inputs: Inputs = this
         val outputs: Outputs = this
 
-        private val onUserTapsAllow = BehaviorSubject.create<Void>()
-        private val onUserTapsDeny = BehaviorSubject.create<Void>()
+        private val userConsentPreference = BehaviorSubject.create<Boolean>()
 
         private val sharedPreferences = requireNotNull(environment.sharedPreferences())
 
         init {
-            onUserTapsAllow
+            userConsentPreference
                 .subscribe {
-                    sharedPreferences.edit().putBoolean(SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE, true).apply()
-                }
-
-            onUserTapsDeny
-                .subscribe {
-                    sharedPreferences.edit().putBoolean(SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE, false).apply()
+                    sharedPreferences.edit().putBoolean(SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE, it).apply()
                 }
         }
 
-        override fun onAllow() {
-            this.onUserTapsAllow.onNext(null)
-        }
-
-        override fun onDeny() {
-            this.onUserTapsDeny.onNext(null)
+        override fun userConsentPreference(consentPreference : Boolean) {
+            this.userConsentPreference.onNext(consentPreference)
         }
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModel.kt
@@ -30,7 +30,7 @@ interface ConsentManagementDialogFragmentViewModel {
                 }
         }
 
-        override fun userConsentPreference(consentPreference : Boolean) {
+        override fun userConsentPreference(consentPreference: Boolean) {
             this.userConsentPreference.onNext(consentPreference)
         }
     }

--- a/app/src/test/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModelTest.kt
@@ -1,0 +1,20 @@
+package com.kickstarter.viewmodels
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Environment
+import rx.observers.TestSubscriber
+import com.kickstarter.viewmodels.ConsentManagementDialogFragmentViewModel.ConsentManagementDialogFragmentViewModel
+
+class ConsentManagementDialogFragmentViewModelTest : KSRobolectricTestCase() {
+
+    private lateinit var vm: ConsentManagementDialogFragmentViewModel
+
+    private val onAllow = TestSubscriber.create<Void>()
+    private val onDeny = TestSubscriber.create<Void>()
+
+    private fun setUpEnvironment(environment: Environment) {
+        this.vm = ConsentManagementDialogFragmentViewModel(environment)
+    }
+
+
+}

--- a/app/src/test/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModelTest.kt
@@ -17,7 +17,7 @@ class ConsentManagementDialogFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun userConsentPreference_whenUserAllowsConsent_shouldWriteTrueToSharedPrefs(){
+    fun userConsentPreference_whenUserAllowsConsent_shouldWriteTrueToSharedPrefs() {
         setUpEnvironment(environment())
 
         this.vm.inputs.userConsentPreference(true)

--- a/app/src/test/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModelTest.kt
@@ -2,19 +2,35 @@ package com.kickstarter.viewmodels
 
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
-import rx.observers.TestSubscriber
+import com.kickstarter.libs.MockSharedPreferences
+import com.kickstarter.ui.SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE
 import com.kickstarter.viewmodels.ConsentManagementDialogFragmentViewModel.ConsentManagementDialogFragmentViewModel
+import org.junit.Test
 
 class ConsentManagementDialogFragmentViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var vm: ConsentManagementDialogFragmentViewModel
-
-    private val onAllow = TestSubscriber.create<Void>()
-    private val onDeny = TestSubscriber.create<Void>()
+    private val mockPreferences = MockSharedPreferences()
 
     private fun setUpEnvironment(environment: Environment) {
-        this.vm = ConsentManagementDialogFragmentViewModel(environment)
+        this.vm = ConsentManagementDialogFragmentViewModel(environment.toBuilder().sharedPreferences(mockPreferences).build())
     }
 
+    @Test
+    fun userConsentPreference_whenUserAllowsConsent_shouldWriteTrueToSharedPrefs(){
+        setUpEnvironment(environment())
 
+        this.vm.inputs.userConsentPreference(true)
+
+        assertTrue(mockPreferences.getBoolean(CONSENT_MANAGEMENT_PREFERENCE, false))
+    }
+
+    @Test
+    fun userConsentPreference_whenUserDenysConsent_shouldWriteFalseToSharedPrefs() {
+        setUpEnvironment(environment())
+
+        this.vm.inputs.userConsentPreference(false)
+
+        assertFalse(mockPreferences.getBoolean(CONSENT_MANAGEMENT_PREFERENCE, true))
+    }
 }


### PR DESCRIPTION
# 📲 What

Saves user consent preference in local storage in response to tapping "Allow" or "Deny" on the consent preference dialog.

# 🤔 Why

Consent management feature

# 🛠 How

- Created a view model for the `ConsentManagementDialogFragment`
- When a user taps "Allow" or "Deny" on the dialog, the preference is emitted to the view model, which then saves the preference in shared prefs

# 👀 See
- Consent management pops up upon app bootstrap
- Once user selects a preference, it should not appear again after restarting the app

https://user-images.githubusercontent.com/19390326/213270821-bdde79f5-99ed-437a-ac18-976077183933.mp4

# 📋 QA

- Make sure you are on staging
- Open app upon fresh install
- Consent management popup should appear
- Tap "allow" or "deny"
- Quit and restart app -> dialog should not appear again
- Clear app data and restart app -> should see dialog again

# Story 📖

[WEB-878: [Android] Save consent preference on user interaction with dialog](https://kickstarter.atlassian.net/browse/WEB-878)
