### PR TITLE
MBL-1324 Fix icon color on "something went wrong" alert

### DIFF
--- a/app/src/main/res/layout/toast_error.xml
+++ b/app/src/main/res/layout/toast_error.xml
@@ -19,7 +19,7 @@
       android:orientation="horizontal"
       android:padding="@dimen/grid_2">
 
-      <ImageView
+      <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/toast_icon"
         android:layout_width="@dimen/grid_5_half"
         android:layout_height="wrap_content"


### PR DESCRIPTION
# 📲 What

Changed ImageView to AppCompatImageView in order to tint the alert icon vector a white color

# 🤔 Why

"Something went wrong" alert icon was black instead of white because white tint was not properly applied

# 🛠 How

More in-depth discussion of the change or implementation.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Screenshot_20240415-105200](https://github.com/kickstarter/android-oss/assets/129205442/f497bf26-a4b5-4ba1-85bc-2142bb4d8876) | ![Screenshot_20240415-141134](https://github.com/kickstarter/android-oss/assets/129205442/1a14ac98-8e02-40b5-adb7-52717a7a4c11) |

# 📋 QA

1. Go through a PBC flow until you get to the confirm pledge details screen
2. Turn on airplane mode
3. Tap "Pledge"
4. Verify that the alert icon on "something went wrong" is white
 
# Story 📖

https://kickstarter.atlassian.net/browse/MBL-1326
