### PR TITLE
MBL-1474: PPO Message creator navigation

### DIFF
--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -1,6 +1,5 @@
 package com.kickstarter.features.pledgedprojectsoverview.ui
 
-import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
@@ -16,17 +15,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
-import com.kickstarter.R
 import com.kickstarter.features.pledgedprojectsoverview.viewmodel.PledgedProjectsOverviewViewModel
 import com.kickstarter.libs.MessagePreviousScreenType
 import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.isDarkModeEnabled
-import com.kickstarter.models.Project
-import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.SharedPreferenceKey
 import com.kickstarter.ui.activities.AppThemes
-import com.kickstarter.ui.activities.MessageCreatorActivity
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
 import com.kickstarter.ui.extensions.startCreatorMessageActivity
 import com.kickstarter.ui.extensions.transition
@@ -89,10 +84,10 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
 
                 val coroutineScope = rememberCoroutineScope()
 
-                        viewModel.provideSnackbarAction {
-                            coroutineScope.launch {
-                                showSnackbar(snackbarHostState, it)
-                            }
+                viewModel.provideSnackbarAction {
+                    coroutineScope.launch {
+                        showSnackbar(snackbarHostState, it)
+                    }
                 }
 
                 onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
@@ -105,7 +100,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
         }
     }
 
-    private suspend fun showSnackbar(snackbarHostState : SnackbarHostState, stringID : Int) {
+    private suspend fun showSnackbar(snackbarHostState: SnackbarHostState, stringID: Int) {
         snackbarHostState.showSnackbar(getString(stringID))
     }
 }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.features.pledgedprojectsoverview.ui
 
+import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
@@ -8,16 +9,25 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.kickstarter.R
 import com.kickstarter.features.pledgedprojectsoverview.viewmodel.PledgedProjectsOverviewViewModel
+import com.kickstarter.libs.MessagePreviousScreenType
 import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.isDarkModeEnabled
+import com.kickstarter.models.Project
+import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.SharedPreferenceKey
 import com.kickstarter.ui.activities.AppThemes
+import com.kickstarter.ui.activities.MessageCreatorActivity
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
+import com.kickstarter.ui.extensions.startCreatorMessageActivity
 import com.kickstarter.ui.extensions.transition
 
 class PledgedProjectsOverviewActivity : AppCompatActivity() {
@@ -39,6 +49,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
 
                 val darkModeEnabled = this.isDarkModeEnabled(env = env)
                 val lazyListState = rememberLazyListState()
+                val snackbarHostState = remember { SnackbarHostState() }
 
                 val ppoCardPagingSource = viewModel.ppoCardsState.collectAsLazyPagingItems()
                 val totalAlerts = viewModel.totalAlertsState.collectAsStateWithLifecycle()
@@ -60,9 +71,24 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                         modifier = Modifier,
                         onBackPressed = { onBackPressedDispatcher.onBackPressed() },
                         lazyColumnListState = lazyListState,
+                        errorSnackBarHostState = snackbarHostState,
                         ppoCards = ppoCardPagingSource,
-                        totalAlerts = totalAlerts.value
+                        totalAlerts = totalAlerts.value,
+                        onSendMessageClick = { projectName ->  viewModel.onMessageCreatorClicked(projectName) }
                     )
+                }
+
+                LaunchedEffect(Unit) {
+                    viewModel.projectFlow
+                        .collect {
+                        startCreatorMessageActivity(it, previousScreen = MessagePreviousScreenType.PLEDGED_PROJECTS_OVERVIEW)
+                    }
+                }
+
+                LaunchedEffect(Unit) {
+                    viewModel.error.collect {
+                        snackbarHostState.showSnackbar(getString(R.string.Something_went_wrong_please_try_again))
+                    }
                 }
 
                 onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
@@ -74,4 +100,12 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
             }
         }
     }
-}
+
+        private fun startComposeMessageActivity(it: Project?) {
+            startActivity(
+                Intent(this, MessageCreatorActivity::class.java)
+                    .putExtra(IntentKey.PROJECT, it)
+            )
+        }
+    }
+

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -84,7 +84,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
 
                 val coroutineScope = rememberCoroutineScope()
 
-                viewModel.provideSnackbarAction {
+                viewModel.provideSnackbarMessage {
                     coroutineScope.launch {
                         snackbarHostState.showSnackbar(getString(it))
                     }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -29,6 +30,7 @@ import com.kickstarter.ui.activities.MessageCreatorActivity
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
 import com.kickstarter.ui.extensions.startCreatorMessageActivity
 import com.kickstarter.ui.extensions.transition
+import kotlinx.coroutines.launch
 
 class PledgedProjectsOverviewActivity : AppCompatActivity() {
 
@@ -85,10 +87,12 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                         }
                 }
 
-                LaunchedEffect(Unit) {
-                    viewModel.error.collect {
-                        snackbarHostState.showSnackbar(getString(R.string.Something_went_wrong_please_try_again))
-                    }
+                val coroutineScope = rememberCoroutineScope()
+
+                        viewModel.provideSnackbarAction {
+                            coroutineScope.launch {
+                                showSnackbar(snackbarHostState, it)
+                            }
                 }
 
                 onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
@@ -101,10 +105,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
         }
     }
 
-    private fun startComposeMessageActivity(it: Project?) {
-        startActivity(
-            Intent(this, MessageCreatorActivity::class.java)
-                .putExtra(IntentKey.PROJECT, it)
-        )
+    private suspend fun showSnackbar(snackbarHostState : SnackbarHostState, stringID : Int) {
+        snackbarHostState.showSnackbar(getString(stringID))
     }
 }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -11,9 +11,9 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.kickstarter.features.pledgedprojectsoverview.viewmodel.PledgedProjectsOverviewViewModel
 import com.kickstarter.libs.MessagePreviousScreenType
@@ -82,10 +82,8 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                         }
                 }
 
-                val coroutineScope = rememberCoroutineScope()
-
                 viewModel.provideSnackbarMessage {
-                    coroutineScope.launch {
+                    lifecycleScope.launch {
                         snackbarHostState.showSnackbar(getString(it))
                     }
                 }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -74,15 +74,15 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                         errorSnackBarHostState = snackbarHostState,
                         ppoCards = ppoCardPagingSource,
                         totalAlerts = totalAlerts.value,
-                        onSendMessageClick = { projectName ->  viewModel.onMessageCreatorClicked(projectName) }
+                        onSendMessageClick = { projectName -> viewModel.onMessageCreatorClicked(projectName) }
                     )
                 }
 
                 LaunchedEffect(Unit) {
                     viewModel.projectFlow
                         .collect {
-                        startCreatorMessageActivity(it, previousScreen = MessagePreviousScreenType.PLEDGED_PROJECTS_OVERVIEW)
-                    }
+                            startCreatorMessageActivity(it, previousScreen = MessagePreviousScreenType.PLEDGED_PROJECTS_OVERVIEW)
+                        }
                 }
 
                 LaunchedEffect(Unit) {
@@ -101,11 +101,10 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
         }
     }
 
-        private fun startComposeMessageActivity(it: Project?) {
-            startActivity(
-                Intent(this, MessageCreatorActivity::class.java)
-                    .putExtra(IntentKey.PROJECT, it)
-            )
-        }
+    private fun startComposeMessageActivity(it: Project?) {
+        startActivity(
+            Intent(this, MessageCreatorActivity::class.java)
+                .putExtra(IntentKey.PROJECT, it)
+        )
     }
-
+}

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -86,7 +86,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
 
                 viewModel.provideSnackbarAction {
                     coroutineScope.launch {
-                        showSnackbar(snackbarHostState, it)
+                        snackbarHostState.showSnackbar(getString(it))
                     }
                 }
 
@@ -98,9 +98,5 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                 })
             }
         }
-    }
-
-    private suspend fun showSnackbar(snackbarHostState: SnackbarHostState, stringID: Int) {
-        snackbarHostState.showSnackbar(getString(stringID))
     }
 }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
@@ -12,6 +12,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Snackbar
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -47,7 +50,9 @@ private fun PledgedProjectsOverviewScreenPreview() {
                 lazyColumnListState = rememberLazyListState(),
                 ppoCards = ppoCardList,
                 totalAlerts = 10,
-                onBackPressed = {}
+                onBackPressed = {},
+                onSendMessageClick = {},
+                errorSnackBarHostState = SnackbarHostState()
             )
         }
     }
@@ -58,14 +63,20 @@ fun PledgedProjectsOverviewScreen(
     modifier: Modifier,
     onBackPressed: () -> Unit,
     lazyColumnListState: LazyListState,
+    errorSnackBarHostState: SnackbarHostState,
     ppoCards: LazyPagingItems<PPOCardDataMock>,
-    totalAlerts: Int = 0
+    totalAlerts: Int = 0,
+    onSendMessageClick : (projectName: String) -> Unit
 ) {
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
         Scaffold(
+            snackbarHost = {
+                SnackbarHost(
+                    hostState = errorSnackBarHostState)
+            },
             modifier = modifier,
             topBar = {
                 TopToolBar(
@@ -113,7 +124,7 @@ fun PledgedProjectsOverviewScreen(
                             imageUrl = it.imageUrl,
                             imageContentDescription = it.imageContentDescription,
                             creatorName = it.creatorName,
-                            sendAMessageClickAction = { },
+                            sendAMessageClickAction = { onSendMessageClick(it.projectSlug) },
                             shippingAddress = it.shippingAddress,
                             showBadge = it.showBadge,
                             onActionButtonClicked = { },
@@ -140,6 +151,7 @@ data class PPOCardDataMock(
     val viewType: PPOCardViewType = PPOCardViewType.FIX_PAYMENT,
     val onCardClick: () -> Unit = { },
     val projectName: String = "This is a project name",
+    val projectSlug: String = "",
     val pledgeAmount: String = "$14.00",
     val imageUrl: String = "",
     val imageContentDescription: String = "",

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Scaffold
-import androidx.compose.material.Snackbar
 import androidx.compose.material.SnackbarHost
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.Text
@@ -66,7 +65,7 @@ fun PledgedProjectsOverviewScreen(
     errorSnackBarHostState: SnackbarHostState,
     ppoCards: LazyPagingItems<PPOCardDataMock>,
     totalAlerts: Int = 0,
-    onSendMessageClick : (projectName: String) -> Unit
+    onSendMessageClick: (projectName: String) -> Unit
 ) {
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -75,7 +74,8 @@ fun PledgedProjectsOverviewScreen(
         Scaffold(
             snackbarHost = {
                 SnackbarHost(
-                    hostState = errorSnackBarHostState)
+                    hostState = errorSnackBarHostState
+                )
             },
             modifier = modifier,
             topBar = {

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.rx2.asFlow
 
 class PledgedProjectsOverviewViewModel(environment: Environment) : ViewModel() {
 
-    private val ppoCards = MutableStateFlow<PagingData<PPOCardDataMock>>(PagingData.from(listOf(PPOCardDataMock(projectSlug = "duality-collection-enamel-pins-by-tabauble-make-100"))))
+    private val ppoCards = MutableStateFlow<PagingData<PPOCardDataMock>>(PagingData.from(listOf(PPOCardDataMock(projectSlug = "duality-collection-enamel-pins-by-tabauble-make-100"), PPOCardDataMock(projectSlug = "duality-collection-enamel-pins-by-tabauble-make-100121e32"))))
     private val totalAlerts = MutableStateFlow<Int>(0)
     private val mutableError = MutableSharedFlow<Unit>()
     private var mutableProjectFlow = MutableSharedFlow<Project>()

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
@@ -15,12 +15,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.shareIn
 
 class PledgedProjectsOverviewViewModel(environment: Environment) : ViewModel() {
 
@@ -29,7 +29,7 @@ class PledgedProjectsOverviewViewModel(environment: Environment) : ViewModel() {
     private val mutableError = MutableSharedFlow<Unit>()
     private var mutableProjectFlow = MutableSharedFlow<Project>()
 
-    private val apolloClient = requireNotNull( environment.apolloClientV2())
+    private val apolloClient = requireNotNull(environment.apolloClientV2())
     val ppoCardsState: StateFlow<PagingData<PPOCardDataMock>> = ppoCards.asStateFlow()
     val totalAlertsState: StateFlow<Int> = totalAlerts.asStateFlow()
 
@@ -55,15 +55,15 @@ class PledgedProjectsOverviewViewModel(environment: Environment) : ViewModel() {
         }
     }
 
-    fun onMessageCreatorClicked(projectName : String) {
+    fun onMessageCreatorClicked(projectName: String) {
         viewModelScope.launch {
             apolloClient.getProject(
                 slug = projectName,
             )
                 .asFlow()
                 .onStart {
-                    //TODO emit loading ui state
-                }.map {project ->
+                    // TODO emit loading ui state
+                }.map { project ->
                     mutableProjectFlow.emit(project)
                 }.catch {
                     mutableError.emit(Unit)

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
@@ -2,25 +2,72 @@ package com.kickstarter.features.pledgedprojectsoverview.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import com.kickstarter.features.pledgedprojectsoverview.ui.PPOCardDataMock
 import com.kickstarter.libs.Environment
+import com.kickstarter.models.Project
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.asFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.shareIn
 
 class PledgedProjectsOverviewViewModel(environment: Environment) : ViewModel() {
 
-    private val ppoCards = MutableStateFlow<PagingData<PPOCardDataMock>>(PagingData.empty())
+    private val ppoCards = MutableStateFlow<PagingData<PPOCardDataMock>>(PagingData.from(listOf(PPOCardDataMock(projectSlug = "duality-collection-enamel-pins-by-tabauble-make-100"))))
     private val totalAlerts = MutableStateFlow<Int>(0)
+    private val mutableError = MutableSharedFlow<Unit>()
+    private var mutableProjectFlow = MutableSharedFlow<Project>()
 
+    private val apolloClient = requireNotNull( environment.apolloClientV2())
     val ppoCardsState: StateFlow<PagingData<PPOCardDataMock>> = ppoCards.asStateFlow()
     val totalAlertsState: StateFlow<Int> = totalAlerts.asStateFlow()
+
+    val error: SharedFlow<Unit>
+        get() = mutableError
+            .asSharedFlow()
+            .shareIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(),
+            )
+    val projectFlow: SharedFlow<Project>
+        get() = mutableProjectFlow
+            .asSharedFlow()
+            .shareIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(),
+            )
 
     class Factory(private val environment: Environment) :
         ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             return PledgedProjectsOverviewViewModel(environment) as T
+        }
+    }
+
+    fun onMessageCreatorClicked(projectName : String) {
+        viewModelScope.launch {
+            apolloClient.getProject(
+                slug = projectName,
+            )
+                .asFlow()
+                .onStart {
+                    //TODO emit loading ui state
+                }.map {project ->
+                    mutableProjectFlow.emit(project)
+                }.catch {
+                    mutableError.emit(Unit)
+                }.collect()
         }
     }
 }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
@@ -8,7 +8,6 @@ import com.kickstarter.R
 import com.kickstarter.features.pledgedprojectsoverview.ui.PPOCardDataMock
 import com.kickstarter.libs.Environment
 import com.kickstarter.models.Project
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -30,7 +29,7 @@ class PledgedProjectsOverviewViewModel(environment: Environment) : ViewModel() {
     private val totalAlerts = MutableStateFlow<Int>(0)
     private val mutableError = MutableSharedFlow<Unit>()
     private var mutableProjectFlow = MutableSharedFlow<Project>()
-    private var snackbarAction : (stringID: Int) -> Unit = {}
+    private var snackbarAction: (stringID: Int) -> Unit = {}
 
     private val apolloClient = requireNotNull(environment.apolloClientV2())
     val ppoCardsState: StateFlow<PagingData<PPOCardDataMock>> = ppoCards.asStateFlow()
@@ -59,7 +58,7 @@ class PledgedProjectsOverviewViewModel(environment: Environment) : ViewModel() {
         }
     }
 
-    fun provideSnackbarAction(snackBarAction : (Int) -> Unit ) {
+    fun provideSnackbarAction(snackBarAction: (Int) -> Unit) {
         this.snackbarAction = snackBarAction
     }
 

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
@@ -25,23 +25,14 @@ import kotlinx.coroutines.rx2.asFlow
 
 class PledgedProjectsOverviewViewModel(environment: Environment) : ViewModel() {
 
-    private val ppoCards = MutableStateFlow<PagingData<PPOCardDataMock>>(PagingData.from(listOf(PPOCardDataMock(projectSlug = "duality-collection-enamel-pins-by-tabauble-make-100"), PPOCardDataMock(projectSlug = "duality-collection-enamel-pins-by-tabauble-make-100121e32"))))
+    private val ppoCards = MutableStateFlow<PagingData<PPOCardDataMock>>(PagingData.empty())
     private val totalAlerts = MutableStateFlow<Int>(0)
-    private val mutableError = MutableSharedFlow<Unit>()
     private var mutableProjectFlow = MutableSharedFlow<Project>()
-    private var snackbarAction: (stringID: Int) -> Unit = {}
+    private var snackbarMessage: (stringID: Int) -> Unit = {}
 
     private val apolloClient = requireNotNull(environment.apolloClientV2())
     val ppoCardsState: StateFlow<PagingData<PPOCardDataMock>> = ppoCards.asStateFlow()
     val totalAlertsState: StateFlow<Int> = totalAlerts.asStateFlow()
-
-    val error: SharedFlow<Unit>
-        get() = mutableError
-            .asSharedFlow()
-            .shareIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(),
-            )
 
     val projectFlow: SharedFlow<Project>
         get() = mutableProjectFlow
@@ -58,8 +49,8 @@ class PledgedProjectsOverviewViewModel(environment: Environment) : ViewModel() {
         }
     }
 
-    fun provideSnackbarAction(snackBarAction: (Int) -> Unit) {
-        this.snackbarAction = snackBarAction
+    fun provideSnackbarMessage(snackBarMessage: (Int) -> Unit) {
+        this.snackbarMessage = snackBarMessage
     }
 
     fun onMessageCreatorClicked(projectName: String) {
@@ -73,7 +64,7 @@ class PledgedProjectsOverviewViewModel(environment: Environment) : ViewModel() {
                 }.map { project ->
                     mutableProjectFlow.emit(project)
                 }.catch {
-                    snackbarAction.invoke(R.string.Something_went_wrong_please_try_again)
+                    snackbarMessage.invoke(R.string.Something_went_wrong_please_try_again)
                 }.collect()
         }
     }

--- a/app/src/main/java/com/kickstarter/libs/MessagePreviousScreenType.kt
+++ b/app/src/main/java/com/kickstarter/libs/MessagePreviousScreenType.kt
@@ -13,5 +13,6 @@ enum class MessagePreviousScreenType(val trackingString: String) {
     CREATOR_BIO_MODAL("creator_bio_modal"),
     MESSAGES("messages"),
     PROJECT_PAGE("project_page"),
-    PUSH("push")
+    PUSH("push"),
+    PLEDGED_PROJECTS_OVERVIEW("pledged_projects_overview")
 }

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -16,6 +16,7 @@ import com.google.android.play.core.review.ReviewInfo
 import com.google.android.play.core.review.ReviewManagerFactory
 import com.kickstarter.R
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.MessagePreviousScreenType
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.libs.utils.TransitionUtils
@@ -36,6 +37,7 @@ import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.DisclaimerItems
 import com.kickstarter.ui.activities.HelpActivity
 import com.kickstarter.ui.activities.LoginToutActivity
+import com.kickstarter.ui.activities.MessagesActivity
 import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ProjectData
@@ -269,4 +271,13 @@ fun Activity.startDisclaimerChromeTab(disclaimerItem: DisclaimerItems, environme
     }
 
     ChromeTabsHelperActivity.openCustomTab(this, UrlUtils.baseCustomTabsIntent(this), uri, fallback)
+}
+
+fun Activity.startCreatorMessageActivity(project: Project, previousScreen: MessagePreviousScreenType) {
+    startActivity(
+        Intent(this, MessagesActivity::class.java)
+            .putExtra(IntentKey.MESSAGE_SCREEN_SOURCE_CONTEXT, previousScreen)
+            .putExtra(IntentKey.PROJECT, project)
+            .putExtra(IntentKey.BACKING, project.backing())
+    )
 }

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreenTest.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.features.pledgedprojectsoverview.ui
 
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -29,7 +30,9 @@ class PledgedProjectsOverviewScreenTest : KSRobolectricTestCase() {
                     modifier = Modifier,
                     onBackPressed = { backClickedCount++ },
                     lazyColumnListState = rememberLazyListState(),
-                    ppoCards = ppoCardList
+                    ppoCards = ppoCardList,
+                    errorSnackBarHostState = SnackbarHostState(),
+                    onSendMessageClick = {}
                 )
             }
         }

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
@@ -51,9 +51,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
     @Test
     fun `emits_error_when_message_creator_called`() =
         runTest {
-            val errorState = mutableListOf<Unit>()
-
-            val project = ProjectFactory.successfulProject()
+            var snackbarAction: Int? = 1234
             viewModel = PledgedProjectsOverviewViewModel.Factory(
                 environment = environment().toBuilder()
                     .apolloClientV2(object : MockApolloClientV2() {
@@ -63,14 +61,13 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
                     }).build()
             ).create(PledgedProjectsOverviewViewModel::class.java)
 
-            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-                viewModel.error.toList(errorState)
-            }
+            viewModel.provideSnackbarAction { snackbarAction = it }
             viewModel.onMessageCreatorClicked("test_project_slug")
 
+            //Should equal error string id
             assertEquals(
-                errorState.size,
-                1
+                snackbarAction,
+                2131952284
             )
         }
 }

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
@@ -29,13 +29,13 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
 
             val project = ProjectFactory.successfulProject()
             viewModel = PledgedProjectsOverviewViewModel.Factory(
-            environment = environment().toBuilder()
-                .apolloClientV2(object : MockApolloClientV2() {
-                    override fun getProject(slug: String): Observable<Project> {
-                        return Observable.just(project)
-                    }
-                }).build()
-        ).create(PledgedProjectsOverviewViewModel::class.java)
+                environment = environment().toBuilder()
+                    .apolloClientV2(object : MockApolloClientV2() {
+                        override fun getProject(slug: String): Observable<Project> {
+                            return Observable.just(project)
+                        }
+                    }).build()
+            ).create(PledgedProjectsOverviewViewModel::class.java)
 
             backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
                 viewModel.projectFlow.toList(projectState)
@@ -46,7 +46,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
                 projectState.last(),
                 project
             )
-    }
+        }
 
     @Test
     fun `emits_error_when_message_creator_called`() =
@@ -55,13 +55,13 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
 
             val project = ProjectFactory.successfulProject()
             viewModel = PledgedProjectsOverviewViewModel.Factory(
-            environment = environment().toBuilder()
-                .apolloClientV2(object : MockApolloClientV2() {
-                    override fun getProject(slug: String): Observable<Project> {
-                        return Observable.error(Throwable("error"))
-                    }
-                }).build()
-        ).create(PledgedProjectsOverviewViewModel::class.java)
+                environment = environment().toBuilder()
+                    .apolloClientV2(object : MockApolloClientV2() {
+                        override fun getProject(slug: String): Observable<Project> {
+                            return Observable.error(Throwable("error"))
+                        }
+                    }).build()
+            ).create(PledgedProjectsOverviewViewModel::class.java)
 
             backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
                 viewModel.error.toList(errorState)
@@ -72,6 +72,5 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
                 errorState.size,
                 1
             )
-    }
-
+        }
 }

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.features.pledgedprojectsoverview.viewmodel
 
 import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.R
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.services.MockApolloClientV2
 import com.kickstarter.models.Project
@@ -51,7 +52,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
     @Test
     fun `emits_error_when_message_creator_called`() =
         runTest {
-            var snackbarAction: Int? = 1234
+            var snackbarAction = 0
             viewModel = PledgedProjectsOverviewViewModel.Factory(
                 environment = environment().toBuilder()
                     .apolloClientV2(object : MockApolloClientV2() {
@@ -61,13 +62,13 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
                     }).build()
             ).create(PledgedProjectsOverviewViewModel::class.java)
 
-            viewModel.provideSnackbarAction { snackbarAction = it }
+            viewModel.provideSnackbarMessage { snackbarAction = it }
             viewModel.onMessageCreatorClicked("test_project_slug")
 
             // Should equal error string id
             assertEquals(
                 snackbarAction,
-                2131952284
+                R.string.Something_went_wrong_please_try_again
             )
         }
 }

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
@@ -1,0 +1,77 @@
+package com.kickstarter.features.pledgedprojectsoverview.viewmodel
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.mock.services.MockApolloClientV2
+import com.kickstarter.models.Project
+import io.reactivex.Observable
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
+
+    private lateinit var viewModel: PledgedProjectsOverviewViewModel
+
+    @Before
+    fun setUpEnvrionment() {
+        viewModel = PledgedProjectsOverviewViewModel.Factory(environment = environment())
+            .create(PledgedProjectsOverviewViewModel::class.java)
+    }
+
+    @Test
+    fun `emits_project_when_message_creator_called`() =
+        runTest {
+            val projectState = mutableListOf<Project>()
+
+            val project = ProjectFactory.successfulProject()
+            viewModel = PledgedProjectsOverviewViewModel.Factory(
+            environment = environment().toBuilder()
+                .apolloClientV2(object : MockApolloClientV2() {
+                    override fun getProject(slug: String): Observable<Project> {
+                        return Observable.just(project)
+                    }
+                }).build()
+        ).create(PledgedProjectsOverviewViewModel::class.java)
+
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.projectFlow.toList(projectState)
+            }
+            viewModel.onMessageCreatorClicked("test_project_slug")
+
+            assertEquals(
+                projectState.last(),
+                project
+            )
+    }
+
+    @Test
+    fun `emits_error_when_message_creator_called`() =
+        runTest {
+            val errorState = mutableListOf<Unit>()
+
+            val project = ProjectFactory.successfulProject()
+            viewModel = PledgedProjectsOverviewViewModel.Factory(
+            environment = environment().toBuilder()
+                .apolloClientV2(object : MockApolloClientV2() {
+                    override fun getProject(slug: String): Observable<Project> {
+                        return Observable.error(Throwable("error"))
+                    }
+                }).build()
+        ).create(PledgedProjectsOverviewViewModel::class.java)
+
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.error.toList(errorState)
+            }
+            viewModel.onMessageCreatorClicked("test_project_slug")
+
+            assertEquals(
+                errorState.size,
+                1
+            )
+    }
+
+}

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
@@ -64,7 +64,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
             viewModel.provideSnackbarAction { snackbarAction = it }
             viewModel.onMessageCreatorClicked("test_project_slug")
 
-            //Should equal error string id
+            // Should equal error string id
             assertEquals(
                 snackbarAction,
                 2131952284


### PR DESCRIPTION
# 📲 What

Added message creator navigations to the PPO card

# 🤔 Why

PPO work

# 🛠 How

When message creator is tapped, performs a network call to grab the project/backing and passes this on to the message activity. 

# 👀 See


https://github.com/kickstarter/android-oss/assets/19390326/3080ad16-36cb-4b73-9ac2-47cbb7d981e4



# 📋 QA

Tested using mocked data, so you will need to grab the slug of one of your backed projects. in the `PledgedProjectsOverviewViewModel`, replace the ppo card list:
![Screenshot 2024-06-18 at 22 26 41](https://github.com/kickstarter/android-oss/assets/19390326/909fefdd-9ee0-4e41-b771-c6a88a2a3088)
with your slug:
```private val ppoCards = MutableStateFlow<PagingData<PPOCardDataMock>>(PagingData.from(listOf(PPOCardDataMock(projectSlug = "insert slug here"))))```
inserting your own slug
to test errors, leave the slug as an empty string or pass in a random string of characters


# Story 📖

[MBL-1474: Message creator navigation](Trello link)
