### PR TITLE
[NoTicket] Bump up the min sdk version from 23 to 24

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,7 +54,7 @@ android {
     defaultConfig {
         compileSdk 34
         applicationId "com.kickstarter"
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion 34
         testApplicationId "com.kickstarter.internal.debug.test"
         testInstrumentationRunner "com.kickstarter.screenshoot.testing.KSScreenShotTestRunner"

--- a/app/src/main/java/com/kickstarter/libs/ApiCapabilities.java
+++ b/app/src/main/java/com/kickstarter/libs/ApiCapabilities.java
@@ -8,8 +8,4 @@ public final class ApiCapabilities {
   public static boolean canCreateNotificationChannels() {
     return android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O;
   }
-
-  public static boolean needsLegacyHtml() {
-    return android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.N;
-  }
 }

--- a/app/src/main/java/com/kickstarter/libs/utils/ViewUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ViewUtils.java
@@ -27,7 +27,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.kickstarter.R;
-import com.kickstarter.libs.ApiCapabilities;
 import com.kickstarter.ui.views.ConfirmDialog;
 
 import rx.functions.Action1;

--- a/app/src/main/java/com/kickstarter/libs/utils/ViewUtils.java
+++ b/app/src/main/java/com/kickstarter/libs/utils/ViewUtils.java
@@ -68,11 +68,7 @@ public final class ViewUtils {
    *
    */
   public static Spanned html(final @NonNull String htmlString) {
-    if (ApiCapabilities.needsLegacyHtml()) {
-      return Html.fromHtml(htmlString);
-    } else {
-      return Html.fromHtml(htmlString, Html.FROM_HTML_MODE_COMPACT);
-    }
+    return Html.fromHtml(htmlString, Html.FROM_HTML_MODE_COMPACT);
   }
 
   public static boolean isFontScaleLarge(final @NonNull Context context) {

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/StringExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/StringExt.kt
@@ -2,7 +2,6 @@
 
 package com.kickstarter.libs.utils.extensions
 
-import android.os.Build
 import android.text.Html
 import android.text.Spanned
 import android.text.TextUtils

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/StringExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/StringExt.kt
@@ -212,11 +212,7 @@ fun String.hrefUrlFromTranslation(): String {
  * Takes a String resource with HTMl Returns displayable styled text from the provided HTML string.
  */
 fun String.toHtml(): Spanned {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-        Html.fromHtml(TextUtils.htmlEncode(this), Html.FROM_HTML_MODE_LEGACY)
-    } else {
-        Html.fromHtml(TextUtils.htmlEncode(this))
-    }
+    return Html.fromHtml(TextUtils.htmlEncode(this), Html.FROM_HTML_MODE_LEGACY)
 }
 
 fun String.toHashedSHAEmail(): String {

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectOverviewFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectOverviewFragment.kt
@@ -2,7 +2,6 @@ package com.kickstarter.ui.fragments.projectpage
 
 import android.app.Activity
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.text.Html
 import android.text.Html.FROM_HTML_MODE_LEGACY

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectOverviewFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ProjectOverviewFragment.kt
@@ -429,11 +429,8 @@ class ProjectOverviewFragment : Fragment(), Configure {
     }
 
     private fun setBlurbTextViews(blurb: String) {
-        val blurbHtml = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        val blurbHtml =
             Html.fromHtml(TextUtils.htmlEncode(blurb), FROM_HTML_MODE_LEGACY)
-        } else {
-            Html.fromHtml(TextUtils.htmlEncode(blurb))
-        }
         binding.blurb.text = blurbHtml
     }
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ThanksShareViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ThanksShareViewHolder.kt
@@ -3,7 +3,6 @@ package com.kickstarter.ui.viewholders
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
 import android.text.Html
 import android.util.Pair
 import com.facebook.share.model.ShareLinkContent

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ThanksShareViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ThanksShareViewHolder.kt
@@ -90,32 +90,18 @@ class ThanksShareViewHolder(private val binding: ThanksShareViewBinding) : KSVie
     }
 
     private fun showPostCampaignPledgeText(pcptext: Pair<Double, Project>) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            binding.backedProject.text = Html.fromHtml(
-                ksString.format(
-                    context().getString(R.string.You_have_successfully_pledged_to_project_post_campaign_html_short),
-                    "pledge_total",
-                    ksCurrency.format(
-                        initialValue = pcptext.first,
-                        project = pcptext.second,
-                        roundingMode = RoundingMode.HALF_UP
-                    )
-                ),
-                Html.FROM_HTML_MODE_LEGACY
-            )
-        } else {
-            binding.backedProject.text = Html.fromHtml(
-                ksString.format(
-                    context().getString(R.string.You_have_successfully_pledged_to_project_post_campaign_html_short),
-                    "pledge_total",
-                    ksCurrency.format(
-                        initialValue = pcptext.first,
-                        project = pcptext.second,
-                        roundingMode = RoundingMode.HALF_UP
-                    )
-                ),
-            )
-        }
+        binding.backedProject.text = Html.fromHtml(
+            ksString.format(
+                context().getString(R.string.You_have_successfully_pledged_to_project_post_campaign_html_short),
+                "pledge_total",
+                ksCurrency.format(
+                    initialValue = pcptext.first,
+                    project = pcptext.second,
+                    roundingMode = RoundingMode.HALF_UP
+                )
+            ),
+            Html.FROM_HTML_MODE_LEGACY
+        )
     }
 
     private fun startShare(projectNameAndShareUrl: Pair<String, String>) {

--- a/app/src/test/java/com/kickstarter/KSRobolectricGradleTestRunner.java
+++ b/app/src/test/java/com/kickstarter/KSRobolectricGradleTestRunner.java
@@ -6,7 +6,7 @@ import org.junit.runners.model.InitializationError;
 import org.robolectric.RobolectricTestRunner;
 
 public class KSRobolectricGradleTestRunner extends RobolectricTestRunner {
-  static final int DEFAULT_SDK = Build.VERSION_CODES.M;
+  static final int DEFAULT_SDK = Build.VERSION_CODES.N;
 
   public KSRobolectricGradleTestRunner(final Class<?> testClass) throws InitializationError {
     super(testClass);

--- a/app/src/test/java/com/kickstarter/viewmodels/usecases/SendThirdPartyEventUseCaseTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/usecases/SendThirdPartyEventUseCaseTest.kt
@@ -222,7 +222,7 @@ class SendThirdPartyEventUseCaseTest : KSRobolectricTestCase() {
         assertEquals(false, input.appData.iOSConsent)
         assertEquals("a2", input.appData.extInfo.first())
         assertEquals(16, input.appData.extInfo.size)
-        assertEquals("6.0.1", input.appData.extInfo[4])
+        assertEquals("7.0", input.appData.extInfo[4])
     }
 
     @Test
@@ -404,7 +404,7 @@ class SendThirdPartyEventUseCaseTest : KSRobolectricTestCase() {
         assertEquals(false, input.appData.iOSConsent)
         assertEquals("a2", input.appData.extInfo.first())
         assertEquals(16, input.appData.extInfo.size)
-        assertEquals("6.0.1", input.appData.extInfo[4])
+        assertEquals("7.0", input.appData.extInfo[4])
     }
 
     private fun subscribeToThirdPartyEvent(

--- a/app/src/test/java/com/kickstarter/viewmodels/usecases/SendThirdPartyEventUseCaseV2Test.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/usecases/SendThirdPartyEventUseCaseV2Test.kt
@@ -232,7 +232,7 @@ class SendThirdPartyEventUseCaseV2Test : KSRobolectricTestCase() {
         assertEquals(false, input.appData.iOSConsent)
         assertEquals("a2", input.appData.extInfo.first())
         assertEquals(16, input.appData.extInfo.size)
-        assertEquals("6.0.1", input.appData.extInfo[4])
+        assertEquals("7.0", input.appData.extInfo[4])
     }
 
     @Test
@@ -416,7 +416,7 @@ class SendThirdPartyEventUseCaseV2Test : KSRobolectricTestCase() {
         assertEquals(false, input.appData.iOSConsent)
         assertEquals("a2", input.appData.extInfo.first())
         assertEquals(16, input.appData.extInfo.size)
-        assertEquals("6.0.1", input.appData.extInfo[4])
+        assertEquals("7.0", input.appData.extInfo[4])
     }
 
     private fun subscribeToThirdPartyEvent(


### PR DESCRIPTION
# 📲 What

Bumping the min sdk version from 23->24

# 🤔 Why

Android 15 devices will require the app minimum to be 24 in order to be installed.  Currently this is the only change needed for kickstarter app to run on android 15, other changes can come later, but this one is required.
see [doc](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/3075538945/Android+15+Spike)

# 🛠 How

Update the min version in the gradle file and robolectric files and remove any unneeded version checks with min bump
