### PR TITLE
SD-3241: Wrong shipping value for Shipping World Wide rewards

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/PledgeDataExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/PledgeDataExt.kt
@@ -18,9 +18,12 @@ fun PledgeData.locationId(): Long {
  *
  */
 fun PledgeData.shippingCostIfShipping(): Double {
-    val rwShippingCost = if (RewardUtils.isShippable(this.reward()))
-        this.shippingRule()?.cost() ?: 0.0
-    else 0.0
+    val rwShippingCost = if (RewardUtils.isShippable(this.reward())) {
+        val matchingLocationIdRule = this.reward().shippingRules()?.find { it.location()?.id() == this.locationId() }
+        // - "Earth" shipping rule has location.id == 1
+        matchingLocationIdRule?.cost()
+            ?: (this.reward().shippingRules()?.find { it.location()?.id() == 1L }?.cost() ?: 0.0)
+    } else 0.0
 
     var addOnsShippingCost = 0.0
     this.addOns()?.map {

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/PledgeDataExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/PledgeDataExtTest.kt
@@ -14,7 +14,9 @@ class PledgeDataExtTest : TestCase() {
     fun `test checkoutTotalAmount for reward shipping with AddOns and bonus support on late pledges`() {
         val project = ProjectFactory.project()
         val shippingRule = ShippingRuleFactory.canadaShippingRule()
-        val rw = RewardFactory.rewardWithShipping().toBuilder().latePledgeAmount(8.0).pledgeAmount(2.0).build()
+        val rw = RewardFactory.rewardWithShipping().toBuilder()
+            .shippingRules(listOf(shippingRule))
+            .latePledgeAmount(8.0).pledgeAmount(2.0).build()
 
         val addOn1 = RewardFactory.addOn().toBuilder()
             .id(1L)
@@ -61,7 +63,9 @@ class PledgeDataExtTest : TestCase() {
     fun `test checkoutTotalAmount for reward shipping with AddOns and bonus support on crowdfund`() {
         val project = ProjectFactory.project()
         val shippingRule = ShippingRuleFactory.canadaShippingRule()
-        val rw = RewardFactory.rewardWithShipping().toBuilder().latePledgeAmount(8.0).pledgeAmount(2.0).build()
+        val rw = RewardFactory.rewardWithShipping().toBuilder()
+            .shippingRules(listOf(shippingRule))
+            .latePledgeAmount(8.0).pledgeAmount(2.0).build()
         val addOn1 = RewardFactory.addOn().toBuilder().id(1L).quantity(3).latePledgeAmount(5.0).pledgeAmount(3.0).build()
         val addOn2 = RewardFactory.addOn().toBuilder().id(2L).quantity(2).latePledgeAmount(6.0).pledgeAmount(2.0).build()
         val addOns = listOf(addOn1, addOn2)
@@ -75,9 +79,12 @@ class PledgeDataExtTest : TestCase() {
     }
 
     fun `test when the selected reward has shipping test shippingCostIfShipping`() {
-        val rw = RewardFactory.rewardWithShipping()
-        val project = ProjectFactory.project()
         val shippingRule = ShippingRuleFactory.canadaShippingRule()
+        val rw = RewardFactory.rewardWithShipping()
+            .toBuilder()
+            .shippingRules(listOf(shippingRule))
+            .build()
+        val project = ProjectFactory.project()
 
         val pledgeData = with(
             PledgeFlowContext.NEW_PLEDGE,


### PR DESCRIPTION
# 📲 What

- Shipping worldwide rewards cost was not correctly being displayed, before the value was within `PledgeData.shippingRule.cost`, after moving shipping selector to rewards carousel is no longer the case, shipping cost now should be present within the `PledgeData.reward.shippingRules`
- `reward.shippingRules` may have different shipping rules, match via locationID, or return the cost for "Earth" with LocationId = 1

# 🤔 Why
- Charge correct shipping amount for all shipping globally rewards


# 👀 See
- For this project, first reward charges $2, Second charges $20, third charges $30

https://github.com/user-attachments/assets/6d7aedf5-cc51-45da-a61e-b62c8d8c394f


- For this project, first reward does not charge for shipping, second charges $17, third charges $31 

https://github.com/user-attachments/assets/32466341-253e-4a46-853d-9fa46e57b41a




|  |  |

# 📋 QA

Steps to repro :
1. Go to a live project such as [The Sword of Kaigen](https://www.kickstarter.com/projects/wraithmarked/tsokandwll)
2. Select a physical reward tier like the $50 tier
3. Skip add-ons
4. On the next screen, notice the shipping to the US is set to $1 which wil lmake the pledge attempt fail

Steps to repro :
1. Go to a live project such as [Cradle (Books 7-9) by Will Wight: Special Editions](https://www.kickstarter.com/projects/author-will-wight/cradle-books-7-9-by-will-wight-special-editions?ref=project_build)
2. Select a physical reward tier like the $45 tier
3. Skip add-ons

Another project on staging able to reproduce -> [Quiet, Brain! Heartfelt Activities for Mental Health](https://staging.kickstarter.com/projects/theawkwardyeti/quiet-brain-heartfelt-activities-for-mental-health?ref=nav_search&result=project&term=quiet%2C%20brain!&total_hits=1)

# Story 📖

[SD-3241](https://kickstarter.atlassian.net/browse/SD-3241)


[SD-3241]: https://kickstarter.atlassian.net/browse/SD-3241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ