### PR TITLE
MBL-767: FrequentlyAskedQuestionViewModel.kt to Jetpack ViewModel and RxJava2.2

### DIFF
--- a/app/quality.gradle
+++ b/app/quality.gradle
@@ -44,6 +44,7 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
     classpath = configurations.ktlint
     mainClass.set("com.pinterest.ktlint.Main")
+    jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED"
     args "-F", "src/**/*.kt"
     ignoreExitValue true
 }

--- a/app/quality.gradle
+++ b/app/quality.gradle
@@ -44,7 +44,6 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
     classpath = configurations.ktlint
     mainClass.set("com.pinterest.ktlint.Main")
-    jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED"
     args "-F", "src/**/*.kt"
     ignoreExitValue true
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/FrequentlyAskedQuestionFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/FrequentlyAskedQuestionFragment.kt
@@ -26,8 +26,8 @@ import com.kickstarter.ui.activities.MessagesActivity
 import com.kickstarter.ui.adapters.FrequentlyAskedQuestionsAdapter
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.projectpage.FrequentlyAskedQuestionViewModel
-import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
 
 class FrequentlyAskedQuestionFragment : Fragment(), Configure {
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/FrequentlyAskedQuestionFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/FrequentlyAskedQuestionFragment.kt
@@ -133,9 +133,9 @@ class FrequentlyAskedQuestionFragment : Fragment(), Configure {
         }
     }
 
-    override fun onDestroy() {
+    override fun onDestroyView() {
         disposables.clear()
-        super.onDestroy()
+        super.onDestroyView()
     }
 
     companion object {

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/FrequentlyAskedQuestionFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/FrequentlyAskedQuestionFragment.kt
@@ -133,6 +133,11 @@ class FrequentlyAskedQuestionFragment : Fragment(), Configure {
         }
     }
 
+    override fun onDestroy() {
+        disposables.clear()
+        super.onDestroy()
+    }
+
     companion object {
         @JvmStatic
         fun newInstance(position: Int): FrequentlyAskedQuestionFragment {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/FrequentlyAskedQuestionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/FrequentlyAskedQuestionViewModel.kt
@@ -96,7 +96,7 @@ interface FrequentlyAskedQuestionViewModel {
             project
                 .compose(Transformers.takeWhenV2(this.askQuestionButtonClicked))
                 .filter { it.isBacking() }
-                .subscribe{ this.startMessageActivity.onNext(it) }
+                .subscribe { this.startMessageActivity.onNext(it) }
                 .addToDisposable(disposables)
         }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/FrequentlyAskedQuestionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/FrequentlyAskedQuestionViewModel.kt
@@ -47,7 +47,7 @@ interface FrequentlyAskedQuestionViewModel {
         val inputs: Inputs = this
         val outputs: Outputs = this
 
-        private val projectDataInput = BehaviorSubject.create<ProjectData>()
+        private val projectDataInput = PublishSubject.create<ProjectData>()
         private val askQuestionButtonClicked = PublishSubject.create<Unit>()
 
         private val askQuestionButtonIsGone = BehaviorSubject.create<Boolean>()
@@ -64,7 +64,7 @@ interface FrequentlyAskedQuestionViewModel {
         init {
             val projectFaqList = projectDataInput
                 .map { it.project().projectFaqs() }
-//                .filter { ObjectUtils.isNotNull(it) }
+                .filter { ObjectUtils.isNotNull(it) }
 
             projectFaqList
                 .filter { it.isNotEmpty() }
@@ -84,7 +84,7 @@ interface FrequentlyAskedQuestionViewModel {
             this.currentUser.observable()
                 .compose(Transformers.combineLatestPair(project))
                 .map { userIsLoggedOutOrProjectCreator(Pair(it.first.getValue(), it.second)) }
-                .subscribe { this.askQuestionButtonIsGone }
+                .subscribe { this.askQuestionButtonIsGone.onNext(it) }
                 .addToDisposable(disposables)
 
             project
@@ -123,6 +123,11 @@ interface FrequentlyAskedQuestionViewModel {
         override fun projectFaqList(): Observable<List<ProjectFaq>> = this.projectFaqList
         @NonNull
         override fun bindEmptyState(): Observable<Unit> = this.bindEmptyState
+
+        override fun onCleared() {
+            disposables.clear()
+            super.onCleared()
+        }
     }
 
     class Factory(private val environment: Environment) : ViewModelProvider.Factory {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/FrequentlyAskedQuestionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/FrequentlyAskedQuestionViewModel.kt
@@ -2,18 +2,20 @@ package com.kickstarter.viewmodels.projectpage
 
 import android.util.Pair
 import androidx.annotation.NonNull
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import com.kickstarter.libs.Environment
-import com.kickstarter.libs.FragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ObjectUtils
+import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.models.Project
 import com.kickstarter.models.ProjectFaq
 import com.kickstarter.models.User
 import com.kickstarter.ui.data.ProjectData
-import com.kickstarter.ui.fragments.projectpage.FrequentlyAskedQuestionFragment
-import rx.Observable
-import rx.subjects.BehaviorSubject
-import rx.subjects.PublishSubject
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subjects.PublishSubject
 
 interface FrequentlyAskedQuestionViewModel {
 
@@ -28,7 +30,7 @@ interface FrequentlyAskedQuestionViewModel {
     interface Outputs {
         /** Emits the current list [ProjectFaq]. */
         fun projectFaqList(): Observable<List<ProjectFaq>>
-        fun bindEmptyState(): Observable<Void>
+        fun bindEmptyState(): Observable<Unit>
         /** Emits a boolean that determines if the message icon should be shown. */
         fun askQuestionButtonIsGone(): Observable<Boolean>
 
@@ -39,60 +41,63 @@ interface FrequentlyAskedQuestionViewModel {
         fun startMessagesActivity(): Observable<Project>
     }
 
-    class ViewModel(@NonNull val environment: Environment) :
-        FragmentViewModel<FrequentlyAskedQuestionFragment>(environment), Inputs, Outputs {
+    class FrequentlyAskedQuestionViewModel(val environment: Environment) :
+        ViewModel(), Inputs, Outputs {
 
         val inputs: Inputs = this
         val outputs: Outputs = this
 
         private val projectDataInput = BehaviorSubject.create<ProjectData>()
-        private val askQuestionButtonClicked = PublishSubject.create<Void>()
+        private val askQuestionButtonClicked = PublishSubject.create<Unit>()
 
         private val askQuestionButtonIsGone = BehaviorSubject.create<Boolean>()
         private val startComposeMessageActivity = PublishSubject.create<Project>()
         private val startMessageActivity = PublishSubject.create<Project>()
 
         private val projectFaqList = BehaviorSubject.create<List<ProjectFaq>>()
-        private val bindEmptyState = BehaviorSubject.create<Void>()
+        private val bindEmptyState = BehaviorSubject.create<Unit>()
 
-        private val currentUser = requireNotNull(environment.currentUser())
+        private val currentUser = requireNotNull(environment.currentUserV2())
+
+        private val disposables = CompositeDisposable()
 
         init {
             val projectFaqList = projectDataInput
                 .map { it.project().projectFaqs() }
-                .filter { ObjectUtils.isNotNull(it) }
-                .map { requireNotNull(it) }
+//                .filter { ObjectUtils.isNotNull(it) }
 
             projectFaqList
                 .filter { it.isNotEmpty() }
-                .compose(bindToLifecycle())
-                .subscribe { this.projectFaqList.onNext(it) }
+                .subscribe { it?.let { this.projectFaqList.onNext(it) } }
+                .addToDisposable(disposables)
 
             projectFaqList
                 .filter { it.isNullOrEmpty() }
-                .compose(bindToLifecycle())
-                .subscribe { this.bindEmptyState.onNext(null) }
+                .subscribe {
+                    this.bindEmptyState.onNext(Unit)
+                }
+                .addToDisposable(disposables)
 
             val project = projectDataInput
                 .map { it.project() }
 
             this.currentUser.observable()
                 .compose(Transformers.combineLatestPair(project))
-                .map { userIsLoggedOutOrProjectCreator(it) }
-                .compose(bindToLifecycle())
-                .subscribe(this.askQuestionButtonIsGone)
+                .map { userIsLoggedOutOrProjectCreator(Pair(it.first.getValue(), it.second)) }
+                .subscribe { this.askQuestionButtonIsGone }
+                .addToDisposable(disposables)
 
             project
-                .compose(Transformers.takeWhen(this.askQuestionButtonClicked))
+                .compose(Transformers.takeWhenV2(this.askQuestionButtonClicked))
                 .filter { !it.isBacking() }
-                .compose(bindToLifecycle())
-                .subscribe(this.startComposeMessageActivity)
+                .subscribe { this.startComposeMessageActivity.onNext(it) }
+                .addToDisposable(disposables)
 
             project
-                .compose(Transformers.takeWhen(this.askQuestionButtonClicked))
+                .compose(Transformers.takeWhenV2(this.askQuestionButtonClicked))
                 .filter { it.isBacking() }
-                .compose(bindToLifecycle())
-                .subscribe(this.startMessageActivity)
+                .subscribe{ this.startMessageActivity.onNext(it) }
+                .addToDisposable(disposables)
         }
 
         private fun userIsLoggedOutOrProjectCreator(userAndProject: Pair<User, Project>) =
@@ -102,7 +107,7 @@ interface FrequentlyAskedQuestionViewModel {
             .onNext(projectData)
 
         override fun askQuestionButtonClicked() {
-            this.askQuestionButtonClicked.onNext(null)
+            this.askQuestionButtonClicked.onNext(Unit)
         }
 
         @NonNull
@@ -117,6 +122,12 @@ interface FrequentlyAskedQuestionViewModel {
         @NonNull
         override fun projectFaqList(): Observable<List<ProjectFaq>> = this.projectFaqList
         @NonNull
-        override fun bindEmptyState(): Observable<Void> = this.bindEmptyState
+        override fun bindEmptyState(): Observable<Unit> = this.bindEmptyState
+    }
+
+    class Factory(private val environment: Environment) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return FrequentlyAskedQuestionViewModel(environment) as T
+        }
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/FrequentlyAskedQuestionViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/FrequentlyAskedQuestionViewModelTest.kt
@@ -11,9 +11,9 @@ import com.kickstarter.models.Project
 import com.kickstarter.models.ProjectFaq
 import com.kickstarter.viewmodels.projectpage.FrequentlyAskedQuestionViewModel
 import io.reactivex.disposables.CompositeDisposable
-import org.junit.Test
 import io.reactivex.subscribers.TestSubscriber
 import org.junit.After
+import org.junit.Test
 
 class FrequentlyAskedQuestionViewModelTest : KSRobolectricTestCase() {
 
@@ -34,7 +34,7 @@ class FrequentlyAskedQuestionViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.bindEmptyState().subscribe { this.bindEmptyState.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.askQuestionButtonIsGone().subscribe { this.askQuestionButtonIsGone.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.startComposeMessageActivity().subscribe { this.startComposeMessageActivity.onNext(it) }.addToDisposable(disposables)
-        this.vm.outputs.startMessagesActivity().subscribe{ this.startMessagesActivity.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.startMessagesActivity().subscribe { this.startMessagesActivity.onNext(it) }.addToDisposable(disposables)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/FrequentlyAskedQuestionViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/FrequentlyAskedQuestionViewModelTest.kt
@@ -2,35 +2,39 @@ package com.kickstarter.viewmodels
 
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
-import com.kickstarter.libs.MockCurrentUser
+import com.kickstarter.libs.MockCurrentUserV2
+import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.mock.factories.ProjectDataFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.Project
 import com.kickstarter.models.ProjectFaq
 import com.kickstarter.viewmodels.projectpage.FrequentlyAskedQuestionViewModel
+import io.reactivex.disposables.CompositeDisposable
 import org.junit.Test
-import rx.observers.TestSubscriber
+import io.reactivex.subscribers.TestSubscriber
+import org.junit.After
 
 class FrequentlyAskedQuestionViewModelTest : KSRobolectricTestCase() {
 
-    private lateinit var vm: FrequentlyAskedQuestionViewModel.ViewModel
+    private lateinit var vm: FrequentlyAskedQuestionViewModel.FrequentlyAskedQuestionViewModel
 
     private val projectFaqList = TestSubscriber.create<List<ProjectFaq>>()
-    private val bindEmptyState = TestSubscriber.create<Void>()
+    private val bindEmptyState = TestSubscriber.create<Unit>()
 
     private val askQuestionButtonIsGone = TestSubscriber<Boolean>()
     private val startComposeMessageActivity = TestSubscriber<Project>()
     private val startMessagesActivity = TestSubscriber<Project>()
+    private val disposables = CompositeDisposable()
 
     private fun setUpEnvironment(environment: Environment) {
-        this.vm = FrequentlyAskedQuestionViewModel.ViewModel(environment)
+        this.vm = FrequentlyAskedQuestionViewModel.FrequentlyAskedQuestionViewModel(environment)
 
-        this.vm.outputs.projectFaqList().subscribe(this.projectFaqList)
-        this.vm.outputs.bindEmptyState().subscribe(this.bindEmptyState)
-        this.vm.outputs.askQuestionButtonIsGone().subscribe(this.askQuestionButtonIsGone)
-        this.vm.outputs.startComposeMessageActivity().subscribe(this.startComposeMessageActivity)
-        this.vm.outputs.startMessagesActivity().subscribe(this.startMessagesActivity)
+        this.vm.outputs.projectFaqList().subscribe { this.projectFaqList.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.bindEmptyState().subscribe { this.bindEmptyState.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.askQuestionButtonIsGone().subscribe { this.askQuestionButtonIsGone.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.startComposeMessageActivity().subscribe { this.startComposeMessageActivity.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.startMessagesActivity().subscribe{ this.startMessagesActivity.onNext(it) }.addToDisposable(disposables)
     }
 
     @Test
@@ -75,7 +79,7 @@ class FrequentlyAskedQuestionViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testGoToComposeMessageActivity_WhenLoggedInUserIsNotBacker() {
-        setUpEnvironment(environment().toBuilder().currentUser(MockCurrentUser(UserFactory.user())).build())
+        setUpEnvironment(environment().toBuilder().currentUserV2(MockCurrentUserV2(UserFactory.user())).build())
 
         this.vm.configureWith(ProjectDataFactory.project(ProjectFactory.project()))
 
@@ -88,7 +92,7 @@ class FrequentlyAskedQuestionViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testGoToMessagesActivity_WhenLoggedInUserIsABacker() {
         val project = ProjectFactory.project().toBuilder().isBacking(true).build()
-        setUpEnvironment(environment().toBuilder().currentUser(MockCurrentUser(UserFactory.user())).build())
+        setUpEnvironment(environment().toBuilder().currentUserV2(MockCurrentUserV2(UserFactory.user())).build())
 
         this.vm.configureWith(ProjectDataFactory.project(project))
 
@@ -107,5 +111,10 @@ class FrequentlyAskedQuestionViewModelTest : KSRobolectricTestCase() {
         this.vm.configureWith(ProjectDataFactory.project(project))
 
         this.askQuestionButtonIsGone.assertValue(true)
+    }
+
+    @After
+    fun clear() {
+        disposables.clear()
     }
 }


### PR DESCRIPTION
# 📲 What

Migration to rxjava 2.2 and jetpacks viewmodel

# 🤔 Why

[Technical Details](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2350317579/ViewModel+Tech+Debt+Epic#Technical-details)

# 👀 See

No user facing changes

# 📋 QA

- Find a project with FAQs (search "FLEXTAIL EVO ICER") , and a project without FAQs (Search "The golden era" tarot deck)
- Test all states:
   - Logged in user, project with FAQs: Should see list of FAQs
   - Logged in user and backer, project without FAQs: Empty state with button prompting users to ask a question, button opens message thread with creator 
   - Logged in user and not backer, project without FAQs: Empty state with button prompting users to ask a question, button opens an edit text to message creator
   - Logged out user, project with FAQs: Should see list of FAQs
   - Logged out user, project without FAQs: Empty state prompting user to login, "ask" button prompt not visible
   - Not sure how to test if the project owner is the creator, but according to the VM and tests, the message button should not be visible

# Story 📖

[FrequentlyAskedQuestionViewModel.kt to Jetpack ViewModel and RxJava2.2](https://kickstarter.atlassian.net/browse/MBL-767)
