### PR TITLE
MBL-1325: Rewards that are unavailable for late pledging are still selectable

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -104,7 +104,6 @@ import com.stripe.android.view.CardInputWidget
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
-import kotlinx.coroutines.flow.collectIndexed
 import kotlinx.coroutines.launch
 import type.CreditCardPaymentType
 import timber.log.Timber
@@ -1068,10 +1067,10 @@ class ProjectPageActivity :
         showSnackbar(binding.snackbarAnchor, getString(R.string.Youve_canceled_your_pledge))
     }
 
-    private fun showCreatePledgeSuccess(checkoutDataAndProjectData: Pair<CheckoutData, PledgeData>, email : String = "") {
+    private fun showCreatePledgeSuccess(checkoutDataAndProjectData: Pair<CheckoutData, PledgeData>, email: String = "") {
         val checkoutData = checkoutDataAndProjectData.first
         val pledgeData = checkoutDataAndProjectData.second
-        val projectData= pledgeData.projectData()
+        val projectData = pledgeData.projectData()
 
         val fFLatePledge = getEnvironment()?.featureFlagClient()?.getBoolean(FlagKey.ANDROID_POST_CAMPAIGN_PLEDGES) ?: false
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -547,7 +547,6 @@ class ProjectPageActivity :
 
                     val checkoutPayment by confirmDetailsViewModel.checkoutPayment.collectAsStateWithLifecycle()
 
-                    val projectData2 by confirmDetailsViewModel.provideProjectData()
                     LaunchedEffect(checkoutPayment.id) {
                         if (checkoutPayment.id != 0L) checkoutFlowViewModel.onConfirmDetailsContinueClicked {
                             startLoginToutActivity()
@@ -1074,7 +1073,9 @@ class ProjectPageActivity :
         val pledgeData = checkoutDataAndProjectData.second
         val projectData= pledgeData.projectData()
 
-//        if (clearFragmentBackStack() || projectData.project().showLatePledgeFlow()) {
+        val fFLatePledge = getEnvironment()?.featureFlagClient()?.getBoolean(FlagKey.ANDROID_POST_CAMPAIGN_PLEDGES) ?: false
+
+        if (clearFragmentBackStack() || (projectData.project().showLatePledgeFlow() && fFLatePledge)) {
             startActivity(
                 Intent(this, ThanksActivity::class.java)
                     .putExtra(IntentKey.EMAIL, email)
@@ -1082,7 +1083,7 @@ class ProjectPageActivity :
                     .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
                     .putExtra(IntentKey.PLEDGE_DATA, pledgeData)
             )
-//        }
+        }
     }
 
     private fun showPledgeNotCancelableDialog() {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -55,8 +55,6 @@ import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.getPaymentSheetConfiguration
-import com.kickstarter.libs.utils.extensions.parseToDouble
-import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.libs.utils.extensions.showLatePledgeFlow
 import com.kickstarter.libs.utils.extensions.toVisibility
 import com.kickstarter.models.Project
@@ -105,8 +103,8 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.launch
-import type.CreditCardPaymentType
 import timber.log.Timber
+import type.CreditCardPaymentType
 
 class ProjectPageActivity :
     AppCompatActivity(),

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -547,6 +547,7 @@ class ProjectPageActivity :
 
                     val checkoutPayment by confirmDetailsViewModel.checkoutPayment.collectAsStateWithLifecycle()
 
+                    val projectData2 by confirmDetailsViewModel.provideProjectData()
                     LaunchedEffect(checkoutPayment.id) {
                         if (checkoutPayment.id != 0L) checkoutFlowViewModel.onConfirmDetailsContinueClicked {
                             startLoginToutActivity()

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -1071,7 +1071,7 @@ class ProjectPageActivity :
     private fun showCreatePledgeSuccess(checkoutDataAndProjectData: Pair<CheckoutData, PledgeData>, email : String = "") {
         val checkoutData = checkoutDataAndProjectData.first
         val pledgeData = checkoutDataAndProjectData.second
-        val projectData = pledgeData.projectData()
+        val projectData= pledgeData.projectData()
 
 //        if (clearFragmentBackStack() || projectData.project().showLatePledgeFlow()) {
             startActivity(

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -716,6 +716,10 @@ class ProjectPageActivity :
                                     .build()
                                 val pledgeData = PledgeData.with(PledgeFlowContext.forPledgeReason(PledgeReason.PLEDGE), projectData, selectedReward)
                                 showCreatePledgeSuccess(Pair(checkoutData, pledgeData), userEmail)
+                                checkoutFlowViewModel.onProjectSuccess()
+                                refreshProject()
+                                binding.pledgeContainerCompose.isGone = true
+                                binding.pledgeContainerLayout.pledgeContainerRoot.isGone = false
                             }
                         }
                     }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
@@ -157,7 +157,13 @@ fun RewardCarouselScreen(
                     else -> false
                 }
                 val isBacked = project.backing()?.isBacked(reward) ?: false
-                val ctaButtonText = RewardViewUtils.pledgeButtonText(project, reward)
+
+                val backing = project.backing()
+
+                val ctaButtonText = when {
+                    ctaButtonEnabled -> R.string.Select
+                    else -> R.string.No_longer_available
+                }
 
                 val remaining = reward.remaining() ?: -1
 

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
@@ -144,14 +144,15 @@ fun RewardCarouselScreen(
             ) { reward ->
 
                 val ctaButtonEnabled = when {
+                    RewardUtils.isNoReward(reward) && (project.postCampaignPledgingEnabled() ?: false && project.isInPostCampaignPledgingPhase() ?: false) -> true
                     !reward.hasAddons() && project.backing()?.isBacked(reward) != true -> true
                     project.backing()?.rewardId() != reward.id() && RewardUtils.isAvailable(
                         project,
                         reward
-                    ) -> true
+                    ) && reward.isAvailable() -> true
 
                     reward.hasAddons() && project.backing()
-                        ?.rewardId() == reward.id() && (project.isLive || (project.postCampaignPledgingEnabled() ?: false && project.isInPostCampaignPledgingPhase() ?: false)) -> true
+                        ?.rewardId() == reward.id() && (project.isLive || (project.postCampaignPledgingEnabled() ?: false && project.isInPostCampaignPledgingPhase() ?: false)) && reward.isAvailable() -> true
 
                     else -> false
                 }

--- a/app/src/main/java/com/kickstarter/ui/adapters/ThanksAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/ThanksAdapter.java
@@ -1,5 +1,6 @@
 package com.kickstarter.ui.adapters;
 
+import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
@@ -60,7 +61,7 @@ public final class ThanksAdapter extends KSAdapter {
   }
 
   public void takeData(final @NonNull ThanksData data) {
-    setSection(SECTION_SHARE_VIEW, Collections.singletonList(data.getBackedProject()));
+    setSection(SECTION_SHARE_VIEW, Collections.singletonList(Pair.create(data.getBackedProject(), data.getCheckoutData())));
     setSection(SECTION_RECOMMENDED_PROJECTS_VIEW, data.getRecommendedProjects());
     setSection(SECTION_CATEGORY_VIEW, Collections.singletonList(data.getCategory()));
     notifyDataSetChanged();

--- a/app/src/main/java/com/kickstarter/ui/adapters/ThanksAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/ThanksAdapter.java
@@ -13,7 +13,6 @@ import com.kickstarter.databinding.ProjectCardViewBinding;
 import com.kickstarter.databinding.ThanksCategoryViewBinding;
 import com.kickstarter.databinding.ThanksShareViewBinding;
 import com.kickstarter.ui.adapters.data.ThanksData;
-import com.kickstarter.ui.data.CheckoutData;
 import com.kickstarter.ui.viewholders.EmptyViewHolder;
 import com.kickstarter.ui.viewholders.KSViewHolder;
 import com.kickstarter.ui.viewholders.ProjectCardViewHolder;
@@ -22,7 +21,6 @@ import com.kickstarter.ui.viewholders.ThanksShareViewHolder;
 
 import java.util.Collections;
 
-import kotlin.Triple;
 
 public final class ThanksAdapter extends KSAdapter {
   private static final int SECTION_SHARE_VIEW = 0;

--- a/app/src/main/java/com/kickstarter/ui/adapters/ThanksAdapter.java
+++ b/app/src/main/java/com/kickstarter/ui/adapters/ThanksAdapter.java
@@ -13,6 +13,7 @@ import com.kickstarter.databinding.ProjectCardViewBinding;
 import com.kickstarter.databinding.ThanksCategoryViewBinding;
 import com.kickstarter.databinding.ThanksShareViewBinding;
 import com.kickstarter.ui.adapters.data.ThanksData;
+import com.kickstarter.ui.data.CheckoutData;
 import com.kickstarter.ui.viewholders.EmptyViewHolder;
 import com.kickstarter.ui.viewholders.KSViewHolder;
 import com.kickstarter.ui.viewholders.ProjectCardViewHolder;
@@ -20,6 +21,8 @@ import com.kickstarter.ui.viewholders.ThanksCategoryViewHolder;
 import com.kickstarter.ui.viewholders.ThanksShareViewHolder;
 
 import java.util.Collections;
+
+import kotlin.Triple;
 
 public final class ThanksAdapter extends KSAdapter {
   private static final int SECTION_SHARE_VIEW = 0;
@@ -61,7 +64,7 @@ public final class ThanksAdapter extends KSAdapter {
   }
 
   public void takeData(final @NonNull ThanksData data) {
-    setSection(SECTION_SHARE_VIEW, Collections.singletonList(Pair.create(data.getBackedProject(), data.getCheckoutData())));
+    setSection(SECTION_SHARE_VIEW, Collections.singletonList(Pair.create(Pair.create(data.getBackedProject(), data.getCheckoutData()), data.getUserEmail())));
     setSection(SECTION_RECOMMENDED_PROJECTS_VIEW, data.getRecommendedProjects());
     setSection(SECTION_CATEGORY_VIEW, Collections.singletonList(data.getCategory()));
     notifyDataSetChanged();

--- a/app/src/main/java/com/kickstarter/ui/adapters/data/ThanksData.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/data/ThanksData.kt
@@ -4,9 +4,12 @@ import android.util.Pair
 import com.kickstarter.models.Category
 import com.kickstarter.models.Project
 import com.kickstarter.services.DiscoveryParams
+import com.kickstarter.ui.data.CheckoutData
+import com.kickstarter.ui.data.PledgeData
 
 class ThanksData(
     val backedProject: Project,
+    val checkoutData: CheckoutData,
     val category: Category,
     val recommendedProjects: List<Pair<Project, DiscoveryParams>>
 )

--- a/app/src/main/java/com/kickstarter/ui/adapters/data/ThanksData.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/data/ThanksData.kt
@@ -10,6 +10,7 @@ import com.kickstarter.ui.data.PledgeData
 class ThanksData(
     val backedProject: Project,
     val checkoutData: CheckoutData,
+    val userEmail : String,
     val category: Category,
     val recommendedProjects: List<Pair<Project, DiscoveryParams>>
 )

--- a/app/src/main/java/com/kickstarter/ui/adapters/data/ThanksData.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/data/ThanksData.kt
@@ -5,12 +5,11 @@ import com.kickstarter.models.Category
 import com.kickstarter.models.Project
 import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.ui.data.CheckoutData
-import com.kickstarter.ui.data.PledgeData
 
 class ThanksData(
     val backedProject: Project,
     val checkoutData: CheckoutData,
-    val userEmail : String,
+    val userEmail: String,
     val category: Category,
     val recommendedProjects: List<Pair<Project, DiscoveryParams>>
 )

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ThanksShareViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ThanksShareViewHolder.kt
@@ -32,9 +32,9 @@ class ThanksShareViewHolder(private val binding: ThanksShareViewBinding) : KSVie
             .addToDisposable(disposables)
 
         viewModel.outputs.postCampaignPledgeText()
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { showPostCampaignPledgeText(it)}
-                .addToDisposable(disposables)
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe { showPostCampaignPledgeText(it) }
+            .addToDisposable(disposables)
 
         viewModel.outputs.startShare()
             .observeOn(AndroidSchedulers.mainThread())
@@ -88,8 +88,8 @@ class ThanksShareViewHolder(private val binding: ThanksShareViewBinding) : KSVie
         binding.backedProject.text = Html.fromHtml(ksString.format(context().getString(R.string.You_have_successfully_backed_project_html), "project_name", projectName))
     }
 
-    private fun showPostCampaignPledgeText(pcptext :Triple<Project, Double, String> ) {
-        binding.backedProject.text = Html.fromHtml(ksString.format(context().getString(R.string.You_have_successfully_pledged_to_project_post_campaign_html), "project_name", pcptext.first.name(), "pledge_total", ksCurrency.format(initialValue = pcptext.second,  project = pcptext.first, roundingMode =  RoundingMode.HALF_UP), "user_email", pcptext.third))
+    private fun showPostCampaignPledgeText(pcptext: Triple<Project, Double, String>) {
+        binding.backedProject.text = Html.fromHtml(ksString.format(context().getString(R.string.You_have_successfully_pledged_to_project_post_campaign_html), "project_name", pcptext.first.name(), "pledge_total", ksCurrency.format(initialValue = pcptext.second, project = pcptext.first, roundingMode = RoundingMode.HALF_UP), "user_email", pcptext.third))
     }
 
     private fun startShare(projectNameAndShareUrl: Pair<String, String>) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ThanksShareViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ThanksShareViewHolder.kt
@@ -76,7 +76,7 @@ class ThanksShareViewHolder(private val binding: ThanksShareViewBinding) : KSVie
 
     @Throws(Exception::class)
     override fun bindData(data: Any?) {
-        val projectAndCheckoutData = requireNotNull(data as Pair<Project, CheckoutData>?)
+        val projectAndCheckoutData = requireNotNull(data as Pair<Pair<Project, CheckoutData>, String>?)
         viewModel.inputs.configureWith(projectAndCheckoutData)
     }
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ThanksShareViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ThanksShareViewHolder.kt
@@ -12,13 +12,16 @@ import com.kickstarter.databinding.ThanksShareViewBinding
 import com.kickstarter.libs.TweetComposer
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.models.Project
+import com.kickstarter.ui.data.CheckoutData
 import com.kickstarter.viewmodels.ThanksShareHolderViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
+import java.math.RoundingMode
 
 class ThanksShareViewHolder(private val binding: ThanksShareViewBinding) : KSViewHolder(binding.root) {
-    private val viewModel = ThanksShareHolderViewModel.ThanksShareViewHolderViewModel()
+    private val viewModel = ThanksShareHolderViewModel.ThanksShareViewHolderViewModel(environment())
     private val ksString = requireNotNull(environment().ksString())
+    private var ksCurrency = requireNotNull(environment().ksCurrency())
     private val shareDialog: ShareDialog = ShareDialog(context() as Activity)
     private var disposables = CompositeDisposable()
 
@@ -27,6 +30,11 @@ class ThanksShareViewHolder(private val binding: ThanksShareViewBinding) : KSVie
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { showBackedProject(it) }
             .addToDisposable(disposables)
+
+        viewModel.outputs.postCampaignPledgeText()
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe { showPostCampaignPledgeText(it)}
+                .addToDisposable(disposables)
 
         viewModel.outputs.startShare()
             .observeOn(AndroidSchedulers.mainThread())
@@ -68,8 +76,8 @@ class ThanksShareViewHolder(private val binding: ThanksShareViewBinding) : KSVie
 
     @Throws(Exception::class)
     override fun bindData(data: Any?) {
-        val project = requireNotNull(data as Project?)
-        viewModel.inputs.configureWith(project)
+        val projectAndCheckoutData = requireNotNull(data as Pair<Project, CheckoutData>?)
+        viewModel.inputs.configureWith(projectAndCheckoutData)
     }
 
     private fun shareString(projectName: String): String {
@@ -78,6 +86,10 @@ class ThanksShareViewHolder(private val binding: ThanksShareViewBinding) : KSVie
 
     private fun showBackedProject(projectName: String) {
         binding.backedProject.text = Html.fromHtml(ksString.format(context().getString(R.string.You_have_successfully_backed_project_html), "project_name", projectName))
+    }
+
+    private fun showPostCampaignPledgeText(pcptext :Triple<Project, Double, String> ) {
+        binding.backedProject.text = Html.fromHtml(ksString.format(context().getString(R.string.You_have_successfully_pledged_to_project_post_campaign_html), "project_name", pcptext.first.name(), "pledge_total", ksCurrency.format(initialValue = pcptext.second,  project = pcptext.first, roundingMode =  RoundingMode.HALF_UP), "user_email", pcptext.third))
     }
 
     private fun startShare(projectNameAndShareUrl: Pair<String, String>) {

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksShareHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksShareHolderViewModel.kt
@@ -81,7 +81,9 @@ interface ThanksShareHolderViewModel {
             thanksShareData
                     .filter { it.first.first.isInPostCampaignPledgingPhase().isTrue() }
                     .filter { it.first.first.postCampaignPledgingEnabled().isTrue() }
-                    .subscribe { postCampaignText.onNext(Triple(it.first.first, it.first.second.amount(),  it.second)) }
+                    .subscribe {
+                        postCampaignText.onNext(Triple(it.first.first, it.first.second.amount(),  it.second))
+                    }
                     .addToDisposable(disposables)
             project
                 .map {

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksShareHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksShareHolderViewModel.kt
@@ -1,13 +1,17 @@
 package com.kickstarter.viewmodels
 
 import android.util.Pair
+import com.kickstarter.libs.CurrentUserTypeV2
+import com.kickstarter.libs.Environment
 import com.kickstarter.libs.RefTag.Companion.thanksFacebookShare
 import com.kickstarter.libs.RefTag.Companion.thanksShare
 import com.kickstarter.libs.RefTag.Companion.thanksTwitterShare
 import com.kickstarter.libs.rx.transformers.Transformers
+import com.kickstarter.libs.rx.transformers.Transformers.combineLatestPair
 import com.kickstarter.libs.utils.UrlUtils.appendRefTag
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.models.Project
+import com.kickstarter.ui.data.CheckoutData
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subjects.BehaviorSubject
@@ -16,7 +20,7 @@ import io.reactivex.subjects.PublishSubject
 interface ThanksShareHolderViewModel {
     interface Inputs {
         /** Call to configure the view model with a project.  */
-        fun configureWith(project: Project)
+        fun configureWith(projectAndCheckoutData: Pair<Project, CheckoutData>)
 
         /** Call when the share button is clicked.  */
         fun shareClick()
@@ -42,10 +46,13 @@ interface ThanksShareHolderViewModel {
 
         /** Emits the project name and url to share using Twitter.  */
         fun startShareOnTwitter(): Observable<Pair<String, String>>
+
+        fun postCampaignPledgeText(): Observable<Triple<Project, Double, String>>
     }
 
-    class ThanksShareViewHolderViewModel : Inputs, Outputs {
+    class ThanksShareViewHolderViewModel(environment: Environment) : Inputs, Outputs {
 
+        private val projectAndCheckoutData = PublishSubject.create<Pair<Project, CheckoutData>>()
         private val project = PublishSubject.create<Project>()
         private val shareClick = PublishSubject.create<Unit>()
         private val shareOnFacebookClick = PublishSubject.create<Unit>()
@@ -54,6 +61,9 @@ interface ThanksShareHolderViewModel {
         private val startShare = PublishSubject.create<Pair<String, String>>()
         private val startShareOnFacebook = PublishSubject.create<Pair<Project, String>>()
         private val startShareOnTwitter = PublishSubject.create<Pair<String, String>>()
+        private val postCampaignText = PublishSubject.create<Triple<Project, Double, String>>()
+
+        private val currentUser = requireNotNull(environment.currentUserV2())
 
         val inputs: Inputs = this
         val outputs: Outputs = this
@@ -61,11 +71,22 @@ interface ThanksShareHolderViewModel {
         private var disposables = CompositeDisposable()
 
         init {
-            project
-                .map { it.name() }
-                .subscribe { projectName.onNext(it) }
-                .addToDisposable(disposables)
+            projectAndCheckoutData
+                    .map { it.first }
+                    .subscribe { project.onNext(it)}
+                    .addToDisposable(disposables)
+//
+//            project
+//                .map { it.name() }
+//                .subscribe { projectName.onNext(it) }
+//                .addToDisposable(disposables)
 
+            projectAndCheckoutData
+//                    .filter { it.isInPostCampaignPledgingPhase().isTrue() }
+//                    .filter { it.postCampaignPledgingEnabled().isTrue() }
+                    .withLatestFrom(currentUser.observable()) { projectAndCheckoutData, user -> Triple(projectAndCheckoutData.first, projectAndCheckoutData.second, user) }
+                    .subscribe { postCampaignText.onNext(Triple(it.first, it.second.amount(),  it.third.getValue()?.email() ?: "")) }
+                    .addToDisposable(disposables)
             project
                 .map {
                     Pair.create(
@@ -100,8 +121,8 @@ interface ThanksShareHolderViewModel {
                 .addToDisposable(disposables)
         }
 
-        override fun configureWith(project: Project) {
-            this.project.onNext(project)
+        override fun configureWith(projectAndCheckoutData: Pair<Project, CheckoutData>) {
+            this.projectAndCheckoutData.onNext(projectAndCheckoutData)
         }
 
         override fun shareClick() {
@@ -121,6 +142,7 @@ interface ThanksShareHolderViewModel {
         override fun startShareOnTwitter(): Observable<Pair<String, String>> = startShareOnTwitter
         override fun projectName(): Observable<String> = projectName
 
+        override fun postCampaignPledgeText() : Observable<Triple<Project, Double, String>> = postCampaignText
         override fun onCleared() {
             disposables.clear()
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksShareHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksShareHolderViewModel.kt
@@ -20,7 +20,7 @@ import io.reactivex.subjects.PublishSubject
 interface ThanksShareHolderViewModel {
     interface Inputs {
         /** Call to configure the view model with a project.  */
-        fun configureWith(projectAndCheckoutData: Pair<Pair<Project, CheckoutData>, String>)
+        fun configureWith(thanksShareData: Pair<Pair<Project, CheckoutData>, String>)
 
         /** Call when the share button is clicked.  */
         fun shareClick()
@@ -122,8 +122,8 @@ interface ThanksShareHolderViewModel {
                 .addToDisposable(disposables)
         }
 
-        override fun configureWith(projectAndCheckoutData: Pair<Pair<Project, CheckoutData>, String>) {
-            this.thanksShareData.onNext(projectAndCheckoutData)
+        override fun configureWith(thanksShareData: Pair<Pair<Project, CheckoutData>, String>) {
+            this.thanksShareData.onNext(thanksShareData)
         }
 
         override fun shareClick() {

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksShareHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksShareHolderViewModel.kt
@@ -70,24 +70,24 @@ interface ThanksShareHolderViewModel {
 
         init {
             thanksShareData
-                    .map { it.first }
-                    .subscribe { project.onNext(it.first)}
-                    .addToDisposable(disposables)
+                .map { it.first }
+                .subscribe { project.onNext(it.first) }
+                .addToDisposable(disposables)
 
             thanksShareData
-                    .filter { it.first.first.isInPostCampaignPledgingPhase().isFalse() }
-                    .filter { it.first.first.postCampaignPledgingEnabled().isFalse() }
-                    .map { it.first.first.name() }
+                .filter { it.first.first.isInPostCampaignPledgingPhase().isFalse() }
+                .filter { it.first.first.postCampaignPledgingEnabled().isFalse() }
+                .map { it.first.first.name() }
                 .subscribe { projectName.onNext(it) }
                 .addToDisposable(disposables)
 
             thanksShareData
-                    .filter { it.first.first.isInPostCampaignPledgingPhase().isTrue() }
-                    .filter { it.first.first.postCampaignPledgingEnabled().isTrue() }
-                    .subscribe {
-                        postCampaignText.onNext(Triple(it.first.first, it.first.second.amount(),  it.second))
-                    }
-                    .addToDisposable(disposables)
+                .filter { it.first.first.isInPostCampaignPledgingPhase().isTrue() }
+                .filter { it.first.first.postCampaignPledgingEnabled().isTrue() }
+                .subscribe {
+                    postCampaignText.onNext(Triple(it.first.first, it.first.second.amount(), it.second))
+                }
+                .addToDisposable(disposables)
             project
                 .map {
                     Pair.create(
@@ -143,7 +143,7 @@ interface ThanksShareHolderViewModel {
         override fun startShareOnTwitter(): Observable<Pair<String, String>> = startShareOnTwitter
         override fun projectName(): Observable<String> = projectName
 
-        override fun postCampaignPledgeText() : Observable<Triple<Project, Double, String>> = postCampaignText
+        override fun postCampaignPledgeText(): Observable<Triple<Project, Double, String>> = postCampaignText
         override fun onCleared() {
             disposables.clear()
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksShareHolderViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksShareHolderViewModel.kt
@@ -8,6 +8,7 @@ import com.kickstarter.libs.RefTag.Companion.thanksTwitterShare
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.UrlUtils.appendRefTag
 import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.libs.utils.extensions.isFalse
 import com.kickstarter.libs.utils.extensions.isTrue
 import com.kickstarter.models.Project
 import com.kickstarter.ui.data.CheckoutData
@@ -72,11 +73,13 @@ interface ThanksShareHolderViewModel {
                     .map { it.first }
                     .subscribe { project.onNext(it.first)}
                     .addToDisposable(disposables)
-//
-//            project
-//                .map { it.name() }
-//                .subscribe { projectName.onNext(it) }
-//                .addToDisposable(disposables)
+
+            thanksShareData
+                    .filter { it.first.first.isInPostCampaignPledgingPhase().isFalse() }
+                    .filter { it.first.first.postCampaignPledgingEnabled().isFalse() }
+                    .map { it.first.first.name() }
+                .subscribe { projectName.onNext(it) }
+                .addToDisposable(disposables)
 
             thanksShareData
                     .filter { it.first.first.isInPostCampaignPledgingPhase().isTrue() }

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.kt
@@ -193,28 +193,6 @@ interface ThanksViewModel {
                     )
                 }
 
-            Observable.combineLatest(
-                project,
-                rootCategory,
-                recommendedProjects.startWith(listOf())
-            ) { backedProject, category, projects ->
-                ThanksData(backedProject, category, projects)
-            }.subscribe { adapterData.onNext(it) }
-                .addToDisposable(disposables)
-
-            adapterData
-                .compose(Transformers.takePairWhenV2(projectOnUserChangeSave))
-                .map {
-                    Pair(it.first, it.second.updateStartedProjectAndDiscoveryParamsList(it.first.recommendedProjects))
-                }
-                .map {
-                    ThanksData(it.first.backedProject, it.first.category, it.second)
-                }.distinctUntilChanged()
-                .subscribe {
-                    adapterData.onNext(it)
-                }
-                .addToDisposable(disposables)
-
             projectOnUserChangeSave
                 .subscribe { this.analyticEvents?.trackWatchProjectCTA(it, THANKS) }
                 .addToDisposable(disposables)
@@ -288,6 +266,29 @@ interface ThanksViewModel {
                     )
                 }
                 .addToDisposable(disposables)
+
+            Observable.combineLatest(
+                    project,
+                    rootCategory,
+                    recommendedProjects.startWith(listOf()),
+                    checkoutData
+            ) { backedProject, category, projects, checkoutData->
+                ThanksData(backedProject, checkoutData, category, projects)
+            }.subscribe { adapterData.onNext(it) }
+                    .addToDisposable(disposables)
+
+            adapterData
+                    .compose(Transformers.takePairWhenV2(projectOnUserChangeSave))
+                    .map {
+                        Pair(it.first, it.second.updateStartedProjectAndDiscoveryParamsList(it.first.recommendedProjects))
+                    }
+                    .map {
+                        ThanksData(it.first.backedProject, it.first.checkoutData, it.first.category, it.second)
+                    }.distinctUntilChanged()
+                    .subscribe {
+                        adapterData.onNext(it)
+                    }
+                    .addToDisposable(disposables)
 
             SendThirdPartyEventUseCaseV2(sharedPreferences, ffClient)
                 .sendThirdPartyEvent(

--- a/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ThanksViewModel.kt
@@ -274,28 +274,28 @@ interface ThanksViewModel {
                 .addToDisposable(disposables)
 
             Observable.combineLatest(
-                    project,
-                    rootCategory,
-                    recommendedProjects.startWith(listOf()),
-                    checkoutData,
-                    userEmail
+                project,
+                rootCategory,
+                recommendedProjects.startWith(listOf()),
+                checkoutData,
+                userEmail
             ) { backedProject, category, projects, checkoutData, email ->
                 ThanksData(backedProject, checkoutData, email, category, projects)
             }.subscribe { adapterData.onNext(it) }
-                    .addToDisposable(disposables)
+                .addToDisposable(disposables)
 
             adapterData
-                    .compose(Transformers.takePairWhenV2(projectOnUserChangeSave))
-                    .withLatestFrom(userEmail) { adapterAndProjectData , email ->
-                        Triple(adapterAndProjectData.first, adapterAndProjectData.second.updateStartedProjectAndDiscoveryParamsList(adapterAndProjectData.first.recommendedProjects), email)
-                    }
-                    .map {
-                        ThanksData(it.first.backedProject, it.first.checkoutData, it.third, it.first.category, it.second)
-                    }.distinctUntilChanged()
-                    .subscribe {
-                        adapterData.onNext(it)
-                    }
-                    .addToDisposable(disposables)
+                .compose(Transformers.takePairWhenV2(projectOnUserChangeSave))
+                .withLatestFrom(userEmail) { adapterAndProjectData, email ->
+                    Triple(adapterAndProjectData.first, adapterAndProjectData.second.updateStartedProjectAndDiscoveryParamsList(adapterAndProjectData.first.recommendedProjects), email)
+                }
+                .map {
+                    ThanksData(it.first.backedProject, it.first.checkoutData, it.third, it.first.category, it.second)
+                }.distinctUntilChanged()
+                .subscribe {
+                    adapterData.onNext(it)
+                }
+                .addToDisposable(disposables)
 
             SendThirdPartyEventUseCaseV2(sharedPreferences, ffClient)
                 .sendThirdPartyEvent(

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CheckoutFlowViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CheckoutFlowViewModel.kt
@@ -107,6 +107,13 @@ class CheckoutFlowViewModel(val environment: Environment) : ViewModel() {
         }
     }
 
+    fun onProjectSuccess() {
+        viewModelScope.launch {
+            // Open Flow
+            mutableFlowUIState.emit(FlowUIState(currentPage = 0, expanded = false))
+        }
+    }
+
     class Factory(private val environment: Environment) :
         ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
@@ -61,9 +61,15 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
     private var selectedReward: Reward? = null
     private var mutableLatePledgeCheckoutUIState = MutableStateFlow(LatePledgeCheckoutUIState())
 
-    private var mutableOnPledgeSuccessAction = MutableSharedFlow<Unit>()
-    val onPledgeSuccess: SharedFlow<Unit>
-        get() = mutableOnPledgeSuccessAction.asSharedFlow()
+    private var mutableOnPledgeSuccessAction = MutableSharedFlow<Boolean>()
+    val onPledgeSuccess: SharedFlow<Boolean>
+        get() = mutableOnPledgeSuccessAction
+            .asSharedFlow()
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(),
+                initialValue = false
+            )
 
     val latePledgeCheckoutUIState: StateFlow<LatePledgeCheckoutUIState>
         get() = mutableLatePledgeCheckoutUIState
@@ -268,7 +274,7 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
             if (iDRequiresActionPair.second) {
                 mutablePaymentRequiresAction.emit(clientSecret)
             } else {
-                mutableOnPledgeSuccessAction.emit(Unit)
+                mutableOnPledgeSuccessAction.emit(true)
             }
         }.onCompletion {
             emitCurrentState()

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
@@ -60,6 +60,11 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
 
     private var selectedReward: Reward? = null
     private var mutableLatePledgeCheckoutUIState = MutableStateFlow(LatePledgeCheckoutUIState())
+
+    private var mutableOnPledgeSuccessAction = MutableSharedFlow<Unit>()
+    val onPledgeSuccess: SharedFlow<Unit>
+        get() = mutableOnPledgeSuccessAction.asSharedFlow()
+
     val latePledgeCheckoutUIState: StateFlow<LatePledgeCheckoutUIState>
         get() = mutableLatePledgeCheckoutUIState
             .asStateFlow()
@@ -263,7 +268,7 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
             if (iDRequiresActionPair.second) {
                 mutablePaymentRequiresAction.emit(clientSecret)
             } else {
-                // Go to Thanks Page, full complete flow
+                mutableOnPledgeSuccessAction.emit(Unit)
             }
         }.onCompletion {
             emitCurrentState()

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
@@ -27,7 +27,7 @@ import java.util.Locale
 
 data class RewardSelectionUIState(
     val rewardList: List<Reward> = listOf(),
-    val selectedReward : Reward = Reward.builder().build(),
+    val selectedReward: Reward = Reward.builder().build(),
     val initialRewardIndex: Int = 0,
     val project: ProjectData = ProjectData.builder().build(),
     val showAlertDialog: Boolean = false

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
@@ -27,6 +27,7 @@ import java.util.Locale
 
 data class RewardSelectionUIState(
     val rewardList: List<Reward> = listOf(),
+    val selectedReward : Reward = Reward.builder().build(),
     val initialRewardIndex: Int = 0,
     val project: ProjectData = ProjectData.builder().build(),
     val showAlertDialog: Boolean = false
@@ -38,8 +39,8 @@ class RewardsSelectionViewModel(environment: Environment) : ViewModel() {
     private lateinit var currentProjectData: ProjectData
     private var previousUserBacking: Backing? = null
     private var previouslyBackedReward: Reward? = null
-    private lateinit var newUserReward: Reward
     private var indexOfBackedReward = 0
+    private var newUserReward: Reward = Reward.builder().build()
 
     private val mutableRewardSelectionUIState = MutableStateFlow(RewardSelectionUIState())
     val rewardSelectionUIState: StateFlow<RewardSelectionUIState>

--- a/app/src/test/java/com/kickstarter/viewmodels/ThanksShareHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThanksShareHolderViewModelTest.kt
@@ -33,7 +33,7 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
         vm.outputs.startShareOnTwitter().subscribe { startShareOnTwitter.onNext(it) }
             .addToDisposable(disposables)
         vm.outputs.postCampaignPledgeText().subscribe { postCampaignText.onNext(it) }
-                .addToDisposable(disposables)
+            .addToDisposable(disposables)
     }
 
     @Test
@@ -42,9 +42,9 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment()
 
         val checkoutData = CheckoutDataFactory.checkoutData(
-                3L,
-                20.0,
-                30.0
+            3L,
+            20.0,
+            30.0
         )
         vm.configureWith(Pair(Pair(project, checkoutData), ""))
 
@@ -57,9 +57,9 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
 
         val project = setUpProjectWithWebUrls()
         val checkoutData = CheckoutDataFactory.checkoutData(
-                3L,
-                20.0,
-                30.0
+            3L,
+            20.0,
+            30.0
         )
         vm.configureWith(Pair(Pair(project, checkoutData), ""))
         vm.inputs.shareClick()
@@ -75,9 +75,9 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
 
         val project = setUpProjectWithWebUrls()
         val checkoutData = CheckoutDataFactory.checkoutData(
-                3L,
-                20.0,
-                30.0
+            3L,
+            20.0,
+            30.0
         )
 
         vm.configureWith(Pair(Pair(project, checkoutData), ""))
@@ -95,9 +95,9 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
 
         val project = setUpProjectWithWebUrls()
         val checkoutData = CheckoutDataFactory.checkoutData(
-                3L,
-                20.0,
-                30.0
+            3L,
+            20.0,
+            30.0
         )
         vm.configureWith(Pair(Pair(project, checkoutData), ""))
         vm.inputs.shareOnTwitterClick()
@@ -113,9 +113,9 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
 
         val project = setUpProjectWithWebUrls().toBuilder().isInPostCampaignPledgingPhase(true).postCampaignPledgingEnabled(true).build()
         val checkoutData = CheckoutDataFactory.checkoutData(
-                3L,
-                20.0,
-                30.0
+            3L,
+            20.0,
+            30.0
         )
         vm.configureWith(Pair(Pair(project, checkoutData), "email@email.com"))
 
@@ -129,9 +129,9 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
 
         val project = setUpProjectWithWebUrls().toBuilder().isInPostCampaignPledgingPhase(false).postCampaignPledgingEnabled(false).build()
         val checkoutData = CheckoutDataFactory.checkoutData(
-                3L,
-                20.0,
-                30.0
+            3L,
+            20.0,
+            30.0
         )
         vm.configureWith(Pair(Pair(project, checkoutData), "email@email.com"))
 
@@ -145,9 +145,9 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
 
         val project = setUpProjectWithWebUrls().toBuilder().isInPostCampaignPledgingPhase(null).postCampaignPledgingEnabled(null).build()
         val checkoutData = CheckoutDataFactory.checkoutData(
-                3L,
-                20.0,
-                30.0
+            3L,
+            20.0,
+            30.0
         )
         vm.configureWith(Pair(Pair(project, checkoutData), "email@email.com"))
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ThanksShareHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThanksShareHolderViewModelTest.kt
@@ -3,6 +3,7 @@ package com.kickstarter.viewmodels
 import android.util.Pair
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.mock.factories.CheckoutDataFactory
 import com.kickstarter.mock.factories.ProjectFactory.project
 import com.kickstarter.mock.factories.UserFactory.creator
 import com.kickstarter.models.Project
@@ -20,16 +21,19 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
     private val startShare = TestSubscriber<Pair<String, String>>()
     private val startShareOnFacebook = TestSubscriber<Pair<Project, String>>()
     private val startShareOnTwitter = TestSubscriber<Pair<String, String>>()
+    private val postCampaignText = TestSubscriber<Triple<Project, Double, String>>()
     private val disposables = CompositeDisposable()
 
     private fun setUpEnvironment() {
-        vm = ThanksShareHolderViewModel.ThanksShareViewHolderViewModel()
+        vm = ThanksShareHolderViewModel.ThanksShareViewHolderViewModel(environment())
         vm.outputs.projectName().subscribe { projectName.onNext(it) }.addToDisposable(disposables)
         vm.outputs.startShare().subscribe { startShare.onNext(it) }.addToDisposable(disposables)
         vm.outputs.startShareOnFacebook().subscribe { startShareOnFacebook.onNext(it) }
             .addToDisposable(disposables)
         vm.outputs.startShareOnTwitter().subscribe { startShareOnTwitter.onNext(it) }
             .addToDisposable(disposables)
+        vm.outputs.postCampaignPledgeText().subscribe { postCampaignText.onNext(it) }
+                .addToDisposable(disposables)
     }
 
     @Test
@@ -37,7 +41,12 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
         val project = project()
         setUpEnvironment()
 
-        vm.configureWith(project)
+        val checkoutData = CheckoutDataFactory.checkoutData(
+                3L,
+                20.0,
+                30.0
+        )
+        vm.configureWith(Pair(Pair(project, checkoutData), ""))
 
         projectName.assertValues(project.name())
     }
@@ -47,8 +56,12 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment()
 
         val project = setUpProjectWithWebUrls()
-
-        vm.configureWith(project)
+        val checkoutData = CheckoutDataFactory.checkoutData(
+                3L,
+                20.0,
+                30.0
+        )
+        vm.configureWith(Pair(Pair(project, checkoutData), ""))
         vm.inputs.shareClick()
         val expectedShareUrl =
             "https://www.kck.str/projects/15/best-project-2k19?ref=android_thanks_share"
@@ -61,7 +74,14 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment()
 
         val project = setUpProjectWithWebUrls()
-        vm.configureWith(project)
+        val checkoutData = CheckoutDataFactory.checkoutData(
+                3L,
+                20.0,
+                30.0
+        )
+
+        vm.configureWith(Pair(Pair(project, checkoutData), ""))
+
         vm.inputs.shareOnFacebookClick()
         val expectedShareUrl =
             "https://www.kck.str/projects/15/best-project-2k19?ref=android_thanks_facebook_share"
@@ -74,12 +94,65 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment()
 
         val project = setUpProjectWithWebUrls()
-        vm.configureWith(project)
+        val checkoutData = CheckoutDataFactory.checkoutData(
+                3L,
+                20.0,
+                30.0
+        )
+        vm.configureWith(Pair(Pair(project, checkoutData), ""))
         vm.inputs.shareOnTwitterClick()
         val expectedShareUrl =
             "https://www.kck.str/projects/15/best-project-2k19?ref=android_thanks_twitter_share"
 
         startShareOnTwitter.assertValue(Pair.create("Best Project 2K19", expectedShareUrl))
+    }
+
+    @Test
+    fun testShowLatePledges_whenTrue_ShowLatePledgeFlow() {
+        setUpEnvironment()
+
+        val project = setUpProjectWithWebUrls().toBuilder().isInPostCampaignPledgingPhase(true).postCampaignPledgingEnabled(true).build()
+        val checkoutData = CheckoutDataFactory.checkoutData(
+                3L,
+                20.0,
+                30.0
+        )
+        vm.configureWith(Pair(Pair(project, checkoutData), "email@email.com"))
+
+        postCampaignText.assertValue(Triple(project, checkoutData.amount(), "email@email.com"))
+        projectName.assertNoValues()
+    }
+
+    @Test
+    fun testShowLatePledges_whenFalse_noEmission() {
+        setUpEnvironment()
+
+        val project = setUpProjectWithWebUrls().toBuilder().isInPostCampaignPledgingPhase(false).postCampaignPledgingEnabled(false).build()
+        val checkoutData = CheckoutDataFactory.checkoutData(
+                3L,
+                20.0,
+                30.0
+        )
+        vm.configureWith(Pair(Pair(project, checkoutData), "email@email.com"))
+
+        postCampaignText.assertNoValues()
+        projectName.assertValue(project.name())
+    }
+
+    @Test
+    fun testShowLatePledges_whenNull_noEmission() {
+        setUpEnvironment()
+
+        val project = setUpProjectWithWebUrls().toBuilder().isInPostCampaignPledgingPhase(null).postCampaignPledgingEnabled(null).build()
+        val checkoutData = CheckoutDataFactory.checkoutData(
+                3L,
+                20.0,
+                30.0
+        )
+        vm.configureWith(Pair(Pair(project, checkoutData), "email@email.com"))
+
+        postCampaignText.assertNoValues()
+        projectName.assertValue(project.name())
     }
 
     private fun setUpProjectWithWebUrls(): Project {

--- a/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.kt
@@ -98,16 +98,16 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
             .build()
 
         val checkoutData = CheckoutDataFactory.checkoutData(
-                3L,
-                20.0,
-                30.0
+            3L,
+            20.0,
+            30.0
         )
 
         setUpEnvironment(
-                intent = Intent()
-                        .putExtra(IntentKey.PROJECT, project)
-                        .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
-                        .putExtra(IntentKey.EMAIL, "email@email.com")
+            intent = Intent()
+                .putExtra(IntentKey.PROJECT, project)
+                .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
+                .putExtra(IntentKey.EMAIL, "email@email.com")
         )
 
         adapterData.assertValueCount(1)
@@ -125,16 +125,16 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
             .build()
 
         val checkoutData = CheckoutDataFactory.checkoutData(
-                3L,
-                20.0,
-                30.0
+            3L,
+            20.0,
+            30.0
         )
 
         setUpEnvironment(
-                intent = Intent()
-                        .putExtra(IntentKey.PROJECT, project)
-                        .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
-                        .putExtra(IntentKey.EMAIL, "email@email.com")
+            intent = Intent()
+                .putExtra(IntentKey.PROJECT, project)
+                .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
+                .putExtra(IntentKey.EMAIL, "email@email.com")
         )
 
         adapterData.assertValueCount(1)

--- a/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.kt
@@ -20,6 +20,7 @@ import com.kickstarter.mock.factories.CategoryFactory.artCategory
 import com.kickstarter.mock.factories.CategoryFactory.category
 import com.kickstarter.mock.factories.CategoryFactory.ceramicsCategory
 import com.kickstarter.mock.factories.CategoryFactory.tabletopGamesCategory
+import com.kickstarter.mock.factories.CheckoutDataFactory
 import com.kickstarter.mock.factories.CheckoutDataFactory.checkoutData
 import com.kickstarter.mock.factories.LocationFactory.germany
 import com.kickstarter.mock.factories.ProjectDataFactory.project
@@ -95,7 +96,19 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
             .toBuilder()
             .category(artCategory())
             .build()
-        setUpEnvironment(intent = Intent().putExtra(IntentKey.PROJECT, project))
+
+        val checkoutData = CheckoutDataFactory.checkoutData(
+                3L,
+                20.0,
+                30.0
+        )
+
+        setUpEnvironment(
+                intent = Intent()
+                        .putExtra(IntentKey.PROJECT, project)
+                        .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
+                        .putExtra(IntentKey.EMAIL, "email@email.com")
+        )
 
         adapterData.assertValueCount(1)
         vm.inputs.onHeartButtonClicked(project)
@@ -111,7 +124,18 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
             .category(artCategory())
             .build()
 
-        setUpEnvironment(intent = Intent().putExtra(IntentKey.PROJECT, project))
+        val checkoutData = CheckoutDataFactory.checkoutData(
+                3L,
+                20.0,
+                30.0
+        )
+
+        setUpEnvironment(
+                intent = Intent()
+                        .putExtra(IntentKey.PROJECT, project)
+                        .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
+                        .putExtra(IntentKey.EMAIL, "email@email.com")
+        )
 
         adapterData.assertValueCount(1)
     }


### PR DESCRIPTION
# 📲 What

Rewards that are marked as unavailable for late pledging were still selectable, you could get through the entire checkout until time to actually pledge, and then an error was returned. This PR fixes that. 

# 🤔 Why

Bugs are bad mmkay

# 🛠 How

Updated the conditions for checking the button availability to include checking the isAvailable field. This part of the code was designed accommodate manage pledge and other use cases, hence the extra conditions, but right now this screen is only viewable on the late pledge flow. should cleanup and refactor later tho

# 👀 See

https://github.com/kickstarter/android-oss/assets/19390326/acd13912-3e93-4f30-bc21-13d5b0be39d0

# 📋 QA

Open the project "zan's late pledge" on staging, open the rewards carousel, should see correct available and unavailable rewards

# Story 📖

[MBL-1325: Rewards that are unavailable for late pledging are still selectable](https://kickstarter.atlassian.net/browse/MBL-1325)
