### PR TITLE
[MBL-1335] Fix issue where shipping location was not preserved after being changed

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
@@ -340,7 +340,7 @@ fun CountryInputWithDropdown(
         mutableStateOf(false)
     }
 
-    var countryInput by remember {
+    var countryInput by remember(key1 = initialCountryInput) {
         mutableStateOf(initialCountryInput ?: "")
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ConfirmPledgeDetailsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ConfirmPledgeDetailsScreen.kt
@@ -411,46 +411,14 @@ fun ConfirmPledgeDetailsScreen(
 
                 if (rewardsList.isNotEmpty() && shippingLocation.isNotEmpty() && rewardsHaveShippables) {
                     item {
-                        Column(
-                            modifier = Modifier.padding(
-                                start = dimensions.paddingMedium,
-                                end = dimensions.paddingMedium,
-                                top = dimensions.paddingMedium
-                            )
-                        ) {
-                            Text(
-                                text = stringResource(id = R.string.Your_shipping_location),
-                                style = typography.subheadlineMedium,
-                                color = colors.textPrimary
-                            )
-
-                            Spacer(modifier = Modifier.height(dimensions.paddingMediumSmall))
-
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                if (countryList.isNotEmpty() && !rewardsContainAddOns && rewardsHaveShippables) {
-                                    CountryInputWithDropdown(
-                                        interactionSource = interactionSource,
-                                        initialCountryInput = shippingLocation,
-                                        countryList = countryList,
-                                        onShippingRuleSelected = onShippingRuleSelected
-                                    )
-                                } else {
-                                    Text(
-                                        text = shippingLocation,
-                                        style = typography.subheadline,
-                                        color = colors.textPrimary
-                                    )
-                                }
-
-                                Spacer(modifier = Modifier.weight(1f))
-
-                                Text(
-                                    text = "+ $shippingAmountString",
-                                    style = typography.title3,
-                                    color = colors.textSecondary
-                                )
-                            }
-                        }
+                        ShippingLocationView(
+                            countryList,
+                            rewardsContainAddOns,
+                            interactionSource,
+                            shippingLocation,
+                            shippingAmountString,
+                            onShippingRuleSelected
+                        )
                     }
                 }
 
@@ -803,6 +771,57 @@ fun ItemizedRewardListContainer(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+fun ShippingLocationView(
+    countryList: List<ShippingRule>,
+    rewardsContainAddOns: Boolean,
+    interactionSource: MutableInteractionSource,
+    shippingLocation: String,
+    shippingAmountString: String,
+    onShippingRuleSelected: (ShippingRule) -> Unit
+) {
+    Column(
+        modifier = Modifier.padding(
+            start = dimensions.paddingMedium,
+            end = dimensions.paddingMedium,
+            top = dimensions.paddingMedium
+        )
+    ) {
+        Text(
+            text = stringResource(id = R.string.Your_shipping_location),
+            style = typography.subheadlineMedium,
+            color = colors.textPrimary
+        )
+
+        Spacer(modifier = Modifier.height(dimensions.paddingMediumSmall))
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            if (countryList.isNotEmpty() && !rewardsContainAddOns) {
+                CountryInputWithDropdown(
+                    interactionSource = interactionSource,
+                    initialCountryInput = shippingLocation,
+                    countryList = countryList,
+                    onShippingRuleSelected = onShippingRuleSelected
+                )
+            } else {
+                Text(
+                    text = shippingLocation,
+                    style = typography.subheadline,
+                    color = colors.textPrimary
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Text(
+                text = "+ $shippingAmountString",
+                style = typography.title3,
+                color = colors.textSecondary
+            )
         }
     }
 }


### PR DESCRIPTION
# 📲 What

Fix an issue where shipping location would not be presented correctly after being changed

# 🤔 Why

We want the flow to feel seamless and have correct information displayed

# 🛠 How

By adding they key to the remember value it will not reevaluate the variable whenever the input is changed, allowing it to show the correct information on first being presented

# 👀 See

https://github.com/kickstarter/android-oss/assets/7563288/cd8aea94-55f8-4ee7-a2f7-3da9efad2c2e


# 📋 QA

Go to a late pledge flow and go through the add-ons screen, changing the shipping location, make sure it is preserved throughout the flow no matter where it was changed

# Story 📖

[MBL-1335](https://kickstarter.atlassian.net/browse/MBL-1335)


[MBL-1335]: https://kickstarter.atlassian.net/browse/MBL-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ