### PR TITLE
[MBL-1726] Make PPO webview use correct endpoint and logs user in automatically

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -380,7 +380,7 @@ fragment shippingRule on ShippingRule {
 
 fragment ppoCard on Backing {
     id
-    backingDetailsPageRoute(type: url)
+    backingDetailsPageRoute(type: url, tab: survey_responses)
     clientSecret
     amount {
         ...amount

--- a/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.kt
+++ b/app/src/main/java/com/kickstarter/services/interceptors/WebRequestInterceptor.kt
@@ -4,13 +4,11 @@ import android.net.Uri
 import com.kickstarter.libs.Build
 import com.kickstarter.libs.CurrentUserType
 import com.kickstarter.libs.InternalToolsType
-import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.libs.utils.WebUtils.userAgent
 import com.kickstarter.libs.utils.extensions.isHivequeenUri
 import com.kickstarter.libs.utils.extensions.isStagingUri
 import com.kickstarter.libs.utils.extensions.isWebUri
 import com.kickstarter.models.User
-import okhttp3.Credentials
 import okhttp3.Interceptor
 import okhttp3.Interceptor.Chain
 import okhttp3.Request
@@ -57,15 +55,15 @@ class WebRequestInterceptor(
                 requestBuilder.addHeader("Authorization", it)
         }
 
-        if (isStaging(initialRequest)) {
-            requestBuilder.header(
-                name = "Authorization",
-                Credentials.basic(
-                    Secrets.WebEndpoint.CredentialsStaging.USER,
-                    Secrets.WebEndpoint.CredentialsStaging.PASS
-                )
-            )
-        }
+//        if (isStaging(initialRequest)) {
+//            requestBuilder.header(
+//                name = "Authorization",
+//                Credentials.basic(
+//                    Secrets.WebEndpoint.CredentialsStaging.USER,
+//                    Secrets.WebEndpoint.CredentialsStaging.PASS
+//                )
+//            )
+//        }
 
         return requestBuilder.build()
     }


### PR DESCRIPTION
# 📲 What

Adjust PPO query to pull the correct endpoint to make it so the user is logged in upon accessing the page

# 🤔 Why

It was asking the user to log in instead of just going to the page

# 🛠 How

Removed a staging header being added and adjust the PPO query to use a specific tab with creds

# 👀 See

https://github.com/user-attachments/assets/9693f020-e3e5-4fe7-ba0b-c1b7c03a0eaa

# 📋 QA

Go to the PPO page with cards, click on the card/survey/edit address button and confirm the page loads correctly (doesnt ask you to log in)

# Story 📖

[MBL-1726](https://kickstarter.atlassian.net/browse/MBL-1726)


[MBL-1726]: https://kickstarter.atlassian.net/browse/MBL-1726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ