### PR TITLE
MBL-1237 Send project page viewed event on Android on the prelaunch page

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AttributionEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AttributionEvents.kt
@@ -28,6 +28,7 @@ class AttributionEvents(
     fun trackProjectPageViewed(projectData: ProjectData) {
         val props: HashMap<String, Any> = hashMapOf(ContextPropertyKeyName.CONTEXT_PAGE.contextName to EventContextValues.ContextPageName.PROJECT.contextName)
         props["context_page_url"] = projectData.fullDeeplink()?.toString() ?: ""
+        props["session_device_type"] = "phone" // Remove when https://kickstarter.atlassian.net/browse/MBL-1275 is complete
         props.putAll(AnalyticEventsUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()))
         track(EventName.PROJECT_PAGE_VIEWED.eventName, props, projectData.project())
     }

--- a/app/src/main/java/com/kickstarter/libs/AttributionEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AttributionEvents.kt
@@ -28,7 +28,7 @@ class AttributionEvents(
     fun trackProjectPageViewed(projectData: ProjectData) {
         val props: HashMap<String, Any> = hashMapOf(ContextPropertyKeyName.CONTEXT_PAGE.contextName to EventContextValues.ContextPageName.PROJECT.contextName)
         props["context_page_url"] = projectData.fullDeeplink()?.toString() ?: ""
-        props["session_device_type"] = "phone" // Remove when https://kickstarter.atlassian.net/browse/MBL-1275 is complete
+        props["session_device_type"] = "phone" // TODO Remove when https://kickstarter.atlassian.net/browse/MBL-1275 is complete
         props.putAll(AnalyticEventsUtils.refTagProperties(projectData.refTagFromIntent(), projectData.refTagFromCookie()))
         track(EventName.PROJECT_PAGE_VIEWED.eventName, props, projectData.project())
     }

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
@@ -11,7 +11,9 @@ import com.kickstarter.libs.utils.I18nUtils
 import com.kickstarter.libs.utils.ListUtils
 import com.kickstarter.models.Category
 import com.kickstarter.models.Project
+import com.kickstarter.models.Urls
 import com.kickstarter.models.User
+import com.kickstarter.models.Web
 import com.kickstarter.services.DiscoveryParams
 import org.joda.time.DateTime
 import org.joda.time.Duration
@@ -302,6 +304,10 @@ fun Project.reduce(): Project {
  * when presenting screens in order to avoid `android.os.TransactionTooLargeException`
  */
 fun Project.reduceToPreLaunchProject(): Project {
+    val web = Web.builder()
+        .project(this.webProjectUrl())
+        .build()
+
     return Project.Builder()
         .id(this.id())
         .slug(this.slug())
@@ -319,5 +325,6 @@ fun Project.reduceToPreLaunchProject(): Project {
         .currency(this.currency())
         .currencySymbol(this.currencySymbol())
         .currencyTrailingCode(this.currencyTrailingCode())
+        .urls(Urls.builder().web(web).build())
         .build()
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/DeepLinkActivity.kt
@@ -107,7 +107,7 @@ class DeepLinkActivity : AppCompatActivity() {
         viewModel.outputs.startPreLaunchProjectActivity()
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
-                startPreLaunchProjectActivity(it, "DEEPLINK")
+                startPreLaunchProjectActivity(it.first, it.second, "DEEPLINK")
             }.addToDisposable(disposables)
     }
 

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -17,6 +17,7 @@ import com.google.android.play.core.review.ReviewManagerFactory
 import com.kickstarter.R
 import com.kickstarter.libs.ActivityRequestCodes
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.UrlUtils
@@ -232,7 +233,8 @@ fun Activity.startPreLaunchProjectActivity(uri: Uri, project: Project, previousS
     )
     // Pass full deeplink for attribution tracking purposes when launching from deeplink
     intent.setData(uri)
-
+    val ref = UrlUtils.refTag(uri.toString())
+    ref?.let { intent.putExtra(IntentKey.REF_TAG, RefTag.from(ref)) }
     previousScreen?.let { intent.putExtra(IntentKey.PREVIOUS_SCREEN, it) }
     startActivity(intent)
     TransitionUtils.transition(this, TransitionUtils.slideInFromRight())

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.ui.extensions
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -222,12 +223,16 @@ fun Activity.transition(transition: Pair<Int, Int>) {
     overridePendingTransition(transition.first, transition.second)
 }
 
-fun Activity.startPreLaunchProjectActivity(project: Project, previousScreen: String? = null) {
+@SuppressLint("IntentWithNullActionLaunch") // Lint bug: https://issuetracker.google.com/issues/294200850
+fun Activity.startPreLaunchProjectActivity(uri: Uri, project: Project, previousScreen: String? = null) {
     val intent = Intent().getPreLaunchProjectActivity(
         this,
         project.slug(),
         project.reduceToPreLaunchProject()
     )
+    // Pass full deeplink for attribution tracking purposes when launching from deeplink
+    intent.setData(uri)
+
     previousScreen?.let { intent.putExtra(IntentKey.PREVIOUS_SCREEN, it) }
     startActivity(intent)
     TransitionUtils.transition(this, TransitionUtils.slideInFromRight())

--- a/app/src/main/java/com/kickstarter/viewmodels/DeepLinkViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DeepLinkViewModel.kt
@@ -76,7 +76,7 @@ interface DeepLinkViewModel {
         fun startProjectActivityToSave(): Observable<Uri>
 
         /** Emits a Project and RefTag pair when we should start the [com.kickstarter.ui.activities.PreLaunchProjectPageActivity].  */
-        fun startPreLaunchProjectActivity(): Observable<Project>
+        fun startPreLaunchProjectActivity(): Observable<Pair<Uri, Project>>
     }
 
     class DeepLinkViewModel(environment: Environment, private val intent: Intent?, externalCall: CustomNetworkClient) :
@@ -97,7 +97,7 @@ interface DeepLinkViewModel {
         private val currentUser = requireNotNull(environment.currentUserV2())
         private val webEndpoint = requireNotNull(environment.webEndpoint())
         private val projectObservable: Observable<Project>
-        private val startPreLaunchProjectActivity = BehaviorSubject.create<Project>()
+        private val startPreLaunchProjectActivity = BehaviorSubject.create<Pair<Uri, Project>>()
 
         private val ffClient = requireNotNull(environment.featureFlagClient())
 
@@ -316,7 +316,7 @@ interface DeepLinkViewModel {
                 it.second.displayPrelaunch() == true &&
                 ffClient.getBoolean(FlagKey.ANDROID_PRE_LAUNCH_SCREEN)
             ) {
-                startPreLaunchProjectActivity.onNext(it.second)
+                startPreLaunchProjectActivity.onNext(Pair(it.first, it.second))
             } else {
                 startProjectPage.onNext(it.first)
             }
@@ -382,7 +382,7 @@ interface DeepLinkViewModel {
 
         override fun startProjectActivityToSave(): Observable<Uri> = startProjectActivityToSave
 
-        override fun startPreLaunchProjectActivity(): Observable<Project> = startPreLaunchProjectActivity
+        override fun startPreLaunchProjectActivity(): Observable<Pair<Uri, Project>> = startPreLaunchProjectActivity
     }
 
     class Factory(private val environment: Environment, private val intent: Intent? = null, private val customNetworkClient: CustomNetworkClient? = null) : ViewModelProvider.Factory {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/PrelaunchProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/PrelaunchProjectViewModel.kt
@@ -122,7 +122,6 @@ interface PrelaunchProjectViewModel {
 
             val initialProject = Observable.merge(reducedProject, loadedProject)
 
-
             // An observable of the ref tag stored in the cookie for the project. Emits an optional since this value can be null.
             val cookieRefTag = initialProject
                 .take(1)

--- a/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.kt
@@ -2,6 +2,7 @@ package com.kickstarter.viewmodels
 
 import android.content.Intent
 import android.net.Uri
+import android.util.Pair
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUserV2
@@ -36,7 +37,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
     private val startProjectActivityForUpdate = TestSubscriber<Uri>()
     private val startProjectActivityToSave = TestSubscriber<Uri>()
     private val startProjectActivityForCommentToUpdate = TestSubscriber<Uri>()
-    private val startPreLaunchProjectActivity = TestSubscriber<Project>()
+    private val startPreLaunchProjectActivity = TestSubscriber<Pair<Uri, Project>>()
     private val finishDeeplinkActivity = TestSubscriber<Unit>()
     private val disposables = CompositeDisposable()
 


### PR DESCRIPTION
# 📲 What

This PR is for Step 7 of the event attribution eng plan https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2699100255/Event+Attribution+Engineering+Plan+AKA+How+To+Wire+Up+a+New+GraphQL+Endpoint+on+Android#7.-Send-event-from-Prelaunch-page-as-well

See PR for sending Project Page Viewed event on Project page for reference: https://github.com/kickstarter/android-oss/pull/1972

# 🤔 Why

Because the Prelaunch page is a separate page from Project page on Android, also send the Project Page Viewed attribution event from the Prelaunch page.

# 🛠 How


# 👀 See

No visible changes in app. Check segment to see new events being fired from Android -> backend -> segment: https://www.kickstarter.com/projects/paintbucketgames/the-darkest-files

# 📋 QA

In both logged in and logged out states, open

a prelaunch project from the discovery page e.g. search for "The Darkest Files" (https://staging.kickstarter.com/projects/paintbucketgames/the-darkest-files?ref=discovery)

a prelaunch project via a deeplink e.g. https://staging.kickstarter.com/projects/paintbucketgames/the-darkest-files?&ref=android_deep_link

Confirm on Segment https://app.segment.com/kickstarter/sources/web_ruby_staging/debugger that you see the following event properties coming from your device:
https://docs.google.com/document/d/1mjutUcmFS0nbNIgXwUbBMUrV97W8NbfmZbKX8375r0w/edit

```
Analytics.track(
  user_id: '854003720',
  event: 'Project Page Viewed',
  properties: {
    context_page: 'project',
    context_page_referrer: '',
    context_page_url: 'ksr://staging.kickstarter.com/projects/1236652055/2054270300?app_banner=1&ref=discovery',
    project_pid: '2054270300',
    project_state: 'submitted',
    project_user_is_backer: false,
    project_user_is_project_creator: false,
    session_client: 'native',
    session_country: 'US',
    session_device_type: 'phone',
    session_display_language: 'en',
    session_os: 'android',
    session_platform: 'native_android',
    session_ref_tag: 'discovery',
    session_referrer_credit: 'discovery',
    session_user_is_logged_in: true,
    user_uid: '854003720'
  }
)
```


# Story 📖

https://kickstarter.atlassian.net/browse/MBL-1237
