### PR TITLE
MBL-921: Broadcast receiver needs flags for "Internal tools" screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,12 +51,12 @@ if (file('signing.gradle').exists()) {
 
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "com.kickstarter"
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdkVersion 34
         testApplicationId "com.kickstarter.internal.debug.test"
         testInstrumentationRunner "com.kickstarter.screenshoot.testing.KSScreenShotTestRunner"
 

--- a/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.kt
+++ b/app/src/internal/java/com/kickstarter/ui/activities/InternalToolsActivity.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.view.View
 import android.webkit.URLUtil
@@ -111,7 +112,13 @@ class InternalToolsActivity : BaseActivity<InternalToolsViewModel>() {
 
     override fun onResume() {
         super.onResume()
-        this.registerReceiver(resetDeviceIdReceiver, IntentFilter(ResetDeviceIdWorker.BROADCAST))
+        // Specifying the RECEIVER_NOT_EXPORTED flag is required by apps targeting android 34, however
+        // this flag parameter was added to registerReceiver in android 33 while our min SDK is 23
+        if (android.os.Build.VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+            this.registerReceiver(resetDeviceIdReceiver, IntentFilter(ResetDeviceIdWorker.BROADCAST), RECEIVER_NOT_EXPORTED)
+        } else {
+            this.registerReceiver(resetDeviceIdReceiver, IntentFilter(ResetDeviceIdWorker.BROADCAST))
+        }
     }
 
     override fun onPause() {


### PR DESCRIPTION
# 📲 What

As apart of android 14 updates, we need to add a broadcast receiver flag when registering any context registered receivers. 

# 🤔 Why

[More information here](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2446065708/Android+14+spike#Runtime-registered-broadcasts-receivers-must-specify-export-behavior )

# 🛠 How

Add broadcast receiver flag to internal tools activity when registering a receiver.
The flags parameter was added in Android 33, so we will call this function in devices above android 33. Anything below defaults to old behavior.

# 👀 See

no user facing changes

# 📋 QA

Run app on device with android 34, as well as anything below android 33. Navigate to internal tools, should be no crashes. 

# Story 📖

[MBL-921: Broadcast receiver needs flags for "Internal tools" screen](https://kickstarter.atlassian.net/browse/MBL-912)
