### PR TITLE
[MBL-1383] Update adding new payment method flow in late pledge flow

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -62,7 +62,6 @@ import com.kickstarter.libs.utils.extensions.showLatePledgeFlow
 import com.kickstarter.libs.utils.extensions.toVisibility
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
-import com.kickstarter.models.StoredCard
 import com.kickstarter.models.chrome.ChromeTabsHelperActivity
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.compose.projectpage.ProjectPledgeButtonAndFragmentContainer
@@ -108,7 +107,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import type.CreditCardPaymentType
 
 class ProjectPageActivity :
@@ -694,7 +692,7 @@ class ProjectPageActivity :
                             }
                         },
                         onAddPaymentMethodClicked = {
-                            latePledgeCheckoutViewModel.onAddNewCardClicked(project = projectData.project(), totalAmount = totalAmount)
+                            latePledgeCheckoutViewModel.onAddNewCardClicked(project = projectData.project())
                         },
                         onDisclaimerItemClicked = { disclaimerItem ->
                             getEnvironment()?.let { environment ->
@@ -1218,14 +1216,8 @@ class ProjectPageActivity :
     // Update the UI with the returned PaymentOption
     private fun onPaymentOption(paymentOption: PaymentOption?) {
         paymentOption?.let {
-            val storedCard = StoredCard.Builder(
-                lastFourDigits = paymentOption.label.takeLast(4),
-                resourceId = paymentOption.drawableResourceId,
-                clientSetupId = "-1"
-            ).build()
-            latePledgeCheckoutViewModel.onNewCardSuccessfullyAdded(storedCard)
-            Timber.d(" ${this.javaClass.canonicalName} onPaymentOption with ${storedCard.lastFourDigits()} and ${storedCard.clientSetupId()}")
             flowController.confirm()
+            latePledgeCheckoutViewModel.onNewCardSuccessfullyAdded()
         }
     }
 
@@ -1268,8 +1260,8 @@ class ProjectPageActivity :
     }
 
     private fun flowControllerPresentPaymentOption(clientSecret: String) {
-        flowController.configureWithPaymentIntent(
-            paymentIntentClientSecret = clientSecret,
+        flowController.configureWithSetupIntent(
+            setupIntentClientSecret = clientSecret,
             configuration = getPaymentSheetConfiguration(),
             callback = ::onConfigured
         )


### PR DESCRIPTION
# 📲 What

Change it so that instead of creating a payment intent and then using that to set up a card via stripe (which would charge immediately) we are using a setupintent and saving the card to backend, similar to what we do in the account card screen.  We then refresh the users stored cards so they show on the list.

# 🤔 Why

When doing the payment intent way it would charge cards immediately, causing double charges via stripe

# 🛠 How

Changed the code to save the new cards instead of have a temporary copy via payment intent

# 📋 QA

1) Go to a project that is accepting late pledges ("testing conversion" on staging)
2) Proceed to the checkout screen
3) add a new card
4) proceed with checkout with the new card
5) Confirm card was only charged once (this may require backend help)

# Story 📖

[MBL-1383](https://kickstarter.atlassian.net/browse/MBL-1383)


[MBL-1383]: https://kickstarter.atlassian.net/browse/MBL-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ