### PR TITLE
MBL-1167: New Login/Sign up Screen with Chrome Tabs (Phase 2)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -197,12 +197,13 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.annotation:annotation:1.3.0'
     implementation 'androidx.appcompat:appcompat:1.4.2'
-    implementation 'androidx.browser:browser:1.4.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.preference:preference-ktx:1.2.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.work:work-runtime-ktx:2.7.1'
+    // Chrome Tabs library
+    implementation 'androidx.browser:browser:1.7.0'
 
     // Architecture components
     def lifecycle_version = "2.2.0"

--- a/app/src/main/java/com/kickstarter/ui/activities/OAuthActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/OAuthActivity.kt
@@ -1,89 +1,51 @@
 package com.kickstarter.ui.activities
 
 import android.app.Activity
-import android.content.ComponentName
+import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
-import androidx.browser.customtabs.CustomTabsCallback
-import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.browser.customtabs.CustomTabsServiceConnection
-import androidx.browser.customtabs.CustomTabsSession
 import androidx.lifecycle.lifecycleScope
-import com.kickstarter.R
-import com.kickstarter.models.chrome.ChromeTabsHelper
+import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.models.chrome.ChromeTabsHelperActivity
-import com.kickstarter.ui.extensions.finishWithAnimation
+import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 class OAuthActivity : AppCompatActivity() {
 
-    private var customClient: CustomTabsClient? = null
-    private var sessionReady: MutableSharedFlow<Boolean> = MutableSharedFlow(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
-    private var session: CustomTabsSession? = null
-
-    val callback = object : CustomTabsCallback() {
-        override fun onNavigationEvent(navigationEvent: Int, extras: Bundle?) {
-            // means the X button has been clicked, therefore ChromeTab has been dismissed
-            if (navigationEvent == TAB_HIDDEN) {
-                finishWithAnimation()
-            }
-            Timber.d(this.javaClass.canonicalName, "onNavigationEvent: Code = $navigationEvent")
-        }
-    }
-    val connection: CustomTabsServiceConnection = object : CustomTabsServiceConnection() {
-        override fun onCustomTabsServiceConnected(
-            name: ComponentName,
-            client: CustomTabsClient
-        ) {
-            customClient = client
-            customClient?.warmup(0)
-            session = customClient?.newSession(callback)
-            session?.mayLaunchUrl(Uri.parse("https://www.kickstarter.com/oauth/authorizations"), null, null)
-            sessionReady.tryEmit(true)
-        }
-        override fun onServiceDisconnected(name: ComponentName) {
-            customClient = null
-            session = null
-        }
-    }
+    private lateinit var helper: ChromeTabsHelperActivity.CustomTabSessionAndClientHelper
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setUpConnectivityStatusCheck(lifecycle)
 
-        this.onBackPressedDispatcher.addCallback {
-            finishWithAnimation()
+        // TODO MBL-1168 the url will be retrieved from the VM,on MBL-1168 alongside PKCE paramenters
+        val uri = Uri.parse("https://www.kickstarter.com/oauth/authorizations")
+
+        // BindCustomTabsService, obtain CustomTabsClient and Client, listens to navigation events
+        helper = ChromeTabsHelperActivity.CustomTabSessionAndClientHelper(this, uri) {
+            finish()
         }
 
-        CustomTabsClient.bindCustomTabsService(
-            this,
-            ChromeTabsHelper.getPackageNameToUse(this) ?: "",
-            connection
-        )
-
-        // TODO MBL-1168 the url will be retrieved from the VM,on MBL-1168
-        val uri = Uri.parse("https://www.kickstarter.com/oauth/authorizations")
+        // - Fallback in case Chrome is not installed, open WebViewActivity
         val fallback = object : ChromeTabsHelperActivity.CustomTabFallback {
             override fun openUri(activity: Activity, uri: Uri) {
+                val intent: Intent = Intent(activity, WebViewActivity::class.java)
+                    .putExtra(IntentKey.URL, uri.toString())
+
                 activity.startActivity(intent)
+                TransitionUtils.slideInFromRight()
             }
         }
 
-        val context = this
         lifecycleScope.launch {
-            sessionReady.collect {
-                val builder = CustomTabsIntent.Builder(session)
-                builder.setStartAnimations(context, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
-                val customTabsIntent = builder.build()
-                ChromeTabsHelperActivity.openCustomTab(context, customTabsIntent, uri, fallback)
+            // - Once the session is ready and client warmed-up load the url
+            helper.isSessionReady().collect {
+                val tabIntent = CustomTabsIntent.Builder(helper.getSession()).build()
+                ChromeTabsHelperActivity.openCustomTab(this@OAuthActivity, tabIntent, uri, fallback)
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/OAuthActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/OAuthActivity.kt
@@ -1,14 +1,58 @@
 package com.kickstarter.ui.activities
 
+import android.app.Activity
+import android.content.ComponentName
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
+import androidx.browser.customtabs.CustomTabsCallback
+import androidx.browser.customtabs.CustomTabsClient
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.CustomTabsServiceConnection
+import androidx.browser.customtabs.CustomTabsSession
+import androidx.lifecycle.lifecycleScope
+import com.kickstarter.R
+import com.kickstarter.models.chrome.ChromeTabsHelper
+import com.kickstarter.models.chrome.ChromeTabsHelperActivity
 import com.kickstarter.ui.extensions.finishWithAnimation
 import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
 
 class OAuthActivity : AppCompatActivity() {
+
+    private var customClient: CustomTabsClient? = null
+    private var sessionReady: MutableSharedFlow<Boolean> = MutableSharedFlow(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    private var session: CustomTabsSession? = null
+
+    val callback = object : CustomTabsCallback() {
+        override fun onNavigationEvent(navigationEvent: Int, extras: Bundle?) {
+            // means the X button has been clicked, therefore ChromeTab has been dismissed
+            if (navigationEvent == TAB_HIDDEN) {
+                finishWithAnimation()
+            }
+            Timber.d(this.javaClass.canonicalName, "onNavigationEvent: Code = $navigationEvent")
+        }
+    }
+    val connection: CustomTabsServiceConnection = object : CustomTabsServiceConnection() {
+        override fun onCustomTabsServiceConnected(
+            name: ComponentName,
+            client: CustomTabsClient
+        ) {
+            customClient = client
+            customClient?.warmup(0)
+            session = customClient?.newSession(callback)
+            session?.mayLaunchUrl(Uri.parse("https://www.kickstarter.com/oauth/authorizations"), null, null)
+            sessionReady.tryEmit(true)
+        }
+        override fun onServiceDisconnected(name: ComponentName) {
+            customClient = null
+            session = null
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -19,6 +63,28 @@ class OAuthActivity : AppCompatActivity() {
             finishWithAnimation()
         }
 
-        // TODO: Will continue work on https://kickstarter.atlassian.net/browse/MBL-1167
+        CustomTabsClient.bindCustomTabsService(
+            this,
+            ChromeTabsHelper.getPackageNameToUse(this) ?: "",
+            connection
+        )
+
+        // TODO MBL-1168 the url will be retrieved from the VM,on MBL-1168
+        val uri = Uri.parse("https://www.kickstarter.com/oauth/authorizations")
+        val fallback = object : ChromeTabsHelperActivity.CustomTabFallback {
+            override fun openUri(activity: Activity, uri: Uri) {
+                activity.startActivity(intent)
+            }
+        }
+
+        val context = this
+        lifecycleScope.launch {
+            sessionReady.collect {
+                val builder = CustomTabsIntent.Builder(session)
+                builder.setStartAnimations(context, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
+                val customTabsIntent = builder.build()
+                ChromeTabsHelperActivity.openCustomTab(context, customTabsIntent, uri, fallback)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -236,13 +236,13 @@ fun Activity.startPreLaunchProjectActivity(project: Project, previousScreen: Str
 fun Activity.startLogin(isOauthPathEnabled: Boolean) {
     val intent = Intent().getStartLoginIntent(isOauthPathEnabled, this)
     startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW)
-    TransitionUtils.transition(this, TransitionUtils.fadeIn())
+    TransitionUtils.transition(this, TransitionUtils.slideInFromRight())
 }
 
 fun Activity.startSignup(isOauthPathEnabled: Boolean) {
     val intent = Intent().getSignupIntent(isOauthPathEnabled, this)
     startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW)
-    TransitionUtils.transition(this, TransitionUtils.fadeIn())
+    TransitionUtils.transition(this, TransitionUtils.slideInFromRight())
 }
 
 fun Activity.startDisclaimerChromeTab(disclaimerItem: DisclaimerItems, environment: Environment?) {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         classpath 'com.google.gms:google-services:4.3.15'
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
# 📲 What

Getting ready for OAuth! 

# 🤔 Why

- OAuth 2.0 implementation for Login & Signup, for more info take a look at the[ Eng plan ](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2571272239/OAuth+2.0+for+Native+Applications)

# 🛠 How

- Set the ChromeTabs that will load  **(OAuth authorization endpoint)** with navigationEvents callback to detect when the tab was closed.
- Updated from `androidx.browser:browser:1.4.0` -> `androidx.browser:browser:1.7.0`
- Updated from `com.android.tools.build:gradle:8.2.0`-> `com.android.tools.build:gradle:8.2.2`
- Using coroutines instead of rxjava

# 👀 See
You can see the navigation events on Logcat filtering the the class name `CustomTabSessionAndClientHelper`
<img width="1135" alt="Screenshot 2024-01-31 at 5 25 52 PM" src="https://github.com/kickstarter/android-oss/assets/4083656/a0b55579-9239-434d-8481-e24cea98bba3">


https://github.com/kickstarter/android-oss/assets/4083656/07ce6419-4735-405e-a2ae-0ec1091d8909


|  |  |

# 📋 QA

- Not much to QA yet, as the login process is still wip, but you can play around with the Chrome tabs, hit the X button, set airplain mode or lose wifi ... etc, 

# Story 📖

[MBL-1167](https://kickstarter.atlassian.net/browse/MBL-1167)


[MBL-1167]: https://kickstarter.atlassian.net/browse/MBL-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ