### PR TITLE
MBL-2038: [Phase 1] UI Updates: Mail icon for message creator

### DIFF
--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -323,31 +323,6 @@ fun CreatorNameSendMessageView(
         }
 
     }
-
-//        Row(
-//            modifier = Modifier
-//                .weight(0.3f)
-//                .padding(
-//                    end = dimensions.paddingMediumSmall,
-//                    top = dimensions.paddingMediumSmall,
-//                    bottom = dimensions.paddingMediumSmall
-//                )
-//                .clickable { sendAMessageClickAction.invoke() }
-//        ) {
-//            Text(
-//                text = stringResource(id = R.string.Send_a_message),
-//                color = colors.textAccentGreen,
-//                style = typography.caption2
-//            )
-//
-//            Image(
-//                modifier = Modifier.size(dimensions.paddingMediumSmall),
-//                imageVector = ImageVector.vectorResource(id = R.drawable.chevron_right),
-//                contentDescription = null,
-//                colorFilter = ColorFilter.tint(color = colors.textAccentGreen)
-//            )
-//        }
-
     KSDividerLineGrey()
 }
 

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -291,10 +292,8 @@ fun CreatorNameSendMessageView(
         modifier = Modifier
             .fillMaxWidth()
             .padding(
-                top = dimensions.paddingSmall,
-                bottom = dimensions.paddingSmall,
                 start = dimensions.paddingMediumSmall,
-                end = dimensions.paddingMediumSmall
+                end = dimensions.paddingSmall
             )
     ) {
         Text(
@@ -312,14 +311,17 @@ fun CreatorNameSendMessageView(
             maxLines = 1
         )
 
-        Image(
-            modifier = Modifier
-                .padding(start = dimensions.paddingSmall)
-                .clickable { sendAMessageClickAction.invoke() },
-            imageVector = ImageVector.vectorResource(id = R.drawable.ic_envelope),
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(color = colors.textSecondary)
-        )
+        Box(
+            modifier = Modifier.width(dimensions.minButtonHeight).height(dimensions.minButtonHeight).clickable { sendAMessageClickAction.invoke() },
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                imageVector = ImageVector.vectorResource(id = R.drawable.ic_envelope),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(color = colors.textSecondary)
+            )
+        }
+
     }
 
 //        Row(

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -304,16 +304,16 @@ fun CreatorNameSendMessageView(
             style = typography.caption2Medium,
             maxLines = 1
         )
-        
-    Image(
-        modifier = Modifier
-            .padding(start = dimensions.paddingSmall)
-            .clickable { sendAMessageClickAction.invoke() },
-        imageVector = ImageVector.vectorResource(id = R.drawable.ic_envelope),
-        contentDescription = null,
-        colorFilter = ColorFilter.tint(color = colors.textSecondary)
-    )
-}
+
+        Image(
+            modifier = Modifier
+                .padding(start = dimensions.paddingSmall)
+                .clickable { sendAMessageClickAction.invoke() },
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_envelope),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(color = colors.textSecondary)
+        )
+    }
 
 //        Row(
 //            modifier = Modifier

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -321,7 +321,6 @@ fun CreatorNameSendMessageView(
                 colorFilter = ColorFilter.tint(color = colors.textSecondary)
             )
         }
-
     }
     KSDividerLineGrey()
 }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Badge
@@ -23,6 +22,7 @@ import androidx.compose.material.BadgedBox
 import androidx.compose.material.Card
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
@@ -280,59 +280,62 @@ fun CreatorNameSendMessageView(
     KSDividerLineGrey()
 
     Row(
-        Modifier
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
             .fillMaxWidth()
+            .padding(
+                top = dimensions.paddingSmall,
+                bottom = dimensions.paddingSmall,
+                start = dimensions.paddingMediumSmall,
+                end = dimensions.paddingMediumSmall
+            )
     ) {
+        Text(
+            text = stringResource(id = R.string.project_menu_created_by),
+            color = colors.textSecondary,
+            style = typography.caption2
+        )
 
-        Row(
-            modifier = Modifier
-                .weight(0.7f)
-                .padding(
-                    top = dimensions.paddingMediumSmall,
-                    bottom = dimensions.paddingMediumSmall,
-                    start = dimensions.paddingMediumSmall,
-                    end = dimensions.paddingSmall
-                )
-        ) {
-            Text(
-                text = stringResource(id = R.string.project_menu_created_by),
-                color = colors.textSecondary,
-                style = typography.caption2
-            )
+        Text(
+            modifier = Modifier.weight(1f),
+            text = " ${creatorName.orEmpty()}",
+            overflow = TextOverflow.Ellipsis,
+            color = colors.textSecondary,
+            style = typography.caption2Medium,
+            maxLines = 1
+        )
+        
+    Image(
+        modifier = Modifier.padding(start = dimensions.paddingSmall),
+        imageVector = ImageVector.vectorResource(id = R.drawable.ic_envelope),
+        contentDescription = null,
+        colorFilter = ColorFilter.tint(color = colors.textSecondary)
+    )
+}
 
-            Text(
-                text = " ${creatorName.orEmpty()}",
-                overflow = TextOverflow.Ellipsis,
-                color = colors.textSecondary,
-                style = typography.caption2Medium,
-                maxLines = 1
-            )
-        }
-
-        Row(
-            modifier = Modifier
-                .weight(0.3f)
-                .padding(
-                    end = dimensions.paddingMediumSmall,
-                    top = dimensions.paddingMediumSmall,
-                    bottom = dimensions.paddingMediumSmall
-                )
-                .clickable { sendAMessageClickAction.invoke() }
-        ) {
-            Text(
-                text = stringResource(id = R.string.Send_a_message),
-                color = colors.textAccentGreen,
-                style = typography.caption2
-            )
-
-            Image(
-                modifier = Modifier.size(dimensions.paddingMediumSmall),
-                imageVector = ImageVector.vectorResource(id = R.drawable.chevron_right),
-                contentDescription = null,
-                colorFilter = ColorFilter.tint(color = colors.textAccentGreen)
-            )
-        }
-    }
+//        Row(
+//            modifier = Modifier
+//                .weight(0.3f)
+//                .padding(
+//                    end = dimensions.paddingMediumSmall,
+//                    top = dimensions.paddingMediumSmall,
+//                    bottom = dimensions.paddingMediumSmall
+//                )
+//                .clickable { sendAMessageClickAction.invoke() }
+//        ) {
+//            Text(
+//                text = stringResource(id = R.string.Send_a_message),
+//                color = colors.textAccentGreen,
+//                style = typography.caption2
+//            )
+//
+//            Image(
+//                modifier = Modifier.size(dimensions.paddingMediumSmall),
+//                imageVector = ImageVector.vectorResource(id = R.drawable.chevron_right),
+//                contentDescription = null,
+//                colorFilter = ColorFilter.tint(color = colors.textAccentGreen)
+//            )
+//        }
 
     KSDividerLineGrey()
 }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -306,7 +306,9 @@ fun CreatorNameSendMessageView(
         )
         
     Image(
-        modifier = Modifier.padding(start = dimensions.paddingSmall),
+        modifier = Modifier
+            .padding(start = dimensions.paddingSmall)
+            .clickable { sendAMessageClickAction.invoke() },
         imageVector = ImageVector.vectorResource(id = R.drawable.ic_envelope),
         contentDescription = null,
         colorFilter = ColorFilter.tint(color = colors.textSecondary)

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -293,7 +293,7 @@ fun CreatorNameSendMessageView(
             .fillMaxWidth()
             .padding(
                 start = dimensions.paddingMediumSmall,
-                end = dimensions.paddingSmall
+                end = dimensions.paddingXSmall
             )
     ) {
         Text(

--- a/app/src/main/res/drawable/ic_envelope.xml
+++ b/app/src/main/res/drawable/ic_envelope.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M19,5H5C3.343,5 2,6.343 2,8V16C2,17.657 3.343,19 5,19H19C20.657,19 22,17.657 22,16V8C22,6.343 20.657,5 19,5ZM4,8.707V16C4,16.552 4.448,17 5,17H19C19.552,17 20,16.552 20,16V8.707L12.636,14.772C12.266,15.076 11.733,15.076 11.364,14.772L4,8.707ZM18.927,7H5.073L12,12.705L18.927,7Z"
+      android:fillColor="#3C3C3C"
+      android:fillType="evenOdd"/>
+</vector>


### PR DESCRIPTION
# 📲 What

Changed message creator CTA text to envelope icon button

# 🤔 Why

Cosmetic updates to PPO cards

# 👀 See

short and long creator name:
<img width="376" alt="Screenshot 2025-02-12 at 15 36 51" src="https://github.com/user-attachments/assets/c97f7807-fcec-4e64-a066-159b27323474" /> <img width="377" alt="Screenshot 2025-02-12 at 15 36 29" src="https://github.com/user-attachments/assets/71d20601-85e0-454c-8dad-444f035c4d3f" />

# 📋 QA

- Every ppo card should have a envelop icon, matching the screenshots above. 
- Tapping the icon opens message creator screen
- try to make sure the row is formatted correctly if creator name is very long

# Story 📖

[MBL-2038: [Phase 1] UI Updates: Mail icon for message creator](https://kickstarter.atlassian.net/browse/MBL-2038)
