### PR TITLE
MBL[1583/1584] Add bonus support visual treatments based on selected reward

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -76,7 +77,8 @@ private fun AddOnsScreenPreview() {
                 bonusAmountChanged = {},
                 onContinueClicked = {},
                 addOnCount = 2,
-                totalPledgeAmount = 30.0
+                totalPledgeAmount = 30.0,
+                totalBonusSupport = 5.0
             )
         }
     }
@@ -96,10 +98,18 @@ fun AddOnsScreen(
     currentShippingRule: ShippingRule = ShippingRule.builder().build(),
     onContinueClicked: () -> Unit,
     addOnCount: Int = 0,
-    totalPledgeAmount: Double
+    totalPledgeAmount: Double,
+    totalBonusSupport: Double
 ) {
     val context = LocalContext.current
     val currencySymbolStartAndEnd = environment.ksCurrency()?.getCurrencySymbols(project)
+    val totalAmountString = environment.ksCurrency()?.let {
+        RewardViewUtils.styleCurrency(
+            value = totalPledgeAmount,
+            project = project,
+            ksCurrency = it
+        ).toString()
+    } ?: ""
 
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -135,7 +145,7 @@ fun AddOnsScreen(
                                     Spacer(modifier = Modifier.weight(1f))
 
                                     Text(
-                                        text = "${currencySymbolStartAndEnd?.first}${totalPledgeAmount}${currencySymbolStartAndEnd?.second}",
+                                        text = totalAmountString,
                                         style = typography.subheadlineMedium,
                                         color = colors.textPrimary
                                     )
@@ -147,7 +157,7 @@ fun AddOnsScreen(
                                     onClickAction = onContinueClicked,
                                     text =
                                     if (addOnCount == 0)
-                                        stringResource(id = R.string.Skip_add_ons)
+                                        stringResource(id = R.string.Continue)
                                     else {
                                         when {
                                             addOnCount == 1 -> environment.ksString()?.format(
@@ -162,7 +172,7 @@ fun AddOnsScreen(
                                                 addOnCount.toString()
                                             ) ?: ""
 
-                                            else -> stringResource(id = R.string.Skip_add_ons)
+                                            else -> stringResource(id = R.string.Continue)
                                         }
                                     },
                                     isEnabled = true
@@ -199,18 +209,23 @@ fun AddOnsScreen(
 
                     val initAmount = if (project.isBacking())
                         project.backing()?.bonusAmount() ?: 0.0
+                    else if (RewardUtils.isNoReward(selectedReward))
+                        RewardUtils.minPledgeAmount(selectedReward, project)
                     else 0.0
 
                     BonusSupportContainer(
-                        noAddOnsRw = addOns.isEmpty(),
+                        selectedReward = selectedReward,
                         initialAmount = initAmount,
                         maxAmount = RewardUtils.maxPledgeAmount(selectedReward, project),
                         minPledge = RewardUtils.minPledgeAmount(selectedReward, project),
+                        totalAmount = totalPledgeAmount,
+                        totalBonusSupport = totalBonusSupport,
                         currencySymbolAtStart = currencySymbolStartAndEnd?.first,
                         currencySymbolAtEnd = currencySymbolStartAndEnd?.second,
                         onBonusSupportPlusClicked = bonusAmountChanged,
                         onBonusSupportMinusClicked = bonusAmountChanged,
-                        onBonusSupportInputted = bonusAmountChanged
+                        onBonusSupportInputted = bonusAmountChanged,
+                        environment = environment
                     )
                 }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ProjectPledgeButtonAndFragmentContainer.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ProjectPledgeButtonAndFragmentContainer.kt
@@ -260,7 +260,8 @@ fun ProjectPledgeButtonAndFragmentContainer(
                                         isLoading = isLoading,
                                         addOnCount = totalSelectedAddOn,
                                         bonusAmountChanged = bonusAmountChanged,
-                                        totalPledgeAmount = totalPledgeAmount
+                                        totalPledgeAmount = totalPledgeAmount,
+                                        totalBonusSupport = totalBonusAmount
                                     )
                                 }
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingAddOnsFragment.kt
@@ -86,7 +86,8 @@ class BackingAddOnsFragment : Fragment() {
                                 viewModelC.bonusAmountUpdated(bonusAmount)
                             },
                             addOnCount = totalCount,
-                            totalPledgeAmount = totalPledgeAmount
+                            totalPledgeAmount = totalPledgeAmount,
+                            totalBonusSupport = addOnsUIState.totalBonusAmount
                         )
                     }
                 }

--- a/app/src/main/java/com/kickstarter/ui/views/compose/checkout/BonusSupport.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/compose/checkout/BonusSupport.kt
@@ -140,7 +140,7 @@ fun BonusSupportContainer(
                         end = dimensions.paddingXSmall
                     ),
 
-                ) {
+            ) {
                 Text(
                     text = currencySymbolAtStart ?: "",
                     color = colors.textAccentGreen

--- a/app/src/main/java/com/kickstarter/ui/views/compose/checkout/BonusSupport.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/compose/checkout/BonusSupport.kt
@@ -13,13 +13,10 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableDoubleStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.integerResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -27,7 +24,11 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.kickstarter.R
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.RewardUtils
+import com.kickstarter.libs.utils.RewardViewUtils
 import com.kickstarter.libs.utils.extensions.parseToDouble
+import com.kickstarter.models.Reward
 import com.kickstarter.ui.compose.designsystem.KSStepper
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
@@ -38,37 +39,55 @@ import com.kickstarter.ui.compose.designsystem.shapes
 @Composable
 fun BonusSupportContainerPreview() {
     BonusSupportContainer(
-        noAddOnsRw = true,
+        selectedReward = Reward.builder().build(),
         initialAmount = 5.0,
         maxAmount = 10.0,
         minPledge = 5.0,
         currencySymbolAtStart = "CAD",
         currencySymbolAtEnd = "$",
+        totalAmount = 100.0,
+        totalBonusSupport = 5.0,
         onBonusSupportPlusClicked = {},
         onBonusSupportMinusClicked = {},
-        onBonusSupportInputted = {}
+        onBonusSupportInputted = {},
+        environment = Environment.builder().build()
     )
 }
 
 @Composable
 fun BonusSupportContainer(
-    noAddOnsRw: Boolean,
+    selectedReward: Reward,
     initialAmount: Double,
     maxAmount: Double,
+    minPledge: Double,
     currencySymbolAtStart: String?,
     currencySymbolAtEnd: String?,
-    minPledge: Double,
+    totalAmount: Double,
+    totalBonusSupport: Double,
     onBonusSupportPlusClicked: (amount: Double) -> Unit,
     onBonusSupportMinusClicked: (amount: Double) -> Unit,
-    onBonusSupportInputted: (amount: Double) -> Unit
+    onBonusSupportInputted: (amount: Double) -> Unit,
+    environment: Environment
 ) {
-    val minStepAmount = minPledge
     val bonusAmountMaxDigits = integerResource(R.integer.max_length)
-    var totalBonusSupport by rememberSaveable { mutableDoubleStateOf(initialAmount) }
+    val isNoReward = RewardUtils.isNoReward(selectedReward)
+    val displayedTotalBonusAmount =
+        if (isNoReward) totalBonusSupport + minPledge else totalBonusSupport
 
     Column {
+        if (isNoReward) {
+            // TODO replace with translated string
+            Text(
+                text = "Customize your reward",
+                style = typography.title3Bold,
+                color = colors.textPrimary
+            )
+
+            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+        }
+
         Text(
-            text = if (noAddOnsRw) stringResource(id = R.string.Your_pledge_amount)
+            text = if (isNoReward) stringResource(id = R.string.Your_pledge_amount)
             else stringResource(id = R.string.Bonus_support),
             style = typography.subheadlineMedium,
             color = colors.textPrimary
@@ -76,7 +95,7 @@ fun BonusSupportContainer(
 
         Spacer(modifier = Modifier.height(dimensions.paddingSmall))
 
-        if (!noAddOnsRw) {
+        if (!isNoReward && !selectedReward.hasAddons()) {
             Text(
                 text = stringResource(id = R.string.A_little_extra_to_help),
                 style = typography.body2,
@@ -91,25 +110,21 @@ fun BonusSupportContainer(
         ) {
             KSStepper(
                 onPlusClicked = {
-                    totalBonusSupport += minStepAmount
-                    onBonusSupportPlusClicked(totalBonusSupport)
+                    onBonusSupportPlusClicked(totalBonusSupport + minPledge)
                 },
-                isPlusEnabled = totalBonusSupport != maxAmount,
+                isPlusEnabled = displayedTotalBonusAmount < maxAmount,
                 onMinusClicked = {
-                    totalBonusSupport -= minStepAmount
-                    onBonusSupportMinusClicked(totalBonusSupport)
+                    onBonusSupportMinusClicked(totalBonusSupport - minPledge)
                 },
-                isMinusEnabled = totalBonusSupport > 0,
+                isMinusEnabled = initialAmount < displayedTotalBonusAmount,
                 enabledButtonBackgroundColor = colors.kds_white
             )
 
             Spacer(modifier = Modifier.weight(1f))
 
-            if (!noAddOnsRw) {
-                Text(text = "+", style = typography.calloutMedium, color = colors.textSecondary)
+            Text(text = "+", style = typography.calloutMedium, color = colors.textSecondary)
 
-                Spacer(modifier = Modifier.width(dimensions.paddingMediumSmall))
-            }
+            Spacer(modifier = Modifier.width(dimensions.paddingMediumSmall))
 
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -125,17 +140,18 @@ fun BonusSupportContainer(
                         end = dimensions.paddingXSmall
                     ),
 
-            ) {
+                ) {
                 Text(
                     text = currencySymbolAtStart ?: "",
                     color = colors.textAccentGreen
                 )
                 BasicTextField(
                     modifier = Modifier.width(IntrinsicSize.Min),
-                    value = if (totalBonusSupport % 1.0 == 0.0) totalBonusSupport.toInt().toString() else totalBonusSupport.toString(),
+                    value =
+                    if (displayedTotalBonusAmount % 1.0 == 0.0) displayedTotalBonusAmount.toInt().toString()
+                    else displayedTotalBonusAmount.toString(),
                     onValueChange = {
-                        if (it.length <= bonusAmountMaxDigits) totalBonusSupport = it.parseToDouble()
-                        onBonusSupportInputted(totalBonusSupport)
+                        if (it.length <= bonusAmountMaxDigits) onBonusSupportInputted(it.parseToDouble())
                     },
                     textStyle = typography.title1.copy(color = colors.textAccentGreen),
                     keyboardOptions = KeyboardOptions(
@@ -143,7 +159,6 @@ fun BonusSupportContainer(
                         imeAction = ImeAction.Done
                     ),
                     cursorBrush = SolidColor(colors.iconSubtle)
-
                 )
                 Text(
                     text = currencySymbolAtEnd ?: "",
@@ -152,12 +167,19 @@ fun BonusSupportContainer(
             }
         }
 
-        if (totalBonusSupport > maxAmount) {
-            // TODO error message
-            // val maxInputString = RewardViewUtils.getMaxInputString(LocalContext.current, selectedReward = , maxPledgeAmount, totalAmount, totalBonusSupport, currencySymbolStartAndEnd, environment)
+        if (totalAmount > maxAmount) {
+            val maxInputString = RewardViewUtils.getMaxInputString(
+                context = LocalContext.current,
+                selectedReward = selectedReward,
+                maxPledgeAmount = maxAmount,
+                totalAmount = totalAmount,
+                totalBonusSupport = totalBonusSupport,
+                currencySymbolStartAndEnd = Pair(currencySymbolAtStart, currencySymbolAtEnd),
+                environment = environment
+            )
 
             Text(
-                text = "Enter amount less that $totalBonusSupport",
+                text = maxInputString,
                 textAlign = TextAlign.Right,
                 style = typography.footnoteMedium,
                 color = colors.textAccentRed,

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
@@ -224,6 +224,7 @@ class AddOnsViewModel(val environment: Environment, bundle: Bundle? = null) : Vi
         if (reward != currentUserReward) {
             currentUserReward = reward
             currentSelection.clear()
+            bonusAmount = 0.0
 
             scope.launch {
                 emitCurrentState()


### PR DESCRIPTION
# 📲 What

Added some visual distinction between add-ons for no rewards vs rewards with no add-ons

# 🤔 Why

We want to user to feel like the experience is relevant to what they picked

# 🛠 How

🧠 

# 👀 See

Late Pledge:
https://github.com/user-attachments/assets/7111fd30-928c-410b-bf84-888ec6a4f4a2

Normal Campaign:
https://github.com/user-attachments/assets/2a4a30ef-7c65-44e6-8b3c-ce968ec23d43


# 📋 QA

Go to a project (late or currently running doesnt matter)
Confirm that the add-ons screen shows the appropriate visuals for the given selection (no reward, reward with add-ons, reward without add-ons)

# Story 📖

[MBL-1583](https://kickstarter.atlassian.net/browse/MBL-1583)
[MBL-1584](https://kickstarter.atlassian.net/browse/MBL-1584)


[MBL-1583]: https://kickstarter.atlassian.net/browse/MBL-1583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MBL-1584]: https://kickstarter.atlassian.net/browse/MBL-1584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ