### PR TITLE
MBL-1618: Create alpha screen for pledge redemption

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -238,6 +238,11 @@
             android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
             android:label="@string/app_name" />
         <activity android:name=".ui.activities.ReportProjectActivity" />
+        <activity
+            android:name=".features.pledgeredemption.ui.PledgeRedemptionActivity"
+            android:parentActivityName=".ui.activities.ProjectPageActivity"
+            android:exported="false"
+            android:theme="@style/KSTheme" />
 
         <activity android:name=".ui.activities.DeepLinkActivity"
             android:exported="true">

--- a/app/src/main/java/com/kickstarter/features/pledgeredemption/ui/PledgeRedemptionActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgeredemption/ui/PledgeRedemptionActivity.kt
@@ -1,0 +1,66 @@
+package com.kickstarter.features.pledgeredemption.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import com.kickstarter.features.pledgeredemption.viewmodels.PledgeRedemptionViewModel
+import com.kickstarter.libs.utils.extensions.getEnvironment
+import com.kickstarter.libs.utils.extensions.isDarkModeEnabled
+import com.kickstarter.mock.factories.RewardFactory
+import com.kickstarter.models.Reward
+import com.kickstarter.models.ShippingRule
+import com.kickstarter.ui.activities.compose.projectpage.CheckoutScreen
+import com.kickstarter.ui.compose.designsystem.KickstarterApp
+import com.kickstarter.ui.data.PledgeReason
+
+class PledgeRedemptionActivity : ComponentActivity() {
+    private lateinit var viewModelFactory: PledgeRedemptionViewModel.Factory
+    private val viewModel: PledgeRedemptionViewModel by viewModels { viewModelFactory }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val env = this.getEnvironment()?.let { env ->
+            viewModelFactory = PledgeRedemptionViewModel.Factory(env, bundle = intent.extras)
+            env
+        }
+        viewModel.start()
+
+        setContent {
+            setContent {
+
+                val backing = viewModel.backing
+                val project = viewModel.project
+                val lists = mutableListOf<Reward>()
+                val shippingAmount = backing.shippingAmount().toDouble()
+                val totalAmount = backing.amount()
+                val bonus = backing.bonusAmount()
+
+                backing.reward()?.let { lists.add(it) }
+                backing.addOns()?.map { lists.add(it) }
+
+                val darModeEnabled = this.isDarkModeEnabled(env = requireNotNull(env))
+                KickstarterApp(useDarkTheme = darModeEnabled) {
+                    CheckoutScreen(
+                        rewardsList = lists.map { Pair(it.title() ?: "", it.pledgeAmount().toString()) },
+                        environment = env,
+                        shippingAmount = shippingAmount,
+                        selectedReward = RewardFactory.rewardWithShipping(),
+                        currentShippingRule = ShippingRule.builder().build(),
+                        totalAmount = totalAmount,
+                        totalBonusSupport = bonus,
+                        storedCards = emptyList(),
+                        project = project,
+                        email = "example@example.com",
+                        pledgeReason = PledgeReason.PLEDGE,
+                        rewardsHaveShippables = true,
+                        onPledgeCtaClicked = { },
+                        newPaymentMethodClicked = { },
+                        onDisclaimerItemClicked = {},
+                        onAccountabilityLinkClicked = {}
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/features/pledgeredemption/viewmodels/PledgeRedemptionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgeredemption/viewmodels/PledgeRedemptionViewModel.kt
@@ -1,0 +1,30 @@
+package com.kickstarter.features.pledgeredemption.viewmodels
+
+import android.os.Bundle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.kickstarter.libs.Environment
+import com.kickstarter.models.Backing
+import com.kickstarter.models.Project
+import com.kickstarter.ui.IntentKey
+
+class PledgeRedemptionViewModel(private val environment: Environment, private val bundle: Bundle? = null) : ViewModel() {
+
+    lateinit var backing: Backing
+    lateinit var project: Project
+
+    fun start() {
+        project = (bundle?.getParcelable(IntentKey.PROJECT) as Project?)?.let {
+            it
+        } ?: Project.builder().build()
+
+        backing = project.backing() ?: Backing.builder().build()
+    }
+
+    class Factory(private val environment: Environment, private val bundle: Bundle? = null) :
+        ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return PledgeRedemptionViewModel(environment, bundle = bundle) as T
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/libs/FirebaseAnalyticsClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/FirebaseAnalyticsClient.kt
@@ -5,12 +5,15 @@ import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.kickstarter.libs.featureflag.FeatureFlagClientType
 import com.kickstarter.libs.featureflag.FlagKey
+import com.kickstarter.models.User
 import com.kickstarter.ui.SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE
 
 interface FirebaseAnalyticsClientType {
     fun isEnabled(): Boolean
 
     fun trackEvent(eventName: String, parameters: Bundle)
+
+    fun sendUserId(user: User)
 }
 
 open class FirebaseAnalyticsClient(
@@ -25,6 +28,14 @@ open class FirebaseAnalyticsClient(
         firebaseAnalytics?.let {
             if (isEnabled()) {
                 firebaseAnalytics.logEvent(eventName, parameters)
+            }
+        }
+    }
+
+    override fun sendUserId(user: User) {
+        firebaseAnalytics?.let {
+            if (isEnabled()) {
+                firebaseAnalytics.setUserId(user.id().toString())
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/libs/featureflag/FeatureFlagClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/FeatureFlagClient.kt
@@ -65,7 +65,8 @@ enum class FlagKey(val key: String) {
     ANDROID_OAUTH("android_oauth"),
     ANDROID_ENCRYPT("android_encrypt_token"),
     ANDROID_STRIPE_LINK("android_stripe_link"),
-    ANDROID_PLEDGED_PROJECTS_OVERVIEW("android_pledged_projects_overview")
+    ANDROID_PLEDGED_PROJECTS_OVERVIEW("android_pledged_projects_overview"),
+    ANDROID_PLEDGE_REDEMPTION("android_pledge_redemption")
 }
 
 fun FeatureFlagClient.getFetchInterval(): Long =

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/IntentExt.kt
@@ -2,6 +2,7 @@ package com.kickstarter.libs.utils.extensions
 
 import android.content.Context
 import android.content.Intent
+import com.kickstarter.features.pledgeredemption.ui.PledgeRedemptionActivity
 import com.kickstarter.models.Project
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.CommentsActivity
@@ -41,6 +42,15 @@ fun Intent.getPreLaunchProjectActivity(context: Context, slug: String?, project:
  */
 fun Intent.getPaymentMethodsIntent(context: Context): Intent {
     return this.setClass(context, PaymentMethodsSettingsActivity::class.java)
+}
+
+fun Intent.getPledgeRedemptionIntent(
+    context: Context,
+    project: Project
+): Intent {
+    this.setClass(context, PledgeRedemptionActivity::class.java)
+        .putExtra(IntentKey.PROJECT, project)
+    return this
 }
 
 fun Intent.getRootCommentsActivityIntent(

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -61,6 +61,7 @@ import com.kickstarter.libs.utils.extensions.showLatePledgeFlow
 import com.kickstarter.libs.utils.extensions.toVisibility
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
+import com.kickstarter.models.User
 import com.kickstarter.models.chrome.ChromeTabsHelperActivity
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.activities.compose.projectpage.ProjectPledgeButtonAndFragmentContainer
@@ -80,6 +81,7 @@ import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.ui.extensions.showErrorToast
 import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.ui.extensions.startDisclaimerChromeTab
+import com.kickstarter.ui.extensions.startPledgeRedemption
 import com.kickstarter.ui.extensions.startRootCommentsActivity
 import com.kickstarter.ui.extensions.startUpdatesActivity
 import com.kickstarter.ui.extensions.startVideoActivity
@@ -466,14 +468,20 @@ class ProjectPageActivity :
                 }
             }.addToDisposable(disposables)
 
+        var pBacking: Project? = null
+        var user: User? = null
         viewModel.outputs.showPledgeRedemptionScreen()
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
+                pBacking = it.first
+                user = it.second
                 binding.pledgeRedemptionAlpha.visibility = View.VISIBLE
             }.addToDisposable(disposables)
 
         binding.pledgeRedemptionAlpha.setOnClickListener {
-            // open new PledgeRedemption Screen
+            pBacking?.let {
+                startPledgeRedemption(it)
+            }
         }
 
         binding.backIcon.setOnClickListener {

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -466,6 +466,16 @@ class ProjectPageActivity :
                 }
             }.addToDisposable(disposables)
 
+        viewModel.outputs.showPledgeRedemptionScreen()
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                binding.pledgeRedemptionAlpha.visibility = View.VISIBLE
+            }.addToDisposable(disposables)
+
+        binding.pledgeRedemptionAlpha.setOnClickListener {
+            // open new PledgeRedemption Screen
+        }
+
         binding.backIcon.setOnClickListener {
             if (binding.pledgeContainerLayout.pledgeContainerRoot.visibility == View.GONE) {
                 onBackPressedDispatcher.onBackPressed()

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -22,6 +22,7 @@ import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.UrlUtils
 import com.kickstarter.libs.utils.extensions.getCreatorBioWebViewActivityIntent
+import com.kickstarter.libs.utils.extensions.getPledgeRedemptionIntent
 import com.kickstarter.libs.utils.extensions.getPreLaunchProjectActivity
 import com.kickstarter.libs.utils.extensions.getProjectUpdatesActivityIntent
 import com.kickstarter.libs.utils.extensions.getReportProjectActivityIntent
@@ -130,6 +131,16 @@ fun Activity.showRatingDialogWidget() {
         } else {
             Timber.v("${this.localClassName} : showRatingDialogWidget request: ${request.isSuccessful} ")
         }
+    }
+}
+
+fun Activity.startPledgeRedemption(project: Project) {
+    startActivity(
+        Intent().getPledgeRedemptionIntent(this, project)
+    )
+
+    this.let {
+        TransitionUtils.transition(it, TransitionUtils.slideInFromRight())
     }
 }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
@@ -806,6 +806,8 @@ interface ProjectPageViewModel {
                 Pair(backing, adminUser)
             }
                 .subscribe {
+                    // remove userId tracking when removing feature flag or giving access to all users
+                    this.environment.firebaseAnalyticsClient()?.sendUserId(it.second)
                     this.showPledgeRedemptionScreen.onNext(it)
                 }
                 .addToDisposable(disposables)

--- a/app/src/main/res/layout/activity_project_page.xml
+++ b/app/src/main/res/layout/activity_project_page.xml
@@ -196,4 +196,14 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginBottom="@dimen/reward_fragment_guideline_constraint_end" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/pledge_redemption_alpha"
+        android:visibility="gone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center|right"
+        android:src="@drawable/ic_face"
+        android:contentDescription="@string/A_little_extra_to_help"
+        android:layout_margin="16dp" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
@@ -100,7 +100,7 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
     private val onOpenVideoInFullScreen = TestSubscriber<kotlin.Pair<String, Long>>()
     private val updateVideoCloseSeekPosition = TestSubscriber<Long>()
     private val postCampaignPledgingEnabled = TestSubscriber<Boolean>()
-    private val pledgeRedemptionIsVisible = TestSubscriber<Pair<Backing, User>>()
+    private val pledgeRedemptionIsVisible = TestSubscriber<Pair<Project, User>>()
 
     private val disposables = CompositeDisposable()
 
@@ -2221,7 +2221,6 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
     fun `Test Pledge Redemption button is visible for admin users when the project is backed and feature flag enabled`() {
         val user = UserFactory.user().toBuilder().isAdmin(true).build()
         val project = ProjectFactory.backedProject()
-        val backing = project.backing()
         val currentUserMock = MockCurrentUserV2(user)
         val mockFeatureFlagClient = object : MockFeatureFlagClient() {
             override fun getBoolean(FlagKey: FlagKey): Boolean {
@@ -2239,7 +2238,7 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
 
         pledgeRedemptionIsVisible.assertValueCount(2)
         this.vm.outputs.showPledgeRedemptionScreen().subscribe {
-            assertEquals(it.first, backing)
+            assertEquals(it.first, project)
             assertEquals(it.second, user)
         }.addToDisposable(disposables)
     }


### PR DESCRIPTION
# 📲 What

**User Story**
As an admin I can access the pledge redemption page If I have an active backing

**Technical Notes**

- Create empty activity, load as UI CheckoutScreen with placeholder values as shown in compose preview
- Create VM, it will have backing information. 
- Add floating button on ProjectPageActivity, will be visible only if the user is admin
- Action button will open the new Activity

# 🤔 Why
WIP for pledge redemption, access to this screen from `ProjectPageActivity` will be removed in the future.

# 👀 See

https://github.com/user-attachments/assets/32e0a2c9-7649-4b44-8570-a0506f35146b



| --- | --- |
|  |  |

# 📋 QA
- Log in with your admin user in stagin/internal releases (ff deactivated on PROD, but active on debug/internal), go to any backed project, you will see the floating button on right middle on project page, you will be able to navigate to pledge redemption screen

# Story 📖

[MBL-1618](https://kickstarter.atlassian.net/browse/MBL-1618)
