### PR TITLE
MBL-942: HTMLParser now accepts headers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -248,7 +248,7 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
     implementation 'net.danlew:android.joda:2.10.7'
-    implementation "org.jsoup:jsoup:1.14.3"
+    implementation "org.jsoup:jsoup:1.16.1"
 
     // Data Store (SharedPreferences like API)
     implementation "androidx.datastore:datastore-preferences:1.0.0"

--- a/app/src/internal/java/com/kickstarter/ui/activities/PlaygroundActivity.kt
+++ b/app/src/internal/java/com/kickstarter/ui/activities/PlaygroundActivity.kt
@@ -3,7 +3,6 @@ package com.kickstarter.ui.activities
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import android.text.method.LinkMovementMethod
 import android.util.Pair
 import android.view.View
 import androidx.annotation.RequiresApi
@@ -35,15 +34,18 @@ class PlaygroundActivity : BaseActivity<PlaygroundViewModel.ViewModel?>() {
         setContentView(view)
 
         // - Allow clickable spans
-        binding.text.linksClickable = true
-        binding.text.isClickable = true
-        binding.text.movementMethod = LinkMovementMethod.getInstance()
-
-        val headerSize = resources.getDimensionPixelSize(R.dimen.title_3)
-        val body = resources.getDimensionPixelSize(R.dimen.callout)
+//        binding.text.linksClickable = true
+//        binding.text.isClickable = true
+//        binding.text.movementMethod = LinkMovementMethod.getInstance()
 
         val url = "https://www.meneame.net/"
         val html = "<ul>\n" +
+            "   <li><h1>This is heading 1</h1></li>\n" +
+            "   <li><h2>This is heading 2</h2></li>\n" +
+            "   <li><h3>This is heading 3</h3></li>\n" +
+            "   <li><h4>This is heading 4</h4></li>\n" +
+            "   <li><h5>This is heading 5</h5></li>\n" +
+            "   <li><h6>This is heading 6</h6></li>\n" +
             "   <li>This</li>\n" +
             "   <li>This and more text <a href=\\\"http://record.pt\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\"><em><strong>lalalalalala</strong></em></a></li>\n" +
             "   <li>More text here <em><strong>lalalalalala</strong></em> and here </li>\n" +
@@ -56,10 +58,23 @@ class PlaygroundActivity : BaseActivity<PlaygroundViewModel.ViewModel?>() {
             "   <li>Hola <strong><em>que tal </em></strong> majete</li>\n" +
             "   <li><a href=$url target=\\\"_blank\\\" rel=\\\"noopener\\\"><em><strong>Meneane </strong></em></a><a href=$url target=\\\"_blank\\\" rel=\\\"noopener\\\">Another URL in this list</a> and some text</li>"
         "</ul>"
-        val listOfElements = HTMLParser().parse(html)
-        val element: TextViewElement = listOfElements.first() as TextViewElement
 
-        binding.text.text = element.getStyledComponents(body, headerSize, this)
+        val html2 = "<h1>This is heading 1</h1>\n" +
+            "<h2>This is heading 2</h2>\n" +
+            "<h3>This is heading 3</h3>\n" +
+            "<h4>This is heading 4</h4>\n" +
+            "<h5>This is heading 5</h5>\n" +
+            "<h6>This is heading 6</h6>"
+
+        val listOfElements = HTMLParser().parse(html2)
+        // val element: TextViewElement = listOfElements.first() as TextViewElement
+
+        binding.h1.text = (listOfElements[0] as TextViewElement).getStyledComponents(this)
+        binding.h2.text = (listOfElements[1] as TextViewElement).getStyledComponents(this)
+        binding.h3.text = (listOfElements[2] as TextViewElement).getStyledComponents(this)
+        binding.h4.text = (listOfElements[3] as TextViewElement).getStyledComponents(this)
+        binding.h5.text = (listOfElements[4] as TextViewElement).getStyledComponents(this)
+        binding.h6.text = (listOfElements[5] as TextViewElement).getStyledComponents(this)
 
         setStepper()
         setProjectActivityButtonClicks()

--- a/app/src/internal/java/com/kickstarter/ui/activities/PlaygroundActivity.kt
+++ b/app/src/internal/java/com/kickstarter/ui/activities/PlaygroundActivity.kt
@@ -33,32 +33,6 @@ class PlaygroundActivity : BaseActivity<PlaygroundViewModel.ViewModel?>() {
         view = binding.root
         setContentView(view)
 
-        // - Allow clickable spans
-//        binding.text.linksClickable = true
-//        binding.text.isClickable = true
-//        binding.text.movementMethod = LinkMovementMethod.getInstance()
-
-        val url = "https://www.meneame.net/"
-        val html = "<ul>\n" +
-            "   <li><h1>This is heading 1</h1></li>\n" +
-            "   <li><h2>This is heading 2</h2></li>\n" +
-            "   <li><h3>This is heading 3</h3></li>\n" +
-            "   <li><h4>This is heading 4</h4></li>\n" +
-            "   <li><h5>This is heading 5</h5></li>\n" +
-            "   <li><h6>This is heading 6</h6></li>\n" +
-            "   <li>This</li>\n" +
-            "   <li>This and more text <a href=\\\"http://record.pt\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\"><em><strong>lalalalalala</strong></em></a></li>\n" +
-            "   <li>More text here <em><strong>lalalalalala</strong></em> and here </li>\n" +
-            "   <li><strong>is</strong></li>\n" +
-            "   <li>is <strong>is</strong> is</li>\n" +
-            "   <li><em><strong>is</strong></em> with some <strong>text</strong> in the middle <em><strong>is</strong></em></li>\n" +
-            "   <li><em>a</em></li>\n" +
-            "   <li><a href=\\\"http://record.pt\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">link</a></li>\n" +
-            "   <li>text with <a href=\\\"http://record.pt\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">link</a></li>\n" +
-            "   <li>Hola <strong><em>que tal </em></strong> majete</li>\n" +
-            "   <li><a href=$url target=\\\"_blank\\\" rel=\\\"noopener\\\"><em><strong>Meneane </strong></em></a><a href=$url target=\\\"_blank\\\" rel=\\\"noopener\\\">Another URL in this list</a> and some text</li>"
-        "</ul>"
-
         val html2 = "<h1>This is heading 1</h1>\n" +
             "<h2>This is heading 2</h2>\n" +
             "<h3>This is heading 3</h3>\n" +
@@ -67,8 +41,9 @@ class PlaygroundActivity : BaseActivity<PlaygroundViewModel.ViewModel?>() {
             "<h6>This is heading 6</h6>"
 
         val listOfElements = HTMLParser().parse(html2)
-        // val element: TextViewElement = listOfElements.first() as TextViewElement
 
+
+        // - The parser detects 6 elements and applies the style to each one
         binding.h1.text = (listOfElements[0] as TextViewElement).getStyledComponents(this)
         binding.h2.text = (listOfElements[1] as TextViewElement).getStyledComponents(this)
         binding.h3.text = (listOfElements[2] as TextViewElement).getStyledComponents(this)

--- a/app/src/internal/java/com/kickstarter/ui/activities/PlaygroundActivity.kt
+++ b/app/src/internal/java/com/kickstarter/ui/activities/PlaygroundActivity.kt
@@ -42,7 +42,6 @@ class PlaygroundActivity : BaseActivity<PlaygroundViewModel.ViewModel?>() {
 
         val listOfElements = HTMLParser().parse(html2)
 
-
         // - The parser detects 6 elements and applies the style to each one
         binding.h1.text = (listOfElements[0] as TextViewElement).getStyledComponents(this)
         binding.h2.text = (listOfElements[1] as TextViewElement).getStyledComponents(this)

--- a/app/src/internal/res/layout/playground_layout.xml
+++ b/app/src/internal/res/layout/playground_layout.xml
@@ -49,16 +49,35 @@
         android:layout_height="match_parent"/>
 
     <TextView
-        android:id="@+id/text"
+        android:id="@+id/h1"
         app:layout_constraintTop_toBottomOf="@id/stepper"
-        android:text="testing"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 
     <TextView
-        android:id="@+id/text2"
-        app:layout_constraintTop_toBottomOf="@id/text"
-        android:text="testing"
+        android:id="@+id/h2"
+        app:layout_constraintTop_toBottomOf="@id/h1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+    <TextView
+        android:id="@+id/h3"
+        app:layout_constraintTop_toBottomOf="@id/h2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+    <TextView
+        android:id="@+id/h4"
+        app:layout_constraintTop_toBottomOf="@id/h3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+    <TextView
+        android:id="@+id/h5"
+        app:layout_constraintTop_toBottomOf="@id/h4"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+    <TextView
+        android:id="@+id/h6"
+        app:layout_constraintTop_toBottomOf="@id/h5"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
   </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/java/com/kickstarter/libs/htmlparser/ElementExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/ElementExt.kt
@@ -3,6 +3,7 @@ package com.kickstarter.libs.htmlparser
 import android.content.Context
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
+import com.kickstarter.R
 import com.kickstarter.libs.utils.ApplicationUtils
 import com.kickstarter.libs.utils.extensions.boldStyle
 import com.kickstarter.libs.utils.extensions.bulletStyle
@@ -197,8 +198,6 @@ fun TextNode.parseTextElement(element: Element): TextComponent {
 }
 
 fun TextViewElement.getStyledComponents(
-    bodySize: Int,
-    headerSize: Int,
     context: Context
 ): SpannableStringBuilder {
     val joinedSpanned = SpannableStringBuilder("")
@@ -212,6 +211,7 @@ fun TextViewElement.getStyledComponents(
         }
 
         val spannable = SpannableString(componentText)
+        val bodySize = context.resources.getDimensionPixelSize(R.dimen.callout)
         spannable.color()
         spannable.size(bodySize)
         textItem.styles.forEach { style ->
@@ -226,8 +226,34 @@ fun TextViewElement.getStyledComponents(
                 }
                 // - The bullet style will be applied only to the FIRST child of the LI element
                 TextComponent.TextStyleType.LIST -> spannable.bulletStyle()
-                TextComponent.TextStyleType.HEADER -> {
-                    spannable.size(headerSize)
+                TextComponent.TextStyleType.HEADER1 -> {
+                    val size = context.resources.getDimensionPixelSize(R.dimen.parser_h1)
+                    spannable.size(size)
+                    spannable.boldStyle()
+                }
+                TextComponent.TextStyleType.HEADER2 -> {
+                    val size = context.resources.getDimensionPixelSize(R.dimen.parser_h2)
+                    spannable.size(size)
+                    spannable.boldStyle()
+                }
+                TextComponent.TextStyleType.HEADER3 -> {
+                    val size = context.resources.getDimensionPixelSize(R.dimen.parser_h3)
+                    spannable.size(size)
+                    spannable.boldStyle()
+                }
+                TextComponent.TextStyleType.HEADER4 -> {
+                    val size = context.resources.getDimensionPixelSize(R.dimen.parser_h4)
+                    spannable.size(size)
+                    spannable.boldStyle()
+                }
+                TextComponent.TextStyleType.HEADER5 -> {
+                    val size = context.resources.getDimensionPixelSize(R.dimen.parser_h5)
+                    spannable.size(size)
+                    spannable.boldStyle()
+                }
+                TextComponent.TextStyleType.HEADER6 -> {
+                    val size = context.resources.getDimensionPixelSize(R.dimen.parser_h6)
+                    spannable.size(size)
                     spannable.boldStyle()
                 }
                 else -> {}

--- a/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLModels.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/HTMLModels.kt
@@ -22,10 +22,15 @@ data class TextComponent(
     val styles: List<TextStyleType>
 ) {
 
-    // - Direct body childs for text allows only TextBlockTypes
+    // - Direct body childs for text allows only TextBlockTypes. All header tags defined by w3school https://www.w3schools.com/tags/tag_hn.asp
     enum class TextBlockType(val tag: String?) {
         PARAGRAPH("p"),
         HEADER1("h1"),
+        HEADER2("h2"),
+        HEADER3("h3"),
+        HEADER4("h4"),
+        HEADER5("h5"),
+        HEADER6("h6"),
         LIST("ul");
 
         companion object {
@@ -42,7 +47,12 @@ data class TextComponent(
         LIST("li"),
         LIST_END("</li>"),
         LINK("a"),
-        HEADER("h1"),
+        HEADER1("h1"),
+        HEADER2("h2"),
+        HEADER3("h3"),
+        HEADER4("h4"),
+        HEADER5("h5"),
+        HEADER6("h6"),
         UNKNOWN(null);
 
         companion object {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/TextElementViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/TextElementViewHolder.kt
@@ -2,7 +2,6 @@ package com.kickstarter.ui.viewholders.projectcampaign
 
 import android.text.method.LinkMovementMethod
 import android.widget.TextView
-import com.kickstarter.R
 import com.kickstarter.databinding.ViewElementTextFromHtmlBinding
 import com.kickstarter.libs.htmlparser.TextViewElement
 import com.kickstarter.libs.htmlparser.getStyledComponents
@@ -19,10 +18,7 @@ class TextElementViewHolder(
         textView.isClickable = true
         textView.movementMethod = LinkMovementMethod.getInstance()
 
-        val headerSize = context().resources.getDimensionPixelSize(R.dimen.title_3)
-        val bodySize = context().resources.getDimensionPixelSize(R.dimen.callout)
-
-        textView.text = element.getStyledComponents(bodySize, headerSize, context())
+        textView.text = element.getStyledComponents(context = context())
     }
 
     override fun bindData(data: Any?) {

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -52,6 +52,12 @@
   <dimen name="title_reward">24sp</dimen>
   <dimen name="title_1">28sp</dimen>
   <dimen name="title_thank_you">36sp</dimen>
+  <dimen name="parser_h1">28sp</dimen>
+  <dimen name="parser_h2">26sp</dimen>
+  <dimen name="parser_h3">24sp</dimen>
+  <dimen name="parser_h4">22sp</dimen>
+  <dimen name="parser_h5">20sp</dimen>
+  <dimen name="parser_h6">18sp</dimen>
 
   <dimen name="caption_line_spacing_extra">2dp</dimen>
   <dimen name="body_line_spacing_extra">2dp</dimen>

--- a/app/src/test/java/com/kickstarter/libs/htmlparser/HTMLParserTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/htmlparser/HTMLParserTest.kt
@@ -209,7 +209,7 @@ class HTMLParserTest {
         val textElement: TextViewElement = listOfElements.last() as TextViewElement
         assert(textElement.components.size == 1)
         assert(textElement.components[0].text == "This is a headline")
-        assert(textElement.components[0].styles[0] == TextComponent.TextStyleType.HEADER)
+        assert(textElement.components[0].styles[0] == TextComponent.TextStyleType.HEADER1)
     }
 
     @Test
@@ -296,5 +296,52 @@ class HTMLParserTest {
 
         val audioElement: AudioViewElement = listOfElements.last() as AudioViewElement
         assertEquals(audioElement.sourceUrl, "")
+    }
+
+    @Test
+    fun parseHeaders() {
+        val html = "<h1>This is heading 1</h1>\n" +
+            "<h2>This is heading 2</h2>\n" +
+            "<h3>This is heading 3</h3>\n" +
+            "<h4>This is heading 4</h4>\n" +
+            "<h5>This is heading 5</h5>\n" +
+            "<h6>This is heading 6</h6>"
+
+        val listOfElements = HTMLParser().parse(html)
+        assert(listOfElements.size == 6)
+
+        listOfElements.map {
+            assert(it is TextViewElement)
+        }
+
+        val h1 = listOfElements[0] as TextViewElement
+        assert(h1.components.size == 1)
+        assert(h1.components[0].styles[0] == TextComponent.TextStyleType.HEADER1)
+        assert(h1.components[0].text == "This is heading 1")
+
+        val h2 = listOfElements[1] as TextViewElement
+        assert(h2.components.size == 1)
+        assert(h2.components[0].styles[0] == TextComponent.TextStyleType.HEADER2)
+        assert(h2.components[0].text == "This is heading 2")
+
+        val h3 = listOfElements[2] as TextViewElement
+        assert(h3.components.size == 1)
+        assert(h3.components[0].styles[0] == TextComponent.TextStyleType.HEADER3)
+        assert(h3.components[0].text == "This is heading 3")
+
+        val h4 = listOfElements[3] as TextViewElement
+        assert(h4.components.size == 1)
+        assert(h4.components[0].styles[0] == TextComponent.TextStyleType.HEADER4)
+        assert(h4.components[0].text == "This is heading 4")
+
+        val h5 = listOfElements[4] as TextViewElement
+        assert(h5.components.size == 1)
+        assert(h5.components[0].styles[0] == TextComponent.TextStyleType.HEADER5)
+        assert(h5.components[0].text == "This is heading 5")
+
+        val h6 = listOfElements[5] as TextViewElement
+        assert(h6.components.size == 1)
+        assert(h6.components[0].styles[0] == TextComponent.TextStyleType.HEADER6)
+        assert(h6.components[0].text == "This is heading 6")
     }
 }


### PR DESCRIPTION
# 📲 What

The HTMLParser was able to recognize only the `h1` html tag, now it supports h1 to h6 following [html headings guideline](https://www.w3schools.com/html/html_headings.asp)

# 🤔 Why
- The website has a new WYSIWYG editor (ckeditor) on the creator experience, it also has been added header anchors for the story campaign, requiring proper headings tag usage.

# 🛠 How

- Added tags to be recognized  on `TextBlockType`
- Added new styles to enum class `TextStyleType`
The parser will do it's work, and recognize the new added tags and will apply the new styles without further changes.

- [Took the change to upgrade `jsoup` dependency ](https://mvnrepository.com/artifact/org.jsoup/jsoup), the previous version had several vulnerabilities.

# 👀 See
- Added on the Playground activity a sample HTML displaying the styles as replacement for the UI tests, since we haven't been able to either migrate to compose or adapt the Screenshot test integration to the new M2 machines, no other quick way to test the UI styles.
- Search in staging the project `CKE Test project for Mobile` in that story campaign you can find an h3 with the text `header` and h4 with the text `subheader`


https://github.com/kickstarter/android-oss/assets/4083656/c03d4a57-5ddd-4726-be37-2ef8d5ec074c


| --- | --- |
|  |  |

# 📋 QA
- Search in staging the project `CKE Test project for Mobile` in that story campaign you can find an h3 with the text `header` and h4 with the text `subheader`
- Load some other project campaigns, H1 will now look slightly bigger that before, but should be all the user facing changes you should see.

# Story 📖

[MBL-942](https://kickstarter.atlassian.net/browse/MBL-942)


[MBL-942]: https://kickstarter.atlassian.net/browse/MBL-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ