### PR TITLE
[MBL-1300] Make confirm details screen use same default location logic as add-ons

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -194,8 +194,8 @@ class ProjectPageActivity :
                     binding.pledgeContainerLayout.pledgeContainerRoot.isGone = true
                     latePledgesSetUp(binding.pledgeContainerCompose)
                 } else {
-                    binding.pledgeContainerLayout.pledgeContainerRoot.isGone = true
-                    latePledgesSetUp(binding.pledgeContainerCompose)
+                    binding.pledgeContainerCompose.isGone = true
+                    binding.pledgeContainerLayout.pledgeContainerRoot.isGone = false
                 }
             }.addToDisposable(disposables)
 
@@ -207,12 +207,11 @@ class ProjectPageActivity :
                 (binding.projectPager.adapter as? ProjectPagerAdapter)?.updatedWithProjectData(it)
                 val fFLatePledge = environment?.featureFlagClient()?.getBoolean(FlagKey.ANDROID_POST_CAMPAIGN_PLEDGES) ?: false
 
-                binding.pledgeContainerLayout.pledgeContainerRoot.isGone = true
-                latePledgesSetUp(binding.pledgeContainerCompose)
+                if (fFLatePledge && it.project().showLatePledgeFlow()) {
                     rewardsSelectionViewModel.provideProjectData(it)
                     addOnsViewModel.provideProjectData(it)
                     confirmDetailsViewModel.provideProjectData(it)
-
+                }
             }.addToDisposable(disposables)
 
         this.viewModel.outputs.updateTabs()

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
@@ -320,7 +320,7 @@ fun CountryInputWithDropdown(
     }
 
     var countryInput by remember {
-        mutableStateOf(initialCountryInput ?: "United States")
+        mutableStateOf(initialCountryInput ?: "")
     }
 
     val focusManager = LocalFocusManager.current

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ConfirmPledgeDetailsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ConfirmPledgeDetailsScreen.kt
@@ -54,6 +54,7 @@ private fun ConfirmPledgeDetailsScreenPreviewNoRewards() {
             selectedReward = null,
             onContinueClicked = {},
             rewardsContainAddOns = false,
+            rewardsHaveShippables = true,
             currentShippingRule = ShippingRule.builder().build(),
             totalAmount = 1.0,
             initialBonusSupport = 1.0,
@@ -79,6 +80,7 @@ private fun ConfirmPledgeDetailsScreenPreviewNoRewardsWarning() {
             selectedReward = null,
             onContinueClicked = {},
             rewardsContainAddOns = false,
+            rewardsHaveShippables = true,
             currentShippingRule = ShippingRule.builder().build(),
             totalAmount = 1001.0,
             initialBonusSupport = 1.0,
@@ -107,6 +109,7 @@ private fun ConfirmPledgeDetailsScreenPreviewNoAddOnsOrBonusSupport() {
                 Pair("Cool Item $it", "$20")
             },
             rewardsContainAddOns = false,
+            rewardsHaveShippables = true,
             shippingAmount = 5.0,
             currentShippingRule = ShippingRule.builder().build(),
             totalAmount = 55.0,
@@ -137,6 +140,7 @@ private fun ConfirmPledgeDetailsScreenPreviewAddOnsOnly() {
                 Pair("Cool Item $it", "$20")
             },
             rewardsContainAddOns = true,
+            rewardsHaveShippables = true,
             shippingAmount = 5.0,
             currentShippingRule = ShippingRule.builder().build(),
             totalAmount = 105.0,
@@ -166,6 +170,7 @@ private fun ConfirmPledgeDetailsScreenPreviewBonusSupportOnly() {
                 Pair("Cool Item $it", "$20")
             },
             rewardsContainAddOns = false,
+            rewardsHaveShippables = true,
             shippingAmount = 5.0,
             currentShippingRule = ShippingRule.builder().build(),
             totalAmount = 55.0,
@@ -196,6 +201,7 @@ private fun ConfirmPledgeDetailsScreenPreviewAddOnsAndBonusSupport() {
                 Pair("Cool Item $it", "$20")
             },
             rewardsContainAddOns = true,
+            rewardsHaveShippables = true,
             shippingAmount = 5.0,
             currentShippingRule = ShippingRule.builder().build(),
             totalAmount = 115.0,
@@ -219,6 +225,7 @@ fun ConfirmPledgeDetailsScreen(
     onContinueClicked: () -> Unit,
     rewardsList: List<Pair<String, String>> = listOf(),
     rewardsContainAddOns: Boolean,
+    rewardsHaveShippables: Boolean,
     shippingAmount: Double = 0.0,
     currentShippingRule: ShippingRule,
     countryList: List<ShippingRule> = listOf(),
@@ -383,7 +390,7 @@ fun ConfirmPledgeDetailsScreen(
                         Spacer(modifier = Modifier.height(dimensions.paddingMediumSmall))
 
                         Row(verticalAlignment = Alignment.CenterVertically) {
-                            if (countryList.isNotEmpty() && !rewardsContainAddOns) {
+                            if (countryList.isNotEmpty() && !rewardsContainAddOns && rewardsHaveShippables) {
                                 CountryInputWithDropdown(
                                     interactionSource = interactionSource,
                                     countryList = countryList,

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ConfirmPledgeDetailsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ConfirmPledgeDetailsScreen.kt
@@ -393,6 +393,7 @@ fun ConfirmPledgeDetailsScreen(
                             if (countryList.isNotEmpty() && !rewardsContainAddOns && rewardsHaveShippables) {
                                 CountryInputWithDropdown(
                                     interactionSource = interactionSource,
+                                    initialCountryInput = shippingLocation,
                                     countryList = countryList,
                                     onShippingRuleSelected = onShippingRuleSelected
                                 )

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ProjectPledgeButtonAndFragmentContainer.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ProjectPledgeButtonAndFragmentContainer.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.kickstarter.R
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.RewardViewUtils
 import com.kickstarter.libs.utils.extensions.isNullOrZero
 import com.kickstarter.models.Project
@@ -287,6 +288,7 @@ fun ProjectPledgeButtonAndFragmentContainer(
                                             selectedRewardAndAddOnList, environment, project
                                         ),
                                         rewardsContainAddOns = selectedRewardAndAddOnList.any { it.isAddOn() },
+                                        rewardsHaveShippables = selectedRewardAndAddOnList.any { RewardUtils.isShippable(it) },
                                         onBonusSupportPlusClicked = onBonusSupportPlusClicked,
                                         onBonusSupportMinusClicked = onBonusSupportMinusClicked
                                     )

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
@@ -67,18 +67,8 @@ class AddOnsViewModel(val environment: Environment) : ViewModel() {
                 initialValue = AddOnsUIState()
             )
 
-    private val mutableFlowUIRequest = MutableSharedFlow<FlowUIState>()
-    val flowUIRequest: SharedFlow<FlowUIState>
-        get() = mutableFlowUIRequest
-            .asSharedFlow()
-
     init {
         currentUserReward
-            .filter {
-                !RewardUtils.isDigital(it) && RewardUtils.isShippable(it) && !RewardUtils.isLocalPickup(
-                    it
-                )
-            }
             .compose<Pair<Reward, List<ShippingRule>>>(
                 Transformers.combineLatestPair(
                     shippingRulesObservable
@@ -214,13 +204,6 @@ class AddOnsViewModel(val environment: Environment) : ViewModel() {
         this.currentAddOnsSelections = currentAddOnsSelections
         viewModelScope.launch {
             emitCurrentState()
-        }
-    }
-
-    fun onAddOnsContinueClicked() {
-        viewModelScope.launch {
-            // Go to confirm page
-            mutableFlowUIRequest.emit(FlowUIState(currentPage = 2, expanded = true))
         }
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
@@ -18,12 +18,9 @@ import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CheckoutFlowViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CheckoutFlowViewModel.kt
@@ -100,6 +100,13 @@ class CheckoutFlowViewModel(val environment: Environment) : ViewModel() {
         }
     }
 
+    fun onAddOnsContinueClicked() {
+        viewModelScope.launch {
+            // Go to confirm page
+            mutableFlowUIState.emit(FlowUIState(currentPage = 2, expanded = true))
+        }
+    }
+
     class Factory(private val environment: Environment) :
         ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ConfirmDetailsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ConfirmDetailsViewModel.kt
@@ -15,7 +15,6 @@ import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeFlowContext
 import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ProjectData
-import io.reactivex.Observable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow


### PR DESCRIPTION
# 📲 What

Make it so that the default location is user based not project based by using the add-ons logic to populate the fields

# 🤔 Why

It was always defaulting to the United States

# 🛠 How

See code

# 📋 QA

Go to a project that has shippable rewards
Confirm a reward selection that has no add-ons
see if the country matches your users country

# Story 📖

[MBL-1300](https://kickstarter.atlassian.net/browse/MBL-1300)


[MBL-1300]: https://kickstarter.atlassian.net/browse/MBL-1300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ