### PR TITLE
MBL-795: RewardsFragment Screen

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -608,8 +608,13 @@ class ProjectPageActivity :
 
     private fun setFragmentsState(expand: Boolean) {
         supportFragmentManager.fragments.map { fragment ->
-            if (fragment is BaseFragment<*>) {
-                fragment.setState(expand && fragment.isVisible)
+            when (fragment) {
+                is BaseFragment<*> -> {
+                    fragment.setState(expand && fragment.isVisible)
+                }
+                is RewardsFragment -> {
+                    fragment.setState(expand && fragment.isVisible)
+                }
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -5,17 +5,23 @@ import android.util.Pair
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isGone
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.kickstarter.R
 import com.kickstarter.databinding.FragmentRewardsBinding
 import com.kickstarter.libs.BaseFragment
 import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
 import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
+import com.kickstarter.libs.rx.transformers.Transformers.observeForUIV2
 import com.kickstarter.libs.utils.NumberUtils
 import com.kickstarter.libs.utils.RewardDecoration
 import com.kickstarter.libs.utils.ViewUtils
+import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.reduce
 import com.kickstarter.libs.utils.extensions.selectPledgeFragment
 import com.kickstarter.models.Reward
@@ -23,14 +29,25 @@ import com.kickstarter.ui.adapters.RewardsAdapter
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ProjectData
-import com.kickstarter.viewmodels.RewardsFragmentViewModel
+import com.kickstarter.viewmodels.BackingAddOnsFragmentViewModel
+import com.kickstarter.viewmodels.MessagesViewModel
+import com.kickstarter.viewmodels.RewardsFragmentViewModel.Factory
+import com.kickstarter.viewmodels.RewardsFragmentViewModel.RewardsFragmentViewModel
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
 
-@RequiresFragmentViewModel(RewardsFragmentViewModel.ViewModel::class)
-class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), RewardsAdapter.Delegate {
+class RewardsFragment : Fragment(), RewardsAdapter.Delegate {
 
     private var rewardsAdapter = RewardsAdapter(this)
     private lateinit var dialog: AlertDialog
     private var binding: FragmentRewardsBinding? = null
+
+    private lateinit var viewModelFactory: Factory
+    private val viewModel:  RewardsFragmentViewModel by viewModels {
+        viewModelFactory
+    }
+
+    private val disposables = CompositeDisposable()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
@@ -40,50 +57,59 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Rewa
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        this.context?.getEnvironment()?.let { env ->
+            viewModelFactory = Factory(env)
+        }
+
         setupRecyclerView()
         createDialog()
 
         this.viewModel.outputs.projectData()
-            .compose(bindToLifecycle())
-            .compose(observeForUI())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe { rewardsAdapter.populateRewards(it) }
+            .addToDisposable(disposables)
 
         this.viewModel.outputs.backedRewardPosition()
-            .compose(bindToLifecycle())
-            .compose(observeForUI())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe { scrollToReward(it) }
+            .addToDisposable(disposables)
 
         this.viewModel.outputs.showPledgeFragment()
-            .compose(bindToLifecycle())
-            .compose(observeForUI())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
                 dialog.dismiss()
                 showPledgeFragment(it.first, it.second)
             }
+            .addToDisposable(disposables)
 
         this.viewModel.outputs.showAddOnsFragment()
-            .compose(bindToLifecycle())
-            .compose(observeForUI())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
                 dialog.dismiss()
                 showAddonsFragment(it)
             }
+            .addToDisposable(disposables)
 
         this.viewModel.outputs.rewardsCount()
-            .compose(bindToLifecycle())
-            .compose(observeForUI())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe { setRewardsCount(it) }
+            .addToDisposable(disposables)
 
         this.viewModel.outputs.showAlert()
-            .compose(bindToLifecycle())
-            .compose(observeForUI())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
                 showAlert()
             }
+            .addToDisposable(disposables)
 
         context?.apply {
             binding?.rewardsCount?.isGone = ViewUtils.isLandscape(this)
         }
+
+//        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+//            this.viewModel.setState(state = false)
+//        }
     }
 
     private fun createDialog() {
@@ -126,7 +152,7 @@ class RewardsFragment : BaseFragment<RewardsFragmentViewModel.ViewModel>(), Rewa
     override fun onDetach() {
         super.onDetach()
         binding?.rewardsRecycler?.adapter = null
-        this.viewModel = null
+        disposables.clear()
     }
 
     override fun rewardClicked(reward: Reward) {

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -5,7 +5,6 @@ import android.util.Pair
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
@@ -13,10 +12,6 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.kickstarter.R
 import com.kickstarter.databinding.FragmentRewardsBinding
-import com.kickstarter.libs.BaseFragment
-import com.kickstarter.libs.qualifiers.RequiresFragmentViewModel
-import com.kickstarter.libs.rx.transformers.Transformers.observeForUI
-import com.kickstarter.libs.rx.transformers.Transformers.observeForUIV2
 import com.kickstarter.libs.utils.NumberUtils
 import com.kickstarter.libs.utils.RewardDecoration
 import com.kickstarter.libs.utils.ViewUtils
@@ -29,8 +24,6 @@ import com.kickstarter.ui.adapters.RewardsAdapter
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ProjectData
-import com.kickstarter.viewmodels.BackingAddOnsFragmentViewModel
-import com.kickstarter.viewmodels.MessagesViewModel
 import com.kickstarter.viewmodels.RewardsFragmentViewModel.Factory
 import com.kickstarter.viewmodels.RewardsFragmentViewModel.RewardsFragmentViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -43,7 +36,7 @@ class RewardsFragment : Fragment(), RewardsAdapter.Delegate {
     private var binding: FragmentRewardsBinding? = null
 
     private lateinit var viewModelFactory: Factory
-    private val viewModel:  RewardsFragmentViewModel by viewModels {
+    private val viewModel: RewardsFragmentViewModel by viewModels {
         viewModelFactory
     }
 
@@ -106,10 +99,11 @@ class RewardsFragment : Fragment(), RewardsAdapter.Delegate {
         context?.apply {
             binding?.rewardsCount?.isGone = ViewUtils.isLandscape(this)
         }
-
-//        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
-//            this.viewModel.setState(state = false)
-//        }
+    }
+    fun setState(state: Boolean?) {
+        state?.let {
+            viewModel.isExpanded(state)
+        }
     }
 
     private fun createDialog() {
@@ -150,9 +144,9 @@ class RewardsFragment : Fragment(), RewardsAdapter.Delegate {
     }
 
     override fun onDetach() {
+        disposables.clear()
         super.onDetach()
         binding?.rewardsRecycler?.adapter = null
-        disposables.clear()
     }
 
     override fun rewardClicked(reward: Reward) {

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
@@ -5,15 +5,17 @@ import android.util.Pair
 import androidx.annotation.NonNull
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
-import com.kickstarter.libs.MockCurrentUser
+import com.kickstarter.libs.MockCurrentUserV2
 import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.utils.EventName
+import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.mock.MockFeatureFlagClient
 import com.kickstarter.mock.factories.BackingFactory
 import com.kickstarter.mock.factories.ProjectDataFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.mock.services.MockApolloClientV2
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.ui.SharedPreferenceKey
@@ -21,14 +23,20 @@ import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeFlowContext
 import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ProjectData
+import com.kickstarter.viewmodels.RewardsFragmentViewModel.Factory
+import com.kickstarter.viewmodels.RewardsFragmentViewModel.RewardsFragmentViewModel
+import com.kickstarter.viewmodels.usecases.TPEventInputData
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subscribers.TestSubscriber
 import org.joda.time.DateTime
+import org.junit.After
 import org.junit.Test
 import org.mockito.Mockito
-import rx.observers.TestSubscriber
 
 class RewardsFragmentViewModelTest : KSRobolectricTestCase() {
 
-    private lateinit var vm: RewardsFragmentViewModel.ViewModel
+    private lateinit var vm: RewardsFragmentViewModel
     private val backedRewardPosition = TestSubscriber.create<Int>()
     private val projectData = TestSubscriber.create<ProjectData>()
     private val rewardsCount = TestSubscriber.create<Int>()
@@ -36,16 +44,21 @@ class RewardsFragmentViewModelTest : KSRobolectricTestCase() {
     private val showAddOnsFragment = TestSubscriber<Pair<PledgeData, PledgeReason>>()
     private val showAlert = TestSubscriber<Pair<PledgeData, PledgeReason>>()
 
+    private val disposables = CompositeDisposable()
     private fun setUpEnvironment(@NonNull environment: Environment) {
-        this.vm = RewardsFragmentViewModel.ViewModel(environment)
-        this.vm.outputs.backedRewardPosition().subscribe(this.backedRewardPosition)
-        this.vm.outputs.projectData().subscribe(this.projectData)
-        this.vm.outputs.rewardsCount().subscribe(this.rewardsCount)
-        this.vm.outputs.showPledgeFragment().subscribe(this.showPledgeFragment)
-        this.vm.outputs.showAddOnsFragment().subscribe(this.showAddOnsFragment)
-        this.vm.outputs.showAlert().subscribe(this.showAlert)
+        this.vm = Factory(environment).create(RewardsFragmentViewModel::class.java)
+        this.vm.outputs.backedRewardPosition().subscribe { this.backedRewardPosition.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.projectData().subscribe { this.projectData.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.rewardsCount().subscribe { this.rewardsCount.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.showPledgeFragment().subscribe { this.showPledgeFragment.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.showAddOnsFragment().subscribe { this.showAddOnsFragment.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.showAlert().subscribe { this.showAlert.onNext(it) }.addToDisposable(disposables)
     }
 
+    @After
+    fun cleanUp() {
+        disposables.clear()
+    }
     @Test
     fun init_whenViewModelInstantiated_shouldSendPagedViewedEventToClient() {
         val project = ProjectFactory.project()
@@ -73,7 +86,12 @@ class RewardsFragmentViewModelTest : KSRobolectricTestCase() {
             .toBuilder()
             .featureFlagClient(mockFeatureFlagClient)
             .sharedPreferences(sharedPreferences)
-            .currentUser(MockCurrentUser(UserFactory.user()))
+            .currentUserV2(MockCurrentUserV2(UserFactory.user()))
+            .apolloClientV2(object : MockApolloClientV2() {
+                override fun triggerThirdPartyEvent(eventInput: TPEventInputData): Observable<Pair<Boolean, String>> {
+                    return Observable.just(Pair(true, ""))
+                }
+            })
             .build()
 
         val project = ProjectFactory.project()
@@ -82,7 +100,8 @@ class RewardsFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(ProjectDataFactory.project(project))
 
         this.vm.isExpanded(true)
-        assertTrue(this.vm.onThirdPartyEventSent.value)
+
+        assertTrue(this.vm.onThirdPartyEventSent.value!!)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- Migration RXJava2 + ViewModel, take a look at the [engineering plan](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2350317579/ViewModel+Tech+Debt+Epic) if any doubt 

# 👀 See

https://github.com/kickstarter/android-oss/assets/4083656/101e41c6-7267-4087-923d-8f56a63581a8



| --- | --- |
|  |  |

# 📋 QA
- Browse several projects open the rewards carousel for addons, rewards, as backer, ... etc.
- Browse several finalized projects open the rewards carousel if no backer.
- Browse several finalized projects as backer, the manage pledge screen should appear.

# Story 📖

[MBL-795](https://kickstarter.atlassian.net/browse/MBL-795)


[MBL-795]: https://kickstarter.atlassian.net/browse/MBL-795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ