### PR TITLE
MBL-1999:  Errored States "Authentication required" not showing

### DIFF
--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
@@ -14,12 +14,9 @@ import com.kickstarter.ui.extensions.finishWithAnimation
 import com.kickstarter.viewmodels.BackingDetailsViewModel
 import kotlinx.coroutines.launch
 import android.view.ViewGroup
-import androidx.activity.addCallback
-import androidx.activity.viewModels
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 const val REFRESH = "refresh"
@@ -45,7 +42,6 @@ class BackingDetailsActivity : AppCompatActivity() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
             val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                // Apply the left, right, top, and bottom margins based on the insets
                 leftMargin = insets.left
                 bottomMargin = insets.bottom
                 rightMargin = insets.right

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
@@ -1,15 +1,10 @@
 package com.kickstarter.features.pledgedprojectsoverview.ui
 
 import android.os.Bundle
-import android.view.ViewGroup
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updateLayoutParams
-import androidx.core.view.updatePadding
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -17,6 +12,7 @@ import com.kickstarter.databinding.ActivityBackingDetailsBinding
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.extensions.finishWithAnimation
+import com.kickstarter.utils.WindowInsetsUtil
 import com.kickstarter.viewmodels.BackingDetailsViewModel
 import kotlinx.coroutines.launch
 
@@ -30,30 +26,17 @@ class BackingDetailsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        WindowCompat.setDecorFitsSystemWindows(window, false)
         binding = ActivityBackingDetailsBinding.inflate(layoutInflater)
-
+        WindowInsetsUtil.manageEdgeToEdge(
+            window,
+            binding.root,
+        )
         this.getEnvironment()?.let { env ->
             viewModelFactory = BackingDetailsViewModel.Factory(env, intent = intent)
             env
         }
 
         setContentView(binding.root)
-
-        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
-            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                leftMargin = insets.left
-                bottomMargin = insets.bottom
-                rightMargin = insets.right
-                topMargin = insets.top
-            }
-
-            val imeInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime())
-            v.updatePadding(bottom = imeInsets.bottom)
-
-            WindowInsetsCompat.CONSUMED
-        }
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
@@ -13,7 +13,15 @@ import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.extensions.finishWithAnimation
 import com.kickstarter.viewmodels.BackingDetailsViewModel
 import kotlinx.coroutines.launch
-
+import android.view.ViewGroup
+import androidx.activity.addCallback
+import androidx.activity.viewModels
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 const val REFRESH = "refresh"
 
 class BackingDetailsActivity : AppCompatActivity() {
@@ -24,6 +32,7 @@ class BackingDetailsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         binding = ActivityBackingDetailsBinding.inflate(layoutInflater)
 
         this.getEnvironment()?.let { env ->
@@ -32,6 +41,22 @@ class BackingDetailsActivity : AppCompatActivity() {
         }
 
         setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                // Apply the left, right, top, and bottom margins based on the insets
+                leftMargin = insets.left
+                bottomMargin = insets.bottom
+                rightMargin = insets.right
+                topMargin = insets.top
+            }
+
+            val imeInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime())
+            v.updatePadding(bottom = imeInsets.bottom)
+
+            WindowInsetsCompat.CONSUMED
+        }
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
@@ -1,9 +1,15 @@
 package com.kickstarter.features.pledgedprojectsoverview.ui
 
 import android.os.Bundle
+import android.view.ViewGroup
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -13,12 +19,7 @@ import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.extensions.finishWithAnimation
 import com.kickstarter.viewmodels.BackingDetailsViewModel
 import kotlinx.coroutines.launch
-import android.view.ViewGroup
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updateLayoutParams
-import androidx.core.view.updatePadding
+
 const val REFRESH = "refresh"
 
 class BackingDetailsActivity : AppCompatActivity() {

--- a/app/src/main/java/com/kickstarter/models/Backing.kt
+++ b/app/src/main/java/com/kickstarter/models/Backing.kt
@@ -236,7 +236,8 @@ class Backing private constructor(
         STATUS_DROPPED,
         STATUS_ERRORED,
         STATUS_PLEDGED,
-        STATUS_PREAUTH
+        STATUS_PREAUTH,
+        STATUS_AUTHENTICATION_REQUIRED
     )
     annotation class Status
 
@@ -250,5 +251,6 @@ class Backing private constructor(
         const val STATUS_ERRORED = "errored"
         const val STATUS_PLEDGED = "pledged"
         const val STATUS_PREAUTH = "preauth"
+        const val STATUS_AUTHENTICATION_REQUIRED = "authentication_required"
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -598,8 +598,8 @@ interface BackingFragmentViewModel {
                                 R.string.If_your_project_reaches_its_funding_goal_the_backer_will_be_charged_total_on_project_deadline
                             }
                         }
-
                         Backing.STATUS_PREAUTH -> R.string.We_re_processing_your_pledge_pull_to_refresh
+                        Backing.STATUS_AUTHENTICATION_REQUIRED -> R.string.fpo_authentication_required_backing_state
                         else -> null
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,7 +97,11 @@
   <string name="fpo_authentication_required">Authentication required</string>
   <string name="fpo_errored_payment">Errored payment</string>
   <string name="fpo_cancelled">Cancelled</string>
-
   <string name="fpo_payment_schedule">Payment schedule</string>
+
+  <!--TODO: Get design fot this string for Backing state authentication_required-->
+  <string name="fpo_authentication_required_backing_state">We can\'t process your pledge. Authentication is required.</string>
+
+
 
 </resources>


### PR DESCRIPTION
# 📲 What
1.- When dealing with 3DS cards, might be required to authenticate again when a project is collected. The Authentication error for PLOT is not showing, while on Pledged Projects Dashboard (aka PPO), that state is clearly shown.

2.- Design fix on Backing Details for android 15

# 🤔 Why

1.- Need to manage `authentication_required` state for `Backing.state` on the Manage Your pledge screen 'cause right now it shows and empty gray card

2.- Toolbar back button was inaccessible 

# 🛠 How

1.- Added `authentication_required` state for `Backing` model. Then created a string resource to assigned to it on the BackingFragmentViewModel Switch's case for the `PledgeStatus string data`

2.- Set the paddings of the layout's root view based on IME insets

# 👀 See



1 .- Authentication required status
| Before 🐛 | 
![2](https://github.com/user-attachments/assets/04942a47-ab64-4a6f-8333-94832f7841da)
 |After 🦋 |
![4](https://github.com/user-attachments/assets/0388d1b3-69f0-4584-a410-75ab165c3c9a)

2.- Backing details
| Before 🐛 | 
[bug-android15.webm](https://github.com/user-attachments/assets/e572412f-5c85-4623-9626-39ae03d404a0)

|After 🦋 |
[bug_fixed.webm](https://github.com/user-attachments/assets/7d5d6062-7b3c-4852-b4e9-17c3524cc320)

# Story 📖

[MBL-1999 Errored States "Authentication required" not showing](https://kickstarter.atlassian.net/browse/MBL-1999)
