### PR TITLE
MBL-2135: SearchAndFilter viewmodel

### DIFF
--- a/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
@@ -68,7 +68,7 @@ class SearchAndFilterActivity : ComponentActivity() {
                 viewModel.provideErrorAction { message ->
                     lifecycleScope.launch {
                         snackbarHostState.showSnackbar(
-                            message = message ?: "Something went wrong",
+                            message = message ?: getString(R.string.Something_went_wrong_please_try_again),
                             actionLabel = KSSnackbarTypes.KS_ERROR.name,
                             duration = SnackbarDuration.Long
                         )

--- a/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
@@ -43,7 +43,7 @@ class SearchAndFilterActivity : ComponentActivity() {
         this.getEnvironment()?.let { env ->
             viewModelFactory = SearchAndFilterViewModel.Factory(env)
 
-            viewModel.getPopularProjects()
+            // viewModel.updateSearchResultsState(withLoading = true)
             setContent {
                 val searchUIState by viewModel.searchUIState.collectAsStateWithLifecycle()
 
@@ -79,9 +79,7 @@ class SearchAndFilterActivity : ComponentActivity() {
                             searchedProjects.isEmpty(),
                         onSearchTermChanged = { searchTerm ->
                             currentSearchTerm = searchTerm
-                            if (searchTerm.isEmpty()) {
-                                viewModel.getPopularProjects()
-                            } else viewModel.searchTerm(searchTerm)
+                            viewModel.updateSearchTerm(searchTerm)
                         },
                         onItemClicked = { project ->
                             // TODO extend on MBL-2135 with proper reftags & analytics for project card clicked

--- a/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
@@ -51,7 +51,7 @@ class SearchAndFilterActivity : ComponentActivity() {
 
                 val popularProjects = searchUIState.popularProjectsList
 
-                var searchedProjects = emptyList<Project>() // TODO will come from VM MBL-2135
+                val searchedProjects = searchUIState.searchList
 
                 val isLoading = searchUIState.isLoading
 
@@ -78,8 +78,10 @@ class SearchAndFilterActivity : ComponentActivity() {
                             !currentSearchTerm.isTrimmedEmpty() &&
                             searchedProjects.isEmpty(),
                         onSearchTermChanged = { searchTerm ->
-                            if (searchTerm.isEmpty()) // TODO will be handled on VM
-                                currentSearchTerm = searchTerm
+                            currentSearchTerm = searchTerm
+                            if (searchTerm.isEmpty()) {
+                                viewModel.getPopularProjects()
+                            } else viewModel.searchTerm(searchTerm)
                         },
                         onItemClicked = { project ->
                             // TODO extend on MBL-2135 with proper reftags & analytics for project card clicked

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
@@ -78,7 +78,7 @@ class SearchAndFilterViewModel(
                         _params.emit(
                             DiscoveryParams.builder()
                                 .term(debouncedTerm)
-                                .sort(DiscoveryParams.Sort.POPULAR) // TODO: update once sort option is ready MBL-2131, by default popular
+                                .sort(DiscoveryParams.Sort.POPULAR) // TODO: update once sort option is ready MBL-2131, by default popular in every search
                                 .build()
                         )
                 }.collectLatest {

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
@@ -103,7 +103,8 @@ class SearchAndFilterViewModel(
         val searchEnvelopeResult = apolloClient.getSearchProjects(params.value)
 
         if (searchEnvelopeResult.isFailure) {
-            errorAction.invoke(searchEnvelopeResult.exceptionOrNull()?.message)
+            // - errorAction.invoke(searchEnvelopeResult.exceptionOrNull()?.message) to return API level message
+            errorAction.invoke(null)
         }
 
         if (searchEnvelopeResult.isSuccess) {

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
@@ -1,9 +1,11 @@
 package com.kickstarter.features.search.viewmodel
 
+import android.util.Pair
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.utils.extensions.isNull
 import com.kickstarter.libs.utils.extensions.isTrue
 import com.kickstarter.models.Project
@@ -25,7 +27,6 @@ import kotlin.text.isNotBlank
 
 data class SearchUIState(
     val isLoading: Boolean = false,
-    val isErrored: Boolean = false,
     val popularProjectsList: List<Project> = emptyList(),
     val searchList: List<Project> = emptyList()
 )
@@ -38,6 +39,7 @@ class SearchAndFilterViewModel(
 
     private val scope = viewModelScope + (testDispatcher ?: EmptyCoroutineContext)
     private val apolloClient = requireNotNull(environment.apolloClientV2())
+    private val analyticEvents = requireNotNull(environment.analytics())
 
     private val _searchUIState = MutableStateFlow(SearchUIState())
     val searchUIState: StateFlow<SearchUIState>
@@ -59,6 +61,11 @@ class SearchAndFilterViewModel(
     private val _searchTerm = MutableStateFlow("")
     private val searchTerm: StateFlow<String> = _searchTerm
 
+    private var errorAction: (message: String?) -> Unit = {}
+
+    private var projectsList = emptyList<Project>()
+    private var popularProjectsList = emptyList<Project>()
+
     init {
         scope.launch {
             searchTerm
@@ -68,44 +75,87 @@ class SearchAndFilterViewModel(
                     if (debouncedTerm.isEmpty() || debouncedTerm.isBlank()) {
                         _params.emit(popularDiscoveryParam)
                     } else
-                        _params.emit(DiscoveryParams.builder().term(debouncedTerm).build())
+                        _params.emit(
+                            DiscoveryParams.builder()
+                                .term(debouncedTerm)
+                                .sort(DiscoveryParams.Sort.POPULAR) // TODO: update once sort option is ready MBL-2131, by default popular
+                                .build()
+                        )
                 }.collectLatest {
                     updateSearchResultsState()
                 }
         }
     }
 
+    fun provideErrorAction(errorAction: (message: String?) -> Unit) {
+        this.errorAction = errorAction
+    }
+
     /**
      * Update UIState with after executing Search query with latest params
      */
     private suspend fun updateSearchResultsState() {
-        _searchUIState.emit(
-            SearchUIState(
-                isLoading = true,
-            )
-        )
+        analyticEvents.trackSearchCTAButtonClicked(params.value)
 
+        emitCurrentState(isLoading = true)
+
+        // - Result from API
         val searchEnvelopeResult = apolloClient.getSearchProjects(params.value)
 
         if (searchEnvelopeResult.isFailure) {
-            _searchUIState.emit(
-                SearchUIState(
-                    isErrored = true,
-                )
-            )
+            errorAction.invoke(searchEnvelopeResult.exceptionOrNull()?.message)
         }
 
         if (searchEnvelopeResult.isSuccess) {
             searchEnvelopeResult.getOrNull()?.projectList?.let {
-                _searchUIState.emit(
-                    SearchUIState(
-                        isErrored = false,
-                        isLoading = false,
-                        popularProjectsList = if (params.value.term().isNull()) it else emptyList(),
-                        searchList = if (params.value.term()?.isNotBlank().isTrue()) it else emptyList()
-                    )
+                if (params.value.term().isNull()) popularProjectsList = it
+                if (params.value.term()?.isNotBlank().isTrue()) projectsList = it
+
+                emitCurrentState(isLoading = false)
+
+                analyticEvents.trackSearchResultPageViewed(
+                    params.value,
+                    1, // TODO: this will contain the page when pagination ready MBL-2139
+                    params.value.sort() ?: DiscoveryParams.Sort.POPULAR
                 )
             }
+        }
+    }
+
+    private suspend fun emitCurrentState(isLoading: Boolean = false) {
+        _searchUIState.emit(
+            SearchUIState(
+                isLoading = isLoading,
+                popularProjectsList = popularProjectsList,
+                searchList = projectsList
+            )
+        )
+    }
+
+    /**
+     * Returns a project and its appropriate ref tag given its location in a list of popular projects or search results.
+     *
+     * @param searchTerm        The search term entered to determine list of search results.
+     * @param projects          The list of popular or search result projects.
+     * @param selectedProject   The project selected by the user.
+     * @return The project and its appropriate ref tag.
+     */
+    private fun projectAndRefTag(
+        searchTerm: String,
+        projects: List<Project>,
+        selectedProject: Project
+    ): Pair<Project, RefTag> {
+        val isFirstResult = if (projects.isEmpty()) false else selectedProject === projects[0]
+        return if (searchTerm.isEmpty()) {
+            if (isFirstResult) Pair.create(
+                selectedProject,
+                RefTag.searchPopularFeatured()
+            ) else Pair.create(selectedProject, RefTag.searchPopular())
+        } else {
+            if (isFirstResult) Pair.create(
+                selectedProject,
+                RefTag.searchFeatured()
+            ) else Pair.create(selectedProject, RefTag.search())
         }
     }
 
@@ -113,6 +163,11 @@ class SearchAndFilterViewModel(
         scope.launch {
             _searchTerm.emit(searchTerm)
         }
+    }
+
+    fun getProjectAndRefTag(project: Project): Pair<Project, RefTag> {
+        val allProjectsList = popularProjectsList.union(projectsList).toList()
+        return projectAndRefTag(searchTerm.value, allProjectsList, project)
     }
 
     class Factory(

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -125,6 +125,7 @@ import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.PublishSubject
 import java.net.SocketTimeoutException
 import java.nio.charset.Charset
+import kotlin.coroutines.cancellation.CancellationException
 
 interface ApolloClientTypeV2 {
     fun getProject(project: Project): Observable<Project>
@@ -1889,6 +1890,9 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
     private suspend fun <T> executeForResult(block: suspend () -> T): Result<T> =
         try {
             Result.success(block())
+        } catch (cancellationException: CancellationException) {
+            // - When using try catch blocks with suspending functions always rethrow CancellationExceptions and not threat them as an error
+            throw cancellationException
         } catch (apolloException: ApolloException) {
             val exception = apolloException.toClientException()
             FirebaseCrashlytics.getInstance().recordException(exception)

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue.Hidden
 import androidx.compose.material.Scaffold
 import androidx.compose.material.ScaffoldState
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.rememberModalBottomSheetState
@@ -47,6 +49,9 @@ import com.kickstarter.libs.utils.extensions.deadlineCountdownValue
 import com.kickstarter.models.Project
 import com.kickstarter.ui.compose.designsystem.KSCircularProgressIndicator
 import com.kickstarter.ui.compose.designsystem.KSDividerLineGrey
+import com.kickstarter.ui.compose.designsystem.KSErrorSnackbar
+import com.kickstarter.ui.compose.designsystem.KSHeadsupSnackbar
+import com.kickstarter.ui.compose.designsystem.KSSnackbarTypes
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
@@ -65,6 +70,7 @@ fun SearchScreenPreviewNonEmpty() {
         SearchScreen(
             onBackClicked = { },
             scaffoldState = rememberScaffoldState(),
+            errorSnackBarHostState = SnackbarHostState(),
             isLoading = false,
             isPopularList = true,
             itemsList = List(100) {
@@ -91,6 +97,7 @@ fun SearchScreenPreviewEmpty() {
         SearchScreen(
             onBackClicked = { },
             scaffoldState = rememberScaffoldState(),
+            errorSnackBarHostState = SnackbarHostState(),
             isLoading = true,
             itemsList = listOf(),
             lazyColumnListState = rememberLazyListState(),
@@ -119,6 +126,7 @@ fun SearchScreen(
     environment: Environment? = null,
     onBackClicked: () -> Unit,
     scaffoldState: ScaffoldState,
+    errorSnackBarHostState: SnackbarHostState = SnackbarHostState(),
     isPopularList: Boolean = true,
     isLoading: Boolean,
     itemsList: List<Project> = listOf(),
@@ -151,6 +159,21 @@ fun SearchScreen(
         Scaffold(
             modifier = Modifier.systemBarsPadding(),
             scaffoldState = scaffoldState,
+            snackbarHost = {
+                SnackbarHost(
+                    modifier = Modifier.padding(dimensions.paddingSmall),
+                    hostState = errorSnackBarHostState,
+                    snackbar = { data ->
+                        // Action label is typically for the action on a snackbar, but we can
+                        // leverage it and show different visuals depending on what we pass in
+                        if (data.actionLabel == KSSnackbarTypes.KS_ERROR.name) {
+                            KSErrorSnackbar(text = data.message)
+                        } else {
+                            KSHeadsupSnackbar(text = data.message)
+                        }
+                    }
+                )
+            },
             topBar = {
                 Surface(elevation = 3.dp) {
                     SearchTopBar(

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
@@ -164,8 +164,6 @@ fun SearchScreen(
                     modifier = Modifier.padding(dimensions.paddingSmall),
                     hostState = errorSnackBarHostState,
                     snackbar = { data ->
-                        // Action label is typically for the action on a snackbar, but we can
-                        // leverage it and show different visuals depending on what we pass in
                         if (data.actionLabel == KSSnackbarTypes.KS_ERROR.name) {
                             KSErrorSnackbar(text = data.message)
                         } else {

--- a/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -48,11 +49,13 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
 
         val searchState = mutableListOf<SearchUIState>()
         backgroundScope.launch(dispatcher) {
-            viewModel.getPopularProjects()
+            viewModel.updateSearchTerm("")
             viewModel.searchUIState.toList(searchState)
         }
 
+        advanceUntilIdle()
         assertEquals(params?.sort(), DiscoveryParams.Sort.POPULAR)
+        assertNull(params?.term())
         assertEquals(searchState.size, 2)
         assertEquals(searchState.last().popularProjectsList, projectList)
     }
@@ -79,11 +82,13 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
 
         val searchState = mutableListOf<SearchUIState>()
         backgroundScope.launch(dispatcher) {
-            viewModel.getPopularProjects()
+            viewModel.updateSearchTerm("")
             viewModel.searchUIState.toList(searchState)
         }
 
+        advanceUntilIdle()
         assertEquals(params?.sort(), DiscoveryParams.Sort.POPULAR)
+        assertNull(params?.term())
         assertEquals(searchState.size, 2)
         assertEquals(searchState.last().popularProjectsList, emptyList<Project>())
         assertEquals(searchState.last().isErrored, true)

--- a/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
@@ -3,6 +3,8 @@ package com.kickstarter.features.search.viewmodel
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.features.search.data.SearchEnvelope
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.RefTag
+import com.kickstarter.libs.utils.EventName
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.services.MockApolloClientV2
 import com.kickstarter.models.Project
@@ -27,7 +29,7 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `test for initial state getPopularProjects will only have sorting parameter POPULAR`() = runTest {
+    fun `test for initial state will only have sorting parameter POPULAR and empty search term`() = runTest {
 
         var params: DiscoveryParams? = null
         val projectList = listOf(ProjectFactory.project(), ProjectFactory.prelaunchProject(""))
@@ -61,7 +63,7 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `test getPopularProjects fails`() = runTest {
+    fun `test initial state fails`() = runTest {
 
         var params: DiscoveryParams? = null
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
@@ -80,8 +82,10 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
 
         setUpEnvironment(environment, dispatcher)
 
+        var errorNumber = 0
         val searchState = mutableListOf<SearchUIState>()
         backgroundScope.launch(dispatcher) {
+            viewModel.provideErrorAction { errorNumber++ }
             viewModel.updateSearchTerm("")
             viewModel.searchUIState.toList(searchState)
         }
@@ -91,6 +95,127 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         assertNull(params?.term())
         assertEquals(searchState.size, 2)
         assertEquals(searchState.last().popularProjectsList, emptyList<Project>())
-        assertEquals(searchState.last().isErrored, true)
+        assertEquals(errorNumber, 1)
+    }
+
+    @Test
+    fun `test for searching a tem`() = runTest {
+        var params: DiscoveryParams? = null
+        val projectList = listOf(ProjectFactory.project(), ProjectFactory.prelaunchProject(""))
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val environment = environment()
+            .toBuilder()
+            .apolloClientV2(
+                object : MockApolloClientV2() {
+                    override suspend fun getSearchProjects(
+                        discoveryParams: DiscoveryParams,
+                        cursor: String?
+                    ): Result<SearchEnvelope> {
+                        params = discoveryParams
+                        return Result.success(SearchEnvelope(projectList))
+                    }
+                }).build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        var errorNumber = 0
+        val searchState = mutableListOf<SearchUIState>()
+        backgroundScope.launch(dispatcher) {
+            viewModel.provideErrorAction { errorNumber++ }
+            viewModel.updateSearchTerm("hello")
+            viewModel.searchUIState.toList(searchState)
+        }
+
+        advanceUntilIdle()
+        assertEquals(params?.sort(), DiscoveryParams.Sort.POPULAR)
+        assertEquals(params?.term(), "hello")
+        assertEquals(searchState.size, 2)
+        assertEquals(searchState.last().popularProjectsList, emptyList<Project>())
+        assertEquals(searchState.last().searchList, projectList)
+        assertEquals(errorNumber, 0)
+    }
+
+    @Test
+    fun `test analytics and reftags when from a search with term`() = runTest {
+        var params: DiscoveryParams? = null
+        val projectList = listOf(ProjectFactory.project(), ProjectFactory.prelaunchProject(""))
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val environment = environment()
+            .toBuilder()
+            .apolloClientV2(
+                object : MockApolloClientV2() {
+                    override suspend fun getSearchProjects(
+                        discoveryParams: DiscoveryParams,
+                        cursor: String?
+                    ): Result<SearchEnvelope> {
+                        params = discoveryParams
+                        return Result.success(SearchEnvelope(projectList))
+                    }
+                }).build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        var errorNumber = 0
+        val searchState = mutableListOf<SearchUIState>()
+        backgroundScope.launch(dispatcher) {
+            viewModel.provideErrorAction { errorNumber++ }
+            viewModel.updateSearchTerm("hello")
+            viewModel.searchUIState.toList(searchState)
+        }
+
+        advanceUntilIdle()
+        assertEquals(params?.sort(), DiscoveryParams.Sort.POPULAR)
+        assertEquals(params?.term(), "hello")
+        assertEquals(searchState.size, 2)
+
+        val projAndRefTag1 = viewModel.getProjectAndRefTag(projectList.first())
+        val projAndRefTag2 = viewModel.getProjectAndRefTag(projectList.last())
+
+        assertEquals(projAndRefTag1.second, RefTag.searchFeatured())
+        assertEquals(projAndRefTag2.second, RefTag.search())
+
+        segmentTrack.assertValues(EventName.CTA_CLICKED.eventName, EventName.PAGE_VIEWED.eventName)
+    }
+
+    @Test
+    fun `test analytics and reftags for initial state with empty term and sorting parameter POPULAR`() = runTest {
+        var params: DiscoveryParams? = null
+        val projectList = listOf(ProjectFactory.project(), ProjectFactory.prelaunchProject(""))
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val environment = environment()
+            .toBuilder()
+            .apolloClientV2(
+                object : MockApolloClientV2() {
+                    override suspend fun getSearchProjects(
+                        discoveryParams: DiscoveryParams,
+                        cursor: String?
+                    ): Result<SearchEnvelope> {
+                        params = discoveryParams
+                        return Result.success(SearchEnvelope(projectList))
+                    }
+                }).build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        var errorNumber = 0
+        val searchState = mutableListOf<SearchUIState>()
+        backgroundScope.launch(dispatcher) {
+            viewModel.provideErrorAction { errorNumber++ }
+            viewModel.updateSearchTerm("")
+            viewModel.searchUIState.toList(searchState)
+        }
+
+        advanceUntilIdle()
+        assertEquals(params?.sort(), DiscoveryParams.Sort.POPULAR)
+        assertNull(params?.term())
+        assertEquals(searchState.size, 2)
+
+        val projAndRefTag1 = viewModel.getProjectAndRefTag(projectList.first())
+        val projAndRefTag2 = viewModel.getProjectAndRefTag(projectList.last())
+
+        assertEquals(projAndRefTag1.second, RefTag.searchPopularFeatured())
+        assertEquals(projAndRefTag2.second, RefTag.searchPopular())
+
+        segmentTrack.assertValues(EventName.CTA_CLICKED.eventName, EventName.PAGE_VIEWED.eventName)
     }
 }

--- a/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
@@ -4,8 +4,6 @@ import com.kickstarter.KSApplication
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.featureflag.StatsigClient
 import com.statsig.androidsdk.InitializationDetails
-import com.statsig.androidsdk.InitializeFailReason
-import com.statsig.androidsdk.InitializeResponse
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestDispatcher

--- a/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
@@ -76,8 +76,7 @@ class StatsigClientTest : KSRobolectricTestCase() {
             exception = e
             eCounter++
         })
-
-        advanceUntilIdle()
+        
         assertEquals(stClient.scope, this)
         assertEquals(eCounter, 1)
         assertEquals(exception?.message, "Something went wrong")

--- a/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
@@ -44,40 +44,4 @@ class StatsigClientTest : KSRobolectricTestCase() {
         assertEquals(stClient.scope, this)
         assertEquals(eCounter, 0)
     }
-
-    @Test
-    fun testInitialize_error_callback() = runTest(testDispatcher) {
-        val mockCurrentUser: CurrentUserTypeV2 = requireNotNull(environment().currentUserV2())
-        val mockBuildObject = mockk<Build>()
-
-        val initDet = InitializationDetails(
-            2,
-            false,
-            InitializeResponse.FailedInitializeResponse(InitializeFailReason.NetworkError, Exception("Something went wrong"))
-        )
-
-        val stClient = object : StatsigClient(build = mockBuildObject, context = application(), currentUser = mockCurrentUser) {
-            override suspend fun init(
-                application: KSApplication,
-                sdkKey: String
-            ): InitializationDetails? {
-                return initDet
-            }
-
-            override fun getSDKKey(): String {
-                return ""
-            }
-        }
-
-        var eCounter = 0
-        var exception: Exception? = null
-        stClient.initialize(this, errorCallback = { e ->
-            exception = e
-            eCounter++
-        })
-
-        assertEquals(stClient.scope, this)
-        assertEquals(eCounter, 1)
-        assertEquals(exception?.message, "Something went wrong")
-    }
 }

--- a/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
@@ -4,13 +4,10 @@ import com.kickstarter.KSApplication
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.featureflag.StatsigClient
 import com.statsig.androidsdk.InitializationDetails
-import com.statsig.androidsdk.InitializeFailReason
-import com.statsig.androidsdk.InitializeResponse
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -46,40 +43,40 @@ class StatsigClientTest : KSRobolectricTestCase() {
         assertEquals(eCounter, 0)
     }
 
-    @Test
-    fun testInitialize_error_callback() = runTest(testDispatcher) {
-        val mockCurrentUser: CurrentUserTypeV2 = requireNotNull(environment().currentUserV2())
-        val mockBuildObject = mockk<Build>()
-
-        val initDet = InitializationDetails(
-            2,
-            false,
-            InitializeResponse.FailedInitializeResponse(InitializeFailReason.NetworkError, Exception("Something went wrong"))
-        )
-
-        val stClient = object : StatsigClient(build = mockBuildObject, context = application(), currentUser = mockCurrentUser) {
-            override suspend fun init(
-                application: KSApplication,
-                sdkKey: String
-            ): InitializationDetails? {
-                return initDet
-            }
-
-            override fun getSDKKey(): String {
-                return ""
-            }
-        }
-
-        var eCounter = 0
-        var exception: Exception? = null
-        stClient.initialize(this, errorCallback = { e ->
-            exception = e
-            eCounter++
-        })
-
-        advanceUntilIdle()
-        assertEquals(stClient.scope, this)
-        assertEquals(eCounter, 1)
-        assertEquals(exception?.message, "Something went wrong")
-    }
+//    @Test
+//    fun testInitialize_error_callback() = runTest(testDispatcher) {
+//        val mockCurrentUser: CurrentUserTypeV2 = requireNotNull(environment().currentUserV2())
+//        val mockBuildObject = mockk<Build>()
+//
+//        val initDet = InitializationDetails(
+//            2,
+//            false,
+//            InitializeResponse.FailedInitializeResponse(InitializeFailReason.NetworkError, Exception("Something went wrong"))
+//        )
+//
+//        val stClient = object : StatsigClient(build = mockBuildObject, context = application(), currentUser = mockCurrentUser) {
+//            override suspend fun init(
+//                application: KSApplication,
+//                sdkKey: String
+//            ): InitializationDetails? {
+//                return initDet
+//            }
+//
+//            override fun getSDKKey(): String {
+//                return ""
+//            }
+//        }
+//
+//        var eCounter = 0
+//        var exception: Exception? = null
+//        stClient.initialize(this, errorCallback = { e ->
+//            exception = e
+//            eCounter++
+//        })
+//
+//        advanceUntilIdle()
+//        assertEquals(stClient.scope, this)
+//        assertEquals(eCounter, 1)
+//        assertEquals(exception?.message, "Something went wrong")
+//    }
 }

--- a/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
@@ -4,10 +4,13 @@ import com.kickstarter.KSApplication
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.featureflag.StatsigClient
 import com.statsig.androidsdk.InitializationDetails
+import com.statsig.androidsdk.InitializeFailReason
+import com.statsig.androidsdk.InitializeResponse
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -41,5 +44,42 @@ class StatsigClientTest : KSRobolectricTestCase() {
 
         assertEquals(stClient.scope, this)
         assertEquals(eCounter, 0)
+    }
+
+    @Test
+    fun testInitialize_error_callback() = runTest(testDispatcher) {
+        val mockCurrentUser: CurrentUserTypeV2 = requireNotNull(environment().currentUserV2())
+        val mockBuildObject = mockk<Build>()
+
+        val initDet = InitializationDetails(
+            2,
+            false,
+            InitializeResponse.FailedInitializeResponse(InitializeFailReason.NetworkError, Exception("Something went wrong"))
+        )
+
+        val stClient = object : StatsigClient(build = mockBuildObject, context = application(), currentUser = mockCurrentUser) {
+            override suspend fun init(
+                application: KSApplication,
+                sdkKey: String
+            ): InitializationDetails? {
+                return initDet
+            }
+
+            override fun getSDKKey(): String {
+                return ""
+            }
+        }
+
+        var eCounter = 0
+        var exception: Exception? = null
+        stClient.initialize(this, errorCallback = { e ->
+            exception = e
+            eCounter++
+        })
+
+        advanceUntilIdle()
+        assertEquals(stClient.scope, this)
+        assertEquals(eCounter, 1)
+        assertEquals(exception?.message, "Something went wrong")
     }
 }

--- a/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
@@ -10,7 +10,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -76,7 +75,7 @@ class StatsigClientTest : KSRobolectricTestCase() {
             exception = e
             eCounter++
         })
-        
+
         assertEquals(stClient.scope, this)
         assertEquals(eCounter, 1)
         assertEquals(exception?.message, "Something went wrong")


### PR DESCRIPTION
# 📲 What

- ViewModel now handles be able to search terms

# 🤔 Why

Some background context on why the change is needed.

# 🛠 How

- on VM init debuncing searchterm will trigger the query with specific discovery params
- - if serarch term is empty will return sorting popular results
- - if search terms contains any term will return results for the terms and sorting popular.
ℹ️ (More sorting and filtering options will be extended in follow up tickets)
- Reftags added when pressing a project result of a search (either with or without terms, take a look at unit tests if more details required).
- Analytics events triggered with every search query execution ( 1CTA, 1 PAGE_VIEWED) with the discovery params.
ℹ️ (PAGE_VIEWD) even will be extended with pagination pages information on following tickets.
- Error handling via red snackbar with generic error message.

- `CancellationException` (within `KSApolloClient`) is not considered an error, when using `collectLatest` previous suspend functions/flow emissions will be canceled, this is the expected behaviour as we want to execute networking and update UI only with the most recent params and should not be considered an error that requires user feedback.

# 👀 See


https://github.com/user-attachments/assets/5021a53d-ef80-43e8-b951-5318d08750fd


|  |  |

# 📋 QA

- Either in staging or production perform some terms searching, when there is no search term a collection of "popular" projects will be presented.
- Try to navigate to some of the project results live or in prelaunch state.

# Story 📖

[MBL-2135](https://kickstarter.atlassian.net/browse/MBL-2135)


[MBL-2135]: https://kickstarter.atlassian.net/browse/MBL-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ