### PR TITLE
[HOTFIX] Fix issue where add-ons were not displayed if non of the rewards were shippable

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
@@ -119,6 +119,8 @@ class AddOnsViewModel(val environment: Environment) : ViewModel() {
                         )
                         shippingRules = shippingRulesEnvelope.shippingRules()
                     }.addToDisposable(disposables)
+                } ?: run {
+                    shippingRulesObservable.onNext(listOf())
                 }
             }
         }
@@ -153,8 +155,12 @@ class AddOnsViewModel(val environment: Environment) : ViewModel() {
         return this.currentConfig.observable()
             .map { it.countryCode() }
             .map { countryCode ->
-                shippingRules.firstOrNull { it.location()?.country() == countryCode }
-                    ?: shippingRules.first()
+                if (shippingRules.isNotEmpty()) {
+                    shippingRules.firstOrNull { it.location()?.country() == countryCode }
+                        ?: shippingRules.first()
+                } else {
+                    ShippingRule.builder().build()
+                }
             }
     }
 


### PR DESCRIPTION
# 📲 What

There is a bug in production for late pledges where if none of the projects rewards are shippable we would not pull add-ons so you could not select any

# 🤔 Why

There are lots of projects with just digital rewards that also have add-ons

# 🛠 How

Make it so there is always a default shipping rule for pulling add-ons, even if it is a blank one

# 👀 See
Staging:

https://github.com/kickstarter/android-oss/assets/7563288/378c091f-1ac7-4129-8c5d-e978c240b7ea

Production:

https://github.com/kickstarter/android-oss/assets/7563288/90740cd8-cf9c-4aaa-9dbd-b9cae8b7fc58

# 📋 QA

On Production:
Go to the "Master of Realms" project (currently collecting late pledges) and select a reward with add-ons.  Add-ons should be displayed and selectable

On Staging:
Go to any testable late pledge project and confirm add-ons work as expected
