### PR TITLE
MBL-1697 Thanks page wrong amount

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/viewholders/ThanksShareViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ThanksShareViewHolder.kt
@@ -16,7 +16,6 @@ import com.kickstarter.ui.data.CheckoutData
 import com.kickstarter.viewmodels.ThanksShareHolderViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
-import java.math.RoundingMode
 
 class ThanksShareViewHolder(private val binding: ThanksShareViewBinding) : KSViewHolder(binding.root) {
     private val viewModel = ThanksShareHolderViewModel.ThanksShareViewHolderViewModel(environment())
@@ -29,11 +28,6 @@ class ThanksShareViewHolder(private val binding: ThanksShareViewBinding) : KSVie
         viewModel.outputs.projectName()
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { showBackedProject(it) }
-            .addToDisposable(disposables)
-
-        viewModel.outputs.postCampaignPledgeText()
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe { showPostCampaignPledgeText(it) }
             .addToDisposable(disposables)
 
         viewModel.outputs.startShare()
@@ -86,21 +80,6 @@ class ThanksShareViewHolder(private val binding: ThanksShareViewBinding) : KSVie
 
     private fun showBackedProject(projectName: String) {
         binding.backedProject.text = Html.fromHtml(ksString.format(context().getString(R.string.You_have_successfully_backed_project_html), "project_name", projectName))
-    }
-
-    private fun showPostCampaignPledgeText(pcptext: Pair<Double, Project>) {
-        binding.backedProject.text = Html.fromHtml(
-            ksString.format(
-                context().getString(R.string.You_have_successfully_pledged_to_project_post_campaign_html_short),
-                "pledge_total",
-                ksCurrency.format(
-                    initialValue = pcptext.first,
-                    project = pcptext.second,
-                    roundingMode = RoundingMode.HALF_UP
-                )
-            ),
-            Html.FROM_HTML_MODE_LEGACY
-        )
     }
 
     private fun startShare(projectNameAndShareUrl: Pair<String, String>) {

--- a/app/src/test/java/com/kickstarter/viewmodels/ThanksShareHolderViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ThanksShareHolderViewModelTest.kt
@@ -32,8 +32,6 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
             .addToDisposable(disposables)
         vm.outputs.startShareOnTwitter().subscribe { startShareOnTwitter.onNext(it) }
             .addToDisposable(disposables)
-        vm.outputs.postCampaignPledgeText().subscribe { postCampaignText.onNext(it) }
-            .addToDisposable(disposables)
     }
 
     @Test
@@ -108,10 +106,13 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testShowLatePledges_whenTrue_ShowLatePledgeFlow() {
+    fun testShowLatePledges_whenTrue_ShowsProjectName() {
         setUpEnvironment()
 
-        val project = setUpProjectWithWebUrls().toBuilder().isInPostCampaignPledgingPhase(true).postCampaignPledgingEnabled(true).build()
+        val project = setUpProjectWithWebUrls().toBuilder()
+            .isInPostCampaignPledgingPhase(true)
+            .postCampaignPledgingEnabled(true)
+            .build()
         val checkoutData = CheckoutDataFactory.checkoutData(
             3L,
             20.0,
@@ -119,40 +120,7 @@ class ThanksShareHolderViewModelTest : KSRobolectricTestCase() {
         )
         vm.configureWith(Pair(project, checkoutData))
 
-        postCampaignText.assertValue(Pair(checkoutData.amount(), project))
-        projectName.assertNoValues()
-    }
-
-    @Test
-    fun testShowLatePledges_whenFalse_noEmission() {
-        setUpEnvironment()
-
-        val project = setUpProjectWithWebUrls().toBuilder().isInPostCampaignPledgingPhase(false).postCampaignPledgingEnabled(false).build()
-        val checkoutData = CheckoutDataFactory.checkoutData(
-            3L,
-            20.0,
-            30.0
-        )
-        vm.configureWith(Pair(project, checkoutData))
-
-        postCampaignText.assertNoValues()
-        projectName.assertValue(project.name())
-    }
-
-    @Test
-    fun testShowLatePledges_whenNull_noEmission() {
-        setUpEnvironment()
-
-        val project = setUpProjectWithWebUrls().toBuilder().isInPostCampaignPledgingPhase(null).postCampaignPledgingEnabled(null).build()
-        val checkoutData = CheckoutDataFactory.checkoutData(
-            3L,
-            20.0,
-            30.0
-        )
-        vm.configureWith(Pair(project, checkoutData))
-
-        postCampaignText.assertNoValues()
-        projectName.assertValue(project.name())
+        projectName.assertValues(project.name())
     }
 
     private fun setUpProjectWithWebUrls(): Project {


### PR DESCRIPTION
# 📲 What

Fixed the incorrect amount displayed on the ThanksShare Screen by unifying the logic to use a single string resource that only shows the project name, without displaying the pledge amount.

# 🤔 Why

Previously, the ThanksShare Screen showed different messages for normal and late pledges, causing confusion and leading to redundant code. To improve consistency and simplify the code,   the message now display only the project name,  regardless of the pledge type.
# 🛠 How

- Unified String Resource:
Replaced the old logic that used separate strings for normal and late pledges with a single string resource that displays only the project name.

- Removed Redundant Code:
Removed the postCampaignText emission and related logic from the ThanksShareViewHolderViewModel, as it was no longer needed.

- Updated Tests:
Modified the test cases to reflect the new unified logic, removing unnecessary checks and making sure the project name is emitted only once.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Screenshot_20250321_144501](https://github.com/user-attachments/assets/27d541ee-3e62-4096-aeb6-120d9a866a16) | ![Screenshot_20250324_102306](https://github.com/user-attachments/assets/e169bf38-20fa-4618-b9af-e75b7308d181)   |

# 📋 QA

Test both normal and late pledges to verify that the project name is displayed correctly on the ThanksShare Screen.

Confirm that the project name appears without the amount, regardless of the pledge type.

# Story 📖

[MBL-1697 Thanks page wrong amount](https://kickstarter.atlassian.net/browse/MBL-1697)
