### PR TITLE
[MBL-1321/1322] Fix payment sheet being presented multiple times

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -562,12 +562,6 @@ class ProjectPageActivity :
                     val checkoutLoading = latePledgeCheckoutUIState.isLoading
 
                     LaunchedEffect(Unit) {
-                        latePledgeCheckoutViewModel.clientSecretForNewPaymentMethod.collect {
-                            flowControllerPresentPaymentOption(it)
-                        }
-                    }
-
-                    LaunchedEffect(Unit) {
                         latePledgeCheckoutViewModel.paymentRequiresAction.collect {
                             stripeNextAction(it)
                         }


### PR DESCRIPTION
# 📲 What

Somewhere in all the chaos of merging we duplicated the call to add a new payment method, so it was causing issues (being presented twice, continue adding multiple of the same card)

# 🤔 Why

Bugs are bad and we want to squash them

# 🛠 How

Removed duplicate code

# 📋 QA

Go through the checkout flow and add a new card, make sure its only presented once and added only once

# Story 📖

[MBL-1321](https://kickstarter.atlassian.net/browse/MBL-1321)
[MBL-1322](https://kickstarter.atlassian.net/browse/MBL-1322)


[MBL-1321]: https://kickstarter.atlassian.net/browse/MBL-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MBL-1322]: https://kickstarter.atlassian.net/browse/MBL-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ