### PR TITLE
[No-jira]: Analytic event added

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/OAuthViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/OAuthViewModel.kt
@@ -47,6 +47,7 @@ class OAuthViewModel(
     private val logcat = "Oauth :"
     private val hostEndpoint = environment.webEndpoint()
     private val loginUseCase = LoginUseCase(environment)
+    private val analyticEvents = requireNotNull(environment.analytics())
     private val apiClient = requireNotNull(environment.apiClientV2())
     private val clientID = when (hostEndpoint) {
         WebEndpoint.PRODUCTION -> Secrets.Api.Client.PRODUCTION
@@ -103,6 +104,7 @@ class OAuthViewModel(
                                 user = user,
                             )
                         )
+                        analyticEvents.trackLogInButtonCtaClicked()
                     }
             }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/OAuthViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/OAuthViewModelTest.kt
@@ -6,6 +6,7 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUserV2
 import com.kickstarter.libs.utils.CodeVerifier
+import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.PKCE
 import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.mock.factories.ApiExceptionFactory
@@ -125,7 +126,7 @@ class OAuthViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testProduceState_getTokeAndUser() = runTest {
+    fun testProduceState_getTokenAndUser() = runTest {
 
         val user = UserFactory.user()
         val apiClient = object : MockApiClientV2() {
@@ -183,6 +184,7 @@ class OAuthViewModelTest : KSRobolectricTestCase() {
         )
 
         assertEquals(currentUserV2.accessToken, "token")
+        this@OAuthViewModelTest.segmentTrack.assertValues(EventName.CTA_CLICKED.eventName)
     }
 
     @Test
@@ -245,6 +247,7 @@ class OAuthViewModelTest : KSRobolectricTestCase() {
         )
 
         assertEquals(currentUserV2.accessToken, null)
+        this@OAuthViewModelTest.segmentTrack.assertNoValues()
     }
 
     fun testProduceState_getTokeAndUser_ErrorWhileToken() = runTest {


### PR DESCRIPTION
# 📲 What

- With the implementation of OAuth, the analytic events tied to the login button got lost. The website will send some, but lacking all the mobile specific context_properties such as build version/name device, OS version ... .
- In order to not lost events around login, it has been decided to sent the same event (-with the exact same properties), as the one that was tied to the non-OAuth login button. The event is tied to the successful response of the token &  user calls being persisted on the app.

# 🤔 Why
- Analytic event

|  |  |

# 📋 QA

- Log in with OAuth (feature flag on), double check on Segment you get the Identify call **AND**  the button clicked with the context_page = 'log_in'

<img width="1507" alt="Screenshot 2024-03-07 at 12 54 57 PM" src="https://github.com/kickstarter/android-oss/assets/4083656/b2d60cc5-3166-462a-b3e6-cb86ac1bf181">

