### PR TITLE
[no-jira] Hotfix for 3.27.2 intent is null

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
@@ -29,6 +29,7 @@ import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.adapters.DiscoveryDrawerAdapter
 import com.kickstarter.ui.adapters.DiscoveryPagerAdapter
 import com.kickstarter.ui.data.LoginReason
+import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.ui.extensions.showErrorSnackBar
 import com.kickstarter.ui.extensions.showSuccessSnackBar
 import com.kickstarter.ui.extensions.startActivityWithTransition
@@ -57,6 +58,8 @@ class DiscoveryActivity : AppCompatActivity() {
         installSplashScreen()
 
         super.onCreate(savedInstanceState)
+        setUpConnectivityStatusCheck(lifecycle)
+
         binding = DiscoveryLayoutBinding.inflate(layoutInflater)
         WindowInsetsUtil.manageEdgeToEdge(
             window,

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
@@ -241,6 +241,11 @@ class DiscoveryActivity : AppCompatActivity() {
             .addToDisposable(disposables)
     }
 
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+    }
+
     private fun activateFeatureFlags(environment: Environment) {
         environment.featureFlagClient()?.activate(this)
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
@@ -244,11 +244,6 @@ class DiscoveryActivity : AppCompatActivity() {
             .addToDisposable(disposables)
     }
 
-    override fun onNewIntent(intent: Intent?) {
-        super.onNewIntent(intent)
-        setIntent(intent)
-    }
-
     private fun activateFeatureFlags(environment: Environment) {
         environment.featureFlagClient()?.activate(this)
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
@@ -480,7 +480,9 @@ interface DiscoveryViewModel {
         }
 
         fun provideIntent(intent: Intent) {
-            this.intent.onNext(intent)
+            if(intent.isNotNull()) {
+                this.intent.onNext(intent)
+            }
         }
 
         override fun onCleared() {

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
@@ -480,7 +480,9 @@ interface DiscoveryViewModel {
         }
 
         fun provideIntent(intent: Intent) {
-            this.intent.onNext(intent)
+            if (intent.isNotNull()) {
+                this.intent.onNext(intent)
+            }
         }
 
         override fun onCleared() {

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
@@ -480,7 +480,7 @@ interface DiscoveryViewModel {
         }
 
         fun provideIntent(intent: Intent) {
-            if(intent.isNotNull()) {
+            if (intent.isNotNull()) {
                 this.intent.onNext(intent)
             }
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
@@ -480,9 +480,7 @@ interface DiscoveryViewModel {
         }
 
         fun provideIntent(intent: Intent) {
-            if (intent.isNotNull()) {
-                this.intent.onNext(intent)
-            }
+            this.intent.onNext(intent)
         }
 
         override fun onCleared() {


### PR DESCRIPTION
# 📲 What

[Crash happening here](https://console.firebase.google.com/u/1/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/d803e95303195bc1e678da30c1cca99a?time=last-seven-days&types=crash&sessionEventKey=67584D07033D00012DD55BE3606108EF_2025320936106674208)

# 🤔 Why

Crash is caused by a null intent being passed down an rx stream, which cannot handle null values

# 🛠 How

For now, since we can't reproduce and don't know exactly what is causing this, we will just check that the intent is not null before we pass it down the stream

# 👀 See

no user facing changes 

# 📋 QA

Unfortunately I was not able to reproduce the issue, but navigate around the app and make sure it does not crash or there is no wonky behavior

# Story 📖

no-jira