### PR TITLE
[no-jira] Add subscriptions in ConsentManagementViewModel to disposable

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ConsentManagementDialogFragmentViewModel.kt
@@ -4,7 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.kickstarter.libs.Environment
 import com.kickstarter.ui.SharedPreferenceKey
-import rx.subjects.BehaviorSubject
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subjects.BehaviorSubject
 
 interface ConsentManagementDialogFragmentViewModel {
 
@@ -23,11 +24,20 @@ interface ConsentManagementDialogFragmentViewModel {
 
         private val sharedPreferences = requireNotNull(environment.sharedPreferences())
 
+        private val disposables = CompositeDisposable()
+
         init {
-            userConsentPreference
-                .subscribe {
-                    sharedPreferences.edit().putBoolean(SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE, it).apply()
-                }
+            disposables.add(
+                userConsentPreference
+                    .subscribe {
+                        sharedPreferences.edit().putBoolean(SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE, it).apply()
+                    }
+            )
+        }
+
+        override fun onCleared() {
+            disposables.clear()
+            super.onCleared()
         }
 
         override fun userConsentPreference(consentPreference: Boolean) {


### PR DESCRIPTION
# 📲 What

Since we have migrated away from using `BaseFragment`, we need to clear any subscriptions we create in the viewmodel. 

# 🛠 How

Add a composite disposable to the view model, add any subscriptions to it, and then dispose of them when the view model is cleared. 

# 👀 See

No visual changes
