### PR TITLE
MBL-1278: Analytic events for rewards

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -117,7 +117,7 @@ class ProjectPageActivity :
     private lateinit var checkoutViewModelFactory: CheckoutFlowViewModel.Factory
     private val checkoutFlowViewModel: CheckoutFlowViewModel by viewModels { checkoutViewModelFactory }
 
-    private val rewardsSelectionViewModelFactory = RewardsSelectionViewModel.Factory()
+    private lateinit var rewardsSelectionViewModelFactory: RewardsSelectionViewModel.Factory
     private val rewardsSelectionViewModel: RewardsSelectionViewModel by viewModels { rewardsSelectionViewModelFactory }
 
     private lateinit var confirmDetailsViewModelFactory: ConfirmDetailsViewModel.Factory
@@ -167,6 +167,7 @@ class ProjectPageActivity :
         val environment = this.getEnvironment()?.let { env ->
             viewModelFactory = ProjectPageViewModel.Factory(env)
             checkoutViewModelFactory = CheckoutFlowViewModel.Factory(env)
+            rewardsSelectionViewModelFactory = RewardsSelectionViewModel.Factory(env)
             confirmDetailsViewModelFactory = ConfirmDetailsViewModel.Factory(env)
             addOnsViewModelFactory = AddOnsViewModel.Factory(env)
             latePledgeCheckoutViewModelFactory = LatePledgeCheckoutViewModel.Factory(env)
@@ -498,11 +499,11 @@ class ProjectPageActivity :
                     val currentPage = flowUIState.currentPage
 
                     val rewardSelectionUIState by rewardsSelectionViewModel.rewardSelectionUIState.collectAsStateWithLifecycle()
-
                     val projectData = rewardSelectionUIState.project
                     val indexOfBackedReward = rewardSelectionUIState.initialRewardIndex
                     val rewardsList = rewardSelectionUIState.rewardList
                     val showRewardCarouselAlertDialog = rewardSelectionUIState.showAlertDialog
+                    rewardsSelectionViewModel.sendEvent(expanded, currentPage, projectData)
 
                     LaunchedEffect(Unit) {
                         rewardsSelectionViewModel.flowUIRequest.collect {

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
@@ -1,6 +1,10 @@
 package com.kickstarter.viewmodels
 
 import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.EventName
+import com.kickstarter.mock.factories.ProjectDataFactory
+import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.models.Backing
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
@@ -19,9 +23,9 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var viewModel: RewardsSelectionViewModel
 
-    private fun createViewModel() {
+    private fun createViewModel(environment: Environment = environment()) {
         viewModel =
-            RewardsSelectionViewModel.Factory().create(RewardsSelectionViewModel::class.java)
+            RewardsSelectionViewModel.Factory(environment).create(RewardsSelectionViewModel::class.java)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -97,6 +101,8 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
             flowState.last(),
             FlowUIState(currentPage = 1, expanded = true)
         )
+
+        this@RewardsSelectionViewModelTest.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -141,6 +147,8 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
             flowState.last(),
             FlowUIState(currentPage = 2, expanded = true)
         )
+
+        this@RewardsSelectionViewModelTest.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -189,6 +197,8 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
             flowState.last(),
             FlowUIState(currentPage = 1, expanded = true)
         )
+
+        this@RewardsSelectionViewModelTest.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -237,6 +247,8 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
             flowState.last(),
             FlowUIState(currentPage = 1, expanded = true)
         )
+
+        this@RewardsSelectionViewModelTest.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -290,6 +302,8 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
                 showAlertDialog = true
             )
         )
+
+        this@RewardsSelectionViewModelTest.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -338,6 +352,8 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
             flowState.last(),
             FlowUIState(currentPage = 2, expanded = true)
         )
+
+        this@RewardsSelectionViewModelTest.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -394,6 +410,8 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
                     showAlertDialog = true
                 )
             )
+
+            this@RewardsSelectionViewModelTest.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
         }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -458,6 +476,8 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
             flowState.last(),
             FlowUIState(currentPage = 1, expanded = true)
         )
+
+        this@RewardsSelectionViewModelTest.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -522,6 +542,8 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
             flowState.last(),
             FlowUIState(currentPage = 2, expanded = true)
         )
+
+        this@RewardsSelectionViewModelTest.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -591,5 +613,30 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
                 showAlertDialog = false
             )
         )
+
+        this@RewardsSelectionViewModelTest.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
+    }
+
+    @Test
+    fun `test send analytic event trackRewardsCarouselViewed() when the currentPage is rewards and is expanded mode`() {
+        createViewModel()
+
+        val projectData = ProjectDataFactory.project(ProjectFactory.project())
+
+        viewModel.sendEvent(expanded = true, currentPage = 0, projectData)
+        this@RewardsSelectionViewModelTest.segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
+    }
+
+    @Test
+    fun `test analytic event trackRewardsCarouselViewed() not sent when the currentPage is not rewards or not expanded`() {
+        createViewModel()
+
+        val projectData = ProjectDataFactory.project(ProjectFactory.project())
+
+        viewModel.sendEvent(expanded = true, currentPage = 1, projectData)
+        this@RewardsSelectionViewModelTest.segmentTrack.assertNoValues()
+
+        viewModel.sendEvent(expanded = false, currentPage = 0, projectData)
+        this@RewardsSelectionViewModelTest.segmentTrack.assertNoValues()
     }
 }


### PR DESCRIPTION
# 📲 What

- Analytic events for rewards screen

# 🤔 Why

- Track usage!

# 🛠 How

- `PageViewed` event triggered when late pledge rewards screen is expanded
- `CTA clicked` event triggered when the user selects a reward

# 👀 See
- Page Viewed
![pageViewedRewardsCarousel](https://github.com/kickstarter/android-oss/assets/4083656/6cfbcac4-be83-42f6-844e-3be06d5751b3)


- CTA clicked
![rewardSelected](https://github.com/kickstarter/android-oss/assets/4083656/3cd77dff-fc2f-48b4-945c-ef8dcf4e7676)


|  |  |

# 📋 QA

- Browse to any of the projects with late pledges available, navigate to the rewards screen and select a reward, you should see the events triggered on Segment, before there was non.

# Story 📖

[MBL-1278](https://kickstarter.atlassian.net/browse/MBL-1278)


[MBL-1278]: https://kickstarter.atlassian.net/browse/MBL-1278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ