### PR TITLE
MBL-1664: Update copy on 3DS validation success and failure snackbars

### DIFF
--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -246,12 +246,12 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                         viewModel.showLoadingState(false)
                     }
                     if (result.outcome == StripeIntentResult.Outcome.SUCCEEDED) {
-                        viewModel.showHeadsUpSnackbar(R.string.successful_validation_please_pull_to_refresh_fpo)
+                        viewModel.showHeadsUpSnackbar(R.string.youve_been_authenticated_successfully_pull_to_refresh_fpo)
                         viewModel.getPledgedProjects()
                     } else if (result.outcome == StripeIntentResult.Outcome.FAILED ||
                         result.outcome == StripeIntentResult.Outcome.TIMEDOUT ||
                         result.outcome == StripeIntentResult.Outcome.UNKNOWN
-                    ) viewModel.showErrorSnackbar(R.string.general_error_something_wrong)
+                    ) viewModel.showErrorSnackbar(R.string.authentication_failed_please_try_again_fpo)
                 }
                 override fun onError(e: Exception) {
                     lifecycleScope.launch {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,8 @@
   <string name="address_confirmed_snackbar_text_fpo">Address confirmed! Need to change your address before it locks? Visit your backing details on our website.</string>
   <string name="backing_details_fpo">Backing details</string>
   <string name="something_went_wrong_pull_to_refresh_fpo">Something went wrong - Pull to refresh</string>
-  <string name="successful_validation_please_pull_to_refresh_fpo">Validation successful! Please pull to refresh</string>
+  <string name="youve_been_authenticated_successfully_pull_to_refresh_fpo">You\'ve been authenticated successfully! Pull to refresh.</string>
+  <string name="authentication_success_please_pull_to_refresh_fpo">Authentication success. Please pull to refresh.</string>
+  <string name="authentication_failed_please_try_again_fpo">"Authentication failed. Please try again."</string>
 
 </resources>


### PR DESCRIPTION
# 📲 What

Updating copy on success and failure snackbars for 3ds in ppo

# 🤔 Why

Slight delay occurs after user authenticates, so we need to educate them to pull to refresh in order to dismiss the card

# 📋 QA

Follow these instructions for creating a 3DS pledge: https://app.getguru.com/card/iybnB9pT/Creating-fix-payment-or-3DS-authentication-needed-Pledges-for-mobile-devs

Successful validation should show a snackbar educating the user to pull to refresh
Failing validation should show an authentication failed snackbar

# Story 📖

[MBL-1664: Update copy on 3DS validation success and failure snackbars](https://kickstarter.atlassian.net/browse/MBL-1664)
