### PR TITLE
[no-jira] Fix pledge redemption notifications not working, update tests

### DIFF
--- a/app/src/internal/java/com/kickstarter/ui/views/DebugPushNotificationsView.kt
+++ b/app/src/internal/java/com/kickstarter/ui/views/DebugPushNotificationsView.kt
@@ -242,7 +242,7 @@ class DebugPushNotificationsView @JvmOverloads constructor(context: Context, att
                     .PledgeRedemption
                     .builder()
                     .id(18249339L)
-                    .pledgeRedemptionPath("/projects/:creator_param/:project_param/backing/redeem")
+                    .pledgeRedemptionPath("/projects/wildcrown/youtuber-collection-1-collectors-edition-enamel-pins/backing/redeem")
                     .build()
             )
             .build()

--- a/app/src/internal/java/com/kickstarter/ui/views/DebugPushNotificationsView.kt
+++ b/app/src/internal/java/com/kickstarter/ui/views/DebugPushNotificationsView.kt
@@ -242,7 +242,7 @@ class DebugPushNotificationsView @JvmOverloads constructor(context: Context, att
                     .PledgeRedemption
                     .builder()
                     .id(18249339L)
-                    .pledgeRedemptionPath("/projects/wildcrown/youtuber-collection-1-collectors-edition-enamel-pins/backing/redeem")
+                    .pledgeRedemptionPath("/projects/:creator_param/:project_param/backing/redeem")
                     .build()
             )
             .build()

--- a/app/src/main/java/com/kickstarter/viewmodels/SurveyResponseViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/SurveyResponseViewModel.kt
@@ -80,9 +80,9 @@ interface SurveyResponseViewModel {
 
             val pledgeRedemptionUrl = intent()
                 .filter {
-                    it.hasExtra(IntentKey.NOTIFICATION_PLEDGE_REDEMPTION) && it.getParcelableExtra<SurveyResponse>(IntentKey.NOTIFICATION_PLEDGE_REDEMPTION).isNotNull()
+                    it.hasExtra(IntentKey.NOTIFICATION_PLEDGE_REDEMPTION) && !it.getStringExtra(IntentKey.NOTIFICATION_PLEDGE_REDEMPTION).isNullOrEmpty()
                 }
-                .map { requireNotNull(it.getParcelableExtra(IntentKey.NOTIFICATION_PLEDGE_REDEMPTION)) }
+                .map { requireNotNull(it.getStringExtra(IntentKey.NOTIFICATION_PLEDGE_REDEMPTION)) }
                 .ofType(String::class.java)
                 .map { UrlUtils.appendPath(environment.webEndpoint(), it) }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/DeepLinkViewModelTest.kt
@@ -323,7 +323,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testProjectSurveyDeeplink_startsSurveyActivity() {
         val url =
-            "https://www.kickstarter.com/projects/creator/project/surveys/survey-param"
+            "https://www.kickstarter.com/projects/alexlidell/power-of-five-collectors-edition-omnibus/backing/survey_responses"
         setUpEnvironment(intent = intentWithData(url))
         startBrowser.assertNoValues()
         startDiscoveryActivity.assertNoValues()
@@ -338,7 +338,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testProjectSurveyEditDeeplink_startsSurveyActivity() {
         val url =
-            "https://www.kickstarter.com/projects/creator/project/surveys/survey-param/edit"
+            "https://www.kickstarter.com/projects/alexlidell/power-of-five-collectors-edition-omnibus/surveys/0/edit"
         setUpEnvironment(intent = intentWithData(url))
         startBrowser.assertNoValues()
         startDiscoveryActivity.assertNoValues()
@@ -368,7 +368,7 @@ class DeepLinkViewModelTest : KSRobolectricTestCase() {
     @Test
     fun testProjectSurveyRedeemDeeplink_startsSurveyActivity() {
         val url =
-            "https://www.kickstarter.com/projects/creator/project/backing/redeem"
+            "https://www.kickstarter.com/projects/alexlidell/power-of-five-collectors-edition-omnibus/backing/redeem"
         setUpEnvironment(intent = intentWithData(url))
         startBrowser.assertNoValues()
         startDiscoveryActivity.assertNoValues()

--- a/app/src/test/java/com/kickstarter/viewmodels/SurveyResponseViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/SurveyResponseViewModelTest.kt
@@ -126,6 +126,15 @@ class SurveyResponseViewModelTest : KSRobolectricTestCase() {
         webViewUrl.assertValues("www.kickstarter.com/projects/1231313/test-project-deeplink/backing/survey_responses")
     }
 
+    @Test
+    fun `open webview when pledge redemption is opened from notification`() {
+        val pledgeRedemptionUrlPath = "projects/1231313/test-project-notification/backing/redeem"
+
+        setUpEnvironment(environment().toBuilder().webEndpoint("www.test.dev/").build(), Intent().putExtra(IntentKey.NOTIFICATION_PLEDGE_REDEMPTION, pledgeRedemptionUrlPath))
+
+        webViewUrl.assertValues("www.test.dev/projects/1231313/test-project-notification/backing/redeem")
+    }
+
     @After
     fun clear() {
         disposables.clear()


### PR DESCRIPTION
# 📲 What

- Fixed pledge redemption notifications that weren't working properly
- Added test case for Pledge redemption to `SurveyResponseViewModelTest`
- Updated test urls for surveys and pledge redemption to not by regex

# 📋 QA

- In order to test push notifications locally, you must update the url path passed in through the notification object in `DebugPushNotificationsView` with a working pledge redemption url. I used the one made available to me during the QA session:
![Screenshot 2024-11-21 at 14 22 40](https://github.com/user-attachments/assets/e3305c2c-b522-4fea-9a22-a5a85cf3145f)

# Story 📖

no-jira