### PR TITLE
[MBL-1535] Fix bug when adding existing payment method it unselects a card

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
@@ -142,12 +142,16 @@ fun CheckoutScreen(
     onDisclaimerItemClicked: (disclaimerItem: DisclaimerItems) -> Unit,
     onAccountabilityLinkClicked: () -> Unit
 ) {
-    var (selectedOption, onOptionSelected) = remember {
+    val selectedOption = remember {
         mutableStateOf(
             storedCards.firstOrNull {
                 project.acceptedCardType(it.type()) || it.isFromPaymentSheet()
             }
         )
+    }
+
+    val onOptionSelected: (StoredCard?) -> Unit = {
+        selectedOption.value = it
     }
 
     // - After adding new payment method, selected card should be updated to the newly added
@@ -189,8 +193,8 @@ fun CheckoutScreen(
                                 modifier = Modifier
                                     .padding(bottom = dimensions.paddingMediumSmall)
                                     .fillMaxWidth(),
-                                onClickAction = { onPledgeCtaClicked(selectedOption) },
-                                isEnabled = project.acceptedCardType(selectedOption?.type()) || selectedOption?.isFromPaymentSheet() ?: false,
+                                onClickAction = { onPledgeCtaClicked(selectedOption.value) },
+                                isEnabled = project.acceptedCardType(selectedOption.value?.type()) || selectedOption.value?.isFromPaymentSheet() ?: false,
                                 text = if (pledgeReason == PledgeReason.PLEDGE) stringResource(id = R.string.Pledge) else stringResource(
                                     id = R.string.Confirm
                                 )
@@ -338,7 +342,7 @@ fun CheckoutScreen(
                             ) {
 
                                 KSRadioButton(
-                                    selected = card == selectedOption,
+                                    selected = card == selectedOption.value,
                                     onClick = { onOptionSelected(card) },
                                     enabled = isAvailable
                                 )


### PR DESCRIPTION
# 📲 What

A description of the change.

# 🤔 Why

Some background context on why the change is needed.

# 🛠 How

More in-depth discussion of the change or implementation.

# 👀 See

First time: adding a new card (it is selected and at the top of the list as expected)
Second time: adding the card via link again (shouldn't do anything, may want to introduce user messaging)

See link for video:
https://kickstarter.slack.com/archives/C01PNFFUXBR/p1718651586663299?thread_ts=1718651173.743469&cid=C01PNFFUXBR


# 📋 QA

1) Go to a late pledge project
2) Go to the checkout screen
3) Click add new payment method

Case 1:  New payment method
4a) Add a payment method you dont already have on kickstarter via link
5) Confirm the screen updated with the new payment method selected

Case 2: Existing payment method
4b) Add a payment method you DO already have on kickstarter
5) Confirm the screen doesnt change once you return

# Story 📖

[MBL-1535](https://kickstarter.atlassian.net/browse/MBL-1535)


[MBL-1535]: https://kickstarter.atlassian.net/browse/MBL-1535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ