### PR TITLE
MBL-738: AccountActivity-ViewModel Migrated to RXJava2 + JetpackViewModel

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -129,6 +129,10 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
     override fun userPrivacy(): io.reactivex.Observable<UserPrivacyQuery.Data> {
         return io.reactivex.Observable.empty<UserPrivacyQuery.Data>()
     }
+
+    override fun updateUserCurrencyPreference(currency: CurrencyCode): io.reactivex.Observable<UpdateUserCurrencyMutation.Data> {
+        return io.reactivex.Observable.empty()
+    }
 }
 
 open class MockApolloClient : ApolloClientType {

--- a/app/src/main/java/com/kickstarter/ui/activities/AccountActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/AccountActivity.kt
@@ -17,7 +17,6 @@ import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.getPaymentMethodsIntent
 import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.viewmodels.AccountViewModel
-import com.kickstarter.viewmodels.LoginViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import type.CurrencyCode
@@ -52,7 +51,7 @@ class AccountActivity : AppCompatActivity() {
         )
     }
 
-    private lateinit var viewModelFactory: LoginViewModel.Factory
+    private lateinit var viewModelFactory: AccountViewModel.Factory
     private val viewModel: AccountViewModel.AccountViewModel by viewModels { viewModelFactory }
 
     private lateinit var disposables: CompositeDisposable
@@ -63,7 +62,7 @@ class AccountActivity : AppCompatActivity() {
         disposables = CompositeDisposable()
 
         val env = this.getEnvironment()?.let { env ->
-            viewModelFactory = LoginViewModel.Factory(env, intent = intent)
+            viewModelFactory = AccountViewModel.Factory(env, intent = intent)
             env
         }
 
@@ -120,6 +119,11 @@ class AccountActivity : AppCompatActivity() {
         binding.changePasswordRow.setOnClickListener { startActivity(Intent(this, ChangePasswordActivity::class.java)) }
         binding.paymentMethodsRow.setOnClickListener { startActivity(Intent().getPaymentMethodsIntent(this)) }
         binding.privacyRow.setOnClickListener { startActivity(Intent(this, PrivacyActivity::class.java)) }
+    }
+
+    override fun onDestroy() {
+        disposables.clear()
+        super.onDestroy()
     }
 
     private fun getListOfCurrencies(): List<String> {

--- a/app/src/main/java/com/kickstarter/viewmodels/AccountViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/AccountViewModel.kt
@@ -152,6 +152,11 @@ interface AccountViewModel {
                 .doOnSubscribe { this.progressBarIsVisible.onNext(true) }
                 .doAfterTerminate { this.progressBarIsVisible.onNext(false) }
         }
+
+        override fun onCleared() {
+            disposables.clear()
+            super.onCleared()
+        }
     }
 
     class Factory(private val environment: Environment, private val intent: Intent? = null) : ViewModelProvider.Factory {

--- a/app/src/main/java/com/kickstarter/viewmodels/AccountViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/AccountViewModel.kt
@@ -2,17 +2,19 @@ package com.kickstarter.viewmodels
 
 import UpdateUserCurrencyMutation
 import UserPrivacyQuery
-import androidx.annotation.NonNull
-import com.kickstarter.libs.ActivityViewModel
+import android.content.Intent
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
-import com.kickstarter.libs.rx.transformers.Transformers.values
+import com.kickstarter.libs.rx.transformers.Transformers.valuesV2
 import com.kickstarter.libs.utils.ObjectUtils
-import com.kickstarter.ui.activities.AccountActivity
-import rx.Observable
-import rx.subjects.BehaviorSubject
-import rx.subjects.PublishSubject
+import com.kickstarter.libs.utils.extensions.addToDisposable
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subjects.PublishSubject
 import type.CurrencyCode
 
 interface AccountViewModel {
@@ -45,7 +47,7 @@ interface AccountViewModel {
         fun success(): Observable<String>
     }
 
-    class ViewModel(@NonNull val environment: Environment) : ActivityViewModel<AccountActivity>(environment), Inputs, Outputs {
+    class AccountViewModel(val environment: Environment, private val intent: Intent? = null) : ViewModel(), Inputs, Outputs {
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -61,51 +63,56 @@ interface AccountViewModel {
 
         private val error = BehaviorSubject.create<String>()
 
-        private val apolloClient = requireNotNull(environment.apolloClient())
+        private val apolloClient = requireNotNull(environment.apolloClientV2())
+        private val disposables = CompositeDisposable()
 
         init {
 
             val userPrivacy = this.apolloClient.userPrivacy()
-                .compose(Transformers.neverError())
+                .compose(Transformers.neverErrorV2())
 
             userPrivacy
                 .map { it.me()?.chosenCurrency() }
                 .map { ObjectUtils.coalesce(it, CurrencyCode.USD.rawValue()) }
-                .compose(bindToLifecycle())
                 .subscribe { this.chosenCurrency.onNext(it) }
+                .addToDisposable(disposables)
 
             userPrivacy
-                .map { it?.me()?.email() }
+                .map { it.me()?.email() ?: "" }
                 .subscribe { this.email.onNext(it) }
+                .addToDisposable(disposables)
 
             userPrivacy
-                .map { it?.me()?.hasPassword() ?: false }
+                .map { it.me()?.hasPassword() ?: false }
                 .subscribe { this.passwordRequiredContainerIsVisible.onNext(it) }
+                .addToDisposable(disposables)
 
             userPrivacy
-                .map { showEmailErrorImage(it) }
+                .map { showEmailErrorImage(it) ?: false }
                 .subscribe { this.showEmailErrorIcon.onNext(it) }
+                .addToDisposable(disposables)
 
             val updateCurrencyNotification = this.onSelectedCurrency
                 .compose(combineLatestPair<CurrencyCode, String>(this.chosenCurrency))
                 .filter { it.first.rawValue() != it.second }
                 .map<CurrencyCode> { it.first }
                 .switchMap { updateUserCurrency(it).materialize() }
-                .compose(bindToLifecycle())
                 .share()
 
             updateCurrencyNotification
-                .compose(values())
-                .map { it.updateUserProfile()?.user()?.chosenCurrency() }
+                .compose(valuesV2())
+                .map { it.updateUserProfile()?.user()?.chosenCurrency() ?: "" }
                 .filter { ObjectUtils.isNotNull(it) }
                 .subscribe {
                     this.chosenCurrency.onNext(it)
                     this.success.onNext(it)
                 }
+                .addToDisposable(disposables)
 
             updateCurrencyNotification
-                .compose(Transformers.errors())
-                .subscribe { this.error.onNext(it.localizedMessage) }
+                .compose(Transformers.errorsV2())
+                .subscribe { this.error.onNext(it?.localizedMessage ?: "") }
+                .addToDisposable(disposables)
         }
 
         override fun onSelectedCurrency(currencyCode: CurrencyCode) {
@@ -144,6 +151,12 @@ interface AccountViewModel {
             return this.apolloClient.updateUserCurrencyPreference(currencyCode)
                 .doOnSubscribe { this.progressBarIsVisible.onNext(true) }
                 .doAfterTerminate { this.progressBarIsVisible.onNext(false) }
+        }
+    }
+
+    class Factory(private val environment: Environment, private val intent: Intent? = null) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return AccountViewModel(environment, intent) as T
         }
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/AccountViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AccountViewModelTest.kt
@@ -88,6 +88,17 @@ class AccountViewModelTest : KSRobolectricTestCase() {
     fun testChosenCurrencyMutation() {
         setUpEnvironment(
             environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
+                override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
+                    return Observable.just(
+                        UserPrivacyQuery.Data(
+                            UserPrivacyQuery.Me(
+                                "", "",
+                                "r@ksr.com", true, true, true, true, "USD"
+                            )
+                        )
+                    )
+                }
+
                 override fun updateUserCurrencyPreference(currency: CurrencyCode): Observable<UpdateUserCurrencyMutation.Data> {
                     return Observable.just(
                         UpdateUserCurrencyMutation.Data(

--- a/app/src/test/java/com/kickstarter/viewmodels/AccountViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AccountViewModelTest.kt
@@ -4,15 +4,18 @@ import UpdateUserCurrencyMutation
 import UserPrivacyQuery
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
-import com.kickstarter.mock.services.MockApolloClient
+import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.mock.services.MockApolloClientV2
+import com.kickstarter.viewmodels.AccountViewModel.AccountViewModel
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subscribers.TestSubscriber
 import org.junit.Test
-import rx.Observable
-import rx.observers.TestSubscriber
 import type.CurrencyCode
 
 class AccountViewModelTest : KSRobolectricTestCase() {
 
-    private lateinit var vm: AccountViewModel.ViewModel
+    private lateinit var vm: AccountViewModel
 
     private val chosenCurrency = TestSubscriber<String>()
     private val email = TestSubscriber<String>()
@@ -21,21 +24,23 @@ class AccountViewModelTest : KSRobolectricTestCase() {
     private val showEmailErrorIcon = TestSubscriber<Boolean>()
     private val success = TestSubscriber<String>()
 
-    private fun setUpEnvironment(environment: Environment) {
-        this.vm = AccountViewModel.ViewModel(environment)
+    private val disposables = CompositeDisposable()
 
-        this.vm.outputs.chosenCurrency().subscribe(this.chosenCurrency)
-        this.vm.outputs.email().subscribe(this.email)
-        this.vm.outputs.error().subscribe(this.error)
-        this.vm.outputs.passwordRequiredContainerIsVisible().subscribe(this.passwordRequiredContainerIsVisible)
-        this.vm.outputs.showEmailErrorIcon().subscribe(this.showEmailErrorIcon)
-        this.vm.outputs.success().subscribe(this.success)
+    private fun setUpEnvironment(environment: Environment) {
+        this.vm = AccountViewModel(environment)
+
+        this.vm.outputs.chosenCurrency().subscribe { this.chosenCurrency.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.email().subscribe { this.email.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.error().subscribe { this.error.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.passwordRequiredContainerIsVisible().subscribe { this.passwordRequiredContainerIsVisible.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.showEmailErrorIcon().subscribe { this.showEmailErrorIcon.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.success().subscribe { this.success.onNext(it) }.addToDisposable(disposables)
     }
 
     @Test
     fun testUserCurrency() {
         setUpEnvironment(
-            environment().toBuilder().apolloClient(object : MockApolloClient() {
+            environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
                 override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                     return Observable.just(
                         UserPrivacyQuery.Data(
@@ -56,7 +61,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testUserEmail() {
         setUpEnvironment(
-            environment().toBuilder().apolloClient(object : MockApolloClient() {
+            environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
                 override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                     return Observable.just(
                         UserPrivacyQuery.Data(
@@ -77,7 +82,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testChosenCurrencyMutation() {
         setUpEnvironment(
-            environment().toBuilder().apolloClient(object : MockApolloClient() {
+            environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
                 override fun updateUserCurrencyPreference(currency: CurrencyCode): Observable<UpdateUserCurrencyMutation.Data> {
                     return Observable.just(
                         UpdateUserCurrencyMutation.Data(
@@ -104,7 +109,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
         val isDeliverable = false
         val isEmailVerified = true
         setUpEnvironment(
-            environment().toBuilder().apolloClient(object : MockApolloClient() {
+            environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
                 override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                     return Observable.just(
                         UserPrivacyQuery.Data(
@@ -128,7 +133,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
         val isDeliverable = false
         val isEmailVerified = false
         setUpEnvironment(
-            environment().toBuilder().apolloClient(object : MockApolloClient() {
+            environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
                 override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                     return Observable.just(
                         UserPrivacyQuery.Data(
@@ -152,7 +157,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
         val isDeliverable = true
         val isEmailVerified = true
         setUpEnvironment(
-            environment().toBuilder().apolloClient(object : MockApolloClient() {
+            environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
                 override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                     return Observable.just(
                         UserPrivacyQuery.Data(
@@ -176,7 +181,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
         val isDeliverable = true
         val isEmailVerified = false
         setUpEnvironment(
-            environment().toBuilder().apolloClient(object : MockApolloClient() {
+            environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
                 override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                     return Observable.just(
                         UserPrivacyQuery.Data(
@@ -200,7 +205,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
         val isDeliverable = true
         val isEmailVerified = false
         setUpEnvironment(
-            environment().toBuilder().apolloClient(object : MockApolloClient() {
+            environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
                 override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                     return Observable.just(
                         UserPrivacyQuery.Data(
@@ -224,7 +229,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
         val isDeliverable = true
         val isEmailVerified = false
         setUpEnvironment(
-            environment().toBuilder().apolloClient(object : MockApolloClient() {
+            environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
                 override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                     return Observable.just(
                         UserPrivacyQuery.Data(
@@ -248,7 +253,7 @@ class AccountViewModelTest : KSRobolectricTestCase() {
         val isDeliverable = false
         val isEmailVerified = false
         setUpEnvironment(
-            environment().toBuilder().apolloClient(object : MockApolloClient() {
+            environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
                 override fun userPrivacy(): Observable<UserPrivacyQuery.Data> {
                     return Observable.just(
                         UserPrivacyQuery.Data(

--- a/app/src/test/java/com/kickstarter/viewmodels/AccountViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AccountViewModelTest.kt
@@ -10,6 +10,7 @@ import com.kickstarter.viewmodels.AccountViewModel.AccountViewModel
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subscribers.TestSubscriber
+import org.junit.After
 import org.junit.Test
 import type.CurrencyCode
 
@@ -26,6 +27,10 @@ class AccountViewModelTest : KSRobolectricTestCase() {
 
     private val disposables = CompositeDisposable()
 
+    @After
+    fun cleanUp() {
+        disposables.clear()
+    }
     private fun setUpEnvironment(environment: Environment) {
         this.vm = AccountViewModel(environment)
 


### PR DESCRIPTION
# 📲 What

One more migration

# 🤔 Why

- Take a look to the engineering plan [here](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2350317579/ViewModel+Tech+Debt+Epic) if needed 


# 👀 See
No user facing changes

|  |  |

# 📋 QA

- You should be able to navigate to all the items presented [Change email, change password ... etc]
- Change your selected currency. ⚠️ once you change your currency kill the app and start again, load a project page, you should see the new selected currency applied.

# Story 📖

[MBL-738](https://kickstarter.atlassian.net/browse/MBL-738)


[MBL-738]: https://kickstarter.atlassian.net/browse/MBL-738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ