### PR TITLE
MBL-2001 Consufing copy

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -478,6 +478,15 @@ class BackingFragment : Fragment() {
                         )
                     }
                 }
+                R.string.fpo_if_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline -> {
+                    this.viewModel.ksString?.let { ksString ->
+                        ksString.format(
+                            getString(it),
+                            "total", pledgeStatusData.pledgeTotal,
+                            "project_deadline", pledgeStatusData.projectDeadline
+                        )
+                    }
+                }
 
                 else -> getString(it)
             }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -595,7 +595,7 @@ interface BackingFragmentViewModel {
                             ) {
                                 R.string.We_collected_your_pledge_for_this_project
                             } else {
-                                R.string.If_your_project_reaches_its_funding_goal_the_backer_will_be_charged_total_on_project_deadline
+                                R.string.fpo_if_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline
                             }
                         }
                         Backing.STATUS_PREAUTH -> R.string.We_re_processing_your_pledge_pull_to_refresh

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
 
   <!-- TODO: Get translations for this and put it in i18n, then remove  -->
   <string name="project_status_project_was_successfully_funded_on_deadline_but_you_can_still_pledge_for_available_rewards" formatted="false">This project was successfully funded on %{deadline}, but you can still pledge for available rewards.</string>
+  <string name="fpo_if_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline" formatted="false">  If the project reaches its funding goal, you will be charged %{total} on %{project_deadline}.</string>
 
   <!--TODO: Get design fot this string for Backing state authentication_required-->
   <string name="fpo_authentication_required_backing_state">We can\'t process your pledge. Authentication is required.</string>

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -812,7 +812,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
 
         this.pledgeStatusData.assertValue(
             PledgeStatusData(
-                R.string.If_your_project_reaches_its_funding_goal_the_backer_will_be_charged_total_on_project_deadline,
+                R.string.fpo_if_the_project_reaches_its_funding_goal_you_will_be_charged_total_on_project_deadline,
                 expectedCurrency(environment, backedProject, 20.0),
                 DateTimeUtils.longDate(deadline),
                 plotData = null


### PR DESCRIPTION
# 📲 What

Fix of the string on the Manage Your Pledge screen for the PledgeStatus disclaimer text when the project was pledged wit **NOT PLOT selected**. It was showing the incorrect string and make it confusing for the user.

# 🤔 Why

Text shows `If your project reaches its funding goal, the backer will be charged $1 on March 17, 2025` and it should be 
`If the project reaches its funding goal, you will be charged %{total} on %{project_deadline}`

# 🛠 How

Added a new string to match the correct acording to [this design](https://www.figma.com/design/vyTjzt9Tb67oHYUVbV2zKh/PLOT-V1-Designs?node-id=1331-25648&t=lhWf7IKfsyz3Ad5y-0
), added the case to BackingFragmentViewModel and BackingFragment.
# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | 
| ![incorrect](https://github.com/user-attachments/assets/3dc66723-353b-4ba0-8a2f-23e86c3405d9) 

| After 🦋 |
 ![100](https://github.com/user-attachments/assets/df8c2866-5a3b-43e4-ac2b-0d11960182b9)|
|  |  |

# 📋 QA

- Pledge a project with the normal flow, not PLOT selected, it doesn't even need to be a PLOT project.
- After the project is pledged go to the Manage Your Pledge screen of the project.
- The disclaimer text rendered should be with the format: 
`If the project reaches its funding goal, you will be charged %{total} on %{project_deadline}`

# Story 📖

[MBL-2001 Confusing copy](https://kickstarter.atlassian.net/browse/MBL-2001)
