### PR TITLE
[MBL-1089] SettingsActivity crash fix, Observe on UI thread

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
@@ -85,7 +85,7 @@ class SettingsActivity : AppCompatActivity() {
         )
 
         this.viewModel.outputs.avatarImageViewUrl()
-            .compose(Transformers.observeForUIV2())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe { url ->
                 Picasso.get().load(url).transform(CircleTransformation())
                     .into(binding.profilePictureImageView)
@@ -109,7 +109,7 @@ class SettingsActivity : AppCompatActivity() {
             .addToDisposable(disposables)
 
         this.viewModel.outputs.userNameTextViewText()
-            .compose(Transformers.observeForUIV2())
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe { binding.nameTextView.text = it }
             .addToDisposable(disposables)
 

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
@@ -18,7 +18,6 @@ import com.kickstarter.libs.Build
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.Logout
 import com.kickstarter.libs.featureflag.FlagKey
-import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.transformations.CircleTransformation
 import com.kickstarter.libs.utils.ApplicationUtils
 import com.kickstarter.libs.utils.ViewUtils

--- a/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SettingsActivity.kt
@@ -113,12 +113,15 @@ class SettingsActivity : AppCompatActivity() {
             .subscribe { binding.nameTextView.text = it }
             .addToDisposable(disposables)
 
-        this.viewModel.isUserPresent.subscribe { isPresent ->
-            binding.editProfileRow.isGone = !BuildConfig.DEBUG || !isPresent
-            binding.accountRow.isGone = !isPresent
-            binding.notificationAndNewsletterContainer.isGone = !isPresent
-            binding.logOutRow.isGone = !isPresent
-        }.addToDisposable(disposables)
+        this.viewModel.isUserPresent
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe { isPresent ->
+                binding.editProfileRow.isGone = !BuildConfig.DEBUG || !isPresent
+                binding.accountRow.isGone = !isPresent
+                binding.notificationAndNewsletterContainer.isGone = !isPresent
+                binding.logOutRow.isGone = !isPresent
+            }
+            .addToDisposable(disposables)
 
         binding.accountRow.setOnClickListener {
             startActivity(Intent(this, AccountActivity::class.java))


### PR DESCRIPTION
# 📲 What

A new crash was found on 3.17.0:
https://console.firebase.google.com/u/0/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/aafc872fb1f42423f44fb9fde52ebd45?time=last-seven-days&versions=3.17.0%20(2014150890)&types=crash&sessionEventKey=65702C2803D000015FAF94B5C6FCD33A_1887839482962394042
This should remove this crash

# 🤔 Why

Crashes suck

# 🛠 How

Make the observable adjusting the UI run on the UI thread


# 📋 QA

Make sure settings activity loads correctly

# Story 📖

[MBL-1089](https://kickstarter.atlassian.net/browse/MBL-1089)


[MBL-1089]: https://kickstarter.atlassian.net/browse/MBL-1089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ