### PR TITLE
MBL-1380: Reward is showing as available for late pledges despite not being available

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.extensions.isBacked
 import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.models.Backing
@@ -176,9 +177,10 @@ class RewardsSelectionViewModel(environment: Environment) : ViewModel() {
     private suspend fun emitCurrentState(
         showAlertDialog: Boolean = false
     ) {
+        val filteredRewards = currentProjectData.project().rewards()?.filter { RewardUtils.isNoReward(it) || it.isAvailable() } ?: listOf()
         mutableRewardSelectionUIState.emit(
             RewardSelectionUIState(
-                rewardList = currentProjectData.project().rewards() ?: listOf(),
+                rewardList = filteredRewards,
                 initialRewardIndex = indexOfBackedReward,
                 project = currentProjectData,
                 showAlertDialog = showAlertDialog,

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
@@ -33,7 +33,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
     fun test_providing_project_should_initialize_UIState() = runTest {
         createViewModel()
 
-        val testRewards = (0..5).map { Reward.builder().title("$it").id(it.toLong()).build() }
+        val testRewards = (0..5).map { Reward.builder().title("$it").id(it.toLong()).isAvailable(true).build() }
         val testBacking =
             Backing.builder().reward(testRewards[2]).rewardId(testRewards[2].id()).build()
         val testProject = Project.builder().rewards(testRewards).backing(testBacking).build()
@@ -65,7 +65,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         createViewModel()
 
         val testRewards =
-            (0..5).map { Reward.builder().title("$it").id(it.toLong()).hasAddons(true).build() }
+            (0..5).map { Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(true).build() }
         val testProject = Project.builder().rewards(testRewards).build()
         val testProjectData = ProjectData.builder().project(testProject).build()
 
@@ -111,7 +111,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         createViewModel()
 
         val testRewards =
-            (0..5).map { Reward.builder().title("$it").id(it.toLong()).hasAddons(false).build() }
+            (0..5).map { Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(false).build() }
         val testProject = Project.builder().rewards(testRewards).build()
         val testProjectData = ProjectData.builder().project(testProject).build()
 
@@ -157,7 +157,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         createViewModel()
 
         val testRewards =
-            (0..5).map { Reward.builder().title("$it").id(it.toLong()).hasAddons(true).build() }
+            (0..5).map { Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(true).build() }
         val testBacking =
             Backing.builder().reward(testRewards[2]).rewardId(testRewards[2].id()).build()
         val testProject =
@@ -207,7 +207,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         createViewModel()
 
         val testRewards =
-            (0..5).map { Reward.builder().title("$it").id(it.toLong()).hasAddons(true).build() }
+            (0..5).map { Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(true).build() }
         val testBacking =
             Backing.builder().reward(testRewards[3]).rewardId(testRewards[3].id()).build()
         val testProject =
@@ -257,7 +257,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         createViewModel()
 
         val testRewards =
-            (0..5).map { Reward.builder().title("$it").id(it.toLong()).hasAddons(it != 2).build() }
+            (0..5).map { Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(it != 2).build() }
         val testBacking =
             Backing.builder().reward(testRewards[3]).rewardId(testRewards[3].id()).build()
         val testProject =
@@ -313,7 +313,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         createViewModel()
 
         val testRewards =
-            (0..5).map { Reward.builder().title("$it").id(it.toLong()).hasAddons(false).build() }
+            (0..5).map { Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(false).build() }
         val testBacking =
             Backing.builder().reward(testRewards[3]).rewardId(testRewards[3].id()).build()
         val testProject =
@@ -364,7 +364,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
             createViewModel()
 
             val testRewards = (0..5).map {
-                Reward.builder().title("$it").id(it.toLong()).hasAddons(true).shippingType("$it")
+                Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(true).shippingType("$it")
                     .build()
             }
             val testBacking =
@@ -422,7 +422,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         createViewModel()
 
         val testRewards = (0..5).map {
-            Reward.builder().title("$it").id(it.toLong()).hasAddons(true).shippingType("$it")
+            Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(true).shippingType("$it")
                 .build()
         }
         val testBacking =
@@ -489,7 +489,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         createViewModel()
 
         val testRewards = (0..5).map {
-            Reward.builder().title("$it").id(it.toLong()).hasAddons(it != 2).shippingType("$it")
+            Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(it != 2).shippingType("$it")
                 .build()
         }
         val testBacking =
@@ -556,7 +556,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         createViewModel()
 
         val testRewards = (0..5).map {
-            Reward.builder().title("$it").id(it.toLong()).hasAddons(it != 2).shippingType("$it")
+            Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(it != 2).shippingType("$it")
                 .build()
         }
         val testBacking =

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
@@ -629,7 +629,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         val testRewards = (0..8).map {
             if (it % 2 == 0)
                 Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(it != 2).shippingType("$it")
-                .build()
+                    .build()
             else
                 Reward.builder().title("$it").id(it.toLong()).isAvailable(false).hasAddons(it != 2).shippingType("$it")
                     .build()


### PR DESCRIPTION
# 📲 What

- Do not show unavailable rewards on late pledges rewards carousel

# 🛠 How

- filtering the rewards by `isAvailable`

# 👀 See

https://github.com/kickstarter/android-oss/assets/4083656/5d7e5c48-2262-497d-b437-bab7235b6db4


|  |  |

# 📋 QA

- Go to project  [The Captain's Logbook: 5E High Seas Adventure & Shipbuilding](https://www.kickstarter.com/projects/captainslogbook/the-captains-logbook-a-journey-of-adventures-for-5e) , before you could select the reward "Access to the pledge manager" which was unavailable, now rewards not available are not presented on the carousel

# Story 📖

[MBL-1380](https://kickstarter.atlassian.net/browse/MBL-1380)


[MBL-1380]: https://kickstarter.atlassian.net/browse/MBL-1380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ