### PR TITLE
[MBL-1530] Add trigger for 3ds flow for post campaign payments

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -563,12 +563,6 @@ class ProjectPageActivity :
                     val userEmail = latePledgeCheckoutUIState.userEmail
                     val checkoutLoading = latePledgeCheckoutUIState.isLoading
 
-                    LaunchedEffect(Unit) {
-                        latePledgeCheckoutViewModel.paymentRequiresAction.collect {
-                            stripeNextAction(it)
-                        }
-                    }
-
                     latePledgeCheckoutViewModel.provideErrorAction { message ->
                         showToastError(message)
                     }
@@ -1227,6 +1221,7 @@ class ProjectPageActivity :
                     binding.pledgeContainerCompose,
                     getString(R.string.general_error_oops)
                 )
+                latePledgeCheckoutViewModel.onNewCardFailed()
             }
 
             is PaymentSheetResult.Failed -> {
@@ -1236,6 +1231,7 @@ class ProjectPageActivity :
                     binding.pledgeContainerCompose,
                     errorMessage
                 )
+                latePledgeCheckoutViewModel.onNewCardFailed()
             }
 
             is PaymentSheetResult.Completed -> {
@@ -1287,11 +1283,12 @@ class ProjectPageActivity :
             object : ApiResultCallback<PaymentIntentResult> {
                 override fun onSuccess(result: PaymentIntentResult) {
                     if (result.outcome == StripeIntentResult.Outcome.SUCCEEDED) {
-                        // Go to thanks page
+                        latePledgeCheckoutViewModel.completeOnSessionCheckoutFor3DS()
                     } else showToastError()
                 }
 
                 override fun onError(e: Exception) {
+                    latePledgeCheckoutViewModel.clear3DSValues()
                     showToastError()
                 }
             }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/LoginToutScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/LoginToutScreenTest.kt
@@ -89,6 +89,7 @@ class LoginToutScreenTest : KSRobolectricTestCase() {
         touPpCookieDisclaimer.assertIsDisplayed()
     }
 
+    @Test
     fun testComponentsVisible_featureFlag_On() {
         composeTestRule.setContent {
             KSTheme {


### PR DESCRIPTION
# 📲 What

Add a trigger for the 3ds flow for stripe in the post campaign flow

# 🤔 Why

Due to other recent changes stripe was not automatically showing the 3ds challenge screen to users in post campaign flow

# 🛠 How

Observe the payment intent being passed back to us from stripe and react accordingly.

# 📋 QA

1) Go to a project currently in post campaign phase
2) Select rewards/add-ons and shipping location
3) Either add or use an existing 3ds card for the payment
4) Make sure you are presented the 3ds challenge
5) Confirm that there was a successful backing (may need backend support to know if payment was successful)

# Story 📖

[MBL-1530](https://kickstarter.atlassian.net/browse/MBL-1530)


[MBL-1530]: https://kickstarter.atlassian.net/browse/MBL-1530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ