### PR TITLE
MBL-1576: Filter rewards by location

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -300,6 +300,9 @@ fragment reward on Reward {
     convertedAmount{
         ... amount
     }
+    shippingRules {
+        ... shippingRule
+    }
     shippingPreference
     remainingQuantity
     limit

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ConfigExtension.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ConfigExtension.kt
@@ -5,6 +5,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.kickstarter.libs.Config
 import com.kickstarter.libs.preferences.StringPreferenceType
+import com.kickstarter.models.Location
 import com.kickstarter.models.ShippingRule
 import org.json.JSONArray
 
@@ -102,6 +103,8 @@ fun Config.setUserFeatureFlagsPrefWithFeatureFlag(
  * if none matches return the first one.
  * Config countryCode is based on IP location,
  * example: if your network is within Canada, it will return Canada
+ * example: if your network is within Canada, but the given shipping Rules does not include
+ * Canada, it will return the first rule given in tha shipping rules list.
  */
 fun Config.getDefaultLocationFrom(shippingRules: List<ShippingRule>): ShippingRule {
     return if (shippingRules.isNotEmpty()) {
@@ -110,4 +113,14 @@ fun Config.getDefaultLocationFrom(shippingRules: List<ShippingRule>): ShippingRu
     } else {
         ShippingRule.builder().build()
     }
+//    val location = Location.builder()
+//        .id(23424814)
+//        .country("FK")
+//        .displayableName("Falkland Islands")
+//        .name("Falkland Islands")
+//        .build()
+//    return ShippingRule.builder()
+//        .id(23424814)
+//        .location(location)
+//        .build()
 }

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ConfigExtension.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ConfigExtension.kt
@@ -5,7 +5,6 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.kickstarter.libs.Config
 import com.kickstarter.libs.preferences.StringPreferenceType
-import com.kickstarter.models.Location
 import com.kickstarter.models.ShippingRule
 import org.json.JSONArray
 

--- a/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
@@ -158,8 +158,14 @@ fun rewardTransformer(
     val limit = if (isAddOn) chooseLimit(rewardGr.limit(), rewardGr.limitPerBacker())
     else rewardGr.limit()
 
-    val shippingRules = shippingRulesExpanded.map {
-        shippingRuleTransformer(it)
+    val shippingRules = if (shippingRulesExpanded.isNotEmpty()) {
+        shippingRulesExpanded.map {
+            shippingRuleTransformer(it)
+        }
+    } else {
+        rewardGr.shippingRules().map {
+            shippingRuleTransformer(it.fragments().shippingRule())
+        }
     }
 
     val localReceiptLocation = locationTransformer(rewardGr.localReceiptLocation()?.fragments()?.location())

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -614,8 +614,7 @@ class ProjectPageActivity :
                             checkoutFlowViewModel.onBackPressed(pagerState.currentPage)
                         },
                         pagerState = pagerState,
-                        isLoading = addOnsIsLoading || checkoutLoading,
-                        isRewardsLoading = rewardLoading,
+                        isLoading = addOnsIsLoading || checkoutLoading || rewardLoading,
                         onAddOnsContinueClicked = {
                             // - if user not logged at this point, start login Flow, and provide after login completed callback
                             checkoutFlowViewModel.onContinueClicked(

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -518,7 +518,8 @@ class ProjectPageActivity :
 
                     val projectData = rewardSelectionUIState.project
                     val indexOfBackedReward = rewardSelectionUIState.initialRewardIndex
-                    val rewardsList = rewardSelectionUIState.rewardList
+                    val rewardsList = shippingUIState.filteredRw
+                    val rewardLoading = shippingUIState.loading
                     val selectedReward = rewardSelectionUIState.selectedReward
                     val currentUserShippingRule = shippingUIState.selectedShippingRule
                     val shippingRules = shippingUIState.shippingRules
@@ -613,7 +614,8 @@ class ProjectPageActivity :
                             checkoutFlowViewModel.onBackPressed(pagerState.currentPage)
                         },
                         pagerState = pagerState,
-                        isLoading = addOnsIsLoading || checkoutLoading, // || confirmDetailsIsLoading
+                        isLoading = addOnsIsLoading || checkoutLoading,
+                        isRewardsLoading = rewardLoading,
                         onAddOnsContinueClicked = {
                             // - if user not logged at this point, start login Flow, and provide after login completed callback
                             checkoutFlowViewModel.onContinueClicked(

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ProjectPledgeButtonAndFragmentContainer.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ProjectPledgeButtonAndFragmentContainer.kt
@@ -81,7 +81,6 @@ private fun ProjectPledgeButtonAndContainerPreview() {
                 }
             },
             isLoading = false,
-            isRewardsLoading = false,
             pagerState = pagerState,
             onAddOnsContinueClicked = {
                 coroutineScope.launch {
@@ -124,7 +123,6 @@ fun ProjectPledgeButtonAndFragmentContainer(
     onBackClicked: () -> Unit,
     pagerState: PagerState,
     isLoading: Boolean,
-    isRewardsLoading: Boolean,
     onAddOnsContinueClicked: () -> Unit,
     shippingRules: List<ShippingRule> = listOf(),
     currentShippingRule: ShippingRule,
@@ -242,7 +240,7 @@ fun ProjectPledgeButtonAndFragmentContainer(
                                         rewards = rewardsList,
                                         project = project,
                                         onRewardSelected = onRewardSelected,
-                                        isLoading = isRewardsLoading,
+                                        isLoading = isLoading,
                                         countryList = shippingRules,
                                         currentShippingRule = currentShippingRule,
                                         onShippingRuleSelected = onShippingRuleSelected,

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ProjectPledgeButtonAndFragmentContainer.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ProjectPledgeButtonAndFragmentContainer.kt
@@ -81,6 +81,7 @@ private fun ProjectPledgeButtonAndContainerPreview() {
                 }
             },
             isLoading = false,
+            isRewardsLoading = false,
             pagerState = pagerState,
             onAddOnsContinueClicked = {
                 coroutineScope.launch {
@@ -123,6 +124,7 @@ fun ProjectPledgeButtonAndFragmentContainer(
     onBackClicked: () -> Unit,
     pagerState: PagerState,
     isLoading: Boolean,
+    isRewardsLoading: Boolean,
     onAddOnsContinueClicked: () -> Unit,
     shippingRules: List<ShippingRule> = listOf(),
     currentShippingRule: ShippingRule,
@@ -240,7 +242,7 @@ fun ProjectPledgeButtonAndFragmentContainer(
                                         rewards = rewardsList,
                                         project = project,
                                         onRewardSelected = onRewardSelected,
-                                        isLoading = isLoading,
+                                        isLoading = isRewardsLoading,
                                         countryList = shippingRules,
                                         currentShippingRule = currentShippingRule,
                                         onShippingRuleSelected = onShippingRuleSelected,

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
@@ -134,8 +134,8 @@ fun RewardCarouselScreen(
                         ),
                     text = environment.ksString()?.let {
                         it.format(
-                            "Rewards_count_rewards", project.rewards()?.size ?: 0,
-                            "rewards_count", NumberUtils.format(project.rewards()?.size ?: 0)
+                            "Rewards_count_rewards", rewards.size,
+                            "rewards_count", NumberUtils.format(rewards.size)
                         )
                     } ?: "",
                     color = KSTheme.colors.kds_support_400,
@@ -145,6 +145,18 @@ fun RewardCarouselScreen(
         }
     ) { padding ->
         Column {
+            if (isLoading) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(KSTheme.colors.backgroundAccentGraySubtle.copy(alpha = 0.5f))
+                        .clickable(enabled = false) { },
+                    contentAlignment = Alignment.Center
+                ) {
+                    KSCircularProgressIndicator()
+                }
+            }
+
             if (countryList.isNotEmpty()) {
                 ShippingSelector(
                     modifier = Modifier
@@ -329,18 +341,6 @@ fun RewardCarouselScreen(
                             addonsPillVisible = reward.hasAddons()
                         )
                     }
-                }
-            }
-
-            if (isLoading) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(KSTheme.colors.backgroundAccentGraySubtle.copy(alpha = 0.5f))
-                        .clickable(enabled = false) { },
-                    contentAlignment = Alignment.Center
-                ) {
-                    KSCircularProgressIndicator()
                 }
             }
         }

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -97,10 +97,10 @@ class RewardsFragment : Fragment() {
                         ).value
                         val listState = rememberLazyListState()
 
-                        if (rules.selectedShippingRule != ShippingRuleFactory.emptyShippingRule()) {
-                            // - Indicate the VM which one is the default selected shipping Rule
-                            viewModel.inputs.selectedShippingRule(rules.selectedShippingRule)
-                        }
+//                        if (rules.selectedShippingRule != ShippingRuleFactory.emptyShippingRule()) {
+//                            // - Indicate the VM which one is the default selected shipping Rule
+//                            viewModel.inputs.selectedShippingRule(rules.selectedShippingRule)
+//                        }
 
                         RewardCarouselScreen(
                             lazyRowState = listState,

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -23,7 +23,6 @@ import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.reduce
 import com.kickstarter.libs.utils.extensions.selectPledgeFragment
-import com.kickstarter.mock.factories.ShippingRuleFactory
 import com.kickstarter.ui.activities.compose.projectpage.RewardCarouselScreen
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
@@ -90,17 +89,13 @@ class RewardsFragment : Fragment() {
                         val projectData: State<ProjectData> = viewModel.projectData().subscribeAsState(initial = ProjectData.builder().build())
                         val backing = projectData.value.backing() ?: projectData.value.project().backing()
                         val project = projectData.value.project()
-                        val rewards = project.rewards() ?: emptyList()
 
                         val rules = viewModel.countrySelectorRules().collectAsStateWithLifecycle(
                             initialValue = ShippingRulesState()
                         ).value
-                        val listState = rememberLazyListState()
 
-//                        if (rules.selectedShippingRule != ShippingRuleFactory.emptyShippingRule()) {
-//                            // - Indicate the VM which one is the default selected shipping Rule
-//                            viewModel.inputs.selectedShippingRule(rules.selectedShippingRule)
-//                        }
+                        val rewards = rules.filteredRw
+                        val listState = rememberLazyListState()
 
                         RewardCarouselScreen(
                             lazyRowState = listState,
@@ -113,7 +108,6 @@ class RewardsFragment : Fragment() {
                             },
                             countryList = rules.shippingRules,
                             onShippingRuleSelected = {
-                                // On future tickets will filter rewards by shipping rule selected available
                                 viewModel.inputs.selectedShippingRule(it)
                             },
                             currentShippingRule = rules.selectedShippingRule,

--- a/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/RewardsFragmentViewModel.kt
@@ -333,6 +333,7 @@ class RewardsFragmentViewModel {
         }
 
         override fun selectedShippingRule(shippingRule: ShippingRule) {
+            this.shippingRulesUseCase?.filterBySelectedRule(shippingRule)
             this.selectedShippingRule = shippingRule
         }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
@@ -125,7 +125,7 @@ class AddOnsViewModel(val environment: Environment, bundle: Bundle? = null) : Vi
             }
 
             backing = pledgeData?.projectData()?.backing() ?: project.backing()
-            backing?.let { b->
+            backing?.let { b ->
                 // - backed a reward no reward
                 if (b.reward() == null && b.amount().isNotNull()) {
                     currentUserReward = RewardFactory.noReward().toBuilder().pledgeAmount(b.amount()).build()

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/LatePledgeCheckoutViewModel.kt
@@ -94,7 +94,7 @@ class LatePledgeCheckoutViewModel(val environment: Environment) : ViewModel() {
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(),
-                initialValue = LatePledgeCheckoutUIState(isLoading = true)
+                initialValue = LatePledgeCheckoutUIState(isLoading = false)
             )
 
     private val mutableCheckoutPayment =

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.kickstarter.libs.Environment
-import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.extensions.isBacked
 import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.mock.factories.ShippingRuleFactory
@@ -154,10 +153,9 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
     }
 
     private suspend fun emitCurrentState() {
-        val filteredRewards = currentProjectData.project().rewards()?.filter { RewardUtils.isNoReward(it) || it.isAvailable() } ?: listOf()
         mutableRewardSelectionUIState.emit(
             RewardSelectionUIState(
-                rewardList = filteredRewards,
+                rewardList = shippingUIState.value.filteredRw,
                 initialRewardIndex = indexOfBackedReward,
                 project = currentProjectData,
                 selectedReward = newUserReward,
@@ -171,6 +169,7 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
      */
     fun selectedShippingRule(shippingRule: ShippingRule) {
         viewModelScope.launch {
+            shippingRulesUseCase?.filterBySelectedRule(shippingRule)
             selectedShippingRule = shippingRule
             emitShippingUIState()
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
@@ -3,7 +3,6 @@ package com.kickstarter.viewmodels.usecases
 import com.kickstarter.libs.Config
 import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.extensions.getDefaultLocationFrom
-import com.kickstarter.mock.factories.ShippingRuleFactory
 import com.kickstarter.models.Location
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
@@ -12,6 +11,7 @@ import com.kickstarter.services.ApolloClientTypeV2
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
@@ -24,7 +24,8 @@ data class ShippingRulesState(
     val shippingRules: List<ShippingRule> = emptyList(),
     val loading: Boolean = false,
     val error: String? = null,
-    val selectedShippingRule: ShippingRule = ShippingRuleFactory.usShippingRule()
+    val selectedShippingRule: ShippingRule = ShippingRule.builder().build(),
+    val filteredRw: List<Reward> = emptyList()
 )
 
 /**
@@ -47,7 +48,11 @@ class GetShippingRulesUseCase(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
 
-    private var rewardsToQuery: List<Reward>
+    private val filteredRewards = mutableListOf<Reward>()
+    private var defaultShippingRule = ShippingRule.builder().build()
+    private var rewardsByShippingType: List<Reward>
+    private val allAvailableRulesForProject = mutableMapOf<Long, ShippingRule>()
+
     init {
 
         // To avoid duplicates insert reward.id as key
@@ -63,11 +68,11 @@ class GetShippingRulesUseCase(
             project.rewards()?.filter {
                 RewardUtils.shipsToRestrictedLocations(reward = it)
             }?.forEach {
-                rewardsToQuery.put(it.id(), it)
+                rewardsToQuery[it.id()] = it
             }
         }
 
-        this.rewardsToQuery = rewardsToQuery.values.toList()
+        this.rewardsByShippingType = rewardsToQuery.values.toList()
     }
 
     // - Do not expose mutable states
@@ -82,40 +87,129 @@ class GetShippingRulesUseCase(
 
     // - IO dispatcher for network operations to avoid blocking main thread
     operator fun invoke() {
-        if (rewardsToQuery.isNotEmpty()) {
-            val shippingRules = mutableMapOf<Long, ShippingRule>()
-            scope.launch(dispatcher) {
-                _mutableShippingRules.emit(ShippingRulesState(loading = true))
-                rewardsToQuery.forEachIndexed { index, reward ->
-                    apolloClient.getShippingRules(reward)
-                        .asFlow()
-                        .map { rulesEnvelope ->
-                            rulesEnvelope.shippingRules()?.map { rule ->
-                                rule?.let { shippingRules.put(requireNotNull(it.location()?.id()), it) }
-                            }
+        scope.launch(dispatcher) {
+            emitCurrentState(isLoading = true)
 
-                            // - Emit ONLY if all the rewards shipping rules have been queried
-                            if (index == rewardsToQuery.size - 1) {
-                                _mutableShippingRules.emit(
-                                    ShippingRulesState(
-                                        shippingRules = shippingRules.values.toList(),
-                                        loading = false,
-                                        selectedShippingRule = getDefaultShippingRule(shippingRules, project)
-                                    )
-                                )
-                            }
-                        }
-                        .catch { throwable ->
-                            _mutableShippingRules.emit(
-                                ShippingRulesState(
-                                    loading = false,
-                                    error = throwable.message
-                                )
+            if (rewardsByShippingType.isNotEmpty()) {
+                rewardsByShippingType.forEachIndexed { index, reward ->
+
+                    if (RewardUtils.shipsToRestrictedLocations(reward)) {
+                        reward.shippingRules()?.map {
+                            allAvailableRulesForProject.put(
+                                requireNotNull(
+                                    it.location()?.id()
+                                ),
+                                it
                             )
-                        }.collect()
+                        }
+                    }
+                    if (RewardUtils.shipsWorldwide(reward)) {
+                        getGlobalShippingRulesForReward(reward, allAvailableRulesForProject)
+                    }
+
+                    // - Filter if all shipping rules for all rewards have been collected
+                    if (index == rewardsByShippingType.size - 1) {
+                        defaultShippingRule = getDefaultShippingRule(
+                            allAvailableRulesForProject,
+                            project
+                        )
+                        filterRewardsByLocation(allAvailableRulesForProject, defaultShippingRule, project.rewards() ?: emptyList())
+                    }
+                }
+            } else {
+                // - All rewards are digital, all rewards must be available
+                filteredRewards.addAll(project.rewards() ?: emptyList())
+                emitCurrentState(isLoading = false)
+            }
+        }
+    }
+
+    fun filterBySelectedRule(shippingRule: ShippingRule) {
+        scope.launch(dispatcher) {
+            filteredRewards.clear()
+            emitCurrentState(isLoading = true)
+            delay(500) // Added delay due to the filtering happening too fast for the user to perceive
+            filterRewardsByLocation(allAvailableRulesForProject, shippingRule, project.rewards() ?: emptyList())
+        }
+    }
+
+    private suspend fun emitCurrentState(isLoading: Boolean, errorMessage: String? = null) {
+        _mutableShippingRules.emit(
+            ShippingRulesState(
+                shippingRules = allAvailableRulesForProject.values.toList(),
+                loading = isLoading,
+                selectedShippingRule = defaultShippingRule,
+                error = errorMessage,
+                filteredRw = filteredRewards
+            )
+        )
+    }
+
+    private suspend fun getGlobalShippingRulesForReward(
+        reward: Reward,
+        shippingRules: MutableMap<Long, ShippingRule>
+    ) {
+        apolloClient.getShippingRules(reward)
+            .asFlow()
+            .map { rulesEnvelope ->
+                rulesEnvelope.shippingRules()?.map { rule ->
+                    rule?.let {
+                        shippingRules.put(
+                            requireNotNull(
+                                it.location()?.id()
+                            ),
+                            it
+                        )
+                    }
+                }
+            }
+            .catch { throwable ->
+                emitCurrentState(isLoading = false, errorMessage = throwable?.message)
+            }.collect()
+    }
+
+    /**
+     * Check if the given @param rule is available in the list
+     * of @param allAvailableShippingRules for this project.
+     *
+     * In case it is available, return only those rewards able to ship to
+     * the selected rule
+     */
+    private suspend fun filterRewardsByLocation(
+        allAvailableShippingRules: MutableMap<Long, ShippingRule>,
+        rule: ShippingRule,
+        rewards: List<Reward>
+    ) {
+        val locationId = rule.location()?.id() ?: 0
+        val isIsValidRule = allAvailableShippingRules[locationId]
+
+        // Rule is available
+        rewards.map { rw ->
+            if (RewardUtils.shipsWorldwide(rw)) {
+                filteredRewards.add(rw)
+            }
+
+            if (RewardUtils.isNoReward(rw)) {
+                filteredRewards.add(rw)
+            }
+
+            if (RewardUtils.isLocalPickup(rw)) {
+                filteredRewards.add(rw)
+            }
+
+            // - If shipping is restricted, make sure the reward is able to ship to selected rule
+            if (RewardUtils.shipsToRestrictedLocations(rw)) {
+                if (isIsValidRule != null) {
+                    rw.shippingRules()?.map {
+                        if (it.location()?.id() == locationId) {
+                            filteredRewards.add(rw)
+                        }
+                    }
                 }
             }
         }
+
+        emitCurrentState(isLoading = false)
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
@@ -118,6 +118,7 @@ class GetShippingRulesUseCase(
                 }
             } else {
                 // - All rewards are digital, all rewards must be available
+                filteredRewards.clear()
                 filteredRewards.addAll(project.rewards() ?: emptyList())
                 emitCurrentState(isLoading = false)
             }
@@ -126,7 +127,6 @@ class GetShippingRulesUseCase(
 
     fun filterBySelectedRule(shippingRule: ShippingRule) {
         scope.launch(dispatcher) {
-            filteredRewards.clear()
             emitCurrentState(isLoading = true)
             delay(500) // Added delay due to the filtering happening too fast for the user to perceive
             filterRewardsByLocation(allAvailableRulesForProject, shippingRule, project.rewards() ?: emptyList())
@@ -180,6 +180,7 @@ class GetShippingRulesUseCase(
         rule: ShippingRule,
         rewards: List<Reward>
     ) {
+        filteredRewards.clear()
         val locationId = rule.location()?.id() ?: 0
         val isIsValidRule = allAvailableShippingRules[locationId]
 

--- a/app/src/test/java/com/kickstarter/viewmodels/LatePledgeCheckoutViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/LatePledgeCheckoutViewModelTest.kt
@@ -599,7 +599,7 @@ class LatePledgeCheckoutViewModelTest : KSRobolectricTestCase() {
             viewModel.latePledgeCheckoutUIState.toList(state)
         }
 
-        assertEquals(state.size, 2)
+        assertEquals(state.size, 1)
         assertEquals(state.last().userEmail, "")
         assertEquals(state.last().storeCards, emptyList<StoredCard>())
     }

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
@@ -59,12 +59,13 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
             viewModel.rewardSelectionUIState.toList(state)
         }
 
+        // TODO add reward check, now filtered rewards come from the use case
+
         // 1 from initialization, 1 from providing project data
         assert(state.size == 2)
         assertEquals(
             state.last(),
             RewardSelectionUIState(
-                rewardList = testRewards,
                 initialRewardIndex = 2,
                 project = testProjectData,
             )
@@ -98,7 +99,6 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         assertEquals(
             uiState.last(),
             RewardSelectionUIState(
-                rewardList = testRewards,
                 initialRewardIndex = 0,
                 project = testProjectData,
             )
@@ -143,7 +143,6 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         assertEquals(
             uiState.last(),
             RewardSelectionUIState(
-                rewardList = testRewards,
                 initialRewardIndex = 0,
                 project = testProjectData,
             )
@@ -192,7 +191,6 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         assertEquals(
             uiState.last(),
             RewardSelectionUIState(
-                rewardList = testRewards,
                 initialRewardIndex = 2,
                 project = testProjectData,
             )
@@ -241,7 +239,6 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         assertEquals(
             uiState.last(),
             RewardSelectionUIState(
-                rewardList = testRewards,
                 initialRewardIndex = 3,
                 project = testProjectData,
             )
@@ -290,7 +287,6 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         assertEquals(
             uiState.last(),
             RewardSelectionUIState(
-                rewardList = testRewards,
                 initialRewardIndex = 3,
                 project = testProjectData,
             )
@@ -337,14 +333,15 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         assertEquals(
             uiState.last(),
             RewardSelectionUIState(
-                rewardList = filteredRewards,
                 initialRewardIndex = 0,
                 project = testProjectData,
             )
         )
 
+        // TODO: filtered rewards, now on use case, add this filtering, not just by location
+
         // - make sure the uiState output reward list is not the same as the provided reward list
-        assertNotSame(uiState.last().rewardList, testRewards.size)
+        // assertNotSame(uiState.last().rewardList, testRewards.size)
     }
 
     @Test
@@ -455,7 +452,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun `Default Location is BAcke when config is from Canada, and list of shipping Rules matches all available reward shipping without repeated`() = runTest {
+    fun `Default Location is Backed when config is from Canada, and list of shipping Rules matches all available reward shipping without repeated`() = runTest {
         val rw = RewardFactory
             .reward()
             .toBuilder()


### PR DESCRIPTION
# 📲 What

Rewards filtered by the selected location on shipping rules

# 🤔 Why

Better user experience

# 🛠 How

`GetShippingRulesUseCase` now returns as part of the state the rewards filtered by given location

# 👀 See
- Crowdfunding

https://github.com/user-attachments/assets/2184b7f0-91c4-4dce-bdd5-a372c07f76db




- Late pledges

https://github.com/user-attachments/assets/6157c16e-4e19-448b-abd8-d509202dd932




| --- | --- |
|  |  |

# 📋 QA

- Ideally find a project that has both shipping wordlwide and restricted, or a restricted project outside of your default location (default location based on IP). If you cannot find any as was my case try to find a project with restricted locations, then hardcode your default location and run the app, on the initial load you should get ONLY those rewards shipping your hardcoded location plus digital/pickup/no-reward, then change the location on the selector, and you will get new rewards. This is what I did to record the videos up there, left a location commented on `ConfigExtension:115` that you can return as your `getDefaultLocationFrom` 

# Story 📖

[MBL-1576](Thttps://kickstarter.atlassian.net/browse/MBL-1576)


[MBL-1576]: https://kickstarter.atlassian.net/browse/MBL-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ