### PR TITLE
MBL-1956: Terms of use hyperlink in checkout screen

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
@@ -403,7 +403,8 @@ fun CheckoutScreen(
                         paymentIncrements = paymentIncrements,
                         ksCurrency = ksCurrency,
                         projectCurrency = project.currency(),
-                        projectCurrentCurrency = project.currentCurrency()
+                        projectCurrentCurrency = project.currentCurrency(),
+                        termsOfUseCallback = onDisclaimerItemClicked
                     )
                     Spacer(modifier = Modifier.height(dimensions.paddingMediumSmall))
                     Text(

--- a/app/src/main/java/com/kickstarter/ui/fragments/CrowdfundCheckoutFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/CrowdfundCheckoutFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kickstarter.R
 import com.kickstarter.databinding.FragmentCrowdfundCheckoutBinding
+import com.kickstarter.libs.Environment
 import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.extensions.getEnvironment
@@ -18,12 +19,14 @@ import com.kickstarter.libs.utils.extensions.getPaymentSheetConfiguration
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.StoredCard
+import com.kickstarter.ui.activities.DisclaimerItems
 import com.kickstarter.ui.activities.compose.projectpage.CheckoutScreen
 import com.kickstarter.ui.activities.compose.projectpage.getRewardListAndPrices
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
 import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.extensions.showErrorToast
+import com.kickstarter.ui.extensions.startDisclaimerChromeTab
 import com.kickstarter.ui.fragments.PledgeFragment.PledgeDelegate
 import com.kickstarter.viewmodels.projectpage.CheckoutUIState
 import com.kickstarter.viewmodels.projectpage.CrowdfundCheckoutViewModel
@@ -157,7 +160,9 @@ class CrowdfundCheckoutFragment : Fragment() {
                             newPaymentMethodClicked = {
                                 viewModel.getSetupIntent()
                             },
-                            onDisclaimerItemClicked = {},
+                            onDisclaimerItemClicked = { disclaimerItem ->
+                                    openDisclaimerScreen(disclaimerItem, environment)
+                            },
                             onAccountabilityLinkClicked = {},
                             onChangedPaymentMethod = { paymentMethodSelected ->
                                 viewModel.userChangedPaymentMethodSelected(paymentMethodSelected)
@@ -206,6 +211,24 @@ class CrowdfundCheckoutFragment : Fragment() {
             }
         }
         this.viewModel.paymentSheetPresented(success)
+    }
+
+    private fun openDisclaimerScreen(disclaimerItem: DisclaimerItems, environment: Environment?) {
+        activity?.let { activity ->
+            environment?.let {
+                activity.startDisclaimerChromeTab(disclaimerItem, environment)
+            } ?: binding?.composeView?.let { view ->
+                context?.let {
+                    activity.runOnUiThread {
+                        showErrorToast(
+                            it,
+                            view,
+                            getString(R.string.general_error_something_wrong)
+                        )
+                    }
+                }
+            }
+        }
     }
 
     // TODO: explore this piece to be more generic/reusable between crowdfund/late pledges/pledge redemption,

--- a/app/src/main/java/com/kickstarter/ui/fragments/CrowdfundCheckoutFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/CrowdfundCheckoutFragment.kt
@@ -164,7 +164,7 @@ class CrowdfundCheckoutFragment : Fragment() {
                                 viewModel.getSetupIntent()
                             },
                             onDisclaimerItemClicked = { disclaimerItem ->
-                                    openDisclaimerScreen(disclaimerItem, environment)
+                                openDisclaimerScreen(disclaimerItem, environment)
                             },
                             onAccountabilityLinkClicked = {
                                 showAccountabilityPage(environment)
@@ -241,23 +241,23 @@ class CrowdfundCheckoutFragment : Fragment() {
             context?.let { context ->
                 environment?.let { env ->
                     env.webEndpoint().let { endpoint ->
-                    val trustUrl = UrlUtils.appendPath(endpoint, "trust")
-                    ChromeTabsHelperActivity.openCustomTab(
-                        activity,
-                        UrlUtils.baseCustomTabsIntent(context),
-                        Uri.parse(trustUrl),
-                        null
-                    )
+                        val trustUrl = UrlUtils.appendPath(endpoint, "trust")
+                        ChromeTabsHelperActivity.openCustomTab(
+                            activity,
+                            UrlUtils.baseCustomTabsIntent(context),
+                            Uri.parse(trustUrl),
+                            null
+                        )
+                    }
+                } ?: binding?.composeView?.let { view ->
+                    activity.runOnUiThread {
+                        showErrorToast(
+                            context,
+                            view,
+                            getString(R.string.general_error_something_wrong)
+                        )
+                    }
                 }
-            } ?: binding?.composeView?.let { view ->
-                activity.runOnUiThread {
-                    showErrorToast(
-                        context,
-                        view,
-                        getString(R.string.general_error_something_wrong)
-                    )
-                }
-            }
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/fragments/CrowdfundCheckoutFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/CrowdfundCheckoutFragment.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.ui.fragments
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -14,11 +15,13 @@ import com.kickstarter.databinding.FragmentCrowdfundCheckoutBinding
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.utils.RewardUtils
+import com.kickstarter.libs.utils.UrlUtils
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.getPaymentSheetConfiguration
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.StoredCard
+import com.kickstarter.models.chrome.ChromeTabsHelperActivity
 import com.kickstarter.ui.activities.DisclaimerItems
 import com.kickstarter.ui.activities.compose.projectpage.CheckoutScreen
 import com.kickstarter.ui.activities.compose.projectpage.getRewardListAndPrices
@@ -163,7 +166,9 @@ class CrowdfundCheckoutFragment : Fragment() {
                             onDisclaimerItemClicked = { disclaimerItem ->
                                     openDisclaimerScreen(disclaimerItem, environment)
                             },
-                            onAccountabilityLinkClicked = {},
+                            onAccountabilityLinkClicked = {
+                                showAccountabilityPage(environment)
+                            },
                             onChangedPaymentMethod = { paymentMethodSelected ->
                                 viewModel.userChangedPaymentMethodSelected(paymentMethodSelected)
                             },
@@ -227,6 +232,32 @@ class CrowdfundCheckoutFragment : Fragment() {
                         )
                     }
                 }
+            }
+        }
+    }
+
+    private fun showAccountabilityPage(environment: Environment?) {
+        activity?.let { activity ->
+            context?.let { context ->
+                environment?.let { env ->
+                    env.webEndpoint().let { endpoint ->
+                    val trustUrl = UrlUtils.appendPath(endpoint, "trust")
+                    ChromeTabsHelperActivity.openCustomTab(
+                        activity,
+                        UrlUtils.baseCustomTabsIntent(context),
+                        Uri.parse(trustUrl),
+                        null
+                    )
+                }
+            } ?: binding?.composeView?.let { view ->
+                activity.runOnUiThread {
+                    showErrorToast(
+                        context,
+                        view,
+                        getString(R.string.general_error_something_wrong)
+                    )
+                }
+            }
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/views/compose/checkout/CollectionPlan.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/compose/checkout/CollectionPlan.kt
@@ -36,6 +36,8 @@ import com.kickstarter.libs.utils.extensions.format
 import com.kickstarter.libs.utils.extensions.parseToDouble
 import com.kickstarter.mock.factories.PaymentIncrementFactory
 import com.kickstarter.models.PaymentIncrement
+import com.kickstarter.ui.activities.ClickableText
+import com.kickstarter.ui.compose.designsystem.KSClickableText
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
@@ -240,11 +242,10 @@ fun PledgeOption(
                         color = colors.textSecondary
                     )
                     Spacer(modifier = Modifier.height(dimensions.paddingXSmall))
-                    Text(
+                    KSClickableText(
                         modifier = Modifier.testTag(CollectionPlanTestTags.TERMS_OF_USE_TEXT.name),
-                        text = stringResource(id = R.string.fpo_see_our_terms_of_use),
-                        style = typography.caption2,
-                        color = colors.textAccentGreen
+                        resourceId = R.string.fpo_see_our_terms_of_use,
+                        clickCallback = 
                     )
                     if (!paymentIncrements.isNullOrEmpty()) {
                         ChargeSchedule(paymentIncrements, ksCurrency, projectCurrency, projectCurrentCurrency)

--- a/app/src/main/java/com/kickstarter/ui/views/compose/checkout/CollectionPlan.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/compose/checkout/CollectionPlan.kt
@@ -37,6 +37,7 @@ import com.kickstarter.libs.utils.extensions.parseToDouble
 import com.kickstarter.mock.factories.PaymentIncrementFactory
 import com.kickstarter.models.PaymentIncrement
 import com.kickstarter.ui.activities.ClickableText
+import com.kickstarter.ui.activities.DisclaimerItems
 import com.kickstarter.ui.compose.designsystem.KSClickableText
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
@@ -126,7 +127,8 @@ fun CollectionPlan(
     plotMinimum: String? = null,
     ksCurrency: KSCurrency? = null,
     projectCurrency: String? = null,
-    projectCurrentCurrency: String? = null
+    projectCurrentCurrency: String? = null,
+    termsOfUseCallback: (DisclaimerItems) -> Unit = {}
 ) {
     var selectedOption by remember { mutableStateOf(initialSelectedOption) }
     changeCollectionPlan.invoke(selectedOption)
@@ -160,6 +162,7 @@ fun CollectionPlan(
             ksCurrency = ksCurrency,
             projectCurrency = projectCurrency,
             projectCurrentCurrency = projectCurrentCurrency,
+            termsOfUseCallback = termsOfUseCallback,
         )
     }
 }
@@ -179,6 +182,7 @@ fun PledgeOption(
     ksCurrency: KSCurrency? = null,
     projectCurrency: String? = null,
     projectCurrentCurrency: String? = null,
+    termsOfUseCallback: (DisclaimerItems) -> Unit = {}
 ) {
     Column(
         modifier = modifier
@@ -245,7 +249,7 @@ fun PledgeOption(
                     KSClickableText(
                         modifier = Modifier.testTag(CollectionPlanTestTags.TERMS_OF_USE_TEXT.name),
                         resourceId = R.string.fpo_see_our_terms_of_use,
-                        clickCallback = 
+                        clickCallback = { termsOfUseCallback.invoke(DisclaimerItems.TERMS) }
                     )
                     if (!paymentIncrements.isNullOrEmpty()) {
                         ChargeSchedule(paymentIncrements, ksCurrency, projectCurrency, projectCurrentCurrency)

--- a/app/src/main/java/com/kickstarter/ui/views/compose/checkout/CollectionPlan.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/compose/checkout/CollectionPlan.kt
@@ -36,7 +36,6 @@ import com.kickstarter.libs.utils.extensions.format
 import com.kickstarter.libs.utils.extensions.parseToDouble
 import com.kickstarter.mock.factories.PaymentIncrementFactory
 import com.kickstarter.models.PaymentIncrement
-import com.kickstarter.ui.activities.ClickableText
 import com.kickstarter.ui.activities.DisclaimerItems
 import com.kickstarter.ui.compose.designsystem.KSClickableText
 import com.kickstarter.ui.compose.designsystem.KSTheme

--- a/app/src/main/java/com/kickstarter/ui/views/compose/checkout/PaymentSchedule.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/compose/checkout/PaymentSchedule.kt
@@ -30,6 +30,8 @@ import com.kickstarter.libs.utils.DateTimeUtils
 import com.kickstarter.libs.utils.extensions.parseToDouble
 import com.kickstarter.models.Amount
 import com.kickstarter.models.PaymentIncrement
+import com.kickstarter.ui.activities.DisclaimerItems
+import com.kickstarter.ui.compose.designsystem.KSClickableText
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
@@ -130,6 +132,7 @@ fun PaymentSchedule(
     isExpanded: Boolean = false,
     onExpandChange: (Boolean) -> Unit = {},
     paymentIncrements: List<PaymentIncrement> = listOf(),
+    onDisclaimerClicked: (DisclaimerItems) -> Unit = {}
 ) {
     Card(
         elevation = 0.dp,
@@ -172,11 +175,10 @@ fun PaymentSchedule(
                     PaymentRow(paymentIncrement)
                 }
                 Spacer(modifier = Modifier.height(dimensions.paddingSmall))
-                Text(
+                KSClickableText(
                     modifier = Modifier.testTag(PaymentScheduleTestTags.TERMS_OF_USE_TEXT.name),
-                    text = stringResource(id = R.string.fpo_terms_of_use),
-                    style = typography.subheadline,
-                    color = colors.textAccentGreen
+                    resourceId = R.string.fpo_terms_of_use,
+                    clickCallback = { onDisclaimerClicked.invoke(DisclaimerItems.TERMS) }
                 )
             }
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
@@ -548,6 +548,23 @@ class CrowdfundCheckoutViewModel(val environment: Environment, bundle: Bundle? =
     }
 
     /**
+     * Required to present the Stripe PaymentSheet to the user
+     */
+    fun openDisclaimer() {
+        scope.launch(dispatcher) {
+            apolloClient.createSetupIntent(project).asFlow()
+                .onStart { emitCurrentState(isLoading = true) }
+                .catch {
+                    emitCurrentState(isLoading = false)
+                    errorAction.invoke(it.message)
+                }
+                .collectLatest {
+                    _presentPaymentSheet.emit(PaymentSheetPresenterState(it))
+                }
+        }
+    }
+
+    /**
      * If @param = PaymentSheetResult.Failed or PaymentSheetResult.Canceled
      * reload remove the payment methods added via payment sheet and keep only those
      * obtained via `apolloClient.getStoredCards()`. PaymentSheetResult.Canceled will be produce

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
@@ -548,23 +548,6 @@ class CrowdfundCheckoutViewModel(val environment: Environment, bundle: Bundle? =
     }
 
     /**
-     * Required to present the Stripe PaymentSheet to the user
-     */
-    fun openDisclaimer() {
-        scope.launch(dispatcher) {
-            apolloClient.createSetupIntent(project).asFlow()
-                .onStart { emitCurrentState(isLoading = true) }
-                .catch {
-                    emitCurrentState(isLoading = false)
-                    errorAction.invoke(it.message)
-                }
-                .collectLatest {
-                    _presentPaymentSheet.emit(PaymentSheetPresenterState(it))
-                }
-        }
-    }
-
-    /**
      * If @param = PaymentSheetResult.Failed or PaymentSheetResult.Canceled
      * reload remove the payment methods added via payment sheet and keep only those
      * obtained via `apolloClient.getStoredCards()`. PaymentSheetResult.Canceled will be produce


### PR DESCRIPTION
# 📲 What

New PLOT checkout UI has a "terms of use hyperlink", we want to open the web page when a user taps this link. Also discovered a bug on checkout screen where the disclaimer and accountability hyperlinks were not hooked up. 

# 🤔 Why

For the new PLOT UI, but we also need all of the hyperlinks to work. 

# 🛠 How

This PR also fixes an issue discovered where the other hyperlinks on the crowdfund checkout are not working. Using the same logic as in the ProjectPageActivity to open the accountability and disclaimer hyperlinks. 

# 📋 QA



Test regular crowdfund checkout, as well as PLOT with a pledge that meets the minimum PLOT threshold. Expand the PLOT ui and tap terms of use, should open the terms of use page on web.
Test the other hyperlinks on the screen and make sure they link to their correct respective pages. 

# Story 📖

[MBL-1956: Terms of use hyperlink in checkout screen](https://kickstarter.atlassian.net/browse/MBL-1956)
[MBL-1963: Disclaimer and Accountability hyperlinks not working in crowdfund checkout](https://kickstarter.atlassian.net/browse/MBL-1963)