### PR TITLE
MBL-798: SetPasswordViewModel.kt to Jetpack ViewModel and RxJava2.2

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/SetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SetPasswordActivity.kt
@@ -16,21 +16,22 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.android.schedulers.AndroidSchedulers
 
 class SetPasswordActivity : AppCompatActivity() {
+    private lateinit var viewModelFactory: SetPasswordViewModel.Factory
     private val viewModel: SetPasswordViewModel.SetPasswordViewModel by viewModels { viewModelFactory }
     private lateinit var binding: ActivitySetPasswordBinding
     private var errorTitleString = R.string.general_error_oops
-    private lateinit var viewModelFactory: SetPasswordViewModel.Factory
     private val disposables = CompositeDisposable()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
         this.getEnvironment()?.let { env ->
             viewModelFactory = SetPasswordViewModel.Factory(env)
         }
-        viewModel.configureWith(intent)
 
         binding = ActivitySetPasswordBinding.inflate(layoutInflater)
 
+        viewModel.configureWith(intent)
         setContentView(binding.root)
         setSupportActionBar(binding.resetPasswordToolbar.loginToolbar)
         binding.resetPasswordToolbar.loginToolbar.setTitle(getString(R.string.Set_your_password))
@@ -84,6 +85,11 @@ class SetPasswordActivity : AppCompatActivity() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { finish() }
                 .addToDisposable(disposables)
+    }
+
+    override fun onDestroy() {
+        disposables.clear()
+        super.onDestroy()
     }
 
     private fun setFormEnabled(isEnabled: Boolean) {

--- a/app/src/main/java/com/kickstarter/ui/activities/SetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SetPasswordActivity.kt
@@ -12,8 +12,8 @@ import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.ui.extensions.onChange
 import com.kickstarter.viewmodels.SetPasswordViewModel
-import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
 
 class SetPasswordActivity : AppCompatActivity() {
     private lateinit var viewModelFactory: SetPasswordViewModel.Factory
@@ -44,19 +44,19 @@ class SetPasswordActivity : AppCompatActivity() {
         }
 
         this.viewModel.outputs.progressBarIsVisible()
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe {
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
                 binding.progressBar.isGone = !it
             }.addToDisposable(disposables)
 
         this.viewModel.outputs.setUserEmail()
-                .observeOn(AndroidSchedulers.mainThread())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
                 binding.setPasswordHint.text = getEnvironment()?.ksString()?.format(getString(R.string.We_will_be_discontinuing_the_ability_to_log_in_via_FB), "email", it)
             }.addToDisposable(disposables)
 
         this.viewModel.outputs.passwordWarning()
-                .observeOn(AndroidSchedulers.mainThread())            .subscribe {
+            .observeOn(AndroidSchedulers.mainThread()).subscribe {
                 binding.warning.text = when {
                     it != null -> {
                         getString(it)
@@ -69,22 +69,22 @@ class SetPasswordActivity : AppCompatActivity() {
         this.viewModel.outputs.error()
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { ViewUtils.showDialog(this, getString(this.errorTitleString), it) }
-                .addToDisposable(disposables)
+            .addToDisposable(disposables)
 
         this.viewModel.outputs.isFormSubmitting()
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { this.setFormDisabled(it) }
-                .addToDisposable(disposables)
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe { this.setFormDisabled(it) }
+            .addToDisposable(disposables)
 
         this.viewModel.outputs.saveButtonIsEnabled()
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { this.setFormEnabled(it) }
-                .addToDisposable(disposables)
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe { this.setFormEnabled(it) }
+            .addToDisposable(disposables)
 
         this.viewModel.outputs.success()
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { finish() }
-                .addToDisposable(disposables)
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe { finish() }
+            .addToDisposable(disposables)
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/kickstarter/ui/activities/SetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SetPasswordActivity.kt
@@ -1,25 +1,34 @@
 package com.kickstarter.ui.activities
 
 import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import com.kickstarter.R
 import com.kickstarter.databinding.ActivitySetPasswordBinding
-import com.kickstarter.libs.BaseActivity
-import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
-import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ViewUtils
+import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.ui.extensions.onChange
 import com.kickstarter.viewmodels.SetPasswordViewModel
-import rx.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.android.schedulers.AndroidSchedulers
 
-@RequiresActivityViewModel(SetPasswordViewModel.ViewModel::class)
-class SetPasswordActivity : BaseActivity<SetPasswordViewModel.ViewModel>() {
+class SetPasswordActivity : AppCompatActivity() {
+    private val viewModel: SetPasswordViewModel.SetPasswordViewModel by viewModels { viewModelFactory }
     private lateinit var binding: ActivitySetPasswordBinding
     private var errorTitleString = R.string.general_error_oops
+    private lateinit var viewModelFactory: SetPasswordViewModel.Factory
+    private val disposables = CompositeDisposable()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        this.getEnvironment()?.let { env ->
+            viewModelFactory = SetPasswordViewModel.Factory(env)
+        }
+        viewModel.configureWith(intent)
+
         binding = ActivitySetPasswordBinding.inflate(layoutInflater)
 
         setContentView(binding.root)
@@ -34,23 +43,19 @@ class SetPasswordActivity : BaseActivity<SetPasswordViewModel.ViewModel>() {
         }
 
         this.viewModel.outputs.progressBarIsVisible()
-            .compose(bindToLifecycle())
-            .compose(Transformers.observeForUI())
-            .subscribe {
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe {
                 binding.progressBar.isGone = !it
-            }
+            }.addToDisposable(disposables)
 
         this.viewModel.outputs.setUserEmail()
-            .compose(bindToLifecycle())
-            .compose(Transformers.observeForUI())
+                .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
-                binding.setPasswordHint.text = this.environment().ksString()?.format(getString(R.string.We_will_be_discontinuing_the_ability_to_log_in_via_FB), "email", it)
-            }
+                binding.setPasswordHint.text = getEnvironment()?.ksString()?.format(getString(R.string.We_will_be_discontinuing_the_ability_to_log_in_via_FB), "email", it)
+            }.addToDisposable(disposables)
 
         this.viewModel.outputs.passwordWarning()
-            .compose(bindToLifecycle())
-            .compose(Transformers.observeForUI())
-            .subscribe {
+                .observeOn(AndroidSchedulers.mainThread())            .subscribe {
                 binding.warning.text = when {
                     it != null -> {
                         getString(it)
@@ -58,27 +63,27 @@ class SetPasswordActivity : BaseActivity<SetPasswordViewModel.ViewModel>() {
                     else -> null
                 }
                 binding.warning.isVisible = (it != null)
-            }
+            }.addToDisposable(disposables)
 
         this.viewModel.outputs.error()
-            .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { ViewUtils.showDialog(this, getString(this.errorTitleString), it) }
+                .addToDisposable(disposables)
 
         this.viewModel.outputs.isFormSubmitting()
-            .compose(bindToLifecycle())
-            .compose(Transformers.observeForUI())
-            .subscribe { this.setFormDisabled(it) }
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe { this.setFormDisabled(it) }
+                .addToDisposable(disposables)
 
         this.viewModel.outputs.saveButtonIsEnabled()
-            .compose(bindToLifecycle())
-            .compose(Transformers.observeForUI())
-            .subscribe { this.setFormEnabled(it) }
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe { this.setFormEnabled(it) }
+                .addToDisposable(disposables)
 
         this.viewModel.outputs.success()
-            .compose(bindToLifecycle())
-            .compose(Transformers.observeForUI())
-            .subscribe { finish() }
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe { finish() }
+                .addToDisposable(disposables)
     }
 
     private fun setFormEnabled(isEnabled: Boolean) {
@@ -87,9 +92,5 @@ class SetPasswordActivity : BaseActivity<SetPasswordViewModel.ViewModel>() {
 
     private fun setFormDisabled(isDisabled: Boolean) {
         setFormEnabled(!isDisabled)
-    }
-
-    override fun back() {
-        // Disable back action Gesture
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/SetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/SetPasswordViewModel.kt
@@ -81,12 +81,8 @@ interface SetPasswordViewModel {
         private val loginUserCase = LoginUseCase(environment)
         init {
             intent
-                .filter { it.hasExtra(IntentKey.EMAIL) }
-                .map {
-                    it.getStringExtra(IntentKey.EMAIL)
-                }
-                .filter { ObjectUtils.isNotNull(it) }
-                .map { requireNotNull(it) }
+                .filter { ObjectUtils.isNotNull(it.hasExtra(IntentKey.EMAIL)) }
+                .map { requireNotNull(it.getStringExtra(IntentKey.EMAIL)) }
                 .map { it.maskEmail() }
                 .subscribe {
                     this.setUserEmail.onNext(it)
@@ -98,10 +94,8 @@ interface SetPasswordViewModel {
             ) { new, confirm -> SetNewPassword(new, confirm) }
 
             setNewPassword
-                .map { it.warning() }
-                .filter { ObjectUtils.isNotNull(it) }
-                .map { requireNotNull(it) }
-                .filter { it != 0 }
+                .filter { ObjectUtils.isNotNull(it.warning()) }
+                .map { requireNotNull(it.warning()) }
                 .distinctUntilChanged()
                 .subscribe { this.passwordWarning.onNext(it) }
                 .addToDisposable(disposables)
@@ -126,10 +120,9 @@ interface SetPasswordViewModel {
             val error = setNewPasswordNotification
                 .compose(Transformers.errorsV2())
                 .map { ErrorEnvelope.fromThrowable(it) }
-                .map { it.errorMessage() }
-                .filter { ObjectUtils.isNotNull(it) }
+                .filter { ObjectUtils.isNotNull(it.errorMessage()) }
                 .map {
-                    requireNotNull(it)
+                    requireNotNull(it.errorMessage())
                 }
 
             Observable.merge(apiError, error)
@@ -202,8 +195,8 @@ interface SetPasswordViewModel {
                     this.confirmPassword == this.newPassword
             }
 
-            fun warning(): Int =
-                newPassword.newPasswordValidationWarnings(confirmPassword) ?: 0
+            fun warning(): Int? =
+                newPassword.newPasswordValidationWarnings(confirmPassword)
         }
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/SetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/SetPasswordViewModel.kt
@@ -81,8 +81,12 @@ interface SetPasswordViewModel {
         private val loginUserCase = LoginUseCase(environment)
         init {
             intent
-                .filter { ObjectUtils.isNotNull(it.hasExtra(IntentKey.EMAIL)) }
-                .map { requireNotNull(it.getStringExtra(IntentKey.EMAIL)) }
+                .filter { it.hasExtra(IntentKey.EMAIL) }
+                .map {
+                    it.getStringExtra(IntentKey.EMAIL)
+                }
+                .filter { ObjectUtils.isNotNull(it) }
+                .map { requireNotNull(it) }
                 .map { it.maskEmail() }
                 .subscribe {
                     this.setUserEmail.onNext(it)

--- a/app/src/main/java/com/kickstarter/viewmodels/SetPasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/SetPasswordViewModel.kt
@@ -14,8 +14,8 @@ import com.kickstarter.libs.utils.extensions.newPasswordValidationWarnings
 import com.kickstarter.services.apiresponses.ErrorEnvelope
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.viewmodels.usecases.LoginUseCase
-import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 
@@ -106,7 +106,6 @@ interface SetPasswordViewModel {
                 .subscribe { this.passwordWarning.onNext(it) }
                 .addToDisposable(disposables)
 
-
             setNewPassword
                 .map { it.isValid() }
                 .distinctUntilChanged()
@@ -116,7 +115,6 @@ interface SetPasswordViewModel {
                 .compose(takeWhenV2(this.changePasswordClicked))
                 .switchMap { cp -> submit(cp).materialize() }
                 .share()
-
 
             val apiError = setNewPasswordNotification
                 .compose(Transformers.errorsV2())
@@ -134,7 +132,6 @@ interface SetPasswordViewModel {
                     requireNotNull(it)
                 }
 
-
             Observable.merge(apiError, error)
                 .distinctUntilChanged()
                 .subscribe { this.error.onNext(it) }
@@ -145,17 +142,17 @@ interface SetPasswordViewModel {
                 .filter { it.updateUserAccount()?.user()?.hasPassword() ?: false }
 
             this.currentUserV2.loggedInUser()
-                    .compose(Transformers.takePairWhenV2(userHasPassword))
-                    .distinctUntilChanged()
-                    .subscribe {
-                        currentUserV2.accessToken?.let { accessToken ->
-                            loginUserCase.login(
-                                    it.first.toBuilder().needsPassword(false).build(),
-                                    accessToken
-                            )
-                        }
-                        this.success.onNext(it.second.updateUserAccount()?.user()?.email() ?: "")
-                    }.addToDisposable(disposables)
+                .compose(Transformers.takePairWhenV2(userHasPassword))
+                .distinctUntilChanged()
+                .subscribe {
+                    currentUserV2.accessToken?.let { accessToken ->
+                        loginUserCase.login(
+                            it.first.toBuilder().needsPassword(false).build(),
+                            accessToken
+                        )
+                    }
+                    this.success.onNext(it.second.updateUserAccount()?.user()?.email() ?: "")
+                }.addToDisposable(disposables)
         }
 
         override fun onCleared() {

--- a/app/src/test/java/com/kickstarter/viewmodels/SetPasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/SetPasswordViewModelTest.kt
@@ -18,7 +18,7 @@ import rx.observers.TestSubscriber
 
 class SetPasswordViewModelTest : KSRobolectricTestCase() {
 
-    private lateinit var vm: SetPasswordViewModel.ViewModel
+    private lateinit var vm: SetPasswordViewModel.SetPasswordViewModel
     private val error = TestSubscriber<String>()
     private val passwordWarning = TestSubscriber<Int>()
     private val progressBarIsVisible = TestSubscriber<Boolean>()
@@ -28,7 +28,7 @@ class SetPasswordViewModelTest : KSRobolectricTestCase() {
     private val setUserEmail = TestSubscriber<String>()
 
     private fun setUpEnvironment(environment: Environment) {
-        this.vm = SetPasswordViewModel.ViewModel(environment)
+        this.vm = SetPasswordViewModel.SetPasswordViewModel(environment)
 
         this.vm.outputs.error().subscribe(this.error)
         this.vm.outputs.passwordWarning().subscribe(this.passwordWarning)

--- a/app/src/test/java/com/kickstarter/viewmodels/SetPasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/SetPasswordViewModelTest.kt
@@ -13,15 +13,15 @@ import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClientV2
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.viewmodels.usecases.LoginUseCase
-import io.reactivex.disposables.CompositeDisposable
-import org.junit.Test
 import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subscribers.TestSubscriber
+import org.junit.Test
 
 class SetPasswordViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var vm: SetPasswordViewModel.SetPasswordViewModel
-    private val disposables : CompositeDisposable = CompositeDisposable()
+    private val disposables: CompositeDisposable = CompositeDisposable()
     private val error = TestSubscriber<String>()
     private val passwordWarning = TestSubscriber<Int>()
     private val progressBarIsVisible = TestSubscriber<Boolean>()
@@ -35,11 +35,11 @@ class SetPasswordViewModelTest : KSRobolectricTestCase() {
 
         this.vm.outputs.error().subscribe { this.error.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.passwordWarning().subscribe { this.passwordWarning.onNext(it) }.addToDisposable(disposables)
-        this.vm.outputs.progressBarIsVisible().subscribe{ this.progressBarIsVisible.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.progressBarIsVisible().subscribe { this.progressBarIsVisible.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.saveButtonIsEnabled().subscribe { this.saveButtonIsEnabled.onNext(it) }.addToDisposable(disposables)
-        this.vm.outputs.success().subscribe{this.success.onNext(it) }.addToDisposable(disposables)
-        this.vm.outputs.isFormSubmitting().subscribe{this.isFormSubmitting.onNext(it)}.addToDisposable(disposables)
-        this.vm.outputs.setUserEmail().subscribe{this.setUserEmail.onNext(it)}.addToDisposable(disposables)
+        this.vm.outputs.success().subscribe { this.success.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.isFormSubmitting().subscribe { this.isFormSubmitting.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.setUserEmail().subscribe { this.setUserEmail.onNext(it) }.addToDisposable(disposables)
     }
 
     @Test
@@ -103,7 +103,7 @@ class SetPasswordViewModelTest : KSRobolectricTestCase() {
         this.passwordWarning.assertValues(R.string.Password_min_length_message, R.string.Passwords_matching_message)
         this.passwordWarning.assertValueCount(2)
         this.vm.inputs.confirmPassword("password")
-        this.passwordWarning.assertValues( R.string.Password_min_length_message, R.string.Passwords_matching_message)
+        this.passwordWarning.assertValues(R.string.Password_min_length_message, R.string.Passwords_matching_message)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Migration to rxjava 2.2 and jetpacks viewmodel

# 🤔 Why

[Technical Details](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2350317579/ViewModel+Tech+Debt+Epic#Technical-details)

# 👀 See

No user facing changes

# 📋 QA

This feature is tricky to test - I had to manually set the `needsPassword` field in the User struct to `true`. I then had to make sure the feature flag for facebook login deprecation was on or the condition was commented out in the discovery view model. This is what made the set password screen appear after logging in.

On the actual set password screen: 
Make sure that the warning text changes if the passwords in each field do not match, or if the password in the first field is fewer than 6 characters. 

To test success or failure in setting the password, some work is required from the backend if you want to QA this

# Story 📖

[MBL-766: FrequentlyAskedQuestionsViewHolderViewModel.kt to Jetpack ViewModel and RxJava2.2](https://kickstarter.atlassian.net/browse/MBL-766)
