### PR TITLE
Upgrade gradle plugin to be compatible win sdk 35

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.4.2'
+        classpath 'com.android.tools.build:gradle:8.6.1'
         classpath 'com.google.gms:google-services:4.3.15'
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.4.0'
+        classpath 'com.android.tools.build:gradle:8.4.2'
         classpath 'com.google.gms:google-services:4.3.15'
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
# 📲 What

Upgrade gradle plugin to be compatible win sdk 35
# 🤔 Why

To delete a warning on the build and make it compatible with sdk 35

# 🛠 How

Upgrade gradle plugin version from 8.4.0 to 8.6.1


