### PR TITLE
[MBL-748] Update ChangePassword Activity, Viewmodel, and tests to RX2

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/rx/transformers/ObserveForUITransformerV2.kt
+++ b/app/src/main/java/com/kickstarter/libs/rx/transformers/ObserveForUITransformerV2.kt
@@ -1,0 +1,20 @@
+package com.kickstarter.libs.rx.transformers
+
+import com.kickstarter.libs.utils.ThreadUtils
+import io.reactivex.Observable
+import io.reactivex.ObservableSource
+import io.reactivex.ObservableTransformer
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+
+class ObserveForUITransformerV2<T>: ObservableTransformer<T, T> {
+    override fun apply(upstream: Observable<T>): ObservableSource<T> {
+        return upstream.flatMap {  value ->
+            if (ThreadUtils.isMainThread()) {
+                Observable.just(value).observeOn(Schedulers.trampoline())
+            } else {
+                Observable.just(value).observeOn(AndroidSchedulers.mainThread())
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/libs/rx/transformers/ObserveForUITransformerV2.kt
+++ b/app/src/main/java/com/kickstarter/libs/rx/transformers/ObserveForUITransformerV2.kt
@@ -7,9 +7,9 @@ import io.reactivex.ObservableTransformer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 
-class ObserveForUITransformerV2<T>: ObservableTransformer<T, T> {
+class ObserveForUITransformerV2<T> : ObservableTransformer<T, T> {
     override fun apply(upstream: Observable<T>): ObservableSource<T> {
-        return upstream.flatMap {  value ->
+        return upstream.flatMap { value ->
             if (ThreadUtils.isMainThread()) {
                 Observable.just(value).observeOn(Schedulers.trampoline())
             } else {

--- a/app/src/main/java/com/kickstarter/libs/rx/transformers/Transformers.java
+++ b/app/src/main/java/com/kickstarter/libs/rx/transformers/Transformers.java
@@ -211,4 +211,8 @@ public final class Transformers {
   public static @NonNull <T> ObserveForUITransformer<T> observeForUI() {
     return new ObserveForUITransformer<>();
   }
+
+  public static @NonNull <T> ObserveForUITransformerV2<T> observeForUIV2() {
+    return new ObserveForUITransformerV2<>();
+  }
 }

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -59,6 +59,19 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
         return io.reactivex.Observable.just(project.toBuilder().isStarred(false).build())
     }
 
+    override fun updateUserPassword(
+        currentPassword: String,
+        newPassword: String,
+        confirmPassword: String
+    ): io.reactivex.Observable<UpdateUserPasswordMutation.Data> {
+        return io.reactivex.Observable.just(UpdateUserPasswordMutation.Data(
+            UpdateUserPasswordMutation.UpdateUserAccount(
+                "",
+                UpdateUserPasswordMutation.User("", "some@email.com", true, true)
+            )
+        ))
+    }
+
     override fun getProject(project: Project): io.reactivex.Observable<Project> {
         return io.reactivex.Observable.just(ProjectFactory.backedProject())
     }

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -64,12 +64,14 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
         newPassword: String,
         confirmPassword: String
     ): io.reactivex.Observable<UpdateUserPasswordMutation.Data> {
-        return io.reactivex.Observable.just(UpdateUserPasswordMutation.Data(
-            UpdateUserPasswordMutation.UpdateUserAccount(
-                "",
-                UpdateUserPasswordMutation.User("", "some@email.com", true, true)
+        return io.reactivex.Observable.just(
+            UpdateUserPasswordMutation.Data(
+                UpdateUserPasswordMutation.UpdateUserAccount(
+                    "",
+                    UpdateUserPasswordMutation.User("", "some@email.com", true, true)
+                )
             )
-        ))
+        )
     }
 
     override fun getProject(project: Project): io.reactivex.Observable<Project> {

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -25,6 +25,7 @@ interface ApolloClientTypeV2 {
     fun userPrivacy(): Observable<UserPrivacyQuery.Data>
     fun watchProject(project: Project): Observable<Project>
     fun unWatchProject(project: Project): Observable<Project>
+    fun updateUserPassword(currentPassword: String = "", newPassword: String, confirmPassword: String): Observable<UpdateUserPasswordMutation.Data>
 }
 
 class KSApolloClientV2(val service: ApolloClient) : ApolloClientTypeV2 {
@@ -297,6 +298,40 @@ class KSApolloClientV2(val service: ApolloClient) : ApolloClientTypeV2 {
                                 response.data?.watchProject()?.project()?.fragments()?.fullProject()
                             )
                         )
+                        ps.onComplete()
+                    }
+                })
+            return@defer ps
+        }
+    }
+
+    override fun updateUserPassword(
+        currentPassword: String,
+        newPassword: String,
+        confirmPassword: String
+    ): Observable<UpdateUserPasswordMutation.Data> {
+        return Observable.defer {
+            val ps = PublishSubject.create<UpdateUserPasswordMutation.Data>()
+            service.mutate(
+                UpdateUserPasswordMutation.builder()
+                    .currentPassword(currentPassword)
+                    .password(newPassword)
+                    .passwordConfirmation(confirmPassword)
+                    .build()
+            )
+                .enqueue(object : ApolloCall.Callback<UpdateUserPasswordMutation.Data>() {
+                    override fun onFailure(exception: ApolloException) {
+                        ps.onError(exception)
+                    }
+
+                    override fun onResponse(response: Response<UpdateUserPasswordMutation.Data>) {
+                        if (response.hasErrors()) {
+                            ps.onError(Exception(response.errors?.first()?.message))
+                        }
+                        response.data?.let {
+                            ps.onNext(it)
+                        }
+
                         ps.onComplete()
                     }
                 })

--- a/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
@@ -173,7 +173,7 @@ interface ChangePasswordViewModel {
         }
     }
 
-    class Factory(private val environment: Environment): ViewModelProvider.Factory {
+    class Factory(private val environment: Environment) : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             return ChangePasswordViewModel(environment) as T
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
@@ -1,18 +1,19 @@
 package com.kickstarter.viewmodels
 
 import UpdateUserPasswordMutation
-import androidx.annotation.NonNull
-import com.kickstarter.libs.ActivityViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import com.kickstarter.libs.Environment
-import com.kickstarter.libs.rx.transformers.Transformers.errors
-import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
-import com.kickstarter.libs.rx.transformers.Transformers.values
+import com.kickstarter.libs.rx.transformers.Transformers.errorsV2
+import com.kickstarter.libs.rx.transformers.Transformers.takeWhenV2
+import com.kickstarter.libs.rx.transformers.Transformers.valuesV2
+import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.isNotEmptyAndAtLeast6Chars
 import com.kickstarter.libs.utils.extensions.newPasswordValidationWarnings
-import com.kickstarter.ui.activities.ChangePasswordActivity
-import rx.Observable
-import rx.subjects.BehaviorSubject
-import rx.subjects.PublishSubject
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subjects.PublishSubject
 
 interface ChangePasswordViewModel {
 
@@ -47,9 +48,9 @@ interface ChangePasswordViewModel {
         fun success(): Observable<String>
     }
 
-    class ViewModel(@NonNull val environment: Environment) : ActivityViewModel<ChangePasswordActivity>(environment), Inputs, Outputs {
+    class ChangePasswordViewModel(val environment: Environment) : ViewModel(), Inputs, Outputs {
 
-        private val changePasswordClicked = PublishSubject.create<Void>()
+        private val changePasswordClicked = PublishSubject.create<Unit>()
         private val confirmPassword = PublishSubject.create<String>()
         private val currentPassword = PublishSubject.create<String>()
         private val newPassword = PublishSubject.create<String>()
@@ -60,60 +61,66 @@ interface ChangePasswordViewModel {
         private val saveButtonIsEnabled = BehaviorSubject.create<Boolean>()
         private val success = BehaviorSubject.create<String>()
 
-        val inputs: ChangePasswordViewModel.Inputs = this
-        val outputs: ChangePasswordViewModel.Outputs = this
+        val inputs: Inputs = this
+        val outputs: Outputs = this
 
-        private val apolloClient = requireNotNull(this.environment.apolloClient())
+        private val apolloClient = requireNotNull(this.environment.apolloClientV2())
         private val analytics = this.environment.analytics()
+
+        private val disposables = CompositeDisposable()
 
         init {
 
             val changePassword = Observable.combineLatest(
                 this.currentPassword.startWith(""),
                 this.newPassword.startWith(""),
-                this.confirmPassword.startWith(""),
-                { current, new, confirm -> ChangePassword(current, new, confirm) }
-            )
+                this.confirmPassword.startWith("")
+            ) { current, new, confirm -> ChangePassword(current, new, confirm) }
 
             changePassword
                 .map { it.warning() }
                 .distinctUntilChanged()
-                .compose(bindToLifecycle())
                 .subscribe(this.passwordWarning)
 
             changePassword
                 .map { it.isValid() }
                 .distinctUntilChanged()
-                .compose(bindToLifecycle())
                 .subscribe(this.saveButtonIsEnabled)
 
             val changePasswordNotification = changePassword
-                .compose(takeWhen<ChangePassword, Void>(this.changePasswordClicked))
+                .compose(takeWhenV2(this.changePasswordClicked))
                 .switchMap { cp -> submit(cp).materialize() }
-                .compose(bindToLifecycle())
                 .share()
 
             changePasswordNotification
-                .compose(errors())
-                .subscribe({ this.error.onNext(it.localizedMessage) })
+                .compose(errorsV2())
+                .subscribe { error ->
+                    error?.localizedMessage?.let { message ->
+                        this.error.onNext(message)
+                    }
+                }
+                .addToDisposable(disposables)
 
             changePasswordNotification
-                .compose(values())
+                .compose(valuesV2())
                 .map { it.updateUserAccount()?.user()?.email() }
-                .subscribe {
+                .subscribe { email ->
                     this.analytics?.reset()
-                    this.success.onNext(it)
+                    email?.let {
+                        this.success.onNext(it)
+                    }
                 }
+                .addToDisposable(disposables)
         }
 
-        private fun submit(changePassword: ChangePasswordViewModel.ViewModel.ChangePassword): Observable<UpdateUserPasswordMutation.Data> {
+        private fun submit(changePassword: ChangePassword): Observable<UpdateUserPasswordMutation.Data> {
             return this.apolloClient.updateUserPassword(changePassword.currentPassword, changePassword.newPassword, changePassword.confirmPassword)
                 .doOnSubscribe { this.progressBarIsVisible.onNext(true) }
                 .doAfterTerminate { this.progressBarIsVisible.onNext(false) }
         }
 
         override fun changePasswordClicked() {
-            this.changePasswordClicked.onNext(null)
+            this.changePasswordClicked.onNext(Unit)
         }
 
         override fun confirmPassword(confirmPassword: String) {
@@ -156,8 +163,19 @@ interface ChangePasswordViewModel {
                     this.confirmPassword == this.newPassword
             }
 
-            fun warning(): Int? =
-                newPassword.newPasswordValidationWarnings(confirmPassword)
+            fun warning(): Int =
+                newPassword.newPasswordValidationWarnings(confirmPassword) ?: 0
+        }
+
+        override fun onCleared() {
+            disposables.clear()
+            super.onCleared()
+        }
+    }
+
+    class Factory(private val environment: Environment): ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return ChangePasswordViewModel(environment) as T
         }
     }
 }


### PR DESCRIPTION
# 📲 What

Remove older library (rx1) and replace with newer version for the change password screen, viewmodel and tests

# 🤔 Why

Rx1 is out of date so we are updating most classes to rx2

# 🛠 How

See code, mostly updating libraries and updating calls as needed

# 👀 See

No Visual changes

# 📋 QA

Go to the change password screen under account in the app and attempt to change your password, including attempts with invalid passwords (under character minimum of 6)

# Story 📖

[MBL-748](https://kickstarter.atlassian.net/browse/MBL-748)


[MBL-748]: https://kickstarter.atlassian.net/browse/MBL-748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ