### PR TITLE
Fix Add-ons field not appearing on pledge screen

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/ExpandableHeaderViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ExpandableHeaderViewHolder.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.ui.viewholders
 
+import android.util.Pair
 import com.kickstarter.databinding.ExpandableHeaderItemBinding
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.models.Project

--- a/app/src/main/java/com/kickstarter/viewmodels/ExpandableHeaderViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ExpandableHeaderViewHolderViewModel.kt
@@ -1,6 +1,6 @@
 package com.kickstarter.viewmodels
 
-import android.util.Pair as Pair
+import android.util.Pair
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.isNotNull

--- a/app/src/main/java/com/kickstarter/viewmodels/ExpandableHeaderViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ExpandableHeaderViewHolderViewModel.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels
 
+import android.util.Pair as Pair
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.isNotNull

--- a/app/src/main/res/layout/fragment_pledge_section_header_reward_sumary.xml
+++ b/app/src/main/res/layout/fragment_pledge_section_header_reward_sumary.xml
@@ -46,7 +46,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.60" />
+        app:layout_constraintGuide_percent="0.65" />
 
     <TextView
         android:id="@+id/pledge_header_summary_amount"

--- a/app/src/test/java/com/kickstarter/viewmodels/ExpandableHeaderViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ExpandableHeaderViewHolderViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels
 
+import android.util.Pair
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.mock.factories.ProjectFactory


### PR DESCRIPTION
# 📲 What

Add-ons view was not being populated on pledge screen. Also the delivery date view was overlapping with a divider so I fixed that too.

# 🤔 Why

We needed to import android.util.Pair otherwise it defaults to kotlin.Pair and the data never gets observed.

# 🛠 How

Import android.util.Pair and change the Guideline constraint % from left from 0.60 to 0.65 to keep delivery date to one line

# 👀 See



| Before 🐛 | After fixing Pair type | After fixing constraint |
| --- | --- | --- |
| <img src="https://github.com/kickstarter/android-oss/assets/129205442/b383b475-e243-4424-b944-ee7e13a86644" width="200"> | <img src="https://github.com/kickstarter/android-oss/assets/129205442/21b3b2d3-5818-4f6b-937e-76ad01ccc3a9" width="200"> | <img src="https://github.com/kickstarter/android-oss/assets/129205442/76cacb5b-6d7a-401b-966a-d30923d70a5b" width="200"> |



# 📋 QA

Back a project with add-on’s. On pledge screen, tap the expandable caret button. Verify itemized list is displaying correctly.

# Story 📖

https://kickstarter.atlassian.net/browse/MBL-1155
