### PR TITLE
MBL-779: ShippingRuleViewHolder migrated to RXJava2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -139,6 +139,7 @@ android {
     buildFeatures {
         compose true
         viewBinding true
+        buildConfig true
     }
 
     composeOptions {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/KSArrayViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/KSArrayViewHolder.kt
@@ -51,7 +51,7 @@ abstract class KSArrayViewHolder(private val view: View) : ActivityLifecycleType
      * Called when the ViewHolder is being detached. Subclasses should override if they need to do any work
      * when the ViewHolder is being de-allocated.
      */
-    protected fun destroy() {}
+    protected open fun destroy() {}
 
     protected fun view(): View {
         return this.view

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ShippingRuleViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ShippingRuleViewHolder.kt
@@ -2,10 +2,12 @@ package com.kickstarter.ui.viewholders
 
 import android.util.Pair
 import com.kickstarter.databinding.ItemShippingRuleBinding
+import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.models.Project
 import com.kickstarter.models.ShippingRule
 import com.kickstarter.viewmodels.ShippingRuleViewHolderViewModel
-import rx.android.schedulers.AndroidSchedulers
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
 
 class ShippingRuleViewHolder(private val binding: ItemShippingRuleBinding, val delegate: Delegate) : KSArrayViewHolder(binding.root) {
 
@@ -14,13 +16,14 @@ class ShippingRuleViewHolder(private val binding: ItemShippingRuleBinding, val d
     }
     private lateinit var shippingRule: ShippingRule
     private val viewModel = ShippingRuleViewHolderViewModel.ViewModel(environment())
+    private val disposables = CompositeDisposable()
 
     init {
 
         this.viewModel.outputs.shippingRuleText()
-            .compose(bindToLifecycle())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { this.binding.shippingRulesItemTextView.text = it }
+            .addToDisposable(disposables)
 
         this.binding.shippingRuleRoot.setOnClickListener {
             this.delegate.ruleSelected(this.shippingRule)
@@ -33,5 +36,10 @@ class ShippingRuleViewHolder(private val binding: ItemShippingRuleBinding, val d
         val project = requireNotNull(shippingRuleAndProject.second) { Project::class.java.toString() + " required to be non-null." }
 
         this.viewModel.inputs.configureWith(this.shippingRule, project)
+    }
+
+    override fun destroy() {
+        this.viewModel.onCleared()
+        disposables.clear()
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModel.kt
@@ -1,15 +1,15 @@
 package com.kickstarter.viewmodels
 
 import android.util.Pair
-import com.kickstarter.libs.ActivityViewModel
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.models.Project
 import com.kickstarter.models.ShippingRule
-import com.kickstarter.ui.viewholders.ShippingRuleViewHolder
-import rx.Observable
-import rx.subjects.BehaviorSubject
-import rx.subjects.PublishSubject
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subjects.PublishSubject
 
 interface ShippingRuleViewHolderViewModel {
 
@@ -23,11 +23,13 @@ interface ShippingRuleViewHolderViewModel {
         fun shippingRuleText(): Observable<String>
     }
 
-    class ViewModel(val environment: Environment) : ActivityViewModel<ShippingRuleViewHolder>(environment), Inputs, Outputs {
+    class ViewModel(val environment: Environment) : Inputs, Outputs {
 
         private val shippingRuleAndProject = PublishSubject.create<Pair<ShippingRule, Project>>()
 
         private val shippingRuleText = BehaviorSubject.create<String>()
+
+        private val disposables = CompositeDisposable()
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -35,13 +37,19 @@ interface ShippingRuleViewHolderViewModel {
         init {
             this.shippingRuleAndProject
                 .filter { it.first.isNotNull() }
-                .map { it.first.location()?.displayableName() }
-                .compose(bindToLifecycle())
-                .subscribe(this.shippingRuleText)
+                .map { it.first.location()?.displayableName() ?: "" }
+                .subscribe {
+                    this.shippingRuleText.onNext(it)
+                }
+                .addToDisposable(disposables)
         }
 
         override fun configureWith(shippingRule: ShippingRule, project: Project) = this.shippingRuleAndProject.onNext(Pair.create(shippingRule, project))
 
         override fun shippingRuleText(): Observable<String> = this.shippingRuleText
+
+        fun onCleared() {
+            disposables.clear()
+        }
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ShippingRuleViewHolderViewModelTest.kt
@@ -2,23 +2,34 @@ package com.kickstarter.viewmodels
 
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.mock.MockCurrentConfig
 import com.kickstarter.mock.factories.ConfigFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.ShippingRuleFactory
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subscribers.TestSubscriber
+import org.junit.After
 import org.junit.Test
-import rx.observers.TestSubscriber
 
 class ShippingRuleViewHolderViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var vm: ShippingRuleViewHolderViewModel.ViewModel
 
     private val shippingRuleText = TestSubscriber.create<String>()
+    private val disposables = CompositeDisposable()
 
     private fun setupEnvironment(environment: Environment) {
         this.vm = ShippingRuleViewHolderViewModel.ViewModel(environment)
 
-        this.vm.outputs.shippingRuleText().subscribe(this.shippingRuleText)
+        this.vm.outputs.shippingRuleText()
+            .subscribe { this.shippingRuleText.onNext(it) }
+            .addToDisposable(disposables)
+    }
+
+    @After
+    fun clean() {
+        disposables.clear()
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,6 @@
 android.enableJetifier=true
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 #android.debug.obsoleteApi=true


### PR DESCRIPTION
# 📲 What

Migration RXJava2 + ViewModel, take a look at the [engineering plan](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2350317579/ViewModel+Tech+Debt+Epic) if any doubt


|  |  |

# 📋 QA

- The viewHolder is triggered when selecting a shipping location, either on BackingAddOns Screen, or in Pledge Screen.

# Story 📖

[MBL-799](https://kickstarter.atlassian.net/browse/MBL-799)
