### PR TITLE
[no-jira] Fix transaction too large crash on send creator message from project FAQ

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/FrequentlyAskedQuestionFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/FrequentlyAskedQuestionFragment.kt
@@ -113,7 +113,7 @@ class FrequentlyAskedQuestionFragment : Fragment(), Configure {
     private fun startComposeMessageActivity(it: Project?) {
         startActivity(
             Intent(requireContext(), MessageCreatorActivity::class.java)
-                .putExtra(IntentKey.PROJECT, it)
+                .putExtra(IntentKey.PROJECT, it?.reduceProjectPayload())
         )
     }
 


### PR DESCRIPTION
# 📲 What

crash here: https://console.firebase.google.com/u/1/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/9ff037ba471aadfd3bdbac8ed439cb02?time=last-seven-days&types=crash&sessionEventKey=6743C9FB036D00014AA402B9083E5BDC_2019459365517263006

# 🤔 Why

Project object is huge, but we dont need that many fields

# 🛠 How

just reduced the project payload to a few fields

# 📋 QA

Go to project FAQ and send a message to the creator, no crashes or issues should happen. do this with backed projects and non-backed projects

# Story 📖

no-jira
