### PR TITLE
MBL-2287: Create UI for tracking number modal in view your pledge screen

### DIFF
--- a/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
+++ b/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
@@ -24,7 +25,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.kickstarter.R
+import com.kickstarter.libs.utils.DateTimeUtils
 import com.kickstarter.libs.utils.extensions.format
+import com.kickstarter.type.DateTime
 import com.kickstarter.ui.compose.TextWithStartIcon
 import com.kickstarter.ui.compose.designsystem.KSButton
 import com.kickstarter.ui.compose.designsystem.KSTheme
@@ -40,7 +43,20 @@ fun RewardTrackingActivityPreview() {
         RewardTrackingActivityFeed(
             trackingNumber = "123291242342",
             modifier = Modifier.background(color = colors.backgroundSurfacePrimary),
-            projectName = "This is a project name"
+            projectName = "This is a project name",
+            publishedAt = "2 days ago"
+        )
+    }
+}
+
+@Composable
+@Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+fun RewardTrackingViewYourPledgePreview() {
+    KSTheme {
+        RewardTrackingViewYourPledge(
+            trackingNumber = "123291242342",
+            modifier = Modifier.background(color = colors.backgroundSurfacePrimary),
         )
     }
 }
@@ -50,7 +66,8 @@ fun RewardTrackingActivityFeed(
     modifier: Modifier = Modifier,
     trackingNumber: String,
     projectPhotoUrl: String? = null,
-    projectName: String
+    projectName: String,
+    publishedAt: String,
 ) {
     Column(
         modifier = modifier.fillMaxWidth()
@@ -69,38 +86,64 @@ fun RewardTrackingActivityFeed(
         Spacer(modifier = Modifier.height(dimensions.paddingMediumSmall))
 
         Text(
-            text = "2 days ago",
+            text = publishedAt,
             style = typographyV2.bodyBoldXXS,
             color = colors.textSecondary
         )
 
         Spacer(modifier = Modifier.height(dimensions.paddingMediumSmall))
 
+        RewardTrackingModal(
+            trackingNumber,
+            RewardTrackingPageType.ACTIVITY_FEED,
+        )
+    }
+}
+
+@Composable
+fun RewardTrackingViewYourPledge(
+    modifier: Modifier = Modifier,
+    trackingNumber: String,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(shape = RoundedCornerShape(dimensions.radiusMediumSmall), color = colors.kds_support_200)
+            .padding(dimensions.paddingMedium)
+    ) {
+
+        RewardTrackingModal(
+            trackingNumber,
+            RewardTrackingPageType.VIEW_YOUR_PLEDGE,
+        )
+    }
+}
+
+@Composable
+fun RewardTrackingModal(
+    trackingNumber: String,
+    pageType: RewardTrackingPageType,
+    onClick: () -> Unit = {},
+) {
+    Column {
         Row {
             TextWithStartIcon(
                 modifier = Modifier,
                 text = stringResource(id = R.string.fpo_your_reward_has_shipped),
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_shipping),
-                style = typographyV2.headingLG,
+                style = when (pageType) {
+                    RewardTrackingPageType.VIEW_YOUR_PLEDGE -> typographyV2.headingMD
+                    RewardTrackingPageType.ACTIVITY_FEED -> typographyV2.headingLG
+                },
                 iconHeight = dimensions.imageSizeMedium,
                 iconPadding = dimensions.paddingXSmall,
                 textColor = colors.textPrimary,
                 iconColor = colors.icon
             )
         }
+
         Spacer(modifier = Modifier.height(dimensions.paddingXSmall))
 
-        TrackingCardFooter(
-            trackingNumber
-        )
-    }
-}
-
-@Composable
-fun TrackingCardFooter(
-    trackingNumber: String
-) {
-    Column {
         Text(
             text = stringResource(R.string.fpo_tracking_number).format(key1 = "tracking_number", value1 = trackingNumber),
             style = typographyV2.bodyMD,
@@ -113,7 +156,7 @@ fun TrackingCardFooter(
             modifier = Modifier,
             backgroundColor = colors.kds_black,
             textColor = colors.kds_white,
-            onClickAction = { },
+            onClickAction = onClick,
             shape = RoundedCornerShape(size = KSTheme.dimensions.radiusExtraSmall),
             text = stringResource(R.string.fpo_track_shipment),
             textStyle = typographyV2.buttonLabel,
@@ -150,4 +193,9 @@ fun ProjectInfoHeader(
             color = colors.textPrimary
         )
     }
+}
+
+enum class RewardTrackingPageType(name : String) {
+    VIEW_YOUR_PLEDGE("view_your_pledge"),
+    ACTIVITY_FEED("activity_feed")
 }

--- a/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
+++ b/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
@@ -15,19 +15,14 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.kickstarter.R
-import com.kickstarter.libs.utils.DateTimeUtils
 import com.kickstarter.libs.utils.extensions.format
-import com.kickstarter.type.DateTime
+import com.kickstarter.models.Photo
+import com.kickstarter.ui.compose.KSAsyncImage
 import com.kickstarter.ui.compose.TextWithStartIcon
 import com.kickstarter.ui.compose.designsystem.KSButton
 import com.kickstarter.ui.compose.designsystem.KSTheme
@@ -44,7 +39,7 @@ fun RewardTrackingActivityPreview() {
             trackingNumber = "123291242342",
             modifier = Modifier.background(color = colors.backgroundSurfacePrimary),
             projectName = "This is a project name",
-            publishedAt = "2 days ago"
+            publishedAt = "2 days ago",
         )
     }
 }
@@ -65,7 +60,7 @@ fun RewardTrackingViewYourPledgePreview() {
 fun RewardTrackingActivityFeed(
     modifier: Modifier = Modifier,
     trackingNumber: String,
-    projectPhotoUrl: String? = null,
+    photo: Photo? = null,
     projectName: String,
     publishedAt: String,
 ) {
@@ -73,7 +68,7 @@ fun RewardTrackingActivityFeed(
         modifier = modifier.fillMaxWidth()
     ) {
         ProjectInfoHeader(
-            projectPhotoUrl = projectPhotoUrl,
+            photo = photo,
             projectName = projectName
         )
 
@@ -167,24 +162,19 @@ fun RewardTrackingModal(
 
 @Composable
 fun ProjectInfoHeader(
-    projectPhotoUrl: String? = null,
+    photo: Photo?,
     projectName: String,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(projectPhotoUrl)
-                .crossfade(true)
-                .build(),
-            contentDescription = "project photo",
+        KSAsyncImage(
+            image = photo,
             modifier = Modifier
                 .height(dimensions.activityFeedProjectImageHeight)
                 .width(dimensions.activityFeedProjectImageWidth),
-            placeholder = ColorPainter(color = colors.backgroundDisabled),
-            contentScale = ContentScale.FillWidth
         )
+
         Spacer(modifier = Modifier.width(dimensions.paddingMediumSmall))
 
         Text(

--- a/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
+++ b/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
@@ -185,7 +185,7 @@ fun ProjectInfoHeader(
     }
 }
 
-enum class RewardTrackingPageType(name : String) {
+enum class RewardTrackingPageType(name: String) {
     VIEW_YOUR_PLEDGE("view_your_pledge"),
     ACTIVITY_FEED("activity_feed")
 }

--- a/app/src/main/java/com/kickstarter/ui/compose/KSImageCompose.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/KSImageCompose.kt
@@ -68,10 +68,12 @@ fun KSRewardAsyncImage(image: Photo) {
 @Composable
 fun KSAsyncImage(modifier: Modifier, image: Photo?) {
     AsyncImage(
-        model = ImageRequest.Builder(LocalContext.current)
-            .data(image?.full())
-            .crossfade(true)
-            .build(),
+        model = image?.let{
+            ImageRequest.Builder(LocalContext.current)
+                .data(image.full())
+                .crossfade(true)
+                .build()
+        },
         contentDescription = image?.altText(),
         modifier = modifier,
         placeholder = ColorPainter(color = colors.backgroundDisabled),

--- a/app/src/main/java/com/kickstarter/ui/compose/KSImageCompose.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/KSImageCompose.kt
@@ -66,13 +66,13 @@ fun KSRewardAsyncImage(image: Photo) {
 }
 
 @Composable
-fun KSAsyncImage(modifier: Modifier, image: Photo) {
+fun KSAsyncImage(modifier: Modifier, image: Photo?) {
     AsyncImage(
         model = ImageRequest.Builder(LocalContext.current)
-            .data(image.full())
+            .data(image?.full())
             .crossfade(true)
             .build(),
-        contentDescription = image.altText(),
+        contentDescription = image?.altText(),
         modifier = modifier,
         placeholder = ColorPainter(color = colors.backgroundDisabled),
         contentScale = ContentScale.Crop

--- a/app/src/main/java/com/kickstarter/ui/compose/KSImageCompose.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/KSImageCompose.kt
@@ -68,7 +68,7 @@ fun KSRewardAsyncImage(image: Photo) {
 @Composable
 fun KSAsyncImage(modifier: Modifier, image: Photo?) {
     AsyncImage(
-        model = image?.let{
+        model = image?.let {
             ImageRequest.Builder(LocalContext.current)
                 .data(image.full())
                 .crossfade(true)


### PR DESCRIPTION
# 📲 What

Created modal in compose for tracking numbers in the view your pledge screen
modified KSAsyncImage to take a null photo

# 🛠 How

Made some edits/cleaned up the reward tracking composables

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Screenshot_20250407_173221](https://github.com/user-attachments/assets/588dc8f5-bed3-476b-95bc-42841733c0f4)  | ![Screenshot_20250407_173058](https://github.com/user-attachments/assets/389e9220-87e0-4368-a92e-572a7d8c1667) |

# 📋 QA

Make sure if you have built something using ksAsyncImage, that it is still working. I checked the similar projects carousel and it was working fine, but please double check if youve used it elsewhere. 

Otherwise, there are no user facing changes

# Story 📖

[MBL-2287: Create UI for tracking number modal in view your pledge screen](https://kickstarter.atlassian.net/browse/MBL-2287)
