### PR TITLE
SD-3241: Wrong shipping value for Shipping World Wide rewards

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/PledgeDataExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/PledgeDataExt.kt
@@ -18,9 +18,10 @@ fun PledgeData.locationId(): Long {
  *
  */
 fun PledgeData.shippingCostIfShipping(): Double {
-    val rwShippingCost = if (RewardUtils.isShippable(this.reward()))
-        this.shippingRule()?.cost() ?: 0.0
-    else 0.0
+    val rwShippingCost = if (RewardUtils.isShippable(this.reward())) {
+        val shippingRule = this.reward().shippingRules()?.find { it.location()?.id() == this.locationId() }
+        return shippingRule?.cost() ?: 0.0
+    } else 0.0
 
     var addOnsShippingCost = 0.0
     this.addOns()?.map {

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/PledgeDataExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/PledgeDataExt.kt
@@ -20,7 +20,7 @@ fun PledgeData.locationId(): Long {
 fun PledgeData.shippingCostIfShipping(): Double {
     val rwShippingCost = if (RewardUtils.isShippable(this.reward())) {
         val shippingRule = this.reward().shippingRules()?.find { it.location()?.id() == this.locationId() }
-        return shippingRule?.cost() ?: 0.0
+        shippingRule?.cost() ?: 0.0
     } else 0.0
 
     var addOnsShippingCost = 0.0

--- a/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
@@ -62,7 +62,6 @@ class GetShippingRulesUseCase(
         // To avoid duplicates insert reward.id as key
         val rewardsToQuery = mutableMapOf<Long, Reward>()
 
-        // Get first reward with unrestricted shipping preference, when quering `getShippingRules` will return ALL available locations, no need to query more rewards locations
         project.rewards()?.filter { RewardUtils.shipsWorldwide(reward = it) }?.map {
             rewardsToQuery.put(it.id(), it)
         }

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/PledgeDataExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/PledgeDataExtTest.kt
@@ -14,7 +14,9 @@ class PledgeDataExtTest : TestCase() {
     fun `test checkoutTotalAmount for reward shipping with AddOns and bonus support on late pledges`() {
         val project = ProjectFactory.project()
         val shippingRule = ShippingRuleFactory.canadaShippingRule()
-        val rw = RewardFactory.rewardWithShipping().toBuilder().latePledgeAmount(8.0).pledgeAmount(2.0).build()
+        val rw = RewardFactory.rewardWithShipping().toBuilder()
+            .shippingRules(listOf(shippingRule))
+            .latePledgeAmount(8.0).pledgeAmount(2.0).build()
 
         val addOn1 = RewardFactory.addOn().toBuilder()
             .id(1L)
@@ -45,7 +47,9 @@ class PledgeDataExtTest : TestCase() {
     fun `test checkoutTotalAmount for reward Not Shipping with AddOns and bonus support on crowdfund`() {
         val project = ProjectFactory.project()
         val shippingRule = ShippingRuleFactory.canadaShippingRule()
-        val rw = RewardFactory.digitalReward().toBuilder().latePledgeAmount(8.0).pledgeAmount(2.0).build()
+        val rw = RewardFactory.digitalReward().toBuilder()
+            .shippingRules(listOf(ShippingRuleFactory.canadaShippingRule()))
+            .latePledgeAmount(8.0).pledgeAmount(2.0).build()
         val addOn1 = RewardFactory.addOn().toBuilder().id(1L).quantity(3).latePledgeAmount(5.0).pledgeAmount(3.0).build()
         val addOn2 = RewardFactory.addOn().toBuilder().id(2L).quantity(2).latePledgeAmount(6.0).pledgeAmount(2.0).build()
         val addOns = listOf(addOn1, addOn2)
@@ -61,7 +65,11 @@ class PledgeDataExtTest : TestCase() {
     fun `test checkoutTotalAmount for reward shipping with AddOns and bonus support on crowdfund`() {
         val project = ProjectFactory.project()
         val shippingRule = ShippingRuleFactory.canadaShippingRule()
-        val rw = RewardFactory.rewardWithShipping().toBuilder().latePledgeAmount(8.0).pledgeAmount(2.0).build()
+        val rw = RewardFactory.rewardWithShipping().toBuilder()
+            .shippingRules(listOf(shippingRule))
+            .latePledgeAmount(8.0)
+            .pledgeAmount(2.0)
+            .build()
         val addOn1 = RewardFactory.addOn().toBuilder().id(1L).quantity(3).latePledgeAmount(5.0).pledgeAmount(3.0).build()
         val addOn2 = RewardFactory.addOn().toBuilder().id(2L).quantity(2).latePledgeAmount(6.0).pledgeAmount(2.0).build()
         val addOns = listOf(addOn1, addOn2)
@@ -75,7 +83,9 @@ class PledgeDataExtTest : TestCase() {
     }
 
     fun `test when the selected reward has shipping test shippingCostIfShipping`() {
-        val rw = RewardFactory.rewardWithShipping()
+        val rw = RewardFactory.rewardWithShipping().toBuilder()
+            .shippingRules(listOf(ShippingRuleFactory.canadaShippingRule()))
+            .build()
         val project = ProjectFactory.project()
         val shippingRule = ShippingRuleFactory.canadaShippingRule()
 

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
@@ -390,14 +390,14 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         // - make sure the uiState output reward list is filtered
         assertEquals(shippingUiState.last().filteredRw.size, filteredRewards.size)
 
-        val obtained = shippingUiState.last().filteredRw
+        val obtainedIDs = shippingUiState.last().filteredRw.map { it.id() }
         assertEquals(
-            obtained,
-            filteredRewards
+            obtainedIDs,
+            filteredRewards.map { it.id() }
         )
 
-        assertEquals(obtained.first(), RewardFactory.noReward())
-        assertEquals(obtained[2].shippingRules()?.first(), ShippingRuleFactory.germanyShippingRule())
+        assertEquals(shippingUiState.last().filteredRw.first(), RewardFactory.noReward())
+        assertEquals(shippingUiState.last().filteredRw[2].shippingRules()?.first(), ShippingRuleFactory.germanyShippingRule())
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- Shipping worldwide rewards cost was not correctly being queried, we were applying the shipping cost of the firs world wide shipping reward to all shipping globally rewards.

# 🤔 Why
- Charge correct shipping amount for all shipping globally rewards


# 👀 See
- For this project, first reward charges $2, Second charges $20, third charges $30

https://github.com/user-attachments/assets/24c658f4-5fba-4a93-bb83-3e0216597be4


- For this project, first reward does not charge for shipping, second charges $17, third charges $31 


https://github.com/user-attachments/assets/1506190b-d867-4f48-ac33-39d29919be44


|  |  |

# 📋 QA

Steps to repro :
1. Go to a live project such as [The Sword of Kaigen](https://www.kickstarter.com/projects/wraithmarked/tsokandwll)
2. Select a physical reward tier like the $50 tier
3. Skip add-ons
4. On the next screen, notice the shipping to the US is set to $1 which wil lmake the pledge attempt fail

Steps to repro :
1. Go to a live project such as [Cradle (Books 7-9) by Will Wight: Special Editions](https://www.kickstarter.com/projects/author-will-wight/cradle-books-7-9-by-will-wight-special-editions?ref=project_build)
2. Select a physical reward tier like the $45 tier
3. Skip add-ons


# Story 📖

[SD-3241](https://kickstarter.atlassian.net/browse/SD-3241)


[SD-3241]: https://kickstarter.atlassian.net/browse/SD-3241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ