### PR TITLE
MBL-1086: ThanksActivity.showGamesNewsletterDialog crash

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ThanksActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ThanksActivity.kt
@@ -59,17 +59,17 @@ class ThanksActivity : AppCompatActivity() {
         binding.thanksRecyclerView.adapter = adapter
 
         viewModel.outputs.adapterData()
-            .compose(Transformers.observeForUIV2())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe { adapter.takeData(it) }
             .addToDisposable(disposables)
 
         viewModel.outputs.showConfirmGamesNewsletterDialog()
-            .compose(Transformers.observeForUIV2())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe { showConfirmGamesNewsletterDialog() }
             .addToDisposable(disposables)
 
         viewModel.outputs.finish()
-            .compose(Transformers.observeForUIV2())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe { finish() }
             .addToDisposable(disposables)
 
@@ -77,7 +77,7 @@ class ThanksActivity : AppCompatActivity() {
         viewModel.outputs.showGamesNewsletterDialog()
             .take(1)
             .delay(700L, TimeUnit.MILLISECONDS)
-            .compose(Transformers.observeForUIV2())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
                 if (!isFinishing) {
                     showGamesNewsletterDialog()
@@ -88,7 +88,7 @@ class ThanksActivity : AppCompatActivity() {
         viewModel.outputs.showRatingDialog()
             .take(1)
             .delay(700L, TimeUnit.MILLISECONDS)
-            .compose(Transformers.observeForUIV2())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
                 if (!isFinishing) {
                     showRatingDialog()
@@ -127,25 +127,33 @@ class ThanksActivity : AppCompatActivity() {
     private fun closeButtonClick() = viewModel.inputs.closeButtonClicked()
 
     private fun showConfirmGamesNewsletterDialog() {
-        val optInDialogMessageString = ksString.format(
-            getString(R.string.profile_settings_newsletter_opt_in_message),
-            "newsletter",
-            getString(R.string.profile_settings_newsletter_games)
-        )
+        this.runOnUiThread(
+            Runnable {
+                val optInDialogMessageString = ksString.format(
+                    getString(R.string.profile_settings_newsletter_opt_in_message),
+                    "newsletter",
+                    getString(R.string.profile_settings_newsletter_games)
+                )
 
-        val builder = AlertDialog.Builder(this)
-            .setMessage(optInDialogMessageString)
-            .setTitle(R.string.profile_settings_newsletter_opt_in_title)
-            .setPositiveButton(R.string.general_alert_buttons_ok) { _: DialogInterface?, _: Int -> }
-        builder.show()
+                val builder = AlertDialog.Builder(this)
+                    .setMessage(optInDialogMessageString)
+                    .setTitle(R.string.profile_settings_newsletter_opt_in_title)
+                    .setPositiveButton(R.string.general_alert_buttons_ok) { _: DialogInterface?, _: Int -> }
+                builder.show()
+            }
+        )
     }
 
     private fun showGamesNewsletterDialog() {
-        val builder = AlertDialog.Builder(this)
-            .setMessage(R.string.project_checkout_games_alert_want_the_coolest_games_delivered_to_your_inbox)
-            .setPositiveButton(R.string.project_checkout_games_alert_yes_please) { _: DialogInterface?, _: Int -> viewModel.inputs.signupToGamesNewsletterClick() }
-            .setNegativeButton(R.string.project_checkout_games_alert_no_thanks) { _: DialogInterface?, _: Int -> }
-        builder.show()
+        this.runOnUiThread(
+            Runnable {
+                val builder = AlertDialog.Builder(this)
+                    .setMessage(R.string.project_checkout_games_alert_want_the_coolest_games_delivered_to_your_inbox)
+                    .setPositiveButton(R.string.project_checkout_games_alert_yes_please) { _: DialogInterface?, _: Int -> viewModel.inputs.signupToGamesNewsletterClick() }
+                    .setNegativeButton(R.string.project_checkout_games_alert_no_thanks) { _: DialogInterface?, _: Int -> }
+                builder.show()
+            }
+        )
     }
 
     private fun showRatingDialog() = showRatingDialogWidget()

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.kt
@@ -140,7 +140,7 @@ interface ThanksViewModel {
                 .map { "games" == it.slug() }
 
             val hasSeenGamesNewsletterDialog = Observable.just(
-                hasSeenGamesNewsletterPreference?.get()
+                hasSeenGamesNewsletterPreference?.get() ?: false
             ).filter { it.isNotNull() }
                 .map { it }
 


### PR DESCRIPTION
# 📲 What

- New crash raised while releasing Android 3.17.0

# 🤔 Why

[Firebase Crash](https://console.firebase.google.com/u/1/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/d31b6ef2fb9b37c8bf68e349eaf72e2d?time=last-seven-days&versions=3.17.0%20(2014150890)&types=crash&sessionEventKey=6570BBD2038C00014D62F3C7BD843843_1887996047463586090)

# 🛠 How

Wrong Thread issues

# 👀 See
<img width="424" alt="Screenshot 2023-12-06 at 11 14 39 AM" src="https://github.com/kickstarter/android-oss/assets/4083656/8b23faa9-d062-4180-817e-c2bae8f2fd73">


|  |  |

# 📋 QA

- Back a project from games category, without being subscribed to the games newsletter, if pressing the `yes please` button on the Dialog the user will be opted-in to the games newsletter 

# Story 📖

[MBL-1086](https://kickstarter.atlassian.net/browse/MBL-1086)


[MBL-1086]: https://kickstarter.atlassian.net/browse/MBL-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ