### PR TITLE
[MBL-1693] Fix add-ons not being flattened for update payment/reward flows

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/PledgeDataExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/PledgeDataExt.kt
@@ -75,6 +75,27 @@ fun PledgeData.rewardsAndAddOnsList(): List<Reward> {
     return list
 }
 
+fun PledgeData.expandedRewardsAndAddOnsList(): List<Reward> {
+    val list = mutableListOf<Reward>()
+
+    list.add(this.reward())
+    val mutableAddOnsList = mutableListOf<Reward>()
+
+    this.addOns()?.map {
+        if (!it.isAddOn()) mutableAddOnsList.add(it)
+        else {
+            val q = it.quantity() ?: 1
+            for (i in 1..q) {
+                mutableAddOnsList.add(it)
+            }
+        }
+    }
+
+    if (mutableAddOnsList.isNotEmpty()) list.addAll(mutableAddOnsList)
+
+    return list
+}
+
 /**
  * Total count of selected add-ons (including multiple quantities of a single add-on)
  *

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
@@ -11,6 +11,7 @@ import com.kickstarter.libs.utils.RefTagUtils
 import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.ThirdPartyEventValues
 import com.kickstarter.libs.utils.extensions.checkoutTotalAmount
+import com.kickstarter.libs.utils.extensions.expandedRewardsAndAddOnsList
 import com.kickstarter.libs.utils.extensions.pledgeAmountTotal
 import com.kickstarter.libs.utils.extensions.rewardsAndAddOnsList
 import com.kickstarter.libs.utils.extensions.shippingCostIfShipping
@@ -412,7 +413,7 @@ class CrowdfundCheckoutViewModel(val environment: Environment, bundle: Bundle? =
                         rwl.add(it)
                     }
                     backing.addOns()?.let {
-                        rwl.addAll(it)
+                        rwl.addAll(RewardUtils.extendAddOns(it))
                     }
 
                     getUpdateBackingData(
@@ -430,7 +431,7 @@ class CrowdfundCheckoutViewModel(val environment: Environment, bundle: Bundle? =
                         else null
                     val isNoRw = pledgeData?.reward()?.let { RewardUtils.isNoReward(it) } ?: false
                     val rwListOrEmpty = if (isNoRw) emptyList<Reward>()
-                    else pledgeData?.rewardsAndAddOnsList() ?: emptyList()
+                    else pledgeData?.expandedRewardsAndAddOnsList() ?: emptyList()
 
                     getUpdateBackingData(
                         backing,


### PR DESCRIPTION
# 📲 What

When updating your payment method or reward selection the add-ons IDs were not being flattened for the quantity they had

# 🤔 Why

This was causing a bug where it would not correctly update the pledge

# 🛠 How

Made it so that instead of a single item in the reward ids list we send to the backend they get flattened ex:
Reward with ID X quantity 1 selected
Add-On with ID Y with quantity 2 selected 
would result in the ID list being < X, Y, Y > 

# 📋 QA

Update a reward selection with more add-ons and make sure that both the total amount, shipping amount, etc are updated correctly on the summary screen/the information sent to the backend is correct

# Story 📖

[MBL-1693](https://kickstarter.atlassian.net/browse/MBL-1693)


[MBL-1693]: https://kickstarter.atlassian.net/browse/MBL-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ