### PR TITLE
MBL-1676: When a project is no longer allowed to collect, view rewards menu should not filter rewards nor show the select button

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
@@ -143,6 +143,14 @@ fun Project.deadlineCountdownValue(): Int {
 }
 
 /**
+ * The project is able to collect pledges during crowdfund or late pledges
+ * and it is not backed already by the current user
+ */
+fun Project.isAllowedToPledge(): Boolean {
+    return (!this.isCompleted() || this.showLatePledgeFlow())
+}
+
+/**
  * Returns `true` if the project is no longer live, `false` otherwise.
  */
 fun Project.isCompleted(): Boolean =

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
@@ -143,8 +143,7 @@ fun Project.deadlineCountdownValue(): Int {
 }
 
 /**
- * The project is able to collect pledges during crowdfund or late pledges
- * and it is not backed already by the current user
+ * The project is allowed to pledges during crowdfund active campaign or late pledges phase
  */
 fun Project.isAllowedToPledge(): Boolean {
     return (!this.isCompleted() || this.showLatePledgeFlow())

--- a/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.kt
@@ -175,7 +175,6 @@ object RewardFactory {
     fun rewardRestrictedShipping(): Reward {
         return reward().toBuilder()
             .shippingPreference(Reward.ShippingPreference.RESTRICTED.name)
-            .shippingType(Reward.SHIPPING_TYPE_MULTIPLE_LOCATIONS)
             .build()
     }
 

--- a/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/RewardFactory.kt
@@ -175,6 +175,7 @@ object RewardFactory {
     fun rewardRestrictedShipping(): Reward {
         return reward().toBuilder()
             .shippingPreference(Reward.ShippingPreference.RESTRICTED.name)
+            .shippingType(Reward.SHIPPING_TYPE_MULTIPLE_LOCATIONS)
             .build()
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
@@ -32,9 +32,12 @@ import com.kickstarter.libs.utils.DateTimeUtils
 import com.kickstarter.libs.utils.NumberUtils
 import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.RewardViewUtils
+import com.kickstarter.libs.utils.extensions.isAllowedToPledge
 import com.kickstarter.libs.utils.extensions.isBacked
+import com.kickstarter.libs.utils.extensions.isCompleted
 import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.libs.utils.extensions.isNullOrZero
+import com.kickstarter.libs.utils.extensions.showLatePledgeFlow
 import com.kickstarter.mock.factories.RewardsItemFactory
 import com.kickstarter.mock.factories.ShippingRuleFactory
 import com.kickstarter.models.Backing
@@ -218,7 +221,8 @@ fun RewardCarouselScreen(
                             description = if (isBacked) stringResource(id = R.string.Thanks_for_bringing_this_project_one_step_closer_to_becoming_a_reality) else stringResource(
                                 id = R.string.Back_it_because_you_believe_in_it
                             ),
-                            onRewardSelectClicked = { onRewardSelected(reward) }
+                            onRewardSelectClicked = { onRewardSelected(reward) },
+                            isCTAButtonVisible = project.isAllowedToPledge()
                         )
                     } else {
                         KSRewardCard(
@@ -339,7 +343,8 @@ fun RewardCarouselScreen(
                                     }
                                 }
                             } else null,
-                            addonsPillVisible = reward.hasAddons()
+                            addonsPillVisible = reward.hasAddons(),
+                            isCTAButtonVisible = project.isAllowedToPledge()
                         )
                     }
                 }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
@@ -34,10 +34,8 @@ import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.RewardViewUtils
 import com.kickstarter.libs.utils.extensions.isAllowedToPledge
 import com.kickstarter.libs.utils.extensions.isBacked
-import com.kickstarter.libs.utils.extensions.isCompleted
 import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.libs.utils.extensions.isNullOrZero
-import com.kickstarter.libs.utils.extensions.showLatePledgeFlow
 import com.kickstarter.mock.factories.RewardsItemFactory
 import com.kickstarter.mock.factories.ShippingRuleFactory
 import com.kickstarter.models.Backing

--- a/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
@@ -129,9 +129,8 @@ class GetShippingRulesUseCase(
                 emitCurrentState(isLoading = false)
             }
 
-            // - Just displaying all rewards, project no collecting any longer
+            // - Just displaying all rewards available or not, project no collecting any longer
             if (!project.isAllowedToPledge()) {
-                // - All rewards are digital, all rewards must be available
                 filteredRewards.clear()
                 filteredRewards.addAll(project.rewards() ?: emptyList())
                 emitCurrentState(isLoading = false)

--- a/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
@@ -4,7 +4,6 @@ import com.kickstarter.libs.Config
 import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.extensions.getDefaultLocationFrom
 import com.kickstarter.libs.utils.extensions.isAllowedToPledge
-import com.kickstarter.libs.utils.extensions.isCompleted
 import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.models.Location
 import com.kickstarter.models.Project

--- a/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
@@ -3,6 +3,8 @@ package com.kickstarter.viewmodels.usecases
 import com.kickstarter.libs.Config
 import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.extensions.getDefaultLocationFrom
+import com.kickstarter.libs.utils.extensions.isAllowedToPledge
+import com.kickstarter.libs.utils.extensions.isCompleted
 import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.models.Location
 import com.kickstarter.models.Project
@@ -93,7 +95,7 @@ class GetShippingRulesUseCase(
             val avShipMap = allAvailableRulesForProject
             emitCurrentState(isLoading = true)
 
-            if (rewardsByShippingType.isNotEmpty()) {
+            if (rewardsByShippingType.isNotEmpty() && project.isAllowedToPledge()) {
                 rewardsByShippingType.forEachIndexed { index, reward ->
 
                     if (RewardUtils.shipsToRestrictedLocations(reward)) {
@@ -119,10 +121,20 @@ class GetShippingRulesUseCase(
                         filterRewardsByLocation(avShipMap, defaultShippingRule, projectRewards)
                     }
                 }
-            } else {
+            }
+            // - all rewards digital
+            if (rewardsByShippingType.isEmpty() && project.isAllowedToPledge()) {
                 // - All rewards are digital, all rewards must be available
                 filteredRewards.clear()
                 filteredRewards.addAll(projectRewards)
+                emitCurrentState(isLoading = false)
+            }
+
+            // - Just displaying all rewards, project no collecting any longer
+            if (!project.isAllowedToPledge()) {
+                // - All rewards are digital, all rewards must be available
+                filteredRewards.clear()
+                filteredRewards.addAll(project.rewards() ?: emptyList())
                 emitCurrentState(isLoading = false)
             }
         }

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
@@ -418,4 +418,52 @@ class ProjectExtTest : KSRobolectricTestCase() {
         assertEquals(reducedProject.projectFaqs(), emptyList<ProjectFaq>()) // Default builder value
         assertEquals(reducedProject.story(), "") // Default builder value
     }
+
+    @Test
+    fun `test if a project is not allowed to collect pledges when has been funded and no late pledges`() {
+        val project = ProjectFactory.project()
+            .toBuilder()
+            .state(Project.STATE_SUCCESSFUL)
+            .isInPostCampaignPledgingPhase(false)
+            .postCampaignPledgingEnabled(false)
+            .build()
+
+        assertFalse(project.isAllowedToPledge())
+    }
+
+    @Test
+    fun `test if a project is allowed to collect pledges when campaign is still ongoing`() {
+        val project = ProjectFactory.project()
+            .toBuilder()
+            .state(Project.STATE_LIVE)
+            .isInPostCampaignPledgingPhase(false)
+            .postCampaignPledgingEnabled(false)
+            .build()
+
+        assertTrue(project.isAllowedToPledge())
+    }
+
+    @Test
+    fun `test if a project is allowed to collect pledges when has been funded but has late pledges enabled and it is collecting`() {
+        val project = ProjectFactory.project()
+            .toBuilder()
+            .state(Project.STATE_SUCCESSFUL)
+            .isInPostCampaignPledgingPhase(true)
+            .postCampaignPledgingEnabled(true)
+            .build()
+
+        assertTrue(project.isAllowedToPledge())
+    }
+
+    @Test
+    fun `test if a project is not allowed to collect pledges when has been funded but has late pledges enabled but not collecting`() {
+        val project = ProjectFactory.project()
+            .toBuilder()
+            .state(Project.STATE_SUCCESSFUL)
+            .isInPostCampaignPledgingPhase(false)
+            .postCampaignPledgingEnabled(true)
+            .build()
+
+        assertFalse(project.isAllowedToPledge())
+    }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCaseTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCaseTest.kt
@@ -1,0 +1,94 @@
+package com.kickstarter.viewmodels.usecases
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.mock.factories.ConfigFactory
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.mock.factories.RewardFactory
+import com.kickstarter.mock.factories.ShippingRuleFactory
+import com.kickstarter.mock.services.MockApolloClientV2
+import com.kickstarter.models.Project
+import com.kickstarter.models.Reward
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class GetShippingRulesUseCaseTest : KSRobolectricTestCase() {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `test useCase returns project reward list unfiltered when not collecting`() = runTest {
+        val apolloClient = MockApolloClientV2()
+        val config = ConfigFactory.configForCA()
+        val project = ProjectFactory.project()
+            .toBuilder()
+            .state(Project.STATE_SUCCESSFUL)
+            .isInPostCampaignPledgingPhase(false)
+            .postCampaignPledgingEnabled(false)
+            .build()
+
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = backgroundScope
+
+        val useCase = GetShippingRulesUseCase(apolloClient, project, config, scope, dispatcher)
+
+        val state = mutableListOf<ShippingRulesState>()
+        scope.launch(dispatcher) {
+            useCase.invoke()
+            useCase.shippingRulesState.toList(state)
+        }
+        advanceUntilIdle()
+
+        assertEquals(state.size, 2)
+        assertEquals(state.last().filteredRw, project.rewards())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `test useCase returns project reward list filtered when collecting late pledges`() = runTest {
+        val apolloClient = MockApolloClientV2()
+        val config = ConfigFactory.configForUSUser()
+
+        val shippingRule1 = ShippingRuleFactory.canadaShippingRule()
+        val shippingRule2 = ShippingRuleFactory.germanyShippingRule()
+        val shippingRule3 = ShippingRuleFactory.usShippingRule()
+
+        val reward = RewardFactory.reward().toBuilder()
+            .shippingPreference(Reward.ShippingPreference.RESTRICTED.name)
+            .shippingType(Reward.SHIPPING_TYPE_MULTIPLE_LOCATIONS)
+            .isAvailable(true)
+            .shippingRules(listOf(shippingRule1))
+            .build()
+        val reward2 = reward.toBuilder()
+            .shippingRules(listOf(shippingRule1, shippingRule2, shippingRule3))
+            .build()
+
+        val project = ProjectFactory.project()
+            .toBuilder()
+            .rewards(listOf(reward, reward2))
+            .state(Project.STATE_SUCCESSFUL)
+            .isInPostCampaignPledgingPhase(true)
+            .postCampaignPledgingEnabled(true)
+            .build()
+
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = backgroundScope
+
+        val useCase = GetShippingRulesUseCase(apolloClient, project, config, scope, dispatcher)
+
+        val state = mutableListOf<ShippingRulesState>()
+        scope.launch(dispatcher) {
+            useCase.invoke()
+            useCase.shippingRulesState.toList(state)
+        }
+        advanceUntilIdle()
+
+        assertEquals(state.size, 2)
+        assertNotSame(state.last().filteredRw, project.rewards())
+        assertEquals(state.last().filteredRw.size, 1)
+        assertEquals(state.last().filteredRw.first(), reward2)
+    }
+}


### PR DESCRIPTION
# 📲 What

- When a project is no longer allowed to collect, view rewards menu should not filter rewards not show the select button


# 🛠 How
- New extension method for project to

# 👀 See
| Before 🐛 |

https://github.com/user-attachments/assets/d173f519-f781-460c-9779-b4e71c81f5b2

| After 🦋 |

https://github.com/user-attachments/assets/41515aa0-9a86-4a86-b837-23597e03ae84

|  |  |

# 📋 QA

- Go to a successful project you backed, hit the view rewards menu, you'll see all the rewards and none of them is able to be selected.
- You can still pledge when the project is Successful but is marked as collecting late pledges, you can try any of the following projects collecting late pledges:
- - https://staging.kickstarter.com/projects/isabel-martin/sustainable-20-community-space
- - https://staging.kickstarter.com/projects/1521513553/locally-sourced-album-watch 

# Story 📖

[MBL-1676](https://kickstarter.atlassian.net/browse/MBL-1676)


[MBL-1676]: https://kickstarter.atlassian.net/browse/MBL-1676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ