### PR TITLE
MBL-727: Create splash screen and launch from Discovery Activity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -215,6 +215,7 @@ dependencies {
     implementation "androidx.fragment:fragment-ktx:$activity_fragment_version"
 
     implementation 'com.android.support.constraint:constraint-layout:2.0.4'
+    implementation("androidx.core:core-splashscreen:1.0.1")
     implementation 'com.apollographql.apollo:apollo-runtime:2.5.12'
     implementation 'com.facebook.android:facebook-android-sdk:14.1.1'
     implementation 'com.google.android.play:core-ktx:1.8.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,7 +73,7 @@
             android:label="@string/app_name"
             android:exported="true"
             android:launchMode="singleTop"
-            android:theme="@style/DiscoveryActivity">
+            android:theme="@style/SplashTheme">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
@@ -5,8 +5,6 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.drawable.Animatable
 import android.os.Bundle
-import android.view.View
-import android.view.ViewTreeObserver
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -42,8 +40,6 @@ import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
 import java.util.concurrent.TimeUnit
 import kotlin.collections.ArrayList
-import kotlinx.coroutines.delay
-import rx.Observable
 
 @RequiresActivityViewModel(DiscoveryViewModel.ViewModel::class)
 class DiscoveryActivity : BaseActivity<DiscoveryViewModel.ViewModel>() {

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
@@ -5,8 +5,11 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.drawable.Animatable
 import android.os.Bundle
+import android.view.View
+import android.view.ViewTreeObserver
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -39,6 +42,8 @@ import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
 import java.util.concurrent.TimeUnit
 import kotlin.collections.ArrayList
+import kotlinx.coroutines.delay
+import rx.Observable
 
 @RequiresActivityViewModel(DiscoveryViewModel.ViewModel::class)
 class DiscoveryActivity : BaseActivity<DiscoveryViewModel.ViewModel>() {
@@ -50,6 +55,8 @@ class DiscoveryActivity : BaseActivity<DiscoveryViewModel.ViewModel>() {
     private lateinit var binding: DiscoveryLayoutBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
+
         super.onCreate(savedInstanceState)
         binding = DiscoveryLayoutBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/res/drawable/ksr_logo_rgb_white.xml
+++ b/app/src/main/res/drawable/ksr_logo_rgb_white.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="612dp"
+    android:height="612dp"
+    android:viewportWidth="612"
+    android:viewportHeight="612">
+  <path
+      android:pathData="M366.35,306l19.5,-19.5c20.24,-20.24 20.24,-53.07 0,-73.31c-20.24,-20.24 -53.07,-20.24 -73.31,0l-7.14,7.14C296.05,206.84 280.46,198 262.8,198c-28.63,0 -51.84,23.21 -51.84,51.84v112.32c0,28.63 23.21,51.84 51.84,51.84c17.66,0 33.25,-8.84 42.61,-22.32l7.14,7.14c20.24,20.24 53.07,20.24 73.31,0c20.24,-20.24 20.24,-53.07 0,-73.31L366.35,306z"
+      android:fillColor="#FFFFFF"/>
+</vector>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -39,6 +39,13 @@
   <!-- Activities -->
   <style name="ActivityFeedActivity" parent="KSTheme" />
 
+  <style name="SplashTheme" parent="Theme.SplashScreen">
+    <item name="windowSplashScreenBackground">@color/kds_create_500</item>
+    <item name="windowSplashScreenIconBackgroundColor">@color/kds_create_500</item>
+    <item name="windowSplashScreenAnimatedIcon">@drawable/ksr_logo_rgb_white</item>
+    <item name="postSplashScreenTheme">@style/DiscoveryActivity</item>
+  </style>
+
   <style name="WhiteActivity" parent="KSTheme">
     <item name="android:windowBackground">@color/kds_white</item>
     <item name="android:windowContentTransitions">true</item>


### PR DESCRIPTION
# 📲 What

Added the android splash screen api to our app. 

# 🛠 How

Add the api, create the theme/style, add the manifest and call from onCreate before `super.onCreate(savedInstanceState)`
Splash screen is automatically dismissed once the first view element in discovery activity is drawn

# 👀 See

![238782188-4b938c34-06bc-47c4-90cf-3e9be0cf628e](https://github.com/kickstarter/android-oss/assets/19390326/b49e419c-6faf-488c-8b14-faab3de1577b)

# 📋 QA

Make sure splash screen loads on devices both below and above api 33

# Story 📖

[MBL-727: Create splash screen and launch from Discovery Activity](https://kickstarter.atlassian.net/browse/MBL-727)
