### PR TITLE
MBL-1417: Crash from PushNotifications.fetchBitmap

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/PushNotifications.java
+++ b/app/src/main/java/com/kickstarter/libs/PushNotifications.java
@@ -8,6 +8,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.os.Build;
 import android.util.Pair;
 
@@ -22,6 +23,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.MultiTransformation;
 import com.bumptech.glide.request.FutureTarget;
 import com.bumptech.glide.request.RequestOptions;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.kickstarter.R;
 import com.kickstarter.libs.qualifiers.ApplicationContext;
 import com.kickstarter.libs.utils.extensions.AnyExtKt;
@@ -420,6 +422,7 @@ public final class PushNotifications {
         final FutureTarget<Bitmap> circleCrop = Glide.with(this.context)
           .asBitmap()
           .load(url)
+          .error(R.drawable.logo)
           .apply(RequestOptions.circleCropTransform())
           .submit();
         return circleCrop.get();
@@ -427,12 +430,15 @@ public final class PushNotifications {
         final FutureTarget<Bitmap> SquareRoundCorners = Glide.with(this.context)
           .asBitmap()
           .load(url)
+          .error(R.drawable.logo)
           .transform(new MultiTransformation<>(new CenterCrop(), new RoundedCorners(10)))
           .submit();
         return SquareRoundCorners.get();
       }
     } catch (ExecutionException | InterruptedException e) {
-      throw new RuntimeException(e);
+      final Throwable error = new Throwable(url, e);
+      FirebaseCrashlytics.getInstance().recordException(error);
+      return BitmapFactory.decodeResource(this.context.getResources(), R.drawable.logo);
     }
   }
 


### PR DESCRIPTION
# 📲 What

- When poor connectivity or no connectvity the request fails, no generating bitmap


# 🛠 How

- Added error Glide loading callback
- Return placeholder bitmap if all previous fails

# 👀 See
<img width="1201" alt="Screenshot 2024-05-29 at 12 39 39 PM" src="https://github.com/kickstarter/android-oss/assets/4083656/c819177c-6a27-4bc1-b85b-fe4a52e5a02e">

<img width="1208" alt="Screenshot 2024-05-29 at 12 39 28 PM" src="https://github.com/kickstarter/android-oss/assets/4083656/803fd6cd-1f99-4685-a527-7197a4045f4e">

<img width="1620" alt="Screenshot 2024-05-29 at 12 53 02 PM" src="https://github.com/kickstarter/android-oss/assets/4083656/3b9d7f77-0d89-4d02-af6d-d322b3dbdac5">

|  |  |

# 📋 QA
- Not able to reproduce in real life scenario, but try loose connectivity, go to internal tools -> push notifications and filter by warning on logcat, you will see nothing crashes. The logcat screenshot with Glide warning was produced this way 

# Story 📖

[MBL-1417](https://kickstarter.atlassian.net/browse/MBL-1417)


[MBL-1417]: https://kickstarter.atlassian.net/browse/MBL-1417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ