### PR TITLE
MBL-1252 Add a createAttributionEvent method to the Apollo client

### DIFF
--- a/app/src/external/java/com/kickstarter/ExternalApplicationModule.java
+++ b/app/src/external/java/com/kickstarter/ExternalApplicationModule.java
@@ -68,7 +68,7 @@ public final class ExternalApplicationModule {
   @Provides
   @Singleton
   @NonNull
-  static ApolloClientTypeV2 provideApolloClientTypeV2(final @NonNull ApolloClient apolloClient) {
-    return Secrets.IS_OSS ? new MockApolloClientV2() : new KSApolloClientV2(apolloClient);
+  static ApolloClientTypeV2 provideApolloClientTypeV2(final @NonNull ApolloClient apolloClient, final @NonNull Gson gson) {
+    return Secrets.IS_OSS ? new MockApolloClientV2() : new KSApolloClientV2(apolloClient, gson);
   }
 }

--- a/app/src/internal/java/com/kickstarter/InternalApplicationModule.java
+++ b/app/src/internal/java/com/kickstarter/InternalApplicationModule.java
@@ -64,8 +64,8 @@ public final class InternalApplicationModule {
   @Provides
   @Singleton
   @NonNull
-  static ApolloClientTypeV2 provideApolloClientTypeV2(final @NonNull ApolloClient apolloClient) {
-    return Secrets.IS_OSS ? new MockApolloClientV2() : new KSApolloClientV2(apolloClient);
+  static ApolloClientTypeV2 provideApolloClientTypeV2(final @NonNull ApolloClient apolloClient, final @NonNull Gson gson) {
+    return Secrets.IS_OSS ? new MockApolloClientV2() : new KSApolloClientV2(apolloClient, gson);
   }
 
   @Provides

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -44,6 +44,7 @@ import com.kickstarter.services.apiresponses.DiscoverEnvelope
 import com.kickstarter.services.apiresponses.ShippingRulesEnvelope
 import com.kickstarter.services.apiresponses.commentresponse.CommentEnvelope
 import com.kickstarter.services.apiresponses.updatesresponse.UpdatesGraphQlEnvelope
+import com.kickstarter.services.mutations.CreateAttributionEventData
 import com.kickstarter.services.mutations.CreateBackingData
 import com.kickstarter.services.mutations.CreateCheckoutData
 import com.kickstarter.services.mutations.PostCommentData
@@ -273,7 +274,7 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
         return io.reactivex.Observable.empty()
     }
 
-    override fun createPaymentIntent(createPaymentIntentInput: CreatePaymentIntentInput): io.reactivex.Observable<String> {
+    override fun createAttributionEvent(eventInput: CreateAttributionEventData): io.reactivex.Observable<Boolean> {
         return io.reactivex.Observable.empty()
     }
 
@@ -290,6 +291,10 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
         paymentIntentClientSecret: String,
         paymentSourceId: String
     ): io.reactivex.Observable<String> {
+        return io.reactivex.Observable.empty()
+    }
+
+    override fun createPaymentIntent(createPaymentIntentInput: CreatePaymentIntentInput): io.reactivex.Observable<String> {
         return io.reactivex.Observable.empty()
     }
 }


### PR DESCRIPTION
# 📲 What

This PR is for Step 5 of https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2699100255/Event+Attribution+Engineering+Plan+AKA+How+To+Wire+Up+a+New+GraphQL+Endpoint+on+Android#5.-In-KSApolloClientV2%2C-add-a-createAttributionEvent-method

Note this is dependent on merging in https://github.com/kickstarter/android-oss/pull/1969 as it has a dependency on [GraphQLTransformers.kt]

# 🤔 Why


# 🛠 How


# 👀 See


| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

Nothing to QA at this time as this method is not called anywhere.

# Story 📖

https://kickstarter.atlassian.net/browse/MBL-1252
