### PR TITLE
MBL-1182: Crash from rx chain returning null in TwoFactorViewModel.kt

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/TwoFactorViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModelProvider
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.extensions.addToDisposable
-import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.models.User
 import com.kickstarter.services.ApiClientTypeV2
 import com.kickstarter.services.apiresponses.AccessTokenEnvelope
@@ -16,7 +15,6 @@ import com.kickstarter.viewmodels.usecases.LoginUseCase
 import com.kickstarter.viewmodels.usecases.RefreshUserUseCase
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.exceptions.CompositeException
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 
@@ -172,7 +170,7 @@ interface TwoFactorViewModel {
                 .map { it.getBooleanExtra(IntentKey.FACEBOOK_LOGIN, false) }
 
             val password = internalIntent
-                    .map { it.getStringExtra(IntentKey.PASSWORD) ?: "" }
+                .map { it.getStringExtra(IntentKey.PASSWORD) ?: "" }
 
             val tfaData = Observable.combineLatest(
                 email,


### PR DESCRIPTION
# 📲 What

Cleanup for TwoFactorViewModel to fix [this crash](https://console.firebase.google.com/u/1/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/6a6721723e30904ab3b6c99276d224e1?time=last-seven-days&types=crash&sessionEventKey=65CE6DE202B7000110ADF28BDECB56CF_1914367294431191217)

# 🤔 Why

Knockin out bugs

# 🛠 How

Can't easily reproduce but:
- Made the intent passed into the viewmodel nonnull
- return an empty string if password or email from intent is null - if an empty string is passed down because there is no email or password in the intent, it will not allow login with an error message. doing the normal filtering for null values will cause there to be no reaction when the user taps submit and there wont be an error message. I figured empty string route is better

# 👀 See

no user facing changes

# 📋 QA

- Login with two factor auth, make sure there are no hiccups

# Story 📖

[MBL-1182: Crash from rx chain returning null in TwoFactorViewModel.kt](https://kickstarter.atlassian.net/browse/MBL-1182)
