### PR TITLE
MBL-2137: ViewModel for FilterMenuBottomSheet

### DIFF
--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
@@ -42,7 +42,7 @@ class FilterMenuViewModel(
 
     private var categoriesList = emptyList<Category>()
 
-    init {
+    fun getRootCategories() {
         scope.launch {
             emitCurrentState(isLoading = true)
             val response = apolloClient.getRootCategories()

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
@@ -1,0 +1,81 @@
+package com.kickstarter.features.search.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.kickstarter.libs.Environment
+import com.kickstarter.models.Category
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import timber.log.Timber
+import kotlin.coroutines.EmptyCoroutineContext
+
+data class FilterMenuUIState(
+    val isLoading: Boolean = false,
+    val categoriesList: List<Category> = emptyList()
+)
+
+class FilterMenuViewModel(
+    private val environment: Environment,
+    private val testDispatcher: CoroutineDispatcher? = null
+) : ViewModel() {
+
+    private val scope = viewModelScope + (testDispatcher ?: EmptyCoroutineContext)
+    private val apolloClient = requireNotNull(environment.apolloClientV2())
+    private var errorAction: (message: String?) -> Unit = {}
+
+    private val _filterMenu = MutableStateFlow(FilterMenuUIState())
+    val filterMenuUIState: StateFlow<FilterMenuUIState>
+        get() = _filterMenu
+            .asStateFlow()
+            .stateIn(
+                scope = scope,
+                started = SharingStarted.WhileSubscribed(),
+                initialValue = FilterMenuUIState()
+            )
+
+    private var categoriesList = emptyList<Category>()
+
+    init {
+        scope.launch {
+            emitCurrentState(isLoading = true)
+            val response = apolloClient.getRootCategories()
+
+            if (response.isSuccess)
+                categoriesList = response.getOrDefault(emptyList())
+            else
+                errorAction.invoke(response.exceptionOrNull()?.message)
+
+            Timber.d("${this.javaClass} rootCategories: ${categoriesList.map { "${it.name()} id: ${it.id()}"}}")
+            emitCurrentState(isLoading = false)
+        }
+    }
+
+    fun provideErrorAction(errorAction: (message: String?) -> Unit) {
+        this.errorAction = errorAction
+    }
+
+    private suspend fun emitCurrentState(isLoading: Boolean = false) {
+        _filterMenu.emit(
+            FilterMenuUIState(
+                isLoading = isLoading,
+                categoriesList = categoriesList
+            )
+        )
+    }
+
+    class Factory(
+        private val environment: Environment,
+        private val testDispatcher: CoroutineDispatcher? = null
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return FilterMenuViewModel(environment, testDispatcher) as T
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
@@ -59,7 +59,7 @@ class SearchAndFilterViewModel(
     private val _params = MutableStateFlow(firstLoadParams)
     val params: StateFlow<DiscoveryParams> = _params
 
-    private val debouncePeriod = 300L
+    val debouncePeriod = 300L
     private val _searchTerm = MutableStateFlow("")
     private val searchTerm: StateFlow<String> = _searchTerm
 

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
@@ -354,6 +354,10 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
         return io.reactivex.Observable.empty()
     }
 
+    override suspend fun getRootCategories(): Result<List<Category>> {
+        return Result.success(emptyList())
+    }
+
     override suspend fun getSearchProjects(discoveryParams: DiscoveryParams, cursor: String?): Result<SearchEnvelope> {
         return Result.success(SearchEnvelope())
     }

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -233,6 +233,7 @@ interface ApolloClientTypeV2 {
     fun updateBackerCompleted(inputData: UpdateBackerCompletedData): Observable<Boolean>
     suspend fun getSearchProjects(discoveryParams: DiscoveryParams, cursor: String? = null): Result<SearchEnvelope>
     suspend fun fetchSimilarProjects(pid: Long): Result<List<Project>>
+    suspend fun getRootCategories(): Result<List<Category>>
     fun cleanDisposables()
 }
 
@@ -1829,6 +1830,23 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
                 }.addToDisposable(disposables)
             return@defer ps
         }.subscribeOn(Schedulers.io())
+    }
+
+    override suspend fun getRootCategories(): Result<List<Category>> = executeForResult {
+        val query = GetRootCategoriesQuery()
+        val response = this.service.query(query).execute()
+
+        if (response.hasErrors())
+            throw buildClientException(response.errors)
+
+        // For now just returning rootCategories, in the future will likely be Map<Category, <List<Category>>> where second parameter is the list of subcategories
+        response.data?.let { responseData ->
+            val rootCategory = responseData.rootCategories.map {
+                categoryTransformer(it.category)
+            }
+
+            rootCategory
+        } ?: emptyList()
     }
 
     override suspend fun getSearchProjects(discoveryParams: DiscoveryParams, cursor: String?): Result<SearchEnvelope> = executeForResult {

--- a/app/src/test/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModelTest.kt
@@ -1,0 +1,85 @@
+package com.kickstarter.features.search.viewmodel
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Environment
+import com.kickstarter.mock.factories.CategoryFactory
+import com.kickstarter.mock.services.MockApolloClientV2
+import com.kickstarter.models.Category
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FilterMenuViewModelTest : KSRobolectricTestCase() {
+
+    private lateinit var viewModel: FilterMenuViewModel
+
+    private fun setUpEnvironment(environment: Environment, dispatcher: CoroutineDispatcher) {
+        viewModel = FilterMenuViewModel.Factory(environment, dispatcher)
+            .create(FilterMenuViewModel::class.java)
+    }
+
+    @Test
+    fun `test obtain rootCategories succeed`() = runTest {
+
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val environment = environment()
+            .toBuilder()
+            .apolloClientV2(
+                object : MockApolloClientV2() {
+                    override suspend fun getRootCategories(): Result<List<Category>> {
+                        return Result.success(CategoryFactory.rootCategories())
+                    }
+                }).build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        var errorCounter = 0
+        val state = mutableListOf<FilterMenuUIState>()
+        backgroundScope.launch(dispatcher) {
+            viewModel.provideErrorAction { errorCounter++ }
+            viewModel.getRootCategories()
+            viewModel.filterMenuUIState.toList(state)
+        }
+
+        advanceUntilIdle()
+        assertEquals(errorCounter, 0)
+        assertEquals(state.size, 2)
+        assertEquals(state.first().categoriesList, emptyList<Category>())
+        assertEquals(state.last().categoriesList, CategoryFactory.rootCategories())
+    }
+
+    @Test
+    fun `test obtain rootCategories errored`() = runTest {
+
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val environment = environment()
+            .toBuilder()
+            .apolloClientV2(
+                object : MockApolloClientV2() {
+                    override suspend fun getRootCategories(): Result<List<Category>> {
+                        return Result.failure(Exception())
+                    }
+                }).build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        var errorCounter = 0
+        val state = mutableListOf<FilterMenuUIState>()
+        backgroundScope.launch(dispatcher) {
+            viewModel.provideErrorAction { errorCounter++ }
+            viewModel.getRootCategories()
+            viewModel.filterMenuUIState.toList(state)
+        }
+
+        advanceUntilIdle()
+        assertEquals(errorCounter, 1)
+        assertEquals(state.size, 1)
+        assertEquals(state.first().categoriesList, emptyList<Category>())
+    }
+}


### PR DESCRIPTION
# 📲 What

- ViewModel specific for the BottomSheet Filter Menu, for Phase 1 it will contain only the query to obtain rootCategories, will be increasing functionality on following phases.

# 🤔 Why

- We need to get the categories from somewhere without ending with 1 only massive viewmodel once all phases completed.

# 🛠 How

- New VM, calling new query
- categories list available in compose to be feed to the UI

# 👀 See

- No user facing changes but take a look on logcat you can see logs with the results from the query loading the search screen
<img width="1257" alt="Screenshot 2025-03-12 at 6 51 10 PM" src="https://github.com/user-attachments/assets/9bbeb7a5-a19f-48d6-93b4-b39a3beeca9d" />

- Can take a look at the network profiler 
<img width="615" alt="Screenshot 2025-03-12 at 6 51 42 PM" src="https://github.com/user-attachments/assets/540e61d5-ddd3-4310-8006-4b08f3c7daf7" />


| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# 📋 QA

Instructions for anyone to be able to QA this work.

# Story 📖

[Name of Trello Story](Trello link)
