### PR TITLE
MBL-1232: Unify and verify sign up/log in buttons

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
@@ -7,7 +7,6 @@ import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.CommentsActivity
 import com.kickstarter.ui.activities.CreatorBioActivity
 import com.kickstarter.ui.activities.LoginActivity
-import com.kickstarter.ui.activities.OAuthActivity
 import com.kickstarter.ui.activities.PaymentMethodsSettingsActivity
 import com.kickstarter.ui.activities.PreLaunchProjectPageActivity
 import com.kickstarter.ui.activities.ProjectPageActivity
@@ -15,7 +14,6 @@ import com.kickstarter.ui.activities.ProjectUpdatesActivity
 import com.kickstarter.ui.activities.ReportProjectActivity
 import com.kickstarter.ui.activities.ResetPasswordActivity
 import com.kickstarter.ui.activities.SetPasswordActivity
-import com.kickstarter.ui.activities.SignupActivity
 import com.kickstarter.ui.activities.UpdateActivity
 import com.kickstarter.ui.activities.VideoActivity
 import com.kickstarter.ui.data.LoginReason
@@ -32,20 +30,6 @@ fun Intent.getPreLaunchProjectActivity(context: Context, slug: String?, project:
         intent.putExtra(IntentKey.PROJECT, project)
     }
     return intent
-}
-
-fun Intent.getStartLoginIntent(isOAuthEnabled: Boolean, context: Context): Intent {
-    return if (isOAuthEnabled) {
-        this.setClass(context, OAuthActivity::class.java)
-    } else
-        this.setClass(context, LoginActivity::class.java)
-}
-
-fun Intent.getSignupIntent(isOAuthEnabled: Boolean, context: Context): Intent {
-    return if (isOAuthEnabled) {
-        this.setClass(context, OAuthActivity::class.java)
-    } else
-        this.setClass(context, SignupActivity::class.java)
 }
 
 /**

--- a/app/src/main/java/com/kickstarter/ui/activities/LoginToutActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/LoginToutActivity.kt
@@ -30,6 +30,7 @@ import com.kickstarter.ui.data.ActivityResult.Companion.create
 import com.kickstarter.ui.data.LoginReason
 import com.kickstarter.ui.extensions.startDisclaimerChromeTab
 import com.kickstarter.ui.extensions.startLogin
+import com.kickstarter.ui.extensions.startOauthActivity
 import com.kickstarter.ui.extensions.startSignup
 import com.kickstarter.viewmodels.LoginToutViewModel
 import io.reactivex.Observable
@@ -54,6 +55,7 @@ class LoginToutActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         var darkModeEnabled = false
+        var oauthFlagEnabled = false
         this.getEnvironment()?.let { env ->
             environment = env
             viewModelFactory = LoginToutViewModel.Factory(env)
@@ -63,6 +65,7 @@ class LoginToutActivity : ComponentActivity() {
             theme = env.sharedPreferences()
                 ?.getInt(SharedPreferenceKey.APP_THEME, AppThemes.MATCH_SYSTEM.ordinal)
                 ?: AppThemes.MATCH_SYSTEM.ordinal
+            oauthFlagEnabled = env.featureFlagClient()?.getBoolean(FlagKey.ANDROID_OAUTH) ?: false
         }
 
         setContent {
@@ -93,6 +96,10 @@ class LoginToutActivity : ComponentActivity() {
                     onCookiePolicyClicked = { viewModel.inputs.disclaimerItemClicked(DisclaimerItems.COOKIES) },
                     onHelpClicked = {
                         viewModel.inputs.disclaimerItemClicked(DisclaimerItems.HELP)
+                    },
+                    featureFlagState = oauthFlagEnabled,
+                    onSignUpOrLogInClicked = {
+                        this@LoginToutActivity.startOauthActivity()
                     }
                 )
             }
@@ -116,14 +123,14 @@ class LoginToutActivity : ComponentActivity() {
         viewModel.outputs.startLoginActivity()
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
-                this.startLogin(it)
+                this.startLogin()
             }
             .addToDisposable(disposables)
 
         viewModel.outputs.startSignupActivity()
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
-                this.startSignup(it)
+                this.startSignup()
             }
             .addToDisposable(disposables)
 

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/login/LoginToutScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/login/LoginToutScreen.kt
@@ -54,7 +54,7 @@ fun LoginToutScreenPreview() {
             {},
             {},
             {},
-            true,
+            false,
             {}
         )
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/login/LoginToutScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/login/LoginToutScreen.kt
@@ -54,6 +54,8 @@ fun LoginToutScreenPreview() {
             {},
             {},
             {},
+            true,
+            {}
         )
     }
 }
@@ -68,7 +70,8 @@ enum class LoginToutTestTag {
     FACEBOOK_DISCLAIMER,
     EMAIL_LOG_IN_BUTTON,
     EMAIL_SIGN_UP_BUTTON,
-    TOU_PP_COOKIE_DISCLAIMER
+    TOU_PP_COOKIE_DISCLAIMER,
+    LOG_IN_OR_SIGN_UP
 }
 
 @Composable
@@ -80,7 +83,9 @@ fun LoginToutScreen(
     onTermsOfUseClicked: () -> Unit,
     onPrivacyPolicyClicked: () -> Unit,
     onCookiePolicyClicked: () -> Unit,
-    onHelpClicked: () -> Unit
+    onHelpClicked: () -> Unit,
+    featureFlagState: Boolean = false,
+    onSignUpOrLogInClicked: () -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
     Scaffold(
@@ -172,22 +177,30 @@ fun LoginToutScreen(
 
             Spacer(modifier = Modifier.height(dimensions.paddingMedium))
 
-            KSPrimaryGreenButton(
-                modifier = Modifier.testTag(LoginToutTestTag.EMAIL_LOG_IN_BUTTON.name),
-                onClickAction = onEmailLoginClicked,
-                text = stringResource(id = R.string.login_buttons_log_in_email),
-                isEnabled = true
-            )
+            if (featureFlagState) {
+                KSPrimaryGreenButton(
+                    modifier = Modifier.testTag(LoginToutTestTag.LOG_IN_OR_SIGN_UP.name),
+                    onClickAction = onSignUpOrLogInClicked,
+                    text = stringResource(id = R.string.discovery_onboarding_buttons_signup_or_login),
+                    isEnabled = true
+                )
+            } else {
+                KSPrimaryGreenButton(
+                    modifier = Modifier.testTag(LoginToutTestTag.EMAIL_LOG_IN_BUTTON.name),
+                    onClickAction = onEmailLoginClicked,
+                    text = stringResource(id = R.string.login_buttons_log_in_email),
+                    isEnabled = true
+                )
 
-            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                Spacer(modifier = Modifier.height(dimensions.paddingMedium))
 
-            KSSecondaryGreyButton(
-                modifier = Modifier.testTag(LoginToutTestTag.EMAIL_SIGN_UP_BUTTON.name),
-                onClickAction = onEmailSignupClicked,
-                text = stringResource(id = R.string.signup_button_email),
-                isEnabled = true
-            )
-
+                KSSecondaryGreyButton(
+                    modifier = Modifier.testTag(LoginToutTestTag.EMAIL_SIGN_UP_BUTTON.name),
+                    onClickAction = onEmailSignupClicked,
+                    text = stringResource(id = R.string.signup_button_email),
+                    isEnabled = true
+                )
+            }
             Spacer(modifier = Modifier.height(dimensions.paddingMedium))
 
             LogInSignUpClickableDisclaimerText(

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -20,12 +20,11 @@ import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.UrlUtils
 import com.kickstarter.libs.utils.extensions.getCreatorBioWebViewActivityIntent
+import com.kickstarter.libs.utils.extensions.getLoginActivityIntent
 import com.kickstarter.libs.utils.extensions.getPreLaunchProjectActivity
 import com.kickstarter.libs.utils.extensions.getProjectUpdatesActivityIntent
 import com.kickstarter.libs.utils.extensions.getReportProjectActivityIntent
 import com.kickstarter.libs.utils.extensions.getRootCommentsActivityIntent
-import com.kickstarter.libs.utils.extensions.getSignupIntent
-import com.kickstarter.libs.utils.extensions.getStartLoginIntent
 import com.kickstarter.libs.utils.extensions.getUpdatesActivityIntent
 import com.kickstarter.libs.utils.extensions.getVideoActivityIntent
 import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
@@ -37,6 +36,8 @@ import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.DisclaimerItems
 import com.kickstarter.ui.activities.HelpActivity
 import com.kickstarter.ui.activities.LoginToutActivity
+import com.kickstarter.ui.activities.OAuthActivity
+import com.kickstarter.ui.activities.SignupActivity
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ProjectData
@@ -233,14 +234,20 @@ fun Activity.startPreLaunchProjectActivity(project: Project, previousScreen: Str
     TransitionUtils.transition(this, TransitionUtils.slideInFromRight())
 }
 
-fun Activity.startLogin(isOauthPathEnabled: Boolean) {
-    val intent = Intent().getStartLoginIntent(isOauthPathEnabled, this)
+fun Activity.startOauthActivity() {
+    val intent = Intent().setClass(this, OAuthActivity::class.java)
     startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW)
     TransitionUtils.transition(this, TransitionUtils.slideInFromRight())
 }
 
-fun Activity.startSignup(isOauthPathEnabled: Boolean) {
-    val intent = Intent().getSignupIntent(isOauthPathEnabled, this)
+fun Activity.startLogin() {
+    val intent = Intent().getLoginActivityIntent(this)
+    startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW)
+    TransitionUtils.transition(this, TransitionUtils.slideInFromRight())
+}
+
+fun Activity.startSignup() {
+    val intent = Intent().setClass(this, SignupActivity::class.java)
     startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW)
     TransitionUtils.transition(this, TransitionUtils.slideInFromRight())
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.kt
@@ -79,10 +79,10 @@ interface LoginToutViewModel {
         fun startFacebookConfirmationActivity(): Observable<Pair<ErrorEnvelope.FacebookUser, String>>
 
         /** Emits when the login activity should be started.  */
-        fun startLoginActivity(): Observable<Boolean>
+        fun startLoginActivity(): Observable<Unit>
 
         /** Emits when the signup activity should be started.  */
-        fun startSignupActivity(): Observable<Boolean>
+        fun startSignupActivity(): Observable<Unit>
 
         /** Emits when a user has successfully logged in using Facebook, but has require two-factor authentication enabled.  */
         fun startTwoFactorChallenge(): Observable<Unit>
@@ -143,14 +143,14 @@ interface LoginToutViewModel {
         @VisibleForTesting
         val facebookAccessToken = PublishSubject.create<String>()
         private val facebookLoginClick = PublishSubject.create<List<String>>()
-        private val loginClick = PublishSubject.create<Boolean>()
+        private val loginClick = PublishSubject.create<Unit>()
         private val onResetPasswordFacebookErrorDialogClicked = PublishSubject.create<Unit>()
         private val onLoginFacebookErrorDialogClicked = PublishSubject.create<Unit>()
 
         @VisibleForTesting
         val loginError = PublishSubject.create<ErrorEnvelope?>()
         private val loginReason = PublishSubject.create<LoginReason>()
-        private val signupClick = PublishSubject.create<Boolean>()
+        private val signupClick = PublishSubject.create<Unit>()
         private val disclaimerItemClicked = PublishSubject.create<DisclaimerItems>()
 
         @VisibleForTesting
@@ -159,8 +159,8 @@ interface LoginToutViewModel {
         private val showFacebookErrorDialog = BehaviorSubject.create<Unit>()
         private val startResetPasswordActivity = BehaviorSubject.create<Unit>()
         private val startFacebookConfirmationActivity: Observable<Pair<ErrorEnvelope.FacebookUser, String>>
-        private val startLoginActivity: Observable<Boolean>
-        private val startSignupActivity: Observable<Boolean>
+        private val startLoginActivity: Observable<Unit>
+        private val startSignupActivity: Observable<Unit>
         private val showDisclaimerActivity: Observable<DisclaimerItems>
 
         private val finishOauthWithSuccessfulResult = BehaviorSubject.create<Unit>()
@@ -191,11 +191,11 @@ interface LoginToutViewModel {
         }
 
         override fun loginClick() {
-            loginClick.onNext(environment.featureFlagClient()?.getBoolean(FlagKey.ANDROID_OAUTH) ?: false)
+            loginClick.onNext(Unit)
         }
 
         override fun signupClick() {
-            signupClick.onNext(environment.featureFlagClient()?.getBoolean(FlagKey.ANDROID_OAUTH) ?: false)
+            signupClick.onNext(Unit)
         }
 
         override fun disclaimerItemClicked(disclaimerItem: DisclaimerItems) {
@@ -240,11 +240,11 @@ interface LoginToutViewModel {
             return startFacebookConfirmationActivity
         }
 
-        override fun startLoginActivity(): Observable<Boolean> {
+        override fun startLoginActivity(): Observable<Unit> {
             return startLoginActivity
         }
 
-        override fun startSignupActivity(): Observable<Boolean> {
+        override fun startSignupActivity(): Observable<Unit> {
             return startSignupActivity
         }
 
@@ -345,7 +345,7 @@ interface LoginToutViewModel {
 
             onLoginFacebookErrorDialogClicked
                 .subscribe {
-                    startLoginActivity.onNext((environment.featureFlagClient()?.getBoolean(FlagKey.ANDROID_OAUTH) ?: false))
+                    startLoginActivity.onNext(Unit)
                 }
                 .addToDisposable(disposables)
 

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/IntentExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/IntentExtTest.kt
@@ -133,28 +133,4 @@ class IntentExtTest : KSRobolectricTestCase() {
         assertEquals(intent.component?.className, "com.kickstarter.ui.activities.SetPasswordActivity")
         assertEquals(intent.extras?.get(IntentKey.EMAIL), "test@kickstarter.com")
     }
-
-    @Test
-    fun testStartLoginIntent() {
-
-        // - Simulates feature flag off
-        val intentOldFlow = Intent().getStartLoginIntent(isOAuthEnabled = false, context())
-        assertEquals(intentOldFlow.component?.className, "com.kickstarter.ui.activities.LoginActivity")
-
-        // - Simulates feature flag on
-        val intentNewFlow = Intent().getStartLoginIntent(isOAuthEnabled = true, context())
-        assertEquals(intentNewFlow.component?.className, "com.kickstarter.ui.activities.OAuthActivity")
-    }
-
-    @Test
-    fun testStartSignupIntent() {
-
-        // - Simulates feature flag off
-        val intentOldFlow = Intent().getSignupIntent(isOAuthEnabled = false, context())
-        assertEquals(intentOldFlow.component?.className, "com.kickstarter.ui.activities.SignupActivity")
-
-        // - Simulates feature flag on
-        val intentNewFlow = Intent().getSignupIntent(isOAuthEnabled = true, context())
-        assertEquals(intentNewFlow.component?.className, "com.kickstarter.ui.activities.OAuthActivity")
-    }
 }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/LoginToutScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/LoginToutScreenTest.kt
@@ -44,9 +44,11 @@ class LoginToutScreenTest : KSRobolectricTestCase() {
         composeTestRule.onNodeWithTag(LoginToutTestTag.EMAIL_SIGN_UP_BUTTON.name)
     private val touPpCookieDisclaimer =
         composeTestRule.onNodeWithTag(LoginToutTestTag.TOU_PP_COOKIE_DISCLAIMER.name)
+    private val signUpOrLogInButton =
+        composeTestRule.onNodeWithTag(LoginToutTestTag.LOG_IN_OR_SIGN_UP.name)
 
     @Test
-    fun testComponentsVisible() {
+    fun testComponentsVisible_featureFlag_Off() {
         composeTestRule.setContent {
             KSTheme {
                 LoginToutScreen(
@@ -57,7 +59,9 @@ class LoginToutScreenTest : KSRobolectricTestCase() {
                     onTermsOfUseClicked = { },
                     onPrivacyPolicyClicked = { },
                     onCookiePolicyClicked = { },
-                    onHelpClicked = { }
+                    onHelpClicked = { },
+                    featureFlagState = false,
+                    {}
                 )
             }
         }
@@ -94,6 +98,57 @@ class LoginToutScreenTest : KSRobolectricTestCase() {
         touPpCookieDisclaimer.assertIsDisplayed()
     }
 
+    fun testComponentsVisible_featureFlag_On() {
+        composeTestRule.setContent {
+            KSTheme {
+                LoginToutScreen(
+                    onBackClicked = { },
+                    onFacebookButtonClicked = { },
+                    onEmailLoginClicked = { },
+                    onEmailSignupClicked = { },
+                    onTermsOfUseClicked = { },
+                    onPrivacyPolicyClicked = { },
+                    onCookiePolicyClicked = { },
+                    onHelpClicked = { },
+                    featureFlagState = true,
+                    {}
+                )
+            }
+        }
+
+        val titleText = context.resources.getString(R.string.login_tout_navbar_title)
+        title.assertTextEquals(titleText)
+
+        val logoTitleText =
+            context.resources.getString(R.string.discovery_onboarding_title_bring_creative_projects_to_life)
+        logoTitle.assertTextEquals(logoTitleText)
+
+        val facebookDisclaimerText =
+            context.resources.getString(R.string.Facebook_login_disclaimer_update)
+        facebookDisclaimer.assertTextEquals(facebookDisclaimerText)
+
+        val touPpCookieDisclaimerText =
+            context.resources.getString(R.string.login_tout_disclaimer_agree_to_terms_html)
+        val formattedText = HtmlCompat.fromHtml(
+            touPpCookieDisclaimerText,
+            0
+        ).toString()
+        touPpCookieDisclaimer.assertTextEquals(formattedText)
+
+        backButton.assertIsDisplayed()
+        title.assertIsDisplayed()
+        optionsIcon.assertIsDisplayed()
+        optionsMenu.assertDoesNotExist()
+        kSLogo.assertIsDisplayed()
+        logoTitle.assertIsDisplayed()
+        facebookButton.assertIsDisplayed()
+        facebookDisclaimer.assertIsDisplayed()
+        emailLogInButton.assertDoesNotExist()
+        emailSignUpButton.assertDoesNotExist()
+        touPpCookieDisclaimer.assertIsDisplayed()
+        signUpOrLogInButton.assertIsDisplayed()
+    }
+
     @Test
     fun testOptionsMenuGetsDisplayed() {
         composeTestRule.setContent {
@@ -106,7 +161,9 @@ class LoginToutScreenTest : KSRobolectricTestCase() {
                     onTermsOfUseClicked = { },
                     onPrivacyPolicyClicked = { },
                     onCookiePolicyClicked = { },
-                    onHelpClicked = { }
+                    onHelpClicked = { },
+                    featureFlagState = false,
+                    {}
                 )
             }
         }
@@ -137,7 +194,7 @@ class LoginToutScreenTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testClickActionsWork() {
+    fun testClickActionsWork_featureFlag_Off() {
         var backClickedCount = 0
         var facebookClickedCount = 0
         var emailLoginClickedCount = 0
@@ -146,6 +203,7 @@ class LoginToutScreenTest : KSRobolectricTestCase() {
         var privacyPolicyClickedCount = 0
         var cookiePolicyClickedCount = 0
         var helpClickedCount = 0
+        var signUpOrLogInClicked = 0
 
         composeTestRule.setContent {
             KSTheme {
@@ -157,7 +215,9 @@ class LoginToutScreenTest : KSRobolectricTestCase() {
                     onTermsOfUseClicked = { termsOfUseClickedCount++ },
                     onPrivacyPolicyClicked = { privacyPolicyClickedCount++ },
                     onCookiePolicyClicked = { cookiePolicyClickedCount++ },
-                    onHelpClicked = { helpClickedCount++ }
+                    onHelpClicked = { helpClickedCount++ },
+                    featureFlagState = false,
+                    onSignUpOrLogInClicked = { signUpOrLogInClicked++ }
                 )
             }
         }
@@ -173,6 +233,9 @@ class LoginToutScreenTest : KSRobolectricTestCase() {
 
         emailSignUpButton.performClick()
         assertEquals(emailSignUpClickedCount, 1)
+
+        signUpOrLogInButton.assertDoesNotExist()
+        assertEquals(signUpOrLogInClicked, 0)
 
         optionsIcon.performClick()
         optionsTerms.performClick()
@@ -191,5 +254,66 @@ class LoginToutScreenTest : KSRobolectricTestCase() {
         assertEquals(helpClickedCount, 1)
 
         // TODO find a way to click hyperlinks in touPpCookieDisclaimer text reliably to test
+    }
+
+    @Test
+    fun testClickActionsWork_featureFlag_On() {
+        var backClickedCount = 0
+        var facebookClickedCount = 0
+        var emailLoginClickedCount = 0
+        var emailSignUpClickedCount = 0
+        var termsOfUseClickedCount = 0
+        var privacyPolicyClickedCount = 0
+        var cookiePolicyClickedCount = 0
+        var helpClickedCount = 0
+        var signUpOrLogInClicked = 0
+
+        composeTestRule.setContent {
+            KSTheme {
+                LoginToutScreen(
+                    onBackClicked = { backClickedCount++ },
+                    onFacebookButtonClicked = { facebookClickedCount++ },
+                    onEmailLoginClicked = { emailLoginClickedCount++ },
+                    onEmailSignupClicked = { emailSignUpClickedCount++ },
+                    onTermsOfUseClicked = { termsOfUseClickedCount++ },
+                    onPrivacyPolicyClicked = { privacyPolicyClickedCount++ },
+                    onCookiePolicyClicked = { cookiePolicyClickedCount++ },
+                    onHelpClicked = { helpClickedCount++ },
+                    featureFlagState = true,
+                    onSignUpOrLogInClicked = { signUpOrLogInClicked++ }
+                )
+            }
+        }
+
+        backButton.performClick()
+        assertEquals(backClickedCount, 1)
+
+        facebookButton.performClick()
+        assertEquals(facebookClickedCount, 1)
+
+        emailLogInButton.assertDoesNotExist()
+        assertEquals(emailLoginClickedCount, 0)
+
+        emailSignUpButton.assertDoesNotExist()
+        assertEquals(emailSignUpClickedCount, 0)
+
+        signUpOrLogInButton.performClick()
+        assertEquals(signUpOrLogInClicked, 1)
+
+        optionsIcon.performClick()
+        optionsTerms.performClick()
+        assertEquals(termsOfUseClickedCount, 1)
+
+        optionsIcon.performClick()
+        optionsPrivacyPolicy.performClick()
+        assertEquals(privacyPolicyClickedCount, 1)
+
+        optionsIcon.performClick()
+        optionsCookie.performClick()
+        assertEquals(cookiePolicyClickedCount, 1)
+
+        optionsIcon.performClick()
+        optionsHelp.performClick()
+        assertEquals(helpClickedCount, 1)
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LoginToutViewModelTest.kt
@@ -29,8 +29,8 @@ class LoginToutViewModelTest : KSRobolectricTestCase() {
     private val finishWithSuccessfulResult = TestSubscriber<Unit>()
     private val finishOathWithSuccessfulResult = TestSubscriber<Unit>()
     private val loginError = TestSubscriber<ErrorEnvelope>()
-    private val startLoginActivity = TestSubscriber<Boolean>()
-    private val startSignupActivity = TestSubscriber<Boolean>()
+    private val startLoginActivity = TestSubscriber<Unit>()
+    private val startSignupActivity = TestSubscriber<Unit>()
     private val currentUser = TestSubscriber<User?>()
     private val showDisclaimerActivity = TestSubscriber<DisclaimerItems>()
     private val startResetPasswordActivity = TestSubscriber<Unit>()
@@ -63,28 +63,8 @@ class LoginToutViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testLoginButtonClicked_when_FFOff() {
-        setUpEnvironment(environment(), LoginReason.DEFAULT)
-
-        startLoginActivity.assertNoValues()
-
-        vm.inputs.loginClick()
-
-        startLoginActivity.assertValueCount(1)
-        startLoginActivity.assertValue(false)
-        segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
-    }
-
-    @Test
-    fun testLoginButtonClicked_when_FFOn() {
+    fun testLoginButtonClicked() {
         val environment = environment()
-            .toBuilder()
-            .featureFlagClient(object : MockFeatureFlagClient() {
-                override fun getBoolean(FlagKey: FlagKey): Boolean {
-                    return true
-                }
-            })
-            .build()
 
         setUpEnvironment(environment, LoginReason.DEFAULT)
 
@@ -93,32 +73,12 @@ class LoginToutViewModelTest : KSRobolectricTestCase() {
         vm.inputs.loginClick()
 
         startLoginActivity.assertValueCount(1)
-        startLoginActivity.assertValue(true)
         segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
     }
 
     @Test
-    fun testSignupButtonClicked_when_FFOff() {
-        setUpEnvironment(environment(), LoginReason.DEFAULT)
-        startSignupActivity.assertNoValues()
-
-        vm.inputs.signupClick()
-
-        startSignupActivity.assertValueCount(1)
-        startSignupActivity.assertValue(false)
-        segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
-    }
-
-    @Test
-    fun testSignupButtonClicked_when_FFOn() {
+    fun testSignupButtonClicked() {
         val environment = environment()
-            .toBuilder()
-            .featureFlagClient(object : MockFeatureFlagClient() {
-                override fun getBoolean(FlagKey: FlagKey): Boolean {
-                    return true
-                }
-            })
-            .build()
 
         setUpEnvironment(environment, LoginReason.DEFAULT)
         startSignupActivity.assertNoValues()
@@ -126,7 +86,6 @@ class LoginToutViewModelTest : KSRobolectricTestCase() {
         vm.inputs.signupClick()
 
         startSignupActivity.assertValueCount(1)
-        startSignupActivity.assertValue(true)
         segmentTrack.assertValues(EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName)
     }
 


### PR DESCRIPTION
# 📲 What

- Unified buttons, `Log in with email` and `Sign up` now happen on the web formulary after OAuth2.0


# 👀 See

| Before 🐛 | After 🦋 |
FF ON
<img width="392" alt="Screenshot 2024-02-28 at 2 17 39 PM" src="https://github.com/kickstarter/android-oss/assets/4083656/c20be04d-f1ee-4c7e-9930-0e2baf1761fd">

FF OFF
<img width="393" alt="Screenshot 2024-02-28 at 2 17 56 PM" src="https://github.com/kickstarter/android-oss/assets/4083656/f06cddb9-6f1f-4344-900c-badfab938afb">


|  |  |

# 📋 QA

- With feature flag on, you will see only one button for `sign up or log in`
- With feature flag off, you will see the old flow with two separated buttons to `log in with email` and `sign up`

# Story 📖

[MBL-1232](https://kickstarter.atlassian.net/browse/MBL-1232)


[MBL-1232]: https://kickstarter.atlassian.net/browse/MBL-1232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ