### PR TITLE
[No Ticket] Update review library from play:core to play:review-ktx library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -220,7 +220,7 @@ dependencies {
     implementation("androidx.core:core-splashscreen:1.0.1")
     implementation 'com.apollographql.apollo:apollo-runtime:2.5.14'
     implementation 'com.facebook.android:facebook-android-sdk:16.0.0'
-    implementation 'com.google.android.play:core-ktx:1.8.1'
+    implementation("com.google.android.play:review-ktx:2.0.1")
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation "com.google.android.exoplayer:exoplayer:2.17.1"
     implementation 'com.google.android.flexbox:flexbox:3.0.0'


### PR DESCRIPTION
# 📲 What

Updating our use of the play:core library for reviews to the more dedicated play:review-ktx library.

# 🤔 Why

This library is not going to be allowed as its not compatible for android 14+ which all libraries must be by end of august

![Screenshot_20240731-153321](https://github.com/user-attachments/assets/bddb6bb2-3261-4796-b5d0-d0526e36ba87)


# 🛠 How

A simnple library swap, no code updates needed (its backwards compatible)

# 📋 QA

Make sure that the review prompt can still show up and works correctly

