### PR TITLE
[MBL-1283] Add SetupIntentContext to SetupIntent calls

### DIFF
--- a/app/src/main/graphql/checkout.graphql
+++ b/app/src/main/graphql/checkout.graphql
@@ -34,8 +34,8 @@ query GetBacking($backingId: ID!) {
   }
 }
 
-mutation CreateSetupIntent($projectId: ID) {
-  createSetupIntent(input: { projectId: $projectId } ) {
+mutation CreateSetupIntent($projectId: ID, $setupIntentContext: StripeIntentContextTypes) {
+  createSetupIntent(input: { projectId: $projectId, setupIntentContext: $setupIntentContext } ) {
     clientSecret
   }
 }

--- a/app/src/main/graphql/checkout.graphql
+++ b/app/src/main/graphql/checkout.graphql
@@ -49,8 +49,8 @@ mutation CreateCheckout($projectId: ID!, $amount: String!, $rewardIds: [ID!], $l
   }
 }
 
-mutation CreatePaymentIntent($projectId: ID!, $amount: String!) {
-  createPaymentIntent(input: { projectId: $projectId, amount: $amount } ) {
+mutation CreatePaymentIntent($projectId: ID!, $amount: String!, $paymentIntentContext: StripeIntentContextTypes) {
+  createPaymentIntent(input: { projectId: $projectId, amount: $amount, paymentIntentContext: $paymentIntentContext } ) {
     clientSecret
   }
 }

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -235,12 +235,7 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
                 .apply {
                     project?.let {
                         this.projectId(encodeRelayId(it))
-                        this.setupIntentContext(
-                            if (it.isInPostCampaignPledgingPhase() == true && it.postCampaignPledgingEnabled() == true)
-                                StripeIntentContextTypes.POST_CAMPAIGN_CHECKOUT
-                            else
-                                StripeIntentContextTypes.CROWDFUNDING_CHECKOUT
-                        )
+                        this.setupIntentContext(StripeIntentContextTypes.CROWDFUNDING_CHECKOUT)
                     } ?: run {
                         this.setupIntentContext(StripeIntentContextTypes.PROFILE_SETTINGS)
                     }
@@ -1504,6 +1499,7 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
                 CreatePaymentIntentMutation.builder()
                     .projectId(encodeRelayId(createPaymentIntentInput.project))
                     .amount(createPaymentIntentInput.amount)
+                    .paymentIntentContext(StripeIntentContextTypes.POST_CAMPAIGN_CHECKOUT)
                     .build()
             ).enqueue(object : ApolloCall.Callback<CreatePaymentIntentMutation.Data>() {
                 override fun onFailure(e: ApolloException) {


### PR DESCRIPTION
# 📲 What

Adding a new field to the setupintent mutation as requested by backend

# 🤔 Why

They want to know when a payment method is added, why/where it was added

# 🛠 How

Graph was updated to have the new ENUM we can use to provide these fields

# 👀 See

{"operationName":"CreateSetupIntent","variables":{"projectId":"UHJvamVjdC0xNzg5OTAyNzU3","setupIntentContext":"CROWDFUNDING_CHECKOUT"},"query":"mutation CreateSetupIntent($projectId: ID, $setupIntentContext: StripeIntentContextTypes) { createSetupIntent(input: {projectId: $projectId, setupIntentContext: $setupIntentContext}) { __typename clientSecret } }"}

{"operationName":"CreateSetupIntent","variables":{"setupIntentContext":"PROFILE_SETTINGS"},"query":"mutation CreateSetupIntent($projectId: ID, $setupIntentContext: StripeIntentContextTypes) { createSetupIntent(input: {projectId: $projectId, setupIntentContext: $setupIntentContext}) { __typename clientSecret } }"}


# 📋 QA

Try to add a payment method on both the profile and in the pledge flow and confirm the correct type is sent

# Story 📖

[MBL-1283](https://kickstarter.atlassian.net/browse/MBL-1283)


[MBL-1283]: https://kickstarter.atlassian.net/browse/MBL-1283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ