### PR TITLE
MBL-700 : Fix bonus amount not being able to go past 3 digits

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/NumberUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/NumberUtils.java
@@ -109,6 +109,9 @@ public final class NumberUtils {
     return value == Math.round(value);
   }
 
+  /**
+   * @deprecated Use com.kickstarter.libs.utils.extensions.StringExt#parseToDouble(java.lang.String)
+   */
   @Deprecated
   public static double parse(final @NonNull String input) {
     return parse(input, Locale.getDefault());

--- a/app/src/main/java/com/kickstarter/libs/utils/NumberUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/NumberUtils.java
@@ -109,6 +109,7 @@ public final class NumberUtils {
     return value == Math.round(value);
   }
 
+  @Deprecated
   public static double parse(final @NonNull String input) {
     return parse(input, Locale.getDefault());
   }

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/StringExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/StringExt.kt
@@ -7,9 +7,11 @@ import android.text.Html
 import android.text.Spanned
 import android.text.TextUtils
 import android.util.Patterns
+import com.braze.support.emptyToNull
 import com.kickstarter.R
 import org.jsoup.Jsoup
 import java.security.MessageDigest
+import java.text.NumberFormat
 import java.util.Locale
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -80,29 +82,19 @@ fun String.parseHtmlTag(): String {
 }
 
 /**
- * Takes an optional String and returns a Double
- * NOTE: NumberUtils.parse(String, Locale)
- * - Depending on the Locale the decimal separator 0.99 or 0,99
- * - Depending on the Locale the Character used for thousand separator can change 9.999 or 9,999
- *
- * We've compiled several Regex to account for use cases as not all the languages are listed as Default Locale
- * as example Spanish or Polish, take a look at
- * @see <a href="https://github.com/frohoff/jdk8u-jdk/blob/da0da73ab82ed714dc5be94acd2f0d00fbdfe2e9/src/share/classes/java/util/Locale.java#L484">Locale.java</a>
- *
- * The Strings will be modified to use "." as a decimal separator, and "" as the thousand separator
- *
- * - In case something wrong, it will return 0.0
+ * Returns a double for the given string taking into account the locale of the device or 0.0
+ * if the string is null or is invalid
  */
 fun String?.parseToDouble(): Double {
-    val numToParse = this?.let { numToParse ->
-        return@let when {
-            "[0-9]+,[0-9]+".toRegex().matches(numToParse) -> numToParse.replace(",", ".")
-            "[0-9]+.[0-9]{3}".toRegex().matches(numToParse) -> numToParse.replace(".", "")
-            "[0-9]+.[0-9]{3},[0-9]+".toRegex().matches(numToParse) -> numToParse.replace(".", "").replace(",", ".")
-            else -> numToParse
-        }
+    val format = NumberFormat.getInstance()
+    try {
+        this?.emptyToNull()?.let {
+            val number = format.parse(it)
+            return number?.toDouble() ?: 0.0
+        } ?: return 0.0
+    } catch (t: Throwable) {
+        return 0.0
     }
-    return numToParse?.toDoubleOrNull() ?: 0.0
 }
 
 /**

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -9,7 +9,6 @@ import com.kickstarter.R
 import com.kickstarter.libs.Config
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.FragmentViewModel
-import com.kickstarter.libs.NumberOptions
 import com.kickstarter.libs.models.Country
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
 import com.kickstarter.libs.rx.transformers.Transformers.errors
@@ -56,6 +55,7 @@ import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
 import type.CreditCardPaymentType
 import java.math.RoundingMode
+import java.text.NumberFormat
 import kotlin.math.max
 
 interface PledgeFragmentViewModel {
@@ -776,7 +776,7 @@ interface PledgeFragmentViewModel {
                 .subscribe(this.decreasePledgeButtonIsEnabled)
 
             pledgeInput
-                .map { NumberUtils.format(it.toFloat(), NumberOptions.builder().precision(NumberUtils.precision(it, RoundingMode.HALF_UP)).build()) }
+                .map { NumberFormat.getNumberInstance().format(it) }
                 .compose(bindToLifecycle())
                 .subscribe(this.pledgeAmount)
 
@@ -816,7 +816,7 @@ interface PledgeFragmentViewModel {
                 .subscribe(this.decreaseBonusButtonIsEnabled)
 
             bonusInput
-                .map { NumberUtils.format(it.toFloat(), NumberOptions.builder().precision(NumberUtils.precision(it, RoundingMode.HALF_UP)).build()) }
+                .map { NumberFormat.getNumberInstance().format(it) }
                 .distinctUntilChanged()
                 .compose(bindToLifecycle())
                 .subscribe(this.bonusAmount)
@@ -906,11 +906,11 @@ interface PledgeFragmentViewModel {
             val totalNR = this.selectedReward
                 .filter { RewardUtils.isNoReward(it) }
                 .compose<Pair<Reward, String>>(combineLatestPair(this.pledgeInput.startWith("")))
-                .map { if (it.second.isNotEmpty()) NumberUtils.parse(it.second) else it.first.minimum() }
+                .map { if (it.second.isNotEmpty()) it.second.parseToDouble() else it.first.minimum() }
 
             // - Calculate total for DigitalRewards || DigitalReward + DigitalAddOns || LocalPickup
             val totalNoShipping = Observable.combineLatest(isDigitalRw, pledgeAmountHeader, this.bonusAmount, pledgeReason) { _, pledgeAmount, bonusAmount, pReason ->
-                return@combineLatest getAmountDigital(pledgeAmount, NumberUtils.parse(bonusAmount), pReason)
+                return@combineLatest getAmountDigital(pledgeAmount, bonusAmount.parseToDouble(), pReason)
             }
                 .distinctUntilChanged()
 
@@ -1373,7 +1373,7 @@ interface PledgeFragmentViewModel {
             )
                 .compose<Pair<Any, PledgeReason>>(combineLatestPair(pledgeReason))
 
-            Observable.combineLatest<Double, Double, String, Checkout, CheckoutData>(shippingAmountSelectedRw, total, this.bonusAmount, Observable.merge(successfulCheckout, successfulSCACheckout)) { s, t, b, c -> checkoutData(s, t, NumberUtils.parse(b), c) }
+            Observable.combineLatest<Double, Double, String, Checkout, CheckoutData>(shippingAmountSelectedRw, total, this.bonusAmount, Observable.merge(successfulCheckout, successfulSCACheckout)) { s, t, b, c -> checkoutData(s, t, b.parseToDouble(), c) }
                 .compose<Pair<CheckoutData, PledgeData>>(combineLatestPair(pledgeData))
                 .filter { it.second.pledgeFlowContext() == PledgeFlowContext.NEW_PLEDGE }
                 .compose(bindToLifecycle())
@@ -1718,7 +1718,7 @@ interface PledgeFragmentViewModel {
             return joinedList.toList()
         }
 
-        private fun getAmount(pAmount: Double, shippingAmount: Double, bAmount: String, pReason: PledgeReason) = pAmount + shippingAmount + NumberUtils.parse(bAmount)
+        private fun getAmount(pAmount: Double, shippingAmount: Double, bAmount: String, pReason: PledgeReason) = pAmount + shippingAmount + bAmount.parseToDouble()
 
         private fun checkoutData(shippingAmount: Double, total: Double, bonusAmount: Double?, checkout: Checkout?): CheckoutData {
             return CheckoutData.builder()

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -776,7 +776,11 @@ interface PledgeFragmentViewModel {
                 .subscribe(this.decreasePledgeButtonIsEnabled)
 
             pledgeInput
-                .map { NumberFormat.getNumberInstance().format(it) }
+                .map {
+                    val formatter = NumberFormat.getNumberInstance()
+                    formatter.maximumFractionDigits = 2
+                    formatter.format(it)
+                }
                 .compose(bindToLifecycle())
                 .subscribe(this.pledgeAmount)
 
@@ -816,7 +820,11 @@ interface PledgeFragmentViewModel {
                 .subscribe(this.decreaseBonusButtonIsEnabled)
 
             bonusInput
-                .map { NumberFormat.getNumberInstance().format(it) }
+                .map {
+                    val formatter = NumberFormat.getNumberInstance()
+                    formatter.maximumFractionDigits = 2
+                    formatter.format(it)
+                }
                 .distinctUntilChanged()
                 .compose(bindToLifecycle())
                 .subscribe(this.bonusAmount)

--- a/app/src/main/res/layout/fragment_pledge_section_bonus_support.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_bonus_support.xml
@@ -129,6 +129,7 @@
             android:imeOptions="actionDone"
             android:importantForAutofill="no"
             android:inputType="numberDecimal"
+            android:digits="0123456789.,"
             android:maxLength="@integer/max_length"
             tools:ignore="LabelFor"
             tools:targetApi="o"

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/StringExtKtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/StringExtKtTest.kt
@@ -4,6 +4,7 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import org.junit.Test
 import org.robolectric.RuntimeEnvironment
+import java.util.Locale
 
 class StringExtKtTest : KSRobolectricTestCase() {
 
@@ -151,10 +152,13 @@ class StringExtKtTest : KSRobolectricTestCase() {
         assertEquals(0.0, "".parseToDouble())
         assertEquals(1.0, "1".parseToDouble())
         assertEquals(10.0, "10.0".parseToDouble())
-        assertEquals(1.5, "1,5".parseToDouble())
         assertEquals(100.0, "100".parseToDouble())
-        assertEquals(100.5, "100,50".parseToDouble())
         assertEquals(1000.0, "1000.0".parseToDouble())
+
+        // Change locale to use different formatting, make sure it still recognizes numbers
+        Locale.setDefault(Locale.GERMAN)
+        assertEquals(1.5, "1,5".parseToDouble())
+        assertEquals(100.5, "100,50".parseToDouble())
         assertEquals(1000.0, "1.000".parseToDouble())
         assertEquals(1000.5, "1.000,50".parseToDouble())
         assertEquals(10000.0, "10.000".parseToDouble())


### PR DESCRIPTION
# 📲 What

Fixes an issue where the bonus amount on pledge pages could not pass 3 digits.  This makes it so it will allow any normal formatting from the locale of the device

# 🤔 Why

You could not pledge up to the limit before

# 🛠 How

Removed the use of deprecated calls and updated formatting/parsing to use standard libraries

# 👀 See

| Before (ANY) 🐛 | After USA 🦋 | After Germany | After France |
| --- | --- | --- | --- |
| https://github.com/kickstarter/android-oss/assets/7563288/fc5202f0-b8b4-405a-a058-84c60e4c81f8 | https://github.com/kickstarter/android-oss/assets/7563288/58d4c723-a121-4adb-9c8c-72de97c8a373 | https://github.com/kickstarter/android-oss/assets/7563288/a9d30296-8715-4153-8767-c07c9da19bf7 | https://github.com/kickstarter/android-oss/assets/7563288/889428a4-bf1f-4a5f-8b44-1f8cb130fa72 |


# 📋 QA

1. Set your location to wherever you want
2. Go through the pledge of a campaign and either 
- don't select an award and pledge
- select an award and proceed to the checkout page
3) Start entering amounts in bonus/pledge

You should see the number being formatted as you enter it and it should allow you to add decimals (though like web it does not limit it to 2 digits)

# Story 📖

[MBL-700](https://kickstarter.atlassian.net/browse/MBL-700)


[MBL-700]: https://kickstarter.atlassian.net/browse/MBL-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ