### PR TITLE
[Bugfix] Fix crash (debug only) and prevent showing blank updates

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectUpdatesViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectUpdatesViewModel.kt
@@ -98,7 +98,11 @@ interface ProjectUpdatesViewModel {
                     .nextPage(nextPage)
                     .distinctUntilChanged(true)
                     .startOverWith(startOverWith)
-                    .envelopeToListOfData { it.updates }
+                    .envelopeToListOfData {
+                        it.updates?.filter { updates ->
+                            !updates.body().isNullOrEmpty()
+                        }
+                    }
                     .loadWithParams {
                         loadWithProjectUpdatesList(Observable.just(it.first), it.second)
                     }

--- a/app/src/main/java/com/kickstarter/viewmodels/UpdateCardViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/UpdateCardViewHolderViewModel.kt
@@ -6,6 +6,7 @@ import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.rx.transformers.Transformers.takeWhen
+import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.libs.utils.extensions.isNullOrZero
 import com.kickstarter.libs.utils.extensions.negate
 import com.kickstarter.libs.utils.extensions.userIsCreator
@@ -132,6 +133,7 @@ interface UpdateCardViewHolderViewModel {
 
             update
                 .map { it.publishedAt() }
+                .filter { it.isNotNull() }
                 .compose(bindToLifecycle())
                 .subscribe(this.publishDate)
 


### PR DESCRIPTION
# 📲 What

Occasionally the backend will send a blank update.  In debug mode this will crash the app.  To prevent that, filtering out a null field.

# 🤔 Why

Some weird behavior with updates on some projects

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Screenshot_20231023-144439](https://github.com/kickstarter/android-oss/assets/7563288/a9bcc56a-b4e5-479c-8a6a-e4240337bcad) | ![Screenshot_20231023-144505](https://github.com/kickstarter/android-oss/assets/7563288/257c4262-05a0-402a-b3ac-887ceb069d2b) |
