### PR TITLE
MBL-933: Facebook Login QA Fixes for release

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/CreatePasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CreatePasswordActivity.kt
@@ -46,8 +46,8 @@ class CreatePasswordActivity : AppCompatActivity() {
         this.logout = environment?.logout()
 
         this.viewModel.outputs.progressBarIsVisible()
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe {
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
                 binding.progressBar.isGone = !it
             }.addToDisposable(disposables)
 

--- a/app/src/main/java/com/kickstarter/ui/activities/CreatePasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CreatePasswordActivity.kt
@@ -46,7 +46,8 @@ class CreatePasswordActivity : AppCompatActivity() {
         this.logout = environment?.logout()
 
         this.viewModel.outputs.progressBarIsVisible()
-            .subscribe {
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe {
                 binding.progressBar.isGone = !it
             }.addToDisposable(disposables)
 

--- a/app/src/main/java/com/kickstarter/ui/activities/SetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SetPasswordActivity.kt
@@ -1,16 +1,19 @@
 package com.kickstarter.ui.activities
 
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import com.kickstarter.R
 import com.kickstarter.databinding.ActivitySetPasswordBinding
+import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.ui.extensions.onChange
+import com.kickstarter.ui.extensions.transition
 import com.kickstarter.viewmodels.SetPasswordViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
@@ -83,6 +86,12 @@ class SetPasswordActivity : AppCompatActivity() {
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { finish() }
             .addToDisposable(disposables)
+
+        onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                // do nothing
+            }
+        })
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/kickstarter/ui/activities/SetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SetPasswordActivity.kt
@@ -8,12 +8,10 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import com.kickstarter.R
 import com.kickstarter.databinding.ActivitySetPasswordBinding
-import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.ui.extensions.onChange
-import com.kickstarter.ui.extensions.transition
 import com.kickstarter.viewmodels.SetPasswordViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable


### PR DESCRIPTION
# 📲 What

- During QA, we discovered a crash on the create password screen after resetting the password
- Set password activity also allows user to back out of screen

# 🤔 Why

Migration to rxjava2 of login milestone required QA of setting a password for facebook kickstarter accounts

# 🛠 How

- Crash was happening due to a threading issue in the CreatePasswordActivity, added `.observeOn(AndroidSchedulers.mainThread())` to fix
- Override the backpress in the SetPasswordActivity to do nothing when a user hits the back button

# 📋 QA

- Testing is tricky, you have to have a kickstarter facebook account on prod. If you have one and have already set a password, you of the backend engineers has to remove your password in order to trigger these flows to happen. 
- to test the back press functionality, you can manually trigger the screen to popup when you login. 

[MBL-933](https://kickstarter.atlassian.net/browse/MBL-933)


[MBL-933]: https://kickstarter.atlassian.net/browse/MBL-933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ