### PR TITLE
[No-jira]: Performance improvements

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -1243,7 +1243,7 @@ interface PledgeFragmentViewModel {
                 .addToDisposable(disposables)
 
             // - Present PaymentSheet if user logged in, and add card button pressed
-            val shouldPresentPaymentSheet = BehaviorSubject.create<Notification<String>>()
+            val shouldPresentPaymentSheet = PublishSubject.create<Notification<String>>()
             this.newCardButtonClicked
                 .withLatestFrom(project) { _, latestProject -> latestProject }
                 .switchMap {
@@ -1257,7 +1257,6 @@ interface PledgeFragmentViewModel {
                             this.pledgeButtonIsEnabled.onNext(true)
                         }
                         .materialize()
-                        .share()
                 }
                 .subscribe {
                     shouldPresentPaymentSheet.onNext(it)

--- a/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/PledgeFragmentViewModel.kt
@@ -53,6 +53,7 @@ import com.kickstarter.ui.viewholders.State
 import com.kickstarter.viewmodels.usecases.SendThirdPartyEventUseCaseV2
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.paymentsheet.PaymentSheetResult
+import io.reactivex.Notification
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subjects.BehaviorSubject
@@ -494,14 +495,18 @@ interface PledgeFragmentViewModel {
                 .map { it.project() }
 
             // Shipping rules section
-
-            val shippingRules = this.selectedReward
+            val shippingRules = BehaviorSubject.create<List<ShippingRule>>()
+            this.selectedReward
                 .distinctUntilChanged()
                 .filter { RewardUtils.isShippable(it) }
                 .switchMap {
                     this.apolloClient.getShippingRules(it).compose(neverErrorV2())
                 }
                 .map { it.shippingRules() }
+                .subscribe {
+                    shippingRules.onNext(it)
+                }
+                .addToDisposable(disposables)
 
             val pledgeReason = arguments()
                 .map { it.getSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON) as PledgeReason }
@@ -1067,11 +1072,13 @@ interface PledgeFragmentViewModel {
                 }
                 .addToDisposable(disposables)
 
-            this.shippingRule
+            val summary: Observable<String> = this.shippingRule
                 .map { it.location()?.displayableName() }
                 .filter { ObjectUtils.isNotNull(it) }
                 .map { requireNotNull(it) }
                 .distinctUntilChanged()
+
+            summary
                 .subscribe { this.shippingSummaryLocation.onNext(it) }
                 .addToDisposable(disposables)
 
@@ -1236,7 +1243,8 @@ interface PledgeFragmentViewModel {
                 .addToDisposable(disposables)
 
             // - Present PaymentSheet if user logged in, and add card button pressed
-            val shouldPresentPaymentSheet = this.newCardButtonClicked
+            val shouldPresentPaymentSheet = BehaviorSubject.create<Notification<String>>()
+            this.newCardButtonClicked
                 .withLatestFrom(project) { _, latestProject -> latestProject }
                 .switchMap {
                     this.apolloClient.createSetupIntent(it)
@@ -1251,6 +1259,10 @@ interface PledgeFragmentViewModel {
                         .materialize()
                         .share()
                 }
+                .subscribe {
+                    shouldPresentPaymentSheet.onNext(it)
+                }
+                .addToDisposable(disposables)
 
             shouldPresentPaymentSheet
                 .compose(valuesV2())

--- a/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PledgeFragmentViewModelTest.kt
@@ -2017,13 +2017,13 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.newCardButtonClicked()
         this.presentPaymentSheet.assertValue(clientSecretID)
         this.segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
-        this.pledgeButtonIsEnabled.assertValues(true, false, false)
-        this.loadingState.assertValues(State.LOADING, State.LOADING)
+        this.pledgeButtonIsEnabled.assertValues(true, false)
+        this.loadingState.assertValues(State.LOADING)
 
         // - PaymentSheet presented
         this.vm.inputs.paymentSheetPresented(true)
-        this.pledgeButtonIsEnabled.assertValues(true, false, false, true)
-        this.loadingState.assertValues(State.LOADING, State.LOADING, State.DEFAULT)
+        this.pledgeButtonIsEnabled.assertValues(true, false, true)
+        this.loadingState.assertValues(State.LOADING, State.DEFAULT)
     }
 
     @Test
@@ -2047,16 +2047,16 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.newCardButtonClicked()
         this.presentPaymentSheet.assertNoValues()
         this.showError.assertValue("Error Message")
-        this.pledgeButtonIsEnabled.assertValues(true, false, true, false, true)
-        this.loadingState.assertValues(State.LOADING, State.DEFAULT, State.LOADING, State.DEFAULT)
+        this.pledgeButtonIsEnabled.assertValues(true, false, true)
+        this.loadingState.assertValues(State.LOADING, State.DEFAULT)
 
         // - User hit button for second time
         this.vm.inputs.newCardButtonClicked()
         this.presentPaymentSheet.assertNoValues()
         this.showError.assertValues("Error Message", "Error Message")
         this.segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
-        this.pledgeButtonIsEnabled.assertValues(true, false, true, false, true, false, true, false, true)
-        this.loadingState.assertValues(State.LOADING, State.DEFAULT, State.LOADING, State.DEFAULT, State.LOADING, State.DEFAULT, State.LOADING, State.DEFAULT)
+        this.pledgeButtonIsEnabled.assertValues(true, false, true, false, true)
+        this.loadingState.assertValues(State.LOADING, State.DEFAULT, State.LOADING, State.DEFAULT)
     }
 
     @Test
@@ -2072,13 +2072,13 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.newCardButtonClicked()
         this.presentPaymentSheet.assertValue("")
         this.segmentTrack.assertNoValues()
-        this.pledgeButtonIsEnabled.assertValues(false, false, false)
-        this.loadingState.assertValues(State.LOADING, State.LOADING)
+        this.pledgeButtonIsEnabled.assertValues(false, false)
+        this.loadingState.assertValues(State.LOADING)
 
         // - PaymentSheet presented
         this.vm.inputs.paymentSheetPresented(true)
-        this.pledgeButtonIsEnabled.assertValues(false, false, false, true)
-        this.loadingState.assertValues(State.LOADING, State.LOADING, State.DEFAULT)
+        this.pledgeButtonIsEnabled.assertValues(false, false, true)
+        this.loadingState.assertValues(State.LOADING, State.DEFAULT)
     }
 
     @Test
@@ -2093,13 +2093,13 @@ class PledgeFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.newCardButtonClicked()
         this.presentPaymentSheet.assertValue("")
         this.segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
-        this.pledgeButtonIsEnabled.assertValues(true, false, false)
-        this.loadingState.assertValues(State.LOADING, State.LOADING)
+        this.pledgeButtonIsEnabled.assertValues(true, false)
+        this.loadingState.assertValues(State.LOADING)
 
         // - PaymentSheet presented
         this.vm.inputs.paymentSheetPresented(true)
-        this.pledgeButtonIsEnabled.assertValues(true, false, false, true)
-        this.loadingState.assertValues(State.LOADING, State.LOADING, State.DEFAULT)
+        this.pledgeButtonIsEnabled.assertValues(true, false, true)
+        this.loadingState.assertValues(State.LOADING, State.DEFAULT)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- Duplicated network calls for: `this.apolloClient.getShippingRules(rewardId)` && `this.apolloClient.createSetupIntent()`, for the `getShippingRules` no unit tests changed required as some `dictinctUntilChanged()` was hiding the second emission, but for `createSetupIntent` unit test you will see how the number of emissions for the loading state and pledge button enabled have been reduced.

# 🤔 Why

- Performance improvements

# 🛠 How

- Both network request were hosted by Observables, having several subscriptions to that observable, executing the `switchMap` block as many times as subscriptions. Now both network requests are hosted on Subjects, able to multicast to other observables subscribed.

# 👀 See
No user facing changes, but you can double check with the Android studio Network Profiles, before when loading `PledgeFragment` or adding a new payment method on `PledgeFragment` you could see the request twice.

**BEFORE**
<img width="1696" alt="Screenshot 2023-07-07 at 3 10 49 PM" src="https://github.com/kickstarter/android-oss/assets/4083656/49813938-8f3d-4ab0-9ada-754429938f0c">
**NOW**
<img width="1688" alt="Screenshot 2023-07-07 at 2 53 18 PM" src="https://github.com/kickstarter/android-oss/assets/4083656/f18e6893-4f9b-40fa-ba57-f950690b3694">

|  |  |

