### PR TITLE
MBL-805: VideoPlayer Screen

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.kt
@@ -12,9 +12,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.google.android.exoplayer2.C
+import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.source.MediaSource
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
 import com.google.android.exoplayer2.source.hls.HlsMediaSource
@@ -37,7 +37,7 @@ import io.reactivex.disposables.CompositeDisposable
 
 class VideoActivity : AppCompatActivity() {
     private lateinit var build: Build
-    private var player: SimpleExoPlayer? = null
+    private var player: ExoPlayer? = null
     private var playerPosition: Long? = null
     private var trackSelector: DefaultTrackSelector? = null
     private lateinit var binding: VideoPlayerLayoutBinding
@@ -147,21 +147,19 @@ class VideoActivity : AppCompatActivity() {
     private fun preparePlayer(videoUrl: String) {
         val adaptiveTrackSelectionFactory: AdaptiveTrackSelection.Factory = AdaptiveTrackSelection.Factory()
         trackSelector = DefaultTrackSelector(this, adaptiveTrackSelectionFactory)
-//        player = ExoPlayerFactory.newSimpleInstance(this, trackSelector)
-        val player2 = trackSelector?.let {
-            SimpleExoPlayer.Builder(this).setTrackSelector(
-                it
-            )
+        trackSelector?.let {
+            ExoPlayer.Builder(this).setTrackSelector(it)
         }
-        val playerBuilder = SimpleExoPlayer.Builder(this)
+
+        val playerBuilder = ExoPlayer.Builder(this)
         trackSelector?.let { playerBuilder.setTrackSelector(it) }
         player = playerBuilder.build()
 
         binding.playerView.player = player
         player?.addListener(eventListener)
 
-        val playerIsResuming = (playerPosition != 0L)
-        player?.prepare(getMediaSource(videoUrl), playerIsResuming, false)
+        player?.setMediaSource(getMediaSource(videoUrl))
+        player?.prepare()
         playerPosition?.let {
             player?.seekTo(it)
         }
@@ -184,7 +182,7 @@ class VideoActivity : AppCompatActivity() {
         if (player != null) {
             playerPosition = player?.currentPosition
             player?.duration?.let {
-                // viewModel.inputs.onVideoCompleted(it, playerPosition ?: 0L)
+                viewModel.inputs.onVideoCompleted(it, playerPosition ?: 0L)
             }
             player?.removeListener(eventListener)
             player?.release()

--- a/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.kt
@@ -95,7 +95,7 @@ class VideoActivity : AppCompatActivity() {
 
     public override fun onDestroy() {
         super.onDestroy()
-        releasePlayer()
+        player = null
     }
 
     public override fun onPause() {

--- a/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/VideoActivity.kt
@@ -6,6 +6,11 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.widget.ImageView
+import androidx.activity.addCallback
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.Player
@@ -19,29 +24,45 @@ import com.google.android.exoplayer2.upstream.DefaultHttpDataSource
 import com.google.android.exoplayer2.util.Util
 import com.kickstarter.R
 import com.kickstarter.databinding.VideoPlayerLayoutBinding
-import com.kickstarter.libs.BaseActivity
 import com.kickstarter.libs.Build
-import com.kickstarter.libs.qualifiers.RequiresActivityViewModel
-import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.WebUtils.userAgent
+import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.ui.IntentKey
-import com.kickstarter.viewmodels.VideoViewModel
-import com.trello.rxlifecycle.ActivityEvent
+import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
+import com.kickstarter.viewmodels.VideoViewModel.Factory
+import com.kickstarter.viewmodels.VideoViewModel.VideoViewModel
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
 
-@RequiresActivityViewModel(VideoViewModel.ViewModel::class)
-class VideoActivity : BaseActivity<VideoViewModel.ViewModel>() {
+class VideoActivity : AppCompatActivity() {
     private lateinit var build: Build
     private var player: SimpleExoPlayer? = null
     private var playerPosition: Long? = null
     private var trackSelector: DefaultTrackSelector? = null
     private lateinit var binding: VideoPlayerLayoutBinding
 
+    private lateinit var viewModelFactory: Factory
+    private val viewModel: VideoViewModel by viewModels { viewModelFactory }
+
+    private var disposables = CompositeDisposable()
+
+    private val lifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onResume(owner: LifecycleOwner) {
+            viewModel.inputs.resume()
+        }
+    }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = VideoPlayerLayoutBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        build = requireNotNull(environment().build())
+        val environment = this.getEnvironment()?.let { env ->
+            viewModelFactory = Factory(env, intent = intent)
+            env
+        }
+
+        build = requireNotNull(environment?.build())
 
         val fullscreenButton: ImageView = binding.playerView.findViewById(R.id.exo_fullscreen_icon)
         fullscreenButton.setImageResource(R.drawable.ic_fullscreen_close)
@@ -51,17 +72,25 @@ class VideoActivity : BaseActivity<VideoViewModel.ViewModel>() {
         }
 
         viewModel.outputs.preparePlayerWithUrl()
-            .compose(Transformers.takeWhen(lifecycle().filter { other: ActivityEvent? -> ActivityEvent.RESUME.equals(other) }))
-            .compose(bindToLifecycle())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe { preparePlayer(it) }
+            .addToDisposable(disposables)
 
         viewModel.outputs.preparePlayerWithUrlAndPosition()
-            .compose(Transformers.takeWhen(lifecycle().filter { other: ActivityEvent? -> ActivityEvent.RESUME.equals(other) }))
-            .compose(bindToLifecycle())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
                 playerPosition = it.second
                 preparePlayer(it.first)
             }
+            .addToDisposable(disposables)
+
+        lifecycle.addObserver(lifecycleObserver)
+
+        this.onBackPressedDispatcher.addCallback {
+            back()
+        }
+
+        setUpConnectivityStatusCheck(lifecycle)
     }
 
     public override fun onDestroy() {
@@ -81,7 +110,7 @@ class VideoActivity : BaseActivity<VideoViewModel.ViewModel>() {
         }
     }
 
-    override fun back() {
+    private fun back() {
         val intent = Intent()
             .putExtra(IntentKey.VIDEO_SEEK_POSITION, player?.currentPosition)
         setResult(Activity.RESULT_OK, intent)
@@ -155,7 +184,7 @@ class VideoActivity : BaseActivity<VideoViewModel.ViewModel>() {
         if (player != null) {
             playerPosition = player?.currentPosition
             player?.duration?.let {
-                viewModel.inputs.onVideoCompleted(it, playerPosition ?: 0L)
+                // viewModel.inputs.onVideoCompleted(it, playerPosition ?: 0L)
             }
             player?.removeListener(eventListener)
             player?.release()

--- a/app/src/main/java/com/kickstarter/viewmodels/VideoViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/VideoViewModel.kt
@@ -1,13 +1,16 @@
 package com.kickstarter.viewmodels
 
-import com.kickstarter.libs.ActivityViewModel
+import android.content.Intent
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.models.Project
 import com.kickstarter.ui.IntentKey
-import com.kickstarter.ui.activities.VideoActivity
-import rx.Observable
-import rx.subjects.BehaviorSubject
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subjects.BehaviorSubject
 import java.util.concurrent.TimeUnit
 
 interface VideoViewModel {
@@ -20,18 +23,26 @@ interface VideoViewModel {
     interface Inputs {
         fun onVideoStarted(videoLength: Long, videoPosition: Long)
         fun onVideoCompleted(videoLength: Long, videoPosition: Long)
+        fun resume(): Observable<Boolean>
     }
 
-    class ViewModel(environment: Environment) : ActivityViewModel<VideoActivity>(environment), Inputs, Outputs {
+    class VideoViewModel(private val environment: Environment, private val intent: Intent? = null) : ViewModel(), Inputs, Outputs {
+
+        private val analyticEvents = requireNotNull(environment.analytics())
         private val preparePlayerWithUrl = BehaviorSubject.create<String>()
         private val preparePlayerWithUrlAndPosition = BehaviorSubject.create<Pair<String, Long>>()
         private val onVideoStarted = BehaviorSubject.create<Pair<Long, Long>>()
         private val onVideoCompleted = BehaviorSubject.create<Pair<Long, Long>>()
+
+        private val disposables = CompositeDisposable()
+
         @JvmField
         val outputs: Outputs = this
 
         @JvmField
         val inputs: Inputs = this
+
+        private fun intent() = intent?.let { Observable.just(it) } ?: Observable.empty()
 
         override fun preparePlayerWithUrl(): Observable<String> {
             return preparePlayerWithUrl
@@ -49,34 +60,33 @@ interface VideoViewModel {
             return onVideoCompleted.onNext(Pair(videoLength, videoPosition))
         }
 
+        override fun resume(): Observable<Boolean> = Observable.just(true)
+
         init {
+            val project = intent()
+                .filter { (it.getParcelableExtra(IntentKey.PROJECT) as? Project).isNotNull() }
+                .map { it.getParcelableExtra(IntentKey.PROJECT) as? Project }
 
             intent()
-                .map { Pair(it?.getStringExtra(IntentKey.VIDEO_URL_SOURCE), it?.getLongExtra(IntentKey.VIDEO_SEEK_POSITION, 0) ?: 0) }
-                .filter { it.first.isNotNull() }
+                .map { Pair(it?.getStringExtra(IntentKey.VIDEO_URL_SOURCE) ?: "", it?.getLongExtra(IntentKey.VIDEO_SEEK_POSITION, -1) ?: -1) }
                 .map { Pair(requireNotNull(it.first), it.second) }
                 .distinctUntilChanged()
                 .take(1)
-                .compose(bindToLifecycle())
-                .subscribe { preparePlayerWithUrlAndPosition.onNext(it) }
-
-            val project = intent()
-                .map { it.getParcelableExtra(IntentKey.PROJECT) as Project? }
-                .filter { it.isNotNull() }
-                .map { requireNotNull(it) }
-
-            project.map { it.video() }
-                .filter { it.isNotNull() }
-                .map { it?.hls() ?: it?.high() }
-                .distinctUntilChanged()
-                .take(1)
-                .compose(bindToLifecycle())
-                .subscribe { preparePlayerWithUrl.onNext(it) }
+                .withLatestFrom(this.resume()) { it, _ ->
+                    it
+                }
+                .subscribe {
+                    if (it.first.isNotEmpty() && it.second >= 0) {
+                        preparePlayerWithUrlAndPosition.onNext(it)
+                    } else {
+                        preparePlayerWithUrl.onNext(it.first)
+                    }
+                }
+                .addToDisposable(disposables)
 
             Observable.combineLatest(project, onVideoStarted) { p, u ->
                 Pair(p, u)
             }.distinctUntilChanged()
-                .compose(bindToLifecycle())
                 .subscribe {
                     this.analyticEvents.trackVideoStarted(
                         it.first,
@@ -84,11 +94,11 @@ interface VideoViewModel {
                         TimeUnit.MILLISECONDS.toSeconds(it.second.second)
                     )
                 }
+                .addToDisposable(disposables)
 
             Observable.combineLatest(project, onVideoCompleted) { p, u ->
                 Pair(p, u)
             }.distinctUntilChanged()
-                .compose(bindToLifecycle())
                 .subscribe {
                     this.analyticEvents.trackVideoCompleted(
                         it.first,
@@ -96,6 +106,18 @@ interface VideoViewModel {
                         TimeUnit.MILLISECONDS.toSeconds(it.second.second)
                     )
                 }
+                .addToDisposable(disposables)
+        }
+
+        override fun onCleared() {
+            disposables.clear()
+            super.onCleared()
+        }
+    }
+
+    class Factory(private val environment: Environment, private val intent: Intent? = null) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return VideoViewModel(environment, intent) as T
         }
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/VideoViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/VideoViewModel.kt
@@ -72,8 +72,8 @@ interface VideoViewModel {
                 .map { Pair(requireNotNull(it.first), it.second) }
                 .distinctUntilChanged()
                 .take(1)
-                .withLatestFrom(this.resume()) { it, _ ->
-                    it
+                .withLatestFrom(this.resume()) { p, _ ->
+                    p
                 }
                 .subscribe {
                     if (it.first.isNotEmpty() && it.second >= 0) {

--- a/app/src/test/java/com/kickstarter/viewmodels/VideoViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/VideoViewModelTest.kt
@@ -1,33 +1,25 @@
-package com.kickstarter.viewmodels;
+package com.kickstarter.viewmodels
 
-import android.content.Intent;
+import android.content.Intent
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.mock.factories.ProjectFactory.project
+import com.kickstarter.mock.factories.VideoFactory.hlsVideo
+import com.kickstarter.ui.IntentKey
+import org.junit.Test
+import rx.observers.TestSubscriber
 
-import com.kickstarter.KSRobolectricTestCase;
-import com.kickstarter.mock.factories.ProjectFactory;
-import com.kickstarter.mock.factories.VideoFactory;
-import com.kickstarter.models.Project;
-import com.kickstarter.ui.IntentKey;
+class VideoViewModelTest : KSRobolectricTestCase() {
+    @Test
+    fun testVideoViewModel_EmitsVideoUrl_WhenHls() {
+        val vm = VideoViewModel.ViewModel(environment())
+        val project = project().toBuilder().video(hlsVideo()).build()
+        val preparePlayerWithUrl = TestSubscriber<String?>()
+        vm.outputs.preparePlayerWithUrl().subscribe(preparePlayerWithUrl)
 
-import org.junit.Test;
-
-import rx.observers.TestSubscriber;
-
-public class VideoViewModelTest extends KSRobolectricTestCase {
-
-  @Test
-  public void testVideoViewModel_EmitsVideoUrl_WhenHls() {
-    final VideoViewModel.ViewModel vm = new VideoViewModel.ViewModel(environment());
-    final Project project = ProjectFactory.project().toBuilder().video(VideoFactory.hlsVideo()).build();
-
-    final TestSubscriber<String> preparePlayerWithUrl = new TestSubscriber<>();
-    vm.outputs.preparePlayerWithUrl().subscribe(preparePlayerWithUrl);
-
-    // Configure the view model with a project intent.
-    vm.intent(new Intent().putExtra(IntentKey.PROJECT, project));
-
-    preparePlayerWithUrl.assertValue(project.video().hls());
-  }
-/*
+        // Configure the view model with a project intent.
+        vm.intent(Intent().putExtra(IntentKey.PROJECT, project))
+        preparePlayerWithUrl.assertValue(project.video()!!.hls())
+    } /*
   @Test
   public void testVideoViewModel_EmitsVideoUrl_WhenNotHls() {
     final VideoViewModel.ViewModel vm = new VideoViewModel.ViewModel(environment());


### PR DESCRIPTION
# 📲 What

- Migration, take a look at the [engineering plan](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2350317579/ViewModel+Tech+Debt+Epic) if any doubt 
- Most of the integration with Exoplayer was using deprecated methods, integration upgraded.

# 👀 See

https://github.com/kickstarter/android-oss/assets/4083656/c4578a8f-651f-447a-9201-e21d1d99ca53


| --- | --- |
|  |  |

# 📋 QA
- Play a video, press fullScreen, the video should play keep player over the same time as when it was in reduce screen.
- Dismiss the fullScreen, player should keep playing at the same time when changed screens. 
- Complete the video, play again, touch the controllers ... 

# Story 📖

[MBL-805](https://kickstarter.atlassian.net/browse/MBL-805)


[MBL-805]: https://kickstarter.atlassian.net/browse/MBL-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ