### PR TITLE
MBL-2144 Fix concurrency crash when preloading images

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import coil.Coil
-import coil.ImageLoader
 import coil.request.ImageRequest
 import com.kickstarter.R
 import com.kickstarter.libs.Environment
@@ -330,7 +329,7 @@ fun AddOnsScreen(
 }
 
 private fun preloadImages(context: Context, rewards: List<Reward>) {
-    val rewardsIterator = rewards.iterator();
+    val rewardsIterator = rewards.iterator()
     while (rewardsIterator.hasNext()) {
         val reward = rewardsIterator.next()
         reward.image()?.let {

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.ui.activities.compose.projectpage
 
+import android.content.Context
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -26,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import coil.Coil
 import coil.ImageLoader
 import coil.request.ImageRequest
 import com.kickstarter.R
@@ -115,18 +117,7 @@ fun AddOnsScreen(
         ).toString()
     } ?: ""
 
-    // Preload add ons images asynchronously
-    val imageLoader = ImageLoader.Builder(context)
-        .crossfade(true)
-        .build()
-    for (reward in addOns) {
-        reward.image()?.let {
-            val request = ImageRequest.Builder(context)
-                .data(reward.image()?.full())
-                .build()
-            imageLoader.enqueue(request)
-        }
-    }
+    preloadImages(context, addOns)
 
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -334,6 +325,19 @@ fun AddOnsScreen(
             contentAlignment = Alignment.Center
         ) {
             KSCircularProgressIndicator()
+        }
+    }
+}
+
+private fun preloadImages(context: Context, rewards: List<Reward>) {
+    val rewardsIterator = rewards.iterator();
+    while (rewardsIterator.hasNext()) {
+        val reward = rewardsIterator.next()
+        reward.image()?.let {
+            val request = ImageRequest.Builder(context)
+                .data(reward.image()?.full())
+                .build()
+            Coil.imageLoader(context).enqueue(request)
         }
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.ui.fragments
 
 import PaymentSchedule
+import android.content.Context
 import android.graphics.Typeface
 import android.os.Bundle
 import android.text.Spannable
@@ -23,6 +24,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import coil.Coil
 import coil.ImageLoader
 import coil.request.ImageRequest
 import com.kickstarter.R
@@ -580,16 +582,14 @@ class BackingFragment : Fragment() {
     }
 
     private fun preloadImages(rewards: List<Reward>) {
-        // Preload reward images asynchronously
-        val imageLoader = ImageLoader.Builder(requireContext())
-            .crossfade(true)
-            .build()
-        for (reward in rewards) {
+        val rewardsIterator = rewards.iterator();
+        while (rewardsIterator.hasNext()) {
+            val reward = rewardsIterator.next()
             reward.image()?.let {
                 val request = ImageRequest.Builder(requireContext())
                     .data(reward.image()?.full())
                     .build()
-                imageLoader.enqueue(request)
+                Coil.imageLoader(requireContext()).enqueue(request)
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -1,7 +1,6 @@
 package com.kickstarter.ui.fragments
 
 import PaymentSchedule
-import android.content.Context
 import android.graphics.Typeface
 import android.os.Bundle
 import android.text.Spannable
@@ -25,7 +24,6 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import coil.Coil
-import coil.ImageLoader
 import coil.request.ImageRequest
 import com.kickstarter.R
 import com.kickstarter.databinding.FragmentBackingBinding
@@ -582,7 +580,7 @@ class BackingFragment : Fragment() {
     }
 
     private fun preloadImages(rewards: List<Reward>) {
-        val rewardsIterator = rewards.iterator();
+        val rewardsIterator = rewards.iterator()
         while (rewardsIterator.hasNext()) {
             val reward = rewardsIterator.next()
             reward.image()?.let {

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -16,7 +16,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.Coil
-import coil.ImageLoader
 import coil.request.ImageRequest
 import com.kickstarter.R
 import com.kickstarter.databinding.FragmentRewardsBinding
@@ -122,7 +121,7 @@ class RewardsFragment : Fragment() {
     }
 
     private fun preloadImages(context: Context, rewards: List<Reward>) {
-        val rewardsIterator = rewards.iterator();
+        val rewardsIterator = rewards.iterator()
         while (rewardsIterator.hasNext()) {
             val reward = rewardsIterator.next()
             reward.image()?.let {

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.ui.fragments
 
+import android.content.Context
 import android.os.Bundle
 import android.util.Pair
 import android.view.LayoutInflater
@@ -9,10 +10,12 @@ import androidx.appcompat.app.AlertDialog
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.Coil
 import coil.ImageLoader
 import coil.request.ImageRequest
 import com.kickstarter.R
@@ -20,6 +23,7 @@ import com.kickstarter.databinding.FragmentRewardsBinding
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.reduce
+import com.kickstarter.models.Reward
 import com.kickstarter.ui.activities.compose.projectpage.RewardCarouselScreen
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
@@ -71,18 +75,7 @@ class RewardsFragment : Fragment() {
                         val indexOfBackedReward = rewardSelectionUIState.initialRewardIndex
                         val rewards = shippingUIState.filteredRw
 
-                        // Preload reward images asynchronously
-                        val imageLoader = ImageLoader.Builder(context)
-                            .crossfade(true)
-                            .build()
-                        for (reward in rewards) {
-                            reward.image()?.let {
-                                val request = ImageRequest.Builder(context)
-                                    .data(reward.image()?.full())
-                                    .build()
-                                imageLoader.enqueue(request)
-                            }
-                        }
+                        preloadImages(LocalContext.current, rewards)
 
                         val project = projectData.project()
                         val backing = projectData.backing()
@@ -124,6 +117,19 @@ class RewardsFragment : Fragment() {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    private fun preloadImages(context: Context, rewards: List<Reward>) {
+        val rewardsIterator = rewards.iterator();
+        while (rewardsIterator.hasNext()) {
+            val reward = rewardsIterator.next()
+            reward.image()?.let {
+                val request = ImageRequest.Builder(context)
+                    .data(reward.image()?.full())
+                    .build()
+                Coil.imageLoader(context).enqueue(request)
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
@@ -148,7 +148,7 @@ class GetShippingRulesUseCase(
                 loading = isLoading,
                 selectedShippingRule = defaultShippingRule,
                 error = errorMessage,
-                filteredRw = filteredRewards
+                filteredRw = filteredRewards.toList()
             )
         )
     }


### PR DESCRIPTION
# 📲 What
Fatal Exception: java.util.ConcurrentModificationException
java.util.ArrayList$Itr.checkForComodification (ArrayList.java:1029)
java.util.ArrayList$Itr.next (ArrayList.java:982)
com.kickstarter.ui.fragments.RewardsFragment$onViewCreated$1$1$1$1.invoke (RewardsFragment.kt:78)

Per @tonyteate, make a copy of the rewards list before emitting it. That way we are not at risk of handling this list while the UseCase class is calling filteredRewards.clear() at various points in the filtering process.

Also use an iterator instead of a for loop just in case.

# 🤔 Why
Crash in 3.29.0 release:

https://console.firebase.google.com/u/0/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/92f9702e8d3411138f15d6e34957f0b8?versions=3.29.0%20(2014150933)&time=last-twenty-four-hours&types=crash&sessionEventKey=67BDCCCF033400012D758290E88FAAED_2053859627073866485

# 🛠 How

[Line 78](https://github.com/kickstarter/android-oss/blob/master/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt#L78) of RewardsFragment is:
```
                        for (reward in rewards) {
                            reward.image()?.let {
                                val request = ImageRequest.Builder(context)
                                    .data(reward.image()?.full())
                                    .build()
                                imageLoader.enqueue(request)
                            }
                        }
```

`rewards` comes from `val rewards = shippingUIState.filteredRw`. The GetShippingRulesUseCase filters out rewards and adds them to the list in an IO thread, which seems to be what the stacktrace is complaining about in terms of concurrent modification. So the patch is to use an iterator instead of a for loop.

# 👀 See

# 📋 QA
I wasn't able to reproduce the crash before, but please view rewards carousel and add ons screen and ensure no crashes.

# Story 📖

https://kickstarter.atlassian.net/browse/MBL-2144
