### PR TITLE
MBL-1169: Redirection step

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -151,14 +151,12 @@
             android:exported="true"
             android:launchMode="singleTop">
             <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
 
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="ksrauth2"
-                    android:host="authorize" />
+                <data android:scheme="ksrauth2" />
+                <data android:host="authorize" />
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,7 +84,6 @@
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
@@ -148,15 +147,15 @@
             android:theme="@style/Login" />
         <activity
             android:name=".ui.activities.OAuthActivity"
-            android:exported="true"
-            android:launchMode="singleTop">
-            <intent-filter>
+            android:launchMode="singleTop"
+            android:exported="true">
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
 
                 <data android:scheme="ksrauth2" />
-                <data android:host="authorize" />
+                <data android:host="authenticate" />
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/java/com/kickstarter/libs/utils/CodeVerifier.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/CodeVerifier.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.libs.utils
 
 import android.util.Base64
+import com.kickstarter.libs.utils.CodeVerifier.Companion.DEFAULT_CODE_VERIFIER_ENTROPY
 import timber.log.Timber
 import java.io.UnsupportedEncodingException
 import java.security.MessageDigest
@@ -13,7 +14,20 @@ import java.util.regex.Pattern
  *
  * @see [Proof Key for Code Exchange by OAuth Public Clients](https://datatracker.ietf.org/doc/html/rfc7636)
  */
-class CodeVerifier {
+interface PKCE {
+    fun generateRandomCodeVerifier(entropy: Int = DEFAULT_CODE_VERIFIER_ENTROPY): String
+    fun generateCodeChallenge(codeVerifier: String): String
+}
+open class CodeVerifier : PKCE {
+
+    override fun generateRandomCodeVerifier(entropy: Int): String {
+        return Companion.generateRandomCodeVerifier(entropyBytes = entropy)
+    }
+
+    override fun generateCodeChallenge(codeVerifier: String): String {
+        return Companion.generateCodeChallenge(codeVerifier)
+    }
+
     companion object {
         /**
          * The minimum permitted length for a code verifier.

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
@@ -35,17 +35,15 @@ fun Intent.getPreLaunchProjectActivity(context: Context, slug: String?, project:
 }
 
 fun Intent.getStartLoginIntent(isOAuthEnabled: Boolean, context: Context): Intent {
-    return if (isOAuthEnabled)
+    return if (isOAuthEnabled) {
         this.setClass(context, OAuthActivity::class.java)
-        this.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
     } else
         this.setClass(context, LoginActivity::class.java)
 }
 
 fun Intent.getSignupIntent(isOAuthEnabled: Boolean, context: Context): Intent {
-    return if (isOAuthEnabled)
+    return if (isOAuthEnabled) {
         this.setClass(context, OAuthActivity::class.java)
-        this.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
     } else
         this.setClass(context, SignupActivity::class.java)
 }

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
@@ -37,14 +37,16 @@ fun Intent.getPreLaunchProjectActivity(context: Context, slug: String?, project:
 fun Intent.getStartLoginIntent(isOAuthEnabled: Boolean, context: Context): Intent {
     return if (isOAuthEnabled)
         this.setClass(context, OAuthActivity::class.java)
-    else
+        this.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+    } else
         this.setClass(context, LoginActivity::class.java)
 }
 
 fun Intent.getSignupIntent(isOAuthEnabled: Boolean, context: Context): Intent {
     return if (isOAuthEnabled)
         this.setClass(context, OAuthActivity::class.java)
-    else
+        this.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+    } else
         this.setClass(context, SignupActivity::class.java)
 }
 

--- a/app/src/main/java/com/kickstarter/models/chrome/ChromeTabsHelperActivity.kt
+++ b/app/src/main/java/com/kickstarter/models/chrome/ChromeTabsHelperActivity.kt
@@ -18,7 +18,6 @@ package com.kickstarter.models.chrome
 
 import android.app.Activity
 import android.content.ComponentName
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -95,7 +94,7 @@ class ChromeTabsHelperActivity {
      * navigation event has been detected
      */
     class CustomTabSessionAndClientHelper(
-        context: Context,
+        context: Activity,
         uri: Uri,
         tabHiddenCallback: () -> Unit
     ) {
@@ -107,7 +106,7 @@ class ChromeTabsHelperActivity {
 
         private val callback = object : CustomTabsCallback() {
             override fun onNavigationEvent(navigationEvent: Int, extras: Bundle?) {
-                Timber.d("onNavigationEvent: Code = $navigationEvent")
+                Timber.d("OAuth onNavigationEvent: Code = $navigationEvent")
                 // - means the X button has been clicked, therefore ChromeTab has been dismissed
                 if (navigationEvent == TAB_HIDDEN) {
                     tabHiddenCallback()
@@ -132,6 +131,7 @@ class ChromeTabsHelperActivity {
                 sessionReady.tryEmit(session.isNotNull())
                 Timber.d("onCustomTabsServiceConnected")
             }
+
             override fun onServiceDisconnected(name: ComponentName) {
                 Timber.d("onServiceDisconnected")
                 customClient = null

--- a/app/src/main/java/com/kickstarter/ui/activities/OAuthActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/OAuthActivity.kt
@@ -4,38 +4,70 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.lifecycle.lifecycleScope
-import com.kickstarter.libs.utils.CodeVerifier
 import com.kickstarter.libs.utils.TransitionUtils
+import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.models.chrome.ChromeTabsHelperActivity
 import com.kickstarter.ui.IntentKey
+import com.kickstarter.ui.extensions.finishWithAnimation
 import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
+import com.kickstarter.viewmodels.OAuthViewModel
+import com.kickstarter.viewmodels.OAuthViewModelFactory
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 class OAuthActivity : AppCompatActivity() {
 
     private lateinit var helper: ChromeTabsHelperActivity.CustomTabSessionAndClientHelper
+    private lateinit var viewModelFactory: OAuthViewModelFactory
+    private val viewModel: OAuthViewModel by viewModels {
+        viewModelFactory
+    }
 
-    val redirectUri = "ksrauth2://authorize"
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         setUpConnectivityStatusCheck(lifecycle)
 
-        // TODO: Will be moved to VM all the URI parameters building on MBL-1169
-        val codeVerifier = CodeVerifier.generateRandomCodeVerifier(entropyBytes = CodeVerifier.MAX_CODE_VERIFIER_ENTROPY)
-        val authParams = mapOf(
-            "redirect_uri" to redirectUri,
-            "response_type" to "code",
-            "code_challenge" to CodeVerifier.generateCodeChallenge(codeVerifier), // Set the code challenge
-            "code_challenge_method" to "S256"
-        ).map { (k, v) -> "${(k)}=$v" }.joinToString("&")
-        val uri = Uri.parse("https://www.kickstarter.com/oauth/authorizations?$authParams")
+        Timber.d("OAuthActivity: onCreate Intent: $intent, onCreate data: ${intent.data}")
+
+        this.getEnvironment()?.let { env ->
+            viewModelFactory = OAuthViewModelFactory(environment = env)
+        }
+
+        viewModel.produceState(intent = intent)
+
+        lifecycleScope.launch {
+
+            viewModel.uiState.collect { state ->
+                // - Intent generated with onCreate
+                if (state.isAuthorizationStep && state.authorizationUrl.isNotEmpty()) {
+                    openChromeTabWithUrl(state.authorizationUrl)
+                }
+
+                if (state.isTokenRetrieveStep && state.code.isNotEmpty()) {
+                    // TODO WIP PHASE 3, call the endpoint with code & code_challenge, retrieve the token, for now it kills the current activity
+                    Timber.d("OAuthActivity Redirect took place: $this")
+                    finishWithAnimation()
+                }
+            }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        Timber.d("OAuthActivity: onNewIntent Intent: $intent, data: ${intent?.data}")
+        // - Intent generated when the deepLink redirection takes place
+        intent?.let { viewModel.produceState(intent = it) }
+    }
+
+    private fun openChromeTabWithUrl(url: String) {
+        val authorizationUri = Uri.parse(url)
 
         // BindCustomTabsService, obtain CustomTabsClient and Client, listens to navigation events
-        helper = ChromeTabsHelperActivity.CustomTabSessionAndClientHelper(this, uri) {
+        helper = ChromeTabsHelperActivity.CustomTabSessionAndClientHelper(this, authorizationUri) {
             finish()
         }
 
@@ -52,9 +84,14 @@ class OAuthActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             // - Once the session is ready and client warmed-up load the url
-            helper.isSessionReady().collect {
+            helper.isSessionReady().collect { ready ->
                 val tabIntent = CustomTabsIntent.Builder(helper.getSession()).build()
-                ChromeTabsHelperActivity.openCustomTab(this@OAuthActivity, tabIntent, uri, fallback)
+                ChromeTabsHelperActivity.openCustomTab(
+                    this@OAuthActivity,
+                    tabIntent,
+                    authorizationUri,
+                    fallback
+                )
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/OAuthActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/OAuthActivity.kt
@@ -12,7 +12,6 @@ import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.models.chrome.ChromeTabsHelperActivity
 import com.kickstarter.ui.IntentKey
-import com.kickstarter.ui.extensions.finishWithAnimation
 import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.viewmodels.OAuthViewModel
 import com.kickstarter.viewmodels.OAuthViewModelFactory
@@ -48,14 +47,16 @@ class OAuthActivity : AppCompatActivity() {
                 }
 
                 if (state.isTokenRetrieveStep && state.code.isNotEmpty()) {
-                    // TODO WIP PHASE 3, call the endpoint with code & code_challenge, retrieve the token, for now it kills the current activity
-                    Timber.d("OAuthActivity Redirect took place: $this")
-                    finishWithAnimation()
+                    // TODO WIP PHASE 3, VM call the endpoint with code & code_challenge, retrieve the token.
                 }
             }
         }
     }
 
+    override fun onDestroy() {
+        Timber.d("OAuthActivity: onDestroy")
+        super.onDestroy()
+    }
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         Timber.d("OAuthActivity: onNewIntent Intent: $intent, data: ${intent?.data}")
@@ -86,6 +87,8 @@ class OAuthActivity : AppCompatActivity() {
             // - Once the session is ready and client warmed-up load the url
             helper.isSessionReady().collect { ready ->
                 val tabIntent = CustomTabsIntent.Builder(helper.getSession()).build()
+                tabIntent.intent.flags = Intent.FLAG_ACTIVITY_NO_HISTORY
+                // tabIntent.intent.addFlags(Intent.FLAG_ACTIVITY_PREVIOUS_IS_TOP)
                 ChromeTabsHelperActivity.openCustomTab(
                     this@OAuthActivity,
                     tabIntent,

--- a/app/src/main/java/com/kickstarter/viewmodels/OAuthViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/OAuthViewModel.kt
@@ -1,0 +1,106 @@
+package com.kickstarter.viewmodels
+
+import android.content.Intent
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.kickstarter.libs.ApiEndpoint
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.CodeVerifier
+import com.kickstarter.libs.utils.PKCE
+import com.kickstarter.libs.utils.Secrets
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * UiState for the OAuthScreen.
+ *  @param authorizationUrl = Url to be loaded withing the ChromeTabs with all PKCE params
+ *  @param code = code retrieved from the redirect deeplink, once the user has logged in successfully on ChromeTabs
+ */
+data class OAuthUiState(
+    val authorizationUrl: String = "",
+    val code: String = "",
+    val isAuthorizationStep: Boolean = false,
+    val isTokenRetrieveStep: Boolean = false
+)
+class OAuthViewModel(
+    private val environment: Environment,
+    private val verifier: PKCE
+) : ViewModel() {
+
+    private val hostEndpoint = environment.webEndpoint()
+    private val clientID = if (hostEndpoint == ApiEndpoint.PRODUCTION.name) Secrets.Api.Client.PRODUCTION else Secrets.Api.Client.STAGING
+    private val codeVerifier = verifier.generateRandomCodeVerifier(entropy = CodeVerifier.MAX_CODE_VERIFIER_ENTROPY)
+
+    private var mutableUIState = MutableStateFlow(OAuthUiState())
+    val uiState: StateFlow<OAuthUiState>
+        get() = mutableUIState.asStateFlow()
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(),
+                initialValue = OAuthUiState()
+            )
+    fun produceState(intent: Intent) {
+        viewModelScope.launch {
+            val uri = Uri.parse(intent.data.toString())
+            val scheme = uri.scheme
+            val host = uri.host
+            val code = uri.getQueryParameter("code")
+
+            if (scheme == REDIRECT_URI_SCHEMA && host == REDIRECT_URI_HOST && code != null) {
+                Timber.d("isTokenRetrieveStep after redirectionDeeplink: $code")
+                mutableUIState.emit(
+                    OAuthUiState(
+                        code = code,
+                        isTokenRetrieveStep = true,
+                        isAuthorizationStep = false
+                    )
+                )
+                // TODO: will call with code and code_challenge once the backend is ready to call the tokenEndpoint
+            }
+
+            if (intent.data == null) {
+                val url = generateAuthorizationUrlWithParams()
+                Timber.d("isAuthorizationStep $url")
+                mutableUIState.emit(
+                    OAuthUiState(
+                        authorizationUrl = url,
+                        isAuthorizationStep = true,
+                        isTokenRetrieveStep = false
+                    )
+                )
+            }
+        }
+    }
+    private fun generateAuthorizationUrlWithParams(): String {
+        val authParams = mapOf(
+            "redirect_uri" to REDIRECT_URI_SCHEMA,
+            "scope" to "1", // profile/email
+            "client_id" to clientID,
+            "response_type" to "1", // code
+            "code_challenge" to verifier.generateCodeChallenge(codeVerifier),
+            "code_challenge_method" to "S256"
+        ).map { (k, v) -> "${(k)}=$v" }.joinToString("&")
+        return "$hostEndpoint/oauth/authorizations/new?$authParams"
+    }
+
+    private companion object {
+        const val REDIRECT_URI_SCHEMA = "ksrauth2"
+        const val REDIRECT_URI_HOST = "authenticate"
+    }
+}
+
+class OAuthViewModelFactory(
+    private val environment: Environment,
+    private val verifier: PKCE = CodeVerifier()
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return OAuthViewModel(environment, verifier = verifier) as T
+    }
+}

--- a/app/src/test/java/com/kickstarter/viewmodels/OAuthActivityViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/OAuthActivityViewModelTest.kt
@@ -1,0 +1,84 @@
+package com.kickstarter.viewmodels
+
+import android.content.Intent
+import android.net.Uri
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.CodeVerifier
+import com.kickstarter.libs.utils.PKCE
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class OAuthActivityViewModelTest : KSRobolectricTestCase() {
+    private lateinit var vm: OAuthViewModel
+
+    private fun setUpEnvironment(environment: Environment, mockCodeVerifier: PKCE) {
+        this.vm = OAuthViewModelFactory(environment, mockCodeVerifier).create(OAuthViewModel::class.java)
+    }
+
+    @Test
+    fun testProduceState_isAuthorizationStep() = runTest {
+
+        val testEndpoint = "testEndpoint"
+        val testCodeVerifier = "testCodeVerifier"
+        val testCodeChallenge = "testCodeChallenge"
+        val environment = environment().toBuilder().webEndpoint(testEndpoint).build()
+
+        val mockCodeVerifier = object : PKCE {
+            override fun generateCodeChallenge(codeVerifier: String): String {
+                return testCodeChallenge
+            }
+
+            override fun generateRandomCodeVerifier(entropy: Int): String {
+                return testCodeVerifier
+            }
+        }
+
+        setUpEnvironment(environment, mockCodeVerifier)
+
+        val state = mutableListOf<OAuthUiState>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            vm.produceState(Intent())
+            vm.uiState.toList(state)
+        }
+
+        val testAuthorizationUrl = "$testEndpoint/oauth/authorizations/new?redirect_uri=ksrauth2&scope=1&client_id=2QEKDK20F5LO2CEOIDZZOW8QGOM6P68AB4A5OQ44XK3N0CUW5T&response_type=1&code_challenge=$testCodeChallenge&code_challenge_method=S256"
+        // - First empty emission due the initialization
+        assertEquals(
+            listOf(
+                OAuthUiState(authorizationUrl = "", isAuthorizationStep = false, isTokenRetrieveStep = false, code = ""),
+                OAuthUiState(
+                    authorizationUrl = testAuthorizationUrl, code = "", isAuthorizationStep = true, isTokenRetrieveStep = false
+                )
+            ),
+            state
+        )
+    }
+
+    @Test
+    fun testProduceState_isTokenRetrieveStep() = runTest {
+
+        setUpEnvironment(environment(), CodeVerifier())
+
+        val testCode = "1235462834129834"
+        val state = mutableListOf<OAuthUiState>()
+        val redirectionUrl = "ksrauth2://authenticate?code=$testCode&redirect_uri=ksrauth2&response_type=1&scope=1"
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            vm.produceState(Intent().setData(Uri.parse(redirectionUrl)))
+            vm.uiState.toList(state)
+        }
+
+        // - First empty emission due the initialization
+        assertEquals(
+            listOf(
+                OAuthUiState(authorizationUrl = "", isAuthorizationStep = false, isTokenRetrieveStep = false, code = ""),
+                OAuthUiState(authorizationUrl = "", isAuthorizationStep = false, isTokenRetrieveStep = true, code = testCode),
+            ),
+            state
+        )
+    }
+}


### PR DESCRIPTION
# 📲 What

- On `AuthorizationStep` the authorization URL is generated adding PKCE parameters to the url
- On redirectionStep an appplink redirects back to the app, so far the redirection only contains `code`, not ready yet to call the token endpoint (WIP) on the backend side.

# 🤔 Why

- OAuth 2.0 on the apps

# 🛠 How

- The VM now receives an `Intent` is able to build the authorization URL is staging and production on the `AuthorizationStep`
-  the VM now receives an `Intent` and is able to collect from it the `code` that will be used later on to call the Token endpoint.
- `OAuthActivity` registers the `redirectionUrl` deeplink.
- Added tests
- Added an Interface wrapper on `CodeVerifier` to be able to mock it on tests.

# 👀 See
- Chroma tab should be able to load AuthorizationUrl
- Once the user has introduced email + password the redirection back to app enters in place back to a currently empty `OAuthActivity`




https://github.com/kickstarter/android-oss/assets/4083656/bbeb721c-e9df-457f-a397-571ca56e90a6





|  |  |

# 📋 QA


- Turn the ff on, try to log in, the ChromeTab will load a formulary, once successful user + password introduced the user is redirected back to the app, to an empty OAuthActivity for now.
- You can also take a look at logcat filtering by `package:mine level:debug OAuth`, and look for the debug messages showing the `AuthorizationStep` + url to load, and the `TokenRetrieveStep` + code
  
<img width="382" alt="Screenshot 2024-02-11 at 3 12 58 PM" src="https://github.com/kickstarter/android-oss/assets/4083656/04e2c949-d6cc-48d9-8330-4742fd41c65a">


# Story 📖

[MBL-1168](https://kickstarter.atlassian.net/browse/MBL-1168)


[MBL-1168]: https://kickstarter.atlassian.net/browse/MBL-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ