### PR TITLE
MBL-1340: 3DS payment method UI removed on error

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -1217,6 +1217,7 @@ class ProjectPageActivity :
     private fun onPaymentOption(paymentOption: PaymentOption?) {
         paymentOption?.let {
             flowController.confirm()
+            latePledgeCheckoutViewModel.loading()
         }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -1217,7 +1217,6 @@ class ProjectPageActivity :
     private fun onPaymentOption(paymentOption: PaymentOption?) {
         paymentOption?.let {
             flowController.confirm()
-            latePledgeCheckoutViewModel.onNewCardSuccessfullyAdded()
         }
     }
 
@@ -1241,6 +1240,7 @@ class ProjectPageActivity :
             }
 
             is PaymentSheetResult.Completed -> {
+                latePledgeCheckoutViewModel.onNewCardSuccessfullyAdded()
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -148,6 +149,9 @@ fun CheckoutScreen(
             }
         )
     }
+
+    // - After adding new payment method, selected card should be updated to the newly added
+    UpdateSelectedCardIfNewCardAdded(remember { mutableStateOf(storedCards.size) }, storedCards, onOptionSelected)
 
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -304,19 +308,22 @@ fun CheckoutScreen(
                 )
                 Spacer(modifier = Modifier.height(dimensions.paddingMediumSmall))
 
-                storedCards.forEach {
-                    val isAvailable = project.acceptedCardType(it.type()) || it.isFromPaymentSheet()
+                storedCards.forEachIndexed { index, card ->
+                    val isAvailable = project.acceptedCardType(card.type()) || card.isFromPaymentSheet()
                     Card(
                         backgroundColor = colors.kds_white,
                         modifier = Modifier
-                            .padding(start = dimensions.paddingMedium, end = dimensions.paddingMedium)
+                            .padding(
+                                start = dimensions.paddingMedium,
+                                end = dimensions.paddingMedium
+                            )
                             .fillMaxWidth()
                             .selectableGroup()
                             .selectable(
                                 enabled = isAvailable,
-                                selected = it == selectedOption,
+                                selected = if (index == 0) true else false,
                                 onClick = {
-                                    onOptionSelected(it)
+                                    onOptionSelected(card)
                                 }
                             )
                     ) {
@@ -331,12 +338,12 @@ fun CheckoutScreen(
                             ) {
 
                                 KSRadioButton(
-                                    selected = it == selectedOption,
-                                    onClick = { onOptionSelected(it) },
+                                    selected = card == selectedOption,
+                                    onClick = { onOptionSelected(card) },
                                     enabled = isAvailable
                                 )
 
-                                KSCardElement(card = it, environment.ksString(), isAvailable)
+                                KSCardElement(card = card, environment.ksString(), isAvailable)
                             }
 
                             if (!isAvailable) {
@@ -479,6 +486,18 @@ fun CheckoutScreen(
                 KSCircularProgressIndicator()
             }
         }
+    }
+}
+
+@Composable
+private fun UpdateSelectedCardIfNewCardAdded(
+    index: MutableState<Int>,
+    storedCards: List<StoredCard>,
+    onOptionSelected: (StoredCard?) -> Unit
+) {
+    if (index.value != storedCards.size) {
+        onOptionSelected(storedCards.first())
+        index.value = storedCards.size
     }
 }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
@@ -18,7 +18,6 @@ import com.kickstarter.ui.data.ProjectData
 import com.stripe.android.Stripe
 import com.stripe.android.confirmPaymentIntent
 import com.stripe.android.model.ConfirmPaymentIntentParams
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -133,7 +132,7 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
     }
 
     fun onNewCardSuccessfullyAdded() {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             apolloClient.savePaymentMethod(
                 SavePaymentMethodData(
                     reusable = true,
@@ -333,6 +332,12 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
 
     fun userRewardSelection(reward: Reward) {
         this.selectedReward = reward
+    }
+
+    fun loading() {
+        viewModelScope.launch {
+            emitCurrentState(isLoading = true)
+        }
     }
 
     class Factory(private val environment: Environment) :

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
@@ -18,6 +18,7 @@ import com.kickstarter.ui.data.ProjectData
 import com.stripe.android.Stripe
 import com.stripe.android.confirmPaymentIntent
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -132,7 +133,7 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
     }
 
     fun onNewCardSuccessfullyAdded() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             apolloClient.savePaymentMethod(
                 SavePaymentMethodData(
                     reusable = true,


### PR DESCRIPTION
# 📲 What

- After failing 3DS challenge no new card UI is added.

# 🤔 Why

- Better user experience

# 🛠 How

- Wait until `is PaymentSheetResult.Completed` callback is received from the `PaymentSheet` in `onPaymentSheetResult` before updating any UI/execute any network call.

# 👀 See

https://github.com/kickstarter/android-oss/assets/4083656/ab1a9d58-7fda-4541-91c2-e87b5155321e


|  |  |

# 📋 QA

- On a late pledge project, in staging you can find : [this project](https://staging.kickstarter.com/projects/sfdasf/birbs-in-canada) or [this one](https://staging.kickstarter.com/projects/latepledgetestparty/testing-closing-a-late-pledge-proj)
- Add a new 3DS payment method, that requires the challenge to be completed, [here stripe cards](https://docs.stripe.com/testing#three-ds-cards) to test, but in the video I use `4000000000003220` 
- Fail the challenge when presented, the error snack bar should be presented to you
- Repeat the process, but succeed the challenge this time, the new payment method added in the cards list and is automatically selected

# Story 📖

[MBL-1340](https://kickstarter.atlassian.net/browse/MBL-1340)


[MBL-1340]: https://kickstarter.atlassian.net/browse/MBL-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ