### PR TITLE
MLB-1923 API | Update the Project object on GraphQl to include isPledgeOverTimeAllowed flag

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -3,6 +3,7 @@ fragment projectCard on Project {
     backersCount
     description
     isLaunched
+    isPledgeOverTimeAllowed
     backing {
         id
     }
@@ -56,6 +57,7 @@ fragment fullProject on Project {
     description
     minPledge
     isLaunched
+    isPledgeOverTimeAllowed
     sendMetaCapiEvents
     sendThirdPartyEvents
     backing {

--- a/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
@@ -305,6 +305,7 @@ fun projectTransformer(projectFragment: FullProject?): Project {
     val goal = projectFragment?.goal?.amount?.amount?.toDouble() ?: 0.0
     val id = decodeRelayId(projectFragment?.id) ?: -1
     val isBacking = projectFragment?.backing?.backing?.let { true } ?: false
+    val isPledgeOverTimeAllowed = projectFragment?.isPledgeOverTimeAllowed ?: false
     val isStarred = projectFragment?.isWatched ?: false
     val launchedAt = projectFragment?.launchedAt
     val location = locationTransformer(projectFragment?.location?.location)
@@ -403,6 +404,7 @@ fun projectTransformer(projectFragment: FullProject?): Project {
         .goal(goal)
         .id(id)
         .isBacking(isBacking)
+        .isPledgeOverTimeAllowed(isPledgeOverTimeAllowed)
         .isStarred(isStarred)
         .lastUpdatePublishedAt(updatedAt)
         .launchedAt(launchedAt)
@@ -560,6 +562,7 @@ fun projectTransformer(projectFragment: ProjectCard?): Project {
     val goal = projectFragment?.goal?.amount?.amount?.toDouble() ?: 0.0
     val id = decodeRelayId(projectFragment?.id) ?: -1
     val isBacking = projectFragment?.backing?.id?.let { true } ?: false
+    val isPledgeOverTimeAllowed = projectFragment?.isPledgeOverTimeAllowed ?: false
     val isStarred = projectFragment?.isWatched ?: false
     val launchedAt = projectFragment?.launchedAt
     val location = locationTransformer(projectFragment?.location?.location)
@@ -596,6 +599,7 @@ fun projectTransformer(projectFragment: ProjectCard?): Project {
         .goal(goal)
         .id(id)
         .isBacking(isBacking)
+        .isPledgeOverTimeAllowed(isPledgeOverTimeAllowed)
         .isStarred(isStarred)
         .launchedAt(launchedAt)
         .location(location)


### PR DESCRIPTION
# 📲 What

Add the new field isPledgeOverTimeAllowed to the Project object on the graphql layer.

# 🤔 Why

So the user can see the new UI for Collection Plan component in the checkout screen.


# 🛠 How

Added isPledgeOverTimeAllowed to fullProject and projectCard on fragments.graphql and to the respective GraphQLTransformers


# Story 📖

[API | Update the Project object on GraphQl to include isPledgeOverTimeAllowed flag](https://kickstarter.atlassian.net/browse/MBL-1923)
