### PR TITLE
[MBL-1480] Add error snackbar visuals/a way to call them for PPO

### DIFF
--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -2,7 +2,6 @@ package com.kickstarter.features.pledgedprojectsoverview.ui
 
 import android.app.Activity
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
@@ -10,7 +9,6 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.LaunchedEffect
@@ -67,7 +65,6 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
 
                 val ppoUIState by viewModel.ppoUIState.collectAsStateWithLifecycle()
 
-                val darkModeEnabled = this.isDarkModeEnabled(env = env)
                 val lazyListState = rememberLazyListState()
                 val snackbarHostState = remember { SnackbarHostState() }
                 val totalAlerts = viewModel.totalAlertsState.collectAsStateWithLifecycle().value
@@ -79,17 +76,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                 val showEmptyState = ppoCardPagingSource.loadState.refresh is LoadState.NotLoading && ppoCardPagingSource.itemCount == 0
 
                 KickstarterApp(
-                    useDarkTheme =
-                    if (darkModeEnabled) {
-                        when (theme) {
-                            AppThemes.MATCH_SYSTEM.ordinal -> isSystemInDarkTheme()
-                            AppThemes.DARK.ordinal -> true
-                            AppThemes.LIGHT.ordinal -> false
-                            else -> false
-                        }
-                    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        isSystemInDarkTheme()
-                    } else false
+                    useDarkTheme = isDarkModeEnabled(env = env)
                 ) {
                     PledgedProjectsOverviewScreen(
                         modifier = Modifier,
@@ -119,9 +106,9 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                         }
                 }
 
-                viewModel.provideSnackbarMessage {
+                viewModel.provideSnackbarMessage { stringId, type ->
                     lifecycleScope.launch {
-                        snackbarHostState.showSnackbar(getString(it))
+                        snackbarHostState.showSnackbar(message = getString(stringId), actionLabel = type)
                     }
                 }
 

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
@@ -45,7 +45,10 @@ import com.kickstarter.features.pledgedprojectsoverview.data.PPOCard
 import com.kickstarter.features.pledgedprojectsoverview.data.PPOCardFactory
 import com.kickstarter.ui.compose.designsystem.KSAlertDialog
 import com.kickstarter.ui.compose.designsystem.KSCircularProgressIndicator
+import com.kickstarter.ui.compose.designsystem.KSErrorSnackbar
+import com.kickstarter.ui.compose.designsystem.KSHeadsupSnackbar
 import com.kickstarter.ui.compose.designsystem.KSPrimaryGreenButton
+import com.kickstarter.ui.compose.designsystem.KSSnackbarTypes
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
@@ -172,7 +175,16 @@ fun PledgedProjectsOverviewScreen(
         Scaffold(
             snackbarHost = {
                 SnackbarHost(
-                    hostState = errorSnackBarHostState
+                    hostState = errorSnackBarHostState,
+                    snackbar = { data ->
+                        // Action label is typically for the action on a snackbar, but we can
+                        // leverage it and show different visuals depending on what we pass in
+                        if (data.actionLabel == KSSnackbarTypes.KS_ERROR.name) {
+                            KSErrorSnackbar(text = data.message)
+                        } else {
+                            KSHeadsupSnackbar(text = data.message)
+                        }
+                    }
                 )
             },
             modifier = modifier,

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSAlerts.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSAlerts.kt
@@ -47,13 +47,19 @@ fun SnackbarsPreview() {
     }
 }
 
+enum class KSSnackbarTypes {
+    KS_ERROR,
+    KS_HEADS_UP,
+    KS_SUCCESS
+}
+
 @Composable
 fun KSErrorSnackbar(
     text: String,
     padding: PaddingValues = PaddingValues(dimensions.none)
 ) {
     Snackbar(
-        backgroundColor = colors.kds_alert,
+        backgroundColor = colors.backgroundDangerBold,
         content = {
             KSErrorRoundedText(text = text, padding = padding)
         }
@@ -66,7 +72,7 @@ fun KSHeadsupSnackbar(
     padding: PaddingValues = PaddingValues(dimensions.none)
 ) {
     Snackbar(
-        backgroundColor = colors.kds_support_700,
+        backgroundColor = colors.backgroundActionPressed,
         content = {
             KSHeadsUpRoundedText(text = text, padding = padding)
         }
@@ -79,7 +85,7 @@ fun KSSuccessSnackbar(
     padding: PaddingValues = PaddingValues(dimensions.none)
 ) {
     Snackbar(
-        backgroundColor = colors.kds_create_300,
+        backgroundColor = colors.backgroundAccentGreenSubtle,
         content = {
             KSSuccessRoundedText(text = text, padding = padding)
         }
@@ -109,8 +115,8 @@ fun KSErrorRoundedText(
     padding: PaddingValues = PaddingValues(dimensions.paddingMedium)
 ) {
     KSRoundedPaddedText(
-        background = colors.kds_alert,
-        textColor = colors.kds_white,
+        background = colors.backgroundDangerBold,
+        textColor = colors.textInversePrimary,
         text = text,
         padding = padding
     )
@@ -122,8 +128,8 @@ fun KSHeadsUpRoundedText(
     padding: PaddingValues = PaddingValues(dimensions.paddingMedium)
 ) {
     KSRoundedPaddedText(
-        background = colors.kds_support_700,
-        textColor = colors.kds_white,
+        background = colors.backgroundActionPressed,
+        textColor = colors.textInversePrimary,
         text = text,
         padding = padding
     )
@@ -135,8 +141,8 @@ fun KSSuccessRoundedText(
     padding: PaddingValues = PaddingValues(dimensions.paddingMedium)
 ) {
     KSRoundedPaddedText(
-        background = colors.kds_create_300,
-        textColor = colors.kds_support_700,
+        background = colors.backgroundAccentGreenSubtle,
+        textColor = colors.textPrimary,
         text = text,
         padding = padding
     )

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
@@ -71,7 +71,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
                     }).build()
             ).create(PledgedProjectsOverviewViewModel::class.java)
 
-            viewModel.provideSnackbarMessage { snackbarAction = it }
+            viewModel.provideSnackbarMessage { message, _ -> snackbarAction = message  }
             viewModel.onMessageCreatorClicked("test_project_slug")
 
             // Should equal error string id
@@ -85,7 +85,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
     fun `emits snackbar when confirms address`() =
         runTest {
             var snackbarAction = 0
-            viewModel.provideSnackbarMessage { snackbarAction = it }
+            viewModel.provideSnackbarMessage { message, _ -> snackbarAction = message  }
             viewModel.showSnackbarAndRefreshCardsList()
 
             // Should equal address confirmed string id

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
@@ -71,7 +71,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
                     }).build()
             ).create(PledgedProjectsOverviewViewModel::class.java)
 
-            viewModel.provideSnackbarMessage { message, _ -> snackbarAction = message  }
+            viewModel.provideSnackbarMessage { message, _ -> snackbarAction = message }
             viewModel.onMessageCreatorClicked("test_project_slug")
 
             // Should equal error string id
@@ -85,7 +85,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
     fun `emits snackbar when confirms address`() =
         runTest {
             var snackbarAction = 0
-            viewModel.provideSnackbarMessage { message, _ -> snackbarAction = message  }
+            viewModel.provideSnackbarMessage { message, _ -> snackbarAction = message }
             viewModel.showSnackbarAndRefreshCardsList()
 
             // Should equal address confirmed string id


### PR DESCRIPTION
# 📲 What

Added the visuals and a way to call the visuals for an error message for PPO

I also updated some of the colors for these to match the newer standards

# 🤔 Why

There can be various times we need to display an error to the user

# 🛠 How

In this case I leverage that we can intervep the snackbarhost data and use the actionLabel in this case to change which visuals are shown

# 👀 See

Alternating between an error and heads up message type
https://github.com/user-attachments/assets/39a03479-610b-4aee-afbe-0a0f9f7ff065


# 📋 QA

You will need to make a way to trigger these calls (i made the back action invoke a method in the viewmodel to display an error and normal message alternatingly)

# Story 📖

[MBL-1480](https://kickstarter.atlassian.net/browse/MBL-1480)


[MBL-1480]: https://kickstarter.atlassian.net/browse/MBL-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ