### PR TITLE
[BugFix] Add ui thread call and some null safety to avoid profile crash

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProfileActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProfileActivity.kt
@@ -111,7 +111,9 @@ class ProfileActivity : ComponentActivity() {
         this.viewModel.outputs.projectList()
             .compose(observeForUIV2())
             .subscribe {
-                this.loadProjects(it)
+                runOnUiThread {
+                    this.loadProjects(it)
+                }
             }
             .addToDisposable(disposables)
 

--- a/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ProfileViewModel.kt
@@ -10,6 +10,7 @@ import com.kickstarter.libs.utils.EventContextValues
 import com.kickstarter.libs.utils.NumberUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.isNonZero
+import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.libs.utils.extensions.isZero
 import com.kickstarter.models.Project
 import com.kickstarter.services.DiscoveryParams
@@ -136,7 +137,8 @@ interface ProfileViewModel {
                 .build()
 
             paginator.isFetching
-                .subscribe(this.isFetchingProjects)
+                .subscribe { this.isFetchingProjects.onNext(it) }
+                .addToDisposable(disposables)
 
             val loggedInUser = this.currentUser.loggedInUser()
 
@@ -166,7 +168,7 @@ interface ProfileViewModel {
             ) { a, b -> Pair.create(a, b) }
                 .map { p -> p.first || p.second }
 
-            this.projectList = paginator.paginatedData()
+            this.projectList = paginator.paginatedData().filter { it.isNotNull() }
             this.resumeDiscoveryActivity = this.exploreProjectsButtonClicked
 
             this.startMessageThreadsActivity = this.messagesButtonClicked


### PR DESCRIPTION
# 📲 What

When entering the profile with no projects backed it was possible for the layout manager to be assigned outside of the ui thread, so wrapped teh call around the adapter with a runOnUiThread call.

# 🤔 Why

Users were crashing on this page and in testing this removed the crashes

# 📋 QA

-Create a new profile/log into one with no backed projects
-go to the profile page
-confirm no crashes
-repeat
