### PR TITLE
MBL-2207: Create and add a placeholder card for SPC

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ui/SimilarProjectPlaceholderCard.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ui/SimilarProjectPlaceholderCard.kt
@@ -1,0 +1,136 @@
+package com.kickstarter.ui.fragments.projectpage.ui
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kickstarter.R
+import com.kickstarter.ui.compose.designsystem.KSTheme
+
+@Preview(
+    name = "Light",
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+)
+@Preview(
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun SimilarProjectPlaceholderCardPreview() {
+    KSTheme {
+        Column(Modifier.fillMaxSize()) {
+            SimilarProjectPlaceholderCard {
+                // Figma size
+                Box(modifier = Modifier.size(320.dp, 270.dp))
+            }
+            Spacer(Modifier.height(8.dp))
+            SimilarProjectPlaceholderCard {
+                Box(modifier = Modifier.size(320.dp, 180.dp))
+            }
+            Spacer(Modifier.height(8.dp))
+            SimilarProjectPlaceholderCard {
+                Box(modifier = Modifier.size(256.dp, 256.dp))
+            }
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+fun SimilarProjectPlaceholderCard(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier
+    ) {
+        Box(
+            // Either this box has alpha 0...
+            modifier = Modifier.alpha(0f)
+        ) {
+            content()
+        }
+        Box(
+            // Or this box has an opaque background color
+            modifier = Modifier.matchParentSize()
+        ) {
+            Column {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(CornerSize(4)))
+                        .background(colorResource(R.color.kds_legacy_grey_500))
+                        .fillMaxWidth()
+                        .weight(198f / 270f)
+                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(72f / 270f)
+                ) {
+                    Spacer(
+                        modifier = Modifier
+                            .weight(12f / 72f)
+                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(20f / 72f)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(24.dp))
+                                .fillMaxHeight()
+                                .weight(227f)
+                                .background(colorResource(R.color.kds_legacy_grey_500))
+                        )
+                        Spacer(
+                            modifier = Modifier
+                                .weight(85f)
+                        )
+                    }
+                    Spacer(
+                        modifier = Modifier
+                            .weight(8f / 72f)
+                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(20f / 72f)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(24.dp))
+                                .fillMaxHeight()
+                                .weight(136f / 312f)
+                                .background(colorResource(R.color.kds_legacy_grey_500))
+                        )
+                        Spacer(
+                            modifier = Modifier
+                                .weight(176f / 312f)
+                        )
+                    }
+                    Spacer(
+                        modifier = Modifier
+                            .weight(12f / 72f)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ui/SimilarProjectsComponent.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ui/SimilarProjectsComponent.kt
@@ -91,6 +91,7 @@ fun SimilarProjectCardPreview() {
 @Composable
 fun SimilarProjectCard(
     project: Project,
+    modifier: Modifier = Modifier,
     onClick: () -> Unit = {}
 ) {
     val context = LocalContext.current
@@ -99,7 +100,7 @@ fun SimilarProjectCard(
     val fundedString = stringResource(R.string.discovery_baseball_card_stats_funded)
 
     KSProjectCardLarge(
-        modifier = Modifier,
+        modifier = modifier,
         photo = project.photo(),
         title = project.name(),
         titleMinMaxLines = 2..2,
@@ -190,6 +191,9 @@ fun SimilarProjectsComponent(
 ) {
     val projects = uiState.value.data
 
+    // Will use `isLoading` & `error` when necessary, but this is the simple truth right now
+    val showPlaceholder = projects.isNullOrEmpty()
+
     val pagerState = rememberPagerState { projects?.size ?: 0 }
 
     Column {
@@ -209,7 +213,7 @@ fun SimilarProjectsComponent(
             )
             Row(
                 Modifier
-                    .weight(1f, true)
+                    .weight(1f)
                     .wrapContentHeight(),
                 horizontalArrangement = Arrangement.End
             ) {
@@ -233,22 +237,24 @@ fun SimilarProjectsComponent(
                 .height(12.dp)
         )
         Box(
-            modifier = Modifier,
             contentAlignment = Alignment.Center
         ) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .absolutePadding(18.dp, 0.dp, 24.dp, 0.dp)
-                    .alpha(0f)
+                    .alpha(if (showPlaceholder) 1f else 0f)
                     .clickable(false) {},
                 contentAlignment = Alignment.Center
             ) {
-                SimilarProjectCard(placeholderProject)
+                SimilarProjectPlaceholderCard {
+                    SimilarProjectCard(placeholderProject)
+                }
             }
             HorizontalPager(
                 state = pagerState,
                 contentPadding = PaddingValues.Absolute(18.dp, 0.dp, 24.dp, 0.dp),
+                verticalAlignment = Alignment.CenterVertically,
                 pageSpacing = 12.dp,
                 modifier = Modifier.pointerInput(Unit) {
                     detectTouch { touching ->
@@ -265,8 +271,7 @@ fun SimilarProjectsComponent(
             }
         }
         Spacer(
-            modifier = Modifier
-                .height(24.dp)
+            modifier = Modifier.height(24.dp)
         )
     }
 }

--- a/app/src/main/res/layout/fragment_project_overview.xml
+++ b/app/src/main/res/layout/fragment_project_overview.xml
@@ -15,8 +15,6 @@
             android:id="@+id/project_creator_dashboard_header"
             layout="@layout/project_creator_dashboard_header" />
 
-
-
         <LinearLayout
             android:id="@+id/project_info"
             android:layout_width="match_parent"


### PR DESCRIPTION
# 📲 What

Create and add a placeholder card for the Similar Projects Carousel.

# 🤔 Why

As a visual indicator that data is loading (and in this case that data is missing).

# 🛠 How

Create a `SimilarProjectPlaceholderCard` component with responsive empty state elements. This component is a container, whose size is determined by its content. Wrap the the existing `SimilarProjectCard` placeholder (used to reserve space) in this placeholder container, and only show the placeholder when the list of similar projects is null or empty.

# 👀 See

When opening a non-prelaunch Project page without an internet connection:

| Before 🐛 | After 🦋 |
| --- | --- |
| <img alt="Screenshot_20250321_162926" src="https://github.com/user-attachments/assets/83a2a6a6-5c97-43b7-99f7-b18e0adf0a99" width="256"> | <img alt="Screenshot_20250321_164311" src="https://github.com/user-attachments/assets/c7784d9a-11f7-45b8-9afd-fef509438366" width="256"> |

# 📋 QA

#### Simple

Open any non-prelaunch Project page without an internet connection and scroll to the bottom of the Overview tab.

#### Normal

Simple QA allows you to see the empty state, which is ok here because the visual indication for the empty & loading states are the same. However, to confirm the loading state + see the data become available + confirm the placeholder component disappears, there are two things you can do:

1. Do the Simple QA steps. Reconnect to the internet. Press the "Content isn't loading right now" refresh button.

2. Make one or both of the following changes:

    - Add a `delay()` to loading the data in `SimilarProjectsViewModel`

      <img width="320" alt="image" src="https://github.com/user-attachments/assets/0575e766-3f9a-41ce-82c2-eab9d3090c7e" />

    - Within `fragment_project_overview.xml`, move the `ComposeView` in which the SPC renders (`@+id/compose_view_spc`) directly below the `include` element `@+id/project_creator_dashboard_header`, above the `LinearLayout` `@+id/project_info`, so you can see it as soon as the Project page opens.

# Story 📖

[\[MBL-2207\] Loading state - Jira](https://kickstarter.atlassian.net/browse/MBL-2207)
