### PR TITLE
MBL-2052 PLOT projects not working after scheme change on BE

### DIFF
--- a/app/src/main/graphql/project.graphql
+++ b/app/src/main/graphql/project.graphql
@@ -203,7 +203,6 @@ mutation CreateFlagging($contentId: ID!, $details: String, $kind: NonDeprecatedF
 query BuildPaymentPlan($slug: String!, $amount: String!) {
   project(slug: $slug) {
     paymentPlan(amount: $amount) {
-      projectIsPledgeOverTimeAllowed
       amountIsPledgeOverTimeEligible
       paymentIncrements {
         amount {

--- a/app/src/main/graphql/schema.graphqls
+++ b/app/src/main/graphql/schema.graphqls
@@ -760,17 +760,11 @@ enum Feature {
 
   reset_backer_survey_2024
 
-  disable_shipping_at_pledge
-
   pledge_projects_overview_2024
 
   pledge_projects_overview_ios_2024
 
   copy_rewards
-
-  pledge_redemption_v1
-
-  pledge_redemption_vat
 
   survey_reward_questions_2024
 
@@ -796,10 +790,6 @@ enum Feature {
 
   notification_banner_update_2024
 
-  multiple_shipfrom_locations_2024
-
-  pledge_redemption_unified_creator_ui
-
   react_backed_projects
 
   copy_addons
@@ -807,6 +797,12 @@ enum Feature {
   KDS_messages_app
 
   pledge_management_refunds
+
+  discover_ui_2025
+
+  pledge_management_beta
+
+  creator_experience_2025
 }
 
 """
@@ -1765,6 +1761,11 @@ type Project implements Node & Commentable {
   The project's profile.
   """
   profile: ProjectProfile
+
+  """
+  The text of the currently applied project notice, empty if there is no notice
+  """
+  projectNotice: String
 
   """
   When this project was Project of the Day.
@@ -5055,27 +5056,7 @@ A hash containing the original, refunded, and remaining amounts.
 """
 type AdjustmentAmount {
   """
-  the original total amount
-  """
-  originalTotal: Int!
-
-  """
-  the refunded total amount
-  """
-  refundedTotal: Int!
-
-  """
-  the remaining total amount
-  """
-  remainingTotal: Int!
-}
-
-"""
-A reward that is modified by an adjustment.
-"""
-type AdjustmentReward {
-  """
-  original total for reward
+  original total amount
   """
   originalTotal: Int!
 
@@ -5090,9 +5071,44 @@ type AdjustmentReward {
   remainingTotal: Int!
 
   """
+  whether the reward has been removed from the backing
+  """
+  removed: Boolean
+}
+
+"""
+A reward that is modified by an adjustment.
+"""
+type AdjustmentReward {
+  """
+  original total amount
+  """
+  originalTotal: Int!
+
+  """
+  uuid for the refund item
+  """
+  refundItemId: ID!
+
+  """
+  amount that has been refunded after all adjustments are applied
+  """
+  refundedTotal: Int!
+
+  """
+  amount remaining after all adjustments are applied
+  """
+  remainingTotal: Int!
+
+  """
+  whether the reward has been removed from the backing
+  """
+  removed: Boolean
+
+  """
    graphql id of reward to be refunded
   """
-  rewardId: ID!
+  rewardId: String!
 }
 
 """
@@ -7082,6 +7098,11 @@ enum FlaggingKind {
   PROTOTYPE_MISREPRESENTATION
 
   """
+  undisclosed-ai-use
+  """
+  UNDISCLOSED_AI_USE
+
+  """
   misrep-support-impersonation
   """
   MISREP_SUPPORT_IMPERSONATION
@@ -8441,11 +8462,6 @@ type PaymentPlan {
   amountIsPledgeOverTimeEligible: Boolean!
 
   paymentIncrements: [PaymentIncrement!]
-
-  """
-  Whether the project permits pledge over time pledges
-  """
-  projectIsPledgeOverTimeAllowed: Boolean!
 }
 
 """
@@ -9108,6 +9124,8 @@ enum UserRestrictionKind {
   edit_spotlight_pages
 
   phone
+
+  prelaunch_early
 }
 
 """
@@ -14517,9 +14535,14 @@ An object removed as part of an adjustment
 """
 input RemovalInput {
   """
+  id of the reward associated with the removal
+  """
+  rewardId: Int!
+
+  """
   id of object to be removed
   """
-  id: Int!
+  refundItemId: ID!
 
   """
   type of object to be removed (reward, reward item, or order item)
@@ -14534,7 +14557,7 @@ input RefundInput {
   """
   id of object to be refunded
   """
-  id: Int
+  refundItemId: ID
 
   """
   type of refund
@@ -14964,6 +14987,11 @@ enum NonDeprecatedFlaggingKind {
   prototype-misrepresentation
   """
   PROTOTYPE_MISREPRESENTATION
+
+  """
+  undisclosed-ai-use
+  """
+  UNDISCLOSED_AI_USE
 
   """
   misrep-support-impersonation

--- a/app/src/main/java/com/kickstarter/mock/factories/PaymentPlanFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/PaymentPlanFactory.kt
@@ -10,12 +10,10 @@ class PaymentPlanFactory {
         fun paymentPlan(
             paymentIncrements: List<PaymentIncrement>?,
             amountIsPledgeOverTimeEligible: Boolean,
-            projectIsPledgeOverTimeAllowed: Boolean,
         ): PaymentPlan {
             return builder()
                 .paymentIncrements(paymentIncrements)
                 .amountIsPledgeOverTimeEligible(amountIsPledgeOverTimeEligible)
-                .projectIsPledgeOverTimeAllowed(projectIsPledgeOverTimeAllowed)
                 .build()
         }
 
@@ -23,7 +21,6 @@ class PaymentPlanFactory {
             return this.paymentPlan(
                 paymentIncrements = paymentIncrements,
                 amountIsPledgeOverTimeEligible = true,
-                projectIsPledgeOverTimeAllowed = true
             )
         }
 
@@ -31,7 +28,6 @@ class PaymentPlanFactory {
             return this.paymentPlan(
                 paymentIncrements = null,
                 amountIsPledgeOverTimeEligible = false,
-                projectIsPledgeOverTimeAllowed = true
             )
         }
     }

--- a/app/src/main/java/com/kickstarter/models/PaymentPlan.kt
+++ b/app/src/main/java/com/kickstarter/models/PaymentPlan.kt
@@ -7,25 +7,20 @@ import kotlinx.parcelize.Parcelize
 data class PaymentPlan(
     val amountIsPledgeOverTimeEligible: Boolean,
     val paymentIncrements: List<PaymentIncrement>?,
-    val projectIsPledgeOverTimeAllowed: Boolean,
 ) : Parcelable {
     fun amountIsPledgeOverTimeEligible() = this.amountIsPledgeOverTimeEligible
     fun paymentIncrements() = this.paymentIncrements
-    fun projectIsPledgeOverTimeAllowed() = this.projectIsPledgeOverTimeAllowed
 
     @Parcelize
     data class Builder(
         var amountIsPledgeOverTimeEligible: Boolean = false,
         var paymentIncrements: List<PaymentIncrement>? = null,
-        var projectIsPledgeOverTimeAllowed: Boolean = false,
     ) : Parcelable {
         fun amountIsPledgeOverTimeEligible(amountIsPledgeOverTimeEligible: Boolean) = apply { this.amountIsPledgeOverTimeEligible = amountIsPledgeOverTimeEligible }
         fun paymentIncrements(paymentIncrements: List<PaymentIncrement>?) = apply { this.paymentIncrements = paymentIncrements }
-        fun projectIsPledgeOverTimeAllowed(projectIsPledgeOverTimeAllowed: Boolean) = apply { this.projectIsPledgeOverTimeAllowed = projectIsPledgeOverTimeAllowed }
         fun build() = PaymentPlan(
             amountIsPledgeOverTimeEligible = amountIsPledgeOverTimeEligible,
             paymentIncrements = paymentIncrements,
-            projectIsPledgeOverTimeAllowed = projectIsPledgeOverTimeAllowed,
         )
     }
 
@@ -36,15 +31,13 @@ data class PaymentPlan(
     fun toBuilder() = Builder(
         amountIsPledgeOverTimeEligible = amountIsPledgeOverTimeEligible,
         paymentIncrements = paymentIncrements,
-        projectIsPledgeOverTimeAllowed = projectIsPledgeOverTimeAllowed,
     )
 
     override fun equals(other: Any?): Boolean {
         var equals = super.equals(other)
         if (other is PaymentPlan) {
             equals = amountIsPledgeOverTimeEligible() == other.amountIsPledgeOverTimeEligible() &&
-                paymentIncrements() == other.paymentIncrements() &&
-                projectIsPledgeOverTimeAllowed() == other.projectIsPledgeOverTimeAllowed()
+                paymentIncrements() == other.paymentIncrements()
         }
         return equals
     }

--- a/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
@@ -1057,7 +1057,6 @@ fun paymentPlanTransformer(buildPaymentPlanResponse: BuildPaymentPlanQuery.Payme
     return PaymentPlan.builder()
         .paymentIncrements(paymentIncrements)
         .amountIsPledgeOverTimeEligible(buildPaymentPlanResponse.amountIsPledgeOverTimeEligible)
-        .projectIsPledgeOverTimeAllowed(buildPaymentPlanResponse.projectIsPledgeOverTimeAllowed)
         .build()
 }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
@@ -277,7 +277,7 @@ class CrowdfundCheckoutViewModel(val environment: Environment, bundle: Bundle? =
                     emitCurrentState(isLoading = false)
                 }
                 .collectLatest {
-                    showPlotWidget = !it.paymentIncrements.isNullOrEmpty()
+                    showPlotWidget = project.isPledgeOverTimeAllowed() == true
                     plotEligible = it.amountIsPledgeOverTimeEligible
                     paymentIncrements = it.paymentIncrements
                     emitCurrentState(isLoading = false)

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
@@ -277,7 +277,7 @@ class CrowdfundCheckoutViewModel(val environment: Environment, bundle: Bundle? =
                     emitCurrentState(isLoading = false)
                 }
                 .collectLatest {
-                    showPlotWidget = it.projectIsPledgeOverTimeAllowed
+                    showPlotWidget = !it.paymentIncrements.isNullOrEmpty()
                     plotEligible = it.amountIsPledgeOverTimeEligible
                     paymentIncrements = it.paymentIncrements
                     emitCurrentState(isLoading = false)


### PR DESCRIPTION
# 📲 What

After a change on BE they remove the prop `projectIsPledgeOverTimeAllowed` from PaymentPlan.
We have to remove it from the project too.

# 🤔 Why

Can't pledge PLOT projects with PLOT becuase the component doesn't render do a validation with that prop.

# 🛠 How

Remove all the uses for that prop and change the only validation where it's used.

# 👀 See


| Before 🐛 |
![error_message](https://github.com/user-attachments/assets/c0469cf6-5b25-44ef-b274-963c928e0fb8)

| After 🦋 |
[plot_fixed.webm](https://github.com/user-attachments/assets/328efafa-12c8-44fe-bdbf-07aedf85f353)


# 📋 QA

Enter with a valid user to staging an look for [Crossfit Watch Hot Sauce](https://staging.kickstarter.com/projects/1768690592/crossfit-watch-hot-sauce?ref=project_build)

the project is a PLOT project so if you follow the PLOT flow you should see the PLOT component rendering correctly and have no problem to pledge it

# Story 📖

[MBL-2052 PLOT projects not working after scheme change on BE](https://kickstarter.atlassian.net/browse/MBL-2052)
