### PR TITLE
[MBL-1541] Update viewmodel to always update if the play button is visible on project videos

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
@@ -963,7 +963,6 @@ interface ProjectPageViewModel {
                 .map {
                     it.hasVideo()
                 }
-                .distinctUntilChanged()
                 .subscribe { this.playButtonIsVisible.onNext(it) }
                 .addToDisposable(disposables)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
@@ -365,7 +365,7 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
 
         this.vm.configureWith(Intent().putExtra(IntentKey.PROJECT, project))
 
-        playButtonIsVisible.assertValues(false)
+        playButtonIsVisible.assertValues(false, false)
     }
 
     @Test
@@ -385,7 +385,7 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
 
         this.vm.configureWith(Intent().putExtra(IntentKey.PROJECT, project))
 
-        playButtonIsVisible.assertValues(true)
+        playButtonIsVisible.assertValues(true, true)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Make it so the play button will always be based on the current project

# 🤔 Why

When entering the project page from discovery we do not have the video as part of the apollo return, so the initial project would not have it so the value would update as expected. On search the video is part of the project because we are still using the api client for that call so the value would not update as expected because its value did not change after initialization.

# 🛠 How

remove the distinct call until we can switch this to apollo client

# 📋 QA

Go to a project and confirm its video is working (do this both from discovery and search).  Search was where the issue was, not any individual project.

Ticket mentioned the project Misty Valley on production if you want to test that directly.

# Story 📖

[MBL-1541](https://kickstarter.atlassian.net/browse/MBL-1541)


[MBL-1541]: https://kickstarter.atlassian.net/browse/MBL-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ