### PR TITLE
MBL-695: Constrain SwipeRefreshLayout height for updates list

### DIFF
--- a/app/src/main/res/layout/activity_updates.xml
+++ b/app/src/main/res/layout/activity_updates.xml
@@ -32,8 +32,9 @@
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/updates_swipe_refresh_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/updates_progress_bar">
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@+id/updates_progress_bar"
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/updates_recycler_view"


### PR DESCRIPTION
# 📲 What

Update height constraints for SwipeRefreshLayout in updates list

# 🤔 Why

When scrolling to the bottom of a project's updates list, the oldest update's card is cut off because the SwipeRefreshLayout's height wasn't constrained properly

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
|![Screenshot_20230404_103422](https://user-images.githubusercontent.com/129205442/230965784-a9ad91dd-49bb-4e2a-b29e-b5ee5bbb1026.png) |  ![mbl-695-bottom](https://user-images.githubusercontent.com/129205442/230965825-aa1b82a5-3ad2-402c-88b7-08c13acbcf85.png)|

# 📋 QA

Find a project that has enough updates that you need to scroll to see all of them. Scroll to the bottom of the updates list. Verify that the oldest update's card is not cut off.

# Story 📖

[MBL-695](https://kickstarter.atlassian.net/browse/MBL-695)
