### PR TITLE
MBL-2242: Catch unhandled exceptions in RefreshPushToken

### DIFF
--- a/app/src/main/java/com/kickstarter/services/firebase/MessageService.kt
+++ b/app/src/main/java/com/kickstarter/services/firebase/MessageService.kt
@@ -30,12 +30,14 @@ interface RefreshPushToken {
             val response = apiClient.registerPushToken(newToken).blockingSingle()
             val message = "$OK_MESSAGE $response"
             successCallback.invoke(message)
-        } catch (exception: ApiException) {
-            val errorMessage = "$KO_MESSAGE ${
-            exception.errorEnvelope().errorMessage()
-            }"
-            if (exception.errorEnvelope().httpCode() != 401) // else OAuth token not authorized
-                errorCallback.invoke(errorMessage)
+        } catch (t: Throwable) {
+            if (t is ApiException) {
+                val errorMessage = "$KO_MESSAGE ${
+                t.errorEnvelope().errorMessage()
+                }"
+                if (t.errorEnvelope().httpCode() != 401) // else OAuth token not authorized
+                    errorCallback.invoke(errorMessage)
+            }
         }
     }
 }

--- a/app/src/test/java/com/kickstarter/services/firebase/MessageServiceTest.kt
+++ b/app/src/test/java/com/kickstarter/services/firebase/MessageServiceTest.kt
@@ -98,7 +98,7 @@ class MessageServiceTest : KSRobolectricTestCase() {
     }
 
     @Test(
-        expected = RuntimeException::class
+//        expected = RuntimeException::class
     )
     fun `test intermittent internet connection`() {
         val apiClient = object : MockApiClientV2() {

--- a/app/src/test/java/com/kickstarter/services/firebase/MessageServiceTest.kt
+++ b/app/src/test/java/com/kickstarter/services/firebase/MessageServiceTest.kt
@@ -1,0 +1,125 @@
+package com.kickstarter.services.firebase
+
+import com.google.gson.JsonObject
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.mock.services.MockApiClientV2
+import com.kickstarter.services.ApiException
+import com.kickstarter.services.apiresponses.ErrorEnvelope
+import io.reactivex.Observable
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.net.UnknownHostException
+
+class MessageServiceTest : KSRobolectricTestCase() {
+
+    private val refreshHandler = object : RefreshPushToken {}
+    private val newToken = ""
+    private val gson get() = environment().gson()!!
+
+    private lateinit var successMessages: MutableList<String>
+    private lateinit var errorMessages: MutableList<String>
+
+    @Before
+    fun before() {
+        successMessages = mutableListOf()
+        errorMessages = mutableListOf()
+    }
+
+    @Test
+    fun `test successfully registering push token`() {
+        val apiClient = object : MockApiClientV2() {
+            override fun registerPushToken(token: String): Observable<JsonObject> {
+                return Observable.just(JsonObject())
+            }
+        }
+
+        refreshHandler.invoke(
+            apiClient = apiClient,
+            newToken = newToken,
+            gson = gson,
+            successCallback = { successMessages.add(it) },
+            errorCallback = { errorMessages.add(it) }
+        )
+
+        assertEquals(1, successMessages.size)
+        assertEquals(0, errorMessages.size)
+    }
+
+    @Test
+    fun `test http 400 error is handled and error callback invoked`() {
+        val apiClient = object : MockApiClientV2() {
+            override fun registerPushToken(token: String): Observable<JsonObject> {
+                return Observable.error(
+                    ApiException(
+                        ErrorEnvelope.builder().httpCode(400).build(),
+                        Response.error<String>(400, "".toResponseBody())
+                    )
+                )
+            }
+        }
+
+        refreshHandler.invoke(
+            apiClient = apiClient,
+            newToken = newToken,
+            gson = gson,
+            successCallback = { successMessages.add(it) },
+            errorCallback = { errorMessages.add(it) }
+        )
+
+        assertEquals(0, successMessages.size)
+        assertEquals(1, errorMessages.size)
+    }
+
+    @Test
+    fun `test http 401 error is handled but error callback is not invoked`() {
+        val apiClient = object : MockApiClientV2() {
+            override fun registerPushToken(token: String): Observable<JsonObject> {
+                return Observable.error(
+                    ApiException(
+                        ErrorEnvelope.builder().httpCode(401).build(),
+                        Response.error<String>(401, "".toResponseBody())
+                    )
+                )
+            }
+        }
+
+        refreshHandler.invoke(
+            apiClient = apiClient,
+            newToken = newToken,
+            gson = gson,
+            successCallback = { successMessages.add(it) },
+            errorCallback = { errorMessages.add(it) }
+        )
+
+        assertEquals(0, successMessages.size)
+        assertEquals(0, errorMessages.size)
+    }
+
+    @Test(
+        expected = RuntimeException::class
+    )
+    fun `test intermittent internet connection`() {
+        val apiClient = object : MockApiClientV2() {
+            override fun registerPushToken(token: String): Observable<JsonObject> {
+                return Observable.error(
+                    UnknownHostException(
+                        "Unable to resolve host \"api.kickstarter.com\": No address associated with hostname"
+                    )
+                )
+            }
+        }
+
+        refreshHandler.invoke(
+            apiClient = apiClient,
+            newToken = newToken,
+            gson = gson,
+            successCallback = { successMessages.add(it) },
+            errorCallback = { errorMessages.add(it) }
+        )
+
+        assertEquals(0, successMessages.size)
+        assertEquals(0, errorMessages.size)
+    }
+}


### PR DESCRIPTION
# 📲 What

Update `RefreshPushToken` to catch all Throwables, but continue to handle `ApiException`s as before.

# 🤔 Why

Unhandled exceptions in `MessageService` caused by intermitted network connectivity become fatal during app startup. (See [Unable to resolve host "api.kickstarter.com": No address associated with hostname](https://console.firebase.google.com/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/2a44cba36dc98cfe834c23ae722f3793?time=last-seven-days&types=crash&sessionEventKey=67E311FB016800016D868962A85680F6_2064296130111721286).)

# 🛠 How

Update error handling in `RefreshPushToken`. Add tests to verify behavior.

# 📋 QA

The first commit in this PR includes a test, `` `test intermittent internet connection` ``, that demonstrates an uncaught `UnknownHostException` (Rx wraps this as a `RuntimeException`), mimicking the crash reported to Firebase.

The second commit updates the error handling in `RefreshPushToken` and comments out the `expected` `RuntimeException` annotation.

# Story 📖

[\[MBL-2242\] Fix unhandled exceptions in RefreshPushToken - Jira](https://kickstarter.atlassian.net/browse/MBL-2242)
