### PR TITLE
MBL-2241: Allow SimilarProjectsViewModel to re-fetch data on error

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/SimilarProjectsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/SimilarProjectsViewModel.kt
@@ -20,8 +20,8 @@ data class ParentUiState(
 
 data class SimilarProjectsUiState(
     val isLoading: Boolean = false,
-    val data: List<Project>? = null,
     val error: Throwable? = null,
+    val data: List<Project>? = null,
 )
 
 class SimilarProjectsViewModel(
@@ -42,7 +42,9 @@ class SimilarProjectsViewModel(
     private var job: Job? = null
 
     fun provideProject(project: Project) {
-        if (this.project?.id() != project.id()) {
+        if (this.project?.id() != project.id() ||
+            (similarProjectsUiState.value.error != null && !similarProjectsUiState.value.isLoading)
+        ) {
             this.project = project
             fetchSimilarProjects()
         }


### PR DESCRIPTION
# 📲 What

Allow SimilarProjectsViewModel to re-fetch data on error

# 🤔 Why

Enables the 'Similar Projects Carousel' in `ProjectOverviewFragment` to recover along with the rest of the screen when content is successfully reloads.

# 🛠 How

Check for an error state when a request comes in to fetch data, even if an attempt has already been made.

# 👀 See

Before 🐛

https://github.com/user-attachments/assets/b5de58c5-9318-4665-8393-b681c057186e

After 🦋

https://github.com/user-attachments/assets/4227475d-3d8e-432c-9a7f-b759f4eaf4c9

# 📋 QA

1. Open a Project without an internet connection
2. Restore your internet connect
3. Press the Reload button next to "Content isn't loading right now"

Confirm that the SPC has also refreshed.

# Story 📖

[\[MBL-2241\] SPC does not always reload data - Jira](https://kickstarter.atlassian.net/browse/MBL-2241)
