### PR TITLE
MBL-1198: Reorder rewards so that unavailable ones show last

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/adapters/RewardsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/RewardsAdapter.kt
@@ -33,7 +33,7 @@ class RewardsAdapter(private val delegate: Delegate) : KSAdapter() {
 
         val rewards = projectData.project().rewards()
 
-        if (!rewards.isNullOrEmpty() ) {
+        if (!rewards.isNullOrEmpty()) {
             addSection(
                 Observable.from(rewards)
                     .map { reward -> Pair.create(projectData, reward) }

--- a/app/src/main/java/com/kickstarter/ui/adapters/RewardsAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/RewardsAdapter.kt
@@ -33,7 +33,7 @@ class RewardsAdapter(private val delegate: Delegate) : KSAdapter() {
 
         val rewards = projectData.project().rewards()
 
-        if (rewards != null) {
+        if (!rewards.isNullOrEmpty() ) {
             addSection(
                 Observable.from(rewards)
                     .map { reward -> Pair.create(projectData, reward) }

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -246,11 +246,10 @@ class RewardsFragmentViewModel {
                 .addToDisposable(disposables)
         }
 
-
         private fun sortAndFilterRewards(pData: ProjectData): ProjectData {
             val startedRewards = pData.project().rewards()?.filter { RewardUtils.hasStarted(it) }
-            val sortedRewards =  pData.project().rewards()?.filter { RewardUtils.isAvailable(pData.project(), it) }?.toMutableList() ?: mutableListOf()
-            val unavailableRewards = startedRewards?.filter { !RewardUtils.isAvailable(pData.project(), it)}?.toMutableList()
+            val sortedRewards = startedRewards?.filter { RewardUtils.isAvailable(pData.project(), it) }?.toMutableList() ?: mutableListOf()
+            val unavailableRewards = startedRewards?.filter { !RewardUtils.isAvailable(pData.project(), it) }?.toMutableList()
 
             unavailableRewards?.let { sortedRewards.addAll(it) }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -112,8 +112,8 @@ class RewardsFragmentViewModel {
                 .addToDisposable(disposables)
 
             this.projectDataInput
-                .filter { filterOutNotStartedRewards(it).isNotNull() }
-                .map { filterOutNotStartedRewards(it) }
+                .filter { sortAndFilterRewards(it).isNotNull() }
+                .map { sortAndFilterRewards(it) }
                 .subscribe { this.projectData.onNext(it) }
                 .addToDisposable(disposables)
 
@@ -246,9 +246,15 @@ class RewardsFragmentViewModel {
                 .addToDisposable(disposables)
         }
 
-        private fun filterOutNotStartedRewards(pData: ProjectData): ProjectData {
-            val rewards = pData.project().rewards()?.filter { RewardUtils.hasStarted(it) }
-            val modifiedProject = pData.project().toBuilder().rewards(rewards).build()
+
+        private fun sortAndFilterRewards(pData: ProjectData): ProjectData {
+            val startedRewards = pData.project().rewards()?.filter { RewardUtils.hasStarted(it) }
+            val sortedRewards =  pData.project().rewards()?.filter { RewardUtils.isAvailable(pData.project(), it) }?.toMutableList() ?: mutableListOf()
+            val unavailableRewards = startedRewards?.filter { !RewardUtils.isAvailable(pData.project(), it)}?.toMutableList()
+
+            unavailableRewards?.let { sortedRewards.addAll(it) }
+
+            val modifiedProject = pData.project().toBuilder().rewards(sortedRewards).build()
             return pData.toBuilder()
                 .project(modifiedProject)
                 .build()

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
@@ -39,7 +39,6 @@ class RewardsFragmentViewModelTest : KSRobolectricTestCase() {
     private lateinit var vm: RewardsFragmentViewModel
     private val backedRewardPosition = TestSubscriber.create<Int>()
     private val projectData = TestSubscriber.create<ProjectData>()
-    private val rewards = TestSubscriber.create<String>()
     private val rewardsCount = TestSubscriber.create<Int>()
     private val showPledgeFragment = TestSubscriber<Pair<PledgeData, PledgeReason>>()
     private val showAddOnsFragment = TestSubscriber<Pair<PledgeData, PledgeReason>>()
@@ -49,7 +48,6 @@ class RewardsFragmentViewModelTest : KSRobolectricTestCase() {
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = Factory(environment).create(RewardsFragmentViewModel::class.java)
         this.vm.outputs.backedRewardPosition().subscribe { this.backedRewardPosition.onNext(it) }.addToDisposable(disposables)
-        this.vm.outputs.projectData().map { it.project().rewards()?.get(4)?.description() }.subscribe { this.rewards.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.projectData().subscribe { this.projectData.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.rewardsCount().subscribe { this.rewardsCount.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.showPledgeFragment().subscribe { this.showPledgeFragment.onNext(it) }.addToDisposable(disposables)

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsFragmentViewModelTest.kt
@@ -39,6 +39,7 @@ class RewardsFragmentViewModelTest : KSRobolectricTestCase() {
     private lateinit var vm: RewardsFragmentViewModel
     private val backedRewardPosition = TestSubscriber.create<Int>()
     private val projectData = TestSubscriber.create<ProjectData>()
+    private val rewards = TestSubscriber.create<String>()
     private val rewardsCount = TestSubscriber.create<Int>()
     private val showPledgeFragment = TestSubscriber<Pair<PledgeData, PledgeReason>>()
     private val showAddOnsFragment = TestSubscriber<Pair<PledgeData, PledgeReason>>()
@@ -48,6 +49,7 @@ class RewardsFragmentViewModelTest : KSRobolectricTestCase() {
     private fun setUpEnvironment(@NonNull environment: Environment) {
         this.vm = Factory(environment).create(RewardsFragmentViewModel::class.java)
         this.vm.outputs.backedRewardPosition().subscribe { this.backedRewardPosition.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.projectData().map { it.project().rewards()?.get(4)?.description() }.subscribe { this.rewards.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.projectData().subscribe { this.projectData.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.rewardsCount().subscribe { this.rewardsCount.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.showPledgeFragment().subscribe { this.showPledgeFragment.onNext(it) }.addToDisposable(disposables)
@@ -279,7 +281,7 @@ class RewardsFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testFilterOutRewards_whenRewardNotStarted() {
+    fun testFilterOutRewards_whenRewardNotStarted_filtersOutReward() {
         val rwNotLimitedStart = RewardFactory.reward()
         val rwLimitedStartNotStartedYet = rwNotLimitedStart.toBuilder().startsAt(DateTime.now().plusDays(1)).build()
         val rwLimitedStartStarted = rwNotLimitedStart.toBuilder().startsAt(DateTime.now()).build()
@@ -299,6 +301,39 @@ class RewardsFragmentViewModelTest : KSRobolectricTestCase() {
         // - We check that the viewModel has filtered out the rewards not started yet
         this.projectData.assertValue(modifiedPData)
         this.rewardsCount.assertValue(2)
+    }
+
+    @Test
+    fun testFilterAndSortRewards_whenRewardUnavailable_sortsRewardToEnd() {
+        val rwNotLimitedStart = RewardFactory.reward()
+        val rwLimitedStartNotStartedYet = rwNotLimitedStart.toBuilder().startsAt(DateTime.now().plusDays(1)).build()
+        val rwLimitedStartStarted = rwNotLimitedStart.toBuilder().startsAt(DateTime.now()).build()
+        val limited = RewardFactory.reward().toBuilder().startsAt(DateTime.now()).limit(5).build()
+        val noRemaining = RewardFactory.limitReached()
+        val expired = RewardFactory.ended()
+
+        val rewards = listOf<Reward>(
+            rwNotLimitedStart,
+            rwLimitedStartNotStartedYet,
+            noRemaining,
+            limited,
+            expired,
+            rwLimitedStartStarted
+        )
+
+        val project = ProjectFactory.project().toBuilder().rewards(rewards).build()
+
+        setUpEnvironment(environment())
+        // - We configure the viewModel with a project that has rewards not started yet
+        this.vm.inputs.configureWith(ProjectDataFactory.project(project))
+
+        val filteredList = listOf(rwNotLimitedStart, limited, rwLimitedStartStarted, noRemaining, expired)
+        val projWithFilteredRewards = project.toBuilder().rewards(filteredList).build()
+        val modifiedPData = ProjectData.builder().project(projWithFilteredRewards).build()
+
+        // - We check that the viewModel has filtered out the rewards not started yet
+        this.projectData.assertValue(modifiedPData)
+        this.rewardsCount.assertValue(5)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

We want the rewards carousel to show available rewards first and push unavailable rewards to the end of the list. 

# 🤔 Why

Available rewards are more relevant

# 🛠 How

Adding additional sorting to the rewards list passed to the recyclerview

# 👀 See

https://github.com/kickstarter/android-oss/assets/19390326/a3815ab0-d98e-4bd7-b8e1-abffd28478eb

# 📋 QA

Test that rewards carousel is properly sorting rewards on a live project that you have not backed yet
For an already backed project, test that rewards are also sorted in manage pledge -> choose different reward 

# Story 📖

[MBL-1198: Reorder rewards so that unavailable ones show last](https://kickstarter.atlassian.net/browse/MBL-1198)
