### PR TITLE
[NoTicket] Adjust usage and visuals of compose screen based on learnings

### DIFF
--- a/app/src/internal/java/com/kickstarter/ui/activities/DesignSystemActivity.kt
+++ b/app/src/internal/java/com/kickstarter/ui/activities/DesignSystemActivity.kt
@@ -59,9 +59,9 @@ import com.kickstarter.ui.compose.designsystem.KSSmallBlueButton
 import com.kickstarter.ui.compose.designsystem.KSSmallButtonFooter
 import com.kickstarter.ui.compose.designsystem.KSSmallRedButton
 import com.kickstarter.ui.compose.designsystem.KSSmallWhiteButton
-import com.kickstarter.ui.compose.designsystem.KSSnackbarError
-import com.kickstarter.ui.compose.designsystem.KSSnackbarHeadsUp
-import com.kickstarter.ui.compose.designsystem.KSSnackbarSuccess
+import com.kickstarter.ui.compose.designsystem.KSErrorRoundedText
+import com.kickstarter.ui.compose.designsystem.KSHeadsUpRoundedText
+import com.kickstarter.ui.compose.designsystem.KSSuccessRoundedText
 import com.kickstarter.ui.compose.designsystem.KSStepper
 import com.kickstarter.ui.compose.designsystem.KSStringDropdown
 import com.kickstarter.ui.compose.designsystem.KSSwitch
@@ -177,15 +177,15 @@ fun AlertsVisuals() {
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        KSSnackbarError(text = "This is some sort of error, better do something about it.  Or don't, im just a text box!")
+        KSErrorRoundedText(text = "This is some sort of error, better do something about it.  Or don't, im just a text box!")
 
         Spacer(Modifier.height(12.dp))
 
-        KSSnackbarHeadsUp(text = "Heads up, something is going on that needs your attention.  Maybe its important, maybe its informational.")
+        KSHeadsUpRoundedText(text = "Heads up, something is going on that needs your attention.  Maybe its important, maybe its informational.")
 
         Spacer(Modifier.height(12.dp))
 
-        KSSnackbarSuccess(text = "Hey, something went right and all is good!")
+        KSSuccessRoundedText(text = "Hey, something went right and all is good!")
 
         Spacer(Modifier.height(12.dp))
 

--- a/app/src/internal/java/com/kickstarter/ui/activities/DesignSystemActivity.kt
+++ b/app/src/internal/java/com/kickstarter/ui/activities/DesignSystemActivity.kt
@@ -41,10 +41,12 @@ import com.kickstarter.ui.compose.designsystem.KSAlertDialogNoHeadline
 import com.kickstarter.ui.compose.designsystem.KSCheckbox
 import com.kickstarter.ui.compose.designsystem.KSCircularProgressIndicator
 import com.kickstarter.ui.compose.designsystem.KSCoralBadge
+import com.kickstarter.ui.compose.designsystem.KSErrorRoundedText
 import com.kickstarter.ui.compose.designsystem.KSFacebookButton
 import com.kickstarter.ui.compose.designsystem.KSFullButtonFooter
 import com.kickstarter.ui.compose.designsystem.KSGooglePayButton
 import com.kickstarter.ui.compose.designsystem.KSGreenBadge
+import com.kickstarter.ui.compose.designsystem.KSHeadsUpRoundedText
 import com.kickstarter.ui.compose.designsystem.KSHiddenTextInput
 import com.kickstarter.ui.compose.designsystem.KSIntercept
 import com.kickstarter.ui.compose.designsystem.KSLinearProgressIndicator
@@ -59,11 +61,9 @@ import com.kickstarter.ui.compose.designsystem.KSSmallBlueButton
 import com.kickstarter.ui.compose.designsystem.KSSmallButtonFooter
 import com.kickstarter.ui.compose.designsystem.KSSmallRedButton
 import com.kickstarter.ui.compose.designsystem.KSSmallWhiteButton
-import com.kickstarter.ui.compose.designsystem.KSErrorRoundedText
-import com.kickstarter.ui.compose.designsystem.KSHeadsUpRoundedText
-import com.kickstarter.ui.compose.designsystem.KSSuccessRoundedText
 import com.kickstarter.ui.compose.designsystem.KSStepper
 import com.kickstarter.ui.compose.designsystem.KSStringDropdown
+import com.kickstarter.ui.compose.designsystem.KSSuccessRoundedText
 import com.kickstarter.ui.compose.designsystem.KSSwitch
 import com.kickstarter.ui.compose.designsystem.KSTextInput
 import com.kickstarter.ui.compose.designsystem.KSTheme

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,7 +51,8 @@
         <activity android:name=".ui.activities.CreatorBioActivity" />
         <activity
             android:name=".ui.activities.ChangePasswordActivity"
-            android:theme="@style/SettingsActivity" />
+            android:theme="@style/SettingsActivity"
+            android:windowSoftInputMode="adjustResize"/>
         <activity
             android:name=".ui.activities.CommentsActivity"
             android:theme="@style/WhiteActivity" />

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/ChangePasswordScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/ChangePasswordScreen.kt
@@ -70,17 +70,17 @@ fun ChangePasswordScreen(
 
     val acceptButtonEnabled = when {
         currentPassword.isNotEmptyAndAtLeast6Chars() &&
-                newPasswordLine1.isNotEmptyAndAtLeast6Chars() &&
-                newPasswordLine2.isNotEmptyAndAtLeast6Chars() &&
-                newPasswordLine1 == newPasswordLine2 -> true
+           newPasswordLine1.isNotEmptyAndAtLeast6Chars() &&
+           newPasswordLine2.isNotEmptyAndAtLeast6Chars() &&
+           newPasswordLine1 == newPasswordLine2 -> true
 
         else -> false
     }
 
     val warningText = when {
         newPasswordLine1.isNotEmptyAndAtLeast6Chars() &&
-                newPasswordLine2.isNotEmpty() &&
-                newPasswordLine2 != newPasswordLine1 -> {
+            newPasswordLine2.isNotEmpty() &&
+            newPasswordLine2 != newPasswordLine1 -> {
             stringResource(id = R.string.Passwords_matching_message)
         }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/ChangePasswordScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/ChangePasswordScreen.kt
@@ -10,25 +10,34 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Divider
 import androidx.compose.material.IconButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.ScaffoldState
+import androidx.compose.material.SnackbarHost
 import androidx.compose.material.Text
+import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kickstarter.R
 import com.kickstarter.libs.utils.extensions.isNotEmptyAndAtLeast6Chars
+import com.kickstarter.ui.compose.designsystem.KSErrorSnackbar
 import com.kickstarter.ui.compose.designsystem.KSHiddenTextInput
 import com.kickstarter.ui.compose.designsystem.KSLinearProgressIndicator
-import com.kickstarter.ui.compose.designsystem.KSSnackbarError
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.typography
@@ -43,7 +52,7 @@ fun ChangePasswordPreview() {
             onBackClicked = { },
             onAcceptButtonClicked = { _, _ -> },
             showProgressBar = false,
-            errorMessage = "This is an error"
+            scaffoldState = rememberScaffoldState()
         )
     }
 }
@@ -53,118 +62,159 @@ fun ChangePasswordScreen(
     onBackClicked: () -> Unit,
     onAcceptButtonClicked: (currentPass: String, newPass: String) -> Unit,
     showProgressBar: Boolean,
-    errorMessage: String = ""
+    scaffoldState: ScaffoldState
 ) {
-    Column(
-        Modifier
-            .background(colors.kds_support_100)
-            .fillMaxSize()
-    ) {
-        var currentPassword by remember { mutableStateOf("") }
-        var newPasswordLine1 by remember { mutableStateOf("") }
-        var newPasswordLine2 by remember { mutableStateOf("") }
+    var currentPassword by remember { mutableStateOf("") }
+    var newPasswordLine1 by remember { mutableStateOf("") }
+    var newPasswordLine2 by remember { mutableStateOf("") }
 
-        val acceptButtonEnabled = when {
-            currentPassword.isNotEmptyAndAtLeast6Chars() &&
+    val acceptButtonEnabled = when {
+        currentPassword.isNotEmptyAndAtLeast6Chars() &&
                 newPasswordLine1.isNotEmptyAndAtLeast6Chars() &&
                 newPasswordLine2.isNotEmptyAndAtLeast6Chars() &&
                 newPasswordLine1 == newPasswordLine2 -> true
 
-            else -> false
-        }
+        else -> false
+    }
 
-        val warningText = when {
-            newPasswordLine1.isNotEmptyAndAtLeast6Chars() &&
+    val warningText = when {
+        newPasswordLine1.isNotEmptyAndAtLeast6Chars() &&
                 newPasswordLine2.isNotEmpty() &&
                 newPasswordLine2 != newPasswordLine1 -> {
-                stringResource(id = R.string.Passwords_matching_message)
-            }
-
-            newPasswordLine1.isNotEmpty() && newPasswordLine1.length < 6 -> {
-                stringResource(id = R.string.Password_min_length_message)
-            }
-
-            else -> ""
+            stringResource(id = R.string.Passwords_matching_message)
         }
 
-        TopToolBar(
-            title = stringResource(id = R.string.Change_password),
-            titleColor = colors.kds_support_700,
-            leftOnClickAction = onBackClicked,
-            leftIconColor = colors.kds_support_700,
-            backgroundColor = colors.kds_white,
-            right = {
-                IconButton(
-                    onClick = { onAcceptButtonClicked.invoke(currentPassword, newPasswordLine1) },
-                    enabled = acceptButtonEnabled
-                ) {
-                    Image(
-                        painter = painterResource(id = R.drawable.icon__check),
-                        contentDescription = null,
-                        colorFilter = ColorFilter.tint(
-                            color =
-                            if (acceptButtonEnabled) colors.kds_create_700
-                            else colors.kds_support_300
+        newPasswordLine1.isNotEmpty() && newPasswordLine1.length < 6 -> {
+            stringResource(id = R.string.Password_min_length_message)
+        }
+
+        else -> ""
+    }
+
+    val focusManager = LocalFocusManager.current
+
+    Scaffold(
+        scaffoldState = scaffoldState,
+        topBar = {
+            TopToolBar(
+                title = stringResource(id = R.string.Change_password),
+                titleColor = colors.kds_support_700,
+                leftOnClickAction = onBackClicked,
+                leftIconColor = colors.kds_support_700,
+                backgroundColor = colors.kds_white,
+                right = {
+                    IconButton(
+                        onClick = {
+                            onAcceptButtonClicked.invoke(
+                                currentPassword,
+                                newPasswordLine1
+                            )
+                        },
+                        enabled = acceptButtonEnabled
+                    ) {
+                        Image(
+                            painter = painterResource(id = R.drawable.icon__check),
+                            contentDescription = null,
+                            colorFilter = ColorFilter.tint(
+                                color =
+                                if (acceptButtonEnabled) colors.kds_create_700
+                                else colors.kds_support_300
+                            )
                         )
-                    )
+                    }
                 }
-            }
-        )
-
-        AnimatedVisibility(visible = showProgressBar) {
-            KSLinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            )
+        },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = scaffoldState.snackbarHostState,
+                snackbar = { data ->
+                    KSErrorSnackbar(text = data.message)
+                }
+            )
         }
-
-        AnimatedVisibility(visible = errorMessage.isNotEmpty()) {
-            KSSnackbarError(text = errorMessage)
-        }
-
-        Text(
-            modifier = Modifier.padding(16.dp),
-            text = stringResource(
-                id = R.string.Well_ask_you_to_sign_back_into_the_Kickstarter_app_once_youve_changed_your_password
-            ),
-            style = typography.body2,
-            color = colors.kds_support_700
-        )
-
+    ) { padding ->
         Column(
             Modifier
-                .background(color = colors.kds_white)
-                .padding(16.dp)
-                .fillMaxWidth()
+                .background(colors.kds_support_100)
+                .fillMaxSize()
+                .padding(padding)
         ) {
+            AnimatedVisibility(visible = showProgressBar) {
+                KSLinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
 
-            KSHiddenTextInput(
-                modifier = Modifier.fillMaxWidth(),
-                onValueChanged = { currentPassword = it },
-                label = stringResource(id = R.string.Current_password)
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = stringResource(
+                    id = R.string.Well_ask_you_to_sign_back_into_the_Kickstarter_app_once_youve_changed_your_password
+                ),
+                style = typography.body2,
+                color = colors.kds_support_700
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Column(
+                Modifier
+                    .background(color = colors.kds_white)
+                    .padding(16.dp)
+                    .fillMaxWidth()
+            ) {
 
-            KSHiddenTextInput(
-                modifier = Modifier.fillMaxWidth(),
-                onValueChanged = { newPasswordLine1 = it },
-                label = stringResource(id = R.string.New_password)
-            )
+                KSHiddenTextInput(
+                    modifier = Modifier.fillMaxWidth(),
+                    onValueChanged = { currentPassword = it },
+                    label = stringResource(id = R.string.Current_password),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                    keyboardActions = KeyboardActions(
+                        onNext = {
+                            focusManager.moveFocus(
+                                focusDirection = FocusDirection.Down
+                            )
+                        }
+                    )
+                )
 
-            Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(16.dp))
 
-            KSHiddenTextInput(
-                modifier = Modifier.fillMaxWidth(),
-                onValueChanged = { newPasswordLine2 = it },
-                label = stringResource(id = R.string.Confirm_password)
-            )
+                KSHiddenTextInput(
+                    modifier = Modifier.fillMaxWidth(),
+                    onValueChanged = { newPasswordLine1 = it },
+                    label = stringResource(id = R.string.New_password),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                    keyboardActions = KeyboardActions(
+                        onNext = {
+                            focusManager.moveFocus(
+                                focusDirection = FocusDirection.Down
+                            )
+                        }
+                    )
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                KSHiddenTextInput(
+                    modifier = Modifier.fillMaxWidth(),
+                    onValueChanged = { newPasswordLine2 = it },
+                    label = stringResource(id = R.string.Confirm_password),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(
+                        onDone = {
+                            focusManager.clearFocus()
+                        }
+                    )
+                )
+            }
+
+            Divider(color = colors.kds_support_300)
+
+            AnimatedVisibility(visible = warningText.isNotEmpty()) {
+                Text(
+                    modifier = Modifier.padding(16.dp),
+                    text = warningText,
+                    style = typography.body2,
+                    color = colors.kds_support_700
+                )
+            }
         }
-
-        Divider(color = colors.kds_support_300)
-
-        Text(
-            modifier = Modifier.padding(16.dp),
-            text = warningText,
-            style = typography.body2,
-            color = colors.kds_support_700
-        )
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/ChangePasswordScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/ChangePasswordScreen.kt
@@ -70,9 +70,9 @@ fun ChangePasswordScreen(
 
     val acceptButtonEnabled = when {
         currentPassword.isNotEmptyAndAtLeast6Chars() &&
-           newPasswordLine1.isNotEmptyAndAtLeast6Chars() &&
-           newPasswordLine2.isNotEmptyAndAtLeast6Chars() &&
-           newPasswordLine1 == newPasswordLine2 -> true
+            newPasswordLine1.isNotEmptyAndAtLeast6Chars() &&
+            newPasswordLine2.isNotEmptyAndAtLeast6Chars() &&
+            newPasswordLine1 == newPasswordLine2 -> true
 
         else -> false
     }

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSAlerts.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSAlerts.kt
@@ -4,6 +4,7 @@ import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Snackbar
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -36,55 +38,95 @@ import com.kickstarter.ui.compose.designsystem.KSTheme.typography
 fun SnackbarsPreview() {
     KSTheme {
         Column() {
-            KSSnackbarError(text = "This is some sort of error, better do something about it.  Or don't, im just a text box!")
+            KSErrorRoundedText(text = "This is some sort of error, better do something about it.  Or don't, im just a text box!")
             Spacer(Modifier.height(12.dp))
-            KSSnackbarHeadsUp(text = "Heads up, something is going on that needs your attention.  Maybe its important, maybe its informational.")
+            KSHeadsUpRoundedText(text = "Heads up, something is going on that needs your attention.  Maybe its important, maybe its informational.")
             Spacer(Modifier.height(12.dp))
-            KSSnackbarSuccess(text = "Hey, something went right and all is good!")
+            KSSuccessRoundedText(text = "Hey, something went right and all is good!")
         }
     }
 }
 
 @Composable
-fun KSSnackbar(
+fun KSErrorSnackbar(
+    text: String,
+    padding: PaddingValues = PaddingValues(0.dp)
+) {
+    Snackbar(
+        backgroundColor = colors.kds_alert,
+        content = {
+            KSErrorRoundedText(text = text, padding = padding)
+        })
+}
+
+@Composable
+fun KSHeadsupSnackbar(
+    text: String,
+    padding: PaddingValues = PaddingValues(0.dp)
+) {
+    Snackbar(
+        backgroundColor = colors.kds_alert,
+        content = {
+            KSHeadsUpRoundedText(text = text, padding = padding)
+        })
+}
+
+@Composable
+fun KSSuccessSnackbar(
+    text: String,
+    padding: PaddingValues = PaddingValues(0.dp)
+) {
+    Snackbar(
+        backgroundColor = colors.kds_alert,
+        content = {
+            KSSuccessRoundedText(text = text, padding = padding)
+        })
+}
+
+@Composable
+fun KSRoundedPaddedText(
     background: Color,
     textColor: Color,
-    text: String
+    text: String,
+    padding: PaddingValues = PaddingValues(16.dp)
 ) {
     Text(
         modifier = Modifier
             .background(background, shape = shapes.small)
             .fillMaxWidth()
-            .padding(16.dp),
+            .padding(padding),
         text = text,
         color = textColor,
     )
 }
 
 @Composable
-fun KSSnackbarError(text: String) {
-    KSSnackbar(
+fun KSErrorRoundedText(text: String, padding: PaddingValues = PaddingValues(16.dp)) {
+    KSRoundedPaddedText(
         background = colors.kds_alert,
         textColor = colors.kds_white,
-        text = text
+        text = text,
+        padding = padding
     )
 }
 
 @Composable
-fun KSSnackbarHeadsUp(text: String) {
-    KSSnackbar(
+fun KSHeadsUpRoundedText(text: String, padding: PaddingValues = PaddingValues(16.dp)) {
+    KSRoundedPaddedText(
         background = colors.kds_support_700,
         textColor = colors.kds_white,
-        text = text
+        text = text,
+        padding = padding
     )
 }
 
 @Composable
-fun KSSnackbarSuccess(text: String) {
-    KSSnackbar(
+fun KSSuccessRoundedText(text: String, padding: PaddingValues = PaddingValues(16.dp)) {
+    KSRoundedPaddedText(
         background = colors.kds_create_300,
         textColor = colors.kds_support_700,
-        text = text
+        text = text,
+        padding = padding
     )
 }
 

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSAlerts.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSAlerts.kt
@@ -56,7 +56,8 @@ fun KSErrorSnackbar(
         backgroundColor = colors.kds_alert,
         content = {
             KSErrorRoundedText(text = text, padding = padding)
-        })
+        }
+    )
 }
 
 @Composable
@@ -68,7 +69,8 @@ fun KSHeadsupSnackbar(
         backgroundColor = colors.kds_alert,
         content = {
             KSHeadsUpRoundedText(text = text, padding = padding)
-        })
+        }
+    )
 }
 
 @Composable
@@ -80,7 +82,8 @@ fun KSSuccessSnackbar(
         backgroundColor = colors.kds_alert,
         content = {
             KSSuccessRoundedText(text = text, padding = padding)
-        })
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSTextInput.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSTextInput.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
@@ -77,7 +79,9 @@ fun KSTextInput(
     assistiveText: String? = null,
     showAssistiveText: Boolean = false,
     hideInput: Boolean = false,
-    trailingIcon: @Composable (() -> Unit)? = null
+    trailingIcon: @Composable (() -> Unit)? = null,
+    keyboardOptions: KeyboardOptions = KeyboardOptions(),
+    keyboardActions: KeyboardActions = KeyboardActions()
 ) {
     var value by remember { mutableStateOf("") }
 
@@ -108,7 +112,9 @@ fun KSTextInput(
             trailingIcon = trailingIcon,
             visualTransformation =
             if (hideInput) PasswordVisualTransformation()
-            else VisualTransformation.None
+            else VisualTransformation.None,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions
         )
 
         if (showAssistiveText) {
@@ -137,7 +143,9 @@ fun KSHiddenTextInput(
     offIconContentDescription: String = stringResource(id = R.string.Hide_password),
     onIconContentDescription: String = stringResource(id = R.string.Show_password),
     offIconTint: Color = colors.kds_create_700,
-    onIconTint: Color = colors.kds_support_400
+    onIconTint: Color = colors.kds_support_400,
+    keyboardOptions: KeyboardOptions = KeyboardOptions(),
+    keyboardActions: KeyboardActions = KeyboardActions()
 ) {
     var showHiddenText by remember { mutableStateOf(!hideTextByDefault) }
 
@@ -162,6 +170,8 @@ fun KSHiddenTextInput(
                     else onIconTint
                 )
             }
-        }
+        },
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions
     )
 }


### PR DESCRIPTION
# 📲 What

- Updated KS Alerts to have actual snackbars and name components accordingly
- Use scaffold for changepassword screen
- move topbar into scaffold
- use new snackbars for the snackbar message

# 🤔 Why

Had to do custom work to make current snackbar show at the top, but we will be moving forward with android standards where we can, so started with that here

# 🛠 How

- Added keyboard options to compose ks input texts
- created new snackbars for ks alerts
- updated logic on change password screen to use error as a state

# 👀 See

https://github.com/kickstarter/android-oss/assets/7563288/6277c9e8-26bf-48ba-8add-0849f531be07


# Story 📖

None/My Head/Slack convos
