### PR TITLE
MBL-691: Fix incorrect end time being displayed for project descriptions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,6 +127,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
@@ -312,6 +313,9 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:1.1.3"
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
+
+    // Desugaring Java 8 to < API 26
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 }
 
 // SHA and timestamp caching courtesy of https://github.com/gdg-x/frisbee/blob/develop/app/build.gradle#L193-L218

--- a/app/src/main/java/com/kickstarter/libs/utils/DateTimeUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/DateTimeUtils.kt
@@ -12,7 +12,12 @@ import org.joda.time.DateTimeZone
 import org.joda.time.Seconds
 import org.joda.time.format.DateTimeFormat
 import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.util.Locale
+import java.util.TimeZone
 import kotlin.math.abs
 import kotlin.math.floor
 
@@ -89,17 +94,30 @@ object DateTimeUtils {
     /**
      * e.g.: Jan 14, 2016 2:20 PM.
      */
-    @JvmOverloads
     fun mediumDateShortTime(
-        dateTime: DateTime,
-        dateTimeZone: DateTimeZone = DateTimeZone.getDefault(),
-        locale: Locale = Locale.getDefault()
+        dateTime: DateTime
     ): String {
-        val mediumShortStyle = DateTimeFormat.patternForStyle("MS", locale)
-        val formatter =
-            DateTimeFormat.forPattern(mediumShortStyle).withZone(dateTimeZone).withLocale(locale)
+        val localTime =
+            Instant.ofEpochMilli(dateTime.millis).atZone(ZoneId.systemDefault()).toLocalDateTime()
+        val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT)
 
-        return dateTime.toString(formatter)
+        return localTime.format(formatter)
+    }
+
+    /**
+     * e.g.: Jan 14, 2016 2:20 PM EST.
+     * Always uses phones timezone for the timezone string
+     */
+    fun mediumDateShortTimeWithTimeZone(
+        dateTime: DateTime
+    ): String {
+        val localTime =
+            Instant.ofEpochMilli(dateTime.millis).atZone(ZoneId.systemDefault()).toLocalDateTime()
+        val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT)
+        val dateTimeString = localTime.format(formatter)
+        val timezoneString = TimeZone.getDefault().getDisplayName(true, TimeZone.SHORT)
+
+        return "$dateTimeString $timezoneString"
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectOverviewFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectOverviewFragment.kt
@@ -459,7 +459,7 @@ class ProjectOverviewFragment : BaseFragment<ProjectOverviewViewModel.ViewModel>
             binding.projectCreatorInfoLayout.projectDisclaimerTextView.text = ksString.format(
                 currentContext.getString(R.string.project_disclaimer_goal_reached),
                 "deadline",
-                DateTimeUtils.mediumDateShortTime(deadline)
+                DateTimeUtils.mediumDateShortTimeWithTimeZone(deadline)
             )
         }
     }
@@ -471,7 +471,7 @@ class ProjectOverviewFragment : BaseFragment<ProjectOverviewViewModel.ViewModel>
                 "goal_currency",
                 goalAndDeadline.first,
                 "deadline",
-                DateTimeUtils.mediumDateShortTime(goalAndDeadline.second)
+                DateTimeUtils.mediumDateShortTimeWithTimeZone(goalAndDeadline.second)
             )
         }
     }

--- a/app/src/test/java/com/kickstarter/libs/utils/DateTimeUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/DateTimeUtilsTest.kt
@@ -131,7 +131,7 @@ class DateTimeUtilsTest : KSRobolectricTestCase() {
             )
         )
         assertEquals(
-            "17 déc. 2015, 18:35:05",
+            "17 déc. 2015 à 18:35:05",
             DateTimeUtils.mediumDateTime(
                 DateTime.parse("2015-12-17T18:35:05Z"),
                 DateTimeZone.UTC,


### PR DESCRIPTION
…o page to display correct time and the phones timezone

# 📲 What

- Add desugaring to allow access to java 8 libraries (normally only available natively with API 26+ (current app minimum is 23)
- Fix issue where end time/deadline for project description was not in the users current time zone (was always UTC)
- Added timezone abbreviation to time for further clarrification

# 🤔 Why

Users could not tell when a project would actually be finished relative to their local time

# 🛠 How

Added desugaring and used the newer standard java.time libraries.  Joda time has been out of date as of Java 8SE libraries:
https://www.joda.org/joda-time/#:~:text=Note%20that%20from%20Java%20SE%208%20onwards%2C%20users%20are%20asked%20to%20migrate%20to%20java.time%20(JSR%2D310)%20%2D%20a%20core%20part%20of%20the%20JDK%20which%20replaces%20this%20project.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
|![before_timezone](https://github.com/kickstarter/android-oss/assets/7563288/c880ba00-1b4b-4e0b-bbd9-655ee838dbb6)|![timezone_pdt_example](https://github.com/kickstarter/android-oss/assets/7563288/78154c37-0c56-4ec3-b1cb-07882b13b056)|

Extra example, in France this time:
![timezone_french_example](https://github.com/kickstarter/android-oss/assets/7563288/8bca6adc-46e5-49f2-b963-5947125c209a)


# 📋 QA

View a project from your local time, view the same project while spoofing your location to make sure the time change is accurate and the correct time zone is shown

# Story 📖
[MBL-691](https://kickstarter.atlassian.net/browse/MBL-691)

[MBL-691]: https://kickstarter.atlassian.net/browse/MBL-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ