### PR TITLE
MBL-2251: SPC & project card polish

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProjectCards.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProjectCards.kt
@@ -1,8 +1,9 @@
+@file:OptIn(ExperimentalMaterialApi::class)
+
 package com.kickstarter.ui.compose.designsystem
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Card
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Text
@@ -155,11 +157,11 @@ fun KSProjectCardLarge(
 ) {
     Card(
         modifier = modifier
-            .fillMaxWidth()
-            .clickable { onClick.invoke() },
+            .fillMaxWidth(),
         backgroundColor = colors.backgroundSurfaceRaised,
         shape = shapes.medium,
         elevation = dimensionResource(id = R.dimen.grid_2),
+        onClick = onClick
     ) {
         Column {
             if (photo != null) {
@@ -214,11 +216,11 @@ fun KSProjectCardSmall(
 ) {
     Card(
         modifier = modifier
-            .fillMaxWidth()
-            .clickable { onClick.invoke() },
+            .fillMaxWidth(),
         backgroundColor = colors.backgroundSurfaceRaised,
         shape = shapes.small,
-        elevation = dimensionResource(id = R.dimen.grid_2)
+        elevation = dimensionResource(id = R.dimen.grid_2),
+        onClick = onClick
     ) {
         Column {
             Row(

--- a/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ui/SimilarProjectsComponent.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/projectpage/ui/SimilarProjectsComponent.kt
@@ -203,7 +203,7 @@ fun SimilarProjectsComponent(
         )
         Row(
             modifier = Modifier
-                .absolutePadding(left = 18.dp, right = 24.dp),
+                .absolutePadding(left = 24.dp, right = 24.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
@@ -242,7 +242,7 @@ fun SimilarProjectsComponent(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .absolutePadding(18.dp, 0.dp, 24.dp, 0.dp)
+                    .absolutePadding(24.dp, 0.dp, 24.dp, 0.dp)
                     .alpha(if (showPlaceholder) 1f else 0f)
                     .clickable(false) {},
                 contentAlignment = Alignment.Center
@@ -253,7 +253,7 @@ fun SimilarProjectsComponent(
             }
             HorizontalPager(
                 state = pagerState,
-                contentPadding = PaddingValues.Absolute(18.dp, 0.dp, 24.dp, 0.dp),
+                contentPadding = PaddingValues.Absolute(24.dp, 0.dp, 24.dp, 0.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 pageSpacing = 12.dp,
                 modifier = Modifier.pointerInput(Unit) {


### PR DESCRIPTION
# 📲 What

Fix SPC padding and restore Card ripple on click

# 🤔 Why

UI/UX

# 🛠 How

Update padding dimensions in the SPC title row, pager, and card placeholder box.

Material Cards in `1.6.2` support `onClick` behind an `ExperimentalMaterialApi` annotation, but this property is stable in Material3. Leverage it here to enable a ripple on click.

# 👀 See

### SPC

#### Spec

<img alt="figma_202503261014" src="https://github.com/user-attachments/assets/fcd568b0-088c-4060-b87c-84033eb0e6c3" width="256"/>

#### Before & After

| Before 🐛 | After 🦋 |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/8a929244-8393-4f4e-97f2-7a26e7664ab6" width="256"/> | <img src="https://github.com/user-attachments/assets/619f658f-15bb-4ac0-af93-2d3e4288f01b" width="256"/> |

### Project Card

#### Before 🐛

https://github.com/user-attachments/assets/cd465661-ab38-46d9-9a9c-c4b0f0174757

#### After 🦋

https://github.com/user-attachments/assets/92117263-aeb3-4265-ba12-0d8e02ae4c4b

# 📋 QA

Normal usage

# Story 📖

[\[MBL-2251\] SPC & project card polish - Jira](https://kickstarter.atlassian.net/browse/MBL-2251)
