### PR TITLE
Go back to roboto

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSTypographyV2.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSTypographyV2.kt
@@ -9,13 +9,10 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
-import com.kickstarter.R
 
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
@@ -104,6 +101,10 @@ data class KSTypographyV2(
 val LocalKSCustomTypographyV2 = staticCompositionLocalOf {
     KSTypographyV2()
 }
+
+/*
+ * TODO: FIX BOLD ISSUE WITH INTER FONT
+
 val interFontFamily = FontFamily(
     Font(R.font.inter_variable, FontWeight.Thin), // 100
     Font(R.font.inter_variable, FontWeight.Light), // 300
@@ -124,12 +125,13 @@ var interFontFamilyItalic = FontFamily(
     Font(R.font.inter_variable_italic, FontWeight.ExtraBold) // 800
 )
 
+ */
+
 val KSCustomTypographyV2 = KSTypographyV2(
     /*
      * NEW DESIGN SYSTEM
      */
     heading2XL = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 24.sp,
         lineHeight = 28.sp,
@@ -137,7 +139,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     headingXL = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 20.sp,
         lineHeight = 24.sp,
@@ -145,7 +146,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     headingLG = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 16.sp,
         lineHeight = 20.sp,
@@ -153,7 +153,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     headingMD = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 14.sp,
         lineHeight = 16.sp,
@@ -161,7 +160,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     headingSM = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 12.sp,
         lineHeight = 16.sp,
@@ -169,7 +167,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     headingXS = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 11.sp,
         lineHeight = 16.sp,
@@ -177,91 +174,78 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     bodyXL = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 20.sp,
         lineHeight = 28.sp,
         color = kds_support_700
     ),
     bodyBoldXL = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 20.sp,
         lineHeight = 28.sp,
         color = kds_support_700
     ),
     bodyLG = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
         lineHeight = 24.sp,
         color = kds_support_700
     ),
     bodyBoldLG = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 16.sp,
         lineHeight = 24.sp,
         color = kds_support_700
     ),
     bodyMD = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 14.sp,
         lineHeight = 20.sp,
         color = kds_support_700
     ),
     bodyBoldMD = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 14.sp,
         lineHeight = 20.sp,
         color = kds_support_700
     ),
     bodySM = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 12.sp,
         lineHeight = 16.sp,
         color = kds_support_700
     ),
     bodyBoldSM = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 12.sp,
         lineHeight = 16.sp,
         color = kds_support_700
     ),
     bodyXS = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 11.sp,
         lineHeight = 14.sp,
         color = kds_support_700
     ),
     bodyBoldXS = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 11.sp,
         lineHeight = 14.sp,
         color = kds_support_700
     ),
     bodyXXS = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 10.sp,
         lineHeight = 13.sp,
         color = kds_support_700
     ),
     bodyBoldXXS = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 10.sp,
         lineHeight = 13.sp,
         color = kds_support_700
     ),
     buttonLabel = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 16.sp,
         lineHeight = 20.sp,
@@ -269,7 +253,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     linkLG = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 16.sp,
         lineHeight = 20.sp,
@@ -278,7 +261,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     linkMD = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 14.sp,
         lineHeight = 20.sp,
@@ -287,7 +269,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     linkSM = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 12.sp,
         lineHeight = 16.sp,
@@ -295,7 +276,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     linkXS = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 11.sp,
         lineHeight = 14.sp,
@@ -309,7 +289,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
      * For any doubt check with design team.
      */
     title1 = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 28.sp,
         lineHeight = 36.sp,
@@ -317,7 +296,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     title1Bold = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 28.sp,
         lineHeight = 32.sp,
@@ -325,7 +303,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     title2 = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 22.sp,
         lineHeight = 30.sp,
@@ -333,7 +310,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     title2Bold = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 22.sp,
         lineHeight = 26.sp,
@@ -341,7 +317,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     titleRewardBold = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.SemiBold,
         fontSize = 24.sp,
         lineHeight = 28.sp,
@@ -349,7 +324,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     headLine = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 18.sp,
         lineHeight = 22.sp,
@@ -357,7 +331,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     body = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 18.sp,
         lineHeight = 21.sp,
@@ -365,7 +338,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     footNote = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 13.sp,
         lineHeight = 17.sp,
@@ -373,7 +345,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     footNoteMedium = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 13.sp,
         lineHeight = 17.sp,
@@ -381,7 +352,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     subHeadline = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 15.sp,
         lineHeight = 21.sp,
@@ -389,7 +359,6 @@ val KSCustomTypographyV2 = KSTypographyV2(
         color = kds_support_700
     ),
     subHeadlineMedium = TextStyle(
-        fontFamily = interFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 15.sp,
         lineHeight = 17.sp,


### PR DESCRIPTION
# 📲 What

Reverted the font used in kSTypographyV2.kt from "Inter" back to "Roboto" to ensure proper rendering of font weights, particularly bold text.

# 🤔 Why

The "Inter" font was causing issues with font weights—most notably, the bold style was not rendering as expected. Switching back to "Roboto" restores the intended visual consistency and reliability across our typography components.

# 🛠 How

- Updated the kSTypographyV2.kt file to remove reference the "Inter" font.
- Verified that all font weights, especially bold, are rendered correctly after the change.
- Ensured that the change did not introduce any regressions in other parts of the application using the font component.
# 👀 See

Trello, screenshots, external resources?

![Screenshot 2025-02-18 at 5 11 05 p m](https://github.com/user-attachments/assets/0aa303fe-c390-42e6-994b-e5e0be411acd)


# 📋 QA

- Open the application and navigate to DesignSystemScreen where the font component (kSTypographyV2.kt) is used.
- Check multiple instances of bold text to ensure they are rendered correctly.
- Verify that there are no unintended side effects on other text styles or UI components.

# Story 📖

[MBL-2119 Revert font family changes ](https://kickstarter.atlassian.net/browse/MBL-2119)
