### PR TITLE
MBL-1760: Update 3DS snackbar with new copy and duration when user fails authentication

### DIFF
--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -165,11 +166,12 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                         }
                 }
 
-                viewModel.provideSnackbarMessage { stringId, type ->
+                viewModel.provideSnackbarMessage { stringId, type, duration ->
                     lifecycleScope.launch {
                         snackbarHostState.showSnackbar(
                             message = getString(stringId),
-                            actionLabel = type
+                            actionLabel = type,
+                            duration = duration
                         )
                     }
                 }
@@ -258,7 +260,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                     } else if (result.outcome == StripeIntentResult.Outcome.FAILED ||
                         result.outcome == StripeIntentResult.Outcome.TIMEDOUT ||
                         result.outcome == StripeIntentResult.Outcome.UNKNOWN
-                    ) viewModel.showErrorSnackbar(R.string.Authentication_failed_please_try_again)
+                    ) viewModel.showErrorSnackbar(R.string.We_are_unable_to_authenticate_your_payment_method_please_pull_to_refresh_and_choose_a_different_payment_method, duration = SnackbarDuration.Long)
                 }
                 override fun onError(e: Exception) {
                     lifecycleScope.launch {

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
@@ -95,7 +95,7 @@ class PledgedProjectsOverviewViewModel(
 
     private val mutablePpoCards = MutableStateFlow<PagingData<PPOCard>>(PagingData.empty())
     private var mutableProjectFlow = MutableSharedFlow<Project>()
-    private var snackbarMessage: (stringID: Int, type: String, duration : SnackbarDuration) -> Unit = { _, _, _ -> }
+    private var snackbarMessage: (stringID: Int, type: String, duration: SnackbarDuration) -> Unit = { _, _, _ -> }
     private val apolloClient = requireNotNull(environment.apolloClientV2())
     private val analyticEvents = requireNotNull(environment.analytics())
 
@@ -219,11 +219,11 @@ class PledgedProjectsOverviewViewModel(
         )
     }
 
-    fun showHeadsUpSnackbar(messageId: Int, duration : SnackbarDuration = SnackbarDuration.Short) {
+    fun showHeadsUpSnackbar(messageId: Int, duration: SnackbarDuration = SnackbarDuration.Short) {
         snackbarMessage.invoke(messageId, KSSnackbarTypes.KS_HEADS_UP.name, duration)
     }
 
-    fun showErrorSnackbar(messageId: Int, duration : SnackbarDuration = SnackbarDuration.Short) {
+    fun showErrorSnackbar(messageId: Int, duration: SnackbarDuration = SnackbarDuration.Short) {
         snackbarMessage.invoke(messageId, KSSnackbarTypes.KS_ERROR.name, duration)
     }
 

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.features.pledgedprojectsoverview.viewmodel
 
+import androidx.compose.material.SnackbarDuration
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -94,7 +95,7 @@ class PledgedProjectsOverviewViewModel(
 
     private val mutablePpoCards = MutableStateFlow<PagingData<PPOCard>>(PagingData.empty())
     private var mutableProjectFlow = MutableSharedFlow<Project>()
-    private var snackbarMessage: (stringID: Int, type: String) -> Unit = { _, _ -> }
+    private var snackbarMessage: (stringID: Int, type: String, duration : SnackbarDuration) -> Unit = { _, _, _ -> }
     private val apolloClient = requireNotNull(environment.apolloClientV2())
     private val analyticEvents = requireNotNull(environment.analytics())
 
@@ -201,7 +202,7 @@ class PledgedProjectsOverviewViewModel(
         }
     }
 
-    fun provideSnackbarMessage(snackBarMessage: (Int, String) -> Unit) {
+    fun provideSnackbarMessage(snackBarMessage: (Int, String, SnackbarDuration) -> Unit) {
         this.snackbarMessage = snackBarMessage
     }
 
@@ -218,12 +219,12 @@ class PledgedProjectsOverviewViewModel(
         )
     }
 
-    fun showHeadsUpSnackbar(messageId: Int) {
-        snackbarMessage.invoke(messageId, KSSnackbarTypes.KS_HEADS_UP.name)
+    fun showHeadsUpSnackbar(messageId: Int, duration : SnackbarDuration = SnackbarDuration.Short) {
+        snackbarMessage.invoke(messageId, KSSnackbarTypes.KS_HEADS_UP.name, duration)
     }
 
-    fun showErrorSnackbar(messageId: Int) {
-        snackbarMessage.invoke(messageId, KSSnackbarTypes.KS_ERROR.name)
+    fun showErrorSnackbar(messageId: Int, duration : SnackbarDuration = SnackbarDuration.Short) {
+        snackbarMessage.invoke(messageId, KSSnackbarTypes.KS_ERROR.name, duration)
     }
 
     class Factory(

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
@@ -77,7 +77,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
                     }).build()
             ).create(PledgedProjectsOverviewViewModel::class.java)
 
-            viewModel.provideSnackbarMessage { message, _ , _-> snackbarAction = message }
+            viewModel.provideSnackbarMessage { message, _, _ -> snackbarAction = message }
             viewModel.onMessageCreatorClicked("test_project_slug", "projectID", "creatorID", listOf(PPOCardFactory.confirmAddressCard()), 10)
 
             // Should equal error string id

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
@@ -77,7 +77,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
                     }).build()
             ).create(PledgedProjectsOverviewViewModel::class.java)
 
-            viewModel.provideSnackbarMessage { message, _ -> snackbarAction = message }
+            viewModel.provideSnackbarMessage { message, _ , _-> snackbarAction = message }
             viewModel.onMessageCreatorClicked("test_project_slug", "projectID", "creatorID", listOf(PPOCardFactory.confirmAddressCard()), 10)
 
             // Should equal error string id
@@ -106,7 +106,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
                 viewModel.ppoUIState.toList(uiState)
             }
 
-            viewModel.provideSnackbarMessage { message, _ -> snackbarAction = message }
+            viewModel.provideSnackbarMessage { message, _, _ -> snackbarAction = message }
             viewModel.confirmAddress("addressID", "backingID")
 
             assertEquals(
@@ -143,7 +143,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
                 viewModel.ppoUIState.toList(uiState)
             }
 
-            viewModel.provideSnackbarMessage { message, _ -> snackbarAction = message }
+            viewModel.provideSnackbarMessage { message, _, _ -> snackbarAction = message }
             viewModel.confirmAddress("addressID", "backingID")
 
             assertEquals(
@@ -178,7 +178,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
             backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
                 viewModel.ppoUIState.toList(uiState)
             }
-            viewModel.provideSnackbarMessage { message, _ -> snackbarAction = message }
+            viewModel.provideSnackbarMessage { message, _, _ -> snackbarAction = message }
             viewModel.confirmAddress("addressID", "backingID")
 
             assertEquals(


### PR DESCRIPTION
# 📲 What

We want the user to know that when they fail 3DS authentication, they should refresh and pick a new payment method. we need the text to stay on the screen a bit longer so they have time to see and read it. 

# 🤔 Why

failing 3DS authentication changes the pledge to fix payment, but we weren't accounting for that, or educating the user. 

# 🛠 How

changed the copy and increased the duration of the text on screen

# 👀 See

![Screenshot_20241007_135606](https://github.com/user-attachments/assets/9fa9c46e-4a5e-4af1-adb1-837ff18f1df7)

# 📋 QA

Fail a 3DS authentication through PPO and make sure the copy and duration are direct 

# Story 📖

[MBL-1760: Update 3DS snackbar with new copy and duration when user fails authentication](https://kickstarter.atlassian.net/browse/MBL-1760)
