### PR TITLE
MBL-2307 [QA] The system does not allow pledging when  adding add-ons

### DIFF
--- a/app/src/main/graphql/rewards.graphql
+++ b/app/src/main/graphql/rewards.graphql
@@ -12,7 +12,7 @@ query GetShippingRulesForRewardId($rewardId: ID!) {
     }
 }
 
-query GetRewardAllowedAddOns($slug: String!, , $rewardImageWidth: Int = 1024) {
+query GetRewardAllowedAddOns($slug: String!, $locationId: ID! , $rewardImageWidth: Int = 1024) {
     project(slug: $slug) {
         rewards {
             nodes {
@@ -20,7 +20,7 @@ query GetRewardAllowedAddOns($slug: String!, , $rewardImageWidth: Int = 1024) {
                 allowedAddons {
                     edges {
                         node {
-                            shippingRulesExpanded {
+                            shippingRulesExpanded(forLocation: $locationId) {
                                 nodes {
                                     ... shippingRule
                                 }

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
@@ -195,7 +195,7 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
         return io.reactivex.Observable.empty()
     }
 
-    override fun getRewardAllowedAddOns(slug: String, rewardId: Long): io.reactivex.Observable<List<Reward>> {
+    override fun getRewardAllowedAddOns(slug: String, locationId: Location, rewardId: Long): io.reactivex.Observable<List<Reward>> {
         return io.reactivex.Observable.empty()
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
@@ -8,7 +8,6 @@ import com.kickstarter.libs.Environment
 import com.kickstarter.libs.utils.RewardUtils
 import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.libs.utils.extensions.pledgeAmountTotalPlusBonus
-import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.models.Backing
 import com.kickstarter.models.Location
@@ -197,7 +196,7 @@ class AddOnsViewModel(val environment: Environment, bundle: Bundle? = null) : Vi
                     .getRewardAllowedAddOns(
                         slug = project.slug() ?: "",
                         rewardId = currentUserReward.id(),
-                        locationId = selectedShippingRule.location() ?: LocationFactory.empty()
+                        locationId = selectedShippingRule.location() ?: Location.builder().build()
                     )
                     .asFlow()
                     .onStart {
@@ -205,7 +204,7 @@ class AddOnsViewModel(val environment: Environment, bundle: Bundle? = null) : Vi
                     }
                     .map { addOns ->
                         if (!addOns.isNullOrEmpty()) {
-                            this@AddOnsViewModel.addOns = getUpdatedList(addOns, backedAddOns, selectedShippingRule.location() ?: LocationFactory.empty())
+                            this@AddOnsViewModel.addOns = getUpdatedList(addOns, backedAddOns, selectedShippingRule.location() ?: Location.builder().build())
                         }
                     }.onCompletion {
                         emitCurrentState(isLoading = false)

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
@@ -230,7 +230,7 @@ class AddOnsViewModel(val environment: Environment, bundle: Bundle? = null) : Vi
 
         val filteredAddOns = addOns.filter { reward ->
             when (reward.shippingPreference()) {
-                "unrestricted", "none" -> true
+                "unrestricted", "none", "local" -> true
                 else -> reward.shippingRules()!!.any { it.location()?.id() == locationId }
             }
         }

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
@@ -124,6 +124,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val apolloClient = object : MockApolloClientV2() {
             override fun getRewardAllowedAddOns(
                 slug: String,
+                locationId: Location,
                 rewardId: Long
             ): Observable<List<Reward>> {
                 assertEquals(99L, rewardId)
@@ -191,6 +192,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val apolloClient = object : MockApolloClientV2() {
             override fun getRewardAllowedAddOns(
                 slug: String,
+                locationId: Location,
                 rewardId: Long
             ): Observable<List<Reward>> {
                 assertEquals(99L, rewardId)
@@ -263,7 +265,8 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val apolloClient = object : MockApolloClientV2() {
             override fun getRewardAllowedAddOns(
                 slug: String,
-                rewardId: Long
+                locationId: Location,
+                rewardId: Long,
             ): Observable<List<Reward>> {
                 assertEquals(99L, rewardId)
                 return Observable.just(listOf(aDifferentAddOnReward))
@@ -341,6 +344,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val apolloClient = object : MockApolloClientV2() {
             override fun getRewardAllowedAddOns(
                 slug: String,
+                locationId: Location,
                 rewardId: Long
             ): Observable<List<Reward>> {
                 assertEquals(99L, rewardId)


### PR DESCRIPTION
# 📲 What

This PR updates the logic used to fetch and display add-ons during the pledge flow, ensuring only valid shipping options are presented based on the selected reward and shipping rule.

# 🤔 Why

Previously, when a user selected a "Reward shipping everywhere" reward, in some cases, the system incorrectly included restricted shipping add-ons in the available options. This behavior did not match the web or iOS platforms and led to users selecting incompatible add-ons, resulting in a checkout error ("Sorry, something went wrong").
# 🛠 How

Updated getRewardAllowedAddOns() to include shipping location (Location) in the GraphQL query.

Modified getAddOnsFromAllowedAddOns() to extract and retain relevant shipping rule data per add-on.

Refactored getUpdatedList() to:

Filter add-ons that do not include the currently selected shipping location in their shipping rules.

Ensure that backed add-ons retain their quantity if still eligible.
# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| [error_shipping_addons.webm](https://github.com/user-attachments/assets/78a94a4f-50bb-4881-be56-a75aa0a2eef6) | [fix_shipping_addons.webm](https://github.com/user-attachments/assets/19930d8e-76c7-4c3b-9047-bfb93d01f4d4) |

# 📋 QA

Check [This project ](https://staging.kickstarter.com/projects/1768690592/purple-watch-3-d?ref=nav_search&result=project&term=purple%20watch&total_hits=5)

Before when you selected Reward shipping everywhere it returns 3 add-ons:
1-Digital reward
2-reward shipping everywhere
3-restricted rewards shipping 

The third option doesn't appear on Web or iOS and when we selected it it end up causing an error on checkout because it wasn't suppose to be there.

Now it should only show:
1-Digital reward
2-reward shipping everywhere

# Story 📖 
[MBL-2307 [QA] The system does not allow pledging when  adding add-ons](https://kickstarter.atlassian.net/browse/MBL-2307)
