### PR TITLE
MBL-1696: AddOns add button lost state

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsContainer.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsContainer.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsContainer.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsContainer.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -75,7 +76,7 @@ fun AddOnsContainer(
     quantity: Int = 0
 ) {
 
-    var count by remember { mutableStateOf(quantity) }
+    var count by rememberSaveable { mutableStateOf(quantity) }
 
     Card(
         modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
# 📲 What

- After selecting addOns, if an scroll event takes place, the UI forgot the state

| Before 🐛 |

https://github.com/user-attachments/assets/7a4bf3a1-cc3f-4e19-949e-c7b8fdfc7796

| After 🦋 |

https://github.com/user-attachments/assets/8aef8e18-2302-456b-b222-5507031c2598


| --- | --- |
|  |  |

# 📋 QA

- Go to any project with several addOns, scroll to the bottom, select addOns, scroll up and down a few times, the selected number of addOns should state the same.

# Story 📖

[MBL-1696](https://kickstarter.atlassian.net/browse/MBL-1696)


[MBL-1696]: https://kickstarter.atlassian.net/browse/MBL-1696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ