### PR TITLE
MBL-2115 Preload images asynchronously

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import coil.ImageLoader
+import coil.request.ImageRequest
 import com.kickstarter.R
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.getCurrencySymbols
@@ -112,6 +114,17 @@ fun AddOnsScreen(
             ksCurrency = it
         ).toString()
     } ?: ""
+
+    // Prefetch add ons images asynchronously
+    for (reward in addOns) {
+        val request = ImageRequest.Builder(context)
+            .data(reward.image()?.full())
+            .build()
+        val imageLoader = ImageLoader.Builder(context)
+            .crossfade(true)
+            .build()
+        imageLoader.enqueue(request)
+    }
 
     Box(
         modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
@@ -120,10 +120,12 @@ fun AddOnsScreen(
         .crossfade(true)
         .build()
     for (reward in addOns) {
-        val request = ImageRequest.Builder(context)
-            .data(reward.image()?.full())
-            .build()
-        imageLoader.enqueue(request)
+        reward.image()?.let {
+            val request = ImageRequest.Builder(context)
+                .data(reward.image()?.full())
+                .build()
+            imageLoader.enqueue(request)
+        }
     }
 
     Box(

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
@@ -115,13 +115,13 @@ fun AddOnsScreen(
         ).toString()
     } ?: ""
 
-    // Prefetch add ons images asynchronously
+    // Preload add ons images asynchronously
+    val imageLoader = ImageLoader.Builder(context)
+        .crossfade(true)
+        .build()
     for (reward in addOns) {
         val request = ImageRequest.Builder(context)
             .data(reward.image()?.full())
-            .build()
-        val imageLoader = ImageLoader.Builder(context)
-            .crossfade(true)
             .build()
         imageLoader.enqueue(request)
     }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -23,6 +23,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import coil.ImageLoader
+import coil.request.ImageRequest
 import com.kickstarter.R
 import com.kickstarter.databinding.FragmentBackingBinding
 import com.kickstarter.libs.Either
@@ -399,6 +401,7 @@ class BackingFragment : Fragment() {
     private fun bindDataToRewardViewHolder(projectAndReward: Pair<ProjectData, Reward>) {
         val project = projectAndReward.first
         val reward = projectAndReward.second
+        preloadImages(listOf(reward))
 
         val projectAndRw = Pair(project, reward)
         rewardsAndAddOnsAdapter.populateDataForReward(projectAndRw)
@@ -407,6 +410,8 @@ class BackingFragment : Fragment() {
     private fun populateAddOns(projectAndAddOn: Pair<ProjectData, List<Reward>>) {
         val project = projectAndAddOn.first
         val addOns = projectAndAddOn.second
+        preloadImages(addOns)
+
         val listData = addOns.map {
             Pair(project, it)
         }.toList()
@@ -571,6 +576,19 @@ class BackingFragment : Fragment() {
                     }
                 }
             }
+        }
+    }
+
+    private fun preloadImages(rewards: List<Reward>) {
+        // Preload reward images asynchronously
+        val imageLoader = ImageLoader.Builder(requireContext())
+            .crossfade(true)
+            .build()
+        for (reward in rewards) {
+            val request = ImageRequest.Builder(requireContext())
+                .data(reward.image()?.full())
+                .build()
+            imageLoader.enqueue(request)
         }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -585,10 +585,12 @@ class BackingFragment : Fragment() {
             .crossfade(true)
             .build()
         for (reward in rewards) {
-            val request = ImageRequest.Builder(requireContext())
-                .data(reward.image()?.full())
-                .build()
-            imageLoader.enqueue(request)
+            reward.image()?.let {
+                val request = ImageRequest.Builder(requireContext())
+                    .data(reward.image()?.full())
+                    .build()
+                imageLoader.enqueue(request)
+            }
         }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.ImageLoader
+import coil.request.ImageRequest
 import com.kickstarter.R
 import com.kickstarter.databinding.FragmentRewardsBinding
 import com.kickstarter.libs.Environment
@@ -68,6 +70,18 @@ class RewardsFragment : Fragment() {
                         val projectData = rewardSelectionUIState.project
                         val indexOfBackedReward = rewardSelectionUIState.initialRewardIndex
                         val rewards = shippingUIState.filteredRw
+
+                        // Prefetch reward images asynchronously
+                        for (reward in rewards) {
+                            val request = ImageRequest.Builder(context)
+                                .data(reward.image()?.full())
+                                .build()
+                            val imageLoader = ImageLoader.Builder(context)
+                                .crossfade(true)
+                                .build()
+                            imageLoader.enqueue(request)
+                        }
+
                         val project = projectData.project()
                         val backing = projectData.backing()
 

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -76,10 +76,12 @@ class RewardsFragment : Fragment() {
                             .crossfade(true)
                             .build()
                         for (reward in rewards) {
-                            val request = ImageRequest.Builder(context)
-                                .data(reward.image()?.full())
-                                .build()
-                            imageLoader.enqueue(request)
+                            reward.image()?.let {
+                                val request = ImageRequest.Builder(context)
+                                    .data(reward.image()?.full())
+                                    .build()
+                                imageLoader.enqueue(request)
+                            }
                         }
 
                         val project = projectData.project()

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -71,13 +71,13 @@ class RewardsFragment : Fragment() {
                         val indexOfBackedReward = rewardSelectionUIState.initialRewardIndex
                         val rewards = shippingUIState.filteredRw
 
-                        // Prefetch reward images asynchronously
+                        // Preload reward images asynchronously
+                        val imageLoader = ImageLoader.Builder(context)
+                            .crossfade(true)
+                            .build()
                         for (reward in rewards) {
                             val request = ImageRequest.Builder(context)
                                 .data(reward.image()?.full())
-                                .build()
-                            val imageLoader = ImageLoader.Builder(context)
-                                .crossfade(true)
                                 .build()
                             imageLoader.enqueue(request)
                         }


### PR DESCRIPTION
# 📲 What

Improve performance of rewards carousel and add ons screen by preloading images and saving them to the disk and memory caches: https://coil-kt.github.io/coil/faq/#how-do-i-preload-an-image

# 🤔 Why

Images on rewards were lazy loading too slowly.

# 🛠 How

Coil's ImageLoader.enqueue(request) appears to be able to preload the image and save it to the disk and memory caches asynchronously.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

Compare with this commit https://github.com/kickstarter/android-oss/commit/fca318a502d436df314a7a4e532663ef0c34b8ba and verify images load faster!

# Story 📖

https://kickstarter.atlassian.net/browse/MBL-2115
