### PR TITLE
MBL-2055: Avoid adding the Authorization header if the token is empty

### DIFF
--- a/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
+++ b/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
@@ -22,7 +22,7 @@ class GraphQLInterceptor(
         val builder = original.newBuilder().method(original.method, original.body)
 
         this.currentUser.accessToken?.let { token ->
-            if (token.isNotEmpty()) builder.addHeader("Authorization", "token $token")
+            if (token.isNotBlank()) builder.addHeader("Authorization", "token $token")
         }
 
         builder.addHeader("User-Agent", WebUtils.userAgent(this.build))

--- a/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
+++ b/app/src/main/java/com/kickstarter/services/interceptors/GraphQLInterceptor.kt
@@ -21,8 +21,8 @@ class GraphQLInterceptor(
         val original = chain.request()
         val builder = original.newBuilder().method(original.method, original.body)
 
-        this.currentUser.accessToken?.let {
-            builder.addHeader("Authorization", "token $it")
+        this.currentUser.accessToken?.let { token ->
+            if (token.isNotEmpty()) builder.addHeader("Authorization", "token $token")
         }
 
         builder.addHeader("User-Agent", WebUtils.userAgent(this.build))


### PR DESCRIPTION
# 📲 What


* Increase of 429 errors detected while rolling out Android 3.28.0. Specially around GraphQL

The rule in graphql_authed was triggered when receiving a header with the word “token “ without any token value associated. (@match_discriminator:token) → [Datadog query](https://app.datadoghq.com/logs?query=%40http.useragent%3A%22Kickstarter%20Android%20Mobile%20Variant%2FexternalRelease%20Code%2F2014150930%20Version%2F3.28.0%22%20source%3Arack_attack%20%40match_discriminator%3Atoken&agg_m=count&agg_m_source=base&agg_q=%40match&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40match&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=toplist&x_missing=true&from_ts=1618865525266&to_ts=1621457525266&live=true)

# 🤔 Why

On the Android app for each API type we have the Interceptor Classes on top of Okhttp Service to add headers to the requests. Take a look at ApiRequestInterceptor for V1 REST api and to GraphQLInterceptor for graphQL.

These interceptors do receive as dependency the currentUser object, that will hold the accessToken required for authorization headers.

When there is no logged in user the accessToken is null, and should not be instances in which accessToken is empty, but this last check was done only for ApiRequestInterceptor and not for GraphQLInterceptor.

 This scenario has been in the app since several versions behind 3.28.0, most likely we’ve seen the problem thanks to the crash rate spiking, keep an eye on the 429 errors registered on Firebase after the release.

# 🛠 How

- Not adding the header if the token is empty

# 👀 See
- Cannot reproduce the 429 errors or violating the rule, but the [datadog](https://app.datadoghq.com/logs?query=%40http.useragent%3A%22Kickstarter%20Android%20Mobile%20Variant%2FexternalRelease%20Code%2F2014150930%20Version%2F3.28.0%22%20source%3Arack_attack%20%40match_discriminator%3Atoken&agg_m=count&agg_m_source=base&agg_q=%40match&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40match&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=toplist&x_missing=true&from_ts=1618865525266&to_ts=1621457525266&live=true) query is clear.
- No user facing changes, just make sure you can browse normally 

|  |  |

# 📋 QA
- Open the app, several calls will be made the graph endpoint, nothing should have changed.

# Story 📖

[MBL-2055](https://kickstarter.atlassian.net/browse/MBL-2055)


[MBL-2055]: https://kickstarter.atlassian.net/browse/MBL-2055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ