### PR TITLE
MBL-2254: remove submodule for material-design-icons

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/material-design-icons"]
-  path = vendor/material-design-icons
-  url = https://github.com/google/material-design-icons

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,7 @@ bootstrap: dependencies secrets
 bootstrap-circle: dependencies secrets
 	./script/bootstrap_configs
 
-dependencies: submodules secrets
-
-submodules:
-	git submodule sync --recursive
-	git submodule update --init --recursive || true
-	git submodule foreach git checkout $(sha1)
+dependencies: secrets
 
 secrets:
 	-@rm -rf vendor/native-secrets


### PR DESCRIPTION
# 📲 What
- Remove submodule for material design icons

# 🤔 Why

<img width="1259" alt="Screenshot 2025-03-26 at 6 31 09 PM" src="https://github.com/user-attachments/assets/49b2e656-8879-47af-af0c-64a5025562a0" />

# 🛠 How
- No longer needed!!!

# 👀 See
- No user facing changes is jut CI stuff

| --- | --- |
|  |  |

# 📋 QA
- if you want to do QA over this branch I'll suggest
- -  deinit the submodule -> `git submodule deinit -f vendor/material-design-icons`
- - remove the folder from your local environment -> `git rm -f vendor/material-design-icons`

# Story 📖

[MBL-2254](https://kickstarter.atlassian.net/browse/MBL-2254)


[MBL-2254]: https://kickstarter.atlassian.net/browse/MBL-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ