### PR TITLE
MBL-1064 Update links for Request My Personal Data and Delete Account

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/Secrets.java.example
+++ b/app/src/main/java/com/kickstarter/libs/utils/Secrets.java.example
@@ -77,8 +77,7 @@ public final class Secrets {
   }
 
   public static final class Privacy {
-    public static final String DELETE_ACCOUNT = "https://kickstarter.privacy";
-    public static final String REQUEST_DATA = "https://www.kickstarter.privacy";
+    public static final String TRANSCEND_PRIVACY_REQUEST_FLOW = "https://legal.kickstarter.com/policies/en/?modal=take-control";
   }
 
   public static final class HelpCenter {

--- a/app/src/main/java/com/kickstarter/ui/activities/PrivacyActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/PrivacyActivity.kt
@@ -67,8 +67,8 @@ class PrivacyActivity : BaseActivity<PrivacyViewModel.ViewModel>() {
         binding.followingSwitch.setOnClickListener { this.viewModel.inputs.optIntoFollowing(binding.followingSwitch.isChecked) }
         binding.privateProfileSwitch.setOnClickListener { this.viewModel.inputs.showPublicProfile(binding.privateProfileSwitch.isChecked) }
         binding.recommendationsSwitch.setOnClickListener { this.viewModel.inputs.optedOutOfRecommendations(binding.recommendationsSwitch.isChecked) }
-        binding.settingsRequestData.setOnClickListener { showPrivacyWebpage(Secrets.Privacy.REQUEST_DATA) }
-        binding.settingsDeleteAccount.setOnClickListener { showPrivacyWebpage(Secrets.Privacy.DELETE_ACCOUNT) }
+        binding.settingsRequestData.setOnClickListener { showPrivacyWebpage(Secrets.Privacy.TRANSCEND_PRIVACY_REQUEST_FLOW) }
+        binding.settingsDeleteAccount.setOnClickListener { showPrivacyWebpage(Secrets.Privacy.TRANSCEND_PRIVACY_REQUEST_FLOW) }
     }
 
     private fun displayPreferences(user: User) {


### PR DESCRIPTION
# 📲 What

Update links in Privacy Activity for "Request My Personal Data" and "Delete My Kickstarter Account" to point to new Trascend flow

# 🤔 Why

Need to use new Trascend flow

https://www.kickstarter.com/profile/request-export-data and https://www.kickstarter.com/profile/destroy -> https://legal.kickstarter.com/policies/en/?modal=take-control

# 🛠 How

Secrets.java also updated

# 👀 See

![Screenshot_20240130-144539](https://github.com/kickstarter/android-oss/assets/129205442/41b0368f-1979-4221-99ac-3abafbd16f06)


# 📋 QA

Profile → Settings → Account → Privacy -> click on "Request My Personal Data" and "Delete My Kickstarter Account" to start Trascend flow. Verify user can initiate the process of a privacy request by choosing a request type and entering their email on the page.

# Story 📖

https://kickstarter.atlassian.net/browse/MBL-1064
