### PR TITLE
[MBL-1942] Hotfix for keyboard covering input fields in Messages, Comments, & Replies

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -3,10 +3,16 @@ package com.kickstarter.ui.activities
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.view.ViewGroup
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.recyclerview.widget.ConcatAdapter
 import com.kickstarter.R
 import com.kickstarter.databinding.ActivityCommentsLayoutBinding
@@ -56,14 +62,27 @@ class CommentsActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityCommentsLayoutBinding.inflate(layoutInflater)
-        WindowInsetsUtil.manageEdgeToEdge(
-            window,
-            binding.root
-        )
-        val view: View = binding.root
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
+        binding = ActivityCommentsLayoutBinding.inflate(layoutInflater)
+        val view: View = binding.root
         setContentView(view)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                // Apply the left, right, top, and bottom margins based on the insets
+                leftMargin = insets.left
+                bottomMargin = insets.bottom
+                rightMargin = insets.right
+                topMargin = insets.top
+            }
+
+            val imeInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime())
+            v.updatePadding(bottom = imeInsets.bottom)
+
+            WindowInsetsCompat.CONSUMED
+        }
 
         setUpConnectivityStatusCheck(lifecycle)
 

--- a/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/CommentsActivity.kt
@@ -36,7 +36,6 @@ import com.kickstarter.ui.extensions.finishWithAnimation
 import com.kickstarter.ui.extensions.hideKeyboard
 import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.ui.views.OnCommentComposerViewClickedListener
-import com.kickstarter.utils.WindowInsetsUtil
 import com.kickstarter.viewmodels.CommentsViewModel.CommentsViewModel
 import com.kickstarter.viewmodels.CommentsViewModel.Factory
 import io.reactivex.disposables.CompositeDisposable

--- a/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/MessagesActivity.kt
@@ -5,10 +5,16 @@ import android.os.Bundle
 import android.text.Html
 import android.util.Pair
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowManager
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.core.widget.doOnTextChanged
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.appbar.AppBarLayout
@@ -30,7 +36,6 @@ import com.kickstarter.ui.adapters.MessagesAdapter
 import com.kickstarter.ui.extensions.finishWithAnimation
 import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.ui.extensions.startActivityWithTransition
-import com.kickstarter.utils.WindowInsetsUtil
 import com.kickstarter.viewmodels.MessagesViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
@@ -52,12 +57,38 @@ class MessagesActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Set the window to allow drawing under the system bars (status, nav bars),
+        // making them transparent, and enabling edge-to-edge display.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
         binding = MessagesLayoutBinding.inflate(layoutInflater)
-        WindowInsetsUtil.manageEdgeToEdge(
-            window,
-            binding.root
-        )
         setContentView(binding.root)
+
+        // Listen for window insets (which represent system UI like status and navigation bars)
+        // and apply those insets to the view's layout parameters.
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            // Extract the insets that represent the system bars (status and navigation bars)
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+
+            // Update the view's layout margins with the insets so the content avoids overlapping
+            // with system bars. You can choose to apply top, left, bottom, and right insets as needed.
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                // Apply the left, right, top, and bottom margins based on the insets
+                leftMargin = insets.left
+                bottomMargin = insets.bottom
+                rightMargin = insets.right
+                topMargin = insets.top
+            }
+
+            val imeInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime())
+
+            v.updatePadding(bottom = imeInsets.bottom)
+
+            // Return CONSUMED to indicate that the window insets have been handled and
+            // should not be passed down to child views. If you want child views to handle insets,
+            // you can return the windowInsets instead.
+            WindowInsetsCompat.CONSUMED
+        }
 
         setUpConnectivityStatusCheck(lifecycle)
 

--- a/app/src/main/java/com/kickstarter/ui/activities/ThreadActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ThreadActivity.kt
@@ -28,7 +28,6 @@ import com.kickstarter.ui.adapters.RepliesStatusAdapter
 import com.kickstarter.ui.adapters.RootCommentAdapter
 import com.kickstarter.ui.extensions.hideKeyboard
 import com.kickstarter.ui.views.OnCommentComposerViewClickedListener
-import com.kickstarter.utils.WindowInsetsUtil
 import com.kickstarter.viewmodels.ThreadViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable

--- a/app/src/main/java/com/kickstarter/ui/activities/ThreadActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ThreadActivity.kt
@@ -1,10 +1,16 @@
 package com.kickstarter.ui.activities
 
 import android.os.Bundle
+import android.view.ViewGroup
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.kickstarter.R
@@ -58,13 +64,27 @@ class ThreadActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         binding = ActivityThreadLayoutBinding.inflate(layoutInflater)
-        WindowInsetsUtil.manageEdgeToEdge(
-            window,
-            binding.root
-        )
         setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                // Apply the left, right, top, and bottom margins based on the insets
+                leftMargin = insets.left
+                bottomMargin = insets.bottom
+                rightMargin = insets.right
+                topMargin = insets.top
+            }
+
+            val imeInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime())
+            v.updatePadding(bottom = imeInsets.bottom)
+
+            WindowInsetsCompat.CONSUMED
+        }
+
         val environment = this.getEnvironment()?.let { env ->
             viewModelFactory = ThreadViewModel.Factory(env)
             ksString = requireNotNull(env.ksString())

--- a/app/src/main/res/layout/messages_layout.xml
+++ b/app/src/main/res/layout/messages_layout.xml
@@ -5,7 +5,7 @@
     android:id="@+id/messages_coordinator_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:fitsSystemWindows="false">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/messages_app_bar_layout"


### PR DESCRIPTION
# 📲 What

Update layout root padding based on IME insets in `MessagesActivity`

# 🤔 Why

Currently, when the device keyboards opens it covers the messaging input field.

# 🛠 How

Set the bottom padding of the layout's root view based on IME insets to keep the input field visible.

This is the same logic as in `WindowInsetsUtil.manageEdgeToEdge()` with a slight adjustment to handle the keyboard.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| [Video](https://github.com/user-attachments/assets/b27d0059-b106-4f8a-b470-b49249d79222) | [Video](https://github.com/user-attachments/assets/ad37e1fb-8108-42e1-b088-05329fbda124) |

# 📋 QA

Instructions for anyone to be able to QA this work.

# Story 📖

[Name of Trello Story](Trello link)
