### PR TITLE
MBL-2155 Add a 'Similar Projects Carousel' to ProjectOverviewFragment

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.kt
@@ -51,6 +51,7 @@ object ProjectFactory {
             .location(LocationFactory.unitedStates())
             .name("Some Name")
             .pledged(50.0)
+            .percentFunded(50)
             .photo(PhotoFactory.photo())
             .rewards(listOf(RewardFactory.noReward(), RewardFactory.reward()))
             .staffPick(false)
@@ -362,6 +363,7 @@ object ProjectFactory {
             .name("halfwayProject")
             .goal(100.0)
             .pledged(50.0)
+            .percentFunded(50)
             .build()
     }
 
@@ -372,6 +374,7 @@ object ProjectFactory {
             .name("allTheWayProject")
             .goal(100.0)
             .pledged(100.0)
+            .percentFunded(50)
             .build()
     }
 
@@ -382,6 +385,7 @@ object ProjectFactory {
             .name("doubledGoalProject")
             .goal(100.0)
             .pledged(200.0)
+            .percentFunded(200)
             .build()
     }
 

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -1869,6 +1869,7 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
     }
 
     override suspend fun fetchSimilarProjects(pid: Long): Result<List<Project>> = executeForResult {
+        // Expose these as necessary
         val query = FetchSimilarProjectsQuery(
             first = Optional.present(4),
             similarToPid = pid.toString(),
@@ -1876,6 +1877,7 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
             recommended = Optional.present(true),
             seed = Optional.present(pid.toInt())
         )
+
         val response = this.service.query(query).execute()
 
         if (response.hasErrors())

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -38,7 +38,10 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
 import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import com.google.firebase.crashlytics.FirebaseCrashlytics
@@ -93,6 +96,7 @@ import com.kickstarter.viewmodels.projectpage.LatePledgeCheckoutViewModel
 import com.kickstarter.viewmodels.projectpage.PagerTabConfig
 import com.kickstarter.viewmodels.projectpage.ProjectPageViewModel
 import com.kickstarter.viewmodels.projectpage.RewardsSelectionViewModel
+import com.kickstarter.viewmodels.projectpage.SimilarProjectsViewModel
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.Stripe
@@ -104,7 +108,9 @@ import com.stripe.android.view.CardInputWidget
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 const val REFRESH = "refresh"
 
@@ -135,6 +141,9 @@ class ProjectPageActivity :
 
     private lateinit var addOnsViewModelFactory: AddOnsViewModel.Factory
     private val addOnsViewModel: AddOnsViewModel by viewModels { addOnsViewModelFactory }
+
+    private lateinit var similarProjectsViewModelFactory: SimilarProjectsViewModel.Factory
+    private val similarProjectsViewModel: SimilarProjectsViewModel by viewModels { similarProjectsViewModelFactory }
 
     private lateinit var stripe: Stripe
     private lateinit var flowController: PaymentSheet.FlowController
@@ -182,6 +191,7 @@ class ProjectPageActivity :
             rewardsSelectionViewModelFactory = RewardsSelectionViewModel.Factory(env)
             addOnsViewModelFactory = AddOnsViewModel.Factory(env)
             latePledgeCheckoutViewModelFactory = LatePledgeCheckoutViewModel.Factory(env)
+            similarProjectsViewModelFactory = SimilarProjectsViewModel.Factory(env)
             stripe = requireNotNull(env.stripe())
             env
         }
@@ -494,6 +504,14 @@ class ProjectPageActivity :
                     binding.projectAppBarLayout.setExpanded(false)
                 }
             }.addToDisposable(disposables)
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                similarProjectsViewModel.parentUiState.collect {
+                    binding.projectPager.isUserInputEnabled = it.scrollable
+                }
+            }
+        }
 
         var pBacking: Project? = null
         var user: User? = null

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -108,9 +108,7 @@ import com.stripe.android.view.CardInputWidget
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 const val REFRESH = "refresh"
 

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProjectCards.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProjectCards.kt
@@ -147,6 +147,7 @@ fun KSProjectCardLarge(
     modifier: Modifier = Modifier,
     photo: Photo? = null,
     title: String,
+    titleMinMaxLines: IntRange = 3..3,
     state: CardProjectState,
     fundingInfoString: String = "",
     fundedPercentage: Int,
@@ -183,6 +184,9 @@ fun KSProjectCardLarge(
                     text = title,
                     style = typographyV2.headingLG,
                     color = colors.textPrimary,
+                    minLines = titleMinMaxLines.first,
+                    maxLines = titleMinMaxLines.last,
+                    overflow = TextOverflow.Ellipsis
                 )
                 Spacer(modifier = Modifier.height(dimensions.paddingSmall))
                 KSFundingInfoRow(

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ui/SimilarProjectsComponent.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ui/SimilarProjectsComponent.kt
@@ -1,0 +1,273 @@
+package com.kickstarter.ui.fragments.projectpage.ui
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.absolutePadding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PageSize
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import com.kickstarter.R
+import com.kickstarter.libs.utils.extensions.deadlineCountdown
+import com.kickstarter.models.Photo
+import com.kickstarter.models.Project
+import com.kickstarter.ui.activities.compose.search.CardProjectState
+import com.kickstarter.ui.compose.designsystem.KSProjectCardLarge
+import com.kickstarter.ui.compose.designsystem.KSTheme
+import com.kickstarter.viewmodels.projectpage.SimilarProjectsUiState
+import org.joda.time.DateTime
+import timber.log.Timber
+
+@Preview(
+    name = "Light",
+    showBackground = true,
+    backgroundColor = 0xFFF0EAE2,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    widthDp = 384
+)
+@Preview(
+    name = "Dark",
+    showBackground = true,
+    backgroundColor = 0xFFF0EAE2,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    widthDp = 384
+)
+@Composable
+fun SimilarProjectCardPreview() {
+    KSTheme {
+        Box(
+            modifier = Modifier
+                .wrapContentSize()
+                .width(312.dp),
+        ) {
+            SimilarProjectCard(
+                Project
+                    .builder()
+                    .name("Dernière Lune, Collection of Dark Fantasy Short Stories")
+                    .photo(Photo.builder().full("https://i-dev.kickstarter.com/assets/043/680/711/102888b0a91af18b778235aac4414cbd_original.png?anim=false&fit=cover&gravity=auto&height=576&origin=ugc-qa&q=92&v=1705426857&width=1024&sig=b8unMD58v%2BZsl3sF%2Fe5BNriEoWNSDAp7CE1EjIRDPGk%3D").build())
+                    .state(Project.STATE_LIVE)
+                    .deadline(DateTime.now().plusDays(10))
+                    .currency("USD")
+                    .currentCurrency("USD")
+                    .build()
+            )
+        }
+    }
+}
+
+@Composable
+fun SimilarProjectCard(
+    project: Project,
+    onClick: () -> Unit = {}
+) {
+    val context = LocalContext.current
+    val countdown = project.deadlineCountdown(context)
+    val percentFunded = project.percentFunded() ?: 0
+    val fundedString = stringResource(R.string.discovery_baseball_card_stats_funded)
+
+    KSProjectCardLarge(
+        modifier = Modifier,
+        photo = project.photo(),
+        title = project.name(),
+        titleMinMaxLines = 2..2,
+        state = CardProjectState.LIVE,
+        fundingInfoString = "$countdown left • $percentFunded% $fundedString",
+        fundedPercentage = project.percentFunded() ?: 0,
+        onClick = onClick,
+    )
+}
+
+@Preview(
+    name = "Light",
+    device = "id:pixel_8_pro",
+    showBackground = true,
+    backgroundColor = 0xFFF0EAE2,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+@Preview(
+    name = "Dark",
+    device = "id:pixel_8_pro",
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+fun SimilarProjectsComponentPreview() {
+    val data: List<Project> = listOf(
+        Project
+            .builder()
+            .name("Dernière Lune, Collection of Dark Fantasy Short Stories")
+            .photo(Photo.builder().full("").build())
+            .state(Project.STATE_LIVE)
+            .currency("USD")
+            .currentCurrency("USD")
+            .build(),
+        Project
+            .builder()
+            .name("Sublime Thresholds Tarot")
+            .photo(Photo.builder().full("").build())
+            .deadline(DateTime.now().plusDays(17))
+            .build()
+    )
+
+    val similarProjectsUiState = SimilarProjectsUiState(data = data)
+
+    val uiState = remember { mutableStateOf(similarProjectsUiState) }
+
+    KSTheme {
+        SimilarProjectsComponent(
+            uiState = uiState
+        )
+    }
+}
+
+private val CustomPageSize = object : PageSize {
+    override fun Density.calculateMainAxisPageSize(
+        availableSpace: Int,
+        pageSpacing: Int
+    ): Int {
+        return availableSpace - pageSpacing
+    }
+}
+
+private val placeholderProject = Project.builder()
+    .name("")
+    .photo(Photo.builder().full("").build())
+    .deadline(DateTime.now())
+    .build()
+
+/**
+ * Does NOT consume, just spies.
+ */
+private suspend fun PointerInputScope.detectTouch(onTouchChange: (Boolean) -> Unit = {}) = awaitEachGesture {
+    awaitFirstDown(false, PointerEventPass.Initial)
+    onTouchChange(true)
+    try {
+        do {
+            val event = awaitPointerEvent(PointerEventPass.Initial)
+        } while (!event.changes.all { it.changedToUpIgnoreConsumed() })
+    } finally {
+        onTouchChange(false)
+    }
+}
+
+@Composable
+fun SimilarProjectsComponent(
+    uiState: State<SimilarProjectsUiState>,
+    onTouchChange: (Boolean) -> Unit = {},
+    onClick: (Project) -> Unit = {},
+) {
+    val projects = uiState.value.data
+
+    val pagerState = rememberPagerState { projects?.size ?: 0 }
+
+    Column {
+        Spacer(
+            modifier = Modifier
+                .height(18.dp)
+        )
+        Row(
+            modifier = Modifier
+                .absolutePadding(left = 18.dp, right = 24.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Similar projects",
+                style = KSTheme.typographyV2.headingXL,
+                color = KSTheme.colors.kds_black
+            )
+            Row(
+                Modifier
+                    .weight(1f, true)
+                    .wrapContentHeight(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                repeat(pagerState.pageCount) { iteration ->
+                    val color = if (pagerState.currentPage == iteration)
+                        KSTheme.colors.backgroundSelected
+                    else
+                        KSTheme.colors.backgroundInversePressed
+                    Box(
+                        modifier = Modifier
+                            .padding(2.dp)
+                            .clip(CircleShape)
+                            .background(color)
+                            .size(8.dp)
+                    )
+                }
+            }
+        }
+        Spacer(
+            modifier = Modifier
+                .height(12.dp)
+        )
+        Box(
+            modifier = Modifier,
+            contentAlignment = Alignment.Center
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .absolutePadding(18.dp, 0.dp, 24.dp, 0.dp)
+                    .alpha(0f)
+                    .clickable(false) {},
+                contentAlignment = Alignment.Center
+            ) {
+                SimilarProjectCard(placeholderProject)
+            }
+            HorizontalPager(
+                state = pagerState,
+                contentPadding = PaddingValues.Absolute(18.dp, 0.dp, 24.dp, 0.dp),
+                pageSpacing = 12.dp,
+                modifier = Modifier.pointerInput(Unit) {
+                    detectTouch { touching ->
+                        onTouchChange(touching)
+                    }
+                }
+            ) { page ->
+                val project = projects?.getOrNull(page)
+                if (project != null) {
+                    SimilarProjectCard(project) {
+                        onClick(project)
+                    }
+                }
+            }
+        }
+        Spacer(
+            modifier = Modifier
+                .height(24.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ui/SimilarProjectsComponent.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ui/SimilarProjectsComponent.kt
@@ -50,7 +50,6 @@ import com.kickstarter.ui.compose.designsystem.KSProjectCardLarge
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.viewmodels.projectpage.SimilarProjectsUiState
 import org.joda.time.DateTime
-import timber.log.Timber
 
 @Preview(
     name = "Light",

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/SimilarProjectsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/SimilarProjectsViewModel.kt
@@ -1,0 +1,89 @@
+package com.kickstarter.viewmodels.projectpage
+
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.kickstarter.libs.Environment
+import com.kickstarter.models.Project
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import kotlin.coroutines.EmptyCoroutineContext
+
+data class ParentUiState(
+    val scrollable: Boolean = true,
+)
+
+data class SimilarProjectsUiState(
+    val isLoading: Boolean = false,
+    val data: List<Project>? = null,
+    val error: Throwable? = null,
+)
+
+class SimilarProjectsViewModel(
+    environment: Environment,
+    testDispatcher: CoroutineDispatcher? = null
+) : ViewModel() {
+
+    private val scope = viewModelScope + (testDispatcher ?: EmptyCoroutineContext)
+    private val apolloClient = environment.apolloClientV2()!!
+
+    private val _parentUiState = MutableStateFlow(ParentUiState())
+    val parentUiState = _parentUiState.asStateFlow()
+
+    private val _similarProjectsUiState = MutableStateFlow(SimilarProjectsUiState())
+    val similarProjectsUiState = _similarProjectsUiState.asStateFlow()
+
+    private var project: Project? = null
+    private var job: Job? = null
+
+    fun provideProject(project: Project) {
+        if (this.project?.id() != project.id()) {
+            this.project = project
+            fetchSimilarProjects()
+        }
+    }
+
+    @VisibleForTesting
+    fun fetchSimilarProjects() {
+        val pid = project?.id() ?: return
+
+        job?.cancel()
+        job = scope.launch {
+            _similarProjectsUiState.value = SimilarProjectsUiState(isLoading = true)
+            apolloClient
+                .fetchSimilarProjects(pid)
+                .onSuccess {
+                    _similarProjectsUiState.value = SimilarProjectsUiState(
+                        isLoading = false,
+                        error = null,
+                        data = it,
+                    )
+                }
+                .onFailure {
+                    _similarProjectsUiState.value = SimilarProjectsUiState(
+                        isLoading = false,
+                        error = it,
+                        data = listOf(),
+                    )
+                }
+        }
+    }
+
+    fun setParentScrollable(scrollable: Boolean) {
+        _parentUiState.value = ParentUiState(scrollable)
+    }
+
+    class Factory(
+        private val environment: Environment,
+        private val testDispatcher: CoroutineDispatcher? = null
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return SimilarProjectsViewModel(environment, testDispatcher) as T
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_project_overview.xml
+++ b/app/src/main/res/layout/fragment_project_overview.xml
@@ -15,6 +15,8 @@
             android:id="@+id/project_creator_dashboard_header"
             layout="@layout/project_creator_dashboard_header" />
 
+
+
         <LinearLayout
             android:id="@+id/project_info"
             android:layout_width="match_parent"
@@ -285,6 +287,11 @@
         <include
             android:id="@+id/project_creator_info_layout"
             layout="@layout/project_creator_info" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/compose_view_spc"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_project_overview.xml
+++ b/app/src/main/res/layout/fragment_project_overview.xml
@@ -5,286 +5,286 @@
     android:layout_height="match_parent">
 
     <LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/kds_white"
-    android:id="@+id/project_scroll_view"
-    android:orientation="vertical">
-
-    <include
-        android:id="@+id/project_creator_dashboard_header"
-        layout="@layout/project_creator_dashboard_header" />
-
-    <LinearLayout
-        android:id="@+id/project_info"
+        android:id="@+id/project_scroll_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/project_padding_x"
-        android:layout_marginTop="@dimen/grid_2"
-        android:layout_marginEnd="@dimen/project_padding_x"
+        android:layout_height="match_parent"
         android:background="@color/kds_white"
         android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/project_name"
-            style="@style/Title2Medium"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textIsSelectable="true"
-            android:focusable="true"
-            android:paddingBottom="@dimen/grid_1_half"
-            tools:ignore="InconsistentLayout"
-            tools:text="Project name" />
+        <include
+            android:id="@+id/project_creator_dashboard_header"
+            layout="@layout/project_creator_dashboard_header" />
 
-        <FrameLayout
+        <LinearLayout
+            android:id="@+id/project_info"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/project_padding_x"
+            android:layout_marginTop="@dimen/grid_2"
+            android:layout_marginEnd="@dimen/project_padding_x"
+            android:background="@color/kds_white"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/project_name"
+                style="@style/Title2Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:paddingBottom="@dimen/grid_1_half"
+                android:textIsSelectable="true"
+                tools:ignore="InconsistentLayout"
+                tools:text="Project name" />
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <LinearLayout
+                    android:id="@+id/creator_info"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/click_indicator_light_masked"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingTop="@dimen/grid_2"
+                    android:paddingBottom="@dimen/grid_3"
+                    android:visibility="visible"
+                    tools:ignore="InconsistentLayout">
+
+                    <ImageView
+                        android:id="@+id/avatar"
+                        android:layout_width="@dimen/project_avatar_width"
+                        android:layout_height="@dimen/project_avatar_height"
+                        android:layout_marginEnd="@dimen/grid_3_half"
+                        android:importantForAccessibility="no"
+                        android:scaleType="centerCrop"
+                        tools:src="@drawable/circle_grey_300" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            style="@style/FootnotePrimary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/project_menu_created_by"
+                            android:textIsSelectable="true" />
+
+                        <TextView
+                            android:id="@+id/creator_name"
+                            style="@style/SubheadlineMedium"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:ellipsize="end"
+                            android:maxLines="1"
+                            android:textIsSelectable="true"
+                            tools:text="Creator Name" />
+                    </LinearLayout>
+
+                </LinearLayout>
+
+                <include
+                    android:id="@+id/loading_placeholder_creator_info_layout"
+                    layout="@layout/loading_placeholder_creator_info"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/grid_2"
+                    android:layout_marginBottom="@dimen/grid_3"
+                    tools:visibility="gone" />
+
+            </FrameLayout>
+
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/compose_view_banner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
             <LinearLayout
-                android:id="@+id/creator_info"
+                android:id="@+id/blurb_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="@drawable/click_indicator_light_masked"
                 android:focusable="true"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:paddingTop="@dimen/grid_2"
-                android:paddingBottom="@dimen/grid_3"
-                android:visibility="visible"
+                android:orientation="vertical"
                 tools:ignore="InconsistentLayout">
 
-                <ImageView
-                    android:id="@+id/avatar"
-                    android:layout_width="@dimen/project_avatar_width"
-                    android:layout_height="@dimen/project_avatar_height"
-                    android:layout_marginEnd="@dimen/grid_3_half"
-                    android:importantForAccessibility="no"
-                    android:scaleType="centerCrop"
-                    tools:src="@drawable/circle_grey_300" />
-
-                <LinearLayout
-                    android:layout_width="0dp"
+                <TextView
+                    android:id="@+id/blurb"
+                    style="@style/Subheadline"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:orientation="vertical">
-
-                    <TextView
-                        style="@style/FootnotePrimary"
-                        android:textIsSelectable="true"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/project_menu_created_by" />
-
-                    <TextView
-                        android:id="@+id/creator_name"
-                        style="@style/SubheadlineMedium"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textIsSelectable="true"
-                        android:ellipsize="end"
-                        android:maxLines="1"
-                        tools:text="Creator Name" />
-                </LinearLayout>
+                    android:textColor="@color/kds_support_700"
+                    android:textIsSelectable="true"
+                    tools:ignore="InconsistentLayout"
+                    tools:text="Description about this project." />
 
             </LinearLayout>
 
-            <include
-                android:id="@+id/loading_placeholder_creator_info_layout"
-                layout="@layout/loading_placeholder_creator_info"
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/grid_2"
-                android:layout_marginBottom="@dimen/grid_3"
-                tools:visibility="gone" />
-
-        </FrameLayout>
-
-        <androidx.compose.ui.platform.ComposeView
-          android:id="@+id/compose_view_banner"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content" />
-
-        <LinearLayout
-            android:id="@+id/blurb_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@drawable/click_indicator_light_masked"
-            android:focusable="true"
-            android:orientation="vertical"
-            tools:ignore="InconsistentLayout">
-
-            <TextView
-                android:id="@+id/blurb"
-                style="@style/Subheadline"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:textColor="@color/kds_support_700"
-                android:textIsSelectable="true"
-                tools:ignore="InconsistentLayout"
-                tools:text="Description about this project." />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/grid_3"
-            android:focusable="true"
-            android:gravity="center_vertical"
-            android:orientation="horizontal">
-
-            <com.kickstarter.ui.views.IconTextView
-                android:id="@+id/category_icon"
-                style="@style/Caption1Primary"
-                android:layout_width="wrap_content"
-                android:textIsSelectable="true"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/discovery_baseball_card_accessibility_category_label"
-                android:text="@string/local_offer_icon"
-                android:textColor="@color/kds_support_400" />
-
-            <TextView
-                android:id="@+id/category"
-                style="@style/Caption1Primary"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textIsSelectable="true"
-                android:paddingStart="@dimen/grid_1"
-                android:paddingEnd="@dimen/grid_5"
-                android:textColor="@color/kds_support_400"
-                tools:ignore="InconsistentLayout"
-                tools:text="Category name" />
-
-            <com.kickstarter.ui.views.IconTextView
-                android:id="@+id/location_icon"
-                style="@style/Caption1Primary"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/discovery_baseball_card_accessibility_location_label"
-                android:textIsSelectable="true"
-                android:text="@string/location_on_icon"
-                android:textColor="@color/kds_support_400" />
-
-            <TextView
-                android:id="@+id/location"
-                style="@style/Caption1Primary"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textIsSelectable="true"
-                android:ellipsize="end"
-                android:maxLines="1"
-                android:paddingStart="@dimen/grid_1"
-                android:paddingEnd="@dimen/grid_1_half"
-                android:textColor="@color/kds_support_400"
-                tools:ignore="InconsistentLayout"
-                tools:text="Location" />
-
-        </LinearLayout>
-
-        <ProgressBar
-            android:id="@+id/percentage_funded"
-            style="@style/ProgressBar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/grid_5"
-            android:importantForAccessibility="no"
-            android:minHeight="@dimen/progress_bar_min_height"
-            android:progress="50"
-            android:visibility="visible" />
-
-        <LinearLayout
-            android:id="@+id/project_state_view_group"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/grid_4"
-            android:layout_marginBottom="@dimen/grid_2"
-            android:focusable="true"
-            android:gravity="center_vertical"
-            android:orientation="vertical"
-            android:paddingStart="@dimen/grid_4"
-            android:paddingTop="@dimen/grid_2"
-            android:paddingEnd="@dimen/grid_4"
-            android:paddingBottom="@dimen/grid_2"
-            android:visibility="gone"
-            tools:visibility="visible">
-
-            <TextView
-                android:id="@+id/project_state_header_text_view"
-                style="@style/BodyPrimaryMedium"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textIsSelectable="true"
-                tools:text="Funded!" />
-
-            <TextView
-                android:id="@+id/project_state_subhead_text_view"
-                style="@style/Caption1Primary"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textIsSelectable="true"
-                tools:text="This project was funded on" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/project_stats_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/grid_3"
-            android:layout_marginBottom="@dimen/grid_5"
-            android:orientation="vertical">
-
-            <include
-                android:id="@+id/stats_view"
-                layout="@layout/project_stats_view" />
-
-            <TextView
-                android:id="@+id/usd_conversion_text_view"
-                style="@style/Caption1Secondary"
-                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/grid_3"
                 android:focusable="true"
-                android:textIsSelectable="true"
-                android:visibility="gone"
-                tools:text="Converted from" />
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
 
-        </LinearLayout>
+                <com.kickstarter.ui.views.IconTextView
+                    android:id="@+id/category_icon"
+                    style="@style/Caption1Primary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/discovery_baseball_card_accessibility_category_label"
+                    android:text="@string/local_offer_icon"
+                    android:textColor="@color/kds_support_400"
+                    android:textIsSelectable="true" />
 
-        <LinearLayout
-            android:id="@+id/project_social_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/grid_4"
-            android:focusable="true"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:paddingTop="@dimen/grid_1"
-            android:paddingBottom="@dimen/grid_1"
-            android:visibility="gone">
+                <TextView
+                    android:id="@+id/category"
+                    style="@style/Caption1Primary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingStart="@dimen/grid_1"
+                    android:paddingEnd="@dimen/grid_5"
+                    android:textColor="@color/kds_support_400"
+                    android:textIsSelectable="true"
+                    tools:ignore="InconsistentLayout"
+                    tools:text="Category name" />
 
-            <ImageView
-                android:id="@+id/project_social_image"
-                android:layout_width="@dimen/project_social_photo_height"
-                android:layout_height="@dimen/project_social_photo_height"
+                <com.kickstarter.ui.views.IconTextView
+                    android:id="@+id/location_icon"
+                    style="@style/Caption1Primary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/discovery_baseball_card_accessibility_location_label"
+                    android:text="@string/location_on_icon"
+                    android:textColor="@color/kds_support_400"
+                    android:textIsSelectable="true" />
+
+                <TextView
+                    android:id="@+id/location"
+                    style="@style/Caption1Primary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:paddingStart="@dimen/grid_1"
+                    android:paddingEnd="@dimen/grid_1_half"
+                    android:textColor="@color/kds_support_400"
+                    android:textIsSelectable="true"
+                    tools:ignore="InconsistentLayout"
+                    tools:text="Location" />
+
+            </LinearLayout>
+
+            <ProgressBar
+                android:id="@+id/percentage_funded"
+                style="@style/ProgressBar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/grid_5"
                 android:importantForAccessibility="no"
-                android:visibility="gone" />
+                android:minHeight="@dimen/progress_bar_min_height"
+                android:progress="50"
+                android:visibility="visible" />
 
-            <TextView
-                android:id="@+id/project_social_text"
-                style="@style/Caption1PrimaryMedium"
+            <LinearLayout
+                android:id="@+id/project_state_view_group"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/grid_4"
+                android:layout_marginBottom="@dimen/grid_2"
+                android:focusable="true"
+                android:gravity="center_vertical"
+                android:orientation="vertical"
+                android:paddingStart="@dimen/grid_4"
+                android:paddingTop="@dimen/grid_2"
+                android:paddingEnd="@dimen/grid_4"
+                android:paddingBottom="@dimen/grid_2"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <TextView
+                    android:id="@+id/project_state_header_text_view"
+                    style="@style/BodyPrimaryMedium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textIsSelectable="true"
+                    tools:text="Funded!" />
+
+                <TextView
+                    android:id="@+id/project_state_subhead_text_view"
+                    style="@style/Caption1Primary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textIsSelectable="true"
+                    tools:text="This project was funded on" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/project_stats_view"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/grid_2"
-                tools:text="Gina Binetti, Christopher Wright, and 5 more are backers" />
+                android:layout_marginTop="@dimen/grid_3"
+                android:layout_marginBottom="@dimen/grid_5"
+                android:orientation="vertical">
+
+                <include
+                    android:id="@+id/stats_view"
+                    layout="@layout/project_stats_view" />
+
+                <TextView
+                    android:id="@+id/usd_conversion_text_view"
+                    style="@style/Caption1Secondary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/grid_3"
+                    android:focusable="true"
+                    android:textIsSelectable="true"
+                    android:visibility="gone"
+                    tools:text="Converted from" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/project_social_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/grid_4"
+                android:focusable="true"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingTop="@dimen/grid_1"
+                android:paddingBottom="@dimen/grid_1"
+                android:visibility="gone">
+
+                <ImageView
+                    android:id="@+id/project_social_image"
+                    android:layout_width="@dimen/project_social_photo_height"
+                    android:layout_height="@dimen/project_social_photo_height"
+                    android:importantForAccessibility="no"
+                    android:visibility="gone" />
+
+                <TextView
+                    android:id="@+id/project_social_text"
+                    style="@style/Caption1PrimaryMedium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/grid_2"
+                    tools:text="Gina Binetti, Christopher Wright, and 5 more are backers" />
+
+            </LinearLayout>
 
         </LinearLayout>
 
+        <include
+            android:id="@+id/project_creator_info_layout"
+            layout="@layout/project_creator_info" />
+
     </LinearLayout>
-
-    <include
-        android:id="@+id/project_creator_info_layout"
-        layout="@layout/project_creator_info" />
-
-</LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/project_creator_info.xml
+++ b/app/src/main/res/layout/project_creator_info.xml
@@ -179,7 +179,7 @@
   <View
     android:layout_width="match_parent"
     android:layout_height="1dp"
-    android:layout_marginTop="@dimen/grid_5"
+    android:layout_marginTop="@dimen/grid_3_half"
     android:layout_marginBottom="@dimen/grid_4"
     android:background="@color/kds_white" />
 

--- a/app/src/test/java/com/kickstarter/viewmodels/SimilarProjectsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/SimilarProjectsViewModelTest.kt
@@ -1,0 +1,195 @@
+package com.kickstarter.viewmodels
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Environment
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.mock.services.MockApolloClientV2
+import com.kickstarter.models.Project
+import com.kickstarter.viewmodels.projectpage.ParentUiState
+import com.kickstarter.viewmodels.projectpage.SimilarProjectsUiState
+import com.kickstarter.viewmodels.projectpage.SimilarProjectsViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalStdlibApi::class)
+class SimilarProjectsViewModelTest : KSRobolectricTestCase() {
+
+    private lateinit var viewModel: SimilarProjectsViewModel
+
+    private fun setUpEnvironment(environment: Environment, dispatcher: CoroutineDispatcher) {
+        viewModel = SimilarProjectsViewModel.Factory(environment, dispatcher)
+            .create(SimilarProjectsViewModel::class.java)
+    }
+
+    @Test
+    fun `test no similar projects are fetched when a project has not been provided`() = runTest {
+        val standardDispatcher = coroutineContext[CoroutineDispatcher]!!
+
+        setUpEnvironment(environment(), standardDispatcher)
+
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val state = mutableListOf<SimilarProjectsUiState>()
+        backgroundScope.launch(unconfinedDispatcher) {
+            viewModel.similarProjectsUiState.toList(state)
+        }
+
+        advanceUntilIdle()
+
+        assertEquals(1, state.size)
+        assertEquals(null, state.last().data)
+    }
+
+    @Test
+    fun `test similar projects are fetched when a project has been provided`() = runTest {
+        val standardDispatcher = coroutineContext[CoroutineDispatcher]!!
+
+        val project = ProjectFactory.successfulProject()
+        val similarProjects = listOf(ProjectFactory.project())
+
+        setUpEnvironment(
+            environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
+                override suspend fun fetchSimilarProjects(pid: Long): Result<List<Project>> {
+                    return Result.success(similarProjects)
+                }
+            }).build(),
+            standardDispatcher
+        )
+
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val state = mutableListOf<SimilarProjectsUiState>()
+        backgroundScope.launch(unconfinedDispatcher) {
+            viewModel.similarProjectsUiState.toList(state)
+        }
+
+        viewModel.provideProject(project)
+
+        advanceUntilIdle()
+
+        assertEquals(3, state.size)
+        assertEquals(similarProjects, state.last().data)
+    }
+
+    @Test
+    fun `test similar projects are fetched only once for the same provided project`() = runTest {
+        val standardDispatcher = coroutineContext[CoroutineDispatcher]!!
+
+        val project = ProjectFactory.successfulProject()
+        val similarProjects = listOf(ProjectFactory.project())
+
+        setUpEnvironment(
+            environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
+                override suspend fun fetchSimilarProjects(pid: Long): Result<List<Project>> {
+                    return Result.success(similarProjects)
+                }
+            }).build(),
+            standardDispatcher
+        )
+
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val state = mutableListOf<SimilarProjectsUiState>()
+        backgroundScope.launch(unconfinedDispatcher) {
+            viewModel.similarProjectsUiState.toList(state)
+        }
+
+        viewModel.provideProject(project)
+        advanceUntilIdle()
+
+        viewModel.provideProject(project)
+        advanceUntilIdle()
+
+        assertEquals(3, state.size)
+        assertEquals(similarProjects, state.last().data)
+    }
+
+    @Test
+    fun `test similar projects are fetched twice for different provided projects`() = runTest {
+        val standardDispatcher = coroutineContext[CoroutineDispatcher]!!
+
+        setUpEnvironment(
+            environment(),
+            standardDispatcher
+        )
+
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val state = mutableListOf<SimilarProjectsUiState>()
+        backgroundScope.launch(unconfinedDispatcher) {
+            viewModel.similarProjectsUiState.toList(state)
+        }
+
+        val project1 = ProjectFactory.successfulProject()
+
+        viewModel.provideProject(project1)
+        advanceUntilIdle()
+
+        val project2 = ProjectFactory.failedProject()
+
+        viewModel.provideProject(project2)
+        advanceUntilIdle()
+
+        assertEquals(5, state.size)
+    }
+
+    @Test
+    fun `test ui state for api error`() = runTest {
+        val standardDispatcher = coroutineContext[CoroutineDispatcher]!!
+
+        val throwable = Exception("Oops")
+
+        setUpEnvironment(
+            environment().toBuilder().apolloClientV2(object : MockApolloClientV2() {
+                override suspend fun fetchSimilarProjects(pid: Long): Result<List<Project>> {
+                    return Result.failure(throwable)
+                }
+            }).build(),
+            standardDispatcher
+        )
+
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val state = mutableListOf<SimilarProjectsUiState>()
+        backgroundScope.launch(unconfinedDispatcher) {
+            viewModel.similarProjectsUiState.toList(state)
+        }
+
+        val project = ProjectFactory.successfulProject()
+
+        viewModel.provideProject(project)
+
+        advanceUntilIdle()
+
+        assertEquals(3, state.size)
+        assertEquals("Oops", state.last().error?.message)
+        assertEquals(emptyList<Project>(), state.last().data)
+    }
+
+    @Test
+    fun `test parent ui state`() = runTest {
+        val standardDispatcher = coroutineContext[CoroutineDispatcher]!!
+
+        setUpEnvironment(environment(), standardDispatcher)
+
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val state = mutableListOf<ParentUiState>()
+        backgroundScope.launch(unconfinedDispatcher) {
+            viewModel.parentUiState.toList(state)
+        }
+
+        assertEquals(1, state.size)
+        assertEquals(true, state.last().scrollable)
+
+        viewModel.setParentScrollable(false)
+
+        assertEquals(2, state.size)
+        assertEquals(false, state.last().scrollable)
+
+        viewModel.setParentScrollable(true)
+
+        assertEquals(3, state.size)
+        assertEquals(true, state.last().scrollable)
+    }
+}


### PR DESCRIPTION
# 📲 What

Add a 'Similar Projects Carousel' to ProjectOverviewFragment

# 🤔 Why

To drive backer engagement, fetch and display a collection of recommended projects on the main project page (non-prelaunch projects).

# 🛠 How

Add `SimilarProjectsViewModel` to contain the logic for fetching and maintaining state related to similar projects. This VM reacts to whatever project is provided, but only fetches similar project data once for a given project. 

Add `SimilarProjectsComponent` to consume a collection of projects from the ViewModel and display them in a Pager. This component leverages custom touch event handling through a `pointerInput` Modifier to prevent scroll gestures from being picked up by the parent `ViewPager2` of `ProjectPageActivity`.

# 👀 See

## Before 🐛

https://github.com/user-attachments/assets/d1547742-9113-4df1-afe5-0af80648fe49

## After 🦋

https://github.com/user-attachments/assets/4f1719b1-f6de-42b0-84f3-181120ecd339

# 📋 QA

(For best results, point to production, as the recommendations on Staging are almost always the same)

Open any non-prelaunch Project page and scroll to the bottom. Swipe and click through the 'similar project' cards. Check the `session_ref_tag` for the `Page Viewed` event in Segment (⚠️ currently an empty string).

<img width="343" alt="image" src="https://github.com/user-attachments/assets/514a613e-df98-43ee-91e0-3834514f3e17" />

# Story 📖

Epic: [\[MBL-2155\] 🤖 Similar Projects Carousel - Jira](https://kickstarter.atlassian.net/browse/MBL-2155)  

Stories included:
- https://kickstarter.atlassian.net/browse/MBL-2158
- https://kickstarter.atlassian.net/browse/MBL-2185
- https://kickstarter.atlassian.net/browse/MBL-2186
