### PR TITLE
MBL-1286: OAuth when default browser not chrome

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -107,6 +107,10 @@
             android:parentActivityName=".ui.activities.DiscoveryActivity"
             android:theme="@style/WebViewActivity" />
         <activity
+            android:name=".ui.activities.OAuthWebViewActivity"
+            android:parentActivityName=".ui.activities.LoginToutActivity"
+            android:theme="@style/WebViewActivity" />
+        <activity
             android:name=".ui.activities.ResetPasswordActivity"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Login" />

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ContextExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ContextExt.kt
@@ -5,16 +5,41 @@ import android.app.AlertDialog
 import android.app.Application
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
 import androidx.core.content.ContextCompat
 import com.kickstarter.KSApplication
 import com.kickstarter.R
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.featureflag.FlagKey
+import com.kickstarter.ui.SharedPreferenceKey
+import com.kickstarter.ui.activities.AppThemes
 import com.stripe.android.paymentsheet.PaymentSheet
 
 fun Context.isKSApplication() = (this is KSApplication) && !this.isInUnitTests
 
 fun Context.getEnvironment(): Environment? {
     return (this.applicationContext as KSApplication).component().environment()
+}
+
+@Composable
+fun Context.isDarkModeEnabled(env: Environment): Boolean {
+    var darkModeEnabled = env.featureFlagClient()?.getBoolean(FlagKey.ANDROID_DARK_MODE_ENABLED) ?: false
+    var theme = env.sharedPreferences()
+        ?.getInt(SharedPreferenceKey.APP_THEME, AppThemes.MATCH_SYSTEM.ordinal)
+        ?: AppThemes.MATCH_SYSTEM.ordinal
+
+    return if (darkModeEnabled) {
+        when (theme) {
+            AppThemes.MATCH_SYSTEM.ordinal -> isSystemInDarkTheme()
+            AppThemes.DARK.ordinal -> true
+            AppThemes.LIGHT.ordinal -> false
+            else -> false
+        }
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        isSystemInDarkTheme() // Force dark mode uses system theme
+    } else false
 }
 
 /**

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ContextExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ContextExt.kt
@@ -25,8 +25,8 @@ fun Context.getEnvironment(): Environment? {
 
 @Composable
 fun Context.isDarkModeEnabled(env: Environment): Boolean {
-    var darkModeEnabled = env.featureFlagClient()?.getBoolean(FlagKey.ANDROID_DARK_MODE_ENABLED) ?: false
-    var theme = env.sharedPreferences()
+    val darkModeEnabled = env.featureFlagClient()?.getBoolean(FlagKey.ANDROID_DARK_MODE_ENABLED) ?: false
+    val theme = env.sharedPreferences()
         ?.getInt(SharedPreferenceKey.APP_THEME, AppThemes.MATCH_SYSTEM.ordinal)
         ?: AppThemes.MATCH_SYSTEM.ordinal
 

--- a/app/src/main/java/com/kickstarter/ui/IntentKey.kt
+++ b/app/src/main/java/com/kickstarter/ui/IntentKey.kt
@@ -54,4 +54,5 @@ object IntentKey {
     const val RESET_PASSWORD_FACEBOOK_LOGIN = "com.kickstarter.kickstarter.intent_reset_password_facebook"
     const val FLAGGINGKIND = "com.kickstarter.kickstarter.intent_report_project"
     const val PREVIOUS_SCREEN = "com.kickstarter.kickstarter.previous_screen"
+    const val OAUTH_REDIRECT_URL = "com.kickstarter.kickstarter.oauth_redirect_url"
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/OAuthWebViewActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/OAuthWebViewActivity.kt
@@ -1,0 +1,83 @@
+package com.kickstarter.ui.activities
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.view.ViewGroup
+import android.webkit.HttpAuthHandler
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.webkit.WebViewDatabase
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.viewinterop.AndroidView
+import com.kickstarter.libs.utils.extensions.getEnvironment
+import com.kickstarter.libs.utils.extensions.isDarkModeEnabled
+import com.kickstarter.ui.IntentKey
+import com.kickstarter.ui.compose.designsystem.KickstarterApp
+import com.kickstarter.viewmodels.OAuthViewModel
+
+class CustomWebViewClient(private val context: Context, private val callback: (String) -> Unit) : WebViewClient() {
+    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        request?.url?.let {
+            if (OAuthViewModel.isAfterRedirectionStep(it)) {
+                callback(it.toString())
+            }
+        } ?: callback("")
+        return false
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    override fun onReceivedHttpAuthRequest(
+        view: WebView?,
+        handler: HttpAuthHandler?,
+        host: String?,
+        realm: String?
+    ) {
+        val webDatabase = WebViewDatabase.getInstance(context)
+        webDatabase.setHttpAuthUsernamePassword(host, realm, "creative", "studyingatewinterfunny")
+        handler?.proceed("creative", "studyingatewinterfunny")
+        return super.onReceivedHttpAuthRequest(view, handler, host, realm)
+    }
+}
+class OAuthWebViewActivity : ComponentActivity() {
+    val callback: (String) -> Unit = { inputString ->
+        val intent = Intent()
+            .putExtra(IntentKey.OAUTH_REDIRECT_URL, inputString)
+        this.setResult(Activity.RESULT_OK, intent)
+        this.finish()
+    }
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val url = intent.getStringExtra(IntentKey.URL) ?: ""
+        this.getEnvironment()?.let { env ->
+            setContent {
+                KickstarterApp(useDarkTheme = this.isDarkModeEnabled(env = env)) {
+                    WebView(url, this, callback)
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun WebView(url: String, context: Context, callback: (String) -> Unit) {
+        AndroidView(factory = {
+            WebView(it).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+                this.webViewClient = CustomWebViewClient(context = context, callback)
+                this.settings.allowFileAccess = true
+            }
+        }, update = {
+                it.loadUrl(url)
+            })
+    }
+}

--- a/app/src/main/java/com/kickstarter/ui/activities/OAuthWebViewActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/OAuthWebViewActivity.kt
@@ -1,7 +1,9 @@
 package com.kickstarter.ui.activities
 
 import android.app.Activity
+import android.app.AlertDialog
 import android.content.Context
+import android.content.DialogInterface
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -11,6 +13,8 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.webkit.WebViewDatabase
+import android.widget.EditText
+import android.widget.LinearLayout
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.annotation.RequiresApi
@@ -18,8 +22,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.viewinterop.AndroidView
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.isDarkModeEnabled
+import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
+import com.kickstarter.ui.extensions.text
 import com.kickstarter.viewmodels.OAuthViewModel
 
 /**
@@ -85,8 +91,35 @@ class CustomWebViewClient(private val context: Context, private val callback: (S
         realm: String?
     ) {
         val webDatabase = WebViewDatabase.getInstance(context)
-        webDatabase.setHttpAuthUsernamePassword(host, realm, "creative", "studyingatewinterfunny")
-        handler?.proceed("creative", "studyingatewinterfunny")
-        return super.onReceivedHttpAuthRequest(view, handler, host, realm)
+
+        val alert: AlertDialog.Builder = AlertDialog.Builder(context)
+
+        val container = LinearLayout(context)
+        container.orientation = LinearLayout.VERTICAL
+        val user = EditText(context)
+        user.hint = "Staging credential User:"
+        val password = EditText(context)
+        password.hint = "Staging credential Password:"
+
+        container.addView(user)
+        container.addView(password)
+
+        alert.setView(container)
+        alert.setPositiveButton(
+            "Send",
+            DialogInterface.OnClickListener { dialog, whichButton ->
+                if (user.isNotNull() && password.isNotNull()) {
+                    webDatabase.setHttpAuthUsernamePassword(
+                        host,
+                        realm,
+                        user.text(),
+                        password.text()
+                    )
+                    handler?.proceed(user.text(), password.text())
+                    super.onReceivedHttpAuthRequest(view, handler, host, realm)
+                }
+            }
+        )
+        alert.show()
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/OAuthWebViewActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/OAuthWebViewActivity.kt
@@ -46,7 +46,8 @@ class OAuthWebViewActivity : ComponentActivity() {
         val url = intent.getStringExtra(IntentKey.URL) ?: ""
         this.getEnvironment()?.let { env ->
             setContent {
-                KickstarterApp(useDarkTheme = this.isDarkModeEnabled(env = env)) {
+                val darModeEnabled = this.isDarkModeEnabled(env = env)
+                KickstarterApp(useDarkTheme = darModeEnabled) {
                     WebView(url, this, callback)
                 }
             }

--- a/app/src/main/java/com/kickstarter/ui/activities/WebViewActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/WebViewActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.addCallback
 import com.kickstarter.databinding.WebViewLayoutBinding
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.extensions.finishWithAnimation
+import com.kickstarter.ui.views.KSWebView
 
 class WebViewActivity : ComponentActivity() {
     private lateinit var binding: WebViewLayoutBinding
@@ -17,6 +18,21 @@ class WebViewActivity : ComponentActivity() {
 
         val toolbarTitle = intent.getStringExtra(IntentKey.TOOLBAR_TITLE)
         toolbarTitle?.let { binding.webViewToolbar.webViewToolbar.setTitle(it) }
+
+        binding.webView.setDelegate(object : KSWebView.Delegate {
+            override fun externalLinkActivated(url: String) {
+            }
+
+            override fun pageIntercepted(url: String) {
+                if (url.contains("authenticate")) {
+                    finish()
+                }
+            }
+
+            override fun onReceivedError(url: String) {
+            }
+        })
+
         val url = intent.getStringExtra(IntentKey.URL)
         url?.let { binding.webView.loadUrl(it) }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/OAuthViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/OAuthViewModel.kt
@@ -123,6 +123,7 @@ class OAuthViewModel(
                                 )
                             )
                             analyticEvents.trackLogInButtonCtaClicked()
+                            codeVerifier = null
                         }
                 } else {
                     mutableUIState.emit(
@@ -131,10 +132,12 @@ class OAuthViewModel(
                             user = null
                         )
                     )
+                    codeVerifier = null
                 }
             }
 
             if (intent.data == null && uri == null) {
+                codeVerifier = null
                 codeVerifier = verifier.generateRandomCodeVerifier(entropy = CodeVerifier.MIN_CODE_VERIFIER_ENTROPY)
                 codeVerifier?.let {
                     val url = generateAuthorizationUrlWithParams(it)

--- a/app/src/test/java/com/kickstarter/viewmodels/OAuthViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/OAuthViewModelTest.kt
@@ -111,7 +111,7 @@ class OAuthViewModelTest : KSRobolectricTestCase() {
         val redirectionUrl = "ksrauth2://authenticate?&redirect_uri=ksrauth2&response_type=1&scope=1"
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            vm.produceState(Intent().setData(Uri.parse(redirectionUrl)))
+            vm.produceState(Intent(), Uri.parse(redirectionUrl))
             vm.uiState.toList(state)
         }
 
@@ -168,7 +168,7 @@ class OAuthViewModelTest : KSRobolectricTestCase() {
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             vm.produceState(Intent())
-            vm.produceState(Intent().setData(Uri.parse(redirectionUrl)))
+            vm.produceState(Intent(), Uri.parse(redirectionUrl))
             vm.uiState.toList(state)
         }
 
@@ -214,7 +214,7 @@ class OAuthViewModelTest : KSRobolectricTestCase() {
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             vm.produceState(Intent())
-            vm.produceState(Intent().setData(Uri.parse(redirectionUrl)))
+            vm.produceState(Intent(), Uri.parse(redirectionUrl))
             vm.uiState.toList(state)
         }
 
@@ -270,7 +270,7 @@ class OAuthViewModelTest : KSRobolectricTestCase() {
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             vm.produceState(Intent())
-            vm.produceState(Intent().setData(Uri.parse(redirectionUrl)))
+            vm.produceState(Intent(), Uri.parse(redirectionUrl))
             vm.uiState.toList(state)
         }
 
@@ -322,7 +322,7 @@ class OAuthViewModelTest : KSRobolectricTestCase() {
         val redirectionUrl = "ksrauth2://authenticate?code=$testCode&redirect_uri=ksrauth2&response_type=1&scope=1"
 
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            vm.produceState(Intent().setData(Uri.parse(redirectionUrl)))
+            vm.produceState(Intent(), Uri.parse(redirectionUrl))
             vm.uiState.toList(state)
         }
 
@@ -344,7 +344,8 @@ class OAuthViewModelTest : KSRobolectricTestCase() {
     fun `test invalid information after redirection`() {
         setUpEnvironment(environment(), CodeVerifier())
 
-        assertFalse(vm.isAfterRedirectionStep(null, null, null, null))
-        assertFalse(vm.isAfterRedirectionStep("http", "someHost.com", "", ""))
+        assertFalse(OAuthViewModel.isAfterRedirectionStep(Uri.parse("")))
+        assertFalse(OAuthViewModel.isAfterRedirectionStep(Uri.parse("http://someurelrandom")))
+        assertTrue(OAuthViewModel.isAfterRedirectionStep(Uri.parse("ksrauth2://authenticate?code=12345")))
     }
 }


### PR DESCRIPTION
# 📲 What

- When default browser not Chrome, load a webview to handle OAuth.

# 🤔 Why

- The issue when default browser not Chrome, customTabs behave differently: redirection does not take place though `onNewIntent`, and tab was never dismissed.


# 👀 See

https://github.com/kickstarter/android-oss/assets/4083656/a40b58fe-7a10-45be-885c-84ae7445b757



|  |  |

# 📋 QA

- Install any other browser (Firefox, Opera, Duck Duck Go, Arc ...) and try to log in.
- Have only Chrome and log in, just to make sure all keeps working as usual.
- Try logIn with facebook (fyi only works in production environment), just to make sure all keeps working as usual.

# Story 📖

[MBL-1286](https://kickstarter.atlassian.net/browse/MBL-1286)


[MBL-1286]: https://kickstarter.atlassian.net/browse/MBL-1286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ