### PR TITLE
[MBL-1135] Add analytics value for session_force_dark_mode

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -124,4 +124,17 @@ abstract class TrackingClient(
             cm.getNetworkCapabilities(it)?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
         } ?: false
     }
+
+    override fun sessionForceDarkMode(): Boolean {
+        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            when (context.resources?.configuration?.uiMode?.and(Configuration.UI_MODE_NIGHT_MASK)) {
+                Configuration.UI_MODE_NIGHT_YES -> {
+                    true
+                }
+                else -> false
+            }
+        } else {
+            false
+        }
+    }
 }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClientType.kt
@@ -33,6 +33,7 @@ abstract class TrackingClientType {
     protected abstract fun userCountry(user: User): String
     protected abstract fun versionName(): String
     protected abstract fun wifiConnection(): Boolean
+    protected abstract fun sessionForceDarkMode(): Boolean
 
     abstract fun track(eventName: String, additionalProperties: Map<String, Any>)
     abstract fun identify(u: User)
@@ -91,6 +92,7 @@ abstract class TrackingClientType {
             this["user_agent"] = userAgent() ?: ""
             this["user_is_logged_in"] = userIsLoggedIn
             this["wifi_connection"] = wifiConnection()
+            this["force_dark_mode"] = sessionForceDarkMode()
         }
 
         return MapUtils.prefixKeys(properties, "session_")

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.kt
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.kt
@@ -131,6 +131,10 @@ class MockTrackingClient(
         return false
     }
 
+    override fun sessionForceDarkMode(): Boolean {
+        return false
+    }
+
     companion object {
         private val DEFAULT_TIME = DateTime.parse("2018-11-02T18:42:05Z").millis / 1000
     }

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -1658,6 +1658,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals(user != null, expectedProperties["session_user_is_logged_in"])
         assertEquals(false, expectedProperties["session_wifi_connection"])
         assertEquals("android_example_experiment[control]", (expectedProperties["session_variants_internal"] as Array<*>).first())
+        assertEquals(false, expectedProperties["session_force_dark_mode"])
     }
 
     private fun assertUserProperties(isAdmin: Boolean) {


### PR DESCRIPTION
# 📲 What

Add an analytic property for the session if the user is in force dark mode

# 🤔 Why

We want to see if there is any sort of impact for users in dark mode vs not

# 🛠 How

Add the session property after checking the system version and dark mode setting

# 📋 QA

Run the app and confirm the `session_force_dark_mode=XXXX` is correct based on system setting and version

# Story 📖

[MBL-1135](https://kickstarter.atlassian.net/browse/MBL-1135)


[MBL-1135]: https://kickstarter.atlassian.net/browse/MBL-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ