### PR TITLE
[MBL-1478][MBL-1482] Add Primary Action button actions for Take Survey and Confirm Address

### DIFF
--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
@@ -9,9 +9,12 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.kickstarter.databinding.ActivityBackingDetailsBinding
 import com.kickstarter.libs.utils.extensions.getEnvironment
+import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.extensions.finishWithAnimation
 import com.kickstarter.viewmodels.BackingDetailsViewModel
 import kotlinx.coroutines.launch
+
+const val REFRESH = "refresh"
 
 class BackingDetailsActivity : AppCompatActivity() {
 
@@ -39,7 +42,7 @@ class BackingDetailsActivity : AppCompatActivity() {
         }
 
         this.onBackPressedDispatcher.addCallback {
-            finishWithAnimation()
+            finishWithAnimation(withResult = REFRESH, intentKey = IntentKey.REFRESH_PPO_LIST)
         }
     }
 }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -41,16 +41,21 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
     private lateinit var viewModelFactory: PledgedProjectsOverviewViewModel.Factory
     private val viewModel: PledgedProjectsOverviewViewModel by viewModels { viewModelFactory }
     private var theme = AppThemes.MATCH_SYSTEM.ordinal
-    private var startForResult = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-        if (result.resultCode == Activity.RESULT_OK) {
-            val data = result.data?.getBooleanExtra(IntentKey.FIX_PAYMENT_SUCCESS, false)
-            data?.let {
-                if (it.isTrue()) {
+    private var startForResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                val data = result.data?.getBooleanExtra(IntentKey.FIX_PAYMENT_SUCCESS, false)
+                data?.let {
+                    if (it.isTrue()) {
+                        viewModel.getPledgedProjects()
+                    }
+                }
+                val refresh = result.data?.getStringExtra(IntentKey.REFRESH_PPO_LIST)
+                if (!refresh.isNullOrEmpty()) {
                     viewModel.getPledgedProjects()
                 }
             }
         }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -71,9 +76,11 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
 
                 val ppoCardPagingSource = viewModel.ppoCardsState.collectAsLazyPagingItems()
 
-                val isLoading = ppoUIState.isLoading || ppoCardPagingSource.loadState.append is LoadState.Loading || ppoCardPagingSource.loadState.refresh is LoadState.Loading
+                val isLoading =
+                    ppoUIState.isLoading || ppoCardPagingSource.loadState.append is LoadState.Loading || ppoCardPagingSource.loadState.refresh is LoadState.Loading
                 val isErrored = ppoUIState.isErrored || ppoCardPagingSource.loadState.hasError
-                val showEmptyState = ppoCardPagingSource.loadState.refresh is LoadState.NotLoading && ppoCardPagingSource.itemCount == 0
+                val showEmptyState =
+                    ppoCardPagingSource.loadState.refresh is LoadState.NotLoading && ppoCardPagingSource.itemCount == 0
 
                 KickstarterApp(
                     useDarkTheme = isDarkModeEnabled(env = env)
@@ -86,29 +93,74 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                         ppoCards = ppoCardPagingSource,
                         totalAlerts = totalAlerts,
                         onAddressConfirmed = { viewModel.showSnackbarAndRefreshCardsList() },
-                        onProjectPledgeSummaryClick = { url -> openBackingDetailsWebView(url) },
-                        onSendMessageClick = { projectName -> viewModel.onMessageCreatorClicked(projectName) },
+                        onProjectPledgeSummaryClick = { url ->
+                            openBackingDetailsWebView(
+                                url = url,
+                                resultLauncher = null
+                            )
+                        },
+                        onSendMessageClick = { projectName ->
+                            viewModel.onMessageCreatorClicked(
+                                projectName
+                            )
+                        },
                         isLoading = isLoading,
                         isErrored = isErrored,
                         showEmptyState = showEmptyState,
                         onSeeAllBackedProjectsClick = { startProfileActivity() },
                         pullRefreshCallback = {
-                            // TODO call viewmodel.getPledgedProjects() here
+                            viewModel.getPledgedProjects()
                         },
-                        onFixPaymentClick = { projectSlug -> openManagePledge(projectSlug, resultLauncher = startForResult) }
+                        onPrimaryActionButtonClicked = { PPOCard ->
+                            when (PPOCard.viewType()) {
+                                PPOCardViewType.FIX_PAYMENT -> {
+                                    openManagePledge(
+                                        PPOCard.projectSlug ?: "",
+                                        resultLauncher = startForResult
+                                    )
+                                }
+
+                                PPOCardViewType.TAKE_SURVEY -> {
+                                    openBackingDetailsWebView(
+                                        url = PPOCard.backingDetailsUrl ?: "",
+                                        resultLauncher = startForResult
+                                    )
+                                }
+
+                                PPOCardViewType.CONFIRM_ADDRESS -> {
+                                    openBackingDetailsWebView(
+                                        url = PPOCard.backingDetailsUrl ?: "",
+                                        resultLauncher = startForResult
+                                    )
+                                }
+
+                                else -> {
+
+                                }
+                            }
+                        },
+                        onSecondaryActionButtonClicked = { PPOCard ->
+
+                        },
                     )
                 }
 
                 LaunchedEffect(Unit) {
                     viewModel.projectFlow
                         .collect {
-                            startCreatorMessageActivity(project = it, previousScreen = MessagePreviousScreenType.PLEDGED_PROJECTS_OVERVIEW)
+                            startCreatorMessageActivity(
+                                project = it,
+                                previousScreen = MessagePreviousScreenType.PLEDGED_PROJECTS_OVERVIEW
+                            )
                         }
                 }
 
                 viewModel.provideSnackbarMessage { stringId, type ->
                     lifecycleScope.launch {
-                        snackbarHostState.showSnackbar(message = getString(stringId), actionLabel = type)
+                        snackbarHostState.showSnackbar(
+                            message = getString(stringId),
+                            actionLabel = type
+                        )
                     }
                 }
 
@@ -122,13 +174,24 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
         }
     }
 
-    private fun openBackingDetailsWebView(url: String) {
-        val intent = Intent(this, BackingDetailsActivity::class.java)
-            .putExtra(IntentKey.URL, url)
-        startActivity(intent)
+    private fun openBackingDetailsWebView(
+        url: String,
+        resultLauncher: ActivityResultLauncher<Intent>?
+    ) {
+        resultLauncher?.launch(
+            Intent(this, BackingDetailsActivity::class.java)
+                .putExtra(IntentKey.URL, url)
+        ) ?: {
+            val intent = Intent(this, BackingDetailsActivity::class.java)
+                .putExtra(IntentKey.URL, url)
+            startActivity(intent)
+        }
+        this.let {
+            TransitionUtils.transition(it, TransitionUtils.slideInFromRight())
+        }
     }
 
-    fun startProfileActivity() {
+    private fun startProfileActivity() {
         startActivity(
             Intent(this, ProfileActivity::class.java)
         )
@@ -137,7 +200,10 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
         }
     }
 
-    private fun openManagePledge(projectSlug: String, resultLauncher: ActivityResultLauncher<Intent>) {
+    private fun openManagePledge(
+        projectSlug: String,
+        resultLauncher: ActivityResultLauncher<Intent>
+    ) {
         resultLauncher.launch(
             Intent().getProjectIntent(this)
                 .putExtra(IntentKey.PROJECT_PARAM, projectSlug)

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -135,12 +135,10 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                                 }
 
                                 else -> {
-
                                 }
                             }
                         },
                         onSecondaryActionButtonClicked = { PPOCard ->
-
                         },
                     )
                 }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
@@ -75,11 +75,12 @@ private fun PledgedProjectsOverviewScreenPreview() {
                 totalAlerts = 10,
                 onBackPressed = {},
                 onAddressConfirmed = {},
+                onPrimaryActionButtonClicked = {},
+                onSecondaryActionButtonClicked = {},
                 onProjectPledgeSummaryClick = {},
                 onSendMessageClick = {},
                 onSeeAllBackedProjectsClick = {},
                 errorSnackBarHostState = SnackbarHostState(),
-                onFixPaymentClick = {}
             )
         }
     }
@@ -104,12 +105,13 @@ private fun PledgedProjectsOverviewScreenErrorPreview() {
                 totalAlerts = 10,
                 onBackPressed = {},
                 onAddressConfirmed = {},
+                onPrimaryActionButtonClicked = {},
+                onSecondaryActionButtonClicked = {},
                 onProjectPledgeSummaryClick = {},
                 onSendMessageClick = {},
                 onSeeAllBackedProjectsClick = {},
                 isErrored = true,
                 errorSnackBarHostState = SnackbarHostState(),
-                onFixPaymentClick = {}
             )
         }
     }
@@ -131,10 +133,11 @@ private fun PledgedProjectsOverviewScreenEmptyPreview() {
                 totalAlerts = 0,
                 onBackPressed = {},
                 onAddressConfirmed = {},
+                onPrimaryActionButtonClicked = {},
+                onSecondaryActionButtonClicked = {},
                 onProjectPledgeSummaryClick = {},
                 onSendMessageClick = {},
                 errorSnackBarHostState = SnackbarHostState(),
-                onFixPaymentClick = {},
                 onSeeAllBackedProjectsClick = {},
             )
         }
@@ -154,11 +157,12 @@ fun PledgedProjectsOverviewScreen(
     onProjectPledgeSummaryClick: (backingDetailsUrl: String) -> Unit,
     onSendMessageClick: (projectName: String) -> Unit,
     onSeeAllBackedProjectsClick: () -> Unit,
+    onPrimaryActionButtonClicked: (PPOCard) -> Unit,
+    onSecondaryActionButtonClicked: (PPOCard) -> Unit,
     isLoading: Boolean = false,
     isErrored: Boolean = false,
     showEmptyState: Boolean = false,
     pullRefreshCallback: () -> Unit = {},
-    onFixPaymentClick: (projectSlug: String) -> Unit,
 ) {
     val openConfirmAddressAlertDialog = remember { mutableStateOf(false) }
     var confirmedAddress by remember { mutableStateOf("") } // TODO: This is either the original shipping address or the user-edited address
@@ -244,12 +248,7 @@ fun PledgedProjectsOverviewScreen(
                                 shippingAddress = it.address() ?: "", // TODO replace with formatted address from PPO response
                                 showBadge = it.showBadge(),
                                 onActionButtonClicked = {
-                                    when (it.viewType()) {
-                                        PPOCardViewType.FIX_PAYMENT -> {
-                                            onFixPaymentClick(it.projectSlug() ?: "")
-                                        }
-                                        else -> {}
-                                    }
+                                    onPrimaryActionButtonClicked(it)
                                 },
                                 onSecondaryActionButtonClicked = {
                                     when (it.viewType()) {
@@ -257,7 +256,9 @@ fun PledgedProjectsOverviewScreen(
                                             confirmedAddress = it.address() ?: ""
                                             openConfirmAddressAlertDialog.value = true
                                         }
-                                        else -> {}
+                                        else -> {
+                                            onSecondaryActionButtonClicked(it)
+                                        }
                                     }
                                 },
                                 timeNumberForAction = it.timeNumberForAction()

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -1724,6 +1724,10 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
                     }
 
                     override fun onResponse(response: Response<PledgedProjectsOverviewQuery.Data>) {
+                        if (response.hasErrors()) {
+                            ps.onError(Exception(response.errors?.first()?.message ?: ""))
+                        }
+
                         response.data?.let { data ->
                             Observable.just(data.pledgeProjectsOverview())
                                 .filter { it.pledges() != null }

--- a/app/src/main/java/com/kickstarter/ui/IntentKey.kt
+++ b/app/src/main/java/com/kickstarter/ui/IntentKey.kt
@@ -56,4 +56,5 @@ object IntentKey {
     const val PREVIOUS_SCREEN = "com.kickstarter.kickstarter.previous_screen"
     const val OAUTH_REDIRECT_URL = "com.kickstarter.kickstarter.oauth_redirect_url"
     const val FIX_PAYMENT_SUCCESS = "com.kickstarter.kickstarter.fix_payment_success"
+    const val REFRESH_PPO_LIST = "com.kickstarter.kickstarter.refresh_ppo_list"
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/ReportProjectActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ReportProjectActivity.kt
@@ -19,6 +19,7 @@ import com.kickstarter.R
 import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.utils.ApplicationUtils
 import com.kickstarter.libs.utils.extensions.getEnvironment
+import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.SharedPreferenceKey
 import com.kickstarter.ui.activities.compose.FormularyScreen
 import com.kickstarter.ui.activities.compose.ReportProjectCategoryScreen
@@ -102,7 +103,7 @@ class ReportProjectActivity : ComponentActivity() {
                                 outputs = viewModel.outputs,
                                 inputs = viewModel.inputs,
                                 callback = {
-                                    finishWithAnimation(finishResult)
+                                    finishWithAnimation(finishResult, IntentKey.FLAGGINGKIND)
                                 }
                             )
                         }

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -231,10 +231,12 @@ fun Activity.startProjectUpdatesActivity(projectAndData: ProjectData) {
     overridePendingTransition(R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
 }
 
-fun Activity.finishWithAnimation(withResult: String? = null) {
-    withResult?.let {
-        val intent = Intent().putExtra(IntentKey.FLAGGINGKIND, withResult)
-        setResult(Activity.RESULT_OK, intent)
+fun Activity.finishWithAnimation(withResult: String? = null, intentKey: String? = null) {
+    intentKey?.let { key ->
+        withResult?.let { result ->
+            val intent = Intent().putExtra(key, result)
+            setResult(Activity.RESULT_OK, intent)
+        }
     }
     finish()
     TransitionUtils.transition(this, TransitionUtils.slideInFromLeft())

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreenTest.kt
@@ -10,7 +10,6 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.features.pledgedprojectsoverview.data.PPOCardFactory
 import com.kickstarter.ui.compose.designsystem.KSTheme
-import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.Test
 

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.features.pledgedprojectsoverview.data.PPOCardFactory
 import com.kickstarter.ui.compose.designsystem.KSTheme
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.Test
 
@@ -38,7 +39,8 @@ PledgedProjectsOverviewScreenTest : KSRobolectricTestCase() {
                     onAddressConfirmed = {},
                     onProjectPledgeSummaryClick = {},
                     onSeeAllBackedProjectsClick = {},
-                    onFixPaymentClick = {}
+                    onPrimaryActionButtonClicked = {},
+                    onSecondaryActionButtonClicked = {}
                 )
             }
         }


### PR DESCRIPTION
# 📲 What

Added the primary action button actions for take survey and confirm address PPO cards
Both should open the webview and should refresh when you leave sad webview to return to the PPO Page

# 🛠 How

Adjusted some code to make all Primary Button Actions done on the activity level}
Adjusted the result launcher and finish code to allow the PPO Activity to know to refresh

# 👀 See

https://github.com/user-attachments/assets/d8c55425-fa61-4183-9cf5-52474562741c


# 📋 QA

You should be able to click the "Take Survey" or "Edit" (Address) buttons to be taken to the Webview.  From there whether or not you made any changes when you leave the webview it should refresh the PPO list and either remove cards if the action was successful or display them still if action is still needed.

# Story 📖

[MBL-1478](https://kickstarter.atlassian.net/browse/MBL-1478)
[MBL-1482](https://kickstarter.atlassian.net/browse/MBL-1482)


[MBL-1478]: https://kickstarter.atlassian.net/browse/MBL-1478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MBL-1482]: https://kickstarter.atlassian.net/browse/MBL-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ