### PR TITLE
[no-jira]: Upgrade android machine version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ base_job: &base_job
   executor:
     name: android/android-machine
     resource-class: xlarge
-    tag: 2023.08.1 #https://circleci.com/developer/images/image/cimg/android
+    tag: 2023.11.1 #https://circleci.com/developer/images/image/cimg/android
   working_directory: "~/project"
   environment:
     TERM: dumb


### PR DESCRIPTION
# 📲 What

- Upgraded machine version, installing firebase CLI was erroring due to an old version of node, this new machine has newer node version.
