### PR TITLE
[no-jira]:  Fix issue for search result Coming soon label

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectSearchResultViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectSearchResultViewHolder.kt
@@ -3,6 +3,7 @@ package com.kickstarter.ui.viewholders
 import android.util.Pair
 import android.view.View
 import androidx.core.view.isGone
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import com.kickstarter.R
 import com.kickstarter.databinding.ProjectSearchResultViewBinding
@@ -54,7 +55,7 @@ class ProjectSearchResultViewHolder(private val binding: ProjectSearchResultView
             .compose(bindToLifecycle())
             .compose(Transformers.observeForUI())
             .subscribe {
-                binding.searchResultGroup.isGone = it
+                binding.searchResultGroup.isInvisible = it
                 binding.searchResultComingSoon.isVisible = it
             }
     }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectSearchResultViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectSearchResultViewHolder.kt
@@ -2,7 +2,6 @@ package com.kickstarter.ui.viewholders
 
 import android.util.Pair
 import android.view.View
-import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import com.kickstarter.R

--- a/app/src/main/res/layout/project_search_result_view.xml
+++ b/app/src/main/res/layout/project_search_result_view.xml
@@ -34,7 +34,7 @@
         android:text="@string/Coming_soon"
         android:textColor="@color/kds_create_700"
         android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@+id/include"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="@+id/project_name_text_view"
         app:layout_constraintTop_toBottomOf="@+id/project_name_text_view"
         tools:visibility="visible" />
@@ -54,7 +54,6 @@
       app:layout_constraintVertical_chainStyle="packed"
       app:layout_constraintVertical_bias="0.5"
       tools:text="Somebody Once Told Me" />
-
 
   <TextView
       android:id="@+id/search_result_percent_funded_text_view"
@@ -119,6 +118,6 @@
       app:constraint_referenced_ids="search_result_percent_funded_text_view,search_result_funded_text_view,search_result_deadline_countdown_text_view,search_result_deadline_unit_text_view"
       tools:layout_editor_absoluteX="12dp"
       tools:layout_editor_absoluteY="12dp"
-      tools:visibility="invisible" />
+      tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
# 📲 What

Fix coming soon label alignment in the search result 

# 🤔 Why
match [figma](https://www.figma.com/file/Wt14jhetT6UVq0HpzMtXFe/Native-Pre-Launch?node-id=85-1451&t=xfwVI70zFKuMTj3Y-0)

# 🛠 How
overlay coming soon to replace fund labels 

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |


![Screenshot_20230323_000737](https://user-images.githubusercontent.com/1075310/227051297-0cbe5688-f5ce-4430-8ab4-4df767cfd97f.png)

![Screenshot_20230323_001950](https://user-images.githubusercontent.com/1075310/227051291-ad99c5ca-6b1e-45fe-a6cc-acdeb2b5b47a.png)

# 📋 QA
test on staging with the search keyword "ion"
