### PR TITLE
MBL-676: Constrain bottom of removed comment textview

### DIFF
--- a/app/src/main/res/layout/comment_card.xml
+++ b/app/src/main/res/layout/comment_card.xml
@@ -202,6 +202,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/info_button"
         app:layout_constraintTop_toBottomOf="@id/avatar"
+        app:layout_constraintBottom_toTopOf="@id/replies"
         tools:visibility="visible"/>
 
     <androidx.appcompat.widget.AppCompatTextView


### PR DESCRIPTION
# 📲 What

In comments activity, constrain the "This comment has been removed by Kickstarter. Learn more about comment guidelines" textview's bottom constraint so that it does not overlap replies.

# 🤔 Why

The textview lacked a bottom constraint and overlapped replies UI below it.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
|  ![mbl-676-before](https://user-images.githubusercontent.com/129205442/229895286-13643e28-8a92-420e-b402-fee050779de6.jpeg) | ![Screenshot_20230404_151943](https://user-images.githubusercontent.com/129205442/229897976-0dcae03d-a3e8-44f9-b48a-e968531231ae.png) |

# 📋 QA

To force a comment to be removed, temporarily override the visibility of commentBody and removedMessage in CommentCard.kt line 169:
```
        binding.commentBody.isVisible = false
        binding.removedMessage.isVisible = true
```
Also override visibility of infoButton:
```
        binding.infoButton.isVisible = true
```

# Story 📖

[[MBL-676](https://kickstarter.atlassian.net/browse/MBL-676)]

[MBL-676]: https://kickstarter.atlassian.net/browse/MBL-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ