### PR TITLE
MBL-1952 Add dynamic root padding to Message Creator screen

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/MessageCreatorActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/MessageCreatorActivity.kt
@@ -2,10 +2,16 @@ package com.kickstarter.ui.activities
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.ViewGroup
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import com.kickstarter.R
 import com.kickstarter.databinding.ActivityMessageCreatorBinding
 import com.kickstarter.libs.KSString
@@ -19,7 +25,6 @@ import com.kickstarter.ui.extensions.finishWithAnimation
 import com.kickstarter.ui.extensions.onChange
 import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.ui.extensions.showSnackbar
-import com.kickstarter.utils.WindowInsetsUtil
 import com.kickstarter.viewmodels.MessageCreatorViewModel.Factory
 import com.kickstarter.viewmodels.MessageCreatorViewModel.MessageCreatorViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -35,12 +40,25 @@ class MessageCreatorActivity : AppCompatActivity() {
     private var disposables = CompositeDisposable()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
         binding = ActivityMessageCreatorBinding.inflate(layoutInflater)
-        WindowInsetsUtil.manageEdgeToEdge(
-            window,
-            binding.root
-        )
         setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                leftMargin = insets.left
+                bottomMargin = insets.bottom
+                rightMargin = insets.right
+                topMargin = insets.top
+            }
+
+            val imeInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime())
+            v.updatePadding(bottom = imeInsets.bottom)
+
+            WindowInsetsCompat.CONSUMED
+        }
 
         setUpConnectivityStatusCheck(lifecycle)
 


### PR DESCRIPTION
# 📲 What

Fix hidden `Send` button in `MessageCreatorActivity`.

# 🤔 Why

When attempting to message a Creator (when not backing their Project), the keyboard hides the Send button. Users must dismiss the keyboard to send the message. This is a regression caused by Android 15 forced edge-to-edge. 

![Screenshot_20250108_163309](https://github.com/user-attachments/assets/3148ac9c-9014-419c-b047-858b2e7faf89)

# 🛠 How

Update layout root padding based on IME insets.
