### PR TITLE
MBL-1077: Coroutines in ChangePasswordViewModel + Tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -150,7 +150,7 @@ android {
             useLegacyPackaging = true
         }
         resources {
-            excludes += ['META-INF/LICENSE.txt', 'LICENSE.txt', 'META-INF/AL2.0', 'META-INF/LGPL2.1']
+            excludes += ['META-INF/LICENSE.txt', 'LICENSE.txt', 'META-INF/AL2.0', 'META-INF/LGPL2.1', 'DebugProbesKt.bin']
         }
     }
 
@@ -287,6 +287,12 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.7.2'
     implementation 'androidx.constraintlayout:constraintlayout-compose:1.0.1'
     implementation "com.google.accompanist:accompanist-systemuicontroller:0.30.1"
+    implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.2"
+
+    // Coroutines
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0-RC"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:1.8.0-RC"
+    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0-RC"
 
     // Zoom on Images
     implementation 'io.github.aghajari:ZoomHelper:1.1.0'

--- a/app/src/main/java/com/kickstarter/ui/activities/ChangePasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ChangePasswordActivity.kt
@@ -8,12 +8,11 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.rxjava2.subscribeAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.kickstarter.libs.Logout
 import com.kickstarter.libs.featureflag.FlagKey
-import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.ApplicationUtils
-import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.SharedPreferenceKey
@@ -21,15 +20,17 @@ import com.kickstarter.ui.activities.compose.ChangePasswordScreen
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
 import com.kickstarter.ui.data.LoginReason
 import com.kickstarter.viewmodels.ChangePasswordViewModel
+import com.kickstarter.viewmodels.ChangePasswordViewModelFactory
 import io.reactivex.disposables.CompositeDisposable
+import kotlinx.coroutines.launch
 
 class ChangePasswordActivity : ComponentActivity() {
 
     private var logout: Logout? = null
     private lateinit var disposables: CompositeDisposable
     private var theme = AppThemes.MATCH_SYSTEM.ordinal
-    private lateinit var viewModelFactory: ChangePasswordViewModel.Factory
-    private val viewModel: ChangePasswordViewModel.ChangePasswordViewModel by viewModels {
+    private lateinit var viewModelFactory: ChangePasswordViewModelFactory
+    private val viewModel: ChangePasswordViewModel by viewModels {
         viewModelFactory
     }
 
@@ -39,18 +40,18 @@ class ChangePasswordActivity : ComponentActivity() {
         var darkModeEnabled = false
 
         this.getEnvironment()?.let { env ->
-            viewModelFactory = ChangePasswordViewModel.Factory(env)
+            viewModelFactory = ChangePasswordViewModelFactory(env)
 
             darkModeEnabled = env.featureFlagClient()?.getBoolean(FlagKey.ANDROID_DARK_MODE_ENABLED) ?: false
             theme = env.sharedPreferences()
                 ?.getInt(SharedPreferenceKey.APP_THEME, AppThemes.MATCH_SYSTEM.ordinal)
                 ?: AppThemes.MATCH_SYSTEM.ordinal
         }
-        setContent {
-            var showProgressBar =
-                viewModel.outputs.progressBarIsVisible().subscribeAsState(initial = false).value
 
-            var error = viewModel.outputs.error().subscribeAsState(initial = "").value
+        setContent {
+            var showProgressBar = viewModel.isLoading.collectAsStateWithLifecycle(initialValue = false)
+
+            var error = viewModel.error.collectAsStateWithLifecycle(initialValue = "")
 
             var scaffoldState = rememberScaffoldState()
 
@@ -68,18 +69,17 @@ class ChangePasswordActivity : ComponentActivity() {
                 ChangePasswordScreen(
                     onBackClicked = { onBackPressedDispatcher.onBackPressed() },
                     onAcceptButtonClicked = { current, new ->
-                        viewModel.updatePasswordData(current, new)
-                        viewModel.inputs.changePasswordClicked()
+                        viewModel.updatePassword(current, new)
                     },
-                    showProgressBar = showProgressBar,
+                    showProgressBar = showProgressBar.value,
                     scaffoldState = scaffoldState
                 )
             }
 
             when {
-                error.isNotEmpty() -> {
+                error.value.isNotEmpty() -> {
                     LaunchedEffect(scaffoldState) {
-                        scaffoldState.snackbarHostState.showSnackbar(error)
+                        scaffoldState.snackbarHostState.showSnackbar(error.value)
                         viewModel.resetError()
                     }
                 }
@@ -88,10 +88,11 @@ class ChangePasswordActivity : ComponentActivity() {
 
         this.logout = getEnvironment()?.logout()
 
-        this.viewModel.outputs.success()
-            .compose(Transformers.observeForUIV2())
-            .subscribe { logout(it) }
-            .addToDisposable(disposables)
+        lifecycleScope.launch {
+            viewModel.success.collect { email ->
+                if (email.isNotEmpty()) logout(email)
+            }
+        }
     }
 
     private fun logout(email: String) {

--- a/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ChangePasswordViewModel.kt
@@ -1,165 +1,62 @@
 package com.kickstarter.viewmodels
 
-import UpdateUserPasswordMutation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import com.kickstarter.libs.Environment
-import com.kickstarter.libs.rx.transformers.Transformers.errorsV2
-import com.kickstarter.libs.rx.transformers.Transformers.takeWhenV2
-import com.kickstarter.libs.rx.transformers.Transformers.valuesV2
-import com.kickstarter.libs.utils.extensions.addToDisposable
-import com.kickstarter.libs.utils.extensions.newPasswordValidationWarnings
-import com.kickstarter.libs.utils.extensions.validPassword
-import io.reactivex.Observable
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.subjects.BehaviorSubject
-import io.reactivex.subjects.PublishSubject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.asFlow
 
-interface ChangePasswordViewModel {
+class ChangePasswordViewModel(val environment: Environment) : ViewModel() {
 
-    interface Inputs {
-        /** Call when the user clicks the change password button. */
-        fun changePasswordClicked()
+    private val mutableError = MutableStateFlow("")
+    val error: StateFlow<String> get() = mutableError.asStateFlow()
 
-        /** Call when the current password field changes.  */
-        fun confirmPassword(confirmPassword: String)
+    private val mutableSuccess = MutableStateFlow("")
+    val success: StateFlow<String> get() = mutableSuccess.asStateFlow()
 
-        /** Call when the current password field changes.  */
-        fun currentPassword(currentPassword: String)
+    private val mutableIsLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> get() = mutableIsLoading.asStateFlow()
 
-        /** Call when the new password field changes.  */
-        fun newPassword(newPassword: String)
-    }
+    private val apolloClient = requireNotNull(this.environment.apolloClientV2())
+    private val analytics = this.environment.analytics()
 
-    interface Outputs {
-        /** Emits when the password update was unsuccessful. */
-        fun error(): Observable<String>
-
-        /** Emits when the progress bar should be visible. */
-        fun progressBarIsVisible(): Observable<Boolean>
-
-        /** Emits when the password update was successful. */
-        fun success(): Observable<String>
-    }
-
-    class ChangePasswordViewModel(val environment: Environment) : ViewModel(), Inputs, Outputs {
-
-        private val changePasswordClicked = PublishSubject.create<Unit>()
-        private val confirmPassword = PublishSubject.create<String>()
-        private val currentPassword = PublishSubject.create<String>()
-        private val newPassword = PublishSubject.create<String>()
-
-        private val error = BehaviorSubject.create<String>()
-        private val progressBarIsVisible = BehaviorSubject.create<Boolean>()
-        private val success = BehaviorSubject.create<String>()
-
-        val inputs: Inputs = this
-        val outputs: Outputs = this
-
-        private val apolloClient = requireNotNull(this.environment.apolloClientV2())
-        private val analytics = this.environment.analytics()
-
-        private val disposables = CompositeDisposable()
-
-        init {
-
-            val changePassword = Observable.combineLatest(
-                this.currentPassword.startWith(""),
-                this.newPassword.startWith(""),
-                this.confirmPassword.startWith("")
-            ) { current, new, confirm -> ChangePassword(current, new, confirm) }
-
-            val changePasswordNotification = changePassword
-                .compose(takeWhenV2(this.changePasswordClicked))
-                .switchMap { cp -> submit(cp).materialize() }
-                .share()
-
-            changePasswordNotification
-                .compose(errorsV2())
-                .subscribe { error ->
-                    error?.localizedMessage?.let { message ->
-                        this.error.onNext(message)
-                    }
+    fun updatePassword(oldPassword: String, newPassword: String) {
+        viewModelScope.launch {
+            apolloClient.updateUserPassword(oldPassword, newPassword, newPassword)
+                .asFlow()
+                .onStart {
+                    mutableIsLoading.emit(true)
                 }
-                .addToDisposable(disposables)
-
-            changePasswordNotification
-                .compose(valuesV2())
-                .map { it.updateUserAccount()?.user()?.email() }
-                .subscribe { email ->
-                    this.analytics?.reset()
-                    email?.let {
-                        this.success.onNext(it)
-                    }
+                .onCompletion {
+                    mutableIsLoading.emit(false)
                 }
-                .addToDisposable(disposables)
-        }
-
-        private fun submit(changePassword: ChangePassword): Observable<UpdateUserPasswordMutation.Data> {
-            return this.apolloClient.updateUserPassword(changePassword.currentPassword, changePassword.newPassword, changePassword.confirmPassword)
-                .doOnSubscribe { this.progressBarIsVisible.onNext(true) }
-                .doAfterTerminate { this.progressBarIsVisible.onNext(false) }
-        }
-
-        fun updatePasswordData(oldPassword: String, newPassword: String) {
-            this.currentPassword.onNext(oldPassword)
-            this.newPassword.onNext(newPassword)
-            this.confirmPassword.onNext(newPassword)
-        }
-
-        fun resetError() {
-            this.error.onNext("")
-        }
-
-        override fun changePasswordClicked() {
-            this.changePasswordClicked.onNext(Unit)
-        }
-
-        override fun confirmPassword(confirmPassword: String) {
-            this.confirmPassword.onNext(confirmPassword)
-        }
-
-        override fun currentPassword(currentPassword: String) {
-            this.currentPassword.onNext(currentPassword)
-        }
-
-        override fun newPassword(newPassword: String) {
-            this.newPassword.onNext(newPassword)
-        }
-
-        override fun error(): Observable<String> {
-            return this.error
-        }
-
-        override fun progressBarIsVisible(): Observable<Boolean> {
-            return this.progressBarIsVisible
-        }
-
-        override fun success(): Observable<String> {
-            return this.success
-        }
-
-        data class ChangePassword(val currentPassword: String, val newPassword: String, val confirmPassword: String) {
-            fun isValid(): Boolean {
-                return this.currentPassword.validPassword() &&
-                    this.newPassword.validPassword() &&
-                    this.confirmPassword.validPassword() &&
-                    this.confirmPassword == this.newPassword
-            }
-
-            fun warning(): Int =
-                newPassword.newPasswordValidationWarnings(confirmPassword) ?: 0
-        }
-
-        override fun onCleared() {
-            disposables.clear()
-            super.onCleared()
+                .catch {
+                    mutableError.emit(it.message ?: "")
+                }
+                .collect {
+                    analytics?.reset()
+                    mutableSuccess.emit(it.updateUserAccount()?.user()?.email() ?: "")
+                }
         }
     }
 
-    class Factory(private val environment: Environment) : ViewModelProvider.Factory {
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return ChangePasswordViewModel(environment) as T
+    fun resetError() {
+        viewModelScope.launch {
+            mutableError.emit("")
         }
+    }
+}
+
+class ChangePasswordViewModelFactory(private val environment: Environment) :
+    ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return ChangePasswordViewModel(environment) as T
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ChangePasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ChangePasswordViewModelTest.kt
@@ -98,7 +98,7 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun userLoggedIn_whenChangePasswordError_userNotReset() = runTest{
+    fun userLoggedIn_whenChangePasswordError_userNotReset() = runTest {
         // - create MockTracking client with user logged in
         val user = UserFactory.user()
         val trackingClient = getMockClientWithUser(user)
@@ -130,7 +130,7 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-   fun serLoggedIn_whenChangePasswordSuccess_userReset() = runTest {
+    fun serLoggedIn_whenChangePasswordSuccess_userReset() = runTest {
         // - create MockTracking client with user logged in
         val user = UserFactory.user()
         val trackingClient = getMockClientWithUser(user)


### PR DESCRIPTION
# 📲 What

Took @mtgriego 's branch https://github.com/kickstarter/android-oss/pull/1858 and did a few changes
- using `StateFlow` to be consumed on compose code (ChangePasswordActivity)
- using `collectAsStateWithLifecycle` when consuming vm's flows
- instead of creating new networking layer methods/client, using ` .asFlow()` from [kotlinx.coroutines.rx2](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/as-flow.html)
- using `onStart`, `onCompletion`,`catch`, and `collect`, it would be a similar usage to RXJava2 `doOnSubscribe`, `doOnTerminate`, `doOnError`, `subscribe`
- Test file migrated to adapt to the coroutines usage

# 🤔 Why

- No RXJava usage on UI or VM's any longer on new screens 🤞 

# 👀 See
- No user facing changes
|  |  |

# 📋 QA

- Change your password

# Story 📖

[MBL-1077](https://kickstarter.atlassian.net/browse/MBL-1077)


[MBL-1077]: https://kickstarter.atlassian.net/browse/MBL-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ