### PR TITLE
MBL-950: Connectivity status check refactor

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/BaseActivity.java
+++ b/app/src/main/java/com/kickstarter/libs/BaseActivity.java
@@ -1,8 +1,6 @@
 package com.kickstarter.libs;
 
 import android.content.Intent;
-import android.content.IntentFilter;
-import android.net.ConnectivityManager;
 import android.os.Bundle;
 import android.util.Pair;
 
@@ -95,7 +93,7 @@ public abstract class BaseActivity<ViewModelType extends ActivityViewModel> exte
 
     this.viewModel.intent(getIntent());
 
-    super.getLifecycle().addObserver(connectivityReceiver);
+    super.getLifecycle().addObserver(this.connectivityReceiver);
   }
 
   /**

--- a/app/src/main/java/com/kickstarter/services/ConnectivityReceiver.kt
+++ b/app/src/main/java/com/kickstarter/services/ConnectivityReceiver.kt
@@ -14,7 +14,7 @@ import androidx.lifecycle.LifecycleOwner
 class ConnectivityReceiver(
     private val connectivityReceiverListener: ConnectivityReceiverListener,
     private val context: Context
-) : BroadcastReceiver(), DefaultLifecycleObserver{
+) : BroadcastReceiver(), DefaultLifecycleObserver {
     interface ConnectivityReceiverListener {
         fun onNetworkConnectionChanged(isConnected: Boolean)
     }
@@ -61,5 +61,4 @@ class ConnectivityReceiver(
         this.unregister(context)
         context.unregisterReceiver(this)
     }
-
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/AccountActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/AccountActivity.kt
@@ -15,6 +15,7 @@ import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.getPaymentMethodsIntent
+import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.viewmodels.AccountViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -70,6 +71,7 @@ class AccountActivity : AppCompatActivity() {
 
         setContentView(binding.root)
 
+        setUpConnectivityStatusCheck(lifecycle)
         this.ksString = requireNotNull(env?.ksString())
 
         setUpSpinner()

--- a/app/src/main/java/com/kickstarter/ui/activities/ChangeEmailActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ChangeEmailActivity.kt
@@ -15,6 +15,7 @@ import com.kickstarter.databinding.ActivityChangeEmailBinding
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.ui.extensions.onChange
+import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.viewmodels.ChangeEmailViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -44,6 +45,7 @@ class ChangeEmailActivity : AppCompatActivity() {
         setContentView(binding.root)
         setSupportActionBar(binding.changeEmailActivityToolbar.changeEmailToolbar)
 
+        setUpConnectivityStatusCheck(lifecycle)
         binding.newEmail.onChange { this.viewModel.inputs.email(it) }
         binding.currentPassword.onChange { this.viewModel.inputs.password(it) }
         binding.sendVerificationEmail.setOnClickListener { this.viewModel.inputs.sendVerificationEmail() }

--- a/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/LoginActivity.kt
@@ -21,6 +21,7 @@ import com.kickstarter.ui.data.LoginReason
 import com.kickstarter.ui.extensions.finishWithAnimation
 import com.kickstarter.ui.extensions.hideKeyboard
 import com.kickstarter.ui.extensions.onChange
+import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.ui.extensions.text
 import com.kickstarter.ui.views.ConfirmDialog
@@ -60,6 +61,7 @@ class LoginActivity : AppCompatActivity() {
 
         setContentView(binding.root)
 
+        setUpConnectivityStatusCheck(lifecycle)
         this.ksString = requireNotNull(env?.ksString())
         binding.loginToolbar.loginToolbar.setTitle(getString(this.loginString))
         binding.loginFormView.forgotYourPasswordTextView.text = ViewUtils.html(getString(this.forgotPasswordString))

--- a/app/src/main/java/com/kickstarter/ui/activities/PaymentMethodsSettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/PaymentMethodsSettingsActivity.kt
@@ -13,6 +13,7 @@ import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.getPaymentSheetConfiguration
 import com.kickstarter.models.StoredCard
 import com.kickstarter.ui.adapters.PaymentMethodsAdapter
+import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.ui.extensions.showErrorSnackBar
 import com.kickstarter.ui.extensions.showErrorToast
 import com.kickstarter.ui.extensions.showSnackbar
@@ -49,6 +50,7 @@ class PaymentMethodsSettingsActivity : AppCompatActivity() {
         binding = ActivitySettingsPaymentMethodsBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        setUpConnectivityStatusCheck(lifecycle)
         setUpRecyclerView()
 
         flowController = PaymentSheet.FlowController.create(

--- a/app/src/main/java/com/kickstarter/ui/activities/SearchActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SearchActivity.kt
@@ -20,8 +20,11 @@ import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.getPreLaunchProjectActivity
 import com.kickstarter.libs.utils.extensions.getProjectIntent
 import com.kickstarter.models.Project
+import com.kickstarter.services.ConnectivityReceiver
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.adapters.SearchAdapter
+import com.kickstarter.ui.extensions.getConnectivityCallback
+import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.ui.viewholders.KSViewHolder
 import com.kickstarter.viewmodels.SearchViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -36,6 +39,7 @@ class SearchActivity : AppCompatActivity(), SearchAdapter.Delegate {
     val viewModel: SearchViewModel.SearchViewModel by viewModels { viewModelFactory }
 
     private lateinit var disposables: CompositeDisposable
+    private lateinit var connectivityReceiver: ConnectivityReceiver
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -46,6 +50,9 @@ class SearchActivity : AppCompatActivity(), SearchAdapter.Delegate {
             viewModelFactory = SearchViewModel.Factory(env, intent = intent)
             env
         }
+
+        connectivityReceiver = ConnectivityReceiver(getConnectivityCallback(), this)
+        lifecycle.addObserver(connectivityReceiver)
 
         binding = SearchLayoutBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/java/com/kickstarter/ui/activities/SearchActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SearchActivity.kt
@@ -24,7 +24,6 @@ import com.kickstarter.services.ConnectivityReceiver
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.adapters.SearchAdapter
 import com.kickstarter.ui.extensions.getConnectivityCallback
-import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.ui.viewholders.KSViewHolder
 import com.kickstarter.viewmodels.SearchViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers

--- a/app/src/main/java/com/kickstarter/ui/activities/SearchActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SearchActivity.kt
@@ -20,10 +20,9 @@ import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.getPreLaunchProjectActivity
 import com.kickstarter.libs.utils.extensions.getProjectIntent
 import com.kickstarter.models.Project
-import com.kickstarter.services.ConnectivityReceiver
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.adapters.SearchAdapter
-import com.kickstarter.ui.extensions.getConnectivityCallback
+import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.ui.viewholders.KSViewHolder
 import com.kickstarter.viewmodels.SearchViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -38,7 +37,6 @@ class SearchActivity : AppCompatActivity(), SearchAdapter.Delegate {
     val viewModel: SearchViewModel.SearchViewModel by viewModels { viewModelFactory }
 
     private lateinit var disposables: CompositeDisposable
-    private lateinit var connectivityReceiver: ConnectivityReceiver
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -50,8 +48,7 @@ class SearchActivity : AppCompatActivity(), SearchAdapter.Delegate {
             env
         }
 
-        connectivityReceiver = ConnectivityReceiver(getConnectivityCallback(), this)
-        lifecycle.addObserver(connectivityReceiver)
+        setUpConnectivityStatusCheck(lifecycle)
 
         binding = SearchLayoutBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/java/com/kickstarter/ui/activities/SetPasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SetPasswordActivity.kt
@@ -12,6 +12,7 @@ import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.ui.extensions.onChange
+import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.viewmodels.SetPasswordViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
@@ -35,6 +36,8 @@ class SetPasswordActivity : AppCompatActivity() {
         viewModel.configureWith(intent)
         setContentView(binding.root)
         setSupportActionBar(binding.resetPasswordToolbar.loginToolbar)
+
+        setUpConnectivityStatusCheck(lifecycle)
         binding.resetPasswordToolbar.loginToolbar.setTitle(getString(R.string.Set_your_password))
         binding.resetPasswordToolbar.backButton.isGone = true
         binding.newPassword.onChange { this.viewModel.inputs.newPassword(it) }

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
@@ -18,6 +18,7 @@ import com.kickstarter.libs.utils.ApplicationUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
+import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.viewmodels.SettingsViewModel
 import com.squareup.picasso.Picasso
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -46,6 +47,7 @@ class SettingsActivity : AppCompatActivity() {
 
         setContentView(binding.root)
 
+        setUpConnectivityStatusCheck(lifecycle)
         if (BuildConfig.DEBUG) {
             binding.editProfileRow.visibility = View.VISIBLE
         }

--- a/app/src/main/java/com/kickstarter/ui/activities/SignupActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SignupActivity.kt
@@ -11,6 +11,7 @@ import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.ui.extensions.hideKeyboard
+import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.ui.views.LoginPopupMenu
 import com.kickstarter.viewmodels.SignupViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -31,6 +32,9 @@ class SignupActivity : AppCompatActivity() {
         }
         binding = SignupLayoutBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        setUpConnectivityStatusCheck(lifecycle)
+
         binding.loginToolbar.loginToolbar.title = getString(R.string.signup_button)
         viewModel.outputs.signupSuccess()
             .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/kickstarter/ui/activities/TwoFactorActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/TwoFactorActivity.kt
@@ -9,6 +9,7 @@ import com.kickstarter.databinding.TwoFactorLayoutBinding
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
+import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.viewmodels.TwoFactorViewModel
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -28,6 +29,7 @@ class TwoFactorActivity : AppCompatActivity() {
         binding = TwoFactorLayoutBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        setUpConnectivityStatusCheck(lifecycle)
         binding.loginToolbar.loginToolbar.setTitle(getString(R.string.two_factor_title))
 
         viewModel.outputs.tfaSuccess()

--- a/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/UpdateActivity.kt
@@ -23,6 +23,7 @@ import com.kickstarter.libs.utils.extensions.isProjectUri
 import com.kickstarter.models.Update
 import com.kickstarter.services.RequestHandler
 import com.kickstarter.ui.IntentKey
+import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.viewmodels.UpdateViewModel
 import io.reactivex.disposables.CompositeDisposable
 import okhttp3.Request
@@ -48,6 +49,9 @@ class UpdateActivity : AppCompatActivity() {
         binding = UpdateLayoutBinding.inflate(layoutInflater)
 
         setContentView(binding.root)
+
+        setUpConnectivityStatusCheck(lifecycle)
+
         ksString = requireNotNull(getEnvironment()?.ksString())
 
         binding.updateWebView.registerRequestHandlers(

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -9,6 +9,7 @@ import android.view.inputmethod.InputMethodManager
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.AnimRes
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import com.google.android.play.core.review.ReviewInfo
 import com.google.android.play.core.review.ReviewManagerFactory
 import com.kickstarter.R
@@ -72,14 +73,16 @@ fun Activity.showErrorSnackBar(anchor: View, message: String) {
     showSnackbarWithColor(anchor, message, backgroundColor, textColor)
 }
 
-fun Activity.getConnectivityCallback(): ConnectivityReceiver.ConnectivityReceiverListener {
-    return object : ConnectivityReceiver.ConnectivityReceiverListener {
+fun Activity.setUpConnectivityStatusCheck(lifecycle: Lifecycle) {
+    val callBack = object : ConnectivityReceiver.ConnectivityReceiverListener {
         override fun onNetworkConnectionChanged(isConnected: Boolean) {
             if (!isConnected) {
                 showSnackbar(findViewById(android.R.id.content), getString(R.string.Youre_offline))
             }
         }
     }
+    val connectivityReceiver = ConnectivityReceiver(callBack, this)
+    lifecycle.addObserver(connectivityReceiver)
 }
 
 fun Activity.showRatingDialogWidget() {

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -24,6 +24,7 @@ import com.kickstarter.libs.utils.extensions.getVideoActivityIntent
 import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
 import com.kickstarter.libs.utils.extensions.withData
 import com.kickstarter.models.Project
+import com.kickstarter.services.ConnectivityReceiver
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.LoginToutActivity
 import com.kickstarter.ui.data.PledgeData
@@ -69,6 +70,16 @@ fun Activity.showErrorSnackBar(anchor: View, message: String) {
     val backgroundColor = this.resources.getColor(R.color.kds_alert, this.theme)
     val textColor = this.resources.getColor(R.color.kds_white, this.theme)
     showSnackbarWithColor(anchor, message, backgroundColor, textColor)
+}
+
+fun Activity.getConnectivityCallback(): ConnectivityReceiver.ConnectivityReceiverListener {
+    return object : ConnectivityReceiver.ConnectivityReceiverListener {
+        override fun onNetworkConnectionChanged(isConnected: Boolean) {
+            if (!isConnected) {
+                showSnackbar(findViewById(android.R.id.content), getString(R.string.Youre_offline))
+            }
+        }
+    }
 }
 
 fun Activity.showRatingDialogWidget() {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.1.1'
         classpath 'com.google.gms:google-services:4.3.15'
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
# 📲 What

- Registering to the connectivity status check is now made using `lifecycle`. Moving functionalities away from `BaseActivity` inheritance hierarchy. 


# 👀 See
- Connectivity status check on `Activities` not inheriting from `BaseActivity`, as example on the video we have `SearchActivity` and `UpdatesActivity` displaying the lost connection message


https://github.com/kickstarter/android-oss/assets/4083656/f1185cdb-eaba-4559-98f4-1a4a7ee2e6d1



|  |  |

# 📋 QA

- Try loosing connection on any of the activities where `setUpConnectivityStatusCheck(lifecycle)` is called

# Story 📖

[MBL-950](https://kickstarter.atlassian.net/browse/MBL-950)


[MBL-950]: https://kickstarter.atlassian.net/browse/MBL-950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ