### PR TITLE
[Bigfix] Fix issue where messages to some creators dont get sent

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/MessagesViewModel.kt
@@ -315,8 +315,7 @@ interface MessagesViewModel {
                 .distinctUntilChanged()
 
             val thread = initialMessageThreadEnvelope
-                .filter { it.messageThread().isNotNull() }
-                .map { it.messageThread() }
+                .map { it.messageThread() ?: MessageThread.builder().build() }
 
             // If view model was not initialized with a MessageThread, participant is
             // the project creator.


### PR DESCRIPTION
# 📲 What

Some creator messages were not able to be sent (button would click, but nothing happened)

# 🤔 Why

Many of our RX observable chains require the previous parts to succeed to move on, in this case:
```
           val thread = initialMessageThreadEnvelope
                .filter { it.messageThread().isNotNull() }
                .map { it.messageThread() }

            // If view model was not initialized with a MessageThread, participant is
            // the project creator.
            val participant =
                Observable.combineLatest(
                    thread,
                    project
                ) {

```
Here you can see the `thread` observable is used in the `participant` observable, but if thread would fail to exist then participant would never get populated and the observables observing it would not get updated or initialized

# 🛠 How

the `thread` object will now always return something, even if its an empty object so that the observables down the chain would still get initialized/populated

# 📋 QA

Go to any creator message through either messages or through a project page that was backed and try and send a message
