### PR TITLE
MBL-1343: Incorrect routing after login

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CheckoutFlowViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CheckoutFlowViewModel.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
 
@@ -90,10 +89,9 @@ class CheckoutFlowViewModel(val environment: Environment) : ViewModel() {
         viewModelScope.launch {
             currentUser.isLoggedIn
                 .asFlow()
-                .take(1)
                 .collect { userLoggedIn ->
-                    // - Show pledge page
-                    if (userLoggedIn) mutableFlowUIState.emit(FlowUIState(currentPage = 3, expanded = true))
+                    // - Show checkout page
+                    if (userLoggedIn) mutableFlowUIState.emit(FlowUIState(currentPage = 4, expanded = true))
                     // - Trigger LoginFlow callback
                     else logInCallback()
                 }

--- a/app/src/test/java/com/kickstarter/viewmodels/usecases/CheckoutFlowViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/usecases/CheckoutFlowViewModelTest.kt
@@ -41,6 +41,7 @@ class CheckoutFlowViewModelTest : KSRobolectricTestCase() {
 
         // - make sure empty FlowUISate has been produced, `onConfirmDetailsContinueClicked` will produce states ONLY if user present
         assertEquals(state, listOf(FlowUIState()))
+        assertNotSame(state, listOf(FlowUIState(currentPage = 4, expanded = true)))
         assertNotSame(state, listOf(FlowUIState(currentPage = 3, expanded = true)))
         assert(state.size == 1)
     }
@@ -70,7 +71,7 @@ class CheckoutFlowViewModelTest : KSRobolectricTestCase() {
         }
 
         // - make sure next page FlowUIState has been generated, not just the initial empty state
-        assertEquals(state, listOf(FlowUIState(), FlowUIState(currentPage = 3, expanded = true)))
+        assertEquals(state, listOf(FlowUIState(), FlowUIState(currentPage = 4, expanded = true)))
         assert(state.size == 2)
     }
 }


### PR DESCRIPTION
# 📲 What

When user logs in within late pledges checkout, after login flow:
-  before: user had to hit continue button to move forward a second time
- now: navigation to checkout screen without user interaction

# 🤔 Why
- One less user interaction required

# 🛠 How
- smoother checkout process

# 👀 See

https://github.com/kickstarter/android-oss/assets/4083656/2029d330-d73e-4bb3-88bf-6c32d7ffda3e



|  |  |

# 📋 QA

- Make sure you are logged out, go to a project with late pledges active, select reward, on confirm screen hit continue, the login flow will be presented, once successfully logged in the checkout screen will be presented.

# Story 📖

[MBL-1343](https://kickstarter.atlassian.net/browse/MBL-1343)


[MBL-1343]: https://kickstarter.atlassian.net/browse/MBL-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ