### PR TITLE
[MBL-1163] Add mutation and models for createPaymentIntent

### DIFF
--- a/app/src/main/graphql/checkout.graphql
+++ b/app/src/main/graphql/checkout.graphql
@@ -48,3 +48,9 @@ mutation CreateCheckout($projectId: ID!, $amount: String!, $rewardIds: [ID!], $l
     }
   }
 }
+
+mutation CreatePaymentIntent($projectId: ID!, $amountDollars: String!) {
+  createPaymentIntent(input: { projectId: $projectId, amountDollars: $amountDollars } ) {
+    clientSecret
+  }
+}

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -27,6 +27,7 @@ import com.kickstarter.models.Category
 import com.kickstarter.models.Checkout
 import com.kickstarter.models.CheckoutPayment
 import com.kickstarter.models.Comment
+import com.kickstarter.models.CreatePaymentIntentInput
 import com.kickstarter.models.CreatorDetails
 import com.kickstarter.models.ErroredBacking
 import com.kickstarter.models.Location
@@ -268,6 +269,10 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
     }
 
     override fun createCheckout(createCheckoutData: CreateCheckoutData): io.reactivex.Observable<CheckoutPayment> {
+        return io.reactivex.Observable.empty()
+    }
+
+    override fun createPaymentIntent(createPaymentIntentInput: CreatePaymentIntentInput): io.reactivex.Observable<String> {
         return io.reactivex.Observable.empty()
     }
 }

--- a/app/src/main/java/com/kickstarter/models/CreatePaymentIntentInput.kt
+++ b/app/src/main/java/com/kickstarter/models/CreatePaymentIntentInput.kt
@@ -1,0 +1,3 @@
+package com.kickstarter.models
+
+data class CreatePaymentIntentInput(val project: Project, val amountDollars: String)

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -1447,7 +1447,7 @@ class KSApolloClientV2(val service: ApolloClient) : ApolloClientTypeV2 {
                     .projectId(encodeRelayId(createPaymentIntentInput.project))
                     .amountDollars(createPaymentIntentInput.amountDollars)
                     .build()
-            ).enqueue(object: ApolloCall.Callback<CreatePaymentIntentMutation.Data>() {
+            ).enqueue(object : ApolloCall.Callback<CreatePaymentIntentMutation.Data>() {
                 override fun onFailure(e: ApolloException) {
                     ps.onError(e)
                 }

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.services
 
+import CreatePaymentIntentMutation
 import android.util.Pair
 import com.apollographql.apollo.ApolloCall
 import com.apollographql.apollo.ApolloClient
@@ -11,6 +12,7 @@ import com.kickstarter.models.Category
 import com.kickstarter.models.Checkout
 import com.kickstarter.models.CheckoutPayment
 import com.kickstarter.models.Comment
+import com.kickstarter.models.CreatePaymentIntentInput
 import com.kickstarter.models.CreatorDetails
 import com.kickstarter.models.ErroredBacking
 import com.kickstarter.models.Location
@@ -128,6 +130,8 @@ interface ApolloClientTypeV2 {
     fun getProjectBacking(slug: String): Observable<Backing>
 
     fun createCheckout(createCheckoutData: CreateCheckoutData): Observable<CheckoutPayment>
+
+    fun createPaymentIntent(createPaymentIntentInput: CreatePaymentIntentInput): Observable<String>
 }
 
 private const val PAGE_SIZE = 25
@@ -1432,5 +1436,32 @@ class KSApolloClientV2(val service: ApolloClient) : ApolloClientTypeV2 {
             })
             return@defer ps
         }.subscribeOn(Schedulers.io())
+    }
+
+    override fun createPaymentIntent(createPaymentIntentInput: CreatePaymentIntentInput): Observable<String> {
+        return Observable.defer {
+            val ps = PublishSubject.create<String>()
+
+            this.service.mutate(
+                CreatePaymentIntentMutation.builder()
+                    .projectId(encodeRelayId(createPaymentIntentInput.project))
+                    .amountDollars(createPaymentIntentInput.amountDollars)
+                    .build()
+            ).enqueue(object: ApolloCall.Callback<CreatePaymentIntentMutation.Data>() {
+                override fun onFailure(e: ApolloException) {
+                    ps.onError(e)
+                }
+
+                override fun onResponse(response: Response<CreatePaymentIntentMutation.Data>) {
+                    if (response.hasErrors()) {
+                        ps.onError(Exception(response.errors?.first()?.message))
+                    } else {
+                        ps.onNext(response.data?.createPaymentIntent()?.clientSecret() ?: "")
+                    }
+                    ps.onComplete()
+                }
+            })
+            return@defer ps
+        }
     }
 }


### PR DESCRIPTION
# 📲 What

Adds support for the new create payment intent mutation used in the post campaign checkout

# 🤔 Why

Implementation is to come later, but this is to add it into the codebase for use when we are moving to implementation

# 🛠 How

Created the mutation and data classes needed to execute the mutation successfully with the backend

# 👀 See

Below is the plaintext and graphql input and output for the call

```
CreatePaymentIntent input: projectId: 629661769, amount: 3.0

X-APOLLO-OPERATION-NAME: CreatePaymentIntent
{"operationName":"CreatePaymentIntent","variables":{"projectId":"UHJvamVjdC02Mjk2NjE3Njk=","amountDollars":"3.0"},"query":"mutation CreatePaymentIntent($projectId: ID!, $amountDollars: String!) { createPaymentIntent(input: {projectId: $projectId, amountDollars: $amountDollars}) { __typename clientSecret } }"}

{"data":{"createPaymentIntent":{"__typename":"CreatePaymentIntentPayload","clientSecret":"pi_3OgXqG4VvJ2PtfhK0b9FgwIj_secret_T8FscEiYKqwrLb60QYdxJ4tRc"}}}

CreatePaymentIntent output: clientSecret: pi_3OgXqG4VvJ2PtfhK0b9FgwIj_secret_T8FscEiYKqwrLb60QYdxJ4tRc
```

# 📋 QA

At the moment it is not implemented, so testing involves adding this call to the pledge fragment and calling with the available data to check for correct result.  As long as this returns the clientSecret that is a success

# Story 📖

[MBL-1163](https://kickstarter.atlassian.net/browse/MBL-1163)

[MBL-1163]: https://kickstarter.atlassian.net/browse/MBL-1163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ