### PR TITLE
MBL-1661 & MBL-1666: Red notification dot in top right corner of PPO tier 1 alert cards & Remove unused composables

### DIFF
--- a/app/src/main/graphql/pledgeProjectsOverview.graphql
+++ b/app/src/main/graphql/pledgeProjectsOverview.graphql
@@ -9,7 +9,6 @@ query PledgedProjectsOverview($first: Int, $after: String, $last: Int, $before: 
                 ...ppoCard
                 }
                 tierType
-                tags
             }
           }
           pageInfo {

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/data/PPOCard.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/data/PPOCard.kt
@@ -21,7 +21,6 @@ class PPOCard private constructor(
     val imageContentDescription: String?,
     val creatorName: String?,
     val backingDetailsUrl: String?,
-    val showBadge: Boolean,
     val timeNumberForAction: Int,
     val viewType: PPOCardViewType?
 
@@ -41,7 +40,6 @@ class PPOCard private constructor(
     fun imageContentDescription() = this.imageContentDescription
     fun creatorName() = this.creatorName
     fun backingDetailsUrl() = this.backingDetailsUrl
-    fun showBadge() = this.showBadge
     fun timeNumberForAction() = this.timeNumberForAction
     fun viewType() = this.viewType
 
@@ -61,7 +59,6 @@ class PPOCard private constructor(
         var imageContentDescription: String? = null,
         var creatorName: String? = null,
         var backingDetailsUrl: String? = null,
-        var showBadge: Boolean = false,
         var timeNumberForAction: Int = 0,
         var viewType: PPOCardViewType? = null,
     ) : Parcelable {
@@ -81,7 +78,6 @@ class PPOCard private constructor(
         fun creatorName(creatorName: String?) = apply { this.creatorName = creatorName }
         fun backingDetailsUrl(backingDetailsUrl: String?) = apply { this.backingDetailsUrl = backingDetailsUrl }
         fun timeNumberForAction(timeNumberForAction: Int) = apply { this.timeNumberForAction = timeNumberForAction }
-        fun showBadge(showBadge: Boolean) = apply { this.showBadge = showBadge }
         fun viewType(viewType: PPOCardViewType?) = apply { this.viewType = viewType }
 
         fun build() = PPOCard(
@@ -99,7 +95,6 @@ class PPOCard private constructor(
             imageContentDescription = imageUrl,
             creatorName = creatorName,
             backingDetailsUrl = backingDetailsUrl,
-            showBadge = showBadge,
             timeNumberForAction = timeNumberForAction,
             viewType = viewType,
         )
@@ -120,7 +115,6 @@ class PPOCard private constructor(
         imageContentDescription = imageContentDescription,
         creatorName = creatorName,
         backingDetailsUrl = backingDetailsUrl,
-        showBadge = showBadge,
         timeNumberForAction = timeNumberForAction,
         viewType = viewType,
     )
@@ -147,7 +141,6 @@ class PPOCard private constructor(
                 imageUrl() == other.imageUrl() &&
                 imageContentDescription() == other.imageContentDescription() &&
                 backingDetailsUrl() == other.backingDetailsUrl() &&
-                showBadge() == other.showBadge() &&
                 timeNumberForAction() == other.timeNumberForAction() &&
                 viewType() == other.viewType()
         }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/data/PPOCardFactory.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/data/PPOCardFactory.kt
@@ -20,7 +20,6 @@ class PPOCardFactory private constructor() {
             creatorName: String?,
             backingDetailsUrl: String?,
             timeNumberForAction: Int,
-            showBadge: Boolean,
             viewType: PPOCardViewType?
         ): PPOCard {
             return PPOCard.builder()
@@ -38,7 +37,6 @@ class PPOCardFactory private constructor() {
                 .backingDetailsUrl(backingDetailsUrl)
                 .viewType(viewType)
                 .timeNumberForAction(timeNumberForAction)
-                .showBadge(showBadge)
                 .build()
         }
 
@@ -57,7 +55,6 @@ class PPOCardFactory private constructor() {
                 creatorName = "creatorName",
                 backingDetailsUrl = "backing/details/url",
                 timeNumberForAction = 10,
-                showBadge = false,
                 viewType = PPOCardViewType.CONFIRM_ADDRESS
             )
         }
@@ -77,7 +74,6 @@ class PPOCardFactory private constructor() {
                 creatorName = "Creator Name",
                 backingDetailsUrl = "backing/details/url",
                 timeNumberForAction = 7,
-                showBadge = false,
                 viewType = PPOCardViewType.FIX_PAYMENT
             )
         }
@@ -98,7 +94,6 @@ class PPOCardFactory private constructor() {
                 creatorName = "Creator Name",
                 backingDetailsUrl = "backing/details/url",
                 timeNumberForAction = 7,
-                showBadge = false,
                 viewType = PPOCardViewType.AUTHENTICATE_CARD
             )
         }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -35,7 +34,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import com.google.android.material.badge.BadgeUtils
 import com.kickstarter.R
 import com.kickstarter.ui.compose.designsystem.KSCoralBadge
 import com.kickstarter.ui.compose.designsystem.KSDividerLineGrey

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -34,6 +35,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.google.android.material.badge.BadgeUtils
 import com.kickstarter.R
 import com.kickstarter.ui.compose.designsystem.KSCoralBadge
 import com.kickstarter.ui.compose.designsystem.KSDividerLineGrey
@@ -570,7 +572,7 @@ fun PledgeWillBeDroppedAlert(daysRemaining: Int = -1) {
     )
 }
 
-fun isTier1Alert(viewType: PPOCardViewType) : Boolean {
+fun isTier1Alert(viewType: PPOCardViewType): Boolean {
     return when (viewType) {
         PPOCardViewType.CONFIRM_ADDRESS, PPOCardViewType.AUTHENTICATE_CARD, PPOCardViewType.OPEN_SURVEY, PPOCardViewType.FIX_PAYMENT -> true
         else -> false

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -65,7 +65,6 @@ fun PPOCardPreview() {
                     creatorName = "Some really really really really really really really long name",
                     sendAMessageClickAction = {},
                     shippingAddress = "Firsty Lasty\n123 First Street, Apt #5678\nLos Angeles, CA 90025-1234\nUnited States",
-                    showBadge = true,
                     onActionButtonClicked = {},
                     onSecondaryActionButtonClicked = {},
                     onProjectPledgeSummaryClick = {},
@@ -82,25 +81,6 @@ fun PPOCardPreview() {
                     pledgeAmount = "$50.00",
                     creatorName = "Some really really really really really really really long name",
                     sendAMessageClickAction = {},
-                    showBadge = true,
-                    onActionButtonClicked = {},
-                    onSecondaryActionButtonClicked = {},
-                    onProjectPledgeSummaryClick = {},
-                    timeNumberForAction = 6
-                )
-
-                Spacer(modifier = Modifier.height(dimensions.paddingMedium))
-            }
-
-            item {
-                PPOCardView(
-                    viewType = PPOCardViewType.PAYMENT_FIXED,
-                    onCardClick = {},
-                    projectName = "Sugardew Island - Your cozy farm shop let’s pretend this is a longer title let’s pretend this is a longer title",
-                    pledgeAmount = "$50.00",
-                    creatorName = "Some really really really really really really really long name",
-                    sendAMessageClickAction = {},
-                    showBadge = false,
                     onActionButtonClicked = {},
                     onSecondaryActionButtonClicked = {},
                     onProjectPledgeSummaryClick = {},
@@ -118,25 +98,6 @@ fun PPOCardPreview() {
                     pledgeAmount = "$60.00",
                     creatorName = "Some really really really really really really really long name",
                     sendAMessageClickAction = {},
-                    showBadge = true,
-                    onActionButtonClicked = {},
-                    onSecondaryActionButtonClicked = {},
-                    onProjectPledgeSummaryClick = {},
-                    timeNumberForAction = 7
-                )
-
-                Spacer(modifier = Modifier.height(dimensions.paddingMedium))
-            }
-
-            item {
-                PPOCardView(
-                    viewType = PPOCardViewType.CARD_AUTHENTICATED,
-                    onCardClick = {},
-                    projectName = "Sugardew Island - Your cozy farm shop let’s pretend this is a longer title let’s pretend this is a longer title",
-                    pledgeAmount = "$60.00",
-                    creatorName = "Some really really really really really really really long name",
-                    sendAMessageClickAction = {},
-                    showBadge = false,
                     onActionButtonClicked = {},
                     onSecondaryActionButtonClicked = {},
                     onProjectPledgeSummaryClick = {},
@@ -154,25 +115,6 @@ fun PPOCardPreview() {
                     pledgeAmount = "$70.00",
                     creatorName = "Some really really really really really really really long name",
                     sendAMessageClickAction = {},
-                    showBadge = true,
-                    onActionButtonClicked = {},
-                    onSecondaryActionButtonClicked = {},
-                    onProjectPledgeSummaryClick = {},
-                    timeNumberForAction = 8
-                )
-
-                Spacer(modifier = Modifier.height(dimensions.paddingMedium))
-            }
-
-            item {
-                PPOCardView(
-                    viewType = PPOCardViewType.SURVEY_SUBMITTED,
-                    onCardClick = {},
-                    projectName = "Sugardew Island - Your cozy farm shop let’s pretend this is a longer title let’s pretend this is a longer title",
-                    pledgeAmount = "$70.00",
-                    creatorName = "Some really really really really really really really long name",
-                    sendAMessageClickAction = {},
-                    showBadge = false,
                     onActionButtonClicked = {},
                     onSecondaryActionButtonClicked = {},
                     onProjectPledgeSummaryClick = {},
@@ -187,13 +129,9 @@ fun PPOCardPreview() {
 
 enum class PPOCardViewType {
     CONFIRM_ADDRESS,
-    ADDRESS_CONFIRMED,
     FIX_PAYMENT,
-    PAYMENT_FIXED,
     AUTHENTICATE_CARD,
-    CARD_AUTHENTICATED,
     OPEN_SURVEY,
-    SURVEY_SUBMITTED,
     UNKNOWN,
 }
 
@@ -214,14 +152,13 @@ fun PPOCardView(
     creatorName: String? = null,
     sendAMessageClickAction: () -> Unit,
     shippingAddress: String? = null,
-    showBadge: Boolean = false,
     onActionButtonClicked: () -> Unit,
     onSecondaryActionButtonClicked: () -> Unit,
     timeNumberForAction: Int = 0,
 ) {
 
     BadgedBox(
-        badge = { if (showBadge) Badge(backgroundColor = colors.textAccentGreen) }
+        badge = { if (isTier1Alert(viewType)) Badge(backgroundColor = colors.backgroundDangerBold) }
     ) {
         Card(
             modifier = Modifier
@@ -236,13 +173,9 @@ fun PPOCardView(
             ) {
                 when (viewType) {
                     PPOCardViewType.CONFIRM_ADDRESS -> ConfirmAddressAlertsView(timeNumberForAction)
-                    PPOCardViewType.ADDRESS_CONFIRMED -> ConfirmAddressAlertsView(timeNumberForAction)
                     PPOCardViewType.FIX_PAYMENT -> FixPaymentAlertsView(timeNumberForAction)
-                    PPOCardViewType.PAYMENT_FIXED -> {}
                     PPOCardViewType.AUTHENTICATE_CARD -> AuthenticateCardAlertsView(timeNumberForAction)
-                    PPOCardViewType.CARD_AUTHENTICATED -> {}
                     PPOCardViewType.OPEN_SURVEY -> TakeSurveyAlertsView(timeNumberForAction)
-                    PPOCardViewType.SURVEY_SUBMITTED -> SurveySubmittedAlertsView(timeNumberForAction)
                     PPOCardViewType.UNKNOWN -> { }
                 }
 
@@ -259,10 +192,7 @@ fun PPOCardView(
                     sendAMessageClickAction = sendAMessageClickAction
                 )
 
-                if (viewType == PPOCardViewType.CONFIRM_ADDRESS ||
-                    viewType == PPOCardViewType.ADDRESS_CONFIRMED ||
-                    viewType == PPOCardViewType.SURVEY_SUBMITTED
-                ) {
+                if (viewType == PPOCardViewType.CONFIRM_ADDRESS) {
                     Spacer(modifier = Modifier.height(dimensions.paddingSmall))
 
                     ShippingAddressView(
@@ -272,13 +202,9 @@ fun PPOCardView(
 
                 when (viewType) {
                     PPOCardViewType.CONFIRM_ADDRESS -> ConfirmAddressButtonsView(onActionButtonClicked, onSecondaryActionButtonClicked)
-                    PPOCardViewType.ADDRESS_CONFIRMED -> AddressConfirmedButtonView()
                     PPOCardViewType.FIX_PAYMENT -> FixPaymentButtonView(onActionButtonClicked)
-                    PPOCardViewType.PAYMENT_FIXED -> PaymentFixedButtonView()
                     PPOCardViewType.AUTHENTICATE_CARD -> AuthenticateCardButtonView(onActionButtonClicked)
-                    PPOCardViewType.CARD_AUTHENTICATED -> CardAuthenticatedButtonView()
                     PPOCardViewType.OPEN_SURVEY -> TakeSurveyButtonView(onActionButtonClicked)
-                    PPOCardViewType.SURVEY_SUBMITTED -> SurveySubmittedButtonView()
                     PPOCardViewType.UNKNOWN -> {}
                 }
             }
@@ -484,27 +410,6 @@ fun ConfirmAddressButtonsView(onEditAddressClicked: () -> Unit, onConfirmAddress
         )
     }
 }
-@Composable
-fun AddressConfirmedButtonView() {
-    // TODO: Replace with translated string
-    KSSecondaryRedButton(
-        modifier = Modifier.padding(dimensions.paddingMedium),
-        leadingIcon = {
-            Image(
-                modifier = Modifier
-                    .padding(end = dimensions.paddingXSmall)
-                    .size(dimensions.paddingMedium),
-                imageVector = ImageVector.vectorResource(id = R.drawable.icon__check),
-                contentDescription = "Address Confirmed",
-                colorFilter = ColorFilter.tint(color = colors.textSecondary)
-            )
-        },
-        onClickAction = {},
-        text = "Address Confirmed",
-        isEnabled = false,
-        textStyle = typography.buttonText
-    )
-}
 
 @Composable
 fun FixPaymentAlertsView(daysRemaining: Int = -1) {
@@ -575,29 +480,6 @@ fun AuthenticateCardAlertsView(daysRemaining: Int = -1) {
         }
     }
 }
-
-@Composable
-fun PaymentFixedButtonView() {
-    // TODO: Replace with translated string
-    KSSecondaryRedButton(
-        modifier = Modifier.padding(dimensions.paddingMediumSmall),
-        leadingIcon = {
-            Image(
-                modifier = Modifier
-                    .padding(end = dimensions.paddingXSmall)
-                    .size(dimensions.paddingMedium),
-                imageVector = ImageVector.vectorResource(id = R.drawable.icon__check),
-                contentDescription = "Payment Fixed",
-                colorFilter = ColorFilter.tint(color = colors.textSecondary)
-            )
-        },
-        onClickAction = { },
-        text = "Payment Fixed",
-        isEnabled = false,
-        textStyle = typography.buttonText
-    )
-}
-
 @Composable
 fun AuthenticateCardButtonView(onAuthenticateCardClicked: () -> Unit) {
     // TODO: Replace with translated string
@@ -606,28 +488,6 @@ fun AuthenticateCardButtonView(onAuthenticateCardClicked: () -> Unit) {
         onClickAction = { onAuthenticateCardClicked.invoke() },
         text = "Authenticate Card",
         isEnabled = true,
-        textStyle = typography.buttonText
-    )
-}
-
-@Composable
-fun CardAuthenticatedButtonView() {
-    // TODO: Replace with translated string
-    KSSecondaryRedButton(
-        modifier = Modifier.padding(dimensions.paddingMediumSmall),
-        leadingIcon = {
-            Image(
-                modifier = Modifier
-                    .padding(end = dimensions.paddingXSmall)
-                    .size(dimensions.paddingMedium),
-                imageVector = ImageVector.vectorResource(id = R.drawable.icon__check),
-                contentDescription = "Card Authenticated",
-                colorFilter = ColorFilter.tint(color = colors.textSecondary)
-            )
-        },
-        onClickAction = { },
-        text = "Card Authenticated",
-        isEnabled = false,
         textStyle = typography.buttonText
     )
 }
@@ -673,44 +533,6 @@ fun TakeSurveyButtonView(onAuthenticateCardClicked: () -> Unit) {
 }
 
 @Composable
-fun SurveySubmittedAlertsView(hoursRemaining: Int = -1) {
-    if (hoursRemaining > 0) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = dimensions.paddingMediumSmall, start = dimensions.paddingMediumSmall)
-        ) {
-            Spacer(modifier = Modifier.height(dimensions.paddingSmall))
-
-            AddressLocksAlertView(hoursRemaining)
-        }
-    }
-}
-
-@Composable
-fun SurveySubmittedButtonView() {
-    // TODO: Replace with translated string
-    KSPrimaryGreenButton(
-        modifier = Modifier
-            .padding(dimensions.paddingMediumSmall),
-        leadingIcon = {
-            Image(
-                modifier = Modifier
-                    .padding(end = dimensions.paddingXSmall)
-                    .size(dimensions.paddingMedium),
-                imageVector = ImageVector.vectorResource(id = R.drawable.icon__check),
-                contentDescription = "x",
-                colorFilter = ColorFilter.tint(color = colors.textSecondary)
-            )
-        },
-        onClickAction = { },
-        text = "Survey Submitted",
-        isEnabled = false,
-        textStyle = typography.buttonText
-    )
-}
-
-@Composable
 fun AddressLocksAlertView(hoursRemaining: Int = -1) {
     KSCoralBadge(
         leadingIcon = {
@@ -746,4 +568,11 @@ fun PledgeWillBeDroppedAlert(daysRemaining: Int = -1) {
         text = "Pledge will be dropped in $daysRemaining days",
         textColor = colors.textAccentRedBold
     )
+}
+
+fun isTier1Alert(viewType: PPOCardViewType) : Boolean {
+    return when (viewType) {
+        PPOCardViewType.CONFIRM_ADDRESS, PPOCardViewType.AUTHENTICATE_CARD, PPOCardViewType.OPEN_SURVEY, PPOCardViewType.FIX_PAYMENT -> true
+        else -> false
+    }
 }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -201,7 +201,7 @@ fun PPOCardView(
                 }
 
                 when (viewType) {
-                    PPOCardViewType.CONFIRM_ADDRESS -> ConfirmAddressButtonsView(onActionButtonClicked, onSecondaryActionButtonClicked)
+                    PPOCardViewType.CONFIRM_ADDRESS -> ConfirmAddressButtonsView(!shippingAddress.isNullOrEmpty(), onActionButtonClicked, onSecondaryActionButtonClicked)
                     PPOCardViewType.FIX_PAYMENT -> FixPaymentButtonView(onActionButtonClicked)
                     PPOCardViewType.AUTHENTICATE_CARD -> AuthenticateCardButtonView(onActionButtonClicked)
                     PPOCardViewType.OPEN_SURVEY -> TakeSurveyButtonView(onActionButtonClicked)

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
@@ -249,7 +249,6 @@ fun PledgedProjectsOverviewScreen(
                                 creatorName = it.creatorName(),
                                 sendAMessageClickAction = { onSendMessageClick(it.projectSlug() ?: "") },
                                 shippingAddress = it.address() ?: "", // TODO replace with formatted address from PPO response
-                                showBadge = it.showBadge(),
                                 onActionButtonClicked = {
                                     onPrimaryActionButtonClicked(it)
                                 },

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/PPOCardViewKtTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/PPOCardViewKtTest.kt
@@ -30,7 +30,6 @@ class PPOCardViewKtTest : KSRobolectricTestCase() {
                     creatorName = "Some really really really really really really really long name",
                     sendAMessageClickAction = {},
                     shippingAddress = "Firsty Lasty\n123 First Street, Apt #5678\nLos Angeles, CA 90025-1234\nUnited States",
-                    showBadge = true,
                     onActionButtonClicked = {},
                     onSecondaryActionButtonClicked = {},
                     timeNumberForAction = timeNumberForAction
@@ -47,37 +46,6 @@ class PPOCardViewKtTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testAddressConfirmedView() {
-        val timeNumberForAction = 5
-        composeTestRule.setContent {
-            KSTheme {
-                PPOCardView(
-                    viewType = PPOCardViewType.ADDRESS_CONFIRMED,
-                    onCardClick = {},
-                    onProjectPledgeSummaryClick = {},
-                    projectName = "Sugardew Island - Your cozy farm shop let’s pretend this is a longer title let’s pretend this is a longer title",
-                    pledgeAmount = "$50.00",
-                    creatorName = "Some really really really really really really really long name",
-                    sendAMessageClickAction = {},
-                    shippingAddress = "Firsty Lasty\n123 First Street, Apt #5678\nLos Angeles, CA 90025-1234\nUnited States",
-                    showBadge = true,
-                    onActionButtonClicked = {},
-                    onSecondaryActionButtonClicked = {},
-                    timeNumberForAction = timeNumberForAction
-                )
-            }
-        }
-
-        // Alerts
-        // TODO: Replace with translated string
-        composeTestRule.onAllNodesWithText("Address locks in $timeNumberForAction hours")[0].assertIsDisplayed()
-        // Shipping address displayed
-        shippingAddressView.assertIsDisplayed()
-        // CTA
-        composeTestRule.onAllNodesWithText("Address Confirmed")[0].assertIsDisplayed()
-    }
-
-    @Test
     fun testFixPaymentView() {
         val timeNumberForAction = 6
         composeTestRule.setContent {
@@ -90,7 +58,6 @@ class PPOCardViewKtTest : KSRobolectricTestCase() {
                     pledgeAmount = "$50.00",
                     creatorName = "Some really really really really really really really long name",
                     sendAMessageClickAction = {},
-                    showBadge = true,
                     onActionButtonClicked = {},
                     onSecondaryActionButtonClicked = {},
                     timeNumberForAction = timeNumberForAction
@@ -109,35 +76,6 @@ class PPOCardViewKtTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPaymentFixedView() {
-        val timeNumberForAction = 6
-        composeTestRule.setContent {
-            KSTheme {
-                PPOCardView(
-                    viewType = PPOCardViewType.PAYMENT_FIXED,
-                    onCardClick = {},
-                    onProjectPledgeSummaryClick = {},
-                    projectName = "Sugardew Island - Your cozy farm shop let’s pretend this is a longer title let’s pretend this is a longer title",
-                    pledgeAmount = "$50.00",
-                    creatorName = "Some really really really really really really really long name",
-                    sendAMessageClickAction = {},
-                    showBadge = false,
-                    onActionButtonClicked = {},
-                    onSecondaryActionButtonClicked = {},
-                    timeNumberForAction = timeNumberForAction
-                )
-            }
-        }
-
-        // No alerts
-        // Shipping address hidden
-        shippingAddressView.assertIsNotDisplayed()
-        // CTA
-        // TODO: Replace with translated strings
-        composeTestRule.onAllNodesWithText("Payment Fixed")[0].assertIsDisplayed()
-    }
-
-    @Test
     fun testAuthenticateCardView() {
         val timeNumberForAction = 7
         composeTestRule.setContent {
@@ -150,7 +88,6 @@ class PPOCardViewKtTest : KSRobolectricTestCase() {
                     pledgeAmount = "$60.00",
                     creatorName = "Some really really really really really really really long name",
                     sendAMessageClickAction = {},
-                    showBadge = true,
                     onActionButtonClicked = {},
                     onSecondaryActionButtonClicked = {},
                     timeNumberForAction = timeNumberForAction
@@ -169,35 +106,6 @@ class PPOCardViewKtTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testCardAuthenticatedView() {
-        val timeNumberForAction = 7
-        composeTestRule.setContent {
-            KSTheme {
-                PPOCardView(
-                    viewType = PPOCardViewType.CARD_AUTHENTICATED,
-                    onCardClick = {},
-                    onProjectPledgeSummaryClick = {},
-                    projectName = "Sugardew Island - Your cozy farm shop let’s pretend this is a longer title let’s pretend this is a longer title",
-                    pledgeAmount = "$60.00",
-                    creatorName = "Some really really really really really really really long name",
-                    sendAMessageClickAction = {},
-                    showBadge = false,
-                    onActionButtonClicked = {},
-                    onSecondaryActionButtonClicked = {},
-                    timeNumberForAction = timeNumberForAction
-                )
-            }
-        }
-
-        // No alerts
-        // Shipping address hidden
-        shippingAddressView.assertIsNotDisplayed()
-        // CTA
-        // TODO: Replace with translated strings
-        composeTestRule.onAllNodesWithText("Card Authenticated")[0].assertIsDisplayed()
-    }
-
-    @Test
     fun testTakeSurveyView() {
         val timeNumberForAction = 8
         composeTestRule.setContent {
@@ -210,7 +118,6 @@ class PPOCardViewKtTest : KSRobolectricTestCase() {
                     pledgeAmount = "$70.00",
                     creatorName = "Some really really really really really really really long name",
                     sendAMessageClickAction = {},
-                    showBadge = true,
                     onActionButtonClicked = {},
                     onSecondaryActionButtonClicked = {},
                     timeNumberForAction = timeNumberForAction
@@ -225,35 +132,5 @@ class PPOCardViewKtTest : KSRobolectricTestCase() {
         shippingAddressView.assertIsNotDisplayed()
         // CTA
         composeTestRule.onAllNodesWithText("Take Survey")[0].assertIsDisplayed()
-    }
-
-    @Test
-    fun testSurveySubmittedView() {
-        val timeNumberForAction = 8
-        composeTestRule.setContent {
-            KSTheme {
-                PPOCardView(
-                    viewType = PPOCardViewType.SURVEY_SUBMITTED,
-                    onCardClick = {},
-                    onProjectPledgeSummaryClick = {},
-                    projectName = "Sugardew Island - Your cozy farm shop let’s pretend this is a longer title let’s pretend this is a longer title",
-                    pledgeAmount = "$70.00",
-                    creatorName = "Some really really really really really really really long name",
-                    sendAMessageClickAction = {},
-                    showBadge = true,
-                    onActionButtonClicked = {},
-                    onSecondaryActionButtonClicked = {},
-                    timeNumberForAction = timeNumberForAction
-                )
-            }
-        }
-
-        // Alerts
-        // TODO: Replace with translated strings
-        composeTestRule.onAllNodesWithText("Address locks in $timeNumberForAction hours")[0].assertIsDisplayed()
-        // Shipping address displayed
-        shippingAddressView.assertIsDisplayed()
-        // CTA
-        composeTestRule.onAllNodesWithText("Survey Submitted")[0].assertIsDisplayed()
     }
 }


### PR DESCRIPTION
# 📲 What

- Changed the way we are displaying the red notification dot on a PPO card to be determined by card type
- Also cleaned up unused disabled PPO cards since we are no longer doing pull to refresh to dismiss a card

# 🤔 Why

PPO! 

# 🛠 How

Red dot is shown if the card type is tier 1.

# 👀 See

![Screenshot 2024-08-14 at 17 37 53](https://github.com/user-attachments/assets/f0aeeb84-75cf-4dae-bdf6-bb21588adbe3)

# 📋 QA

Make sure any ppo cards displayed had a red dot in the upper right corner

# Story 📖

[MBL-1661: Red notification dot in top right corner of PPO tier 1 alert cards](https://kickstarter.atlassian.net/browse/MBL-1661)
[MBL-1666: Remove unused composables](https://kickstarter.atlassian.net/browse/MBL-1666)
