### PR TITLE
MBL-1278: Analytics on late pledge checkout screen

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -36,12 +36,12 @@ import com.kickstarter.libs.utils.EventContextValues.CtaContextName.COMMENT_POST
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.DISCOVER
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.DISCOVER_FILTER
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.DISCOVER_SORT
+import com.kickstarter.libs.utils.EventContextValues.CtaContextName.LATE_PLEDGE
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.LOGIN_INITIATE
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.LOGIN_OR_SIGN_UP
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.LOGIN_SUBMIT
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.PLEDGE_CONFIRM
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.PLEDGE_INITIATE
-import com.kickstarter.libs.utils.EventContextValues.CtaContextName.LATE_PLEDGE
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.PLEDGE_SUBMIT
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.REWARD_CONTINUE
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.SEARCH

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -41,6 +41,7 @@ import com.kickstarter.libs.utils.EventContextValues.CtaContextName.LOGIN_OR_SIG
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.LOGIN_SUBMIT
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.PLEDGE_CONFIRM
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.PLEDGE_INITIATE
+import com.kickstarter.libs.utils.EventContextValues.CtaContextName.LATE_PLEDGE
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.PLEDGE_SUBMIT
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.REWARD_CONTINUE
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.SEARCH
@@ -406,6 +407,20 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      */
     fun trackPledgeSubmitCTA(checkoutData: CheckoutData, pledgeData: PledgeData) {
         val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA.contextName to PLEDGE_SUBMIT.contextName)
+        props[CONTEXT_TYPE.contextName] = CREDIT_CARD.contextName
+        props[CONTEXT_PAGE.contextName] = CHECKOUT.contextName
+        props.putAll(AnalyticEventsUtils.checkoutDataProperties(checkoutData, pledgeData, client.loggedInUser()))
+        client.track(CTA_CLICKED.eventName, props)
+    }
+
+    /**
+     * Sends data associated with the submit CTA click event to the client.
+     *
+     * @param checkoutData: The checkout data.
+     * @param pledgeData: The selected pledge data.
+     */
+    fun trackLatePledgeSubmitCTA(checkoutData: CheckoutData, pledgeData: PledgeData) {
+        val props: HashMap<String, Any> = hashMapOf(CONTEXT_CTA.contextName to LATE_PLEDGE.contextName)
         props[CONTEXT_TYPE.contextName] = CREDIT_CARD.contextName
         props[CONTEXT_PAGE.contextName] = CHECKOUT.contextName
         props.putAll(AnalyticEventsUtils.checkoutDataProperties(checkoutData, pledgeData, client.loggedInUser()))

--- a/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
@@ -44,6 +44,7 @@ class EventContextValues {
         SIGN_UP_INITIATE("sign_up_initiate"),
         COMMENT_POST("comment_post"),
         PROJECT_SELECT("project_select"),
+        LATE_PLEDGE("late_pledge"),
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -613,8 +613,18 @@ class ProjectPageActivity :
 
                     var selectedReward: Reward? = null
 
-                    if (currentPage == 3) {
-                        latePledgeCheckoutViewModel.sendPageViewedEvent(projectData, addOns, currentUserShippingRule, selectedReward, shippingAmount, totalAmount, totalBonusSupportAmount)
+                    LaunchedEffect(Unit) {
+                        if (currentPage == 3) {
+                            latePledgeCheckoutViewModel.sendPageViewedEvent(
+                                projectData,
+                                addOns,
+                                currentUserShippingRule,
+                                selectedReward,
+                                shippingAmount,
+                                totalAmount,
+                                totalBonusSupportAmount
+                            )
+                        }
                     }
 
                     ProjectPledgeButtonAndFragmentContainer(
@@ -681,8 +691,10 @@ class ProjectPageActivity :
                         onBonusSupportPlusClicked = { confirmDetailsViewModel.incrementBonusSupport() },
                         selectedAddOnsMap = selectedAddOnsMap,
                         onPledgeCtaClicked = { selectedCard ->
-                            latePledgeCheckoutViewModel.sendSubmitCTAEvent(projectData, addOns, currentUserShippingRule, selectedReward, shippingAmount, totalAmount, totalBonusSupportAmount)
-                            //latePledgeCheckoutViewModel.onPledgeButtonClicked(selectedCard = selectedCard, project = projectData.project(), totalAmount = totalAmount)
+                            selectedCard?.apply {
+                                latePledgeCheckoutViewModel.sendSubmitCTAEvent(projectData, addOns, currentUserShippingRule, selectedReward, shippingAmount, totalAmount, totalBonusSupportAmount)
+                                latePledgeCheckoutViewModel.onPledgeButtonClicked(selectedCard = selectedCard, project = projectData.project(), totalAmount = totalAmount)
+                            }
                         },
                         onAddPaymentMethodClicked = {
                             latePledgeCheckoutViewModel.onAddNewCardClicked(project = projectData.project(), totalAmount = totalAmount)

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -612,6 +612,10 @@ class ProjectPageActivity :
 
                     var selectedReward: Reward? = null
 
+                    if (currentPage == 3) {
+                        latePledgeCheckoutViewModel.sendPageViewedEvent(projectData, addOns, currentUserShippingRule, selectedReward, shippingAmount, totalAmount, totalBonusSupportAmount)
+                    }
+
                     ProjectPledgeButtonAndFragmentContainer(
                         expanded = expanded,
                         onContinueClicked = { checkoutFlowViewModel.onBackThisProjectClicked() },
@@ -676,7 +680,8 @@ class ProjectPageActivity :
                         onBonusSupportPlusClicked = { confirmDetailsViewModel.incrementBonusSupport() },
                         selectedAddOnsMap = selectedAddOnsMap,
                         onPledgeCtaClicked = { selectedCard ->
-                            latePledgeCheckoutViewModel.onPledgeButtonClicked(selectedCard = selectedCard, project = projectData.project(), totalAmount = totalAmount)
+                            latePledgeCheckoutViewModel.sendSubmitCTAEvent(projectData, addOns, currentUserShippingRule, selectedReward, shippingAmount, totalAmount, totalBonusSupportAmount)
+                            //latePledgeCheckoutViewModel.onPledgeButtonClicked(selectedCard = selectedCard, project = projectData.project(), totalAmount = totalAmount)
                         },
                         onAddPaymentMethodClicked = {
                             latePledgeCheckoutViewModel.onAddNewCardClicked(project = projectData.project(), totalAmount = totalAmount)

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -608,25 +608,21 @@ class ProjectPageActivity :
                                     easing = FastOutSlowInEasing
                                 )
                             )
+
+                            if (currentPage == 3) {
+                                latePledgeCheckoutViewModel.sendPageViewedEvent(
+                                    projectData,
+                                    addOns,
+                                    currentUserShippingRule,
+                                    shippingAmount,
+                                    totalAmount,
+                                    totalBonusSupportAmount
+                                )
+                            }
                         }
                     }
 
                     var selectedReward: Reward? = null
-
-                    LaunchedEffect(Unit) {
-                        if (currentPage == 3) {
-                            latePledgeCheckoutViewModel.sendPageViewedEvent(
-                                projectData,
-                                addOns,
-                                currentUserShippingRule,
-                                selectedReward,
-                                shippingAmount,
-                                totalAmount,
-                                totalBonusSupportAmount
-                            )
-                        }
-                    }
-
                     ProjectPledgeButtonAndFragmentContainer(
                         expanded = expanded,
                         onContinueClicked = { checkoutFlowViewModel.onBackThisProjectClicked() },
@@ -659,6 +655,7 @@ class ProjectPageActivity :
                             addOnsViewModel.userRewardSelection(reward)
                             rewardsSelectionViewModel.onUserRewardSelection(reward)
                             confirmDetailsViewModel.onUserSelectedReward(reward)
+                            latePledgeCheckoutViewModel.userRewardSelection(reward)
                         },
                         onAddOnAddedOrRemoved = { updateAddOnRewardCount ->
                             selectedAddOnsMap[updateAddOnRewardCount.keys.first()] =
@@ -692,7 +689,7 @@ class ProjectPageActivity :
                         selectedAddOnsMap = selectedAddOnsMap,
                         onPledgeCtaClicked = { selectedCard ->
                             selectedCard?.apply {
-                                latePledgeCheckoutViewModel.sendSubmitCTAEvent(projectData, addOns, currentUserShippingRule, selectedReward, shippingAmount, totalAmount, totalBonusSupportAmount)
+                                latePledgeCheckoutViewModel.sendSubmitCTAEvent(projectData, addOns, currentUserShippingRule, shippingAmount, totalAmount, totalBonusSupportAmount)
                                 latePledgeCheckoutViewModel.onPledgeButtonClicked(selectedCard = selectedCard, project = projectData.project(), totalAmount = totalAmount)
                             }
                         },

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
@@ -58,6 +58,7 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
     private var newStoredCard: StoredCard? = null
     private var errorAction: (message: String?) -> Unit = {}
 
+    private var selectedReward: Reward? = null
     private var mutableLatePledgeCheckoutUIState = MutableStateFlow(LatePledgeCheckoutUIState())
     val latePledgeCheckoutUIState: StateFlow<LatePledgeCheckoutUIState>
         get() = mutableLatePledgeCheckoutUIState
@@ -304,12 +305,11 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
         projectData: ProjectData,
         addOns: List<Reward>,
         currentUserShippingRule: ShippingRule,
-        selectedReward: Reward?,
         shippingAmount: Double,
         totalAmount: Double,
         totalBonusSupportAmount: Double
     ) {
-        selectedReward?.let {
+        this.selectedReward?.let {
             val pledgeData = createPledgeData(projectData, addOns, currentUserShippingRule, it)
             val checkOutData =
                 createCheckoutData(shippingAmount, totalAmount, totalBonusSupportAmount)
@@ -323,12 +323,11 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
         projectData: ProjectData,
         addOns: List<Reward>,
         currentUserShippingRule: ShippingRule,
-        selectedReward: Reward?,
         shippingAmount: Double,
         totalAmount: Double,
         totalBonusSupportAmount: Double
     ) {
-        selectedReward?.let {
+        this.selectedReward?.let {
             val pledgeData = createPledgeData(projectData, addOns, currentUserShippingRule, it)
             val checkOutData =
                 createCheckoutData(shippingAmount, totalAmount, totalBonusSupportAmount)
@@ -337,6 +336,10 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
                 pledgeData = pledgeData
             )
         }
+    }
+
+    fun userRewardSelection(reward: Reward) {
+        this.selectedReward = reward
     }
 
     class Factory(private val environment: Environment) :

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
@@ -299,18 +299,23 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
         )
     }
 
-    fun sendPageViewedEvent(projectData: ProjectData,
-                            addOns: List<Reward>,
-                            currentUserShippingRule: ShippingRule,
-                            selectedReward: Reward?,
-                            shippingAmount: Double,
-                            totalAmount: Double,
-                            totalBonusSupportAmount: Double
+    fun sendPageViewedEvent(
+        projectData: ProjectData,
+        addOns: List<Reward>,
+        currentUserShippingRule: ShippingRule,
+        selectedReward: Reward?,
+        shippingAmount: Double,
+        totalAmount: Double,
+        totalBonusSupportAmount: Double
     ) {
         selectedReward?.let {
             val pledgeData = createPledgeData(projectData, addOns, currentUserShippingRule, it)
-            val checkOutData = createCheckoutData(shippingAmount, totalAmount, totalBonusSupportAmount)
-            this.analytics.trackCheckoutScreenViewed(checkoutData = checkOutData, pledgeData = pledgeData)
+            val checkOutData =
+                createCheckoutData(shippingAmount, totalAmount, totalBonusSupportAmount)
+            this@LatePledgeCheckoutViewModel.analytics.trackCheckoutScreenViewed(
+                checkoutData = checkOutData,
+                pledgeData = pledgeData
+            )
         }
     }
     fun sendSubmitCTAEvent(
@@ -322,13 +327,14 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
         totalAmount: Double,
         totalBonusSupportAmount: Double
     ) {
-        viewModelScope.launch {
-            selectedReward?.let {
-                val pledgeData = createPledgeData(projectData, addOns, currentUserShippingRule, it)
-                val checkOutData = createCheckoutData(shippingAmount, totalAmount, totalBonusSupportAmount)
-                this@LatePledgeCheckoutViewModel.analytics.trackCheckoutScreenViewed(checkoutData = checkOutData, pledgeData = pledgeData)
-                this@LatePledgeCheckoutViewModel.analytics.trackLatePledgeSubmitCTA(checkoutData = checkOutData, pledgeData = pledgeData)
-            }
+        selectedReward?.let {
+            val pledgeData = createPledgeData(projectData, addOns, currentUserShippingRule, it)
+            val checkOutData =
+                createCheckoutData(shippingAmount, totalAmount, totalBonusSupportAmount)
+            this@LatePledgeCheckoutViewModel.analytics.trackLatePledgeSubmitCTA(
+                checkoutData = checkOutData,
+                pledgeData = pledgeData
+            )
         }
     }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/LatePledgeCheckoutViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LatePledgeCheckoutViewModelTest.kt
@@ -1,0 +1,75 @@
+package com.kickstarter.viewmodels
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.EventName
+import com.kickstarter.mock.factories.ProjectDataFactory
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.mock.factories.RewardFactory
+import com.kickstarter.mock.factories.ShippingRuleFactory
+import com.kickstarter.models.Reward
+import com.kickstarter.viewmodels.projectpage.LatePledgeCheckoutViewModel
+import org.junit.Test
+
+class LatePledgeCheckoutViewModelTest : KSRobolectricTestCase() {
+
+    private lateinit var viewModel: LatePledgeCheckoutViewModel
+
+    private fun setUpEnvironment(environment: Environment) {
+        viewModel = LatePledgeCheckoutViewModel.Factory(environment).create(LatePledgeCheckoutViewModel::class.java)
+    }
+
+    @Test
+    fun `test send PageViewed event`() {
+        setUpEnvironment(environment())
+
+        val rw = RewardFactory.rewardWithShipping()
+        val project = ProjectFactory.project().toBuilder().rewards(listOf(rw)).build()
+        val addOns = listOf<Reward>(rw, rw, rw)
+        val rule = ShippingRuleFactory.germanyShippingRule()
+        val shipAmount = 3.0
+        val totalAmount = 300.0
+        val bonusAmount = 5.0
+
+        val projectData = ProjectDataFactory.project(project = project)
+
+        viewModel.sendPageViewedEvent(
+            projectData,
+            addOns,
+            rule,
+            rw,
+            shipAmount,
+            totalAmount,
+            bonusAmount
+        )
+
+        this.segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
+    }
+
+    @Test
+    fun `test send CTAClicked event`() {
+        setUpEnvironment(environment())
+
+        val rw = RewardFactory.rewardWithShipping()
+        val project = ProjectFactory.project().toBuilder().rewards(listOf(rw)).build()
+        val addOns = listOf<Reward>(rw, rw, rw)
+        val rule = ShippingRuleFactory.germanyShippingRule()
+        val shipAmount = 3.0
+        val totalAmount = 300.0
+        val bonusAmount = 5.0
+
+        val projectData = ProjectDataFactory.project(project = project)
+
+        viewModel.sendSubmitCTAEvent(
+            projectData,
+            addOns,
+            rule,
+            rw,
+            shipAmount,
+            totalAmount,
+            bonusAmount
+        )
+
+        this.segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
+    }
+}

--- a/app/src/test/java/com/kickstarter/viewmodels/LatePledgeCheckoutViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LatePledgeCheckoutViewModelTest.kt
@@ -7,7 +7,6 @@ import com.kickstarter.mock.factories.ProjectDataFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.mock.factories.ShippingRuleFactory
-import com.kickstarter.models.Reward
 import com.kickstarter.viewmodels.projectpage.LatePledgeCheckoutViewModel
 import org.junit.Test
 
@@ -25,7 +24,7 @@ class LatePledgeCheckoutViewModelTest : KSRobolectricTestCase() {
 
         val rw = RewardFactory.rewardWithShipping()
         val project = ProjectFactory.project().toBuilder().rewards(listOf(rw)).build()
-        val addOns = listOf<Reward>(rw, rw, rw)
+        val addOns = listOf(rw, rw, rw)
         val rule = ShippingRuleFactory.germanyShippingRule()
         val shipAmount = 3.0
         val totalAmount = 300.0
@@ -33,11 +32,11 @@ class LatePledgeCheckoutViewModelTest : KSRobolectricTestCase() {
 
         val projectData = ProjectDataFactory.project(project = project)
 
+        viewModel.userRewardSelection(rw)
         viewModel.sendPageViewedEvent(
             projectData,
             addOns,
             rule,
-            rw,
             shipAmount,
             totalAmount,
             bonusAmount
@@ -52,19 +51,18 @@ class LatePledgeCheckoutViewModelTest : KSRobolectricTestCase() {
 
         val rw = RewardFactory.rewardWithShipping()
         val project = ProjectFactory.project().toBuilder().rewards(listOf(rw)).build()
-        val addOns = listOf<Reward>(rw, rw, rw)
+        val addOns = listOf(rw, rw, rw)
         val rule = ShippingRuleFactory.germanyShippingRule()
         val shipAmount = 3.0
         val totalAmount = 300.0
         val bonusAmount = 5.0
 
         val projectData = ProjectDataFactory.project(project = project)
-
+        viewModel.userRewardSelection(rw)
         viewModel.sendSubmitCTAEvent(
             projectData,
             addOns,
             rule,
-            rw,
             shipAmount,
             totalAmount,
             bonusAmount


### PR DESCRIPTION
# 📲 What

- Added `PageViewed` when latePledge checkout screen presented
- Added `CTAClicked` when the user hits pledge on latePledge checkout screen with new `context_cta` = `late_pledge`

# 🤔 Why

- Track usage and money collection

# 🛠 How
- Used same format & property as crowdfunding checkout analytics

# 👀 See
- PageViewed

![pageViewdLatePledgeCheckout](https://github.com/kickstarter/android-oss/assets/4083656/a9650361-f73a-4c68-b436-6c1c6937e84a)



- CTAClicked
![pledgeCTALatePledgeCheckout](https://github.com/kickstarter/android-oss/assets/4083656/da27efd7-e218-473d-bbf0-5b19f6826e4f)



| --- | --- |
|  |  |

# 📋 QA

- Navigate to a project that has late pledges active, and complete a pledge, you should see on Segment both the `PageViewed` event and the `CTAClicked`

# Story 📖

[MBL-1278](https://kickstarter.atlassian.net/browse/MBL-1278)


[MBL-1278]: https://kickstarter.atlassian.net/browse/MBL-1278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ