### PR TITLE
MBL-1585: small touch ups

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -163,10 +163,17 @@ object RewardViewUtils {
         var minTotal = 0.0
         var maxtotal = 0.0
         rewards.forEach { reward ->
-            if (!RewardUtils.isDigital(reward) && RewardUtils.isShippable(reward) && !RewardUtils.isLocalPickup(reward)) {
+            if (!RewardUtils.isDigital(reward) && RewardUtils.shipsToRestrictedLocations(reward) && !RewardUtils.isLocalPickup(reward)) {
                 reward.shippingRules()?.filter {
                     it.location()?.id() == selectedShippingRule.location()?.id()
                 }?.map {
+                    minTotal += (it.estimatedMin() * (reward.quantity() ?: 1))
+                    maxtotal += (it.estimatedMax() * (reward.quantity() ?: 1))
+                }
+            }
+
+            if (RewardUtils.shipsWorldwide(reward) && !reward.shippingRules().isNullOrEmpty()) {
+                reward.shippingRules()?.first()?.let {
                     minTotal += (it.estimatedMin() * (reward.quantity() ?: 1))
                     maxtotal += (it.estimatedMax() * (reward.quantity() ?: 1))
                 }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsContainer.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsContainer.kt
@@ -161,7 +161,7 @@ fun AddOnsContainer(
             if (!estimatedShippingCost.isNullOrEmpty()) {
                 Spacer(modifier = Modifier.height(dimensions.paddingMediumLarge))
                 Text(
-                    text = stringResource(id = R.string.project_view_pledge_includes),
+                    text = stringResource(id = R.string.estimated_shipping_fpo),
                     color = colors.kds_support_400,
                     style = typography.calloutMedium
                 )


### PR DESCRIPTION
# 📲 What

- Rewards shipping globally where not showing the shipping range

# 🤔 Why
- no location.id matching for this case, as the only shipping rule available id is "1", with name "Rest of the world"
<img width="781" alt="Screenshot 2024-08-26 at 2 27 04 PM" src="https://github.com/user-attachments/assets/f16b176c-4c36-4770-a443-1a904a7dafcb">


# 👀 See

| Before 🐛 | After 🦋 |
<img width="953" alt="Screenshot 2024-08-26 at 3 48 05 PM" src="https://github.com/user-attachments/assets/96bac15c-400f-4b6c-b1b4-e31584ad748a">


|  |  |

# 📋 QA
- Go to [this project for crowdfund ](https://staging.kickstarter.com/projects/isabel-martin/sustainable-20-community-space) there is a globally shipping reward with range $1-10. There is a restricted reward shipping only to Canada ($5-9) and United States ($2-7)

- Go to [this project for late pledges](https://staging.kickstarter.com/projects/isabel-martin/dubstep-restoration-video-game)  there is a globally shipping reward with range $1-10. There is a restricted reward shipping only to Canada/ Denmark and Greece with different shippings ranges

Story 📖
https://kickstarter.atlassian.net/browse/MBL-1585
