### PR TITLE
[NoTicket] Fix add-ons shipping rule logic 

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rxjava2.subscribeAsState
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.content.ContextCompat
 import androidx.core.view.isGone

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -173,6 +173,8 @@ class ProjectPageActivity :
                     val shippingSelectorIsGone = addOnsUIState.shippingSelectorIsGone
                     val currentUserShippingRule = addOnsUIState.currentShippingRule
                     val selectedAddOnsMap: MutableMap<Reward, Int> = addOnsUIState.currentAddOnsSelection
+                    val addOns = addOnsUIState.addOns
+                    val shippingRules = addOnsUIState.shippingRules
 
                     LaunchedEffect(Unit) {
                         addOnsViewModel.flowUIRequest.collect {
@@ -218,12 +220,7 @@ class ProjectPageActivity :
                         }
                     }
 
-                    val shippingRules = checkoutFlowViewModel.shippingRules.subscribeAsState(initial = listOf()).value
-
                     var selectedReward: Reward? = null
-
-                    val addOns =
-                        checkoutFlowViewModel.addOns.subscribeAsState(initial = listOf()).value
 
                     ProjectPledgeButtonAndFragmentContainer(
                         expanded = expanded,
@@ -253,7 +250,7 @@ class ProjectPageActivity :
                         onRewardSelected = { reward ->
                             selectedReward = reward
                             checkoutFlowViewModel.userRewardSelection(reward)
-                            addOnsViewModel.userRewardSelection(reward, shippingRules)
+                            addOnsViewModel.userRewardSelection(reward)
                             rewardsSelectionViewModel.onUserRewardSelection(reward)
                             confirmDetailsViewModel.onUserSelectedReward(reward)
                         },
@@ -335,8 +332,8 @@ class ProjectPageActivity :
                 // - Every time the ProjectData gets updated
                 // - the fragments on the viewPager are updated as well
                 (binding.projectPager.adapter as? ProjectPagerAdapter)?.updatedWithProjectData(it)
-                checkoutFlowViewModel.provideProjectData(it)
                 rewardsSelectionViewModel.provideProjectData(it)
+                addOnsViewModel.provideProjectData(it)
                 confirmDetailsViewModel.provideProjectData(it)
             }.addToDisposable(disposables)
 

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
@@ -243,7 +243,7 @@ fun AddOnsScreen(
                         getShippingCost(
                             reward = reward,
                             ksCurrency = it,
-                            shippingRules = countryList,
+                            shippingRules = reward.shippingRules(),
                             selectedShippingRule = currentShippingRule,
                             project = project
                         )

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CheckoutFlowViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CheckoutFlowViewModel.kt
@@ -28,17 +28,7 @@ data class FlowUIState(
 
 class CheckoutFlowViewModel(val environment: Environment) : ViewModel() {
 
-    private val apolloClient = requireNotNull(environment.apolloClientV2())
-
-    private val disposables = CompositeDisposable()
-
-    val shippingRules = PublishSubject.create<List<ShippingRule>>()
-    val addOns = PublishSubject.create<List<Reward>>()
-    val projectData = PublishSubject.create<ProjectData>()
-
-    private lateinit var currentProjectData: ProjectData
     private lateinit var newUserReward: Reward
-    private lateinit var allAddOns: List<Reward>
 
     private val mutableFlowUIState = MutableStateFlow(FlowUIState())
     val flowUIState: StateFlow<FlowUIState>
@@ -56,58 +46,8 @@ class CheckoutFlowViewModel(val environment: Environment) : ViewModel() {
         }
     }
 
-    fun provideProjectData(projectData: ProjectData) {
-        currentProjectData = projectData
-        viewModelScope.launch {
-            projectData.project().rewards()?.let { rewards ->
-                if (rewards.isNotEmpty()) {
-                    val reward = rewards.firstOrNull { theOne ->
-                        !theOne.isAddOn() && theOne.isAvailable() && RewardUtils.isShippable(theOne)
-                    }
-                    reward?.let {
-                        apolloClient.getShippingRules(
-                            reward = reward
-                        ).subscribe { shippingRulesEnvelope ->
-                            if (shippingRulesEnvelope.isNotNull()) shippingRules.onNext(
-                                shippingRulesEnvelope.shippingRules()
-                            )
-                        }.addToDisposable(disposables)
-                    }
-                }
-            }
-        }
-
-        apolloClient
-            .getProjectAddOns(
-                projectData.project().slug() ?: "",
-                projectData.project().location() ?: Location.builder().build()
-            )
-            .onErrorResumeNext(Observable.empty())
-            .filter { it.isNotNull() }
-            .subscribe {
-                allAddOns = it
-                addOns.onNext(it)
-            }
-            .addToDisposable(disposables)
-    }
-
     fun userRewardSelection(reward: Reward) {
-        viewModelScope.launch {
-            newUserReward = reward
-
-            val cannotShip = RewardUtils.isDigital(newUserReward) || !RewardUtils.isShippable(newUserReward) || RewardUtils.isLocalPickup(newUserReward)
-            // If reward cannot be shipped, only display addons that also cannot be shipped
-            if (newUserReward.hasAddons() && cannotShip) {
-                addOns.onNext(
-                    allAddOns
-                        .filter { addOn ->
-                            RewardUtils.isDigital(addOn) || !RewardUtils.isShippable(addOn) || RewardUtils.isLocalPickup(addOn)
-                        }
-                )
-            } else {
-                addOns.onNext(allAddOns)
-            }
-        }
+        newUserReward = reward
     }
 
     fun onBackPressed(currentPage: Int) {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CheckoutFlowViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CheckoutFlowViewModel.kt
@@ -4,16 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.kickstarter.libs.Environment
-import com.kickstarter.libs.utils.RewardUtils
-import com.kickstarter.libs.utils.extensions.addToDisposable
-import com.kickstarter.libs.utils.extensions.isNotNull
-import com.kickstarter.models.Location
 import com.kickstarter.models.Reward
-import com.kickstarter.models.ShippingRule
-import com.kickstarter.ui.data.ProjectData
-import io.reactivex.Observable
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.subjects.PublishSubject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow


### PR DESCRIPTION

# 📲 What

- fix shipping display on add-ons screen (was using default shipping rule before, now its the rewards shipping rule)
- updating the shipping rule updates the prices on the add-ons screen (and reward selected shipping amount on confirm details screen)
- add-ons shipping are now properly displayed in the confirm details screen
- this filters the add-ons so only non shippable add-ons are displayed for a non shippable reward

# 🤔 Why

Need to hammer out them bugs

# 👀 See


https://github.com/kickstarter/android-oss/assets/7563288/419d981b-74cb-43a6-85be-d517deb57a0c



# 📋 QA

- Go to a project
- select a reward with shipping/add-ons
- select any add-ons
- if changing shipping rule, make sure add-on selection is cleared and new prices are reflected
- confirm prices add up correctly in confirm details screen

