### PR TITLE
no-jira: Replace "Edit" string in ppo with correct string

### DIFF
--- a/app/src/main/assets/json/server-config.json
+++ b/app/src/main/assets/json/server-config.json
@@ -7823,7 +7823,7 @@
       "Double_tap_to_toggle_setting": "Cliquez deux fois pour activer/désactiver le réglage",
       "Download_your_personal_data": "Téléchargement de vos données personnelles",
       "Earth": "Terre",
-      "Edit": "Edit",
+      "Edit": "Modifier",
       "Edit_profile": "Modifier mon profil",
       "Edit_reward": "Modifier la récompense",
       "Either_the_pledge_or_the_project_was_canceled": "Soit l'engagement soit le projet a été annulé avant la date limite.",

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -415,7 +415,7 @@ fun ConfirmAddressButtonsView(isConfirmButtonEnabled: Boolean, onEditAddressClic
             modifier = Modifier
                 .weight(0.5f),
             onClickAction = { onEditAddressClicked.invoke() },
-            text = stringResource(id = R.string.discovery_favorite_categories_buttons_edit),
+            text = stringResource(id = R.string.Edit),
             isEnabled = true,
             textStyle = typography.buttonText
         )

--- a/app/src/main/res/values-fr/strings_i18n.xml
+++ b/app/src/main/res/values-fr/strings_i18n.xml
@@ -221,7 +221,7 @@ Cliquez pour réessayer.</string>
   <string name="Double_tap_to_toggle_setting" formatted="false">Cliquez deux fois pour activer/désactiver le réglage</string>
   <string name="Download_your_personal_data" formatted="false">Téléchargement de vos données personnelles</string>
   <string name="Earth" formatted="false">Terre</string>
-  <string name="Edit" formatted="false">Edit</string>
+  <string name="Edit" formatted="false">Modifier</string>
   <string name="Edit_profile" formatted="false">Modifier mon profil</string>
   <string name="Edit_reward" formatted="false">Modifier la récompense</string>
   <string name="Either_the_pledge_or_the_project_was_canceled" formatted="false">Soit l\'engagement soit le projet a été annulé avant la date limite.</string>


### PR DESCRIPTION
# 📲 What

There was a mistake that the translations team had to fix for the copy "edit" in french. For some reason it took a while for the string to populate on our end, but it's here. This ticket downloaded all the new strings and replaced the old "edit" string with the new one with the correct translated string. 
