### PR TITLE
MBL-890: Include the web url in "reduced" Project objects

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
@@ -285,6 +285,10 @@ fun Project.updateStartedProjectAndDiscoveryParamsList(
  * when presenting screens in order to avoid `android.os.TransactionTooLargeException`
  */
 fun Project.reduce(): Project {
+    val web = Web.builder()
+        .project(this.webProjectUrl())
+        .build()
+
     return Project.Builder()
         .id(this.id())
         .slug(this.slug())
@@ -305,6 +309,7 @@ fun Project.reduce(): Project {
         .backing(backing())
         .availableCardTypes(this.availableCardTypes())
         .category(this.category())
+        .urls(Urls.builder().web(web).build())
         .build()
 }
 


### PR DESCRIPTION
# 📲 What

Include the web url in "reduced" Project objects.

# 🤔 Why

Ensure that users of a reduced Project object have access to the web url. For example, when such a Project object is sent to `ThanksActivity`, that web project url is used in the Share text.

# 🛠 How

Include a Project's `webProjectUrl()` in its reduced form. This change specifically fixes a bug where the web url of a Project is missing from the Share text generated in ThanksActivity.

If the entry points to ThanksActivity are likely to change, or this fix somehow does not cover all entry points, a more complete fix targeting `ThanksShareViewHolderViewModel` can be found in [another PR.](https://github.com/kickstarter/android-oss/pull/2284)

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| Missing Project web url  | Including Project web url |
| <img alt="Screenshot_20250401_020828" src="https://github.com/user-attachments/assets/147fa85d-4bfe-4c6e-b792-a4f327a79833" width="352"/>  | <img alt="Screenshot_20250401_021457" src="https://github.com/user-attachments/assets/7570ff09-3a85-4106-a578-b0d26bc19169" width="352"/> |

# 📋 QA

Back a regular campaign Project and confirm that the project's web url is included in the Share text on the Thank You screen.

# Story 📖

[\[MBL-890\] Twitter share tweet includes ref tags - Jira](https://kickstarter.atlassian.net/browse/MBL-890)
