### PR TITLE
MBL-2292 Open a Backing Details webview for users who have gone through PM: Project Page

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -156,6 +156,7 @@ fragment backing on Backing {
     cancelable
     pledgedOn
     backerCompleted
+    backingDetailsPageRoute(type: url, tab: details)
     isPostCampaign
     incremental
     project {

--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -156,7 +156,7 @@ fragment backing on Backing {
     cancelable
     pledgedOn
     backerCompleted
-    backingDetailsPageRoute(type: url, tab: details)
+    backingDetailsPageRoute(type: url, tab: survey_responses)
     isPostCampaign
     incremental
     project {

--- a/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.mock.factories
 
 import com.kickstarter.models.Backing
+import com.kickstarter.models.Order
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.Urls
@@ -133,6 +134,37 @@ object ProjectFactory {
             .isBacking(true)
             .build()
     }
+
+    @JvmStatic
+    fun backedProjectWithPMCheckoutOrder(): Project {
+        val project = project()
+        val reward = RewardFactory.reward()
+        val order = Order.builder().checkoutState(Order.CheckoutStateEnum.COMPLETE).build()
+        val backing = Backing.builder()
+            .amount(10.0)
+            .backerId(IdFactory.id().toLong())
+            .backingDetailsPageRoute("https://ksr.com/backing/details")
+            .cancelable(true)
+            .id(IdFactory.id().toLong())
+            .sequence(1)
+            .order(order)
+            .reward(reward)
+            .rewardId(reward.id())
+            .paymentSource(PaymentSourceFactory.visa())
+            .pledgedAt(DateTime.now())
+            .projectId(project.id())
+            .shippingAmount(0.0f)
+            .status(Backing.STATUS_PLEDGED)
+            .build()
+        return project
+            .toBuilder()
+            .availableCardTypes(listOf(PaymentSourceFactory.visa().type() ?: CreditCardPaymentType.CREDIT_CARD.rawValue))
+            .canComment(true)
+            .backing(backing)
+            .isBacking(true)
+            .build()
+    }
+
     @JvmStatic
     fun backedProjectWithPlotSelected(): Project {
         val project = project().toBuilder().isPledgeOverTimeAllowed(true).build()

--- a/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/ProjectFactory.kt
@@ -143,7 +143,7 @@ object ProjectFactory {
         val backing = Backing.builder()
             .amount(10.0)
             .backerId(IdFactory.id().toLong())
-            .backingDetailsPageRoute("https://ksr.com/backing/details")
+            .backingDetailsPageRoute("https://ksr.com/backing/survey_responses")
             .cancelable(true)
             .id(IdFactory.id().toLong())
             .sequence(1)

--- a/app/src/main/java/com/kickstarter/models/Backing.kt
+++ b/app/src/main/java/com/kickstarter/models/Backing.kt
@@ -15,6 +15,7 @@ class Backing private constructor(
     private val backerName: String?,
     private val backerUrl: String?,
     private val backerCompletedAt: DateTime?,
+    private val backingDetailsPageRoute: String?,
     private val cancelable: Boolean,
     private val completedAt: DateTime?,
     private val completedByBacker: Boolean,
@@ -46,6 +47,7 @@ class Backing private constructor(
     fun backerName() = this.backerName
     fun backerUrl() = this.backerUrl
     fun backerCompletedAt() = this.backerCompletedAt
+    fun backingDetailsPageRoute() = this.backingDetailsPageRoute
     fun cancelable() = this.cancelable
     fun completedAt() = this.completedAt
     fun completedByBacker() = this.completedByBacker
@@ -79,6 +81,7 @@ class Backing private constructor(
         private var backerName: String? = null,
         private var backerUrl: String? = null,
         private var backerCompletedAt: DateTime? = null,
+        private var backingDetailsPageRoute: String? = null,
         private var cancelable: Boolean = false,
         private var completedAt: DateTime? = null,
         private var completedByBacker: Boolean = false,
@@ -110,6 +113,7 @@ class Backing private constructor(
         fun backerUrl(backerUrl: String?) = apply { this.backerUrl = backerUrl }
         fun backerId(backerId: Long?) = apply { this.backerId = backerId ?: 0L }
         fun backerCompletedAt(backerCompletedAt: DateTime?) = apply { this.backerCompletedAt = backerCompletedAt }
+        fun backingDetailsPageRoute(backingDetailsPageRoute: String?) = apply { this.backingDetailsPageRoute = backingDetailsPageRoute }
         fun cancelable(cancelable: Boolean?) = apply { this.cancelable = cancelable ?: false }
         fun completedAt(completedAt: DateTime?) = apply { this.completedAt = completedAt }
         fun completedByBacker(completedByBacker: Boolean?) = apply { this.completedByBacker = completedByBacker ?: false }
@@ -140,6 +144,7 @@ class Backing private constructor(
             backerUrl = backerUrl,
             backerId = backerId,
             backerCompletedAt = backerCompletedAt,
+            backingDetailsPageRoute = backingDetailsPageRoute,
             cancelable = cancelable,
             completedAt = completedAt,
             completedByBacker = completedByBacker,
@@ -173,6 +178,7 @@ class Backing private constructor(
         backerUrl = backerUrl,
         backerId = backerId,
         backerCompletedAt = backerCompletedAt,
+        backingDetailsPageRoute =  backingDetailsPageRoute,
         cancelable = cancelable,
         completedAt = completedAt,
         completedByBacker = completedByBacker,
@@ -209,6 +215,7 @@ class Backing private constructor(
                 backerUrl() == other.backerUrl() &&
                 backerId() == other.backerId() &&
                 backerCompletedAt() == other.backerCompletedAt() &&
+                backingDetailsPageRoute() == other.backingDetailsPageRoute() &&
                 cancelable() == other.cancelable() &&
                 completedAt() == other.completedAt() &&
                 completedByBacker() == other.completedByBacker() &&

--- a/app/src/main/java/com/kickstarter/models/Backing.kt
+++ b/app/src/main/java/com/kickstarter/models/Backing.kt
@@ -178,7 +178,7 @@ class Backing private constructor(
         backerUrl = backerUrl,
         backerId = backerId,
         backerCompletedAt = backerCompletedAt,
-        backingDetailsPageRoute =  backingDetailsPageRoute,
+        backingDetailsPageRoute = backingDetailsPageRoute,
         cancelable = cancelable,
         completedAt = completedAt,
         completedByBacker = completedByBacker,

--- a/app/src/main/java/com/kickstarter/models/Order.kt
+++ b/app/src/main/java/com/kickstarter/models/Order.kt
@@ -28,7 +28,7 @@ class Order private constructor(
         private var currency: CurrencyCode = CurrencyCode.UNKNOWN__,
         private var total: Int? = null
     ) : Parcelable {
-        fun id(id: String?) = apply { this.id = id ?: "" }
+        fun id(id: String) = apply { this.id = id }
         fun checkoutState(checkoutState: CheckoutStateEnum) = apply { this.checkoutState = checkoutState }
         fun currency(currency: CurrencyCode?) = apply { this.currency = currency ?: CurrencyCode.UNKNOWN__ }
         fun total(total: Int?) = apply { this.total = total }

--- a/app/src/main/java/com/kickstarter/models/Order.kt
+++ b/app/src/main/java/com/kickstarter/models/Order.kt
@@ -17,6 +17,7 @@ class Order private constructor(
 ) : Parcelable {
 
     fun id() = this.id
+    fun checkoutState() = this.checkoutState
     fun currency() = this.currency
     fun total() = this.total
 

--- a/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
@@ -838,6 +838,7 @@ fun backingTransformer(backingGr: com.kickstarter.fragment.Backing?): Backing {
         .backerUrl(backerData?.imageUrl)
         .backerName(nameBacker)
         .backer(backer)
+        .backingDetailsPageRoute(backingGr?.backingDetailsPageRoute)
         .id(id)
         .incremental(incremental)
         .reward(reward)

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -47,6 +47,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.R
 import com.kickstarter.databinding.ActivityProjectPageBinding
+import com.kickstarter.features.pledgedprojectsoverview.ui.BackingDetailsActivity
 import com.kickstarter.libs.ActivityRequestCodes
 import com.kickstarter.libs.Either
 import com.kickstarter.libs.Environment
@@ -454,6 +455,11 @@ class ProjectPageActivity :
         this.viewModel.outputs.startThanksActivity()
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { showCreatePledgeSuccess(it) }
+            .addToDisposable(disposables)
+
+        this.viewModel.outputs.openBackingDetailsWebview()
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe { openBackingDetailsWebView(it) }
             .addToDisposable(disposables)
 
         this.viewModel.outputs.projectMedia()
@@ -1235,6 +1241,12 @@ class ProjectPageActivity :
                 .putExtra(IntentKey.PROJECT, project.reduceProjectPayload())
                 .putExtra(IntentKey.BACKING, project.backing())
         )
+    }
+
+    private fun openBackingDetailsWebView(url: String) {
+        val intent = Intent(this, BackingDetailsActivity::class.java)
+            .putExtra(IntentKey.URL, url)
+        startActivity(intent)
     }
 
     private fun styleProjectActionButton(detailsAreVisible: Boolean) {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
@@ -774,7 +774,8 @@ interface ProjectPageViewModel {
                     val order = project.backing()?.order()
                     val completedPM = order != null && order.checkoutState() == Order.CheckoutStateEnum.COMPLETE
                     if (completedPM) {
-                        // Open webview url = "${environment.webEndpoint()}/projects/${project.slug()}/backing/detail"
+                        // Open webview to backing/survey_responses endpoint instead of backing/details
+                        // endpoint to avoid prompting user to re-login
                         project.backing()?.backingDetailsPageRoute()?.let {
                             openBackingDetailsWebview.onNext(it)
                         }

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
@@ -47,6 +47,7 @@ import com.kickstarter.libs.utils.extensions.showLatePledgeFlow
 import com.kickstarter.libs.utils.extensions.updateProjectWith
 import com.kickstarter.libs.utils.extensions.userIsCreator
 import com.kickstarter.models.Backing
+import com.kickstarter.models.Order
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.User
@@ -244,6 +245,9 @@ interface ProjectPageViewModel {
         /** Emits when we the pledge was successful and should start the [com.kickstarter.ui.activities.ThanksActivity]. */
         fun startThanksActivity(): Observable<Pair<CheckoutData, PledgeData>>
 
+        /** Emits when user clicks View Pledge button and should start the [com.kickstarter.features.pledgedprojectsoverview.ui.BackingDetailsActivity.kt]. */
+        fun openBackingDetailsWebview(): Observable<String>
+
         /** Emits when we should update the [com.kickstarter.ui.fragments.BackingFragment] and [com.kickstarter.ui.fragments.RewardsFragment].  */
         fun updateFragments(): Observable<ProjectData>
 
@@ -349,6 +353,7 @@ interface ProjectPageViewModel {
         private val startProjectUpdateToRepliesDeepLinkActivity =
             PublishSubject.create<Pair<Pair<String, String>, Pair<Project, ProjectData>>>()
         private val startThanksActivity = PublishSubject.create<Pair<CheckoutData, PledgeData>>()
+        private val openBackingDetailsWebview = PublishSubject.create<String>()
         private val updateFragments = BehaviorSubject.create<ProjectData>()
         private val hideVideoPlayer = BehaviorSubject.create<Boolean>()
         private val tabSelected = PublishSubject.create<Int>()
@@ -764,8 +769,19 @@ interface ProjectPageViewModel {
                 .addToDisposable(disposables)
 
             this.nativeProjectActionButtonClicked
-                .map { Pair(true, true) }
-                .subscribe { this.expandPledgeSheet.onNext(it) }
+                .withLatestFrom(currentProject) { _, project -> project }
+                .subscribe { project ->
+                    val order = project.backing()?.order()
+                    val completedPM = order != null && order.checkoutState() == Order.CheckoutStateEnum.COMPLETE
+                    if (completedPM) {
+                        // Open webview
+                        val url = "${environment.webEndpoint()}/projects/${project.slug()}/backing/details"
+                        openBackingDetailsWebview.onNext(url)
+                    } else {
+                        // Open native view pledge screen
+                        this.expandPledgeSheet.onNext(Pair(true, true))
+                    }
+                }
                 .addToDisposable(disposables)
 
             val fragmentStackCount = this.fragmentStackCount.startWith(0)
@@ -1392,6 +1408,9 @@ interface ProjectPageViewModel {
 
         override fun startProjectUpdateToRepliesDeepLinkActivity(): Observable<Pair<Pair<String, String>, Pair<Project, ProjectData>>> =
             this.startProjectUpdateToRepliesDeepLinkActivity
+
+        override fun openBackingDetailsWebview(): Observable<String> =
+            this.openBackingDetailsWebview
 
         override fun onOpenVideoInFullScreen(): Observable<kotlin.Pair<String, Long>> =
             this.onOpenVideoInFullScreen

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
@@ -774,9 +774,10 @@ interface ProjectPageViewModel {
                     val order = project.backing()?.order()
                     val completedPM = order != null && order.checkoutState() == Order.CheckoutStateEnum.COMPLETE
                     if (completedPM) {
-                        // Open webview
-                        val url = "${environment.webEndpoint()}/projects/${project.slug()}/backing/details"
-                        openBackingDetailsWebview.onNext(url)
+                        // Open webview url = "${environment.webEndpoint()}/projects/${project.slug()}/backing/detail"
+                        project.backing()?.backingDetailsPageRoute()?.let {
+                            openBackingDetailsWebview.onNext(it)
+                        }
                     } else {
                         // Open native view pledge screen
                         this.expandPledgeSheet.onNext(Pair(true, true))

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
@@ -2070,7 +2070,7 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
 
         this.vm.inputs.nativeProjectActionButtonClicked()
 
-        val url = "https://ksr.com/backing/details"
+        val url = "https://ksr.com/backing/survey_responses"
         this.openBackingDetailsWebview.assertValue(url)
     }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ProjectPageViewModelTest.kt
@@ -91,6 +91,7 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
     private val startLoginToutActivity = TestSubscriber<Unit>()
     private val startMessagesActivity = TestSubscriber<Project>()
     private val startThanksActivity = TestSubscriber<Pair<CheckoutData, PledgeData>>()
+    private val openBackingDetailsWebview = TestSubscriber<String>()
     private val updateFragments = TestSubscriber<ProjectData>()
     private val projectMedia = BehaviorSubject.create<MediaElement>()
     private val playButtonIsVisible = TestSubscriber<Boolean>()
@@ -143,6 +144,7 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
         this.vm.outputs.startProjectUpdateActivity().subscribe { this.startProjectUpdateActivity.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.startMessagesActivity().subscribe { this.startMessagesActivity.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.startThanksActivity().subscribe { this.startThanksActivity.onNext(it) }.addToDisposable(disposables)
+        this.vm.outputs.openBackingDetailsWebview().subscribe { this.openBackingDetailsWebview.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.updateFragments().subscribe { this.updateFragments.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.startRootCommentsForCommentsThreadActivity().subscribe { this.startRootCommentsForCommentsThreadActivity.onNext(it) }.addToDisposable(disposables)
         this.vm.outputs.startProjectUpdateToRepliesDeepLinkActivity().subscribe { this.startProjectUpdateToRepliesDeepLinkActivity.onNext(it) }.addToDisposable(disposables)
@@ -2056,6 +2058,20 @@ class ProjectPageViewModelTest : KSRobolectricTestCase() {
         this.expandPledgeSheet.assertValue(Pair(false, false))
         this.startThanksActivity.assertValue(Pair(checkoutData, pledgeData))
         this.projectData.assertValueCount(2)
+    }
+
+    @Test
+    fun testOpenBackingDetailsWebview() { // The testExpandPledgeSheet_ suite of tests covers projects that do not have PM checkout
+        setUpEnvironment(environment().toBuilder().apolloClientV2(apolloClientSuccessfulGetProject()).build())
+
+        // Start the view model with a backed project with PM checkout order
+        val backedProject = ProjectFactory.backedProjectWithPMCheckoutOrder()
+        this.vm.configureWith(Intent().putExtra(IntentKey.PROJECT, backedProject))
+
+        this.vm.inputs.nativeProjectActionButtonClicked()
+
+        val url = "https://ksr.com/backing/details"
+        this.openBackingDetailsWebview.assertValue(url)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

For a net new backer or a PM backer that has completed PM checkout, when they click on View Your Pledge button on a project that is in PM stage, they will be directed to Backing Details webview instead of our native backing fragment. 

Any other user will be directed to our native backing fragment.

# 🤔 Why

Our native backing fragment isn't ready to support the various complex PM transactions that could occur.

# 🛠 How

https://kickstarter.atlassian.net/wiki/spaces/NT/pages/3618504789/PM+Crunch+-+Net+new+backers+spike

# 👀 See

https://github.com/user-attachments/assets/93094792-a025-4d48-a65e-778b17887131

# 📋 QA

See https://kickstarter.atlassian.net/browse/MBL-2313 for accounts you can log into for QA

# Story 📖

https://kickstarter.atlassian.net/browse/MBL-2292
