### PR TITLE
MBL-890: Ensure a Project's web url is available on the Thanks Screen

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
@@ -285,6 +285,10 @@ fun Project.updateStartedProjectAndDiscoveryParamsList(
  * when presenting screens in order to avoid `android.os.TransactionTooLargeException`
  */
 fun Project.reduce(): Project {
+    val web = Web.builder()
+        .project(this.webProjectUrl())
+        .build()
+
     return Project.Builder()
         .id(this.id())
         .slug(this.slug())
@@ -305,6 +309,7 @@ fun Project.reduce(): Project {
         .backing(backing())
         .availableCardTypes(this.availableCardTypes())
         .category(this.category())
+        .urls(Urls.builder().web(web).build())
         .build()
 }
 


### PR DESCRIPTION
# 📲 What

Ensure a Project's web url is available in `ThanksShareViewHolderViewModel`.

# 🤔 Why

This change specifically fixes a bug where the web url of a Project is missing from the Share text generated in ThanksActivity.

# 🛠 How

- Include a Project's `webProjectUrl()` in its reduced form.
- In `ThanksShareViewHolderViewModel`, if the given Project's `webProjectUrl()` is blank, re-fetch the Project.
- In In `ThanksShareViewHolderViewModel`, if for whatever reason the Project's `webProjectUrl()` is blank upon request, return a fallback url leveraging `Environment.webEndpoint()` and the Project's `slug()`.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| Missing Project web url  | Including Project web url |
| <img alt="Screenshot_20250401_020828" src="https://github.com/user-attachments/assets/147fa85d-4bfe-4c6e-b792-a4f327a79833" width="352"/>  | <img alt="Screenshot_20250401_021457" src="https://github.com/user-attachments/assets/7570ff09-3a85-4106-a578-b0d26bc19169" width="352"/> |

# 📋 QA

Back a regular campaign Project and confirm that the project's web url is included in the Share text on the Thank You screen.

# Story 📖

[\[MBL-890\] Twitter share tweet includes ref tags - Jira](https://kickstarter.atlassian.net/browse/MBL-890)
