### PR TITLE
[MBL-1758] Only send event for rewards carousel if the currentProjectData is available

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
@@ -149,7 +149,11 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
         if (expanded && currentPage == 0) {
             projectData?.let {
                 analytics.trackRewardsCarouselViewed(projectData = projectData)
-            } ?: analytics.trackRewardsCarouselViewed(projectData = currentProjectData)
+            } ?: {
+                if (::currentProjectData.isInitialized) {
+                    analytics.trackRewardsCarouselViewed(projectData = currentProjectData)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
# 📲 What

Fixes a crash where the currentProjectData was not initialize but being used when a late pledge project was being used for a fix pledge flow

# 🤔 Why

The app would crash when entering the fix payment flow from PPO or Activity

# 🛠 How

Check if the variable is initialized before using it for analytics

# 📋 QA

-Sign in on an account that has errored payments on one or more pledged (ppotest1@test.com)
-Go to the activity or PPO flow and click the fix payment button
-App should not crash

# Story 📖

[MBL-1758](https://kickstarter.atlassian.net/browse/MBL-1758)


[MBL-1758]: https://kickstarter.atlassian.net/browse/MBL-1758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ