### PR TITLE
MBL-684: Migrate feature flag ANDROID_FACEBOOK_LOGIN_REMOVE

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/models/OptimizelyFeature.kt
+++ b/app/src/main/java/com/kickstarter/libs/models/OptimizelyFeature.kt
@@ -2,7 +2,6 @@ package com.kickstarter.libs.models
 
 class OptimizelyFeature {
     enum class Key(val key: String) {
-        ANDROID_FACEBOOK_LOGIN_REMOVE("android_facebook_login_remove"),
         ANDROID_CAPI_INTEGRATION("android_capi_integration"),
         ANDROID_GOOGLE_ANALYTICS("android_google_analytics"),
         ANDROID_PRE_LAUNCH_SCREEN("android_pre_launch_screen"),

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Pair
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.FragmentViewModel
 import com.kickstarter.libs.RefTag
+import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.loadmore.ApolloPaginate.Companion.builder
 import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.rx.transformers.Transformers
@@ -131,6 +132,7 @@ interface DiscoveryFragmentViewModel {
         private val cookieManager = requireNotNull(environment.cookieManager())
         private val currentUser = requireNotNull(environment.currentUser())
         private val lifecycleObservable = BehaviorSubject.create<FragmentEvent>()
+        private val featureFlagClient = environment.featureFlagClient()
 
         @JvmField
         val inputs: Inputs = this
@@ -343,8 +345,8 @@ interface DiscoveryFragmentViewModel {
             paramsFromActivity
                 .compose(Transformers.combineLatestPair(userIsLoggedIn))
                 .filter {
-                    it.second && optimizely?.isFeatureEnabled(
-                        OptimizelyFeature.Key.ANDROID_FACEBOOK_LOGIN_REMOVE
+                    it.second && featureFlagClient?.getBoolean(
+                        FlagKey.ANDROID_FACEBOOK_LOGIN_REMOVE
                     ) == true
                 }
                 .compose(Transformers.combineLatestPair(currentUser.loggedInUser()))

--- a/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.kt
@@ -12,7 +12,7 @@ import com.facebook.login.LoginResult
 import com.kickstarter.libs.ActivityRequestCodes
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
-import com.kickstarter.libs.models.OptimizelyFeature
+import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.EventContextValues.ContextPageName
 import com.kickstarter.libs.utils.EventContextValues.ContextTypeName
@@ -192,7 +192,7 @@ interface LoginToutViewModel {
 
         override fun showFacebookAuthorizationErrorDialog(): Observable<String> {
             return facebookAuthorizationError
-                .filter { environment.optimizely()?.isFeatureEnabled(OptimizelyFeature.Key.ANDROID_FACEBOOK_LOGIN_REMOVE) == false }
+                .filter { environment.featureFlagClient()?.getBoolean(FlagKey.ANDROID_FACEBOOK_LOGIN_REMOVE) == false }
                 .map { it.localizedMessage }
         }
 
@@ -308,7 +308,7 @@ interface LoginToutViewModel {
 
             facebookAuthorizationError
                 .filter {
-                    environment.optimizely()?.isFeatureEnabled(OptimizelyFeature.Key.ANDROID_FACEBOOK_LOGIN_REMOVE) == true
+                    environment.featureFlagClient()?.getBoolean(FlagKey.ANDROID_FACEBOOK_LOGIN_REMOVE) == true
                 }
                 .compose(bindToLifecycle())
                 .subscribe {

--- a/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
@@ -3,7 +3,6 @@ package com.kickstarter.viewmodels
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.featureflag.FlagKey
-import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.rx.transformers.Transformers.errors
 import com.kickstarter.libs.rx.transformers.Transformers.values

--- a/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ResetPasswordViewModel.kt
@@ -2,6 +2,7 @@ package com.kickstarter.viewmodels
 
 import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.rx.transformers.Transformers.errors
@@ -91,8 +92,8 @@ interface ResetPasswordViewModel {
 
             val resetFacebookPasswordFlag = intent()
                 .filter {
-                    it.hasExtra(IntentKey.RESET_PASSWORD_FACEBOOK_LOGIN) && environment.optimizely()?.isFeatureEnabled(
-                        OptimizelyFeature.Key.ANDROID_FACEBOOK_LOGIN_REMOVE
+                    it.hasExtra(IntentKey.RESET_PASSWORD_FACEBOOK_LOGIN) && environment.featureFlagClient()?.getBoolean(
+                        FlagKey.ANDROID_FACEBOOK_LOGIN_REMOVE
                     ) == true
                 }
                 .map {

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.kt
@@ -407,12 +407,12 @@ class DiscoveryFragmentViewModelTest : KSRobolectricTestCase() {
         currentUser.refresh(user)
         startSetPasswordActivity.assertValueCount(0)
 
-      val mockFeatureFlagClientType: MockFeatureFlagClient =
-              object : MockFeatureFlagClient() {
-                  override fun getBoolean(FlagKey: FlagKey): Boolean {
-                      return true
-                  }
-              }
+        val mockFeatureFlagClientType: MockFeatureFlagClient =
+            object : MockFeatureFlagClient() {
+                override fun getBoolean(FlagKey: FlagKey): Boolean {
+                    return true
+                }
+            }
 
         val mockApolloClient = object : MockApolloClient() {
             override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.kt
@@ -8,12 +8,14 @@ import com.kickstarter.libs.MockCurrentUser
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.RefTag.Companion.collection
 import com.kickstarter.libs.RefTag.Companion.discovery
+import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.preferences.MockIntPreference
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.ExperimentData
 import com.kickstarter.libs.utils.ListUtils
 import com.kickstarter.mock.MockExperimentsClientType
+import com.kickstarter.mock.MockFeatureFlagClient
 import com.kickstarter.mock.factories.ActivityEnvelopeFactory.activityEnvelope
 import com.kickstarter.mock.factories.ActivityFactory.activity
 import com.kickstarter.mock.factories.ActivityFactory.updateActivity
@@ -405,12 +407,12 @@ class DiscoveryFragmentViewModelTest : KSRobolectricTestCase() {
         currentUser.refresh(user)
         startSetPasswordActivity.assertValueCount(0)
 
-        val mockExperimentsClientType: MockExperimentsClientType =
-            object : MockExperimentsClientType() {
-                override fun isFeatureEnabled(feature: OptimizelyFeature.Key): Boolean {
-                    return true
-                }
-            }
+      val mockFeatureFlagClientType: MockFeatureFlagClient =
+              object : MockFeatureFlagClient() {
+                  override fun getBoolean(FlagKey: FlagKey): Boolean {
+                      return true
+                  }
+              }
 
         val mockApolloClient = object : MockApolloClient() {
             override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
@@ -433,7 +435,7 @@ class DiscoveryFragmentViewModelTest : KSRobolectricTestCase() {
 
         setUpEnvironment(
             environment().toBuilder().currentUser(currentUser)
-                .optimizely(mockExperimentsClientType)
+                .featureFlagClient(mockFeatureFlagClientType)
                 .apolloClient(mockApolloClient)
                 .build()
         )

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.kt
@@ -5,9 +5,11 @@ import com.facebook.FacebookAuthorizationException
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUser
+import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.mock.MockExperimentsClientType
+import com.kickstarter.mock.MockFeatureFlagClient
 import com.kickstarter.mock.factories.ApiExceptionFactory
 import com.kickstarter.mock.services.MockApiClient
 import com.kickstarter.models.User
@@ -93,9 +95,9 @@ class LoginToutViewModelTest : KSRobolectricTestCase() {
     @Test
     fun facebookLogin_error_reset_password_WithFeatureFlag_Enabled() {
         val currentUser = MockCurrentUser()
-        val mockExperimentsClientType: MockExperimentsClientType =
-            object : MockExperimentsClientType() {
-                override fun isFeatureEnabled(feature: OptimizelyFeature.Key): Boolean {
+        val mockFeatureFlagClientType: MockFeatureFlagClient =
+            object : MockFeatureFlagClient() {
+                override fun getBoolean(FlagKey: FlagKey): Boolean {
                     return true
                 }
             }
@@ -103,7 +105,7 @@ class LoginToutViewModelTest : KSRobolectricTestCase() {
         val environment = environment()
             .toBuilder()
             .currentUser(currentUser)
-            .optimizely(mockExperimentsClientType)
+            .featureFlagClient(mockFeatureFlagClientType)
             .build()
         setUpEnvironment(environment, LoginReason.DEFAULT)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ResetPasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ResetPasswordViewModelTest.kt
@@ -2,8 +2,10 @@ package com.kickstarter.viewmodels
 
 import android.content.Intent
 import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.models.OptimizelyFeature
 import com.kickstarter.mock.MockExperimentsClientType
+import com.kickstarter.mock.MockFeatureFlagClient
 import com.kickstarter.mock.factories.ApiExceptionFactory
 import com.kickstarter.mock.services.MockApiClient
 import com.kickstarter.models.User
@@ -87,15 +89,15 @@ class ResetPasswordViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testResetFacebookPasswordViewModel_resetSuccess() {
-        val mockExperimentsClientType: MockExperimentsClientType =
-            object : MockExperimentsClientType() {
-                override fun isFeatureEnabled(feature: OptimizelyFeature.Key): Boolean {
+        val mockFeatureFlagClientType: MockFeatureFlagClient =
+            object : MockFeatureFlagClient() {
+                override fun getBoolean(FlagKey: FlagKey): Boolean {
                     return true
                 }
             }
         val environment = environment()
             .toBuilder()
-            .optimizely(mockExperimentsClientType)
+            .featureFlagClient(mockFeatureFlagClientType)
             .build()
 
         val vm = ResetPasswordViewModel.ViewModel(environment)
@@ -197,16 +199,16 @@ class ResetPasswordViewModelTest : KSRobolectricTestCase() {
         val preFillEmail = TestSubscriber<String>()
         val resetPasswordScreenStatus = TestSubscriber<ResetPasswordScreenState>()
 
-        val mockExperimentsClientType: MockExperimentsClientType =
-            object : MockExperimentsClientType() {
-                override fun isFeatureEnabled(feature: OptimizelyFeature.Key): Boolean {
+        val mockFeatureFlagClientType: MockFeatureFlagClient =
+            object : MockFeatureFlagClient() {
+                override fun getBoolean(FlagKey: FlagKey): Boolean {
                     return true
                 }
             }
 
         val environment = environment()
             .toBuilder()
-            .optimizely(mockExperimentsClientType)
+            .featureFlagClient(mockFeatureFlagClientType)
             .build()
 
         val vm = ResetPasswordViewModel.ViewModel(environment)


### PR DESCRIPTION
# 📲 What

In the viewModel/viewModelTests level change the calls:

optimizely.isFeatureEnabled(OptimizelyFeature.Key.ANDROID_FACEBOOK_LOGIN_REMOVE)  

to 

featureFlagClient.getBoolean(FlagKey.ANDROID_FACEBOOK_LOGIN_REMOVE)

# 🤔 Why

This is one feature flag migration as part of overall migration from optimizely to firebase remote config [MBL-661](https://kickstarter.atlassian.net/browse/MBL-661)

# 👀 See

No visible changes.

# 📋 QA

In firebase console, change the value of ANDROID_FACEBOOK_LOGIN_REMOVE in the three build variants. Verify that the facebook login is shown or not shown in the login screen. 

# Story 📖

https://kickstarter.atlassian.net/browse/MBL-681



[MBL-661]: https://kickstarter.atlassian.net/browse/MBL-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ