### PR TITLE
Leigh/mbl 1635 ppo tidying

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -366,6 +366,7 @@ fragment shippingRule on ShippingRule {
 
 fragment ppoCard on Backing {
     id
+    backingDetailsPageUrl
     clientSecret
     amount {
         ...amount

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/data/PPOCardFactory.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/data/PPOCardFactory.kt
@@ -55,7 +55,7 @@ class PPOCardFactory private constructor() {
                 projectSlug = "hello/hello",
                 imageUrl = "image/url",
                 creatorName = "creatorName",
-                backingDetailsUrl = "/projects/grimacecards/monochrome-muse-playing-cards/backing/details",
+                backingDetailsUrl = "backing/details/url",
                 timeNumberForAction = 10,
                 showBadge = false,
                 viewType = PPOCardViewType.CONFIRM_ADDRESS

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/data/PPOCardFactory.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/data/PPOCardFactory.kt
@@ -55,7 +55,7 @@ class PPOCardFactory private constructor() {
                 projectSlug = "hello/hello",
                 imageUrl = "image/url",
                 creatorName = "creatorName",
-                backingDetailsUrl = "backing/details/url",
+                backingDetailsUrl = "/projects/grimacecards/monochrome-muse-playing-cards/backing/details",
                 timeNumberForAction = 10,
                 showBadge = false,
                 viewType = PPOCardViewType.CONFIRM_ADDRESS

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -456,7 +456,7 @@ fun ConfirmAddressAlertsView(hoursRemaining: Int = -1) {
     }
 }
 @Composable
-fun ConfirmAddressButtonsView(isConfirmButtonEnabled : Boolean, onEditAddressClicked: () -> Unit, onConfirmAddressClicked: () -> Unit) {
+fun ConfirmAddressButtonsView(isConfirmButtonEnabled: Boolean, onEditAddressClicked: () -> Unit, onConfirmAddressClicked: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -271,7 +271,7 @@ fun PPOCardView(
                 }
 
                 when (viewType) {
-                    PPOCardViewType.CONFIRM_ADDRESS -> ConfirmAddressButtonsView(onActionButtonClicked, onSecondaryActionButtonClicked)
+                    PPOCardViewType.CONFIRM_ADDRESS -> ConfirmAddressButtonsView(!shippingAddress.isNullOrEmpty(), onActionButtonClicked, onSecondaryActionButtonClicked)
                     PPOCardViewType.ADDRESS_CONFIRMED -> AddressConfirmedButtonView()
                     PPOCardViewType.FIX_PAYMENT -> FixPaymentButtonView(onActionButtonClicked)
                     PPOCardViewType.PAYMENT_FIXED -> PaymentFixedButtonView()
@@ -456,7 +456,7 @@ fun ConfirmAddressAlertsView(hoursRemaining: Int = -1) {
     }
 }
 @Composable
-fun ConfirmAddressButtonsView(onEditAddressClicked: () -> Unit, onConfirmAddressClicked: () -> Unit) {
+fun ConfirmAddressButtonsView(isConfirmButtonEnabled : Boolean, onEditAddressClicked: () -> Unit, onConfirmAddressClicked: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -479,7 +479,7 @@ fun ConfirmAddressButtonsView(onEditAddressClicked: () -> Unit, onConfirmAddress
                 .weight(0.5f),
             onClickAction = { onConfirmAddressClicked.invoke() },
             text = "Confirm",
-            isEnabled = true,
+            isEnabled = isConfirmButtonEnabled,
             textStyle = typography.buttonText
         )
     }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -185,14 +185,16 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
         url: String,
         resultLauncher: ActivityResultLauncher<Intent>?
     ) {
-        if(resultLauncher.isNotNull()) {
+        if (resultLauncher.isNotNull()) {
             resultLauncher?.launch(
                 Intent(this, BackingDetailsActivity::class.java)
                     .putExtra(IntentKey.URL, url)
             )
         } else {
-            startActivity(Intent(this, BackingDetailsActivity::class.java)
-                .putExtra(IntentKey.URL, url))
+            startActivity(
+                Intent(this, BackingDetailsActivity::class.java)
+                    .putExtra(IntentKey.URL, url)
+            )
         }
 
         this.let {

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -25,7 +25,6 @@ import com.kickstarter.features.pledgedprojectsoverview.viewmodel.PledgedProject
 import com.kickstarter.libs.MessagePreviousScreenType
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.utils.TransitionUtils
-import com.kickstarter.libs.utils.UrlUtils
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.getProjectIntent
 import com.kickstarter.libs.utils.extensions.isDarkModeEnabled
@@ -36,14 +35,12 @@ import com.kickstarter.ui.activities.AppThemes
 import com.kickstarter.ui.activities.ProfileActivity
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
 import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
-import com.kickstarter.ui.extensions.showSnackbar
 import com.kickstarter.ui.extensions.startCreatorMessageActivity
 import com.kickstarter.ui.extensions.transition
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.Stripe
 import com.stripe.android.StripeIntentResult
-import com.kickstarter.viewmodels.projectpage.ProjectRiskViewModel
 import kotlinx.coroutines.launch
 
 class PledgedProjectsOverviewActivity : AppCompatActivity() {
@@ -81,7 +78,6 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                 val ppoUIState by viewModel.ppoUIState.collectAsStateWithLifecycle()
 
                 val lazyListState = rememberLazyListState()
-                val snackbarHostState = remember { SnackbarHostState() }
                 val totalAlerts = viewModel.totalAlertsState.collectAsStateWithLifecycle().value
 
                 val ppoCardPagingSource = viewModel.ppoCardsState.collectAsLazyPagingItems()

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
@@ -43,6 +43,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.kickstarter.R
 import com.kickstarter.features.pledgedprojectsoverview.data.PPOCard
 import com.kickstarter.features.pledgedprojectsoverview.data.PPOCardFactory
+import com.kickstarter.libs.utils.extensions.isNullOrZero
 import com.kickstarter.ui.compose.designsystem.KSAlertDialog
 import com.kickstarter.ui.compose.designsystem.KSCircularProgressIndicator
 import com.kickstarter.ui.compose.designsystem.KSErrorSnackbar
@@ -225,11 +226,13 @@ fun PledgedProjectsOverviewScreen(
                     state = lazyColumnListState
                 ) {
                     item {
-                        Text(
-                            text = stringResource(id = R.string.alerts_fpo, totalAlerts),
-                            style = typography.title3Bold,
-                            color = colors.textPrimary
-                        )
+                        if(!totalAlerts.isNullOrZero()) {
+                            Text(
+                                text = stringResource(id = R.string.alerts_fpo, totalAlerts),
+                                style = typography.title3Bold,
+                                color = colors.textPrimary
+                            )
+                        }
                     }
 
                     items(

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
@@ -226,7 +226,7 @@ fun PledgedProjectsOverviewScreen(
                     state = lazyColumnListState
                 ) {
                     item {
-                        if(!totalAlerts.isNullOrZero()) {
+                        if (!totalAlerts.isNullOrZero()) {
                             Text(
                                 text = stringResource(id = R.string.alerts_fpo, totalAlerts),
                                 style = typography.title3Bold,

--- a/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
@@ -922,6 +922,7 @@ fun pledgedProjectsOverviewEnvelopeTransformer(ppoResponse: PledgedProjectsOverv
             val ppoBackingData = it.node()?.backing()?.fragments()?.ppoCard()
             PPOCard.builder()
                 .backingId(ppoBackingData?.id())
+                .backingDetailsUrl(ppoBackingData?.backingDetailsPageUrl())
                 .clientSecret(ppoBackingData?.clientSecret())
                 .amount(ppoBackingData?.amount()?.fragments()?.amount()?.amount())
                 .currencyCode(ppoBackingData?.amount()?.fragments()?.amount()?.currency())


### PR DESCRIPTION
### What
Small, mostly cosmetic cleanup for PPO

- Fix broken backing details page not loading
- Fix total alerts (0) showing when refreshing PPO screen
- Disable confirm address button when users address is null

All other cleanup is in separate tickets

### 🤔 Why
Cleanup cleanup

### 📋 QA
This will be tricky to test, and will require mock data. You can modify the ppo card factory and hardcode these cards into the graphql transformer function:

Testing backing details page:
1. Add a mock card to the ppo list created in the graphql transformer function
2. In the field for backing details url, you can use your own or this url "/projects/grimacecards/monochrome-muse-playing-cards/backing/details"
3. Tapping on project title area of card should open a webview and load the backing details page
4. Tapping "edit" on a confirm address or survey card should open a webview and load the backing details page

Testing total alerts heading
1. When you have no alerts, visit the PPO page and swipe to refresh. You should not see the total alerts heading appear

Testing edit address button disabled
1. Create a confirm address card with the PPOCardFactory, but leave the address field null. Add this to the ppo screen list in the graphql transformer function
2. Go to the PPO screen, it should not display an address, and the edit button should be disabled and not clickable.

### Story 📖
[MBL-1635: Mock data to real data, and cleanup](https://kickstarter.atlassian.net/browse/MBL-1635)