### PR TITLE
MBL-2248 [Pledge] The system does not allow pledging when  adding add-ons

### DIFF
--- a/app/src/main/graphql/project.graphql
+++ b/app/src/main/graphql/project.graphql
@@ -24,6 +24,7 @@ query FetchProjectRewards($slug: String!, $rewardImageWidth: Int = 1024) {
     minPledge
     rewards {
       nodes {
+        id
         ... reward
         allowedAddons {
             pageInfo {

--- a/app/src/main/graphql/rewards.graphql
+++ b/app/src/main/graphql/rewards.graphql
@@ -12,7 +12,7 @@ query GetShippingRulesForRewardId($rewardId: ID!) {
     }
 }
 
-query GetRewardAllowedAddOns($slug: String!) {
+query GetRewardAllowedAddOns($slug: String!, , $rewardImageWidth: Int = 1024) {
     project(slug: $slug) {
         rewards {
             nodes {

--- a/app/src/main/graphql/rewards.graphql
+++ b/app/src/main/graphql/rewards.graphql
@@ -11,3 +11,30 @@ query GetShippingRulesForRewardId($rewardId: ID!) {
         }
     }
 }
+
+query GetRewardAllowedAddOns($slug: String!) {
+    project(slug: $slug) {
+        rewards {
+            nodes {
+                id
+                allowedAddons {
+                    edges {
+                        node {
+                            shippingRulesExpanded {
+                                nodes {
+                                    ... shippingRule
+                                }
+                            }
+                            ... reward
+                            items {
+                                ... rewardItems
+                            }
+                            ...rewardImage
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
@@ -194,6 +194,11 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
     ): io.reactivex.Observable<List<Reward>> {
         return io.reactivex.Observable.empty()
     }
+
+    override fun getRewardAllowedAddOns(slug: String, rewardId: Long): io.reactivex.Observable<List<Reward>> {
+        return io.reactivex.Observable.empty()
+    }
+
     override fun updateBacking(updateBackingData: UpdateBackingData): io.reactivex.Observable<Checkout> {
         return io.reactivex.Observable.empty()
     }

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -1,7 +1,6 @@
 package com.kickstarter.services
 
 import android.annotation.SuppressLint
-import android.util.Log
 import android.util.Pair
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloResponse
@@ -820,9 +819,8 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
                 addOnItems = complexRewardItemsTransformer(node.items?.rewardItems),
                 rewardImage = node.rewardImage
             )
-        } ?.toList() ?: emptyList()
+        }?.toList() ?: emptyList()
     }
-
     override fun getRewardAllowedAddOns(slug: String, rewardId: Long): Observable<List<Reward>> {
         return Observable.defer {
             val ps = PublishSubject.create<List<Reward>>()
@@ -858,7 +856,6 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
             return@defer ps
         }
     }
-
 
     override fun getProjectAddOns(slug: String, locationId: Location): Observable<List<Reward>> {
         return Observable.defer {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
@@ -2,7 +2,6 @@ package com.kickstarter.viewmodels.projectpage
 
 import android.annotation.SuppressLint
 import android.os.Bundle
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -10,7 +9,6 @@ import com.kickstarter.libs.Environment
 import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.libs.utils.extensions.pledgeAmountTotalPlusBonus
-import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.models.Backing
 import com.kickstarter.models.Project

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
@@ -1,6 +1,8 @@
 package com.kickstarter.viewmodels.projectpage
 
+import android.annotation.SuppressLint
 import android.os.Bundle
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -187,14 +189,15 @@ class AddOnsViewModel(val environment: Environment, bundle: Bundle? = null) : Vi
         }
     }
 
+    @SuppressLint("LogNotTimber")
     private fun getAddOns(selectedShippingRule: ShippingRule) {
         // - Do not execute call unless reward has addOns
         if (currentUserReward.hasAddons()) {
             scope.launch(dispatcher) {
                 apolloClient
-                    .getProjectAddOns(
+                    .getRewardAllowedAddOns(
                         slug = project.slug() ?: "",
-                        locationId = selectedShippingRule.location() ?: LocationFactory.empty()
+                        rewardId = currentUserReward.id(),
                     )
                     .asFlow()
                     .onStart {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
@@ -1,6 +1,5 @@
 package com.kickstarter.viewmodels.projectpage
 
-import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -155,7 +154,7 @@ class AddOnsViewModel(val environment: Environment, bundle: Bundle? = null) : Vi
                 }
             }
 
-            getAddOns(shippingRule)
+            getAddOns()
         }
     }
 
@@ -183,12 +182,11 @@ class AddOnsViewModel(val environment: Environment, bundle: Bundle? = null) : Vi
     fun provideSelectedShippingRule(shippingRule: ShippingRule) {
         if (this.shippingRule != shippingRule) {
             this.shippingRule = shippingRule
-            getAddOns(selectedShippingRule = shippingRule)
+            getAddOns()
         }
     }
 
-    @SuppressLint("LogNotTimber")
-    private fun getAddOns(selectedShippingRule: ShippingRule) {
+    private fun getAddOns() {
         // - Do not execute call unless reward has addOns
         if (currentUserReward.hasAddons()) {
             scope.launch(dispatcher) {

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
@@ -222,8 +222,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         }
 
         advanceUntilIdle()
-
-        val finalState = uiState.last { !it.isLoading }
+        val loadedState = uiState.last { !it.isLoading }
 
         assertEquals(
             AddOnsUIState(
@@ -234,13 +233,13 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
                 totalBonusAmount = 0.0,
                 totalPledgeAmount = rw.pledgeAmount()
             ),
-            finalState
+            loadedState
         )
 
         viewModel.bonusAmountUpdated(3.0)
 
         advanceUntilIdle()
-        val finalBonusState = uiState.last { it.totalBonusAmount == 3.0 }
+        val bonusUpdatedState = uiState.last { it.totalBonusAmount == 3.0 }
 
         assertEquals(
             AddOnsUIState(
@@ -251,7 +250,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
                 totalBonusAmount = 3.0,
                 totalPledgeAmount = rw.pledgeAmount() + 3.0
             ),
-            finalBonusState
+            bonusUpdatedState
         )
     }
 


### PR DESCRIPTION
# 📲 What

There was an error on some checkouts when selecting add-ons. This was cause previously when this was implemented the Rewards didn't have the AllowedAddOns.
Fixes the issue where users were able to select add-ons that were not allowed for the selected reward, which caused checkout errors later in the pledge flow.

# 🤔 Why

Previously, when a user selected a reward, all available add-ons were loaded, regardless of whether they were permitted for that specific reward. This caused situations where a user could select an invalid reward + add-on combination.

When proceeding to the final pledge step (createCheckout mutation), the backend rejected the request due to the mismatch, resulting in an error that was hard to trace.

# 🛠 How

- Ensured the app only loads and displays allowed add-ons for the selected reward.

- Updated logic to correctly filter allowedAddOns when reward is selected.

- Verified that only valid add-ons are passed downstream into the checkout flow.

- Updated any affected transformer or GraphQL response processing logic to use allowedAddOns instead of allAddOns.

# 👀 See

SS of the different 

|  Old query: FetchProjectRewards 🐛 | New Query 🦋 |
| --- | --- |
| ![Screenshot 2025-04-01 at 2 47 58 p m](https://github.com/user-attachments/assets/14b5615b-5dfa-44c7-a1c7-be16284b7452) | ![Screenshot 2025-04-01 at 1 27 59 p m](https://github.com/user-attachments/assets/dfbdcebb-e775-416f-8578-b96c3838ce1f) |

# 📋 QA

Launch any project with add-ons enabled.

Select a reward with specific allowed add-ons.

Confirm that:

Only the allowed add-ons for that reward are visible.

Complete the pledge and confirm checkout works without errors.


# Story 📖

[MBL-2248 [Pledge] The system does not allow pledging when  adding add-ons](https://kickstarter.atlassian.net/browse/MBL-2248)
