### PR TITLE
MBL-2057: [Phase 2] New card states: New info flag type

### DIFF
--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PPOCardView.kt
@@ -44,6 +44,7 @@ import com.kickstarter.features.pledgedprojectsoverview.data.Flag
 import com.kickstarter.libs.utils.extensions.format
 import com.kickstarter.ui.compose.designsystem.KSAlertBadge
 import com.kickstarter.ui.compose.designsystem.KSDividerLineGrey
+import com.kickstarter.ui.compose.designsystem.KSGreenBadge
 import com.kickstarter.ui.compose.designsystem.KSPrimaryGreenButton
 import com.kickstarter.ui.compose.designsystem.KSSecondaryRedButton
 import com.kickstarter.ui.compose.designsystem.KSTheme
@@ -76,6 +77,24 @@ fun PPOCardPreview() {
                     onSecondaryActionButtonClicked = {},
                     onProjectPledgeSummaryClick = {},
                     flags = listOf(Flag.builder().message("Address locks in 7 days").type("warning").icon("time").build(), Flag.builder().message("Address locks in 7 days").type("warning").icon("time").build(), Flag.builder().message("Address").type("warning").icon("time").build()),
+                )
+
+                Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+            }
+
+            item {
+                PPOCardView(
+                    viewType = PPOCardViewType.CONFIRM_ADDRESS,
+                    onCardClick = {},
+                    projectName = "Sugardew Island - Your cozy farm shop let’s pretend this is a longer title let’s pretend this is a longer title",
+                    pledgeAmount = "$50.00",
+                    creatorName = "Some really really really really really really really long name",
+                    sendAMessageClickAction = {},
+                    shippingAddress = "Firsty Lasty\n123 First Street, Apt #5678\nLos Angeles, CA 90025-1234\nUnited States",
+                    onActionButtonClicked = {},
+                    onSecondaryActionButtonClicked = {},
+                    onProjectPledgeSummaryClick = {},
+                    flags = listOf(Flag.builder().message("In fulfillment").type("info").icon(null).build()),
                 )
 
                 Spacer(modifier = Modifier.height(dimensions.paddingMedium))
@@ -403,6 +422,7 @@ fun AlertFlagsView(flags: List<Flag?>) {
             when (it?.type) {
                 "alert" -> KSAlertBadge(icon = icon, message = it.message)
                 "warning" -> KSWarningBadge(icon = icon, message = it.message)
+                "info" -> it.message?.let { message -> KSGreenBadge(text = message) }
                 else -> {}
             }
         }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/PPOCardViewKtTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/PPOCardViewKtTest.kt
@@ -133,7 +133,8 @@ class PPOCardViewKtTest : KSRobolectricTestCase() {
                     flags = listOf(
                         Flag.builder().message("Address locks in 7 days").type("alert").icon("time")
                             .build(),
-                        Flag.builder().message("Open Survey").type("warning").icon("time").build()
+                        Flag.builder().message("Open Survey").type("warning").icon("time").build(),
+                        Flag.builder().message("Reward Received").type("info").icon(null).build()
                     ),
                 )
             }
@@ -142,6 +143,7 @@ class PPOCardViewKtTest : KSRobolectricTestCase() {
         flagsListView.assertIsDisplayed()
         composeTestRule.onAllNodesWithText("Address locks in 7 days")[0].assertIsDisplayed()
         composeTestRule.onAllNodesWithText("Open Survey")[0].assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("Reward Received")[0].assertIsDisplayed()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

New info flag type for ppo v2 cards

# 🤔 Why

ppo v2

# 🛠 How

Add check for flag type `info`, render green badge with no icon

# 👀 See

<img width="363" alt="Screenshot 2025-03-11 at 14 31 42" src="https://github.com/user-attachments/assets/113248f4-3cfc-4550-b978-e470250190bc" />

# 📋 QA

Nothing to QA really, this is backend driven so we will be able to test later during feature QA. 
You can preview the badge in the compose preview in the `PPOCardView.kt` file

# Story 📖

[MBL-2057: [Phase 2] New card states: New info flag type](https://kickstarter.atlassian.net/browse/MBL-2061)
