### PR TITLE
MBL-1950: Double charge late pledges

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
@@ -235,12 +235,11 @@ interface DiscoveryViewModel {
             val paramsFromIntent = intentObservable
                 .map { it }
                 .flatMap { DiscoveryIntentMapper.params(it, apiClient, apolloClient) }
-                .compose(Transformers.neverErrorV2())
 
             val verification = uriFromVerification
                 .map { it.getTokenFromQueryParams() }
                 .filter { it.isNotNull() }
-                .switchMap { apiClient.verifyEmail(it).compose(Transformers.neverErrorV2()) }
+                .switchMap { apiClient.verifyEmail(it) }
                 .materialize()
                 .share()
                 .distinctUntilChanged()

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
@@ -235,11 +235,12 @@ interface DiscoveryViewModel {
             val paramsFromIntent = intentObservable
                 .map { it }
                 .flatMap { DiscoveryIntentMapper.params(it, apiClient, apolloClient) }
+                .compose(Transformers.neverErrorV2())
 
             val verification = uriFromVerification
                 .map { it.getTokenFromQueryParams() }
                 .filter { it.isNotNull() }
-                .switchMap { apiClient.verifyEmail(it) }
+                .switchMap { apiClient.verifyEmail(it).compose(Transformers.neverErrorV2()) }
                 .materialize()
                 .share()
                 .distinctUntilChanged()


### PR DESCRIPTION
# 📲 What

A backer was double charged when they were backing a project in the late pledge phase.

# 🤔 Why

What we observed:
- two payment intents were created within 1s of each other
- two payment intents were confirmed at the same time

Further observations were made [here](https://kickstarter.atlassian.net/wiki/spaces/PAYM/pages/3363733506/SD-3397+Backer+double+charged+-+Jan+2024). We will need further investigations by an android engineer to reproduce and confirm. There is some speculation based on past double charge scenarios that this could be related to creating new payment methods in the payment sheet using the payment intent – saving the new payment method with a payment intent will confirm/collect the payment.

# 🛠 How

- Made sure there is only 1 call to `CreatePaymentIntent` within `LatePledgeCheckoutViewModel` (it's the first call when user hits pledge button).
- - Canceling the job that launches the coroutine in case several consecutive call happen
- - Saving the response from `CreatePaymentIntent` in a VM global variable, to be used in validate checkout

# 👀 See

https://github.com/user-attachments/assets/ca50461a-4ab7-44a7-8963-cf30d1274f17


|  |  |

# 📋 QA

⚠️  if you run into the loading issue on rewards screen go to `ProjectPageActivity:656` and remove the `checkoutLoading`, this will be fixed in a [follow up ticket ](https://kickstarter.atlassian.net/browse/MBL-1971)

<img width="673" alt="Screenshot 2025-01-09 at 11 55 13 AM" src="https://github.com/user-attachments/assets/f070c49a-d5fb-4d33-89bb-c761bd10b8ba" />

Late pledges projects on Staging:
- https://staging.kickstarter.com/projects/isabel-martin/organic-board-game-robot
- https://staging.kickstarter.com/projects/1768690592/purple-think-tank-robot?ref=discovery_newest&total_hits=251531&category_id=17
- https://staging.kickstarter.com/projects/1768690592/reclaimed-album-hot-sauce?ref=discovery_newest&total_hits=251531&category_id=31
- https://staging.kickstarter.com/projects/1768690592/dubstep-coffee-microbrew
- https://staging.kickstarter.com/projects/1768690592/solar-board-game-wallet?ref=android_project_share


1 - Go to a late pledge project
2 - Try generating several new payment methods -> https://docs.stripe.com/testing#cards
3 - Finally hit pledge
- Monitor the networking calls to double check `CreatePaymentIntent` mutation has been called only once, you can either use the android studio networking profiler or datatog with a query similar [to this one](https://app.datadoghq.com/logs?query=%40remote_ip%3A174.7.234.23%20%40params.query%3A%2ACreatePaymentIntent%2A&agg_m=count&agg_m_source=base&agg_q=%40current_user&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40current_user%2C%40params.variables.amount%2C%40params.variables.backingId&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&saved-view-id=2665467&sort=time&storage=hot&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1733349536419&to_ts=1735941536419&live=true) (it filters by the mutation in question and my IP, you can change filtering parameters)

# Story 📖

[MBL-1950](https://kickstarter.atlassian.net/browse/MBL-1950)


[MBL-1950]: https://kickstarter.atlassian.net/browse/MBL-1950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ