### PR TITLE
[MBL-1342] Fix non-shippable rewards being able to select shippable add-ons

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
@@ -83,7 +83,7 @@ class AddOnsViewModel(val environment: Environment) : ViewModel() {
                 viewModelScope.launch {
                     emitCurrentState()
                 }
-                getAddOns(noShippingRule = false)
+                getAddOns(noShippingRule = shippingSelectorIsGone)
             }.addToDisposable(disposables)
 
         val shippingRule = getSelectedShippingRule(defaultShippingRuleObservable, currentUserReward)
@@ -191,8 +191,6 @@ class AddOnsViewModel(val environment: Environment) : ViewModel() {
             emitCurrentState()
         }
 
-        if (shippingSelectorIsGone) getAddOns(noShippingRule = true)
-
         this.currentUserReward.onNext(reward)
     }
 
@@ -205,7 +203,7 @@ class AddOnsViewModel(val environment: Environment) : ViewModel() {
             emitCurrentState()
         }
 
-        getAddOns(noShippingRule = false)
+        getAddOns(noShippingRule = shippingSelectorIsGone)
     }
 
     fun onAddOnsAddedOrRemoved(currentAddOnsSelections: MutableMap<Reward, Int>) {


### PR DESCRIPTION
# 📲 What

Fixed an issue where digital/non shippable rewards could select shippable add-ons

Also removed a duplicated add-on call

# 🤔 Why

We dont want the shippables/non shippables mixed with rewards and add-ons

# 🛠 How

🧠 

# 📋 QA

Go to any late pledge campaign with digital rewards and add-ons as well as physical (bacon bacon bacon was recently changed to have this) and confirm when picking a digital reward only digital add-ons are presented and when picking a physical reward all add-ons are presented

# Story 📖

[MBL-1342](https://kickstarter.atlassian.net/browse/MBL-1342)


[MBL-1342]: https://kickstarter.atlassian.net/browse/MBL-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ