### PR TITLE
MBL-693 Prioritize superbacker badge before you badge

### DIFF
--- a/app/src/main/java/com/kickstarter/models/extensions/CommentExt.kt
+++ b/app/src/main/java/com/kickstarter/models/extensions/CommentExt.kt
@@ -50,10 +50,10 @@ fun Comment.updateCommentFailedToPost(
 }
 
 fun Comment.assignAuthorBadge(user: User? = null): CommentCardBadge {
+    if (this.authorBadges()?.contains(CommentBadge.SUPERBACKER.rawValue()) == true) return CommentCardBadge.SUPERBACKER
     if (this.author()?.id() == user?.id()) return CommentCardBadge.YOU
     if (this.authorBadges()?.contains(CommentBadge.CREATOR.rawValue()) == true) return CommentCardBadge.CREATOR
     if (this.authorBadges()?.contains(CommentBadge.COLLABORATOR.rawValue()) == true) return CommentCardBadge.COLLABORATOR
-    if (this.authorBadges()?.contains(CommentBadge.SUPERBACKER.rawValue()) == true) return CommentCardBadge.SUPERBACKER
     return CommentCardBadge.NO_BADGE
 }
 

--- a/app/src/main/java/com/kickstarter/models/extensions/CommentExt.kt
+++ b/app/src/main/java/com/kickstarter/models/extensions/CommentExt.kt
@@ -50,10 +50,10 @@ fun Comment.updateCommentFailedToPost(
 }
 
 fun Comment.assignAuthorBadge(user: User? = null): CommentCardBadge {
-    if (this.authorBadges()?.contains(CommentBadge.SUPERBACKER.rawValue()) == true) return CommentCardBadge.SUPERBACKER
-    if (this.author()?.id() == user?.id()) return CommentCardBadge.YOU
     if (this.authorBadges()?.contains(CommentBadge.CREATOR.rawValue()) == true) return CommentCardBadge.CREATOR
     if (this.authorBadges()?.contains(CommentBadge.COLLABORATOR.rawValue()) == true) return CommentCardBadge.COLLABORATOR
+    if (this.authorBadges()?.contains(CommentBadge.SUPERBACKER.rawValue()) == true) return CommentCardBadge.SUPERBACKER
+    if (this.author()?.id() == user?.id()) return CommentCardBadge.YOU
     return CommentCardBadge.NO_BADGE
 }
 

--- a/app/src/main/res/layout/comment_card.xml
+++ b/app/src/main/res/layout/comment_card.xml
@@ -202,6 +202,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/info_button"
         app:layout_constraintTop_toBottomOf="@id/avatar"
+        app:layout_constraintBottom_toTopOf="@id/replies"
         tools:visibility="visible"/>
 
     <androidx.appcompat.widget.AppCompatTextView

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
@@ -619,7 +619,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun commentBadge_whenYou_shouldEmitYou() {
+    fun commentBadge_whenYouAndSuperbacker_shouldEmitSuperbacker() {
         val authorBadges = listOf<String>(CommentBadge.SUPERBACKER.rawValue())
         val author = UserFactory.user().toBuilder().id(1).build()
         val currentUser = UserFactory.user().toBuilder().id(1).build()
@@ -637,7 +637,7 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.configureWith(commentCardData)
 
-        this.authorBadge.assertValue(CommentCardBadge.YOU)
+        this.authorBadge.assertValue(CommentCardBadge.SUPERBACKER)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/RootCommentViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RootCommentViewHolderViewModelTest.kt
@@ -71,7 +71,7 @@ class RootCommentViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun commentBadge_whenYou_shouldEmitYou() {
+    fun commentBadge_whenYouAndSuperbacker_shouldEmitSuperbacker() {
         val authorBadges = listOf<String>(CommentBadge.SUPERBACKER.rawValue())
         val author = UserFactory.user().toBuilder().id(1).build()
         val currentUser = UserFactory.user().toBuilder().id(1).build()
@@ -88,7 +88,7 @@ class RootCommentViewHolderViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.configureWith(commentCardData)
 
-        this.authorBadge.assertValue(CommentCardBadge.YOU)
+        this.authorBadge.assertValue(CommentCardBadge.SUPERBACKER)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Previously https://github.com/kickstarter/android-oss/pull/1337 prioritized user badges in this order:  `You, Creator/Collaborator, Superbacker` per product requirements

Update priority to `Creator/Collaborator, Superbacker, You` 

# 🤔 Why

Superbacker users expressed a preference to see a `Superbacker` badge on their own comments rather than just a regular `You` badge

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| ![superbacker_badge_before](https://user-images.githubusercontent.com/129205442/230150785-af188c52-85de-4f31-8696-0ba537e18085.png) | ![superbacker_badge_after](https://user-images.githubusercontent.com/129205442/230150807-0f14e200-267f-4721-a463-9482c76824ff.png) |

# 📋 QA

Temporarily override `Comment.kt` L31 to set your own user as a Superbacker. 

```
fun authorBadges() : List<String>? {
    return if (author.id() == <<YOUR USER ID HERE EG 12345678L>>) {
        listOf(CommentBadge.SUPERBACKER.rawValue())
    } else {
        this.authorBadges
    }
}
```

Verify that your comments have a `Superbacker` badge rather than a `You` badge

# Story 📖

[MBL-693](https://kickstarter.atlassian.net/browse/MBL-693)


[MBL-693]: https://kickstarter.atlassian.net/browse/MBL-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ