### PR TITLE
[MBL-1060] Add dark mode toggle in settings, make settings visible to non logged in users

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/SharedPreferenceKey.kt
+++ b/app/src/main/java/com/kickstarter/ui/SharedPreferenceKey.kt
@@ -12,4 +12,5 @@ object SharedPreferenceKey {
     const val FEATURE_FLAG = "feature_flags"
     const val HAS_SEEN_NOTIF_PERMISSIONS = "has_seen_notif_permissions"
     const val CONSENT_MANAGEMENT_PREFERENCE = "consent_management_preference"
+    const val APP_THEME = "app_theme"
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/ChangePasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ChangePasswordActivity.kt
@@ -16,6 +16,7 @@ import com.kickstarter.libs.utils.ApplicationUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.ui.IntentKey
+import com.kickstarter.ui.SharedPreferenceKey
 import com.kickstarter.ui.activities.compose.ChangePasswordScreen
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
 import com.kickstarter.ui.data.LoginReason
@@ -26,7 +27,7 @@ class ChangePasswordActivity : ComponentActivity() {
 
     private var logout: Logout? = null
     private lateinit var disposables: CompositeDisposable
-
+    private var theme = AppThemes.MATCH_SYSTEM.ordinal
     private lateinit var viewModelFactory: ChangePasswordViewModel.Factory
     private val viewModel: ChangePasswordViewModel.ChangePasswordViewModel by viewModels {
         viewModelFactory
@@ -41,6 +42,9 @@ class ChangePasswordActivity : ComponentActivity() {
             viewModelFactory = ChangePasswordViewModel.Factory(env)
 
             darkModeEnabled = env.featureFlagClient()?.getBoolean(FlagKey.ANDROID_DARK_MODE_ENABLED) ?: false
+            theme = env.sharedPreferences()
+                ?.getInt(SharedPreferenceKey.APP_THEME, AppThemes.MATCH_SYSTEM.ordinal)
+                ?: AppThemes.MATCH_SYSTEM.ordinal
         }
         setContent {
             var showProgressBar =
@@ -50,7 +54,17 @@ class ChangePasswordActivity : ComponentActivity() {
 
             var scaffoldState = rememberScaffoldState()
 
-            KickstarterApp(useDarkTheme = if (darkModeEnabled) isSystemInDarkTheme() else false) {
+            KickstarterApp(
+                useDarkTheme =
+                if (darkModeEnabled) {
+                    when (theme) {
+                        AppThemes.MATCH_SYSTEM.ordinal -> isSystemInDarkTheme()
+                        AppThemes.DARK.ordinal -> true
+                        AppThemes.LIGHT.ordinal -> false
+                        else -> false
+                    }
+                } else false
+            ) {
                 ChangePasswordScreen(
                     onBackClicked = { onBackPressedDispatcher.onBackPressed() },
                     onAcceptButtonClicked = { current, new ->

--- a/app/src/main/java/com/kickstarter/ui/activities/LoginToutActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/LoginToutActivity.kt
@@ -23,6 +23,7 @@ import com.kickstarter.libs.utils.extensions.getResetPasswordIntent
 import com.kickstarter.libs.utils.extensions.showAlertDialog
 import com.kickstarter.services.apiresponses.ErrorEnvelope.FacebookUser
 import com.kickstarter.ui.IntentKey
+import com.kickstarter.ui.SharedPreferenceKey
 import com.kickstarter.ui.activities.compose.login.LoginToutScreen
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
 import com.kickstarter.ui.data.ActivityResult.Companion.create
@@ -42,6 +43,8 @@ class LoginToutActivity : ComponentActivity() {
         viewModelFactory
     }
 
+    private var theme = AppThemes.MATCH_SYSTEM.ordinal
+
     private var environment: Environment? = null
 
     private val disposables = CompositeDisposable()
@@ -55,10 +58,23 @@ class LoginToutActivity : ComponentActivity() {
             this.ksString = requireNotNull(env.ksString())
             darkModeEnabled =
                 env.featureFlagClient()?.getBoolean(FlagKey.ANDROID_DARK_MODE_ENABLED) ?: false
+            theme = env.sharedPreferences()
+                ?.getInt(SharedPreferenceKey.APP_THEME, AppThemes.MATCH_SYSTEM.ordinal)
+                ?: AppThemes.MATCH_SYSTEM.ordinal
         }
 
         setContent {
-            KickstarterApp(useDarkTheme = if (darkModeEnabled) isSystemInDarkTheme() else false) {
+            KickstarterApp(
+                useDarkTheme =
+                if (darkModeEnabled) {
+                    when (theme) {
+                        AppThemes.MATCH_SYSTEM.ordinal -> isSystemInDarkTheme()
+                        AppThemes.DARK.ordinal -> true
+                        AppThemes.LIGHT.ordinal -> false
+                        else -> false
+                    }
+                } else false
+            ) {
                 LoginToutScreen(
                     onBackClicked = { onBackPressedDispatcher.onBackPressed() },
                     onFacebookButtonClicked = { facebookLoginClick() },

--- a/app/src/main/java/com/kickstarter/ui/activities/SearchActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SearchActivity.kt
@@ -29,6 +29,7 @@ import com.kickstarter.libs.utils.extensions.getProjectIntent
 import com.kickstarter.libs.utils.extensions.isTrimmedEmpty
 import com.kickstarter.models.Project
 import com.kickstarter.ui.IntentKey
+import com.kickstarter.ui.SharedPreferenceKey
 import com.kickstarter.ui.activities.compose.search.SearchScreen
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
 import com.kickstarter.viewmodels.SearchViewModel
@@ -42,6 +43,7 @@ class SearchActivity : ComponentActivity() {
 
     private var darkModeEnabled: Boolean = false
     private lateinit var disposables: CompositeDisposable
+    private var theme = AppThemes.MATCH_SYSTEM.ordinal
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -52,6 +54,9 @@ class SearchActivity : ComponentActivity() {
             viewModelFactory = SearchViewModel.Factory(env, intent = intent)
             darkModeEnabled =
                 env.featureFlagClient()?.getBoolean(FlagKey.ANDROID_DARK_MODE_ENABLED) ?: false
+            theme = env.sharedPreferences()
+                ?.getInt(SharedPreferenceKey.APP_THEME, AppThemes.MATCH_SYSTEM.ordinal)
+                ?: AppThemes.MATCH_SYSTEM.ordinal
             env
         }
 
@@ -76,7 +81,17 @@ class SearchActivity : ComponentActivity() {
                 }
             }
 
-            KickstarterApp(useDarkTheme = if (darkModeEnabled) isSystemInDarkTheme() else false) {
+            KickstarterApp(
+                useDarkTheme =
+                if (darkModeEnabled) {
+                    when (theme) {
+                        AppThemes.MATCH_SYSTEM.ordinal -> isSystemInDarkTheme()
+                        AppThemes.DARK.ordinal -> true
+                        AppThemes.LIGHT.ordinal -> false
+                        else -> false
+                    }
+                } else false
+            ) {
                 SearchScreen(
                     // GET RID OF ENVIRONMENT WHEN WE CAN
                     environment = env,

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
@@ -1,23 +1,29 @@
 package com.kickstarter.ui.activities
 
 import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.AppCompatSpinner
 import com.kickstarter.BuildConfig
 import com.kickstarter.R
 import com.kickstarter.databinding.SettingsLayoutBinding
 import com.kickstarter.libs.Build
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.Logout
+import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.transformations.CircleTransformation
 import com.kickstarter.libs.utils.ApplicationUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
+import com.kickstarter.ui.SharedPreferenceKey
 import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.viewmodels.SettingsViewModel
 import com.squareup.picasso.Picasso
@@ -31,6 +37,11 @@ class SettingsActivity : AppCompatActivity() {
     private var logoutConfirmationDialog: AlertDialog? = null
     private lateinit var binding: SettingsLayoutBinding
     private lateinit var disposables: CompositeDisposable
+    private lateinit var spinner: AppCompatSpinner
+    private var sharedPrefs: SharedPreferences? = null
+    private var darkModeEnabled = false
+
+    private lateinit var themeItems: Array<String>
 
     private lateinit var viewModelFactory: SettingsViewModel.Factory
     private val viewModel: SettingsViewModel.SettingsViewModel by viewModels {
@@ -39,13 +50,27 @@ class SettingsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        themeItems = arrayOf(
+            getString(R.string.match_system),
+            getString(R.string.light),
+            getString(R.string.dark)
+        )
         binding = SettingsLayoutBinding.inflate(layoutInflater)
         this.getEnvironment()?.let { env ->
             viewModelFactory = SettingsViewModel.Factory(env)
+            sharedPrefs = env.sharedPreferences()
+            darkModeEnabled =
+                env.featureFlagClient()?.getBoolean(FlagKey.ANDROID_DARK_MODE_ENABLED) ?: false
         }
         disposables = CompositeDisposable()
 
         setContentView(binding.root)
+
+        spinner = binding.appThemeSpinner
+        if (darkModeEnabled) {
+            binding.appThemeContainer.visibility = View.VISIBLE
+            setUpThemeSpinner()
+        }
 
         setUpConnectivityStatusCheck(lifecycle)
         if (BuildConfig.DEBUG) {
@@ -142,4 +167,29 @@ class SettingsActivity : AppCompatActivity() {
         disposables.clear()
         super.onDestroy()
     }
+
+    private fun setUpThemeSpinner() {
+        val adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, themeItems)
+        spinner.adapter = adapter
+
+        val currentSelection =
+            sharedPrefs?.getInt(SharedPreferenceKey.APP_THEME, AppThemes.MATCH_SYSTEM.ordinal)
+                ?: AppThemes.MATCH_SYSTEM.ordinal
+        spinner.setSelection(currentSelection)
+
+        spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(p0: AdapterView<*>?, p1: View?, p2: Int, p3: Long) {
+                sharedPrefs?.edit()?.putInt(SharedPreferenceKey.APP_THEME, p2)?.apply()
+            }
+
+            override fun onNothingSelected(p0: AdapterView<*>?) {
+            }
+        }
+    }
+}
+
+enum class AppThemes {
+    MATCH_SYSTEM,
+    LIGHT,
+    DARK
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatSpinner
+import androidx.core.view.isGone
 import com.kickstarter.BuildConfig
 import com.kickstarter.R
 import com.kickstarter.databinding.SettingsLayoutBinding
@@ -73,9 +74,6 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         setUpConnectivityStatusCheck(lifecycle)
-        if (BuildConfig.DEBUG) {
-            binding.editProfileRow.visibility = View.VISIBLE
-        }
 
         this.build = requireNotNull(getEnvironment()?.build())
         this.ksString = requireNotNull(getEnvironment()?.ksString())
@@ -114,6 +112,13 @@ class SettingsActivity : AppCompatActivity() {
             .compose(Transformers.observeForUIV2())
             .subscribe { binding.nameTextView.text = it }
             .addToDisposable(disposables)
+
+        this.viewModel.isUserPresent.subscribe { isPresent ->
+            binding.editProfileRow.isGone = !BuildConfig.DEBUG || !isPresent
+            binding.accountRow.isGone = !isPresent
+            binding.notificationAndNewsletterContainer.isGone = !isPresent
+            binding.logOutRow.isGone = !isPresent
+        }.addToDisposable(disposables)
 
         binding.accountRow.setOnClickListener {
             startActivity(Intent(this, AccountActivity::class.java))

--- a/app/src/main/java/com/kickstarter/ui/activities/TwoFactorActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/TwoFactorActivity.kt
@@ -17,6 +17,7 @@ import com.kickstarter.libs.Environment
 import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
+import com.kickstarter.ui.SharedPreferenceKey
 import com.kickstarter.ui.activities.compose.login.TwoFactorScreen
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
 import com.kickstarter.ui.extensions.startDisclaimerChromeTab
@@ -31,6 +32,7 @@ class TwoFactorActivity : AppCompatActivity() {
     private val disposables = CompositeDisposable()
     private var darkModeEnabled = false
     private var environment: Environment? = null
+    private var theme = AppThemes.MATCH_SYSTEM.ordinal
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -40,6 +42,9 @@ class TwoFactorActivity : AppCompatActivity() {
             viewModelFactory = TwoFactorViewModel.Factory(env, intent)
             darkModeEnabled =
                 env.featureFlagClient()?.getBoolean(FlagKey.ANDROID_DARK_MODE_ENABLED) ?: false
+            theme = env.sharedPreferences()
+                ?.getInt(SharedPreferenceKey.APP_THEME, AppThemes.MATCH_SYSTEM.ordinal)
+                ?: AppThemes.MATCH_SYSTEM.ordinal
         }
 
         setContent {
@@ -75,7 +80,17 @@ class TwoFactorActivity : AppCompatActivity() {
                 }
             }
 
-            KickstarterApp(useDarkTheme = if (darkModeEnabled) isSystemInDarkTheme() else false) {
+            KickstarterApp(
+                useDarkTheme =
+                if (darkModeEnabled) {
+                    when (theme) {
+                        AppThemes.MATCH_SYSTEM.ordinal -> isSystemInDarkTheme()
+                        AppThemes.DARK.ordinal -> true
+                        AppThemes.LIGHT.ordinal -> false
+                        else -> false
+                    }
+                } else false
+            ) {
                 TwoFactorScreen(
                     scaffoldState = scaffoldState,
                     onBackClicked = { onBackPressedDispatcher.onBackPressed() },

--- a/app/src/main/java/com/kickstarter/ui/viewholders/discoverydrawer/LoggedOutViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/discoverydrawer/LoggedOutViewHolder.kt
@@ -9,6 +9,7 @@ class LoggedOutViewHolder(private val binding: DiscoveryDrawerLoggedOutViewBindi
         fun loggedOutViewHolderInternalToolsClick(viewHolder: LoggedOutViewHolder)
         fun loggedOutViewHolderLoginToutClick(viewHolder: LoggedOutViewHolder)
         fun loggedOutViewHolderHelpClick(viewHolder: LoggedOutViewHolder)
+        fun loggedOutViewHolderSettingsClick(viewHolder: LoggedOutViewHolder)
     }
 
     @Throws(Exception::class)
@@ -28,6 +29,9 @@ class LoggedOutViewHolder(private val binding: DiscoveryDrawerLoggedOutViewBindi
         binding.loggedOutTextView.setOnClickListener {
             loginToutClick()
         }
+        binding.drawerSettings.setOnClickListener {
+            settingsClick()
+        }
     }
 
     private fun activityClick() {
@@ -44,5 +48,9 @@ class LoggedOutViewHolder(private val binding: DiscoveryDrawerLoggedOutViewBindi
 
     private fun loginToutClick() {
         delegate.loggedOutViewHolderLoginToutClick(this)
+    }
+
+    private fun settingsClick() {
+        delegate.loggedOutViewHolderSettingsClick(this)
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
@@ -139,7 +139,7 @@ interface DiscoveryViewModel {
         private val childFilterRowClick = PublishSubject.create<NavigationDrawerData.Section.Row?>()
         private val internalToolsClick = PublishSubject.create<Void?>()
         private val loggedOutLoginToutClick = PublishSubject.create<Void?>()
-        private val loggedOutSettingsClick = PublishSubject.create<Void?>()
+        private val loggedOutHelpClick = PublishSubject.create<Void?>()
         private val messagesClick = PublishSubject.create<Void?>()
         private val openDrawer = PublishSubject.create<Boolean>()
         private val pagerSetPrimaryPage = PublishSubject.create<Int>()
@@ -171,7 +171,7 @@ interface DiscoveryViewModel {
 
         init {
             showActivityFeed = activityFeedClick
-            showHelp = loggedOutSettingsClick
+            showHelp = loggedOutHelpClick
             showInternalTools = internalToolsClick
             showLoginTout = loggedOutLoginToutClick
             showMessages = messagesClick
@@ -375,7 +375,7 @@ interface DiscoveryViewModel {
                 topFilterRowClick.map { false },
                 internalToolsClick.map { false },
                 loggedOutLoginToutClick.map { false },
-                loggedOutSettingsClick.map { false },
+                loggedOutHelpClick.map { false },
                 activityFeedClick.map { false },
                 messagesClick.map { false },
                 profileClick.map { false },
@@ -411,7 +411,8 @@ interface DiscoveryViewModel {
         override fun loggedOutViewHolderActivityClick(viewHolder: LoggedOutViewHolder) { activityFeedClick.onNext(null) }
         override fun loggedOutViewHolderInternalToolsClick(viewHolder: LoggedOutViewHolder) { internalToolsClick.onNext(null) }
         override fun loggedOutViewHolderLoginToutClick(viewHolder: LoggedOutViewHolder) { loggedOutLoginToutClick.onNext(null) }
-        override fun loggedOutViewHolderHelpClick(viewHolder: LoggedOutViewHolder) { loggedOutSettingsClick.onNext(null) }
+        override fun loggedOutViewHolderHelpClick(viewHolder: LoggedOutViewHolder) { loggedOutHelpClick.onNext(null) }
+        override fun loggedOutViewHolderSettingsClick(viewHolder: LoggedOutViewHolder) { settingsClick.onNext(null) }
         override fun topFilterViewHolderRowClick(viewHolder: TopFilterViewHolder, row: NavigationDrawerData.Section.Row) {
             topFilterRowClick.onNext(row)
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/SettingsViewModel.kt
@@ -47,6 +47,8 @@ interface SettingsViewModel {
         private val showConfirmLogoutPrompt = BehaviorSubject.create<Boolean>()
         private val userOutput = BehaviorSubject.create<User>()
 
+        val isUserPresent = BehaviorSubject.create<Boolean>()
+
         private val avatarImageViewUrl: Observable<String>
         private val userNameTextViewText: Observable<String>
 
@@ -68,6 +70,9 @@ interface SettingsViewModel {
             this.currentUser.observable()
                 .take(1)
                 .subscribe { it.getValue()?.let { user -> this.userOutput.onNext(user) } }
+                .addToDisposable(disposables)
+
+            this.currentUser.observable().subscribe { isUserPresent.onNext(it.isPresent()) }
                 .addToDisposable(disposables)
 
             this.confirmLogoutClicked

--- a/app/src/main/res/layout/discovery_drawer_logged_out_view.xml
+++ b/app/src/main/res/layout/discovery_drawer_logged_out_view.xml
@@ -41,4 +41,12 @@
     android:text="@string/Help"
     app:drawableStartCompat="@drawable/ic_help" />
 
+  <TextView
+      android:id="@+id/drawer_settings"
+      style="@style/DrawerTextView"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="@string/profile_buttons_settings"
+      app:drawableStartCompat="@drawable/ic_settings" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/settings_layout.xml
+++ b/app/src/main/res/layout/settings_layout.xml
@@ -122,8 +122,12 @@
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:spinnerMode="dropdown"/>
-
       </LinearLayout>
+
+      <View
+          android:layout_width="match_parent"
+          android:layout_height="1dp"
+          android:background="@color/kds_support_300" />
 
       <LinearLayout
         style="@style/SettingsLinearRow"

--- a/app/src/main/res/layout/settings_layout.xml
+++ b/app/src/main/res/layout/settings_layout.xml
@@ -85,6 +85,7 @@
         style="@style/SettingsLinearRow">
 
         <LinearLayout
+          android:id="@+id/notification_and_newsletter_container"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:orientation="vertical">

--- a/app/src/main/res/layout/settings_layout.xml
+++ b/app/src/main/res/layout/settings_layout.xml
@@ -103,6 +103,29 @@
       </LinearLayout>
 
       <LinearLayout
+          android:id="@+id/app_theme_container"
+          android:orientation="horizontal"
+          style="@style/SettingsLinearRow"
+          android:layout_marginTop="@dimen/grid_3"
+          android:visibility="gone"
+          tools:visibility="visible">
+
+        <TextView
+            android:id="@+id/app_theme_text"
+            android:layout_width="0dp"
+            style="@style/SettingsSingleRow"
+            android:layout_weight="1"
+            android:text="@string/app_theme" />
+
+        <androidx.appcompat.widget.AppCompatSpinner
+            android:id="@+id/app_theme_spinner"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:spinnerMode="dropdown"/>
+
+      </LinearLayout>
+
+      <LinearLayout
         style="@style/SettingsLinearRow"
         android:layout_marginBottom="@dimen/grid_3"
         android:layout_marginTop="@dimen/grid_3">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,4 +81,8 @@
   <!-- Risks Mock String-->
   <string name="risk_description">"The largest risk comes from the creation/manufacturing of the pins at the pin factory. We are working with a vendor in China, who has lots of experience in projects for us. Still, there is a chance that something may go wrong during the manufacturing process and if that happens it could cause a delay in shipping. It can be common in the pin-making world that manus are delayed or make mistakes with an order. However, we don’t anticipate this being an issue, as our vendor has done many similar projects with us, but there is always a possibility. These items are handmade! If anything does happen, we will make sure to keep everyone informed and up to date regarding where we are in the process. The timeline for shipping is NOT solid due to these factors but we will keep all backers updated each step of the way. Also- Please be aware, there might be a delay due to the situation with the COVID-19 virus. This is causing delays all over the world as shipping gets limited, cities shutting down services and other issues arise. At this point, we do not think this will impact our project timeline. However, we cannot predict how things will go and our pin factory is located in China (they are all back at work now and we have gotten pins from them within the last month, so things appear to be going well now.) If this will affect our production, I will inform everyone through an update as soon as I know."</string>
 
+  <string name="app_theme">App Theme</string>
+  <string name="match_system">Match System</string>
+  <string name="light">Light</string>
+  <string name="dark">Dark</string>
 </resources>


### PR DESCRIPTION
# 📲 What

Add a shared prefs value for the selected app theme mode (match system[0], light[1], or dark[2])

# 🤔 Why

Users should have a way to set the app theme once we are ready to let them use dark mode (defaults to system)

# 🛠 How

Add a shared prefs value (default pulls to match system)

# 👀 See

![Screenshot_20231114-163732](https://github.com/kickstarter/android-oss/assets/7563288/75717d93-e1f2-4de7-9bbf-d7a1fdbfb4b6)
![Screenshot_20231114-163737](https://github.com/kickstarter/android-oss/assets/7563288/5d9b8aab-c114-466a-a431-6ae6aff73dd1)
![Screenshot_20231114-163728](https://github.com/kickstarter/android-oss/assets/7563288/fb76a02c-4af4-4d2f-9151-279aef7e0ada)


# 📋 QA

1) Log in
2) Go to settings
3) Change mode to desired choice
4) GO to search or login flow to check selection changed theme
5) Log out
6) Do it again

# Story 📖

[MBL-1060](https://kickstarter.atlassian.net/browse/MBL-1060)


[MBL-1060]: https://kickstarter.atlassian.net/browse/MBL-1060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ