### PR TITLE
[MBL-1164] Add post campaign fields to project queries/mutations

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -45,6 +45,8 @@ fragment projectCard on Project {
     state
     stateChangedAt
     url
+    isInPostCampaignPledgingPhase
+    postCampaignPledgingEnabled
 }
 
 # Fragment used to load all the Project information on Project Page
@@ -146,6 +148,8 @@ fragment fullProject on Project {
         ... environmentalCommitment
     }
     watchesCount
+    isInPostCampaignPledgingPhase
+    postCampaignPledgingEnabled
 }
 
 fragment backing on Backing {

--- a/app/src/main/java/com/kickstarter/models/Project.kt
+++ b/app/src/main/java/com/kickstarter/models/Project.kt
@@ -65,7 +65,9 @@ class Project private constructor(
     private val risks: String?,
     private val story: String?,
     private val isFlagged: Boolean?,
-    private val watchesCount: Int
+    private val watchesCount: Int,
+    private val isInPostCampaignPledgingPhase: Boolean? = null,
+    private val postCampaignPledgingEnabled: Boolean? = null
 ) : Parcelable, Relay {
     fun availableCardTypes() = this.availableCardTypes
     fun backersCount() = this.backersCount
@@ -121,6 +123,8 @@ class Project private constructor(
     fun story() = this.story
     fun isFlagged() = this.isFlagged
     fun watchesCount() = this.watchesCount
+    fun isInPostCampaignPledgingPhase() = this.isInPostCampaignPledgingPhase
+    fun postCampaignPledgingEnabled() = this.postCampaignPledgingEnabled
 
     @Parcelize
     data class Builder(
@@ -178,7 +182,9 @@ class Project private constructor(
         private var risks: String? = "",
         private var story: String? = "",
         private var isFlagged: Boolean? = null,
-        private var watchesCount: Int = 0
+        private var watchesCount: Int = 0,
+        private var isInPostCampaignPledgingPhase: Boolean? = null,
+        private var postCampaignPledgingEnabled: Boolean? = null
     ) : Parcelable {
         fun availableCardTypes(availableCardTypes: List<String>?) = apply { this.availableCardTypes = availableCardTypes }
         fun backersCount(backersCount: Int?) = apply { this.backersCount = backersCount ?: 0 }
@@ -288,7 +294,9 @@ class Project private constructor(
             risks = risks,
             story = story,
             isFlagged = isFlagged,
-            watchesCount = watchesCount
+            watchesCount = watchesCount,
+            isInPostCampaignPledgingPhase = isInPostCampaignPledgingPhase,
+            postCampaignPledgingEnabled = postCampaignPledgingEnabled
         )
     }
 
@@ -346,7 +354,9 @@ class Project private constructor(
         risks = risks,
         story = story,
         isFlagged = isFlagged,
-        watchesCount = watchesCount
+        watchesCount = watchesCount,
+        isInPostCampaignPledgingPhase = isInPostCampaignPledgingPhase,
+        postCampaignPledgingEnabled = postCampaignPledgingEnabled
     )
 
     @kotlin.annotation.Retention(AnnotationRetention.SOURCE)


### PR DESCRIPTION
# 📲 What

Add two fields to the project model in graphql and in app:
-isPostCampaignEnabled
-postCampaignPledgingEnabled

# 🤔 Why

These fields will be used to determine if the campaign will be allowed to go into the post campaign flow (only if both are true)

# 🛠 How

Added the fields to the fragments for graph, added them to the model for app model

# 📋 QA

Check the logs on staging for these fields:
(Look up the project Baconbaconbacon on staging for a true result)
`"isInPostCampaignPledgingPhase":true,"postCampaignPledgingEnabled":true,`
(Most projects will be false as its not enabled creator side yet)
`"isInPostCampaignPledgingPhase":false,"postCampaignPledgingEnabled":false,`

# Story 📖

[MBL-1164](https://kickstarter.atlassian.net/browse/MBL-1164)


[MBL-1164]: https://kickstarter.atlassian.net/browse/MBL-1164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ