### PR TITLE
Fix typo on hyperlink

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -506,11 +506,10 @@ class BackingFragment : Fragment() {
                 R.string.We_cant_process_your_Pledge_Over_Time_payment -> {
                     val url = pledgeStatusData.plotData?.fixPledgeUrl
                     if (url != null) {
-                        val linkText = "<a href=\"$url\"</a>"
                         this.viewModel.ksString?.let { ksString ->
                             ksString.format(
                                 getString(it),
-                                "view your pledge", linkText
+                                "view_your_pledge_link", url
                             )
                         }
                     } else {

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -507,7 +507,12 @@ class BackingFragment : Fragment() {
                     val url = pledgeStatusData.plotData?.fixPledgeUrl
                     if (url != null) {
                         val linkText = "<a href=\"$url\"</a>"
-                        getString(it).replace("%{view_your_pledge_link}>", linkText)
+                        this.viewModel.ksString?.let { ksString ->
+                            ksString.format(
+                                getString(it),
+                                "view your pledge", linkText
+                            )
+                        }
                     } else {
                         getString(it)
                     }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -507,7 +507,7 @@ class BackingFragment : Fragment() {
                     val url = pledgeStatusData.plotData?.fixPledgeUrl
                     if (url != null) {
                         val linkText = "<a href=\"$url\"</a>"
-                        getString(it).replace("%{view_your_pledge_link}", linkText)
+                        getString(it).replace("%{view_your_pledge_link}>", linkText)
                     } else {
                         getString(it)
                     }


### PR DESCRIPTION
# 📲 What

Fix Typo in hyperlink in string for PLOT authentication required blurb in manage pledge
# 🤔 Why

Extra “>” in string/hyperlink:


# 🛠 How

Fix the typo on the function that creates the link
# 👀 See
BEFORE
![Screenshot_20250124-160530](https://github.com/user-attachments/assets/ca10b167-3c6d-410b-9768-03a6f9619a6b)


FIXED
[fix_typo.webm](https://github.com/user-attachments/assets/4d67f76a-25dd-4db4-98da-f412b08bef13)




# 📋 QA

Using test credentials:
Email: [jluna+test01@arkusnexus.com](mailto:jluna+test01@arkusnexus.com)
Password: q...

Go to the profile these projects and open the Manage screen for each:

This one has PLOT selected and Backing.status.ERRORED so the fixed string should appear and the hyperlink should send you to that project details to fix the pledge on an external navigator. 
[Revolutionary Restoration Coffee](https://staging.kickstarter.com/projects/1768690592/revolutionary-restoration-coffee?ref=profile_backed&category_id=294)

This one has PLOT selected and Backing.status.AUTHENTICATION_REQUIRED so the fixed string should appear and the hyperlink should send you to that project details to fix the pledge on an external navigator. 
[Paleo Video Game Hot Sauce](https://staging.kickstarter.com/projects/1768690592/paleo-video-game-hot-sauce?ref=profile_backed&category_id=350)

# Story 📖

[MBL-2015 Typo in hyperlink in string for PLOT authentication required blurb in manage pledge](https://kickstarter.atlassian.net/browse/MBL-2015)
