### PR TITLE
MBL-1876: Firebase crashes Caused by android.os.TransactionTooLargeException

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
@@ -312,7 +312,7 @@ fun Project.reduce(): Project {
  * The end goal is to reduce to the bare minimum the amount of memory required to be serialized on Intents
  * when presenting screens in order to avoid `android.os.TransactionTooLargeException`
  */
-fun Project.reduceToPreLaunchProject(): Project {
+fun Project.reduceProjectPayload(): Project {
     val web = Web.builder()
         .project(this.webProjectUrl())
         .build()

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
@@ -319,6 +319,7 @@ fun Project.reduceToPreLaunchProject(): Project {
 
     return Project.Builder()
         .id(this.id())
+        .canComment(this.canComment())
         .slug(this.slug())
         .name(this.name())
         .creator(this.creator())
@@ -331,9 +332,14 @@ fun Project.reduceToPreLaunchProject(): Project {
         .currentCurrency(this.currentCurrency())
         .sendThirdPartyEvents(this.sendThirdPartyEvents())
         .isStarred(this.isStarred())
+        .isBacking(this.isBacking())
         .currency(this.currency())
         .currencySymbol(this.currencySymbol())
         .currencyTrailingCode(this.currencyTrailingCode())
         .urls(Urls.builder().web(web).build())
+        .isInPostCampaignPledgingPhase(this.isInPostCampaignPledgingPhase())
+        .postCampaignPledgingEnabled(this.postCampaignPledgingEnabled())
+        .sendThirdPartyEvents(this.sendThirdPartyEvents())
+        .state(this.state())
         .build()
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -17,6 +17,7 @@ import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.UrlUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
+import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
 import com.kickstarter.libs.utils.extensions.showAlertDialog
 import com.kickstarter.libs.utils.extensions.toVisibility
 import com.kickstarter.models.Comment
@@ -302,8 +303,9 @@ class CommentsActivity :
      * // TODO: https://kickstarter.atlassian.net/browse/NT-1955
      */
     private fun startThreadActivity(commentData: CommentCardData, openKeyboard: Boolean, projectUpdateId: String? = null) {
+        val reducedProject = commentData.project?.reduceToPreLaunchProject()
         val threadIntent = Intent(this, ThreadActivity::class.java).apply {
-            putExtra(IntentKey.COMMENT_CARD_DATA, commentData)
+            putExtra(IntentKey.COMMENT_CARD_DATA, commentData.toBuilder().project(reducedProject).build())
             putExtra(IntentKey.REPLY_EXPAND, openKeyboard)
             putExtra(IntentKey.UPDATE_POST_ID, projectUpdateId)
         }
@@ -315,8 +317,9 @@ class CommentsActivity :
     }
 
     private fun startThreadActivityFromDeepLink(commentData: CommentCardData, projectUpdateId: String? = null) {
+        val reducedProject = commentData.project?.reduceToPreLaunchProject()
         val threadIntent = Intent(this, ThreadActivity::class.java).apply {
-            putExtra(IntentKey.COMMENT_CARD_DATA, commentData)
+            putExtra(IntentKey.COMMENT_CARD_DATA, commentData.toBuilder().project(reducedProject).build())
             putExtra(IntentKey.REPLY_EXPAND, false)
             putExtra(IntentKey.REPLY_SCROLL_BOTTOM, true)
             putExtra(IntentKey.UPDATE_POST_ID, projectUpdateId)

--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -17,7 +17,7 @@ import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.UrlUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
-import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
+import com.kickstarter.libs.utils.extensions.reduceProjectPayload
 import com.kickstarter.libs.utils.extensions.showAlertDialog
 import com.kickstarter.libs.utils.extensions.toVisibility
 import com.kickstarter.models.Comment
@@ -303,7 +303,7 @@ class CommentsActivity :
      * // TODO: https://kickstarter.atlassian.net/browse/NT-1955
      */
     private fun startThreadActivity(commentData: CommentCardData, openKeyboard: Boolean, projectUpdateId: String? = null) {
-        val reducedProject = commentData.project?.reduceToPreLaunchProject()
+        val reducedProject = commentData.project?.reduceProjectPayload()
         val threadIntent = Intent(this, ThreadActivity::class.java).apply {
             putExtra(IntentKey.COMMENT_CARD_DATA, commentData.toBuilder().project(reducedProject).build())
             putExtra(IntentKey.REPLY_EXPAND, openKeyboard)
@@ -317,7 +317,7 @@ class CommentsActivity :
     }
 
     private fun startThreadActivityFromDeepLink(commentData: CommentCardData, projectUpdateId: String? = null) {
-        val reducedProject = commentData.project?.reduceToPreLaunchProject()
+        val reducedProject = commentData.project?.reduceProjectPayload()
         val threadIntent = Intent(this, ThreadActivity::class.java).apply {
             putExtra(IntentKey.COMMENT_CARD_DATA, commentData.toBuilder().project(reducedProject).build())
             putExtra(IntentKey.REPLY_EXPAND, false)

--- a/app/src/main/java/com/kickstarter/ui/activities/PreLaunchProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/PreLaunchProjectPageActivity.kt
@@ -18,12 +18,14 @@ import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getCreatorBioWebViewActivityIntent
 import com.kickstarter.libs.utils.extensions.getEnvironment
+import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
 import com.kickstarter.models.Project
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.SharedPreferenceKey
 import com.kickstarter.ui.activities.compose.PreLaunchProjectPageScreen
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
 import com.kickstarter.ui.data.LoginReason
+import com.kickstarter.ui.extensions.startCreatorBioWebViewActivity
 import com.kickstarter.viewmodels.projectpage.PrelaunchProjectViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
@@ -142,11 +144,6 @@ class PreLaunchProjectPageActivity : ComponentActivity() {
         val intent = Intent(this, LoginToutActivity::class.java)
             .putExtra(IntentKey.LOGIN_REASON, LoginReason.STAR_PROJECT)
         startActivityForResult(intent, ActivityRequestCodes.LOGIN_FLOW)
-    }
-
-    fun Activity.startCreatorBioWebViewActivity(project: Project) {
-        startActivity(Intent().getCreatorBioWebViewActivityIntent(this, project))
-        overridePendingTransition(R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 
     @Override

--- a/app/src/main/java/com/kickstarter/ui/activities/PreLaunchProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/PreLaunchProjectPageActivity.kt
@@ -1,6 +1,5 @@
 package com.kickstarter.ui.activities
 
-import android.app.Activity
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -16,10 +15,7 @@ import com.kickstarter.libs.KSString
 import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
-import com.kickstarter.libs.utils.extensions.getCreatorBioWebViewActivityIntent
 import com.kickstarter.libs.utils.extensions.getEnvironment
-import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
-import com.kickstarter.models.Project
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.SharedPreferenceKey
 import com.kickstarter.ui.activities.compose.PreLaunchProjectPageScreen

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -58,6 +58,7 @@ import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.getPaymentSheetConfiguration
+import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
 import com.kickstarter.libs.utils.extensions.showLatePledgeFlow
 import com.kickstarter.libs.utils.extensions.toVisibility
 import com.kickstarter.models.Project
@@ -1065,7 +1066,7 @@ class ProjectPageActivity :
         if (clearFragmentBackStack() || (projectData.project().showLatePledgeFlow() && fFLatePledge)) {
             startActivity(
                 Intent(this, ThanksActivity::class.java)
-                    .putExtra(IntentKey.PROJECT, projectData.project())
+                    .putExtra(IntentKey.PROJECT, projectData.project().reduceToPreLaunchProject())
                     .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
                     .putExtra(IntentKey.PLEDGE_DATA, pledgeData)
             )
@@ -1135,7 +1136,7 @@ class ProjectPageActivity :
         startActivity(
             Intent(this, MessagesActivity::class.java)
                 .putExtra(IntentKey.MESSAGE_SCREEN_SOURCE_CONTEXT, MessagePreviousScreenType.PROJECT_PAGE)
-                .putExtra(IntentKey.PROJECT, project)
+                .putExtra(IntentKey.PROJECT, project.reduceToPreLaunchProject())
                 .putExtra(IntentKey.BACKING, project.backing())
         )
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -58,7 +58,7 @@ import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.getPaymentSheetConfiguration
-import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
+import com.kickstarter.libs.utils.extensions.reduceProjectPayload
 import com.kickstarter.libs.utils.extensions.showLatePledgeFlow
 import com.kickstarter.libs.utils.extensions.toVisibility
 import com.kickstarter.models.Project
@@ -1066,7 +1066,7 @@ class ProjectPageActivity :
         if (clearFragmentBackStack() || (projectData.project().showLatePledgeFlow() && fFLatePledge)) {
             startActivity(
                 Intent(this, ThanksActivity::class.java)
-                    .putExtra(IntentKey.PROJECT, projectData.project().reduceToPreLaunchProject())
+                    .putExtra(IntentKey.PROJECT, projectData.project().reduceProjectPayload())
                     .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
                     .putExtra(IntentKey.PLEDGE_DATA, pledgeData)
             )
@@ -1136,7 +1136,7 @@ class ProjectPageActivity :
         startActivity(
             Intent(this, MessagesActivity::class.java)
                 .putExtra(IntentKey.MESSAGE_SCREEN_SOURCE_CONTEXT, MessagePreviousScreenType.PROJECT_PAGE)
-                .putExtra(IntentKey.PROJECT, project.reduceToPreLaunchProject())
+                .putExtra(IntentKey.PROJECT, project.reduceProjectPayload())
                 .putExtra(IntentKey.BACKING, project.backing())
         )
     }

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -31,7 +31,7 @@ import com.kickstarter.libs.utils.extensions.getReportProjectActivityIntent
 import com.kickstarter.libs.utils.extensions.getRootCommentsActivityIntent
 import com.kickstarter.libs.utils.extensions.getUpdatesActivityIntent
 import com.kickstarter.libs.utils.extensions.getVideoActivityIntent
-import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
+import com.kickstarter.libs.utils.extensions.reduceProjectPayload
 import com.kickstarter.libs.utils.extensions.withData
 import com.kickstarter.models.Project
 import com.kickstarter.models.chrome.ChromeTabsHelperActivity
@@ -168,7 +168,7 @@ fun Activity.startPledgeRedemption(project: Project) {
  * @param commentableId -> specific for deeplinking to a concrete thread
  */
 fun Activity.startRootCommentsActivity(projectData: ProjectData, commentableId: String? = null) {
-    val reducedProject = projectData.project().reduceToPreLaunchProject()
+    val reducedProject = projectData.project().reduceProjectPayload()
     startActivity(
         Intent().getRootCommentsActivityIntent(this, projectData.toBuilder().project(reducedProject).build(), commentableId)
     )
@@ -186,12 +186,12 @@ fun Activity.startReportProjectActivity(
     project: Project,
     startForResult: ActivityResultLauncher<Intent>
 ) {
-    startForResult.launch(Intent().getReportProjectActivityIntent(this, project = project.reduceToPreLaunchProject()))
+    startForResult.launch(Intent().getReportProjectActivityIntent(this, project = project.reduceProjectPayload()))
     overridePendingTransition(R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
 }
 
 fun Activity.startCreatorBioWebViewActivity(project: Project) {
-    startActivity(Intent().getCreatorBioWebViewActivityIntent(this, project.reduceToPreLaunchProject()))
+    startActivity(Intent().getCreatorBioWebViewActivityIntent(this, project.reduceProjectPayload()))
     overridePendingTransition(R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
 }
 
@@ -236,7 +236,7 @@ fun Activity.startUpdatesActivity(
  * @param projectAndData
  */
 fun Activity.startProjectUpdatesActivity(projectAndData: ProjectData) {
-    val reducedProject = projectAndData.project().reduceToPreLaunchProject()
+    val reducedProject = projectAndData.project().reduceProjectPayload()
     startActivity(Intent().getProjectUpdatesActivityIntent(this, projectAndData.toBuilder().project(reducedProject).build()))
     overridePendingTransition(R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
 }
@@ -261,7 +261,7 @@ fun Activity.startPreLaunchProjectActivity(uri: Uri, project: Project, previousS
     val intent = Intent().getPreLaunchProjectActivity(
         this,
         project.slug(),
-        project.reduceToPreLaunchProject()
+        project.reduceProjectPayload()
     )
     // Pass full deeplink for attribution tracking purposes when launching from deeplink
     intent.setData(uri)

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -168,8 +168,9 @@ fun Activity.startPledgeRedemption(project: Project) {
  * @param commentableId -> specific for deeplinking to a concrete thread
  */
 fun Activity.startRootCommentsActivity(projectData: ProjectData, commentableId: String? = null) {
+    val reducedProject = projectData.project().reduceToPreLaunchProject()
     startActivity(
-        Intent().getRootCommentsActivityIntent(this, projectData, commentableId)
+        Intent().getRootCommentsActivityIntent(this, projectData.toBuilder().project(reducedProject).build(), commentableId)
     )
 
     this.let {
@@ -185,12 +186,12 @@ fun Activity.startReportProjectActivity(
     project: Project,
     startForResult: ActivityResultLauncher<Intent>
 ) {
-    startForResult.launch(Intent().getReportProjectActivityIntent(this, project = project))
+    startForResult.launch(Intent().getReportProjectActivityIntent(this, project = project.reduceToPreLaunchProject()))
     overridePendingTransition(R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
 }
 
 fun Activity.startCreatorBioWebViewActivity(project: Project) {
-    startActivity(Intent().getCreatorBioWebViewActivityIntent(this, project))
+    startActivity(Intent().getCreatorBioWebViewActivityIntent(this, project.reduceToPreLaunchProject()))
     overridePendingTransition(R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
 }
 
@@ -235,7 +236,8 @@ fun Activity.startUpdatesActivity(
  * @param projectAndData
  */
 fun Activity.startProjectUpdatesActivity(projectAndData: ProjectData) {
-    startActivity(Intent().getProjectUpdatesActivityIntent(this, projectAndData))
+    val reducedProject = projectAndData.project().reduceToPreLaunchProject()
+    startActivity(Intent().getProjectUpdatesActivityIntent(this, projectAndData.toBuilder().project(reducedProject).build()))
     overridePendingTransition(R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
 }
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/FrequentlyAskedQuestionFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/FrequentlyAskedQuestionFragment.kt
@@ -18,7 +18,7 @@ import com.kickstarter.libs.MessagePreviousScreenType
 import com.kickstarter.libs.SimpleDividerItemDecoration
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
-import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
+import com.kickstarter.libs.utils.extensions.reduceProjectPayload
 import com.kickstarter.models.Project
 import com.kickstarter.ui.ArgumentsKey
 import com.kickstarter.ui.IntentKey
@@ -121,7 +121,7 @@ class FrequentlyAskedQuestionFragment : Fragment(), Configure {
         startActivity(
             Intent(requireContext(), MessagesActivity::class.java)
                 .putExtra(IntentKey.MESSAGE_SCREEN_SOURCE_CONTEXT, MessagePreviousScreenType.CREATOR_BIO_MODAL)
-                .putExtra(IntentKey.PROJECT, project.reduceToPreLaunchProject())
+                .putExtra(IntentKey.PROJECT, project.reduceProjectPayload())
                 .putExtra(IntentKey.BACKING, project.backing())
         )
     }

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/FrequentlyAskedQuestionFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/FrequentlyAskedQuestionFragment.kt
@@ -18,6 +18,7 @@ import com.kickstarter.libs.MessagePreviousScreenType
 import com.kickstarter.libs.SimpleDividerItemDecoration
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
+import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
 import com.kickstarter.models.Project
 import com.kickstarter.ui.ArgumentsKey
 import com.kickstarter.ui.IntentKey
@@ -120,7 +121,7 @@ class FrequentlyAskedQuestionFragment : Fragment(), Configure {
         startActivity(
             Intent(requireContext(), MessagesActivity::class.java)
                 .putExtra(IntentKey.MESSAGE_SCREEN_SOURCE_CONTEXT, MessagePreviousScreenType.CREATOR_BIO_MODAL)
-                .putExtra(IntentKey.PROJECT, project)
+                .putExtra(IntentKey.PROJECT, project.reduceToPreLaunchProject())
                 .putExtra(IntentKey.BACKING, project.backing())
         )
     }

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
@@ -389,7 +389,7 @@ class ProjectExtTest : KSRobolectricTestCase() {
         val user = UserFactory.germanUser().toBuilder().chosenCurrency("CAD").build()
         val deadline = DateTime(DateTimeZone.UTC).plusDays(10)
         val project = ProjectFactory.project().toBuilder().watchesCount(10).isStarred(true).creator(user).build()
-        val reducedProject = project.reduceToPreLaunchProject().toBuilder().deadline(deadline).build()
+        val reducedProject = project.reduceProjectPayload().toBuilder().deadline(deadline).build()
 
         assertEquals(project.id(), reducedProject.id())
         assertEquals(project.name(), reducedProject.name())

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -2,11 +2,13 @@ package com.kickstarter.viewmodels
 
 import android.content.Intent
 import android.util.Pair
+import bo.app.p5
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.MockCurrentUser
 import com.kickstarter.libs.MockCurrentUserV2
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.libs.utils.extensions.reduceProjectPayload
 import com.kickstarter.mock.factories.ApiExceptionFactory
 import com.kickstarter.mock.factories.AvatarFactory
 import com.kickstarter.mock.factories.CommentEnvelopeFactory
@@ -60,7 +62,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     fun testCommentsViewModel_whenUserLoggedInAndBacking_shouldShowEnabledComposer() {
 
         // Start the view model with a backed project.
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.backedProject()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.backedProject().reduceProjectPayload()))
         val vm = Factory(
             environment().toBuilder().currentUserV2(MockCurrentUserV2(UserFactory.user())).build(),
             intent
@@ -77,7 +79,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testCommentsViewModel_whenUserIsLoggedOut_composerShouldBeGone() {
         // Start the view model with a backed project.
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(
             environment().toBuilder().build(),
             intent
@@ -94,7 +96,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testCommentsViewModel_whenUserIsLoggedInNotBacking_shouldShowDisabledComposer() {
         // Start the view model with a backed project.
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(
             environment().toBuilder().currentUserV2(MockCurrentUserV2(UserFactory.user())).build(),
             intent
@@ -114,7 +116,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         val project = ProjectFactory.project()
             .toBuilder()
             .canComment(true)
-            .build()
+            .build().reduceProjectPayload()
         val vm = Factory(
             environment().toBuilder().currentUserV2(MockCurrentUserV2(currentUser)).build(),
             Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(project))
@@ -134,10 +136,10 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         val project = ProjectFactory.project()
             .toBuilder()
             .canComment(false)
-            .build()
+            .build().reduceProjectPayload()
         val vm = Factory(
             environment().toBuilder().currentUserV2(MockCurrentUserV2(currentUser)).build(),
-            Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+            Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(project))
         ).create(CommentsViewModel::class.java)
 
         vm.outputs.commentComposerStatus().subscribe { commentComposerStatus.onNext(it) }.addToDisposable(disposables)
@@ -156,11 +158,11 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .toBuilder()
             .creator(creator)
             .isBacking(false)
-            .build()
+            .build().reduceProjectPayload()
 
         val vm = Factory(
             environment().toBuilder().currentUserV2(MockCurrentUserV2(currentUser)).build(),
-            Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+            Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(project))
         ).create(CommentsViewModel::class.java)
 
         vm.outputs.commentComposerStatus().subscribe { commentComposerStatus.onNext(it) }.addToDisposable(disposables)
@@ -179,11 +181,11 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
         val project = ProjectFactory.project()
             .toBuilder()
             .isBacking(false)
-            .build()
+            .build().reduceProjectPayload()
 
         val vm = Factory(
             environment().toBuilder().currentUserV2(MockCurrentUserV2(currentUser)).build(),
-            Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+            Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(project))
         ).create(CommentsViewModel::class.java)
 
         val currentUserAvatar = TestSubscriber<String?>()
@@ -230,7 +232,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             }
         }).build()
 
-        val vm = Factory(env, Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))).create(CommentsViewModel::class.java)
+        val vm = Factory(env, Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))).create(CommentsViewModel::class.java)
         val commentsList = TestSubscriber<List<CommentCardData>>()
 
         vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
@@ -277,7 +279,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             }
         }).build()
 
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(env, intent).create(CommentsViewModel::class.java)
         val commentsList = TestSubscriber<List<CommentCardData>?>()
 
@@ -289,7 +291,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testCommentsViewModel_ProjectCommentsEmit() {
         val commentsList = BehaviorSubject.create<List<CommentCardData>?>()
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(environment(), intent).create(CommentsViewModel::class.java)
 
         vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
@@ -353,7 +355,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             }
         }).build()
 
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(env, intent).create(CommentsViewModel::class.java)
         vm.outputs.setEmptyState().subscribe { showEmptyState.onNext(it) }.addToDisposable(disposables)
 
@@ -380,7 +382,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testCommentsViewModel_ProjectRefresh() {
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(environment(), intent).create(CommentsViewModel::class.java)
 
         // Start the view model with a project.
@@ -399,7 +401,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             }
         }).build()
 
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
         vm.outputs.initialLoadCommentsError().subscribe { initialLoadError.onNext(it) }.addToDisposable(disposables)
@@ -434,7 +436,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             }
         }).build()
 
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
         firstCall = false
@@ -475,7 +477,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             })
             .schedulerV2(testScheduler).build()
 
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
         vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
@@ -566,7 +568,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun backButtonPressed_whenEmits_shouldEmitToCloseActivityStream_FromProject() {
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(environment(), intent).create(CommentsViewModel::class.java)
 
         vm.outputs.closeCommentsPage().subscribe { closeCommentPage.onNext(it) }.addToDisposable(disposables)
@@ -633,7 +635,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .schedulerV2(testScheduler)
             .build()
 
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
         vm.inputs.onReplyClicked(comment1, true)
@@ -685,7 +687,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .commentCardState(CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus)
             .build()
 
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(env, intent = intent).create(CommentsViewModel::class.java)
 
         vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
@@ -783,7 +785,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .commentCardState(CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus)
             .build()
 
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
         vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
@@ -890,7 +892,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .commentCardState(CommentCardStatus.COMMENT_FOR_LOGIN_BACKED_USERS.commentCardStatus)
             .build()
 
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
         vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
@@ -981,7 +983,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .commentCardState(CommentCardStatus.CANCELED_PLEDGE_COMMENT.commentCardStatus)
             .build()
 
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
         vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)
@@ -1034,7 +1036,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
 
         val intent = Intent().apply {
             putExtra(IntentKey.COMMENT, commentID)
-            putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+            putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         }
         val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
@@ -1090,7 +1092,7 @@ class CommentsViewModelTest : KSRobolectricTestCase() {
             .schedulerV2(testScheduler)
             .build()
 
-        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project()))
+        val intent = Intent().putExtra(IntentKey.PROJECT_DATA, ProjectDataFactory.project(ProjectFactory.project().reduceProjectPayload()))
         val vm = Factory(env, intent).create(CommentsViewModel::class.java)
 
         vm.outputs.commentsList().subscribe { commentsList.onNext(it) }.addToDisposable(disposables)

--- a/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CommentsViewModelTest.kt
@@ -2,7 +2,6 @@ package com.kickstarter.viewmodels
 
 import android.content.Intent
 import android.util.Pair
-import bo.app.p5
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.MockCurrentUser
 import com.kickstarter.libs.MockCurrentUserV2

--- a/app/src/test/java/com/kickstarter/viewmodels/CreatorBioViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CreatorBioViewModelTest.kt
@@ -5,6 +5,7 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUserV2
 import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.libs.utils.extensions.reduceProjectPayload
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.Project
@@ -27,7 +28,7 @@ class CreatorBioViewModelTest : KSRobolectricTestCase() {
     private fun setUpEnvironment(environment: Environment, project: Project? = ProjectFactory.project()) {
         // Configure the view model with a project and url intent.
         val intent =
-            Intent().putExtra(IntentKey.PROJECT, project)
+            Intent().putExtra(IntentKey.PROJECT, project?.reduceProjectPayload())
                 .putExtra(IntentKey.URL, "http://www.project.com/creator-bio")
 
         this.vm = CreatorBioViewModel.Factory(environment, intent).create(CreatorBioViewModel::class.java)

--- a/app/src/test/java/com/kickstarter/viewmodels/PrelaunchProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PrelaunchProjectViewModelTest.kt
@@ -10,7 +10,7 @@ import com.kickstarter.libs.MockCurrentUserV2
 import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.utils.ThirdPartyEventValues
 import com.kickstarter.libs.utils.extensions.addToDisposable
-import com.kickstarter.libs.utils.extensions.reduceToPreLaunchProject
+import com.kickstarter.libs.utils.extensions.reduceProjectPayload
 import com.kickstarter.mock.MockFeatureFlagClient
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.UserFactory
@@ -147,7 +147,7 @@ class PrelaunchProjectViewModelTest : KSRobolectricTestCase() {
             .isStarred(true)
             .creator(user)
             .build()
-            .reduceToPreLaunchProject().toBuilder().deadline(deadline).build()
+            .reduceProjectPayload().toBuilder().deadline(deadline).build()
 
         setUpEnvironment(testEnvironment)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectUpdatesViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectUpdatesViewModelTest.kt
@@ -6,6 +6,7 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.libs.utils.extensions.reduceProjectPayload
 import com.kickstarter.mock.factories.ProjectDataFactory.project
 import com.kickstarter.mock.factories.ProjectFactory.project
 import com.kickstarter.mock.factories.UpdateFactory.update
@@ -42,7 +43,7 @@ class ProjectUpdatesViewModelTest : KSRobolectricTestCase() {
     private fun setUpEnvironment(env: Environment, project: Project, projectData: ProjectData) {
 
         // Configure the view model with a project intent.
-        val intent = Intent().putExtra(IntentKey.PROJECT, project)
+        val intent = Intent().putExtra(IntentKey.PROJECT, project.reduceProjectPayload())
             .putExtra(IntentKey.PROJECT_DATA, projectData)
 
         vm = Factory(env, intent).create(ProjectUpdatesViewModel::class.java)

--- a/app/src/test/java/com/kickstarter/viewmodels/ReportProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ReportProjectViewModelTest.kt
@@ -3,6 +3,7 @@ package com.kickstarter.viewmodels
 import android.os.Bundle
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.extensions.reduceProjectPayload
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.services.MockApolloClientV2
 import com.kickstarter.models.Project
@@ -50,7 +51,7 @@ class ReportProjectViewModelTest : KSRobolectricTestCase() {
         val bundle = Bundle()
         bundle.putParcelable(
             IntentKey.PROJECT,
-            project
+            project.reduceProjectPayload()
         )
 
         return bundle

--- a/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThanksViewModelTest.kt
@@ -15,6 +15,7 @@ import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.preferences.MockBooleanPreference
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.libs.utils.extensions.reduceProjectPayload
 import com.kickstarter.mock.MockFeatureFlagClient
 import com.kickstarter.mock.factories.CategoryFactory.artCategory
 import com.kickstarter.mock.factories.CategoryFactory.category
@@ -105,7 +106,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
 
         setUpEnvironment(
             intent = Intent()
-                .putExtra(IntentKey.PROJECT, project)
+                .putExtra(IntentKey.PROJECT, project.reduceProjectPayload())
                 .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
         )
 
@@ -131,7 +132,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
 
         setUpEnvironment(
             intent = Intent()
-                .putExtra(IntentKey.PROJECT, project)
+                .putExtra(IntentKey.PROJECT, project.reduceProjectPayload())
                 .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
         )
 
@@ -140,7 +141,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testFinishEmits() {
-        setUpEnvironment(intent = Intent().putExtra(IntentKey.PROJECT, project()))
+        setUpEnvironment(intent = Intent().putExtra(IntentKey.PROJECT, project().reduceProjectPayload()))
 
         vm.inputs.closeButtonClicked()
         finish.assertValueCount(1)
@@ -164,7 +165,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
             .hasSeenGamesNewsletterPreference(hasSeenGamesNewsletterPreference)
             .build()
 
-        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project()))
+        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project().reduceProjectPayload()))
 
         showRatingDialogTest.assertValueCount(0)
     }
@@ -187,7 +188,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
             .hasSeenGamesNewsletterPreference(hasSeenGamesNewsletterPreference)
             .build()
 
-        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project()))
+        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project().reduceProjectPayload()))
 
         showRatingDialogTest.assertValueCount(1)
     }
@@ -210,7 +211,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
             .hasSeenGamesNewsletterPreference(hasSeenGamesNewsletterPreference)
             .build()
 
-        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project()))
+        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project().reduceProjectPayload()))
 
         showRatingDialogTest.assertValueCount(0)
     }
@@ -241,7 +242,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
             .hasSeenGamesNewsletterPreference(hasSeenGamesNewsletterPreference)
             .build()
 
-        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project))
+        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project.reduceProjectPayload()))
 
         showRatingDialogTest.assertValueCount(0)
     }
@@ -262,7 +263,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
             .category(tabletopGamesCategory())
             .build()
 
-        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project))
+        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project.reduceProjectPayload()))
 
         showGamesNewsletterDialogTest.assertValueCount(1)
         assertEquals(listOf(false, true), hasSeenGamesNewsletterPreference.values())
@@ -284,7 +285,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
             .category(ceramicsCategory())
             .build()
 
-        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project))
+        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project.reduceProjectPayload()))
 
         showGamesNewsletterDialogTest.assertValueCount(0)
     }
@@ -305,7 +306,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
             .category(tabletopGamesCategory())
             .build()
 
-        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project))
+        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project.reduceProjectPayload()))
 
         showGamesNewsletterDialogTest.assertValueCount(0)
     }
@@ -326,7 +327,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
             .category(tabletopGamesCategory())
             .build()
 
-        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project))
+        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project.reduceProjectPayload()))
 
         showGamesNewsletterDialogTest.assertValueCount(0)
     }
@@ -355,7 +356,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(
             environment,
             mockApiClientV2 = mockApiClientV2,
-            intent = Intent().putExtra(IntentKey.PROJECT, project)
+            intent = Intent().putExtra(IntentKey.PROJECT, project.reduceProjectPayload())
         )
 
         vm.signupToGamesNewsletterClick()
@@ -377,7 +378,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
 
         val project = project().toBuilder().category(tabletopGamesCategory()).build()
 
-        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project))
+        setUpEnvironment(environment, intent = Intent().putExtra(IntentKey.PROJECT, project.reduceProjectPayload()))
 
         vm.signupToGamesNewsletterClick()
         showConfirmGamesNewsletterDialogTest.assertValueCount(1)
@@ -385,7 +386,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun testThanksViewModel_startDiscovery() {
-        setUpEnvironment(intent = Intent().putExtra(IntentKey.PROJECT, project()))
+        setUpEnvironment(intent = Intent().putExtra(IntentKey.PROJECT, project().reduceProjectPayload()))
 
         val category = category()
 
@@ -414,7 +415,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
         val intent = Intent()
             .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
             .putExtra(IntentKey.PLEDGE_DATA, pledgeData)
-            .putExtra(IntentKey.PROJECT, project)
+            .putExtra(IntentKey.PROJECT, project.reduceProjectPayload())
 
         setUpEnvironment(intent = intent)
 
@@ -458,7 +459,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
         val intent = Intent()
             .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
             .putExtra(IntentKey.PLEDGE_DATA, pledgeData)
-            .putExtra(IntentKey.PROJECT, project)
+            .putExtra(IntentKey.PROJECT, project.reduceProjectPayload())
 
         setUpEnvironment(
             environment().toBuilder()
@@ -521,7 +522,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
         val intent = Intent()
             .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
             .putExtra(IntentKey.PLEDGE_DATA, pledgeData)
-            .putExtra(IntentKey.PROJECT, project)
+            .putExtra(IntentKey.PROJECT, project.reduceProjectPayload())
 
         setUpEnvironment(
             environment().toBuilder()
@@ -575,7 +576,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
         val intent = Intent()
             .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
             .putExtra(IntentKey.PLEDGE_DATA, pledgeData)
-            .putExtra(IntentKey.PROJECT, project)
+            .putExtra(IntentKey.PROJECT, project.reduceProjectPayload())
 
         setUpEnvironment(environment, intent = intent)
 
@@ -608,7 +609,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
         val intent = Intent()
             .putExtra(IntentKey.CHECKOUT_DATA, checkoutData)
             .putExtra(IntentKey.PLEDGE_DATA, pledgeData)
-            .putExtra(IntentKey.PROJECT, project)
+            .putExtra(IntentKey.PROJECT, project.reduceProjectPayload())
 
         setUpEnvironment(intent = intent)
 
@@ -618,7 +619,7 @@ class ThanksViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testTracking_whenCheckoutDataAndPledgeDataExtrasNull() {
         val intent = Intent()
-            .putExtra(IntentKey.PROJECT, project())
+            .putExtra(IntentKey.PROJECT, project().reduceProjectPayload())
 
         setUpEnvironment(intent = intent)
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThreadViewModelTest.kt
@@ -7,6 +7,7 @@ import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUserV2
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.libs.utils.extensions.reduceProjectPayload
 import com.kickstarter.mock.factories.AvatarFactory
 import com.kickstarter.mock.factories.CommentCardDataFactory
 import com.kickstarter.mock.factories.CommentEnvelopeFactory
@@ -65,7 +66,8 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
     fun testGetRootComment() {
         setUpEnvironment()
 
-        val commentCardData = CommentCardDataFactory.commentCardData()
+        val project = ProjectFactory.project().reduceProjectPayload()
+        val commentCardData = CommentCardDataFactory.commentCardData().toBuilder().project(project).build()
 
         this.vm.intent(Intent().putExtra(IntentKey.COMMENT_CARD_DATA, commentCardData))
         getComment.assertValue(commentCardData)
@@ -122,11 +124,12 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         vm.outputs.showReplyComposer().subscribe { showReplyComposer.onNext(it) }
             .addToDisposable(disposables)
 
+        val project = ProjectFactory.backedProject().reduceProjectPayload()
         // Start the view model with a backed project and comment.
         vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardDataBacked()
+                CommentCardDataFactory.commentCardDataBacked().toBuilder().project(project).build()
             )
         )
 
@@ -145,10 +148,11 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
             .addToDisposable(disposables)
 
         // Start the view model with a backed project and comment.
+        val project = ProjectFactory.backedProject().reduceProjectPayload()
         vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardData()
+                CommentCardDataFactory.commentCardData().toBuilder().project(project).build()
             )
         )
 
@@ -167,11 +171,12 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         vm.outputs.showReplyComposer().subscribe { showReplyComposer.onNext(it) }
             .addToDisposable(disposables)
 
-        // Start the view model with a backed project and comment.
+        // Start the view model with a project and comment.
+        val project = ProjectFactory.project().reduceProjectPayload()
         vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardData()
+                CommentCardDataFactory.commentCardData().toBuilder().project(project).build()
             )
         )
 
@@ -193,10 +198,11 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
             .addToDisposable(disposables)
 
         // Start the view model with a backed project and comment.
+        val project = ProjectFactory.backedProject().reduceProjectPayload()
         vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardDataBacked()
+                CommentCardDataFactory.commentCardDataBacked().toBuilder().project(project).build()
             )
         )
 
@@ -218,10 +224,11 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
             .addToDisposable(disposables)
 
         // Start the view model with a backed project and comment.
+        val project = ProjectFactory.project().reduceProjectPayload()
         vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardData()
+                CommentCardDataFactory.commentCardData().toBuilder().project(project).build()
             )
         )
 
@@ -248,10 +255,11 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(env)
 
         // Start the view model with a backed project and comment.
+        val project = ProjectFactory.project().reduceProjectPayload()
         vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardData()
+                CommentCardDataFactory.commentCardData().toBuilder().project(project).build()
             )
         )
 
@@ -275,10 +283,11 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(env)
 
         // Start the view model with a backed project and comment.
+        val project = ProjectFactory.project().reduceProjectPayload()
         vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardData()
+                CommentCardDataFactory.commentCardData().toBuilder().project(project).build()
             )
         )
 
@@ -311,10 +320,11 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
         this.vm.onCommentReplies().subscribe { onReplies.onNext(it) }.addToDisposable(disposables)
 
         // Start the view model with a backed project and comment.
+        val project = ProjectFactory.project().reduceProjectPayload()
         vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardData()
+                CommentCardDataFactory.commentCardData().toBuilder().project(project).build()
             )
         )
 
@@ -333,10 +343,11 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
     fun testThreadsViewModel_openCommentGuidelinesLink() {
         setUpEnvironment()
 
-        this.vm.intent(
+        val project = ProjectFactory.project().reduceProjectPayload()
+        vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardData()
+                CommentCardDataFactory.commentCardData().toBuilder().project(project).build()
             )
         )
 
@@ -396,10 +407,12 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
 
         val onReplies = BehaviorSubject.create<Pair<List<CommentCardData>, Boolean>>()
         val vm = ThreadViewModel.ThreadViewModel(env)
+
+        val project = ProjectFactory.project().reduceProjectPayload()
         vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardData()
+                CommentCardDataFactory.commentCardData().toBuilder().project(project).build()
             )
         )
         vm.outputs.onCommentReplies().subscribe { onReplies.onNext(it) }
@@ -482,10 +495,12 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
 
         val vm = ThreadViewModel.ThreadViewModel(env)
         // Start the view model with a backed project and comment.
+
+        val project = ProjectFactory.project().reduceProjectPayload()
         vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardData()
+                CommentCardDataFactory.commentCardData().toBuilder().project(project).build()
             )
         )
         vm.outputs.onCommentReplies().subscribe { onReplies.onNext(it) }
@@ -612,10 +627,11 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
 
         val vm = ThreadViewModel.ThreadViewModel(env)
         // Start the view model with a backed project and comment.
+        val project = ProjectFactory.project().reduceProjectPayload()
         vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardData()
+                CommentCardDataFactory.commentCardData().toBuilder().project(project).build()
             )
         )
         vm.outputs.onCommentReplies().subscribe { onReplies.onNext(it) }
@@ -767,10 +783,11 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
 
         val vm = ThreadViewModel.ThreadViewModel(env)
         // Start the view model with a backed project and comment.
+        val project = ProjectFactory.project().reduceProjectPayload()
         vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardData()
+                CommentCardDataFactory.commentCardData().toBuilder().project(project).build()
             )
         )
         vm.outputs.onCommentReplies().subscribe { onReplies.onNext(it) }
@@ -887,10 +904,11 @@ class ThreadViewModelTest : KSRobolectricTestCase() {
 
         val vm = ThreadViewModel.ThreadViewModel(env)
         // Start the view model with a backed project and comment.
+        val project = ProjectFactory.project().reduceProjectPayload()
         vm.intent(
             Intent().putExtra(
                 IntentKey.COMMENT_CARD_DATA,
-                CommentCardDataFactory.commentCardData()
+                CommentCardDataFactory.commentCardData().toBuilder().project(project).build()
             )
         )
         vm.outputs.onCommentReplies().subscribe { onReplies.onNext(it) }


### PR DESCRIPTION
# 📲 What

Fix for crashes happening from TransactionTooLarge

# 🤔 Why

Take a look at the crashes in the linked ticket

This is not a new issue, we have seen this before. This happens when we the project payload is too big to be passed via intent between activities. 

# 🛠 How

In places we are seeing the crash, we can reduce the project payload with .reduceProjectPayload() from
ProjectExt when attaching it to an intent. 

Added some additional fields to the reduced object payload that are needed by the affected activities

Updated some tests to make sure the reduced payload didn't break anything. 

# 📋 QA

Navigate through app and make sure everything is working and not crashing or missing information 

# Story 📖

[MBL-1876: Firebase crashes Caused by android.os.TransactionTooLargeException](https://kickstarter.atlassian.net/browse/MBL-1876)
