### PR TITLE
Migrate TwoFactorViewModel.kt to Jetpack ViewModel and RxJava2.2

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/TwoFactorActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/TwoFactorActivity.kt
@@ -63,6 +63,11 @@ class TwoFactorActivity : AppCompatActivity() {
         }
     }
 
+    override fun onDestroy() {
+        disposables.clear()
+        super.onDestroy()
+    }g
+
     private fun errorMessages(): Observable<String> {
         return viewModel.outputs.tfaCodeMismatchError().map { getString(R.string.two_factor_error_message) }
             .mergeWith(viewModel.outputs.genericTfaError().map { getString(R.string.login_errors_unable_to_log_in) })

--- a/app/src/main/java/com/kickstarter/ui/activities/TwoFactorActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/TwoFactorActivity.kt
@@ -1,46 +1,54 @@
 package com.kickstarter.ui.activities
 
 import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.doOnTextChanged
 import com.kickstarter.R
 import com.kickstarter.databinding.TwoFactorLayoutBinding
-import com.kickstarter.libs.BaseActivity
-import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
-import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
+import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.viewmodels.TwoFactorViewModel
-import rx.Observable
-import rx.android.schedulers.AndroidSchedulers
+import io.reactivex.Observable
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
 
-@RequiresActivityViewModel(TwoFactorViewModel.ViewModel::class)
-class TwoFactorActivity : BaseActivity<TwoFactorViewModel.ViewModel>() {
+class TwoFactorActivity : AppCompatActivity() {
     private lateinit var binding: TwoFactorLayoutBinding
+    private lateinit var viewModelFactory: TwoFactorViewModel.Factory
+    private val viewModel: TwoFactorViewModel.TwoFactorViewModel by viewModels { viewModelFactory }
+    private val disposables = CompositeDisposable()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        this.getEnvironment()?.let { env ->
+            viewModelFactory = TwoFactorViewModel.Factory(env)
+        }
         binding = TwoFactorLayoutBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         binding.loginToolbar.loginToolbar.setTitle(getString(R.string.two_factor_title))
 
         viewModel.outputs.tfaSuccess()
-            .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { onSuccess() }
+            .addToDisposable(disposables)
 
         viewModel.outputs.formSubmitting()
-            .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { setFormDisabled(it) }
+            .addToDisposable(disposables)
 
         viewModel.outputs.formIsValid()
-            .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { setFormEnabled(it) }
+            .addToDisposable(disposables)
 
         errorMessages()
-            .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { ViewUtils.showDialog(this, getString(R.string.login_errors_title), it) }
+            .addToDisposable(disposables)
 
         binding.twoFactorFormView.code.doOnTextChanged { text, _, _, _ ->
             text?.let { codeEditTextOnTextChanged(it) }
@@ -82,6 +90,4 @@ class TwoFactorActivity : BaseActivity<TwoFactorViewModel.ViewModel>() {
     }
 
     private fun setFormDisabled(disabled: Boolean) = setFormEnabled(!disabled)
-
-    override fun exitTransition() = TransitionUtils.slideInFromLeft()
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/TwoFactorActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/TwoFactorActivity.kt
@@ -23,7 +23,7 @@ class TwoFactorActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         this.getEnvironment()?.let { env ->
-            viewModelFactory = TwoFactorViewModel.Factory(env)
+            viewModelFactory = TwoFactorViewModel.Factory(env, intent)
         }
         binding = TwoFactorLayoutBinding.inflate(layoutInflater)
         setContentView(binding.root)
@@ -66,7 +66,7 @@ class TwoFactorActivity : AppCompatActivity() {
     override fun onDestroy() {
         disposables.clear()
         super.onDestroy()
-    }g
+    }
 
     private fun errorMessages(): Observable<String> {
         return viewModel.outputs.tfaCodeMismatchError().map { getString(R.string.two_factor_error_message) }

--- a/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.kt
@@ -262,6 +262,11 @@ interface TwoFactorViewModel {
 
             analytics.trackTwoFactorAuthPageViewed()
         }
+
+        override fun onCleared() {
+            disposables.clear()
+            super.onCleared()
+        }
     }
 
     class Factory(private val environment: Environment) : ViewModelProvider.Factory {

--- a/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.kt
@@ -269,9 +269,9 @@ interface TwoFactorViewModel {
         }
     }
 
-    class Factory(private val environment: Environment) : ViewModelProvider.Factory {
+    class Factory(private val environment: Environment, private val intent: Intent? = null) : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return TwoFactorViewModel(environment) as T
+            return TwoFactorViewModel(environment, intent) as T
         }
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.kt
@@ -171,7 +171,7 @@ interface TwoFactorViewModel {
                 .filter { ObjectUtils.isNotNull(it) }
 
             val fbAccessToken = internalIntent
-                .map { it.getStringExtra(IntentKey.FACEBOOK_TOKEN) }
+                .map { it.getStringExtra(IntentKey.FACEBOOK_TOKEN) ?: "" }
 
             val isFacebookLogin = internalIntent
                 .map { it.getBooleanExtra(IntentKey.FACEBOOK_LOGIN, false) }

--- a/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.kt
@@ -207,7 +207,6 @@ interface TwoFactorViewModel {
                 .subscribe { formIsValid.onNext(it) }
                 .addToDisposable(disposables)
 
-
             this.code
                 .compose(Transformers.combineLatestPair(tfaData))
                 .compose(Transformers.takeWhenV2(loginClick))

--- a/app/src/test/java/com/kickstarter/viewmodels/SignupViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/SignupViewModelTest.kt
@@ -105,7 +105,7 @@ class SignupViewModelTest : KSRobolectricTestCase() {
 
         formSubmittingTest.assertValues(true, false)
         signupSuccessTest.assertValueCount(1)
-        environment().currentUserV2()?.observable()?.subscribe {
+        environment.currentUserV2()?.observable()?.subscribe {
             assertEquals("hello@kickstarter.com", it.getValue()?.email())
         }?.addToDisposable(disposables)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/TwoFactorViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/TwoFactorViewModelTest.kt
@@ -206,7 +206,7 @@ class TwoFactorViewModelTest : KSRobolectricTestCase() {
         vm = TwoFactorViewModel.TwoFactorViewModel(environment(), intent)
 
         vm.outputs.showResendCodeConfirmation()
-            .subscribe { showResendCodeConfirmation .onNext(it) }
+            .subscribe { showResendCodeConfirmation.onNext(it) }
             .addToDisposable(disposables)
 
         vm.inputs.resendClick()

--- a/app/src/test/java/com/kickstarter/viewmodels/TwoFactorViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/TwoFactorViewModelTest.kt
@@ -1,21 +1,24 @@
 package com.kickstarter.viewmodels
 
+import UserPrivacyQuery
 import android.content.Intent
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.mock.factories.ApiExceptionFactory
-import com.kickstarter.mock.services.MockApiClient
+import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.mock.services.MockApiClientV2
+import com.kickstarter.mock.services.MockApolloClientV2
 import com.kickstarter.models.User
-import com.kickstarter.services.ApiClientType
+import com.kickstarter.services.ApiClientTypeV2
 import com.kickstarter.services.apiresponses.AccessTokenEnvelope
 import com.kickstarter.services.apiresponses.ErrorEnvelope.Companion.builder
 import com.kickstarter.ui.IntentKey
+import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subscribers.TestSubscriber
+import org.junit.After
 import org.junit.Test
-import rx.Observable
-import rx.observers.TestSubscriber
-import rx.subjects.BehaviorSubject
 
 class TwoFactorViewModelTest : KSRobolectricTestCase() {
 
@@ -27,6 +30,7 @@ class TwoFactorViewModelTest : KSRobolectricTestCase() {
     private val showResendCodeConfirmation = TestSubscriber<Unit>()
     private val tfaCodeMismatchError = TestSubscriber<Unit>()
     private val tfaSuccess = TestSubscriber<Unit>()
+    private val userTest = TestSubscriber<User>()
     private val disposables = CompositeDisposable()
 
     @Test
@@ -61,23 +65,52 @@ class TwoFactorViewModelTest : KSRobolectricTestCase() {
         intent.putExtra(IntentKey.FACEBOOK_LOGIN, false)
         intent.putExtra(IntentKey.FACEBOOK_TOKEN, "")
 
-        val user = BehaviorSubject.create<User>()
-        environment().currentUser()?.loggedInUser()?.subscribe(user)
+        val user = UserFactory.user()
+        val token = AccessTokenEnvelope.builder()
+            .user(user)
+            .accessToken("token")
+            .build()
+        val apiClient = object : MockApiClientV2() {
+            override fun login(email: String, password: String, code: String): Observable<AccessTokenEnvelope> {
+                return Observable.just(token)
+            }
+        }
+        val apolloClient = object : MockApolloClientV2() {
+            override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
+                return Observable.just(
+                    UserPrivacyQuery.Data(
+                        UserPrivacyQuery.Me(
+                            "", user.name(),
+                            "gina@kickstarter.com", true, true, true, true, "USD"
+                        )
+                    )
+                )
+            }
+        }
 
-        vm = TwoFactorViewModel.TwoFactorViewModel(environment(), intent)
+        val environment = environment().toBuilder()
+            .apiClientV2(apiClient)
+            .apolloClientV2(apolloClient)
+            .build()
+
+        vm = TwoFactorViewModel.TwoFactorViewModel(environment, intent)
 
         vm.outputs.tfaSuccess().subscribe { tfaSuccess.onNext(it) }.addToDisposable(disposables)
         vm.outputs.formSubmitting()
             .subscribe { formSubmitting.onNext(it) }
             .addToDisposable(disposables)
+        environment.currentUserV2()?.observable()?.subscribe {
+            userTest.onNext(it.getValue())
+        }?.addToDisposable(disposables)
 
         vm.inputs.code("88888")
         vm.inputs.loginClick()
 
         formSubmitting.assertValues(true, false)
         tfaSuccess.assertValueCount(1)
-
-        assertEquals("some@email.com", user.value?.email())
+        userTest.assertValue {
+            it.email() == "gina@kickstarter.com"
+        }
 
         segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
     }
@@ -91,19 +124,52 @@ class TwoFactorViewModelTest : KSRobolectricTestCase() {
         intent.putExtra(IntentKey.FACEBOOK_LOGIN, true)
         intent.putExtra(IntentKey.FACEBOOK_TOKEN, "pajamas1234")
 
-        vm = TwoFactorViewModel.TwoFactorViewModel(environment())
+        val user = UserFactory.user()
+        val token = AccessTokenEnvelope.builder()
+            .user(user)
+            .accessToken("token")
+            .build()
+        val apiClient = object : MockApiClientV2() {
+            override fun loginWithFacebook(fbAccessToken: String, code: String): Observable<AccessTokenEnvelope> {
+                return Observable.just(token)
+            }
+        }
+        val apolloClient = object : MockApolloClientV2() {
+            override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
+                return Observable.just(
+                    UserPrivacyQuery.Data(
+                        UserPrivacyQuery.Me(
+                            "", user.name(),
+                            "gina@kickstarter.com", true, true, true, true, "USD"
+                        )
+                    )
+                )
+            }
+        }
+
+        val environment = environment().toBuilder()
+            .apiClientV2(apiClient)
+            .apolloClientV2(apolloClient)
+            .build()
+
+        vm = TwoFactorViewModel.TwoFactorViewModel(environment, intent)
 
         vm.outputs.tfaSuccess().subscribe { tfaSuccess.onNext(it) }.addToDisposable(disposables)
         vm.outputs.formSubmitting()
             .subscribe { formSubmitting.onNext(it) }
             .addToDisposable(disposables)
+        environment.currentUserV2()?.observable()?.subscribe {
+            userTest.onNext(it.getValue())
+        }?.addToDisposable(disposables)
 
         vm.inputs.code("88888")
         vm.inputs.loginClick()
 
         formSubmitting.assertValues(true, false)
         tfaSuccess.assertValueCount(1)
-
+        userTest.assertValue {
+            it.email() == "gina@kickstarter.com"
+        }
         segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
     }
 
@@ -151,7 +217,7 @@ class TwoFactorViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testTwoFactorViewModel_GenericError() {
-        val apiClient: ApiClientType = object : MockApiClient() {
+        val apiClient: ApiClientTypeV2 = object : MockApiClientV2() {
             override fun login(
                 email: String,
                 password: String,
@@ -159,13 +225,13 @@ class TwoFactorViewModelTest : KSRobolectricTestCase() {
             ): Observable<AccessTokenEnvelope> {
                 return Observable.error(
                     ApiExceptionFactory.apiError(
-                        builder().httpCode(400).build()
+                        builder().httpCode(400).errorMessages(listOf("Generic Error")).build()
                     )
                 )
             }
         }
 
-        val environment = environment().toBuilder().apiClient(apiClient).build()
+        val environment = environment().toBuilder().apiClientV2(apiClient).build()
 
         val intent = Intent()
 
@@ -195,7 +261,7 @@ class TwoFactorViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testTwoFactorViewModel_CodeMismatchError() {
-        val apiClient: ApiClientType = object : MockApiClient() {
+        val apiClient: ApiClientTypeV2 = object : MockApiClientV2() {
             override fun login(
                 email: String,
                 password: String,
@@ -205,7 +271,7 @@ class TwoFactorViewModelTest : KSRobolectricTestCase() {
             }
         }
 
-        val environment = environment().toBuilder().apiClient(apiClient).build()
+        val environment = environment().toBuilder().apiClientV2(apiClient).build()
         val intent = Intent()
 
         intent.putExtra(IntentKey.EMAIL, "gina@kickstarter.com")
@@ -230,5 +296,10 @@ class TwoFactorViewModelTest : KSRobolectricTestCase() {
         tfaSuccess.assertNoValues()
         tfaCodeMismatchError.assertValueCount(1)
         segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
+    }
+
+    @After
+    fun cleanUp() {
+        disposables.clear()
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/TwoFactorViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/TwoFactorViewModelTest.kt
@@ -99,18 +99,14 @@ class TwoFactorViewModelTest : KSRobolectricTestCase() {
         vm.outputs.formSubmitting()
             .subscribe { formSubmitting.onNext(it) }
             .addToDisposable(disposables)
-        environment.currentUserV2()?.observable()?.subscribe {
-            userTest.onNext(it.getValue())
-        }?.addToDisposable(disposables)
-
         vm.inputs.code("88888")
         vm.inputs.loginClick()
 
         formSubmitting.assertValues(true, false)
         tfaSuccess.assertValueCount(1)
-        userTest.assertValue {
-            it.email() == "gina@kickstarter.com"
-        }
+        environment.currentUserV2()?.observable()?.subscribe {
+            assertEquals("hello@kickstarter.com", it.getValue()?.email())
+        }?.addToDisposable(disposables)
 
         segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
     }
@@ -158,18 +154,16 @@ class TwoFactorViewModelTest : KSRobolectricTestCase() {
         vm.outputs.formSubmitting()
             .subscribe { formSubmitting.onNext(it) }
             .addToDisposable(disposables)
-        environment.currentUserV2()?.observable()?.subscribe {
-            userTest.onNext(it.getValue())
-        }?.addToDisposable(disposables)
 
         vm.inputs.code("88888")
         vm.inputs.loginClick()
 
         formSubmitting.assertValues(true, false)
         tfaSuccess.assertValueCount(1)
-        userTest.assertValue {
-            it.email() == "gina@kickstarter.com"
-        }
+        environment.currentUserV2()?.observable()?.subscribe {
+            assertEquals("hello@kickstarter.com", it.getValue()?.email())
+        }?.addToDisposable(disposables)
+
         segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
     }
 


### PR DESCRIPTION
# 📲 What

Used Jetpack ViewModel() and updated rxjava disposables in TwoFactorActivity and TwoFactorViewModel by following these steps: https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2350317579/ViewModel+Tech+Debt+Epic#Technical-details

# 🤔 Why

[ViewModel Tech Debt Epic](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2350317579/ViewModel+Tech+Debt+Epic)

# 🛠 How


# 👀 See

No visible changes

# 📋 QA

Instructions for anyone to be able to QA this work.

# Story 📖

[MBL-829](https://kickstarter.atlassian.net/browse/MBL-829)


[MBL-829]: https://kickstarter.atlassian.net/browse/MBL-829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ