### PR TITLE
MBL-1922: Crash from lateinit variable viewModelFactory uninitialized in FacebookConfirmationActivity.kt

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/FacebookConfirmationActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/FacebookConfirmationActivity.kt
@@ -11,7 +11,9 @@ import com.kickstarter.libs.utils.SwitchCompatUtils
 import com.kickstarter.libs.utils.TransitionUtils
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.utils.WindowInsetsUtil
+import com.kickstarter.viewmodels.BackingDetailsViewModel
 import com.kickstarter.viewmodels.FacebookConfirmationViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
@@ -26,6 +28,10 @@ class FacebookConfirmationActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        this.getEnvironment()?.let { env ->
+            viewModelFactory = FacebookConfirmationViewModel.Factory(env)
+        }
+
         binding = FacebookConfirmationLayoutBinding.inflate(layoutInflater)
         WindowInsetsUtil.manageEdgeToEdge(
             window,

--- a/app/src/main/java/com/kickstarter/ui/activities/FacebookConfirmationActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/FacebookConfirmationActivity.kt
@@ -13,7 +13,6 @@ import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.utils.WindowInsetsUtil
-import com.kickstarter.viewmodels.BackingDetailsViewModel
 import com.kickstarter.viewmodels.FacebookConfirmationViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable

--- a/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.kt
@@ -271,7 +271,7 @@ interface LoginToutViewModel {
                 .addToDisposable(disposables)
 
             startFacebookConfirmationActivity = loginError
-                .filter(ErrorEnvelope::isConfirmFacebookSignupError)
+//                .filter(ErrorEnvelope::isConfirmFacebookSignupError)
                 .filter { it.facebookUser() != null }
                 .map { it.facebookUser() }
                 .compose(Transformers.combineLatestPair(facebookAccessToken))

--- a/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/LoginToutViewModel.kt
@@ -271,7 +271,7 @@ interface LoginToutViewModel {
                 .addToDisposable(disposables)
 
             startFacebookConfirmationActivity = loginError
-//                .filter(ErrorEnvelope::isConfirmFacebookSignupError)
+                .filter(ErrorEnvelope::isConfirmFacebookSignupError)
                 .filter { it.facebookUser() != null }
                 .map { it.facebookUser() }
                 .compose(Transformers.combineLatestPair(facebookAccessToken))


### PR DESCRIPTION
# 📲 What

[Crash happening in FacebookConfirmationActivity, related to the `viewModelFactory`](https://console.firebase.google.com/u/1/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/c5fa0dbef48c6083f08707c65613f1cc?time=last-seven-days&sessionEventKey=6751C10001DE0001347DF18C41D740E3_2023390136830454411)

# 🤔 Why

We aren't initializing the lateinit variable `viewModelFactory` in onCreate, which is causing a `UninitializedPropertyAccessException`

# 🛠 How

Just initialize the `viewModelFactory` in `onCreate`, as we are doing in all other activities

# 📋 QA

Not sure how to QA this

# Story 📖

[MBL-1922: Crash from lateinit variable viewModelFactory uninitialized in FacebookConfirmationActivity.kt](https://kickstarter.atlassian.net/browse/MBL-1922)
