### PR TITLE
MBL-1262: QA party bug fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,7 +70,6 @@
             android:label="@string/app_name"
             android:exported="true"
             android:launchMode="singleTop"
-            android:taskAffinity=""
             android:theme="@style/SplashTheme">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -111,7 +110,6 @@
             android:name=".ui.activities.ResetPasswordActivity"
             android:parentActivityName=".ui.activities.LoginActivity"
             android:windowSoftInputMode="adjustResize"
-            android:taskAffinity=""
             android:theme="@style/Login" />
         <activity
             android:name=".ui.activities.SetPasswordActivity"
@@ -149,7 +147,7 @@
             android:name=".ui.activities.LoginToutActivity"
             android:parentActivityName=".ui.activities.DiscoveryActivity"
             android:theme="@style/Login"
-            android:launchMode="singleInstancePerTask"
+            android:launchMode="singleTop"
             android:exported="true">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW"/>
@@ -213,7 +211,6 @@
             android:theme="@style/SettingsActivity" />
         <activity
             android:name=".ui.activities.SignupActivity"
-            android:taskAffinity=""
             android:parentActivityName=".ui.activities.LoginToutActivity"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Login" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -253,7 +253,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data
-                    android:host="*.kickstarter.com"
+                    android:host="www.kickstarter.com"
                     android:scheme="https" />
             </intent-filter>
             <!-- Website Main page deeplink  -->

--- a/app/src/main/java/com/kickstarter/ui/activities/ChangePasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ChangePasswordActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.google.android.datatransport.runtime.scheduling.jobscheduling.SchedulerConfig.Flag
 import com.kickstarter.libs.Logout
 import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.utils.ApplicationUtils

--- a/app/src/main/java/com/kickstarter/ui/activities/ChangePasswordActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ChangePasswordActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.android.datatransport.runtime.scheduling.jobscheduling.SchedulerConfig.Flag
 import com.kickstarter.libs.Logout
 import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.utils.ApplicationUtils
@@ -33,6 +34,7 @@ class ChangePasswordActivity : ComponentActivity() {
     private val viewModel: ChangePasswordViewModel by viewModels {
         viewModelFactory
     }
+    private var oAuthIsEnabled = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -46,6 +48,8 @@ class ChangePasswordActivity : ComponentActivity() {
             theme = env.sharedPreferences()
                 ?.getInt(SharedPreferenceKey.APP_THEME, AppThemes.MATCH_SYSTEM.ordinal)
                 ?: AppThemes.MATCH_SYSTEM.ordinal
+
+            oAuthIsEnabled = env.featureFlagClient()?.getBoolean(FlagKey.ANDROID_OAUTH) ?: false
         }
 
         setContent {
@@ -98,10 +102,15 @@ class ChangePasswordActivity : ComponentActivity() {
     private fun logout(email: String) {
         this.logout?.execute()
         ApplicationUtils.startNewDiscoveryActivity(this)
-        startActivity(
+        val intent = if (oAuthIsEnabled) {
+            Intent(this, LoginToutActivity::class.java)
+        } else {
             Intent(this, LoginActivity::class.java)
                 .putExtra(IntentKey.LOGIN_REASON, LoginReason.CHANGE_PASSWORD)
                 .putExtra(IntentKey.EMAIL, email)
+        }
+        startActivity(
+            intent
         )
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/LoginToutActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/LoginToutActivity.kt
@@ -275,7 +275,6 @@ class LoginToutActivity : ComponentActivity() {
         val authorizationUri = Uri.parse(url)
 
         val tabIntent = CustomTabsIntent.Builder().build()
-        tabIntent.intent.flags = Intent.FLAG_ACTIVITY_NO_HISTORY
 
         val packageName = ChromeTabsHelper.getPackageNameToUse(this)
         tabIntent.intent.setPackage(packageName)


### PR DESCRIPTION
# 📲 What
3 bug fixes in this PR :) 

# 👀 See

1 - Navigate away to other apps while chrome tab is presented: 
- the chrome tab no longer gets killed when lost foreground.
- the activity task remains the parent, not a new one.

https://github.com/kickstarter/android-oss/assets/4083656/187a88af-64de-4d1a-8b9d-5a5874b51217

2 - Not related with OAuth bot found it by chance :) the issue is with verified deeplinks, the '*' wildcard regex, even though specified in the manifest as auto-verified, it had to manually by added as verified link, exchanged over `www` to not have to manually add it.
| Before 🐛 | 
<img width="459" alt="Screenshot 2024-03-07 at 1 26 55 PM" src="https://github.com/kickstarter/android-oss/assets/4083656/b9f1431c-d641-495c-9f1b-fe9287909749">

https://github.com/kickstarter/android-oss/assets/4083656/54e14052-0e26-4020-a1eb-1020de560a41

After 🦋 |
<img width="439" alt="Screenshot 2024-03-07 at 1 28 20 PM" src="https://github.com/kickstarter/android-oss/assets/4083656/a0983629-bc53-43e9-ad79-360e7091998c">

https://github.com/kickstarter/android-oss/assets/4083656/05a7a959-a41a-4532-8a56-6b74414766a9


3 - During Change Password flow, the user gets logged out after the password was changed successfully, and presented the login flow to access again. The presented flow was the non-OAuth version. 



| --- | --- |
|  |  |

# 📋 QA
1 - For number 1 just navigate away from the app to retrieve credentials, (any password manager etc), come back to the app. There should be only 1 instance of the app, the Chrome tab parent task is now the app and not a new one, Chrome tab no longer killed after losing foreground.

2 - For number two, fresh install a version of the app with this branch, and take a look App info -> open by default -> 1 verified links. Previous versions to this branch will show 0 verified links, even though the documentation says the wildcard regex is valid for hosts, it seems not be able to autoverify automatically when used.
<img width="858" alt="Screenshot 2024-03-07 at 1 38 23 PM" src="https://github.com/kickstarter/android-oss/assets/4083656/abe1c117-7bb5-4e64-8bf6-563e4f0e19c5">


3 - Follow the change password flow -> change your password -> when feature flag on now you should be presented with `LoginToutActivity`, when feature flag off you should be presented with `LoginActivity`


# Story 📖

[MBL-1262](https://kickstarter.atlassian.net/browse/MBL-1262)


[MBL-1262]: https://kickstarter.atlassian.net/browse/MBL-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ