### PR TITLE
MBL-1258: Analytics, changes on project properties for Late Pledges

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -16,6 +16,7 @@ import com.kickstarter.libs.utils.extensions.refTag
 import com.kickstarter.libs.utils.extensions.rewardCost
 import com.kickstarter.libs.utils.extensions.round
 import com.kickstarter.libs.utils.extensions.shippingAmount
+import com.kickstarter.libs.utils.extensions.showLatePledgeFlow
 import com.kickstarter.libs.utils.extensions.timeInDaysOfDuration
 import com.kickstarter.libs.utils.extensions.timeInSecondsUntilDeadline
 import com.kickstarter.libs.utils.extensions.totalAmount
@@ -276,6 +277,7 @@ object AnalyticEventsUtils {
             put("has_add_ons", hasAddOns?.hasAddons() ?: false)
             put("tags", project.tags()?.let { it.joinToString(", ") } ?: "")
             put("url", project.urls().web().project())
+            put("project_post_campaign_enabled", project.showLatePledgeFlow())
             project.photo()?.full()?.let { put("image_url", it) }
         }
 

--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -264,7 +264,7 @@ object AnalyticEventsUtils {
                 val rewards = a.filter { isReward(it) }
                 put("rewards_count", rewards.size)
             }
-            put("state", project.state())
+            put("state", if (!project.showLatePledgeFlow()) project.state() else "post_campaign")
             put("static_usd_rate", project.staticUsdRate())
             project.updatesCount()?.let { put("updates_count", it) }
             put("user_is_project_creator", project.userIsCreator(loggedInUser))

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -712,7 +712,7 @@ class SegmentTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testProjectProperties_project_post_campaign_enabled_true() {
+    fun `testProjectProperties project_post_campaign_enabled=true and project_state=post_campaign when latePledges enabled`() {
         val project = ProjectFactory.projectWithAddOns()
             .toBuilder()
             .isInPostCampaignPledgingPhase(true)
@@ -731,12 +731,14 @@ class SegmentTest : KSRobolectricTestCase() {
 
         val expectedProperties = this.propertiesTest.value
         assertEquals(true, expectedProperties["project_project_post_campaign_enabled"])
+        assertEquals("post_campaign", expectedProperties["project_state"])
     }
 
     @Test
-    fun testProjectProperties_project_post_campaign_enabled_false() {
+    fun `testProjectProperties project_post_campaign_enabled=false and project_state=live when latePledges disabled`() {
         val project = ProjectFactory.projectWithAddOns()
             .toBuilder()
+            .state("live")
             .isInPostCampaignPledgingPhase(false)
             .postCampaignPledgingEnabled(true)
             .build()
@@ -753,6 +755,7 @@ class SegmentTest : KSRobolectricTestCase() {
 
         val expectedProperties = this.propertiesTest.value
         assertEquals(false, expectedProperties["project_project_post_campaign_enabled"])
+        assertEquals("live", expectedProperties["project_state"])
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -712,6 +712,50 @@ class SegmentTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testProjectProperties_project_post_campaign_enabled_true() {
+        val project = ProjectFactory.projectWithAddOns()
+            .toBuilder()
+            .isInPostCampaignPledgingPhase(true)
+            .postCampaignPledgingEnabled(true)
+            .build()
+
+        val client = client(null)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackProjectScreenViewed(
+            ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()),
+            EventContextValues.ContextSectionName.OVERVIEW.contextName
+        )
+
+        val expectedProperties = this.propertiesTest.value
+        assertEquals(true, expectedProperties["project_project_post_campaign_enabled"])
+    }
+
+    @Test
+    fun testProjectProperties_project_post_campaign_enabled_false() {
+        val project = ProjectFactory.projectWithAddOns()
+            .toBuilder()
+            .isInPostCampaignPledgingPhase(false)
+            .postCampaignPledgingEnabled(true)
+            .build()
+
+        val client = client(null)
+        client.eventNames.subscribe(this.segmentTrack)
+        client.eventProperties.subscribe(this.propertiesTest)
+        val segment = AnalyticEvents(listOf(client))
+
+        segment.trackProjectScreenViewed(
+            ProjectDataFactory.project(project, RefTag.discovery(), RefTag.recommended()),
+            EventContextValues.ContextSectionName.OVERVIEW.contextName
+        )
+
+        val expectedProperties = this.propertiesTest.value
+        assertEquals(false, expectedProperties["project_project_post_campaign_enabled"])
+    }
+
+    @Test
     fun testProjectProperties_hasProject_prelaunch_activated() {
         val project = ProjectFactory.projectWithAddOns()
 


### PR DESCRIPTION
# 📲 What

- new property added `project_post_campaign_enabled`
- modified property `project_state` when late pledges activated should say `post_campaign`

# 👀 See

 Go to Segment, any event with project properties such as page viewed event for example, and look for the property
- When the project has **not** activated late pledges: 
<img width="715" alt="disabled" src="https://github.com/kickstarter/android-oss/assets/4083656/03a4932b-47ff-4b57-89f2-b3462d0c4d78">



- When the project has activated late pledges:
<img width="758" alt="enabled" src="https://github.com/kickstarter/android-oss/assets/4083656/7bae8528-594d-4733-9440-1f0d60b6fcb7">



|  |  |

# 📋 QA
- navigate a bit to any random project, check segment events that the value of the property `project_post_campaign_enabled` = false
- navigate to the `baconbaconbacon` check segment events that the value of the property `project_post_campaign_enabled` = true

# Story 📖

[MBL-1278](https://kickstarter.atlassian.net/browse/MBL-1278)


[MBL-1278]: https://kickstarter.atlassian.net/browse/MBL-1278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ