### PR TITLE
[MBL-1574] Add estimated shipping visuals to checkout screens

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -156,6 +156,8 @@ object RewardViewUtils {
         isAddOn: Boolean,
         multipleQuantitiesAllowed: Boolean,
         shippingRules: List<ShippingRule>?,
+        useUserPreference: Boolean = false,
+        useAbout: Boolean = true
     ): String {
         var min = ""
         var max = ""
@@ -165,14 +167,30 @@ object RewardViewUtils {
                     it.location()?.id() == selectedShippingRule.location()?.id()
                 }.map {
                     if (it.estimatedMin() <= 0 || it.estimatedMax() <= 0) return ""
-                    min = ksCurrency.format(it.estimatedMin(), project, RoundingMode.HALF_UP)
-                    max = ksCurrency.format(it.estimatedMax(), project, RoundingMode.HALF_UP)
+                    min = if (useUserPreference) {
+                        ksCurrency.formatWithUserPreference(it.estimatedMin(), project, RoundingMode.HALF_UP, precision = 2)
+                    } else {
+                        ksCurrency.format(it.estimatedMin(), project, RoundingMode.HALF_UP)
+                    }
+                    max = if (useUserPreference) {
+                        ksCurrency.formatWithUserPreference(it.estimatedMin(), project, RoundingMode.HALF_UP, precision = 2)
+                    } else {
+                        ksCurrency.format(it.estimatedMax(), project, RoundingMode.HALF_UP)
+                    }
                 }
             } else return ""
         } else {
             if (selectedShippingRule.estimatedMin() <= 0 || selectedShippingRule.estimatedMax() <= 0) return ""
-            min = ksCurrency.format(selectedShippingRule.estimatedMin(), project, RoundingMode.HALF_UP)
-            max = ksCurrency.format(selectedShippingRule.estimatedMax(), project, RoundingMode.HALF_UP)
+            min = if (useUserPreference) {
+                ksCurrency.formatWithUserPreference(selectedShippingRule.estimatedMin(), project, RoundingMode.HALF_UP, precision = 2)
+            } else {
+                ksCurrency.format(selectedShippingRule.estimatedMin(), project, RoundingMode.HALF_UP)
+            }
+            max = if (useUserPreference) {
+                ksCurrency.formatWithUserPreference(selectedShippingRule.estimatedMax(), project, RoundingMode.HALF_UP, precision = 2)
+            } else {
+                ksCurrency.format(selectedShippingRule.estimatedMax(), project, RoundingMode.HALF_UP)
+            }
         }
 
         if (min.isEmpty() || max.isEmpty()) return ""
@@ -180,11 +198,11 @@ object RewardViewUtils {
         // TODO: Replace with defined string
         val minToMaxString = if (multipleQuantitiesAllowed) "$min-$max each" else "$min-$max"
 
-        return ksString.format(
-            context.getString(R.string.About_reward_amount),
-            "reward_amount",
+        return if (useAbout) {
+            ksString.format(context.getString(R.string.About_reward_amount), "reward_amount", minToMaxString)
+        } else {
             minToMaxString
-        )
+        }
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
@@ -281,13 +281,14 @@ fun AddOnsScreen(
                                 environment.ksString()?.let { ksString ->
                                     RewardViewUtils.getEstimatedShippingCostString(
                                         context = context,
-                                        ksCurrency,
-                                        ksString,
-                                        project,
-                                        currentShippingRule,
-                                        isAddOn = true,
+                                        ksCurrency = ksCurrency,
+                                        ksString = ksString,
+                                        project = project,
+                                        rewards = listOf(reward),
+                                        selectedShippingRule = currentShippingRule,
                                         multipleQuantitiesAllowed = (reward.limit() ?: -1) > 1,
-                                        shippingRules = reward.shippingRules()
+                                        useUserPreference = false,
+                                        useAbout = true
                                     )
                                 }
                             }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
@@ -215,7 +215,7 @@ fun CheckoutScreen(
                                     .fillMaxWidth(),
                                 onClickAction = { onPledgeCtaClicked(selectedOption.value) },
                                 isEnabled = project.acceptedCardType(selectedOption.value?.type()) || selectedOption.value?.isFromPaymentSheet() ?: false,
-                                text = if (pledgeReason == PledgeReason.PLEDGE) stringResource(id = R.string.Pledge) + " $totalAmountString" else stringResource(
+                                text = if (pledgeReason == PledgeReason.PLEDGE || pledgeReason == PledgeReason.LATE_PLEDGE) stringResource(id = R.string.Pledge) + " $totalAmountString" else stringResource(
                                     id = R.string.Confirm
                                 )
                             )

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
@@ -134,6 +134,7 @@ fun CheckoutScreen(
     project: Project,
     email: String?,
     ksString: KSString? = null,
+    selectedRewardsAndAddOns: List<Reward> = listOf(),
     rewardsList: List<Pair<String, String>> = listOf(),
     shippingAmount: Double = 0.0,
     pledgeReason: PledgeReason,
@@ -498,13 +499,12 @@ fun CheckoutScreen(
                     val estimatedShippingRangeString =
                         RewardViewUtils.getEstimatedShippingCostString(
                             context = LocalContext.current,
-                            environment.ksCurrency()!!,
-                            environment.ksString()!!,
-                            project,
-                            currentShippingRule!!,
-                            isAddOn = false,
+                            ksCurrency = environment.ksCurrency()!!,
+                            ksString = environment.ksString()!!,
+                            project = project,
+                            rewards = selectedRewardsAndAddOns,
+                            selectedShippingRule = currentShippingRule!!,
                             multipleQuantitiesAllowed = false,
-                            shippingRules = null,
                             useUserPreference = false,
                             useAbout = false
                         )
@@ -514,13 +514,12 @@ fun CheckoutScreen(
                         else {
                             RewardViewUtils.getEstimatedShippingCostString(
                                 context = LocalContext.current,
-                                environment.ksCurrency()!!,
-                                environment.ksString()!!,
-                                project,
-                                currentShippingRule,
-                                isAddOn = false,
+                                ksCurrency = environment.ksCurrency()!!,
+                                ksString = environment.ksString()!!,
+                                project = project,
+                                rewards = selectedRewardsAndAddOns,
+                                selectedShippingRule = currentShippingRule,
                                 multipleQuantitiesAllowed = false,
-                                shippingRules = null,
                                 useUserPreference = true,
                                 useAbout = true
                             )

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -74,6 +75,7 @@ import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
 import com.kickstarter.ui.compose.designsystem.KSTheme.typography
 import com.kickstarter.ui.compose.designsystem.kds_white
+import com.kickstarter.ui.compose.designsystem.shapes
 import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.views.compose.checkout.ItemizedRewardListContainer
 import type.CreditCardTypes
@@ -159,8 +161,20 @@ fun CheckoutScreen(
         onChangedPaymentMethod.invoke(it)
     }
 
+    val totalAmountString = environment.ksCurrency()?.let {
+        RewardViewUtils.styleCurrency(
+            totalAmount,
+            project,
+            it
+        ).toString()
+    } ?: ""
+
     // - After adding new payment method, selected card should be updated to the newly added
-    UpdateSelectedCardIfNewCardAdded(remember { mutableStateOf(storedCards.size) }, storedCards, onOptionSelected)
+    UpdateSelectedCardIfNewCardAdded(
+        remember { mutableStateOf(storedCards.size) },
+        storedCards,
+        onOptionSelected
+    )
 
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -200,7 +214,7 @@ fun CheckoutScreen(
                                     .fillMaxWidth(),
                                 onClickAction = { onPledgeCtaClicked(selectedOption.value) },
                                 isEnabled = project.acceptedCardType(selectedOption.value?.type()) || selectedOption.value?.isFromPaymentSheet() ?: false,
-                                text = if (pledgeReason == PledgeReason.PLEDGE) stringResource(id = R.string.Pledge) else stringResource(
+                                text = if (pledgeReason == PledgeReason.PLEDGE) stringResource(id = R.string.Pledge) + " $totalAmountString" else stringResource(
                                     id = R.string.Confirm
                                 )
                             )
@@ -215,10 +229,12 @@ fun CheckoutScreen(
                                 }
                             }
 
-                            if (!formattedEmailDisclaimerString.isNullOrEmpty()) {
+                            if (!formattedEmailDisclaimerString.isNullOrEmpty() && project.isInPostCampaignPledgingPhase() == true) {
                                 Text(
-                                    text = formattedEmailDisclaimerString, textAlign = TextAlign.Center,
-                                    style = typography.caption2, color = colors.kds_support_400
+                                    text = formattedEmailDisclaimerString,
+                                    textAlign = TextAlign.Center,
+                                    style = typography.caption2,
+                                    color = colors.kds_support_400
                                 )
                             }
 
@@ -241,22 +257,15 @@ fun CheckoutScreen(
             }
         ) { padding ->
 
-            val totalAmountString = environment.ksCurrency()?.let {
-                RewardViewUtils.styleCurrency(
-                    totalAmount,
-                    project,
-                    it
-                ).toString()
-            } ?: ""
-
-            val totalAmountConvertedString = if (project.currentCurrency() == project.currency()) "" else {
-                environment.ksCurrency()?.formatWithUserPreference(
-                    totalAmount,
-                    project,
-                    RoundingMode.UP,
-                    2
-                ) ?: ""
-            }
+            val totalAmountConvertedString =
+                if (project.currentCurrency() == project.currency()) "" else {
+                    environment.ksCurrency()?.formatWithUserPreference(
+                        totalAmount,
+                        project,
+                        RoundingMode.UP,
+                        2
+                    ) ?: ""
+                }
 
             val shippingAmountString = environment.ksCurrency()?.let {
                 RewardViewUtils.styleCurrency(
@@ -318,7 +327,8 @@ fun CheckoutScreen(
                 Spacer(modifier = Modifier.height(dimensions.paddingMediumSmall))
 
                 storedCards.forEachIndexed { index, card ->
-                    val isAvailable = project.acceptedCardType(card.type()) || card.isFromPaymentSheet()
+                    val isAvailable =
+                        project.acceptedCardType(card.type()) || card.isFromPaymentSheet()
                     Card(
                         backgroundColor = colors.kds_white,
                         modifier = Modifier
@@ -482,6 +492,46 @@ fun CheckoutScreen(
                         totalBonusSupport = totalAmountString,
                         shippingAmount = shippingAmount,
                     )
+                }
+
+                if (environment.ksCurrency().isNotNull() && environment.ksString().isNotNull() && currentShippingRule.isNotNull()) {
+                    val estimatedShippingRangeString =
+                        RewardViewUtils.getEstimatedShippingCostString(
+                            context = LocalContext.current,
+                            environment.ksCurrency()!!,
+                            environment.ksString()!!,
+                            project,
+                            currentShippingRule!!,
+                            isAddOn = false,
+                            multipleQuantitiesAllowed = false,
+                            shippingRules = null,
+                            useUserPreference = false,
+                            useAbout = false
+                        )
+
+                    val estimatedShippingRangeConversionString =
+                        if (project.currentCurrency() == project.currency()) null
+                        else {
+                            RewardViewUtils.getEstimatedShippingCostString(
+                                context = LocalContext.current,
+                                environment.ksCurrency()!!,
+                                environment.ksString()!!,
+                                project,
+                                currentShippingRule,
+                                isAddOn = false,
+                                multipleQuantitiesAllowed = false,
+                                shippingRules = null,
+                                useUserPreference = true,
+                                useAbout = true
+                            )
+                        }
+
+                    if (estimatedShippingRangeString.isNotEmpty()) {
+                        KSEstimatedShippingCheckoutView(
+                            estimatedShippingRange = estimatedShippingRangeString,
+                            estimatedShippingRangeConversion = estimatedShippingRangeConversionString
+                        )
+                    }
                 }
             }
         }
@@ -750,6 +800,85 @@ fun KSCardElement(card: StoredCard, ksString: KSString?, isAvailable: Boolean) {
                     color = if (isAvailable) colors.kds_support_700 else colors.kds_support_400,
                     text = expirationString
                 )
+            }
+        }
+    }
+}
+
+@Composable
+@Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+fun KSEstimatedShippingCheckoutViewPreview() {
+    KSTheme {
+        KSEstimatedShippingCheckoutView(
+            estimatedShippingRange = "€5-€10",
+            estimatedShippingRangeConversion = "About $6-$11"
+        )
+    }
+}
+
+@Composable
+fun KSEstimatedShippingCheckoutView(
+    estimatedShippingRange: String,
+    estimatedShippingRangeConversion: String?,
+) {
+    Card(
+        modifier = Modifier.padding(dimensions.paddingMediumLarge),
+        shape = shapes.medium,
+        backgroundColor = colors.backgroundSurfacePrimary
+    ) {
+        // TODO: Get these strings translations in place
+        Row {
+            Column(modifier = Modifier.weight(0.6f)) {
+                Text(
+                    modifier = Modifier.padding(
+                        start = dimensions.paddingLarge,
+                        top = dimensions.paddingMedium
+                    ),
+                    text = "Estimated Shipping",
+                    style = typography.calloutMedium,
+                    color = colors.textPrimary
+                )
+
+                Spacer(modifier = Modifier.height(dimensions.paddingSmall))
+
+                Text(
+                    modifier = Modifier.padding(
+                        start = dimensions.paddingLarge,
+                        bottom = dimensions.paddingMedium
+                    ),
+                    text = "This is meant to give you an idea of what shipping might cost. Once the creator is ready to fulfill your reward, you’ll return to pay shipping and applicable taxes.",
+                    style = typography.caption2,
+                    color = colors.textSecondary
+                )
+            }
+
+            Spacer(modifier = Modifier.width(dimensions.paddingMedium))
+
+            Column(modifier = Modifier.weight(0.4f), horizontalAlignment = Alignment.End) {
+                Text(
+                    modifier = Modifier.padding(
+                        end = dimensions.paddingLarge,
+                        top = dimensions.paddingMedium
+                    ),
+                    text = estimatedShippingRange,
+                    style = typography.calloutMedium,
+                    color = colors.textPrimary
+                )
+
+                Spacer(modifier = Modifier.height(dimensions.paddingSmall))
+
+                if (!estimatedShippingRangeConversion.isNullOrEmpty()) {
+                    Text(
+                        modifier = Modifier.padding(
+                            end = dimensions.paddingLarge,
+                            bottom = dimensions.paddingMedium
+                        ),
+                        text = estimatedShippingRangeConversion,
+                        style = typography.caption1,
+                        color = colors.textSecondary
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ProjectPledgeButtonAndFragmentContainer.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/ProjectPledgeButtonAndFragmentContainer.kt
@@ -273,6 +273,7 @@ fun ProjectPledgeButtonAndFragmentContainer(
                                         project = project,
                                         email = userEmail,
                                         selectedReward = selectedReward,
+                                        selectedRewardsAndAddOns = selectedRewardAndAddOnList,
                                         rewardsList = getRewardListAndPrices(
                                             selectedRewardAndAddOnList,
                                             environment,

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
@@ -326,14 +326,15 @@ fun RewardCarouselScreen(
                                 environment.ksCurrency()?.let { ksCurrency ->
                                     environment.ksString()?.let { ksString ->
                                         RewardViewUtils.getEstimatedShippingCostString(
-                                            context,
-                                            ksCurrency,
-                                            ksString,
-                                            project,
-                                            currentShippingRule,
-                                            isAddOn = false,
+                                            context = context,
+                                            ksCurrency = ksCurrency,
+                                            ksString = ksString,
+                                            project = project,
+                                            rewards = listOf(reward),
+                                            selectedShippingRule = currentShippingRule,
                                             multipleQuantitiesAllowed = false,
-                                            shippingRules = null
+                                            useUserPreference = false,
+                                            useAbout = true
                                         )
                                     }
                                 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/CrowdfundCheckoutFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/CrowdfundCheckoutFragment.kt
@@ -117,6 +117,7 @@ class CrowdfundCheckoutFragment : Fragment() {
                         // TODO: hide bonus support if 0
                         CheckoutScreen(
                             rewardsList = getRewardListAndPrices(rwList, environment, project),
+                            selectedRewardsAndAddOns = rwList,
                             environment = requireNotNull(environment),
                             shippingAmount = shippingAmount,
                             selectedReward = selectedRw,

--- a/app/src/main/java/com/kickstarter/ui/views/compose/checkout/PledgeItemizedDetails.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/compose/checkout/PledgeItemizedDetails.kt
@@ -200,7 +200,7 @@ fun ItemizedRewardListContainer(
 
         Row {
             Text(
-                text = stringResource(id = R.string.Total_amount),
+                text = stringResource(id = R.string.Pledge_amount),
                 style = typography.calloutMedium,
                 color = colors.textPrimary
             )


### PR DESCRIPTION
# 📲 What

Adding an estimated shipping visual to the checkout screen for pledge flows

# 🤔 Why

We need to show the user at checkout what their estimated shipping will be

# 🛠 How

🧠 

# 👀 See

Campaign checkout:
![Screenshot_20240820-101835](https://github.com/user-attachments/assets/c4c685b9-6807-49dc-9939-b183ed65b1e2)

Late pledge checkout:
![Screenshot_20240820-102724](https://github.com/user-attachments/assets/6a64030e-0a78-4121-b8b5-73e4320e4343)


# 📋 QA

Go to a project with estimated shipping (both late pledge and normal) and confirm this view is shown on both versions.  Confirm that the non late pledge does NOT have the immediate charge text near the pledge button

# Story 📖

[MBL-1574](https://kickstarter.atlassian.net/browse/MBL-1574)


[MBL-1574]: https://kickstarter.atlassian.net/browse/MBL-1574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ