### PR TITLE
MBL-2211 Change default sort from POPULAR to MAGIC/RECOMMENDED

### DIFF
--- a/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
@@ -81,7 +81,7 @@ class SearchAndFilterActivity : ComponentActivity() {
                         scaffoldState = rememberScaffoldState(),
                         errorSnackBarHostState = snackbarHostState,
                         isLoading = isLoading,
-                        isPopularList = currentSearchTerm.isTrimmedEmpty(),
+                        isDefaultList = currentSearchTerm.isTrimmedEmpty(),
                         itemsList = if (currentSearchTerm.isTrimmedEmpty()) {
                             popularProjects
                         } else {

--- a/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
@@ -109,7 +109,7 @@ class SearchAndFilterActivity : ComponentActivity() {
                         onDismissBottomSheet = { category, sort ->
                             viewModel.updateParamsToSearchWith(
                                 category,
-                                sort ?: DiscoveryParams.Sort.POPULAR // popular is the default sort
+                                sort ?: DiscoveryParams.Sort.MAGIC // magic is the default sort
                             )
                         }
                     )

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
@@ -54,7 +54,7 @@ class SearchAndFilterViewModel(
             )
 
     // - Popular projects sorting selection
-    private val firstLoadParams = DiscoveryParams.builder().sort(DiscoveryParams.Sort.POPULAR).build()
+    private val firstLoadParams = DiscoveryParams.builder().sort(DiscoveryParams.Sort.MAGIC).build()
 
     private val _params = MutableStateFlow(firstLoadParams)
     val params: StateFlow<DiscoveryParams> = _params
@@ -134,7 +134,7 @@ class SearchAndFilterViewModel(
                 analyticEvents.trackSearchResultPageViewed(
                     params,
                     1, // TODO: this will contain the page when pagination ready MBL-2139
-                    params.sort() ?: DiscoveryParams.Sort.POPULAR
+                    params.sort() ?: DiscoveryParams.Sort.MAGIC
                 )
             }
         }

--- a/app/src/main/java/com/kickstarter/ui/activities/SearchActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SearchActivity.kt
@@ -101,7 +101,7 @@ class SearchActivity : ComponentActivity() {
                     onBackClicked = { onBackPressedDispatcher.onBackPressed() },
                     scaffoldState = rememberScaffoldState(),
                     isLoading = isLoading,
-                    isPopularList = currentSearchTerm.isTrimmedEmpty(),
+                    isDefaultList = currentSearchTerm.isTrimmedEmpty(),
                     itemsList = if (currentSearchTerm.isTrimmedEmpty()) {
                         popularProjects
                     } else {

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
@@ -80,7 +80,7 @@ fun SearchScreenPreviewNonEmpty() {
             scaffoldState = rememberScaffoldState(),
             errorSnackBarHostState = SnackbarHostState(),
             isLoading = false,
-            isPopularList = true,
+            isDefaultList = true,
             itemsList = List(100) {
                 Project.builder()
                     .name("This is a test $it")
@@ -126,7 +126,7 @@ enum class SearchScreenTestTag {
     LOADING_VIEW,
     IN_LIST_LOADING_VIEW,
     LIST_VIEW,
-    POPULAR_PROJECTS_TITLE,
+    DISCOVER_PROJECTS_TITLE,
     FEATURED_PROJECT_VIEW,
     NORMAL_PROJECT_VIEW,
 }
@@ -162,7 +162,7 @@ fun SearchScreen(
     onBackClicked: () -> Unit,
     scaffoldState: ScaffoldState,
     errorSnackBarHostState: SnackbarHostState = SnackbarHostState(),
-    isPopularList: Boolean = true,
+    isDefaultList: Boolean = true,
     isLoading: Boolean,
     itemsList: List<Project> = listOf(),
     lazyColumnListState: LazyListState,
@@ -187,7 +187,7 @@ fun SearchScreen(
     }
     val initialCategoryPillText = stringResource(R.string.fpo_category)
     var categoryPillText = remember { mutableStateOf(initialCategoryPillText) }
-    var currentSort by remember { mutableStateOf(DiscoveryParams.Sort.POPULAR) }
+    var currentSort by remember { mutableStateOf(DiscoveryParams.Sort.MAGIC) }
     var currentCategory by remember { mutableStateOf<Category?>(null) }
 
     val activeBottomSheet = remember {
@@ -323,14 +323,14 @@ fun SearchScreen(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     itemsIndexed(itemsList) { index, project ->
-                        if (index == 0 && isPopularList) {
+                        if (index == 0 && isDefaultList) {
                             Spacer(modifier = Modifier.height(dimensions.paddingMedium))
 
                             Text(
                                 modifier = Modifier
-                                    .testTag(SearchScreenTestTag.POPULAR_PROJECTS_TITLE.name)
+                                    .testTag(SearchScreenTestTag.DISCOVER_PROJECTS_TITLE.name)
                                     .fillMaxWidth(),
-                                text = stringResource(id = R.string.Popular_Projects),
+                                text = stringResource(id = R.string.activity_empty_state_logged_in_button),
                                 style = typographyV2.title2,
                                 color = colors.kds_support_700,
                                 textAlign = TextAlign.Start

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SortSelectionBottomSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SortSelectionBottomSheet.kt
@@ -53,7 +53,7 @@ private fun BetaMessagingBottomSheetPreview() {
 @Composable
 fun SortSelectionBottomSheet(
     sorts: List<DiscoveryParams.Sort>,
-    currentSelection: DiscoveryParams.Sort = DiscoveryParams.Sort.POPULAR,
+    currentSelection: DiscoveryParams.Sort = DiscoveryParams.Sort.MAGIC,
     onDismiss: (DiscoveryParams.Sort) -> Unit = { },
     isLoading: Boolean = false,
 ) {

--- a/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
@@ -30,7 +30,7 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `test for initial state will only have sorting parameter POPULAR and empty search term`() = runTest {
+    fun `test for initial state will only have sorting parameter MAGIC and empty search term`() = runTest {
 
         var params: DiscoveryParams? = null
         val projectList = listOf(ProjectFactory.project(), ProjectFactory.prelaunchProject(""))
@@ -57,7 +57,7 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         }
 
         advanceUntilIdle()
-        assertEquals(params?.sort(), DiscoveryParams.Sort.POPULAR)
+        assertEquals(params?.sort(), DiscoveryParams.Sort.MAGIC)
         assertNull(params?.term())
         assertEquals(searchState.size, 2)
         assertEquals(searchState.last().popularProjectsList, projectList)
@@ -92,7 +92,7 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         }
 
         advanceUntilIdle()
-        assertEquals(params?.sort(), DiscoveryParams.Sort.POPULAR)
+        assertEquals(params?.sort(), DiscoveryParams.Sort.MAGIC)
         assertNull(params?.term())
         assertEquals(searchState.size, 2)
         assertEquals(searchState.last().popularProjectsList, emptyList<Project>())
@@ -128,7 +128,7 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         }
 
         advanceUntilIdle()
-        assertEquals(params?.sort(), DiscoveryParams.Sort.POPULAR)
+        assertEquals(params?.sort(), DiscoveryParams.Sort.MAGIC)
         assertEquals(params?.term(), "hello")
         assertEquals(searchState.size, 2)
         assertEquals(searchState.last().popularProjectsList, emptyList<Project>())
@@ -165,7 +165,7 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         }
 
         advanceUntilIdle()
-        assertEquals(params?.sort(), DiscoveryParams.Sort.POPULAR)
+        assertEquals(params?.sort(), DiscoveryParams.Sort.MAGIC)
         assertEquals(params?.term(), "hello")
         assertEquals(searchState.size, 2)
 
@@ -207,7 +207,7 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         }
 
         advanceUntilIdle()
-        assertEquals(params?.sort(), DiscoveryParams.Sort.POPULAR)
+        assertEquals(params?.sort(), DiscoveryParams.Sort.MAGIC)
         assertNull(params?.term())
         assertEquals(searchState.size, 2)
 

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchScreenTest.kt
@@ -27,7 +27,7 @@ class SearchScreenTest : KSRobolectricTestCase() {
         composeTestRule.onNodeWithTag(SearchScreenTestTag.IN_LIST_LOADING_VIEW.name)
     private val listView = composeTestRule.onNodeWithTag(SearchScreenTestTag.LIST_VIEW.name)
     private val popularProjectsTitle =
-        composeTestRule.onNodeWithTag(SearchScreenTestTag.POPULAR_PROJECTS_TITLE.name)
+        composeTestRule.onNodeWithTag(SearchScreenTestTag.DISCOVER_PROJECTS_TITLE.name)
     private val featuredProjectView =
         composeTestRule.onNodeWithTag(SearchScreenTestTag.FEATURED_PROJECT_VIEW.name)
 
@@ -68,7 +68,7 @@ class SearchScreenTest : KSRobolectricTestCase() {
                     isLoading = false,
                     lazyColumnListState = rememberLazyListState(),
                     showEmptyView = false,
-                    isPopularList = true,
+                    isDefaultList = true,
                     itemsList = List(20) {
                         Project.builder()
                             .name("This is a test $it")
@@ -115,7 +115,7 @@ class SearchScreenTest : KSRobolectricTestCase() {
                     isLoading = false,
                     lazyColumnListState = rememberLazyListState(),
                     showEmptyView = false,
-                    isPopularList = false,
+                    isDefaultList = false,
                     itemsList = List(20) {
                         Project.builder()
                             .name("This is a test $it")
@@ -186,7 +186,7 @@ class SearchScreenTest : KSRobolectricTestCase() {
                     isLoading = true,
                     lazyColumnListState = rememberLazyListState(),
                     showEmptyView = false,
-                    isPopularList = false,
+                    isDefaultList = false,
                     itemsList = List(20) {
                         Project.builder()
                             .name("This is a test $it")
@@ -234,7 +234,7 @@ class SearchScreenTest : KSRobolectricTestCase() {
                     isLoading = false,
                     lazyColumnListState = rememberLazyListState(),
                     showEmptyView = false,
-                    isPopularList = false,
+                    isDefaultList = false,
                     itemsList = List(20) {
                         Project.builder()
                             .name("This is a test $it")
@@ -278,7 +278,7 @@ class SearchScreenTest : KSRobolectricTestCase() {
                     isLoading = false,
                     lazyColumnListState = rememberLazyListState(),
                     showEmptyView = false,
-                    isPopularList = false,
+                    isDefaultList = false,
                     itemsList = List(20) {
                         Project.builder()
                             .name("This is a test $it")

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchScreenTest.kt
@@ -91,7 +91,7 @@ class SearchScreenTest : KSRobolectricTestCase() {
         inListLoadingView.assertDoesNotExist()
         listView.assertIsDisplayed()
 
-        val popularProjectTitleText = context.getString(R.string.Popular_Projects)
+        val popularProjectTitleText = context.getString(R.string.activity_empty_state_logged_in_button)
         popularProjectsTitle.assertIsDisplayed()
         popularProjectsTitle.assertTextEquals(popularProjectTitleText)
 


### PR DESCRIPTION
# 📲 What

Always show pill bar, even before user searches a query (we already do this)
Change default sort from POPULAR to MAGIC/RECOMMENDED
On Search screen change text from "Popular Projects" to "Discover Projects"  (activity_empty_state_logged_in_button)
Anywhere else in the sort bottom sheet logic where we default to POPULAR, change to MAGIC

# 🤔 Why


# 🛠 How


# 👀 See

https://github.com/user-attachments/assets/b92751d6-88ec-4c57-aa89-7c11a58bf3f6

# 📋 QA

Instructions for anyone to be able to QA this work.

# Story 📖

https://kickstarter.atlassian.net/browse/MBL-2211
