### PR TITLE
MBL-1615:  backingId sent to createPaymentIntent as param on the late pledges checkout flow

### DIFF
--- a/app/src/main/graphql/checkout.graphql
+++ b/app/src/main/graphql/checkout.graphql
@@ -45,12 +45,15 @@ mutation CreateCheckout($projectId: ID!, $amount: String!, $rewardIds: [ID!], $l
     checkout{
       id
       paymentUrl
+      backing {
+        id
+      }
     }
   }
 }
 
-mutation CreatePaymentIntent($projectId: ID!, $amount: String!, $paymentIntentContext: StripeIntentContextTypes, $checkoutId: ID!) {
-  createPaymentIntent(input: { projectId: $projectId, amount: $amount, paymentIntentContext: $paymentIntentContext, checkoutId: $checkoutId } ) {
+mutation CreatePaymentIntent($projectId: ID!, $amount: String!, $paymentIntentContext: StripeIntentContextTypes, $checkoutId: ID!, $backingId: ID) {
+  createPaymentIntent(input: { projectId: $projectId, amount: $amount, paymentIntentContext: $paymentIntentContext, checkoutId: $checkoutId, backingId: $backingId } ) {
     clientSecret
   }
 }

--- a/app/src/main/java/com/kickstarter/models/CheckoutPayment.kt
+++ b/app/src/main/java/com/kickstarter/models/CheckoutPayment.kt
@@ -1,3 +1,3 @@
 package com.kickstarter.models
 
-data class CheckoutPayment(val id: Long, val paymentUrl: String?)
+data class CheckoutPayment(val id: Long, val paymentUrl: String?, val backing: Backing? = null)

--- a/app/src/main/java/com/kickstarter/models/CreatePaymentIntentInput.kt
+++ b/app/src/main/java/com/kickstarter/models/CreatePaymentIntentInput.kt
@@ -1,3 +1,3 @@
 package com.kickstarter.models
 
-data class CreatePaymentIntentInput(val project: Project, val amount: String, val checkoutId: String)
+data class CreatePaymentIntentInput(val project: Project, val amount: String, val checkoutId: String, val backing: Backing)

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -106,7 +106,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.launch
-import okhttp3.internal.wait
 import type.CreditCardPaymentType
 
 class ProjectPageActivity :

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -106,6 +106,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.launch
+import okhttp3.internal.wait
 import type.CreditCardPaymentType
 
 class ProjectPageActivity :
@@ -549,7 +550,9 @@ class ProjectPageActivity :
                         if (checkoutPayment.id != 0L) checkoutFlowViewModel.onConfirmDetailsContinueClicked {
                             startLoginToutActivity()
                         }
-                        latePledgeCheckoutViewModel.provideCheckoutId(checkoutPayment.id)
+                        checkoutPayment.backing?.let {
+                            latePledgeCheckoutViewModel.provideCheckoutIdAndBacking(checkoutPayment.id, it)
+                        }
                     }
 
                     confirmDetailsViewModel.provideErrorAction { message ->

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ConfirmDetailsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ConfirmDetailsViewModel.kt
@@ -66,14 +66,14 @@ class ConfirmDetailsViewModel(val environment: Environment) : ViewModel() {
             )
 
     private val mutableCheckoutPayment =
-        MutableStateFlow(CheckoutPayment(id = 0L, paymentUrl = null))
+        MutableStateFlow(CheckoutPayment(id = 0L, paymentUrl = null, backing = null))
     val checkoutPayment: StateFlow<CheckoutPayment>
         get() = mutableCheckoutPayment
             .asStateFlow()
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(),
-                initialValue = CheckoutPayment(id = 0L, paymentUrl = null)
+                initialValue = CheckoutPayment(id = 0L, paymentUrl = null, null)
             )
 
     fun provideProjectData(projectData: ProjectData) {

--- a/app/src/test/java/com/kickstarter/viewmodels/LatePledgeCheckoutViewModelTests.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LatePledgeCheckoutViewModelTests.kt
@@ -323,7 +323,7 @@ class LatePledgeCheckoutViewModelTests : KSRobolectricTestCase() {
             errorActionCount++
         }
 
-        viewModel.provideCheckoutId(100L)
+        viewModel.provideCheckoutIdAndBacking(100L, checkoutPayment.backingId)
 
         viewModel.onPledgeButtonClicked(cardList.first(), ProjectFactory.project(), 100.0)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/LatePledgeCheckoutViewModelTests.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LatePledgeCheckoutViewModelTests.kt
@@ -12,6 +12,7 @@ import com.kickstarter.mock.factories.ShippingRuleFactory
 import com.kickstarter.mock.factories.StoredCardFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClientV2
+import com.kickstarter.models.Backing
 import com.kickstarter.models.CreatePaymentIntentInput
 import com.kickstarter.models.PaymentValidationResponse
 import com.kickstarter.models.Project
@@ -323,7 +324,7 @@ class LatePledgeCheckoutViewModelTests : KSRobolectricTestCase() {
             errorActionCount++
         }
 
-        viewModel.provideCheckoutIdAndBacking(100L, checkoutPayment.backingId)
+        viewModel.provideCheckoutIdAndBacking(100L, Backing.builder().id(101L).build())
 
         viewModel.onPledgeButtonClicked(cardList.first(), ProjectFactory.project(), 100.0)
 


### PR DESCRIPTION
# 📲 What

- Payments has requested for us to add `BackingId` as parameter when calling `createPaymentIntent`
- In order to obtain `BackingId` now `CreateCheckout` mutation queries for the `BackingId` as response

# 🤔 Why

Some background context on why the change is needed.

# 🛠 How

More in-depth discussion of the change or implementation.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

Instructions for anyone to be able to QA this work.

# Story 📖

[Name of Trello Story](Trello link)
