### PR TITLE
MBL-750: CommentsScreen to RXJava2 + ViewModel

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -208,6 +208,38 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
                 .build()
         )
     }
+    override fun getComment(commentableId: String): io.reactivex.Observable<Comment> {
+        return io.reactivex.Observable.just(CommentFactory.comment())
+    }
+
+    override fun getProjectUpdateComments(
+        updateId: String,
+        cursor: String?,
+        limit: Int
+    ): io.reactivex.Observable<CommentEnvelope> {
+        return io.reactivex.Observable.just(
+            CommentEnvelope.builder()
+                .pageInfoEnvelope(
+                    PageInfoEnvelopeFactory.pageInfoEnvelope()
+                )
+                .comments(listOf(CommentFactory.comment()))
+                .commentableId(updateId)
+                .totalCount(1)
+                .build()
+        )
+    }
+
+    override fun getProjectComments(slug: String, cursor: String?, limit: Int): io.reactivex.Observable<CommentEnvelope> {
+        return io.reactivex.Observable.just(
+            CommentEnvelope.builder()
+                .pageInfoEnvelope(
+                    PageInfoEnvelopeFactory.pageInfoEnvelope()
+                )
+                .comments(listOf(CommentFactory.comment()))
+                .totalCount(1)
+                .build()
+        )
+    }
 }
 
 open class MockApolloClient : ApolloClientType {

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -195,7 +195,7 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
 
     override fun getProjectUpdates(
         slug: String,
-        cursor: String?,
+        cursor: String,
         limit: Int
     ): io.reactivex.Observable<UpdatesGraphQlEnvelope> {
         return io.reactivex.Observable.just(
@@ -214,7 +214,7 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
 
     override fun getProjectUpdateComments(
         updateId: String,
-        cursor: String?,
+        cursor: String,
         limit: Int
     ): io.reactivex.Observable<CommentEnvelope> {
         return io.reactivex.Observable.just(
@@ -229,7 +229,7 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
         )
     }
 
-    override fun getProjectComments(slug: String, cursor: String?, limit: Int): io.reactivex.Observable<CommentEnvelope> {
+    override fun getProjectComments(slug: String, cursor: String, limit: Int): io.reactivex.Observable<CommentEnvelope> {
         return io.reactivex.Observable.just(
             CommentEnvelope.builder()
                 .pageInfoEnvelope(

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -9,6 +9,7 @@ import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.models.Backing
 import com.kickstarter.models.Category
 import com.kickstarter.models.Checkout
+import com.kickstarter.models.Comment
 import com.kickstarter.models.CreatorDetails
 import com.kickstarter.models.Location
 import com.kickstarter.models.Project
@@ -17,6 +18,7 @@ import com.kickstarter.models.StoredCard
 import com.kickstarter.models.User
 import com.kickstarter.models.UserPrivacy
 import com.kickstarter.services.apiresponses.ShippingRulesEnvelope
+import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope
 import com.kickstarter.services.apiresponses.commentresponse.PageInfoEnvelope
 import com.kickstarter.services.apiresponses.updatesresponse.UpdatesGraphQlEnvelope
 import com.kickstarter.services.mutations.CreateBackingData
@@ -24,6 +26,7 @@ import com.kickstarter.services.mutations.SavePaymentMethodData
 import com.kickstarter.services.mutations.UpdateBackingData
 import com.kickstarter.services.transformers.backingTransformer
 import com.kickstarter.services.transformers.categoryTransformer
+import com.kickstarter.services.transformers.commentTransformer
 import com.kickstarter.services.transformers.complexRewardItemsTransformer
 import com.kickstarter.services.transformers.decodeRelayId
 import com.kickstarter.services.transformers.encodeRelayId
@@ -93,6 +96,17 @@ interface ApolloClientTypeV2 {
         cursor: String?,
         limit: Int = PAGE_SIZE
     ): Observable<UpdatesGraphQlEnvelope>
+    fun getComment(commentableId: String): Observable<Comment>
+    fun getProjectUpdateComments(
+        updateId: String,
+        cursor: String?,
+        limit: Int = PAGE_SIZE
+    ): Observable<CommentEnvelope>
+    fun getProjectComments(
+        slug: String,
+        cursor: String?,
+        limit: Int = PAGE_SIZE
+    ): Observable<CommentEnvelope>
 }
 private const val PAGE_SIZE = 25
 
@@ -1008,5 +1022,172 @@ class KSApolloClientV2(val service: ApolloClient) : ApolloClientTypeV2 {
             .hasPreviousPage(pageFr?.hasPreviousPage() ?: false)
             .startCursor(pageFr?.startCursor() ?: "")
             .build()
+    }
+
+    override fun getComment(commentableId: String): Observable<Comment> {
+        return Observable.defer {
+            val ps = PublishSubject.create<Comment>()
+            this.service.query(
+                GetCommentQuery.builder()
+                    .commentableId(commentableId)
+                    .build()
+            ).enqueue(object : ApolloCall.Callback<GetCommentQuery.Data>() {
+                override fun onFailure(e: ApolloException) {
+                    ps.onError(e)
+                }
+
+                override fun onResponse(response: Response<GetCommentQuery.Data>) {
+                    if (response.hasErrors()) {
+                        ps.onError(Exception(response.errors?.first()?.message))
+                    }
+                    else {
+                        response.data?.let { responseData ->
+                            Observable.just(mapGetCommentQueryResponseToComment(responseData))
+                                .subscribe {
+                                    ps.onNext(it)
+                                }
+                        }
+                    }
+                    ps.onComplete()
+                }
+            })
+            return@defer ps
+        }.subscribeOn(Schedulers.io())
+    }
+
+    private fun mapGetCommentQueryResponseToComment(responseData: GetCommentQuery.Data): Comment {
+        val commentFragment =
+            (responseData.commentable() as? GetCommentQuery.AsComment)?.fragments()?.comment()
+        return commentTransformer(commentFragment)
+    }
+
+    override fun getProjectUpdateComments(
+        updateId: String,
+        cursor: String?,
+        limit: Int
+    ): Observable<CommentEnvelope> {
+        return Observable.defer {
+            val ps = PublishSubject.create<CommentEnvelope>()
+
+            this.service.query(
+                GetProjectUpdateCommentsQuery.builder()
+                    .cursor(cursor)
+                    .id(updateId)
+                    .limit(limit)
+                    .build()
+            )
+                .enqueue(object : ApolloCall.Callback<GetProjectUpdateCommentsQuery.Data>() {
+                    override fun onFailure(e: ApolloException) {
+                        ps.onError(e)
+                    }
+
+                    override fun onResponse(response: Response<GetProjectUpdateCommentsQuery.Data>) {
+                        if (response.hasErrors()) {
+                            ps.onError(Exception(response.errors?.first()?.message))
+                        } else {
+                            response.data?.let { data ->
+                                Observable.just(data.post())
+                                    .filter { it?.fragments()?.freeformPost()?.comments() != null }
+                                    .map { post ->
+
+                                        val comments =
+                                            post?.fragments()?.freeformPost()?.comments()?.edges()
+                                                ?.map { edge ->
+                                                    commentTransformer(
+                                                        edge?.node()?.fragments()?.comment()
+                                                    ).toBuilder()
+                                                        .cursor(edge?.cursor())
+                                                        .build()
+                                                }
+
+                                        CommentEnvelope.builder()
+                                            .comments(comments)
+                                            .commentableId(post?.id())
+                                            .totalCount(
+                                                post?.fragments()?.freeformPost()?.comments()
+                                                    ?.totalCount() ?: 0
+                                            )
+                                            .pageInfoEnvelope(
+                                                createPageInfoObject(
+                                                    post?.fragments()?.freeformPost()?.comments()
+                                                        ?.pageInfo()?.fragments()?.pageInfo()
+                                                )
+                                            )
+                                            .build()
+                                    }
+                                    .filter { it.isNotNull() }
+                                    .subscribe {
+                                        ps.onNext(it)
+                                    }
+                            }
+                        }
+                        ps.onComplete()
+                    }
+                })
+            return@defer ps
+        }.subscribeOn(Schedulers.io())
+    }
+
+    override fun getProjectComments(
+        slug: String,
+        cursor: String?,
+        limit: Int
+    ): Observable<CommentEnvelope> {
+        return Observable.defer {
+            val ps = PublishSubject.create<CommentEnvelope>()
+
+            this.service.query(
+                GetProjectCommentsQuery.builder()
+                    .cursor(cursor)
+                    .slug(slug)
+                    .limit(limit)
+                    .build()
+            )
+                .enqueue(object : ApolloCall.Callback<GetProjectCommentsQuery.Data>() {
+                    override fun onFailure(e: ApolloException) {
+                        ps.onError(e)
+                    }
+
+                    override fun onResponse(response: Response<GetProjectCommentsQuery.Data>) {
+                        if (response.hasErrors()) {
+                            ps.onError(Exception(response.errors?.first()?.message))
+                        } else {
+
+                            response.data?.let { data ->
+                                Observable.just(data.project())
+                                    .filter { it?.comments() != null }
+                                    .map { project ->
+
+                                        val comments = project?.comments()?.edges()?.map { edge ->
+                                            commentTransformer(
+                                                edge?.node()?.fragments()?.comment()
+                                            ).toBuilder()
+                                                .cursor(edge?.cursor())
+                                                .build()
+                                        }
+
+                                        CommentEnvelope.builder()
+                                            .commentableId(project?.id())
+                                            .comments(comments)
+                                            .totalCount(project?.comments()?.totalCount() ?: 0)
+                                            .pageInfoEnvelope(
+                                                createPageInfoObject(
+                                                    project?.comments()?.pageInfo()?.fragments()
+                                                        ?.pageInfo()
+                                                )
+                                            )
+                                            .build()
+                                    }
+                                    .filter { it.isNotNull() }
+                                    .subscribe {
+                                        ps.onNext(it)
+                                    }
+                            }
+                        }
+                        ps.onComplete()
+                    }
+                })
+            return@defer ps
+        }.subscribeOn(Schedulers.io())
     }
 }

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -1039,8 +1039,7 @@ class KSApolloClientV2(val service: ApolloClient) : ApolloClientTypeV2 {
                 override fun onResponse(response: Response<GetCommentQuery.Data>) {
                     if (response.hasErrors()) {
                         ps.onError(Exception(response.errors?.first()?.message))
-                    }
-                    else {
+                    } else {
                         response.data?.let { responseData ->
                             Observable.just(mapGetCommentQueryResponseToComment(responseData))
                                 .subscribe {

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -93,18 +93,18 @@ interface ApolloClientTypeV2 {
 
     fun getProjectUpdates(
         slug: String,
-        cursor: String?,
+        cursor: String,
         limit: Int = PAGE_SIZE
     ): Observable<UpdatesGraphQlEnvelope>
     fun getComment(commentableId: String): Observable<Comment>
     fun getProjectUpdateComments(
         updateId: String,
-        cursor: String?,
+        cursor: String,
         limit: Int = PAGE_SIZE
     ): Observable<CommentEnvelope>
     fun getProjectComments(
         slug: String,
-        cursor: String?,
+        cursor: String,
         limit: Int = PAGE_SIZE
     ): Observable<CommentEnvelope>
 }
@@ -961,7 +961,7 @@ class KSApolloClientV2(val service: ApolloClient) : ApolloClientTypeV2 {
 
     override fun getProjectUpdates(
         slug: String,
-        cursor: String?,
+        cursor: String,
         limit: Int
     ): Observable<UpdatesGraphQlEnvelope> {
         return Observable.defer {
@@ -1062,7 +1062,7 @@ class KSApolloClientV2(val service: ApolloClient) : ApolloClientTypeV2 {
 
     override fun getProjectUpdateComments(
         updateId: String,
-        cursor: String?,
+        cursor: String,
         limit: Int
     ): Observable<CommentEnvelope> {
         return Observable.defer {
@@ -1070,7 +1070,7 @@ class KSApolloClientV2(val service: ApolloClient) : ApolloClientTypeV2 {
 
             this.service.query(
                 GetProjectUpdateCommentsQuery.builder()
-                    .cursor(cursor)
+                    .cursor(cursor.ifEmpty { null })
                     .id(updateId)
                     .limit(limit)
                     .build()
@@ -1129,15 +1129,14 @@ class KSApolloClientV2(val service: ApolloClient) : ApolloClientTypeV2 {
 
     override fun getProjectComments(
         slug: String,
-        cursor: String?,
+        cursor: String,
         limit: Int
     ): Observable<CommentEnvelope> {
         return Observable.defer {
             val ps = PublishSubject.create<CommentEnvelope>()
-
             this.service.query(
                 GetProjectCommentsQuery.builder()
-                    .cursor(cursor)
+                    .cursor(cursor.ifEmpty { null })
                     .slug(slug)
                     .limit(limit)
                     .build()

--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -219,7 +219,7 @@ class CommentsActivity :
         viewModel.outputs.isFetchingComments()
             .compose(Transformers.observeForUIV2())
             .subscribe {
-                binding.commentsLoadingIndicator.isVisible = it
+                binding.commentsSwipeRefreshLayout.isRefreshing = it
             }
             .addToDisposable(disposables)
 

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -1,15 +1,18 @@
 package com.kickstarter.viewmodels
 
+import android.content.Intent
 import android.util.Pair
-import androidx.annotation.NonNull
 import androidx.annotation.VisibleForTesting
-import com.kickstarter.libs.ActivityViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import com.kickstarter.libs.Either
 import com.kickstarter.libs.Environment
-import com.kickstarter.libs.loadmore.ApolloPaginate
+import com.kickstarter.libs.loadmore.ApolloPaginateV2
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
-import com.kickstarter.libs.rx.transformers.Transformers.takePairWhen
+import com.kickstarter.libs.rx.transformers.Transformers.takePairWhenV2
+import com.kickstarter.libs.utils.KsOptional
+import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.models.Comment
 import com.kickstarter.models.Project
 import com.kickstarter.models.Update
@@ -20,15 +23,15 @@ import com.kickstarter.models.extensions.updateCommentAfterSuccessfulPost
 import com.kickstarter.models.extensions.updateCommentFailedToPost
 import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope
 import com.kickstarter.ui.IntentKey
-import com.kickstarter.ui.activities.CommentsActivity
 import com.kickstarter.ui.data.CommentCardData
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.ui.views.CommentCardStatus
 import com.kickstarter.ui.views.CommentComposerStatus
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subjects.PublishSubject
 import org.joda.time.DateTime
-import rx.Observable
-import rx.subjects.BehaviorSubject
-import rx.subjects.PublishSubject
 
 interface CommentsViewModel {
 
@@ -49,7 +52,7 @@ interface CommentsViewModel {
     }
 
     interface Outputs {
-        fun closeCommentsPage(): Observable<Void>
+        fun closeCommentsPage(): Observable<Unit>
         fun currentUserAvatar(): Observable<String?>
         fun commentComposerStatus(): Observable<CommentComposerStatus>
         fun enableReplyButton(): Observable<Boolean>
@@ -57,7 +60,7 @@ interface CommentsViewModel {
         fun commentsList(): Observable<List<CommentCardData>>
         fun scrollToTop(): Observable<Boolean>
         fun setEmptyState(): Observable<Boolean>
-        fun showCommentGuideLinesLink(): Observable<Void>
+        fun showCommentGuideLinesLink(): Observable<Unit>
         fun initialLoadCommentsError(): Observable<Throwable>
         fun paginateCommentsError(): Observable<Throwable>
         fun pullToRefreshError(): Observable<Throwable>
@@ -74,29 +77,32 @@ interface CommentsViewModel {
         fun shouldShowInitialLoadErrorUI(): Observable<Boolean>
     }
 
-    class ViewModel(@NonNull val environment: Environment) : ActivityViewModel<CommentsActivity>(environment), Inputs, Outputs {
+    class CommentsViewModel(val environment: Environment, private val intent: Intent? = null) : ViewModel(), Inputs, Outputs {
 
-        private val apolloClient = requireNotNull(environment.apolloClient())
-        private val currentUserStream = requireNotNull(environment.currentUser())
+        private val apolloClient = requireNotNull(environment.apolloClientV2())
+        private val currentUserStream = requireNotNull(environment.currentUserV2())
+        private val analyticEvents = requireNotNull(environment.analytics())
+
         val inputs: Inputs = this
         val outputs: Outputs = this
-        private val backPressed = PublishSubject.create<Void>()
-        private val refresh = PublishSubject.create<Void>()
-        private val nextPage = PublishSubject.create<Void>()
-        private val onShowGuideLinesLinkClicked = PublishSubject.create<Void>()
+
+        private val backPressed = PublishSubject.create<Unit>()
+        private val refresh = PublishSubject.create<Unit>()
+        private val nextPage = PublishSubject.create<Unit>()
+        private val onShowGuideLinesLinkClicked = PublishSubject.create<Unit>()
         private val onReplyClicked = PublishSubject.create<Pair<Comment, Boolean>>()
         private val checkIfThereAnyPendingComments = PublishSubject.create<Boolean>()
         private val failedCommentCardToRefresh = PublishSubject.create<Pair<Comment, Int>>()
         private val showCanceledPledgeComment = PublishSubject.create<Comment>()
-        private val onResumeActivity = PublishSubject.create<Void>()
+        private val onResumeActivity = PublishSubject.create<Unit>()
 
-        private val closeCommentsPage = BehaviorSubject.create<Void>()
+        private val closeCommentsPage = BehaviorSubject.create<Unit>()
         private val currentUserAvatar = BehaviorSubject.create<String?>()
         private val commentComposerStatus = BehaviorSubject.create<CommentComposerStatus>()
         private val showCommentComposer = BehaviorSubject.create<Boolean>()
         private val commentsList = BehaviorSubject.create<List<CommentCardData>>()
         private val outputCommentList = BehaviorSubject.create<List<CommentCardData>>()
-        private val showGuideLinesLink = BehaviorSubject.create<Void>()
+        private val showGuideLinesLink = BehaviorSubject.create<Unit>()
         private val disableReplyButton = BehaviorSubject.create<Boolean>()
         private val scrollToTop = BehaviorSubject.create<Boolean>()
 
@@ -120,33 +126,34 @@ interface CommentsViewModel {
         private val isFetchingComments = BehaviorSubject.create<Boolean>()
         private lateinit var project: Project
 
-        private var currentUser: User? = null
-
         private var openedThreadActivityFromDeepLink = false
 
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         val newlyPostedCommentsList = mutableListOf<CommentCardData>()
+
+        private val disposables = CompositeDisposable()
+
+        private var currentUser: User? = null
+        private fun intent() = intent?.let { Observable.just(it) } ?: Observable.empty()
         init {
 
-            this.currentUserStream.observable()
-                .compose(bindToLifecycle())
-                .subscribe { this.currentUser = it }
-
             val loggedInUser = this.currentUserStream.loggedInUser()
-                .filter { u -> u != null }
-                .map { requireNotNull(it) }
+                .map {
+                    currentUser = it
+                    it
+                }
 
             loggedInUser
-                .compose(bindToLifecycle())
                 .subscribe {
                     currentUserAvatar.onNext(it.avatar().small())
                 }
+                .addToDisposable(disposables)
 
             loggedInUser
-                .compose(bindToLifecycle())
                 .subscribe {
                     showCommentComposer.onNext(true)
                 }
+                .addToDisposable(disposables)
 
             val projectOrUpdate = intent()
                 .map<Any?> {
@@ -165,7 +172,10 @@ interface CommentsViewModel {
             }.flatMap {
                 it?.either<Observable<Project?>>(
                     { value: Project? -> Observable.just(value) },
-                    { u: Update? -> apolloClient.getProject(u?.projectId().toString()).compose(Transformers.neverError()) }
+                    { u: Update? ->
+                        apolloClient.getProject(u?.projectId().toString())
+                            .compose(Transformers.neverErrorV2())
+                    }
                 )
             }.map {
                 requireNotNull(it)
@@ -176,12 +186,12 @@ interface CommentsViewModel {
 
             initialProject
                 .compose(combineLatestPair(currentUserStream.observable()))
-                .compose(bindToLifecycle())
                 .subscribe {
                     val composerStatus = getCommentComposerStatus(Pair(it.first, it.second))
                     showCommentComposer.onNext(composerStatus != CommentComposerStatus.GONE)
                     commentComposerStatus.onNext(composerStatus)
                 }
+                .addToDisposable(disposables)
 
             val projectOrUpdateComment = projectOrUpdate.map {
                 it as? Either<Project?, Update?>
@@ -192,10 +202,9 @@ interface CommentsViewModel {
 
             loadCommentListFromProjectOrUpdate(projectOrUpdateComment)
 
-            val deepLinkCommentableId =
-                intent().filter {
-                    it.getStringExtra(IntentKey.COMMENT)?.isNotEmpty()
-                }.map { requireNotNull(it.getStringExtra(IntentKey.COMMENT)) }
+            val deepLinkCommentableId = intent()
+                .filter { it.getStringExtra(IntentKey.COMMENT)?.isNotEmpty() ?: false }
+                .map { requireNotNull(it.getStringExtra(IntentKey.COMMENT)) }
 
             projectOrUpdateComment
                 .distinctUntilChanged()
@@ -211,14 +220,13 @@ interface CommentsViewModel {
                     !it.second
                 }
                 .map { it.first }
-                .compose(bindToLifecycle())
                 .subscribe {
                     trackRootCommentPageViewEvent(it)
                 }
+                .addToDisposable(disposables)
 
             projectOrUpdateComment
-                .compose(Transformers.takeWhen(onResumeActivity))
-                .compose(bindToLifecycle())
+                .compose(Transformers.takeWhenV2(onResumeActivity))
                 .subscribe {
                     // send event after back action after deep link to thread activity
                     if (openedThreadActivityFromDeepLink) {
@@ -226,30 +234,32 @@ interface CommentsViewModel {
                         openedThreadActivityFromDeepLink = false
                     }
                 }
+                .addToDisposable(disposables)
 
             deepLinkCommentableId
-                .compose(takePairWhen(projectOrUpdateComment))
+                .compose(takePairWhenV2(projectOrUpdateComment))
                 .switchMap {
                     return@switchMap apolloClient.getComment(it.first)
-                }.compose(Transformers.neverError())
+                }.compose(Transformers.neverErrorV2())
                 .compose(combineLatestPair(deepLinkCommentableId))
                 .compose(combineLatestPair(commentableId))
                 .compose(combineLatestPair(currentUserStream.observable()))
+                .filter { it.second.isPresent() }
                 .map {
                     CommentCardData.builder()
                         .comment(it.first.first.first)
                         .project(this.project)
-                        .commentCardState(it.first.first.first.cardStatus(it.second))
+                        .commentCardState(it.first.first.first.cardStatus(it.second.getValue()))
                         .commentableId(it.first.second)
                         .build()
                 }.withLatestFrom(projectOrUpdateComment) { commentData, projectOrUpdate ->
                     Pair(commentData, projectOrUpdate)
                 }
-                .compose(bindToLifecycle())
                 .subscribe {
                     this.startThreadActivityFromDeepLink.onNext(Pair(it.first, it.second.second?.id()?.toString()))
                     openedThreadActivityFromDeepLink = true
                 }
+                .addToDisposable(disposables)
 
             this.insertNewCommentToList
                 .withLatestFrom(this.currentUserStream.loggedInUser()) {
@@ -286,10 +296,11 @@ interface CommentsViewModel {
                     list.toMutableList().apply {
                         add(0, it.second)
                     }.toList()
-                }.compose(bindToLifecycle())
+                }
                 .subscribe {
                     commentsList.onNext(it)
                 }
+                .addToDisposable(disposables)
 
             this.commentToRefresh
                 .map { it.first }
@@ -300,58 +311,58 @@ interface CommentsViewModel {
                 }.subscribe {
                     this.analyticEvents.trackCommentCTA(it.second.first, it.first.id().toString(), it.first.body(), it.second.second?.id()?.toString())
                 }
+                .addToDisposable(disposables)
 
             this.onShowGuideLinesLinkClicked
-                .compose(bindToLifecycle())
                 .subscribe {
-                    showGuideLinesLink.onNext(null)
+                    showGuideLinesLink.onNext(Unit)
                 }
+                .addToDisposable(disposables)
 
             this.commentsList
                 .map { it.size }
                 .distinctUntilChanged()
-                .compose(bindToLifecycle())
                 .subscribe {
                     this.setEmptyState.onNext(it == 0)
                 }
+                .addToDisposable(disposables)
 
             this.initialError
-                .compose(bindToLifecycle())
                 .subscribe {
                     this.displayInitialError.onNext(true)
                 }
+                .addToDisposable(disposables)
 
             this.paginationError
-                .compose(bindToLifecycle())
                 .subscribe {
                     this.displayPaginationError.onNext(true)
                 }
+                .addToDisposable(disposables)
 
             this.commentsList
-                .compose(takePairWhen(checkIfThereAnyPendingComments))
-                .compose(bindToLifecycle())
+                .compose(takePairWhenV2(checkIfThereAnyPendingComments))
                 .subscribe { pair ->
                     this.hasPendingComments.onNext(
                         Pair(
                             pair.first.any {
                                 it.commentCardState == CommentCardStatus.TRYING_TO_POST.commentCardStatus ||
-                                    it.commentCardState == CommentCardStatus.FAILED_TO_SEND_COMMENT.commentCardStatus
+                                        it.commentCardState == CommentCardStatus.FAILED_TO_SEND_COMMENT.commentCardStatus
                             },
                             pair.second
                         )
                     )
                 }
+                .addToDisposable(disposables)
 
             this.backPressed
-                .compose(bindToLifecycle())
                 .subscribe { this.closeCommentsPage.onNext(it) }
+                .addToDisposable(disposables)
 
-            val subscribe = commentsList
+            commentsList
                 .withLatestFrom(projectOrUpdateComment) { commentData, projectOrUpdate ->
                     Pair(commentData, projectOrUpdate)
                 }
-                .compose(takePairWhen(onReplyClicked))
-                .compose(bindToLifecycle())
+                .compose(takePairWhenV2(onReplyClicked))
                 .subscribe { pair ->
 
                     val cardData =
@@ -367,10 +378,11 @@ interface CommentsViewModel {
                         )
                     )
                 }
+                .addToDisposable(disposables)
 
             // - Update internal mutable list with the latest state after successful response
             this.commentsList
-                .compose(takePairWhen(this.commentToRefresh))
+                .compose(takePairWhenV2(this.commentToRefresh))
                 .map {
                     val mappedList = it.second.first.updateCommentAfterSuccessfulPost(it.first, it.second.second)
                     updateNewlyPostedCommentWithNewStatus(mappedList[it.second.second])
@@ -380,42 +392,43 @@ interface CommentsViewModel {
                 .doOnNext {
                     this.scrollToTop.onNext(false)
                 }
-                .compose(bindToLifecycle())
                 .subscribe {
                     this.commentsList.onNext(it)
                 }
+                .addToDisposable(disposables)
 
             // - Reunite in only one place where the output list gets new updates
             this.commentsList
                 .filter { it.isNotEmpty() }
-                .compose(bindToLifecycle())
                 .subscribe {
                     this.outputCommentList.onNext(it)
                 }
+                .addToDisposable(disposables)
+
             // - Update internal mutable list with the latest state after failed response
             this.commentsList
-                .compose(takePairWhen(this.failedCommentCardToRefresh))
+                .compose(takePairWhenV2(this.failedCommentCardToRefresh))
                 .map {
                     val mappedList = it.second.first.updateCommentFailedToPost(it.first, it.second.second)
                     updateNewlyPostedCommentWithNewStatus(mappedList[it.second.second])
                     mappedList
                 }
                 .distinctUntilChanged()
-                .compose(bindToLifecycle())
                 .subscribe {
                     this.commentsList.onNext(it)
                 }
+                .addToDisposable(disposables)
 
             this.commentsList
-                .compose(takePairWhen(this.showCanceledPledgeComment))
+                .compose(takePairWhenV2(this.showCanceledPledgeComment))
                 .map {
                     it.second.updateCanceledPledgeComment(it.first)
                 }
                 .distinctUntilChanged()
-                .compose(bindToLifecycle())
                 .subscribe {
                     this.commentsList.onNext(it)
                 }
+                .addToDisposable(disposables)
         }
 
         private fun updateNewlyPostedCommentWithNewStatus(
@@ -444,14 +457,14 @@ interface CommentsViewModel {
                 Observable.merge(
                     projectOrUpdate,
                     projectOrUpdate.compose(
-                        Transformers.takeWhen(
+                        Transformers.takeWhenV2(
                             refresh
                         )
                     )
                 )
 
             val apolloPaginate =
-                ApolloPaginate.builder<CommentCardData, CommentEnvelope, Pair<Project, Update?>>()
+                ApolloPaginateV2.builder<CommentCardData, CommentEnvelope, Pair<Project, Update?>>()
                     .nextPage(nextPage)
                     .distinctUntilChanged(true)
                     .startOverWith(startOverWith)
@@ -464,9 +477,9 @@ interface CommentsViewModel {
                     .clearWhenStartingOver(false)
                     .build()
 
-            apolloPaginate.isFetching()
-                .compose(bindToLifecycle<Boolean>())
-                .subscribe(this.isFetchingComments)
+            apolloPaginate.isFetching
+                .subscribe { this.isFetchingComments.onNext(it) }
+                .addToDisposable(disposables)
 
             apolloPaginate.paginatedData()
                 ?.share()
@@ -480,33 +493,35 @@ interface CommentsViewModel {
                 ?.subscribe {
                     this.commentsList.onNext(it)
                 }
+                ?.addToDisposable(disposables)
 
             this.internalError
                 .map { Pair(it, commentsList.value) }
                 .filter {
                     it.second.isNullOrEmpty()
                 }
-                .compose(bindToLifecycle())
                 .subscribe {
                     this.initialError.onNext(it.first)
                 }
+                .addToDisposable(disposables)
 
-            commentsList.compose(takePairWhen(this.internalError))
+            commentsList.compose(takePairWhenV2(this.internalError))
                 .filter {
                     it.first.isNotEmpty()
                 }
-                .compose(bindToLifecycle())
                 .subscribe {
                     this.paginationError.onNext(it.second)
                 }
+                .addToDisposable(disposables)
 
             this.refresh
                 .doOnNext {
                     this.isRefreshing.onNext(true)
-                }.compose(bindToLifecycle())
+                }
                 .subscribe {
                     this.newlyPostedCommentsList.clear()
                 }
+                .addToDisposable(disposables)
 
             this.internalError
                 .compose(combineLatestPair(isRefreshing))
@@ -514,10 +529,10 @@ interface CommentsViewModel {
                 .filter {
                     it.second.isNullOrEmpty()
                 }
-                .compose(bindToLifecycle())
                 .subscribe {
                     this.isRefreshing.onNext(false)
                 }
+                .addToDisposable(disposables)
         }
 
         private fun loadWithProjectOrUpdateComments(
@@ -531,7 +546,10 @@ interface CommentsViewModel {
                     apolloClient.getProjectComments(it.first?.slug() ?: "", cursor)
                 }
             }.doOnNext {
-                commentableId.onNext(it.commentableId)
+                it.commentableId?.let { comId ->
+                    commentableId.onNext(comId)
+                }
+
                 // Remove Pagination errorFrom View
                 this.displayPaginationError.onNext(false)
                 this.displayInitialError.onNext(false)
@@ -572,19 +590,24 @@ interface CommentsViewModel {
                 .build()
         }
 
-        private fun getCommentComposerStatus(projectAndUser: Pair<Project, User?>) =
+        private fun getCommentComposerStatus(projectAndUser: Pair<Project, KsOptional<User>>) =
             when {
                 projectAndUser.second == null -> CommentComposerStatus.GONE
                 projectAndUser.first.canComment() ?: false -> CommentComposerStatus.ENABLED
                 else -> CommentComposerStatus.DISABLED
             }
 
+        override fun onCleared() {
+            disposables.clear()
+            super.onCleared()
+        }
+
         // - Inputs
-        override fun backPressed() = backPressed.onNext(null)
-        override fun refresh() = refresh.onNext(null)
-        override fun nextPage() = nextPage.onNext(null)
+        override fun backPressed() = backPressed.onNext(Unit)
+        override fun refresh() = refresh.onNext(Unit)
+        override fun nextPage() = nextPage.onNext(Unit)
         override fun insertNewCommentToList(comment: String, createdAt: DateTime) = insertNewCommentToList.onNext(Pair(comment, createdAt))
-        override fun onShowGuideLinesLinkClicked() = onShowGuideLinesLinkClicked.onNext(null)
+        override fun onShowGuideLinesLinkClicked() = onShowGuideLinesLinkClicked.onNext(Unit)
         override fun refreshComment(comment: Comment, position: Int) = this.commentToRefresh.onNext(Pair(comment, position))
         override fun onReplyClicked(comment: Comment, openKeyboard: Boolean) = onReplyClicked.onNext(Pair(comment, openKeyboard))
         override fun checkIfThereAnyPendingComments(isBackAction: Boolean) = checkIfThereAnyPendingComments.onNext(isBackAction)
@@ -594,15 +617,15 @@ interface CommentsViewModel {
             this.showCanceledPledgeComment.onNext(comment)
 
         override fun onResumeActivity() =
-            this.onResumeActivity.onNext(null)
+            this.onResumeActivity.onNext(Unit)
         // - Outputs
-        override fun closeCommentsPage(): Observable<Void> = closeCommentsPage
+        override fun closeCommentsPage(): Observable<Unit> = closeCommentsPage
         override fun currentUserAvatar(): Observable<String?> = currentUserAvatar
         override fun commentComposerStatus(): Observable<CommentComposerStatus> = commentComposerStatus
         override fun showCommentComposer(): Observable<Boolean> = showCommentComposer
         override fun commentsList(): Observable<List<CommentCardData>> = this.outputCommentList
         override fun enableReplyButton(): Observable<Boolean> = disableReplyButton
-        override fun showCommentGuideLinesLink(): Observable<Void> = showGuideLinesLink
+        override fun showCommentGuideLinesLink(): Observable<Unit> = showGuideLinesLink
         override fun initialLoadCommentsError(): Observable<Throwable> = this.initialError
         override fun paginateCommentsError(): Observable<Throwable> = this.paginationError
         override fun pullToRefreshError(): Observable<Throwable> = this.pullToRefreshError
@@ -618,5 +641,11 @@ interface CommentsViewModel {
         override fun isFetchingComments(): Observable<Boolean> = this.isFetchingComments
 
         override fun hasPendingComments(): Observable<Pair<Boolean, Boolean>> = this.hasPendingComments
+    }
+
+    class Factory(private val environment: Environment, private val intent: Intent? = null) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return CommentsViewModel(environment, intent) as T
+        }
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -531,7 +531,7 @@ interface CommentsViewModel {
 
         private fun loadWithProjectOrUpdateComments(
             projectOrUpdate: Observable<Pair<Project, Update?>>,
-            cursor: String?
+            cursor: String
         ): Observable<CommentEnvelope> {
             return projectOrUpdate.switchMap {
                 return@switchMap if (it.second?.id() != null) {

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewModel.kt
@@ -472,6 +472,7 @@ interface CommentsViewModel {
                     .build()
 
             apolloPaginate.isFetching
+                .share()
                 .subscribe { this.isFetchingComments.onNext(it) }
                 .addToDisposable(disposables)
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ProjectUpdatesViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProjectUpdatesViewModel.kt
@@ -144,7 +144,7 @@ interface ProjectUpdatesViewModel {
         }
         private fun loadWithProjectUpdatesList(
             project: Observable<Project>,
-            cursor: String?
+            cursor: String
         ): Observable<UpdatesGraphQlEnvelope> {
             return project.switchMap {
                 return@switchMap client.getProjectUpdates(it.slug() ?: "", cursor)

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -62,7 +62,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         // Start the view model with a backed project.
         val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.backedProject()))
         val vm = Factory(
-            environment().toBuilder().currentUser(MockCurrentUser(UserFactory.user())).build(),
+            environment().toBuilder().currentUserV2(MockCurrentUserV2(UserFactory.user())).build(),
             intent
         ).create(CommentsViewModel::class.java)
 
@@ -71,7 +71,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         // The comment composer should be shown to backer and enabled to write comments
         commentComposerStatus.assertValue(CommentComposerStatus.ENABLED)
-        showCommentComposer.assertValues(true, true)
+        showCommentComposer.assertValues(true)
     }
 
     @Test
@@ -96,7 +96,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         // Start the view model with a backed project.
         val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
         val vm = Factory(
-            environment().toBuilder().currentUser(MockCurrentUser(UserFactory.user())).build(),
+            environment().toBuilder().currentUserV2(MockCurrentUserV2(UserFactory.user())).build(),
             intent
         ).create(CommentsViewModel::class.java)
 
@@ -105,7 +105,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         // The comment composer should show but in disabled state
         commentComposerStatus.assertValue(CommentComposerStatus.DISABLED)
-        showCommentComposer.assertValues(true, true)
+        showCommentComposer.assertValues(true)
     }
 
     @Test
@@ -116,7 +116,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .canComment(true)
             .build()
         val vm = Factory(
-            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build(),
+            environment().toBuilder().currentUserV2(MockCurrentUserV2(currentUser)).build(),
             Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(project))
         ).create(CommentsViewModel::class.java)
 
@@ -124,7 +124,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         vm.outputs.showCommentComposer().subscribe { showCommentComposer.onNext(it) }.addToDisposable(disposables)
 
         // The comment composer enabled to write comments for creator
-        showCommentComposer.assertValues(true, true)
+        showCommentComposer.assertValues(true)
         commentComposerStatus.assertValues(CommentComposerStatus.ENABLED)
     }
 
@@ -136,7 +136,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .canComment(false)
             .build()
         val vm = Factory(
-            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build(),
+            environment().toBuilder().currentUserV2(MockCurrentUserV2(currentUser)).build(),
             Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
         ).create(CommentsViewModel::class.java)
 
@@ -144,7 +144,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         vm.outputs.showCommentComposer().subscribe { showCommentComposer.onNext(it) }.addToDisposable(disposables)
 
         // The comment composer enabled to write comments for creator
-        showCommentComposer.assertValues(true, true)
+        showCommentComposer.assertValues(true)
         commentComposerStatus.assertValues(CommentComposerStatus.DISABLED)
     }
 
@@ -479,9 +479,9 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
         vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
+        vm.outputs.scrollToTop().subscribe { scrollToTop.onNext(it) }.addToDisposable(disposables)
 
         val commentCardData = CommentFactory.liveCommentCardData(createdAt = createdAt, currentUser = currentUser)
-        vm.outputs.scrollToTop().subscribe { scrollToTop.onNext(it) }.addToDisposable(disposables)
 
         // post a comment
         vm.inputs.insertNewCommentToList(commentCardData.comment?.body()!!, createdAt)
@@ -492,8 +492,6 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         firstCall = false
         // get the next page which is end of page
         vm.inputs.nextPage()
-        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
-
         assertEquals(1, vm.newlyPostedCommentsList.size)
         assertEquals(2, commentsList.value?.size)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -159,7 +159,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .build()
 
         val vm = Factory(
-            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build(),
+            environment().toBuilder().currentUserV2(MockCurrentUserV2(currentUser)).build(),
             Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
         ).create(CommentsViewModel::class.java)
 
@@ -167,7 +167,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         vm.outputs.showCommentComposer().subscribe { showCommentComposer.onNext(it) }.addToDisposable(disposables)
 
         // Comment composer should be disabled and shown the disabled msg if not backing and not creator.
-        showCommentComposer.assertValues(true, true)
+        showCommentComposer.assertValues(true)
         commentComposerStatus.assertValue(CommentComposerStatus.DISABLED)
     }
     @Test
@@ -182,7 +182,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .build()
 
         val vm = Factory(
-            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build(),
+            environment().toBuilder().currentUserV2(MockCurrentUserV2(currentUser)).build(),
             Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
         ).create(CommentsViewModel::class.java)
 
@@ -515,7 +515,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         val intent = Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update())
         val vm = Factory(
-            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build(),
+            environment().toBuilder().currentUserV2(MockCurrentUserV2(currentUser)).build(),
             intent
         ).create(CommentsViewModel::class.java)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -198,12 +198,12 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectUpdateComments(
                 updateId: String,
-                cursor: String?,
+                cursor: String,
                 limit: Int
             ): Observable<CommentEnvelope> {
                 return Observable.empty()
             }
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.empty()
             }
         }).build()
@@ -220,12 +220,12 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectUpdateComments(
                 updateId: String,
-                cursor: String?,
+                cursor: String,
                 limit: Int
             ): Observable<CommentEnvelope> {
                 return Observable.empty()
             }
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.empty()
             }
         }).build()
@@ -242,13 +242,13 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectUpdateComments(
                 updateId: String,
-                cursor: String?,
+                cursor: String,
                 limit: Int
             ): Observable<CommentEnvelope> {
                 return Observable.error(Exception())
             }
 
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.error(Exception())
             }
         }).build()
@@ -266,13 +266,13 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectUpdateComments(
                 updateId: String,
-                cursor: String?,
+                cursor: String,
                 limit: Int
             ): Observable<CommentEnvelope> {
                 return Observable.error(Exception())
             }
 
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.error(Exception())
             }
         }).build()
@@ -310,7 +310,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
             override fun getProjectComments(
                 slug: String,
-                cursor: String?,
+                cursor: String,
                 limit: Int
             ): Observable<CommentEnvelope> {
                 return Observable.just(CommentEnvelopeFactory.emptyCommentsEnvelope())
@@ -318,7 +318,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
             override fun getProjectUpdateComments(
                 updateId: String,
-                cursor: String?,
+                cursor: String,
                 limit: Int
             ): Observable<CommentEnvelope> {
                 return Observable.just(CommentEnvelopeFactory.emptyCommentsEnvelope())
@@ -338,7 +338,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
             override fun getProjectComments(
                 slug: String,
-                cursor: String?,
+                cursor: String,
                 limit: Int
             ): Observable<CommentEnvelope> {
                 return Observable.just(CommentEnvelopeFactory.emptyCommentsEnvelope())
@@ -346,7 +346,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
             override fun getProjectUpdateComments(
                 updateId: String,
-                cursor: String?,
+                cursor: String,
                 limit: Int
             ): Observable<CommentEnvelope> {
                 return Observable.just(CommentEnvelopeFactory.emptyCommentsEnvelope())
@@ -366,7 +366,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testCommentsViewModel_CommentsAvailableState() {
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(CommentEnvelopeFactory.commentsEnvelope())
             }
         }).build()
@@ -394,7 +394,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testCommentsViewModel_ProjectRefresh_AndInitialLoad_withError() {
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.error(ApiExceptionFactory.badRequestException())
             }
         }).build()
@@ -426,7 +426,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     fun testCommentsViewModel_ProjectLoadingMore() {
         var firstCall = true
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return if (firstCall)
                     Observable.just(CommentEnvelopeFactory.commentsEnvelope())
                 else
@@ -466,7 +466,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         val env = environment().toBuilder()
             .currentUserV2(MockCurrentUserV2(currentUser))
             .apolloClientV2(object : MockApolloClientV2() {
-                override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+                override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                     return if (firstCall)
                         Observable.just(CommentEnvelopeFactory.commentsEnvelope())
                     else
@@ -591,7 +591,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         val testScheduler = TestScheduler()
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(commentEnvelope)
             }
         })
@@ -625,7 +625,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         val testScheduler = TestScheduler()
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(commentEnvelope)
             }
         })
@@ -660,7 +660,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         val testScheduler = TestScheduler()
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(commentEnvelope)
             }
         })
@@ -758,7 +758,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         val testScheduler = TestScheduler()
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(commentEnvelope)
             }
         })
@@ -865,7 +865,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         val testScheduler = TestScheduler()
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(commentEnvelope)
             }
         })
@@ -963,7 +963,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         val testScheduler = TestScheduler()
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(commentEnvelope)
             }
         })
@@ -1021,7 +1021,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             override fun getComment(commentableId: String): Observable<Comment> {
                 return Observable.just(comment1)
             }
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(
                     CommentEnvelopeFactory.commentsEnvelope().toBuilder().commentableId(commentableId).comments(
                         listOf(comment1)
@@ -1082,7 +1082,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         val testScheduler = TestScheduler()
         val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
-            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+            override fun getProjectComments(slug: String, cursor: String, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(commentEnvelope)
             }
         })

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -4,7 +4,9 @@ import android.content.Intent
 import android.util.Pair
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.MockCurrentUser
+import com.kickstarter.libs.MockCurrentUserV2
 import com.kickstarter.libs.utils.EventName
+import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.mock.factories.ApiExceptionFactory
 import com.kickstarter.mock.factories.AvatarFactory
 import com.kickstarter.mock.factories.CommentEnvelopeFactory
@@ -13,26 +15,29 @@ import com.kickstarter.mock.factories.ProjectDataFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.UpdateFactory
 import com.kickstarter.mock.factories.UserFactory
-import com.kickstarter.mock.services.MockApolloClient
+import com.kickstarter.mock.services.MockApolloClientV2
 import com.kickstarter.models.Comment
 import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.data.CommentCardData
 import com.kickstarter.ui.views.CommentCardStatus
 import com.kickstarter.ui.views.CommentComposerStatus
+import com.kickstarter.viewmodels.CommentsViewModel.CommentsViewModel
+import com.kickstarter.viewmodels.CommentsViewModel.Factory
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.TestScheduler
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subscribers.TestSubscriber
 import org.joda.time.DateTime
+import org.junit.After
 import org.junit.Test
-import rx.Observable
-import rx.observers.TestSubscriber
-import rx.schedulers.TestScheduler
-import rx.subjects.BehaviorSubject
 import java.lang.Exception
 import java.util.concurrent.TimeUnit
 
 class CommentsViewModelTest : KSRobolectricTestCase() {
-    private val closeCommentPage = TestSubscriber<Void>()
+    private val closeCommentPage = TestSubscriber<Unit>()
     private val commentsList = TestSubscriber<List<CommentCardData>?>()
-    private val commentCardStatus = TestSubscriber<CommentCardStatus>()
     private val commentComposerStatus = TestSubscriber<CommentComposerStatus>()
     private val showCommentComposer = TestSubscriber<Boolean>()
     private val showEmptyState = TestSubscriber<Boolean>()
@@ -41,20 +46,28 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     private val paginationError = TestSubscriber.create<Throwable>()
     private val shouldShowPaginatedCell = TestSubscriber.create<Boolean>()
     private val shouldShowInitialLoadErrorCell = TestSubscriber.create<Boolean>()
-    private val openCommentGuideLines = TestSubscriber<Void>()
-    private val startThreadActivity = BehaviorSubject.create<Pair<CommentCardData, Boolean>>()
+    private val openCommentGuideLines = TestSubscriber<Unit>()
     private val hasPendingComments = TestSubscriber<Pair<Boolean, Boolean>>()
+
+    private val disposables = CompositeDisposable()
+
+    @After
+    fun cleanUp() {
+        disposables.clear()
+    }
 
     @Test
     fun testCommentsViewModel_whenUserLoggedInAndBacking_shouldShowEnabledComposer() {
-        val vm = CommentsViewModel.ViewModel(
-            environment().toBuilder().currentUser(MockCurrentUser(UserFactory.user())).build()
-        )
-        vm.outputs.commentComposerStatus().subscribe(commentComposerStatus)
-        vm.outputs.showCommentComposer().subscribe(showCommentComposer)
 
         // Start the view model with a backed project.
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.backedProject())))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.backedProject()))
+        val vm = Factory(
+            environment().toBuilder().currentUser(MockCurrentUser(UserFactory.user())).build(),
+            intent
+        ).create(CommentsViewModel::class.java)
+
+        vm.outputs.commentComposerStatus().subscribe { commentComposerStatus.onNext(it) }.addToDisposable(disposables)
+        vm.outputs.showCommentComposer().subscribe { showCommentComposer.onNext(it) }.addToDisposable(disposables)
 
         // The comment composer should be shown to backer and enabled to write comments
         commentComposerStatus.assertValue(CommentComposerStatus.ENABLED)
@@ -63,13 +76,15 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testCommentsViewModel_whenUserIsLoggedOut_composerShouldBeGone() {
-        val vm = CommentsViewModel.ViewModel(environment().toBuilder().build())
-
-        vm.outputs.commentComposerStatus().subscribe(commentComposerStatus)
-        vm.outputs.showCommentComposer().subscribe(showCommentComposer)
-
         // Start the view model with a backed project.
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(
+            environment().toBuilder().build(),
+            intent
+        ).create(CommentsViewModel::class.java)
+
+        vm.outputs.commentComposerStatus().subscribe { commentComposerStatus.onNext(it) }.addToDisposable(disposables)
+        vm.outputs.showCommentComposer().subscribe { showCommentComposer.onNext(it) }.addToDisposable(disposables)
 
         // The comment composer should be hidden and disabled to write comments as no user logged-in
         showCommentComposer.assertValue(false)
@@ -78,14 +93,15 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testCommentsViewModel_whenUserIsLoggedInNotBacking_shouldShowDisabledComposer() {
-        val vm = CommentsViewModel.ViewModel(
-            environment().toBuilder().currentUser(MockCurrentUser(UserFactory.user())).build()
-        )
-        vm.outputs.commentComposerStatus().subscribe(commentComposerStatus)
-        vm.outputs.showCommentComposer().subscribe(showCommentComposer)
-
         // Start the view model with a backed project.
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(
+            environment().toBuilder().currentUser(MockCurrentUser(UserFactory.user())).build(),
+            intent
+        ).create(CommentsViewModel::class.java)
+
+        vm.outputs.commentComposerStatus().subscribe { commentComposerStatus.onNext(it) }.addToDisposable(disposables)
+        vm.outputs.showCommentComposer().subscribe { showCommentComposer.onNext(it) }.addToDisposable(disposables)
 
         // The comment composer should show but in disabled state
         commentComposerStatus.assertValue(CommentComposerStatus.DISABLED)
@@ -99,15 +115,13 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .toBuilder()
             .canComment(true)
             .build()
-        val vm = CommentsViewModel.ViewModel(
-            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build()
-        )
+        val vm = Factory(
+            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build(),
+            Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(project))
+        ).create(CommentsViewModel::class.java)
 
-        vm.outputs.commentComposerStatus().subscribe(commentComposerStatus)
-        vm.outputs.showCommentComposer().subscribe(showCommentComposer)
-
-        // Start the view model with a project.
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(project)))
+        vm.outputs.commentComposerStatus().subscribe { commentComposerStatus.onNext(it) }.addToDisposable(disposables)
+        vm.outputs.showCommentComposer().subscribe { showCommentComposer.onNext(it) }.addToDisposable(disposables)
 
         // The comment composer enabled to write comments for creator
         showCommentComposer.assertValues(true, true)
@@ -121,15 +135,13 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .toBuilder()
             .canComment(false)
             .build()
-        val vm = CommentsViewModel.ViewModel(
-            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build()
-        )
+        val vm = Factory(
+            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build(),
+            Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        ).create(CommentsViewModel::class.java)
 
-        vm.outputs.commentComposerStatus().subscribe(commentComposerStatus)
-        vm.outputs.showCommentComposer().subscribe(showCommentComposer)
-
-        // Start the view model with a project.
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
+        vm.outputs.commentComposerStatus().subscribe { commentComposerStatus.onNext(it) }.addToDisposable(disposables)
+        vm.outputs.showCommentComposer().subscribe { showCommentComposer.onNext(it) }.addToDisposable(disposables)
 
         // The comment composer enabled to write comments for creator
         showCommentComposer.assertValues(true, true)
@@ -145,15 +157,14 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .creator(creator)
             .isBacking(false)
             .build()
-        val vm = CommentsViewModel.ViewModel(
-            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build()
-        )
 
-        vm.outputs.commentComposerStatus().subscribe(commentComposerStatus)
-        vm.outputs.showCommentComposer().subscribe(showCommentComposer)
+        val vm = Factory(
+            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build(),
+            Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        ).create(CommentsViewModel::class.java)
 
-        // Start the view model with a project.
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
+        vm.outputs.commentComposerStatus().subscribe { commentComposerStatus.onNext(it) }.addToDisposable(disposables)
+        vm.outputs.showCommentComposer().subscribe { showCommentComposer.onNext(it) }.addToDisposable(disposables)
 
         // Comment composer should be disabled and shown the disabled msg if not backing and not creator.
         showCommentComposer.assertValues(true, true)
@@ -170,21 +181,21 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .isBacking(false)
             .build()
 
-        val vm = CommentsViewModel.ViewModel(
-            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build()
-        )
+        val vm = Factory(
+            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build(),
+            Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        ).create(CommentsViewModel::class.java)
+
         val currentUserAvatar = TestSubscriber<String?>()
-        vm.outputs.currentUserAvatar().subscribe(currentUserAvatar)
-        // Start the view model with a project.
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
+        vm.outputs.currentUserAvatar().subscribe { currentUserAvatar.onNext(it) }.addToDisposable(disposables)
 
         // set user avatar with small url
         currentUserAvatar.assertValue(userAvatar.small())
     }
 
     @Test
-    fun testCommentsViewModel_EmptyState() {
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+    fun testCommentsViewModel_EmptyState_FromUpdate() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectUpdateComments(
                 updateId: String,
                 cursor: String?,
@@ -196,22 +207,39 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
                 return Observable.empty()
             }
         }).build()
-        val vm = CommentsViewModel.ViewModel(env)
+
+        val vm = Factory(env, Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update())).create(CommentsViewModel::class.java)
         val commentsList = TestSubscriber<List<CommentCardData>>()
-        vm.outputs.commentsList().subscribe(commentsList)
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
 
-        // Start the view model with an update.
-        vm.intent(Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update()))
-        commentsList.assertNoValues()
-
-        // Start the view model with a project.
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
         commentsList.assertNoValues()
     }
 
     @Test
-    fun testCommentsViewModel_InitialLoad_Error() {
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+    fun testCommentsViewModel_EmptyState_FromProject() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
+            override fun getProjectUpdateComments(
+                updateId: String,
+                cursor: String?,
+                limit: Int
+            ): Observable<CommentEnvelope> {
+                return Observable.empty()
+            }
+            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+                return Observable.empty()
+            }
+        }).build()
+
+        val vm = Factory(env, Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))).create(CommentsViewModel::class.java)
+        val commentsList = TestSubscriber<List<CommentCardData>>()
+
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
+        commentsList.assertNoValues()
+    }
+
+    @Test
+    fun testCommentsViewModel_InitialLoad_Error_ForUpdate() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectUpdateComments(
                 updateId: String,
                 cursor: String?,
@@ -224,26 +252,47 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
                 return Observable.error(Exception())
             }
         }).build()
-        val vm = CommentsViewModel.ViewModel(env)
+        val intent = Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update())
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
         val commentsList = TestSubscriber<List<CommentCardData>?>()
-        vm.outputs.commentsList().subscribe(commentsList)
 
-        // Start the view model with an update.
-        vm.intent(Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update()))
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
+
         commentsList.assertNoValues()
+    }
 
-        // Start the view model with a project.
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
+    @Test
+    fun testCommentsViewModel_InitialLoad_Error_ForProject() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
+            override fun getProjectUpdateComments(
+                updateId: String,
+                cursor: String?,
+                limit: Int
+            ): Observable<CommentEnvelope> {
+                return Observable.error(Exception())
+            }
+
+            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+                return Observable.error(Exception())
+            }
+        }).build()
+
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
+        val commentsList = TestSubscriber<List<CommentCardData>?>()
+
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
+
         commentsList.assertNoValues()
     }
 
     @Test
     fun testCommentsViewModel_ProjectCommentsEmit() {
         val commentsList = BehaviorSubject.create<List<CommentCardData>?>()
-        val vm = CommentsViewModel.ViewModel(environment())
-        vm.outputs.commentsList().subscribe(commentsList)
-        // Start the view model with a project.
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(environment(), intent).create(CommentsViewModel::class.java)
+
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
 
         // Comments should emit.
         val commentCardDataList = commentsList.value
@@ -256,8 +305,8 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
    */
 
     @Test
-    fun testCommentsViewModel_EmptyCommentState() {
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+    fun testCommentsViewModel_EmptyCommentState_ForUpdate() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
 
             override fun getProjectComments(
                 slug: String,
@@ -275,15 +324,39 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
                 return Observable.just(CommentEnvelopeFactory.emptyCommentsEnvelope())
             }
         }).build()
-        val vm = CommentsViewModel.ViewModel(env)
-        vm.outputs.setEmptyState().subscribe(showEmptyState)
 
-        // Start the view model with an update.
-        vm.intent(Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update()))
+        val intent = Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update())
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
+        vm.outputs.setEmptyState().subscribe { showEmptyState.onNext(it) }.addToDisposable(disposables)
+
         showEmptyState.assertValue(true)
+    }
 
-        // Start the view model with a project.
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
+    @Test
+    fun testCommentsViewModel_EmptyCommentState_ForProject() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
+
+            override fun getProjectComments(
+                slug: String,
+                cursor: String?,
+                limit: Int
+            ): Observable<CommentEnvelope> {
+                return Observable.just(CommentEnvelopeFactory.emptyCommentsEnvelope())
+            }
+
+            override fun getProjectUpdateComments(
+                updateId: String,
+                cursor: String?,
+                limit: Int
+            ): Observable<CommentEnvelope> {
+                return Observable.just(CommentEnvelopeFactory.emptyCommentsEnvelope())
+            }
+        }).build()
+
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
+        vm.outputs.setEmptyState().subscribe { showEmptyState.onNext(it) }.addToDisposable(disposables)
+
         showEmptyState.assertValue(true)
     }
 
@@ -292,27 +365,27 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
      */
     @Test
     fun testCommentsViewModel_CommentsAvailableState() {
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(CommentEnvelopeFactory.commentsEnvelope())
             }
         }).build()
-        val vm = CommentsViewModel.ViewModel(env)
-        vm.outputs.setEmptyState().subscribe(showEmptyState)
 
-        // Start the view model with an update.
-        vm.intent(Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update()))
+        val intent = Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update())
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
+        vm.outputs.setEmptyState().subscribe { showEmptyState.onNext(it) }.addToDisposable(disposables)
+
         showEmptyState.assertValues(false)
     }
 
     @Test
     fun testCommentsViewModel_ProjectRefresh() {
-        val vm = CommentsViewModel.ViewModel(environment())
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(environment(), intent).create(CommentsViewModel::class.java)
 
         // Start the view model with a project.
         vm.inputs.refresh()
-        vm.outputs.commentsList().subscribe(commentsList)
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
 
         // Comments should emit.
         commentsList.assertValueCount(1)
@@ -320,23 +393,24 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testCommentsViewModel_ProjectRefresh_AndInitialLoad_withError() {
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
                 return Observable.error(ApiExceptionFactory.badRequestException())
             }
         }).build()
 
-        val vm = CommentsViewModel.ViewModel(env)
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
-        vm.outputs.initialLoadCommentsError().subscribe(initialLoadError)
-        vm.outputs.shouldShowInitialLoadErrorUI().subscribe(shouldShowInitialLoadErrorCell)
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
-        vm.outputs.paginateCommentsError().subscribe(paginationError)
-        vm.outputs.shouldShowPaginationErrorUI().subscribe(shouldShowPaginatedCell)
+        vm.outputs.initialLoadCommentsError().subscribe { initialLoadError.onNext(it) }.addToDisposable(disposables)
+        vm.outputs.shouldShowInitialLoadErrorUI().subscribe { shouldShowInitialLoadErrorCell.onNext(it) }.addToDisposable(disposables)
+
+        vm.outputs.paginateCommentsError().subscribe { paginationError.onNext(it) }.addToDisposable(disposables)
+        vm.outputs.shouldShowPaginationErrorUI().subscribe { shouldShowPaginatedCell.onNext(it) }.addToDisposable(disposables)
 
         // Start the view model with a project.
         vm.inputs.refresh()
-        vm.outputs.commentsList().subscribe(commentsList)
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
 
         // Comments should emit.
         commentsList.assertValueCount(0)
@@ -351,7 +425,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testCommentsViewModel_ProjectLoadingMore() {
         var firstCall = true
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
                 return if (firstCall)
                     Observable.just(CommentEnvelopeFactory.commentsEnvelope())
@@ -360,13 +434,13 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             }
         }).build()
 
-        val vm = CommentsViewModel.ViewModel(env)
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
         firstCall = false
         // get the next page which is end of page
         vm.inputs.nextPage()
-        vm.outputs.commentsList().subscribe(commentsList)
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
 
         commentsList.assertValueCount(1)
     }
@@ -389,8 +463,9 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         val commentsList = BehaviorSubject.create<List<CommentCardData>>()
         val testScheduler = TestScheduler()
 
-        val env = environment().toBuilder().currentUser(MockCurrentUser(currentUser))
-            .apolloClient(object : MockApolloClient() {
+        val env = environment().toBuilder()
+            .currentUserV2(MockCurrentUserV2(currentUser))
+            .apolloClientV2(object : MockApolloClientV2() {
                 override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
                     return if (firstCall)
                         Observable.just(CommentEnvelopeFactory.commentsEnvelope())
@@ -398,14 +473,15 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
                         Observable.just(CommentEnvelopeFactory.emptyCommentsEnvelope())
                 }
             })
-            .scheduler(testScheduler).build()
+            .schedulerV2(testScheduler).build()
 
-        val vm = CommentsViewModel.ViewModel(env)
-        vm.outputs.commentsList().subscribe(commentsList)
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
+
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
 
         val commentCardData = CommentFactory.liveCommentCardData(createdAt = createdAt, currentUser = currentUser)
-        vm.outputs.scrollToTop().subscribe(scrollToTop)
+        vm.outputs.scrollToTop().subscribe { scrollToTop.onNext(it) }.addToDisposable(disposables)
 
         // post a comment
         vm.inputs.insertNewCommentToList(commentCardData.comment?.body()!!, createdAt)
@@ -416,7 +492,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         firstCall = false
         // get the next page which is end of page
         vm.inputs.nextPage()
-        vm.outputs.commentsList().subscribe(commentsList)
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
 
         assertEquals(1, vm.newlyPostedCommentsList.size)
         assertEquals(2, commentsList.value?.size)
@@ -439,16 +515,17 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         val createdAt = DateTime.now()
 
-        val vm = CommentsViewModel.ViewModel(
-            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build()
-        )
+        val intent = Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update())
+        val vm = Factory(
+            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build(),
+            intent
+        ).create(CommentsViewModel::class.java)
 
         val commentCardData = CommentFactory.liveCommentCardData(createdAt = createdAt, currentUser = currentUser)
-        // Start the view model with an update.
-        vm.intent(Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update()))
+
         val commentsList = BehaviorSubject.create<List<CommentCardData>>()
-        vm.outputs.commentsList().subscribe(commentsList)
-        vm.outputs.scrollToTop().subscribe(scrollToTop)
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
+        vm.outputs.scrollToTop().subscribe { scrollToTop.onNext(it) }.addToDisposable(disposables)
 
         // post a comment
         vm.inputs.insertNewCommentToList(commentCardData.comment?.body()!!, createdAt)
@@ -465,13 +542,13 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .avatar(AvatarFactory.avatar())
             .build()
 
-        val vm = CommentsViewModel.ViewModel(
-            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build()
-        )
+        val intent = Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update())
+        val vm = Factory(
+            environment().toBuilder().currentUser(MockCurrentUser(currentUser)).build(),
+            intent
+        ).create(CommentsViewModel::class.java)
 
-        // Start the view model with an update.
-        vm.intent(Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update()))
-        vm.outputs.showCommentGuideLinesLink().subscribe(openCommentGuideLines)
+        vm.outputs.showCommentGuideLinesLink().subscribe { openCommentGuideLines.onNext(it) }.addToDisposable(disposables)
 
         // post a comment
         vm.inputs.onShowGuideLinesLinkClicked()
@@ -479,16 +556,29 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun backButtonPressed_whenEmits_shouldEmitToCloseActivityStream() {
-        val vm = CommentsViewModel.ViewModel(environment())
-        vm.outputs.closeCommentsPage().subscribe(closeCommentPage)
+    fun backButtonPressed_whenEmits_shouldEmitToCloseActivityStream_FromUpdate() {
+        val intent = Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update())
+        val vm = Factory(environment(), intent).create(CommentsViewModel::class.java)
+
+        vm.outputs.closeCommentsPage().subscribe { closeCommentPage.onNext(it) }.addToDisposable(disposables)
 
         vm.inputs.backPressed()
         closeCommentPage.assertValueCount(1)
     }
 
     @Test
-    fun onReplyClicked_whenEmits_shouldEmitToCloseThreadActivity() {
+    fun backButtonPressed_whenEmits_shouldEmitToCloseActivityStream_FromProject() {
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(environment(), intent).create(CommentsViewModel::class.java)
+
+        vm.outputs.closeCommentsPage().subscribe { closeCommentPage.onNext(it) }.addToDisposable(disposables)
+
+        vm.inputs.backPressed()
+        closeCommentPage.assertValueCount(1)
+    }
+
+    @Test
+    fun onReplyClicked_whenEmits_shouldEmitToCloseThreadActivity_FromUpdate() {
         val currentUser = UserFactory.user()
             .toBuilder()
             .id(1)
@@ -502,23 +592,57 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .build()
 
         val testScheduler = TestScheduler()
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(commentEnvelope)
             }
         })
-            .currentUser(MockCurrentUser(currentUser))
-            .scheduler(testScheduler)
+            .currentUserV2(MockCurrentUserV2(currentUser))
+            .schedulerV2(testScheduler)
             .build()
 
-        val vm = CommentsViewModel.ViewModel(env)
-        // Start the view model with a project.
+        val intent = Intent().putExtra(IntentKey.UPDATE, UpdateFactory.update())
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
         vm.inputs.onReplyClicked(comment1, true)
         vm.outputs.startThreadActivity().take(0).subscribe {
             assertEquals(it.first.first.comment, comment1)
             assertTrue(it.first.second)
-        }
+        }.addToDisposable(disposables)
+    }
+
+    @Test
+    fun onReplyClicked_whenEmits_shouldEmitToCloseThreadActivity_FromProject() {
+        val currentUser = UserFactory.user()
+            .toBuilder()
+            .id(1)
+            .avatar(AvatarFactory.avatar())
+            .build()
+
+        val comment1 = CommentFactory.commentToPostWithUser(currentUser).toBuilder().id(1).body("comment1").build()
+
+        val commentEnvelope = CommentEnvelopeFactory.commentsEnvelope().toBuilder()
+            .comments(listOf(comment1))
+            .build()
+
+        val testScheduler = TestScheduler()
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
+            override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
+                return Observable.just(commentEnvelope)
+            }
+        })
+            .currentUserV2(MockCurrentUserV2(currentUser))
+            .schedulerV2(testScheduler)
+            .build()
+
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
+
+        vm.inputs.onReplyClicked(comment1, true)
+        vm.outputs.startThreadActivity().take(0).subscribe {
+            assertEquals(it.first.first.comment, comment1)
+            assertTrue(it.first.second)
+        }.addToDisposable(disposables)
     }
 
     @Test
@@ -537,13 +661,13 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .build()
 
         val testScheduler = TestScheduler()
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(commentEnvelope)
             }
         })
-            .currentUser(MockCurrentUser(currentUser))
-            .scheduler(testScheduler)
+            .currentUserV2(MockCurrentUserV2(currentUser))
+            .schedulerV2(testScheduler)
             .build()
 
         val commentCardData1 = CommentCardData.builder()
@@ -563,9 +687,10 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .commentCardState(CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus)
             .build()
 
-        val vm = CommentsViewModel.ViewModel(env)
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
-        vm.outputs.commentsList().subscribe(commentsList)
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(env, intent = intent).create(CommentsViewModel::class.java)
+
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
 
         commentsList.assertValueCount(1)
         vm.outputs.commentsList().take(0).subscribe {
@@ -576,7 +701,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
             assertTrue(newList[1].comment?.body() == commentCardData2.comment?.body())
             assertTrue(newList[1].commentCardState == commentCardData2.commentCardState)
-        }
+        }.addToDisposable(disposables)
 
         // - New posted comment with status "TRYING_TO_POST"
         vm.inputs.insertNewCommentToList(newPostedComment.body(), DateTime.now())
@@ -596,7 +721,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
             assertTrue(newList[2].comment?.body() == commentCardData2.comment?.body())
             assertTrue(newList[2].commentCardState == commentCardData2.commentCardState)
-        }
+        }.addToDisposable(disposables)
 
         // - Check the status of the newly posted comment has been updated to "COMMENT_FOR_LOGIN_BACKED_USERS"
         vm.inputs.refreshComment(newPostedComment, 0)
@@ -614,7 +739,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
             assertTrue(newList[2].comment?.body() == commentCardData2.comment?.body())
             assertTrue(newList[2].commentCardState == commentCardData2.commentCardState)
-        }
+        }.addToDisposable(disposables)
         segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
     }
 
@@ -634,13 +759,13 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .build()
 
         val testScheduler = TestScheduler()
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(commentEnvelope)
             }
         })
-            .currentUser(MockCurrentUser(currentUser))
-            .scheduler(testScheduler)
+            .currentUserV2(MockCurrentUserV2(currentUser))
+            .schedulerV2(testScheduler)
             .build()
 
         val commentCardData1 = CommentCardData.builder()
@@ -660,11 +785,11 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .commentCardState(CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus)
             .build()
 
-        val vm = CommentsViewModel.ViewModel(env)
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
-        vm.outputs.commentsList().subscribe(commentsList)
-        vm.outputs.hasPendingComments().subscribe(hasPendingComments)
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
+        vm.outputs.hasPendingComments().subscribe { hasPendingComments.onNext(it) }.addToDisposable(disposables)
 
         commentsList.assertValueCount(1)
         vm.outputs.commentsList().take(0).subscribe {
@@ -675,7 +800,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
             assertTrue(newList[1].comment?.body() == commentCardData2.comment?.body())
             assertTrue(newList[1].commentCardState == commentCardData2.commentCardState)
-        }
+        }.addToDisposable(disposables)
 
         vm.inputs.checkIfThereAnyPendingComments(false)
 
@@ -699,7 +824,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
             assertTrue(newList[2].comment?.body() == commentCardData2.comment?.body())
             assertTrue(newList[2].commentCardState == commentCardData2.commentCardState)
-        }
+        }.addToDisposable(disposables)
 
         vm.inputs.checkIfThereAnyPendingComments(false)
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
@@ -741,13 +866,13 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .build()
 
         val testScheduler = TestScheduler()
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(commentEnvelope)
             }
         })
-            .currentUser(MockCurrentUser(currentUser))
-            .scheduler(testScheduler)
+            .currentUserV2(MockCurrentUserV2(currentUser))
+            .schedulerV2(testScheduler)
             .build()
 
         val commentCardData1 = CommentCardData.builder()
@@ -767,10 +892,11 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .commentCardState(CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus)
             .build()
 
-        val vm = CommentsViewModel.ViewModel(env)
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
-        vm.outputs.commentsList().subscribe(commentsList)
-        vm.outputs.hasPendingComments().subscribe(hasPendingComments)
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
+
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
+        vm.outputs.hasPendingComments().subscribe { hasPendingComments.onNext(it) }.addToDisposable(disposables)
 
         commentsList.assertValueCount(1)
         vm.outputs.commentsList().take(0).subscribe {
@@ -781,7 +907,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
             assertTrue(newList[1].comment?.body() == commentCardData2.comment?.body())
             assertTrue(newList[1].commentCardState == commentCardData2.commentCardState)
-        }
+        }.addToDisposable(disposables)
 
         vm.inputs.checkIfThereAnyPendingComments(true)
 
@@ -801,7 +927,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
             assertTrue(newList[2].comment?.body() == commentCardData2.comment?.body())
             assertTrue(newList[2].commentCardState == commentCardData2.commentCardState)
-        }
+        }.addToDisposable(disposables)
 
         vm.inputs.checkIfThereAnyPendingComments(true)
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
@@ -838,13 +964,13 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .build()
 
         val testScheduler = TestScheduler()
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(commentEnvelope)
             }
         })
-            .currentUser(MockCurrentUser(currentUser))
-            .scheduler(testScheduler)
+            .currentUserV2(MockCurrentUserV2(currentUser))
+            .schedulerV2(testScheduler)
             .build()
 
         val commentCardData1 = CommentCardData.builder()
@@ -857,16 +983,17 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .commentCardState(CommentCardStatus.CANCELED_PLEDGE_COMMENT.commentCardStatus)
             .build()
 
-        val vm = CommentsViewModel.ViewModel(env)
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
-        vm.outputs.commentsList().subscribe(commentsList)
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
+
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
 
         commentsList.assertValueCount(0)
         vm.outputs.commentsList().take(0).subscribe {
             val newList = it
             assertTrue(newList[0].comment?.body() == commentCardData1.comment?.body())
             assertTrue(newList[0].commentCardState == commentCardData1.commentCardState)
-        }
+        }.addToDisposable(disposables)
 
         vm.inputs.onShowCanceledPledgeComment(comment1)
 
@@ -874,7 +1001,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             val newList = it
             assertTrue(newList[0].comment?.body() == commentCardData2.comment?.body())
             assertTrue(newList[0].commentCardState == commentCardData2.commentCardState)
-        }
+        }.addToDisposable(disposables)
     }
 
     @Test
@@ -892,7 +1019,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         val testScheduler = TestScheduler()
 
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getComment(commentableId: String): Observable<Comment> {
                 return Observable.just(comment1)
             }
@@ -903,25 +1030,20 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
                     ).build()
                 )
             }
-        }).currentUser(MockCurrentUser(currentUser))
-            .scheduler(testScheduler)
+        }).currentUserV2(MockCurrentUserV2(currentUser))
+            .schedulerV2(testScheduler)
             .build()
 
-        val vm = CommentsViewModel.ViewModel(env)
-
-        // Start the view model with a project.
-
-        vm.intent(
-            Intent().apply {
-                putExtra(IntentKey.COMMENT, commentID)
-                vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
-            }
-        )
+        val intent = Intent().apply {
+            putExtra(IntentKey.COMMENT, commentID)
+            putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        }
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
         vm.outputs.startThreadActivity().take(0).subscribe {
             assertEquals(it.first.first.commentableId, commentID)
             assertFalse(it.first.second)
-        }
+        }.addToDisposable(disposables)
 
         vm.onResumeActivity()
         segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName)
@@ -961,19 +1083,19 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .build()
 
         val testScheduler = TestScheduler()
-        val env = environment().toBuilder().apolloClient(object : MockApolloClient() {
+        val env = environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
             override fun getProjectComments(slug: String, cursor: String?, limit: Int): Observable<CommentEnvelope> {
                 return Observable.just(commentEnvelope)
             }
         })
-            .currentUser(MockCurrentUser(currentUser))
-            .scheduler(testScheduler)
+            .currentUserV2(MockCurrentUserV2(currentUser))
+            .schedulerV2(testScheduler)
             .build()
 
-        val vm = CommentsViewModel.ViewModel(env)
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
-        vm.intent(Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project())))
-        vm.outputs.commentsList().subscribe(commentsList)
+        vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
 
         commentsList.assertValueCount(1)
         vm.outputs.commentsList().take(0).subscribe {
@@ -984,6 +1106,6 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
             assertTrue(newList[1].comment?.body() == commentCardData3.comment?.body())
             assertTrue(newList[1].commentCardState == commentCardData3.commentCardState)
-        }
+        }.addToDisposable(disposables)
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectUpdatesViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectUpdatesViewModelTest.kt
@@ -89,7 +89,7 @@ class ProjectUpdatesViewModelTest : KSRobolectricTestCase() {
             environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
                 override fun getProjectUpdates(
                     slug: String,
-                    cursor: String?,
+                    cursor: String,
                     limit: Int
                 ): Observable<UpdatesGraphQlEnvelope> {
                     return Observable.just(
@@ -118,7 +118,7 @@ class ProjectUpdatesViewModelTest : KSRobolectricTestCase() {
             environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
                 override fun getProjectUpdates(
                     slug: String,
-                    cursor: String?,
+                    cursor: String,
                     limit: Int
                 ): Observable<UpdatesGraphQlEnvelope> {
                     return Observable.just(
@@ -157,7 +157,7 @@ class ProjectUpdatesViewModelTest : KSRobolectricTestCase() {
             environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
                 override fun getProjectUpdates(
                     slug: String,
-                    cursor: String?,
+                    cursor: String,
                     limit: Int
                 ): Observable<UpdatesGraphQlEnvelope> {
                     return Observable.just(


### PR DESCRIPTION
- Migration RXJava2 + ViewModel, take a look at the [engineering plan](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2350317579/ViewModel+Tech+Debt+Epic) if any doubt 
- Added connectivity check
- Improved back navigation
- Using loading indicator on top screen instead of bottom to unify user experience

# 👀 See

https://github.com/kickstarter/android-oss/assets/4083656/b5db31e8-1f1e-4329-9aa2-de1f2ffe257c



|  |  |

# 📋 QA
- As logged off user you can just see comments on a Project/Update, but comment composer is not visible
- As logged in user, but no backer, you can see comments, but no posting allowed
- As logged in user, and backer, you are allowed to post a comment, on a Project or Update.
- - When posting a comment there will be scroll to the top
- - When posting a comment there will be optimistic posting
- - when leading the comments screen (back navigation), a dialog will be shown in case there is some content on composer or comment no published yet

# Story 📖

[MBL-750](https://kickstarter.atlassian.net/browse/MBL-750)


[MBL-750]: https://kickstarter.atlassian.net/browse/MBL-750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ