### PR TITLE
MBL-1202: Crash on CommentsViewHolderViewModel

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -15,12 +15,12 @@ import com.squareup.picasso.Picasso
 
 fun ImageView.loadCircleImage(url: String?) {
     url?.let {
-        if (it.isBlank()) {
+        if (it.isBlank()) { // - load with drawable
             Picasso.get()
                 .load(R.drawable.circle_grey_500)
                 .transform(CircleTransformation())
                 .into(this)
-        } else {
+        } else { // - load with url string
             Picasso.get()
                 .load(it)
                 .placeholder(R.drawable.circle_grey_500)

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -15,9 +15,18 @@ import com.squareup.picasso.Picasso
 
 fun ImageView.loadCircleImage(url: String?) {
     url?.let {
-        Picasso.get().load(it)
-            .transform(CircleTransformation())
-            .into(this)
+        if (it.isBlank()) {
+            Picasso.get()
+                .load(R.drawable.circle_grey_500)
+                .transform(CircleTransformation())
+                .into(this)
+        } else {
+            Picasso.get()
+                .load(it)
+                .placeholder(R.drawable.circle_grey_500)
+                .transform(CircleTransformation())
+                .into(this)
+        }
     }
 }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/CommentsViewHolderViewModel.kt
@@ -243,9 +243,14 @@ interface CommentsViewHolderViewModel {
                 .subscribe { this.commentAuthorName.onNext(it) }
                 .addToDisposable(disposables)
 
-            comment
-                .filter { it.author()?.avatar()?.medium().isNotNull() }
-                .map { it.author()?.avatar()?.medium() ?: "" }
+            comment // TODO: extract all logic around selecting image to an Avatar extension function, and refactor entire app
+                .filter { it.author().avatar().medium().isNotNull() }
+                .map { aComment ->
+                    return@map aComment.author().avatar().medium().ifBlank {
+                        return@ifBlank if (aComment.author().avatar().small().isNullOrBlank()) ""
+                        else aComment.author().avatar().small()
+                    }
+                }
                 .subscribe { this.commentAuthorAvatarUrl.onNext(it) }
                 .addToDisposable(disposables)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewHolderViewModelTest.kt
@@ -135,6 +135,39 @@ class CommentsViewHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testUserAvatarUrl_whenMediumIsEmpty_TrySmall() {
+        setUpEnvironment(environment())
+        val userAvatar = AvatarFactory.avatar().toBuilder()
+            .medium("")
+            .build()
+        val currentUser = UserFactory.user().toBuilder().id(111).avatar(
+            userAvatar
+        ).build()
+        val commentCardData = CommentFactory.liveCommentCardData(createdAt = createdAt, currentUser = currentUser)
+        this.vm.inputs.configureWith(commentCardData)
+
+        this.commentAuthorAvatarUrl.assertValue(userAvatar.small())
+        this.commentCardStatus.assertValue(CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS)
+    }
+
+    @Test
+    fun testUserAvatarUrl_whenMediumAndSmallEmpty_Empty() {
+        setUpEnvironment(environment())
+        val userAvatar = AvatarFactory.avatar().toBuilder()
+            .medium("")
+            .small("")
+            .build()
+        val currentUser = UserFactory.user().toBuilder().id(111).avatar(
+            userAvatar
+        ).build()
+        val commentCardData = CommentFactory.liveCommentCardData(createdAt = createdAt, currentUser = currentUser)
+        this.vm.inputs.configureWith(commentCardData)
+
+        this.commentAuthorAvatarUrl.assertValue("")
+        this.commentCardStatus.assertValue(CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS)
+    }
+
+    @Test
     fun testCommentAuthorName() {
         setUpEnvironment(environment())
         val commentCardData = CommentFactory.liveCommentCardData(createdAt = createdAt, currentUser = currentUser)


### PR DESCRIPTION
# 📲 What

- Crash caused due to sending empty string to `ImageView.loadCircleImage(url: String?)` empty paths. Picasso fails with an exception 
<img width="1128" alt="Screenshot 2024-02-13 at 9 15 59 AM" src="https://github.com/kickstarter/android-oss/assets/4083656/8c3eb8a7-230a-477e-98b2-8b06b4b5226d">


# 🛠 How
- If path for avatar.medium is empty, try to load avatar.small, if this is empty too send empty
- On `ImageView.loadCircleImage(url: String?)` check if the string is empty, if so load a local drawable
- On `ImageView.loadCircleImage(url: String?)` Added placeholder drawable

# 👀 See
- See by the end of the video, how the placeholder is transitioned over the real avatar image, providing a way better user experience than suddenly appearing images


https://github.com/kickstarter/android-oss/assets/4083656/73ea967b-65b3-4023-92dc-6906670e36d5

| --- | --- |
|  |  |

# 📋 QA

- Cannot reproduce, but if you want to, modify the source code to always send `""` on  and launch the `CommentsViewHolderViewModel` and double check the app does not crash.

# Story 📖

[MBL-1202](https://kickstarter.atlassian.net/browse/MBL-1202)


[MBL-1202]: https://kickstarter.atlassian.net/browse/MBL-1202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ