### PR TITLE
[Late Pledge Bugs] Add saving payment method to late pledge flow

### DIFF
--- a/app/src/main/graphql/checkout.graphql
+++ b/app/src/main/graphql/checkout.graphql
@@ -64,8 +64,8 @@ query ValidateCheckout($checkoutId:ID!, $paymentSourceId:String!, $paymentIntent
   }
 }
 
-mutation CompleteOnSessionCheckout($checkoutId: ID!, $paymentIntentClientSecret: String!, $paymentSourceId: String) {
-  completeOnSessionCheckout(input:{ checkoutId: $checkoutId, paymentIntentClientSecret: $paymentIntentClientSecret, paymentSourceId: $paymentSourceId } ) {
+mutation CompleteOnSessionCheckout($checkoutId: ID!, $paymentIntentClientSecret: String!, $paymentSourceId: String, $paymentSourceReusable: Boolean) {
+  completeOnSessionCheckout(input:{ checkoutId: $checkoutId, paymentIntentClientSecret: $paymentIntentClientSecret, paymentSourceId: $paymentSourceId, paymentSourceReusable: $paymentSourceReusable } ) {
     checkout {
       id
       backing {

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClient.kt
@@ -289,7 +289,8 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
     override fun completeOnSessionCheckout(
         checkoutId: String,
         paymentIntentClientSecret: String,
-        paymentSourceId: String?
+        paymentSourceId: String?,
+        paymentSourceReusable: Boolean
     ): io.reactivex.Observable<Pair<String, Boolean>> {
         return io.reactivex.Observable.empty()
     }

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -187,7 +187,8 @@ interface ApolloClientTypeV2 {
     fun completeOnSessionCheckout(
         checkoutId: String,
         paymentIntentClientSecret: String,
-        paymentSourceId: String?
+        paymentSourceId: String?,
+        paymentSourceReusable: Boolean
     ): Observable<Pair<String, Boolean>>
 
     fun createAttributionEvent(eventInput: CreateAttributionEventData): Observable<Boolean>
@@ -1565,7 +1566,8 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
     override fun completeOnSessionCheckout(
         checkoutId: String,
         paymentIntentClientSecret: String,
-        paymentSourceId: String?
+        paymentSourceId: String?,
+        paymentSourceReusable: Boolean
     ): Observable<Pair<String, Boolean>> {
         return Observable.defer {
             val ps = PublishSubject.create<Pair<String, Boolean>>()
@@ -1575,6 +1577,7 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
                     .checkoutId(Base64Utils.encodeUrlSafe(("Checkout-$checkoutId").toByteArray(Charset.defaultCharset())))
                     .paymentIntentClientSecret(paymentIntentClientSecret)
                     .paymentSourceId(paymentSourceId)
+                    .paymentSourceReusable(paymentSourceReusable)
                     .build()
             ).enqueue(object : ApolloCall.Callback<CompleteOnSessionCheckoutMutation.Data>() {
                 override fun onFailure(e: ApolloException) {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
@@ -248,7 +248,8 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
         apolloClient.completeOnSessionCheckout(
             checkoutId = checkoutId ?: "",
             paymentIntentClientSecret = clientSecret,
-            paymentSourceId = if (selectedCard == newStoredCard) null else selectedCard.id() ?: ""
+            paymentSourceId = if (selectedCard == newStoredCard) null else selectedCard.id() ?: "",
+            paymentSourceReusable = true
         ).asFlow().map { iDRequiresActionPair ->
             if (iDRequiresActionPair.second) {
                 mutablePaymentRequiresAction.emit(clientSecret)


### PR DESCRIPTION
# 📲 What

The payment method was not being saved when doing a full late pledge flow, but this pr adds a field to save the current payment method

# 🤔 Why

If a user adds a new card they should be able to use it for any future purchases

# 🛠 How

There is a field called paymentSourceReusable and it needed to be set to true in this call

# 📋 QA

Go through a late pledge flow and add a new card during it, check your saved cards after a successful backing is created

