### PR TITLE
[MBL-1650] Fix crashes with large WEBP images

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.ui.extensions
 
 import android.content.Context
+import android.content.res.Resources
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
@@ -11,6 +12,7 @@ import com.bumptech.glide.integration.webp.decoder.WebpDrawable
 import com.bumptech.glide.integration.webp.decoder.WebpDrawableTransformation
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.RequestOptions
@@ -133,6 +135,8 @@ fun ImageView.loadWebp(url: String?, context: Context) {
             val roundedCorners = RoundedCorners(1)
             Glide.with(this)
                 .load(it)
+                .downsample(DownsampleStrategy.AT_LEAST)
+                .override(Resources.getSystem().displayMetrics.widthPixels, Resources.getSystem().displayMetrics.heightPixels)
                 .optionalTransform(roundedCorners)
                 .optionalTransform(WebpDrawable::class.java, WebpDrawableTransformation(roundedCorners))
                 .diskCacheStrategy(DiskCacheStrategy.AUTOMATIC)
@@ -144,6 +148,7 @@ fun ImageView.loadWebp(url: String?, context: Context) {
         }
     }
 }
+
 fun ImageView.loadGifImage(url: String?, context: Context) {
     url?.let {
         if (context.applicationContext.isKSApplication()) {

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -156,6 +156,8 @@ fun ImageView.loadGifImage(url: String?, context: Context) {
                 Glide.with(context)
                     .asGif()
                     .load(it)
+                    .downsample(DownsampleStrategy.AT_LEAST)
+                    .override(Resources.getSystem().displayMetrics.widthPixels, Resources.getSystem().displayMetrics.heightPixels)
                     .diskCacheStrategy(DiskCacheStrategy.AUTOMATIC)
                     .into(this)
             } catch (e: Exception) {

--- a/app/src/main/java/com/kickstarter/ui/views/ImageWithCaptionView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/ImageWithCaptionView.kt
@@ -50,11 +50,13 @@ class ImageWithCaptionView @JvmOverloads constructor(
                     binding.imageView.visibility = VISIBLE
                     binding.composeViewImage.visibility = GONE
                 }
+
                 src.isGif() -> {
                     binding.imageView.visibility = VISIBLE
                     binding.imageView.loadGifImage(src, context)
                     binding.composeViewImage.visibility = GONE
                 }
+
                 else -> {
                     binding.composeViewImage.visibility = VISIBLE
                     binding.imageView.visibility = GONE


### PR DESCRIPTION
# 📲 What

Downsample images based on screen resolution (at least) so images cant cache too much space

# 🤔 Why

Projects with primarily webp were causing crashes in the app

# 🛠 How

Added a size override and downsampling strategy for glide for WEBP

# 👀 See

Project on prod and staging to test with: Dogs with Jobs

# 📋 QA

Go to the Dogs with Jobs project and make sure all images load and look good

# Story 📖

[MBL-1650](https://kickstarter.atlassian.net/browse/MBL-1650)


[MBL-1650]: https://kickstarter.atlassian.net/browse/MBL-1650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ