### PR TITLE
[MBL-1763] add redeem and pledge redemption survey deeplinks

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/UriExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/UriExt.kt
@@ -161,11 +161,11 @@ fun Uri.isModalUri(webEndpoint: String): Boolean {
 
 fun Uri.isProjectSurveyUri(webEndpoint: String): Boolean {
     return isKickstarterUri(webEndpoint) && (
-            PROJECT_SURVEY.matcher(path()).matches() || PROJECT_SURVEY_EDIT.matcher(path())
-                .matches() || PROJECT_SURVEY_EDIT_ADDRESS.matcher(path())
-                .matches() || PROJECT_SURVEY_BACKING_REDEEM.matcher(path())
-                .matches() || PROJECT_SURVEY_BACKING_PLEDGE_REDEMPTION.matcher(path()).matches()
-            )
+        PROJECT_SURVEY.matcher(path()).matches() || PROJECT_SURVEY_EDIT.matcher(path())
+            .matches() || PROJECT_SURVEY_EDIT_ADDRESS.matcher(path())
+            .matches() || PROJECT_SURVEY_BACKING_REDEEM.matcher(path())
+            .matches() || PROJECT_SURVEY_BACKING_PLEDGE_REDEMPTION.matcher(path()).matches()
+        )
 }
 
 fun Uri.isProjectCommentUri(webEndpoint: String): Boolean {

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/UriExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/UriExt.kt
@@ -264,7 +264,7 @@ private val PROJECT_SURVEY_BACKING_PLEDGE_REDEMPTION = Pattern.compile(
     "\\A\\/projects(\\/[a-zA-Z0-9_-]+)?\\/[a-zA-Z0-9_-]+\\/backing\\/edit_address\\z"
 )
 
-//  /projects/:creator_param/:project_param/backing/pledge_redemption
+//  /projects/:creator_param/:project_param/backing/redeem
 private val PROJECT_SURVEY_BACKING_REDEEM = Pattern.compile(
     "\\A\\/projects(\\/[a-zA-Z0-9_-]+)?\\/[a-zA-Z0-9_-]+\\/backing\\/redeem\\z"
 )

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/UriExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/UriExt.kt
@@ -261,7 +261,7 @@ private val PROJECT_SURVEY_EDIT_ADDRESS = Pattern.compile(
 
 //  /projects/:creator_param/:project_param/backing/pledge_redemption
 private val PROJECT_SURVEY_BACKING_PLEDGE_REDEMPTION = Pattern.compile(
-    "\\A\\/projects(\\/[a-zA-Z0-9_-]+)?\\/[a-zA-Z0-9_-]+\\/backing\\/edit_address\\z"
+    "\\A\\/projects(\\/[a-zA-Z0-9_-]+)?\\/[a-zA-Z0-9_-]+\\/backing\\/pledge_redemption\\z"
 )
 
 //  /projects/:creator_param/:project_param/backing/redeem

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/UriExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/UriExt.kt
@@ -161,9 +161,11 @@ fun Uri.isModalUri(webEndpoint: String): Boolean {
 
 fun Uri.isProjectSurveyUri(webEndpoint: String): Boolean {
     return isKickstarterUri(webEndpoint) && (
-        PROJECT_SURVEY.matcher(path()).matches() || PROJECT_SURVEY_EDIT.matcher(path())
-            .matches() || PROJECT_SURVEY_EDIT_ADDRESS.matcher(path()).matches()
-        )
+            PROJECT_SURVEY.matcher(path()).matches() || PROJECT_SURVEY_EDIT.matcher(path())
+                .matches() || PROJECT_SURVEY_EDIT_ADDRESS.matcher(path())
+                .matches() || PROJECT_SURVEY_BACKING_REDEEM.matcher(path())
+                .matches() || PROJECT_SURVEY_BACKING_PLEDGE_REDEMPTION.matcher(path()).matches()
+            )
 }
 
 fun Uri.isProjectCommentUri(webEndpoint: String): Boolean {
@@ -255,6 +257,16 @@ private val PROJECT_SURVEY_EDIT = Pattern.compile(
 //  /projects/:creator_param/:project_param/surveys/:survey_param/edit_address
 private val PROJECT_SURVEY_EDIT_ADDRESS = Pattern.compile(
     "\\A\\/projects(\\/[a-zA-Z0-9_-]+)?\\/[a-zA-Z0-9_-]+\\/surveys\\/[a-zA-Z0-9-_]+\\/edit_address\\z"
+)
+
+//  /projects/:creator_param/:project_param/backing/pledge_redemption
+private val PROJECT_SURVEY_BACKING_PLEDGE_REDEMPTION = Pattern.compile(
+    "\\A\\/projects(\\/[a-zA-Z0-9_-]+)?\\/[a-zA-Z0-9_-]+\\/backing\\/edit_address\\z"
+)
+
+//  /projects/:creator_param/:project_param/backing/pledge_redemption
+private val PROJECT_SURVEY_BACKING_REDEEM = Pattern.compile(
+    "\\A\\/projects(\\/[a-zA-Z0-9_-]+)?\\/[a-zA-Z0-9_-]+\\/backing\\/redeem\\z"
 )
 
 //  /projects/:creator_param/:project_param/mark_reward_fulfilled/true

--- a/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.kt
@@ -366,6 +366,36 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testProjectSurveyRedeemDeeplink_startsSurveyActivity() {
+        val url =
+            "https://www.kickstarter.com/projects/creator/project/backing/redeem"
+        setUpEnvironment(intent = intentWithData(url))
+        startBrowser.assertNoValues()
+        startDiscoveryActivity.assertNoValues()
+        startProjectActivity.assertNoValues()
+        startProjectActivityForCheckout.assertNoValues()
+        startProjectActivityForComment.assertNoValues()
+        startProjectActivityToSave.assertNoValues()
+        startPreLaunchProjectActivity.assertNoValues()
+        startProjectSurveyActivity.assertValueCount(1)
+    }
+
+    @Test
+    fun testProjectSurveyPledgeRedemptionDeeplink_startsSurveyActivity() {
+        val url =
+            "https://www.kickstarter.com/projects/creator/project/backing/pledge_redemption"
+        setUpEnvironment(intent = intentWithData(url))
+        startBrowser.assertNoValues()
+        startDiscoveryActivity.assertNoValues()
+        startProjectActivity.assertNoValues()
+        startProjectActivityForCheckout.assertNoValues()
+        startProjectActivityForComment.assertNoValues()
+        startProjectActivityToSave.assertNoValues()
+        startPreLaunchProjectActivity.assertNoValues()
+        startProjectSurveyActivity.assertValueCount(1)
+    }
+
+    @Test
     fun testProjectDeepLinkWithRefTag_startsProjectActivity() {
         val mockUser = MockCurrentUserV2()
         val project = ProjectFactory.backedProject().toBuilder().displayPrelaunch(false)


### PR DESCRIPTION
# 📲 What

Added the URIs for our URI parser to recognize and open deeplinsk for project surveys for redeem/pledge_redemption

# 🤔 Why

These links will need to be supported in order to use the new web pages for pledge redemption

# 🛠 How

Added the link patters for 
- .../projects/:creator_param/:project_param/backing/pledge_redemption
- ...//projects/:creator_param/:project_param/backing/redeem
in the uri parser 

# 📋 QA

-Have an account with a pledge redemption backing or create a project for testing and back it
- Have the project send pledge redemption surveys
- confirm the deeplinks work

# Story 📖

[MBL-1763](https://kickstarter.atlassian.net/browse/MBL-1763)


[MBL-1763]: https://kickstarter.atlassian.net/browse/MBL-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ