### PR TITLE
MBL-2047 Bold styling not showing on first charge amount for PLOT

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -534,6 +534,8 @@ class BackingFragment : Fragment() {
                 pledgeStatusData.projectDeadline?.let {
                     ViewUtils.addBoldSpan(spannablePledgeStatus, it)
                 }
+                pledgeStatusData.plotData?.plotAmount?.let { ViewUtils.addBoldSpan(spannablePledgeStatus, it) }
+                pledgeStatusData.plotData?.plotFirstScheduleCollection?.let { ViewUtils.addBoldSpan(spannablePledgeStatus, it) }
 
                 binding?.backerPledgeStatus?.text = spannablePledgeStatus
             }


### PR DESCRIPTION
# 📲 What

On the disclaimer text on the **Manage your pledge screen** for projects with PLOT selected the text should be:

"You have selected Pledge Over Time. If the project reaches its funding goal, the first charge of **%{amount}** will be collected on **%{date}**"

The amount and date should have **BOLD** style

# 🤔 Why

Right now the amount has no BOLD style

# 🛠 How

Used View ViewUtils.addBoldSpa to add the bold style to the corresponding text on the BakingFragment

# 👀 See


| Before 🐛 |

![image](https://github.com/user-attachments/assets/2b37a5c2-e9d2-43be-b762-a1cdf23290eb)

  |After 🦋 |
  
  
![fix_bold](https://github.com/user-attachments/assets/76df37e8-3c8a-435e-890a-1bf060009eaf)

|  |  |

# 📋 QA

Using test credentials:
Email: [jluna+test01@arkusnexus.com](mailto:jluna+test01@arkusnexus.com)
Password: qwertyuiop

- Go to the profile and select: [Purple Tarot Community Space](https://staging.kickstarter.com/projects/1768690592/purple-tarot-community-space
)

- Go to Manage Your Pledge

- Text should be: "You have selected Pledge Over Time. If the project reaches its funding goal, the first charge of **%{amount}** will be collected on **%{date}**" 

# Story 📖

[MBL-2047 Bold styling not showing on first charge amount for PLOT](https://kickstarter.atlassian.net/browse/MBL-2047)
