### PR TITLE
MBL-932: Connectivity status check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ base_job: &base_job
   executor:
     name: android/android-machine
     resource-class: xlarge
-    tag: 2023.07.1
+    tag: 2023.08.1 #https://circleci.com/developer/images/image/cimg/android
   working_directory: "~/project"
   environment:
     TERM: dumb

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,12 +51,11 @@ if (file('signing.gradle').exists()) {
 
 
 android {
-    compileSdkVersion 33
-
     defaultConfig {
+        compileSdk 34
         applicationId "com.kickstarter"
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdkVersion 34
         testApplicationId "com.kickstarter.internal.debug.test"
         testInstrumentationRunner "com.kickstarter.screenshoot.testing.KSScreenShotTestRunner"
 

--- a/app/src/main/java/com/kickstarter/libs/BaseActivity.java
+++ b/app/src/main/java/com/kickstarter/libs/BaseActivity.java
@@ -148,6 +148,7 @@ public abstract class BaseActivity<ViewModelType extends ActivityViewModel> exte
       this.viewModel.onPause();
     }
 
+    this.connectivityReceiver.unregister(this);
     this.unregisterReceiver(this.connectivityReceiver);
   }
 

--- a/app/src/main/java/com/kickstarter/services/ConnectivityReceiver.kt
+++ b/app/src/main/java/com/kickstarter/services/ConnectivityReceiver.kt
@@ -7,8 +7,6 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
-import com.kickstarter.BuildConfig
-import timber.log.Timber
 
 class ConnectivityReceiver : BroadcastReceiver() {
 
@@ -21,17 +19,11 @@ class ConnectivityReceiver : BroadcastReceiver() {
         override fun onAvailable(network: Network) { // when given network becomes available
             super.onAvailable(network)
             connectivityReceiverListener.onNetworkConnectionChanged(isConnected = true)
-            if (BuildConfig.DEBUG) {
-                Timber.d(" *************** $network has become Available")
-            }
         }
 
         override fun onLost(network: Network) { // when given network loses connectivity or is disconnected
             super.onLost(network)
             connectivityReceiverListener.onNetworkConnectionChanged(isConnected = false)
-            if (BuildConfig.DEBUG) {
-                Timber.d(" ************* $network has lost connection")
-            }
         }
     }
 
@@ -54,10 +46,6 @@ class ConnectivityReceiver : BroadcastReceiver() {
     }
 
     interface ConnectivityReceiverListener {
-        fun onNetworkConnectionChanged(isConnected: Boolean) {
-            if (BuildConfig.DEBUG) {
-                Timber.d("Network changed isConnected: $isConnected")
-            }
-        }
+        fun onNetworkConnectionChanged(isConnected: Boolean)
     }
 }

--- a/app/src/main/java/com/kickstarter/services/ConnectivityReceiver.kt
+++ b/app/src/main/java/com/kickstarter/services/ConnectivityReceiver.kt
@@ -4,6 +4,9 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
 import com.kickstarter.BuildConfig
 import timber.log.Timber
 
@@ -14,19 +17,47 @@ class ConnectivityReceiver : BroadcastReceiver() {
         lateinit var connectivityReceiverListener: ConnectivityReceiverListener
     }
 
-    override fun onReceive(context: Context, intent: Intent) {
-        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        val activeNetwork = cm.activeNetworkInfo
-        val isConnected = activeNetwork != null
+    private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) { // when given network becomes available
+            super.onAvailable(network)
+            connectivityReceiverListener.onNetworkConnectionChanged(isConnected = true)
+            if (BuildConfig.DEBUG) {
+                Timber.d(" *************** $network has become Available")
+            }
+        }
 
-        connectivityReceiverListener.onNetworkConnectionChanged(isConnected)
-
-        if (BuildConfig.DEBUG) {
-            Timber.d("$isConnected Network changed")
+        override fun onLost(network: Network) { // when given network loses connectivity or is disconnected
+            super.onLost(network)
+            connectivityReceiverListener.onNetworkConnectionChanged(isConnected = false)
+            if (BuildConfig.DEBUG) {
+                Timber.d(" ************* $network has lost connection")
+            }
         }
     }
 
+    override fun onReceive(context: Context, intent: Intent) {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+        // - Check capabilities for WIFI or cellular connection
+        val networkRequest = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+            .build()
+
+        cm.registerNetworkCallback(networkRequest, networkCallback)
+    }
+
+    fun unregister(context: Context) {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        cm.unregisterNetworkCallback(networkCallback)
+    }
+
     interface ConnectivityReceiverListener {
-        fun onNetworkConnectionChanged(isConnected: Boolean)
+        fun onNetworkConnectionChanged(isConnected: Boolean) {
+            if (BuildConfig.DEBUG) {
+                Timber.d("Network changed isConnected: $isConnected")
+            }
+        }
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -199,7 +199,3 @@ fun Activity.startPreLaunchProjectActivity(project: Project, previousScreen: Str
     startActivity(intent)
     TransitionUtils.transition(this, TransitionUtils.slideInFromRight())
 }
-
-fun Activity.listenNetworkChanges() {
-    val connectivityReceiver = ConnectivityReceiver()
-}

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -24,6 +24,7 @@ import com.kickstarter.libs.utils.extensions.getVideoActivityIntent
 import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
 import com.kickstarter.libs.utils.extensions.withData
 import com.kickstarter.models.Project
+import com.kickstarter.services.ConnectivityReceiver
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.LoginToutActivity
 import com.kickstarter.ui.data.PledgeData
@@ -197,4 +198,8 @@ fun Activity.startPreLaunchProjectActivity(project: Project, previousScreen: Str
     previousScreen?.let { intent.putExtra(IntentKey.PREVIOUS_SCREEN, it) }
     startActivity(intent)
     TransitionUtils.transition(this, TransitionUtils.slideInFromRight())
+}
+
+fun Activity.listenNetworkChanges() {
+    val connectivityReceiver = ConnectivityReceiver()
 }

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -24,7 +24,6 @@ import com.kickstarter.libs.utils.extensions.getVideoActivityIntent
 import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
 import com.kickstarter.libs.utils.extensions.withData
 import com.kickstarter.models.Project
-import com.kickstarter.services.ConnectivityReceiver
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.LoginToutActivity
 import com.kickstarter.ui.data.PledgeData

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath 'com.google.gms:google-services:4.3.15'
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
# 📲 What

- Upgraded connectivity status check
- Upgraded gradle version
- Upgraded CI image tag

# 🤔 Why

- `activeNetworkInfo` [was deprecated on API 29 ](https://developer.android.com/reference/android/net/NetworkInfo) substituted by [`registerNetworkCallback()`](https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback) 
- `compileSdkVersion` [is deprecated](https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/dsl/CommonExtension#compileSdkVersion(kotlin.Int)) substituted by `compileSdk`
- [CI image now includes API 34](https://circleci.com/developer/images/image/cimg/android)
![Screenshot 2023-08-22 at 11 29 44 AM](https://github.com/kickstarter/android-oss/assets/4083656/fd0573f4-4d46-46d0-a82e-5eacac0fd0d0)



# 👀 See

https://github.com/kickstarter/android-oss/assets/4083656/ff0e0695-d3c2-4132-b431-d8f8448ec631




|  |  |

# 📋 QA
- On `Discovery` or search or any of the activities still inheriting from `BaseActivity.java` when the connexion is lost (WIFI or Cellular) a message is displayed.


# Story 📖

[MBL-932](https://kickstarter.atlassian.net/browse/MBL-932)


[MBL-932]: https://kickstarter.atlassian.net/browse/MBL-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ