### PR TITLE
MBL-1833: Compose UI tests for PledgeItemizedDetails composable

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/views/compose/checkout/PledgeItemizedDetails.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/compose/checkout/PledgeItemizedDetails.kt
@@ -59,7 +59,7 @@ fun ItemizedRewardListContainerPreview() {
                 rewardsList = emptyList<Pair<String, String>>(),
                 shippingAmount = 20.0,
                 shippingAmountString = "",
-                initialShippingLocation = "USA",
+                initialShippingLocation = "",
                 totalAmount = "50$",
                 totalAmountCurrencyConverted = "About CA\$ 1.38",
                 initialBonusSupport = "0",
@@ -122,9 +122,10 @@ fun ItemizedRewardListContainer(
         )
 
         if (deliveryDateString.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(dimensions.paddingXSmall).testTag(PledgeItemizedDetailsTestTag.DELIVERY_DATE.name))
+            Spacer(modifier = Modifier.height(dimensions.paddingXSmall))
 
             Text(
+                modifier = Modifier.testTag(PledgeItemizedDetailsTestTag.DELIVERY_DATE.name),
                 text = deliveryDateString,
                 style = typography.caption1,
                 color = colors.textSecondary

--- a/app/src/main/java/com/kickstarter/ui/views/compose/checkout/PledgeItemizedDetails.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/compose/checkout/PledgeItemizedDetails.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.kickstarter.R
@@ -58,7 +59,7 @@ fun ItemizedRewardListContainerPreview() {
                 rewardsList = emptyList<Pair<String, String>>(),
                 shippingAmount = 20.0,
                 shippingAmountString = "",
-                initialShippingLocation = "",
+                initialShippingLocation = "USA",
                 totalAmount = "50$",
                 totalAmountCurrencyConverted = "About CA\$ 1.38",
                 initialBonusSupport = "0",
@@ -69,6 +70,21 @@ fun ItemizedRewardListContainerPreview() {
             )
         }
     }
+}
+
+enum class PledgeItemizedDetailsTestTag {
+    DELIVERY_DATE,
+    PAGE_TITLE,
+    ITEM_NAME,
+    ITEM_COST,
+    PLEDGE_AMOUNT_TITLE,
+    TOTAL_AMOUNT,
+    BONUS_SUPPORT_TITLE,
+    DISCLAIMER_TEXT,
+    BONUS_SUPPORT,
+    SHIPPING_TITLE,
+    SHIPPING_AMOUNT,
+    CURRENCY_CONVERSION,
 }
 
 @Composable
@@ -99,13 +115,14 @@ fun ItemizedRewardListContainer(
             )
     ) {
         Text(
+            modifier = Modifier.testTag(PledgeItemizedDetailsTestTag.PAGE_TITLE.name),
             text = stringResource(id = R.string.Your_pledge),
             style = typography.headline,
             color = colors.textPrimary
         )
 
         if (deliveryDateString.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(dimensions.paddingXSmall))
+            Spacer(modifier = Modifier.height(dimensions.paddingXSmall).testTag(PledgeItemizedDetailsTestTag.DELIVERY_DATE.name))
 
             Text(
                 text = deliveryDateString,
@@ -123,6 +140,7 @@ fun ItemizedRewardListContainer(
 
             Row {
                 Text(
+                    modifier = Modifier.testTag(PledgeItemizedDetailsTestTag.ITEM_NAME.name),
                     text = it.first,
                     style = typography.subheadlineMedium,
                     color = colors.textSecondary
@@ -131,6 +149,7 @@ fun ItemizedRewardListContainer(
                 Spacer(modifier = Modifier.weight(1f))
 
                 Text(
+                    modifier = Modifier.testTag(PledgeItemizedDetailsTestTag.ITEM_COST.name),
                     text = it.second,
                     style = typography.subheadlineMedium,
                     color = colors.textSecondary
@@ -147,6 +166,7 @@ fun ItemizedRewardListContainer(
 
             Row {
                 Text(
+                    modifier = Modifier.testTag(PledgeItemizedDetailsTestTag.SHIPPING_TITLE.name),
                     text = ksString?.format(
                         stringResource(id = R.string.Shipping_to_country),
                         "country",
@@ -159,6 +179,7 @@ fun ItemizedRewardListContainer(
                 Spacer(modifier = Modifier.weight(1f))
 
                 Text(
+                    modifier = Modifier.testTag(PledgeItemizedDetailsTestTag.SHIPPING_AMOUNT.name),
                     text = shippingAmountString,
                     style = typography.subheadlineMedium,
                     color = colors.textSecondary
@@ -175,6 +196,7 @@ fun ItemizedRewardListContainer(
 
             Row {
                 Text(
+                    modifier = Modifier.testTag(PledgeItemizedDetailsTestTag.BONUS_SUPPORT_TITLE.name),
                     text = stringResource(
                         id =
                         if (rewardsList.isNotEmpty()) R.string.Bonus_support
@@ -187,6 +209,7 @@ fun ItemizedRewardListContainer(
                 Spacer(modifier = Modifier.weight(1f))
 
                 Text(
+                    modifier = Modifier.testTag(PledgeItemizedDetailsTestTag.BONUS_SUPPORT.name),
                     text = totalBonusSupport,
                     style = typography.subheadlineMedium,
                     color = colors.textSecondary
@@ -202,6 +225,7 @@ fun ItemizedRewardListContainer(
 
         Row {
             Text(
+                modifier = Modifier.testTag(PledgeItemizedDetailsTestTag.PLEDGE_AMOUNT_TITLE.name),
                 text = stringResource(id = R.string.Pledge_amount),
                 style = typography.calloutMedium,
                 color = colors.textPrimary
@@ -211,6 +235,7 @@ fun ItemizedRewardListContainer(
 
             Column(horizontalAlignment = Alignment.End) {
                 Text(
+                    modifier = Modifier.testTag(PledgeItemizedDetailsTestTag.TOTAL_AMOUNT.name),
                     text = totalAmount,
                     style = typography.subheadlineMedium,
                     color = colors.textPrimary
@@ -220,6 +245,7 @@ fun ItemizedRewardListContainer(
                     Spacer(modifier = Modifier.height(dimensions.paddingXSmall))
 
                     Text(
+                        modifier = Modifier.testTag(PledgeItemizedDetailsTestTag.CURRENCY_CONVERSION.name),
                         text = totalAmountCurrencyConverted,
                         style = typography.footnote,
                         color = colors.textPrimary
@@ -232,6 +258,7 @@ fun ItemizedRewardListContainer(
             Spacer(modifier = Modifier.height(dimensions.paddingMedium))
             Row {
                 Text(
+                    modifier = Modifier.testTag(PledgeItemizedDetailsTestTag.DISCLAIMER_TEXT.name),
                     text = disclaimerText,
                     style = typography.footnote,
                     color = colors.textPrimary

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/PledgeItemizedDetailsTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/PledgeItemizedDetailsTest.kt
@@ -45,7 +45,6 @@ class PledgeItemizedDetailsTest : KSRobolectricTestCase() {
     private val currencyConversion =
         composeTestRule.onNodeWithTag(PledgeItemizedDetailsTestTag.CURRENCY_CONVERSION.name)
 
-
     @Test
     fun `test view init`() {
         val rewardsList = listOf(Pair("T-shirt", "$22"), Pair("Pin", "$10"))
@@ -78,12 +77,12 @@ class PledgeItemizedDetailsTest : KSRobolectricTestCase() {
         composeTestRule.onAllNodesWithTag("ITEM_NAME")[0].assertIsDisplayed()
         composeTestRule.onAllNodesWithTag("ITEM_NAME")[1].assertIsDisplayed()
         composeTestRule.onAllNodesWithTag("ITEM_NAME")[0].assertTextEquals("T-shirt")
-        composeTestRule.onAllNodesWithTag("ITEM_NAME")[1].assertTextEquals( "Pin")
+        composeTestRule.onAllNodesWithTag("ITEM_NAME")[1].assertTextEquals("Pin")
 
         composeTestRule.onAllNodesWithTag("ITEM_COST")[0].assertIsDisplayed()
         composeTestRule.onAllNodesWithTag("ITEM_COST")[1].assertIsDisplayed()
         composeTestRule.onAllNodesWithTag("ITEM_COST")[0].assertTextEquals("$22")
-        composeTestRule.onAllNodesWithTag("ITEM_COST")[1].assertTextEquals( "$10")
+        composeTestRule.onAllNodesWithTag("ITEM_COST")[1].assertTextEquals("$10")
 
         pledgeAmountTitle.assertIsDisplayed()
         pledgeAmountTitle.assertTextEquals(pledgeAmountTitleText)

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/PledgeItemizedDetailsTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/PledgeItemizedDetailsTest.kt
@@ -1,0 +1,241 @@
+package com.kickstarter.ui.activities.compose
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.R
+import com.kickstarter.ui.compose.designsystem.KSTheme
+import com.kickstarter.ui.views.compose.checkout.ItemizedRewardListContainer
+import com.kickstarter.ui.views.compose.checkout.PledgeItemizedDetailsTestTag
+import org.junit.Test
+
+class PledgeItemizedDetailsTest : KSRobolectricTestCase() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val pageTitle =
+        composeTestRule.onNodeWithTag(PledgeItemizedDetailsTestTag.PAGE_TITLE.name)
+
+    private val deliveryDate =
+        composeTestRule.onNodeWithTag(PledgeItemizedDetailsTestTag.DELIVERY_DATE.name)
+
+    private val pledgeAmountTitle =
+        composeTestRule.onNodeWithTag(PledgeItemizedDetailsTestTag.PLEDGE_AMOUNT_TITLE.name)
+
+    private val totalAmount =
+        composeTestRule.onNodeWithTag(PledgeItemizedDetailsTestTag.TOTAL_AMOUNT.name)
+
+    private val bonusSupportTitle =
+        composeTestRule.onNodeWithTag(PledgeItemizedDetailsTestTag.BONUS_SUPPORT_TITLE.name)
+
+    private val bonusSupport =
+        composeTestRule.onNodeWithTag(PledgeItemizedDetailsTestTag.BONUS_SUPPORT.name)
+
+    private val disclaimerText =
+        composeTestRule.onNodeWithTag(PledgeItemizedDetailsTestTag.DISCLAIMER_TEXT.name)
+
+    private val shippingTitle =
+        composeTestRule.onNodeWithTag(PledgeItemizedDetailsTestTag.SHIPPING_TITLE.name)
+
+    private val shippingAmount =
+        composeTestRule.onNodeWithTag(PledgeItemizedDetailsTestTag.SHIPPING_AMOUNT.name)
+
+    private val currencyConversion =
+        composeTestRule.onNodeWithTag(PledgeItemizedDetailsTestTag.CURRENCY_CONVERSION.name)
+
+
+    @Test
+    fun `test view init`() {
+        val rewardsList = listOf(Pair("T-shirt", "$22"), Pair("Pin", "$10"))
+
+        composeTestRule.setContent {
+            KSTheme {
+                ItemizedRewardListContainer(
+                    ksString = null,
+                    rewardsList = rewardsList,
+                    shippingAmount = 20.0,
+                    shippingAmountString = "",
+                    initialShippingLocation = "",
+                    totalAmount = "50$",
+                    totalAmountCurrencyConverted = "",
+                    initialBonusSupport = "0",
+                    totalBonusSupport = "0",
+                    deliveryDateString = "",
+                    rewardsHaveShippables = false,
+                    disclaimerText = ""
+                )
+            }
+        }
+        val pageTitleText = context.getString(R.string.Your_pledge)
+        val pledgeAmountTitleText = context.getString(R.string.Pledge_amount)
+
+        pageTitle.assertIsDisplayed()
+        pageTitle.assertTextEquals(pageTitleText)
+        deliveryDate.assertDoesNotExist()
+
+        composeTestRule.onAllNodesWithTag("ITEM_NAME")[0].assertIsDisplayed()
+        composeTestRule.onAllNodesWithTag("ITEM_NAME")[1].assertIsDisplayed()
+        composeTestRule.onAllNodesWithTag("ITEM_NAME")[0].assertTextEquals("T-shirt")
+        composeTestRule.onAllNodesWithTag("ITEM_NAME")[1].assertTextEquals( "Pin")
+
+        composeTestRule.onAllNodesWithTag("ITEM_COST")[0].assertIsDisplayed()
+        composeTestRule.onAllNodesWithTag("ITEM_COST")[1].assertIsDisplayed()
+        composeTestRule.onAllNodesWithTag("ITEM_COST")[0].assertTextEquals("$22")
+        composeTestRule.onAllNodesWithTag("ITEM_COST")[1].assertTextEquals( "$10")
+
+        pledgeAmountTitle.assertIsDisplayed()
+        pledgeAmountTitle.assertTextEquals(pledgeAmountTitleText)
+
+        totalAmount.assertIsDisplayed()
+        totalAmount.assertTextEquals("50$")
+
+        bonusSupportTitle.assertDoesNotExist()
+        bonusSupport.assertDoesNotExist()
+        disclaimerText.assertDoesNotExist()
+        shippingAmount.assertDoesNotExist()
+        shippingTitle.assertDoesNotExist()
+        currencyConversion.assertDoesNotExist()
+    }
+
+    @Test
+    fun `test bonus support, when no rewards and initial is not the same as total bonus, displays pledge without reward copy`() {
+        composeTestRule.setContent {
+            KSTheme {
+                ItemizedRewardListContainer(
+                    ksString = null,
+                    rewardsList = emptyList<Pair<String, String>>(),
+                    shippingAmount = 20.0,
+                    shippingAmountString = "",
+                    initialShippingLocation = "",
+                    totalAmount = "50$",
+                    totalAmountCurrencyConverted = "About CA\$ 1.38",
+                    initialBonusSupport = "1",
+                    totalBonusSupport = "10",
+                    deliveryDateString = "",
+                    rewardsHaveShippables = false,
+                    disclaimerText = ""
+                )
+            }
+        }
+        val bonusSupportTitleText = context.getString(R.string.Pledge_without_a_reward)
+
+        bonusSupportTitle.assertIsDisplayed()
+        bonusSupportTitle.assertTextEquals(bonusSupportTitleText)
+        bonusSupport.assertIsDisplayed()
+        bonusSupport.assertTextEquals("10")
+    }
+
+    @Test
+    fun `test bonus support, when rewards exist and initial is not the same as total bonus, displays bonus support copy`() {
+        val rewardsList = listOf(Pair("T-shirt", "$22"), Pair("Pin", "$10"))
+
+        composeTestRule.setContent {
+            KSTheme {
+                ItemizedRewardListContainer(
+                    ksString = null,
+                    rewardsList = rewardsList,
+                    shippingAmount = 20.0,
+                    shippingAmountString = "",
+                    initialShippingLocation = "",
+                    totalAmount = "50$",
+                    totalAmountCurrencyConverted = "About CA\$ 1.38",
+                    initialBonusSupport = "1",
+                    totalBonusSupport = "10",
+                    deliveryDateString = "",
+                    rewardsHaveShippables = false,
+                    disclaimerText = ""
+                )
+            }
+        }
+        val bonusSupportTitleText = context.getString(R.string.Bonus_support)
+
+        bonusSupportTitle.assertIsDisplayed()
+        bonusSupportTitle.assertTextEquals(bonusSupportTitleText)
+        bonusSupport.assertIsDisplayed()
+        bonusSupport.assertTextEquals("10")
+    }
+
+    @Test
+    fun `test shipping, when rewards are shippable and backer has shipping location, should show shipping location ui`() {
+        val rewardsList = listOf(Pair("T-shirt", "$22"), Pair("Pin", "$10"))
+
+        composeTestRule.setContent {
+            KSTheme {
+                ItemizedRewardListContainer(
+                    ksString = null,
+                    rewardsList = rewardsList,
+                    shippingAmount = 20.0,
+                    shippingAmountString = "$20.0",
+                    initialShippingLocation = "USA",
+                    totalAmount = "50$",
+                    totalAmountCurrencyConverted = "About CA\$ 1.38",
+                    initialBonusSupport = "1",
+                    totalBonusSupport = "10",
+                    deliveryDateString = "",
+                    rewardsHaveShippables = true,
+                    disclaimerText = ""
+                )
+            }
+        }
+
+        shippingTitle.assertIsDisplayed()
+        shippingAmount.assertIsDisplayed()
+        shippingAmount.assertTextEquals("$20.0")
+    }
+
+    @Test
+    fun `test currency conversion, when currency conversion not null, should show currency conversion text`() {
+        val rewardsList = listOf(Pair("T-shirt", "$22"), Pair("Pin", "$10"))
+
+        composeTestRule.setContent {
+            KSTheme {
+                ItemizedRewardListContainer(
+                    ksString = null,
+                    rewardsList = rewardsList,
+                    shippingAmount = 20.0,
+                    shippingAmountString = "$20.0",
+                    initialShippingLocation = "USA",
+                    totalAmount = "50$",
+                    totalAmountCurrencyConverted = "About CA\$ 1.38",
+                    initialBonusSupport = "1",
+                    totalBonusSupport = "10",
+                    deliveryDateString = "",
+                    rewardsHaveShippables = true,
+                    disclaimerText = ""
+                )
+            }
+        }
+
+        currencyConversion.assertIsDisplayed()
+        currencyConversion.assertTextEquals("About CA\$ 1.38")
+    }
+
+    @Test
+    fun `test disclaimer, when disclaimer not null, should show disclaimer text`() {
+        val rewardsList = listOf(Pair("T-shirt", "$22"), Pair("Pin", "$10"))
+        val disclaimer = context.getString(R.string.If_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline)
+
+        composeTestRule.setContent {
+            KSTheme {
+                ItemizedRewardListContainer(
+                    ksString = null,
+                    rewardsList = rewardsList,
+                    shippingAmount = 20.0,
+                    shippingAmountString = "$20.0",
+                    initialShippingLocation = "USA",
+                    totalAmount = "50$",
+                    totalAmountCurrencyConverted = "About CA\$ 1.38",
+                    initialBonusSupport = "1",
+                    totalBonusSupport = "10",
+                    deliveryDateString = "",
+                    rewardsHaveShippables = true,
+                    disclaimerText = disclaimer
+                )
+            }
+        }
+        disclaimerText.assertIsDisplayed()
+        disclaimerText.assertTextEquals(disclaimer)
+    }
+}

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/PledgeItemizedDetailsTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/PledgeItemizedDetailsTest.kt
@@ -214,7 +214,7 @@ class PledgeItemizedDetailsTest : KSRobolectricTestCase() {
     @Test
     fun `test disclaimer, when disclaimer not null, should show disclaimer text`() {
         val rewardsList = listOf(Pair("T-shirt", "$22"), Pair("Pin", "$10"))
-        val disclaimer = context.getString(R.string.If_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline)
+        val disclaimer = context.getString(R.string.If_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline_and_receive_proof_of_pledge)
 
         composeTestRule.setContent {
             KSTheme {

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/PledgeItemizedDetailsTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/PledgeItemizedDetailsTest.kt
@@ -241,7 +241,6 @@ class PledgeItemizedDetailsTest : KSRobolectricTestCase() {
     @Test
     fun `test delivery date, when delivery date not null, should show delivery date`() {
         val rewardsList = listOf(Pair("T-shirt", "$22"), Pair("Pin", "$10"))
-        val disclaimer = context.getString(R.string.If_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline_and_receive_proof_of_pledge)
 
         composeTestRule.setContent {
             KSTheme {
@@ -257,7 +256,7 @@ class PledgeItemizedDetailsTest : KSRobolectricTestCase() {
                     totalBonusSupport = "10",
                     deliveryDateString = "April 10",
                     rewardsHaveShippables = true,
-                    disclaimerText = disclaimer
+                    disclaimerText = ""
                 )
             }
         }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/PledgeItemizedDetailsTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/PledgeItemizedDetailsTest.kt
@@ -237,4 +237,31 @@ class PledgeItemizedDetailsTest : KSRobolectricTestCase() {
         disclaimerText.assertIsDisplayed()
         disclaimerText.assertTextEquals(disclaimer)
     }
+
+    @Test
+    fun `test delivery date, when delivery date not null, should show delivery date`() {
+        val rewardsList = listOf(Pair("T-shirt", "$22"), Pair("Pin", "$10"))
+        val disclaimer = context.getString(R.string.If_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline_and_receive_proof_of_pledge)
+
+        composeTestRule.setContent {
+            KSTheme {
+                ItemizedRewardListContainer(
+                    ksString = null,
+                    rewardsList = rewardsList,
+                    shippingAmount = 20.0,
+                    shippingAmountString = "$20.0",
+                    initialShippingLocation = "USA",
+                    totalAmount = "50$",
+                    totalAmountCurrencyConverted = "About CA\$ 1.38",
+                    initialBonusSupport = "1",
+                    totalBonusSupport = "10",
+                    deliveryDateString = "April 10",
+                    rewardsHaveShippables = true,
+                    disclaimerText = disclaimer
+                )
+            }
+        }
+        deliveryDate.assertIsDisplayed()
+        deliveryDate.assertTextEquals("April 10")
+    }
 }


### PR DESCRIPTION
# 📲 What

Create ui tests for PledgeItemizedDetails composable

# 🤔 Why

Compose makes testing ui much easier, and we should be taking advantage of this to make sure ui is working as expected.

# 🛠 How

New test suite that tests screen initialization, no reward, bonus support, shipping, etc etc

# 👀 See

no user facing changes

# 📋 QA

Nothing to QA, but you can run the tests locally

# Story 📖

[MBL-1833: Compose UI tests for PledgeItemizedDetails composable](https://kickstarter.atlassian.net/browse/MBL-1833)
