### PR TITLE
MBL-2159: NullPointerException on ToastExtKt.showErrorToast

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -1345,11 +1345,13 @@ class ProjectPageActivity :
     }
 
     private fun showToastError(message: String? = null) {
-        showErrorToast(
-            applicationContext,
-            binding.pledgeContainerCompose,
-            message ?: getString(R.string.general_error_something_wrong)
-        )
+        this.runOnUiThread {
+            showErrorToast(
+                applicationContext,
+                binding.pledgeContainerCompose,
+                message ?: getString(R.string.general_error_something_wrong)
+            )
+        }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {


### PR DESCRIPTION
# 📲 What

Fixing this npe when an error toast is called in the project page activity: https://console.firebase.google.com/u/1/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/edb7989d61828a6bb9e6f3418539caf9?time=last-seven-days&types=crash&sessionEventKey=67CEFF3F014500013497842F8210C9B5_2058642386456165646

# 🛠 How

This is triggered when backing late pledges and there is an error and we try to show a toast. Fixed this by calling the toast on the ui thread

# 📋 QA
Before pulling and running this branch, try backing a late pledge project on staging like "Japanese late pledge project". this should crash the app (i also used an old stripe test card, in order to make sure the error toast triggered). This should crash the app when tapping pledge. 

Now pull and run this branch. Follow the same steps as above, try pledging to a late pledge reward in the "Japanese late pledge project", observe the error toast and no crashes

# Story 📖

[MBL-2159: NullPointerException on ToastExtKt.showErrorToast](https://kickstarter.atlassian.net/browse/MBL-2159)
