### PR TITLE
[MBL-1299] Make it so late pledge flow is not shown if user has backed the project

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
@@ -52,7 +52,7 @@ fun Project.updateProjectWith(config: Config, user: User?): Project {
         .build()
 }
 
-fun Project.showLatePledgeFlow() = this.isInPostCampaignPledgingPhase() ?: false && this.postCampaignPledgingEnabled() ?: false
+fun Project.showLatePledgeFlow() = this.isInPostCampaignPledgingPhase() ?: false && this.postCampaignPledgingEnabled() ?: false && !this.isBacking()
 
 /**
  * Checks if the given card type is listed in the available card types


### PR DESCRIPTION
# 📲 What

Make it so that the old view your pledge flow is shown when a user has already backed a late pledge project

# 🤔 Why

Late pledges cannot be changed, and this flow just lets you view, not change your pledges

# 🛠 How

A boolean

# 👀 See


https://github.com/kickstarter/android-oss/assets/7563288/0ae34805-3931-43b4-9a0d-0324aa5c0a25



# 📋 QA

In a project that is late pledge enabled, back the project and then come back to the project page

# Story 📖

[MBL-1299](https://kickstarter.atlassian.net/browse/MBL-1299)


[MBL-1299]: https://kickstarter.atlassian.net/browse/MBL-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ