### PR TITLE
MBL-1183: Crash caused by index out of bounds in SearchViewModel.kt

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/SearchViewModel.kt
@@ -80,7 +80,7 @@ interface SearchViewModel {
             projects: List<Project>,
             selectedProject: Project
         ): Pair<Project, RefTag> {
-            val isFirstResult = selectedProject === projects[0]
+            val isFirstResult = if (projects.isEmpty()) false else selectedProject === projects[0]
             return if (searchTerm.isEmpty()) {
                 if (isFirstResult) Pair.create(
                     selectedProject,


### PR DESCRIPTION
# 📲 What

[Crash appearing in crashlytics for index out of bounds in search view model](https://console.firebase.google.com/u/1/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/d6637e45ec6367d6c866fc464ca87b1e?time=last-seven-days&types=crash&sessionEventKey=65BB3C3401D6000156F1B67ACD784C05_1908965023381374439)

# 🛠 How

Could not reproduce but i gated the project list with an empty check to ensure we aren't trying to pull from an empty list. 

# 📋 QA

Since i could not reproduce this, just mess around in the search screen and make sure it doesn't crash, even if you try really really hard to break it 😅 

# Story 📖

[MBL-1183: Crash caused by index out of bounds in SearchViewModel.kt](https://kickstarter.atlassian.net/browse/MBL-1183)
