### PR TITLE
MBL-2225 && MBL-2223: Navigation between Main Filter menu screen (includes project state filter), and the Category Selection screen

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/CategorySelectionSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/CategorySelectionSheet.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -21,6 +19,7 @@ import androidx.compose.material.RadioButtonDefaults
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -63,6 +62,7 @@ fun CategorySelectionSheet(
     onDismiss: () -> Unit,
     onApply: (Category) -> Unit,
     isLoading: Boolean,
+    onNavigate: () -> Unit = {},
 ) {
     val backgroundDisabledColor = colors.backgroundDisabled
     val dimensions: KSDimensions = KSTheme.dimensions
@@ -71,10 +71,6 @@ fun CategorySelectionSheet(
 
     KSTheme {
         Surface(
-            modifier = Modifier
-                .fillMaxWidth()
-                .navigationBarsPadding()
-                .heightIn(min = 200.dp, max = 770.dp),
             color = colors.backgroundSurfacePrimary
         ) {
             Column(modifier = Modifier.fillMaxWidth()) {
@@ -89,13 +85,25 @@ fun CategorySelectionSheet(
                                 strokeWidth = dimensions.dividerThickness.toPx()
                             )
                         }
-                        .padding(start = dimensions.paddingLarge, top = dimensions.paddingLarge, bottom = dimensions.paddingLarge, end = dimensions.paddingMediumSmall),
+                        .padding(top = dimensions.paddingLarge, bottom = dimensions.paddingLarge, end = dimensions.paddingMediumSmall),
 
                     verticalAlignment = Alignment.CenterVertically
                 ) {
+                    IconButton(
+                        onClick = onNavigate,
+                        modifier = Modifier
+                            .padding(start = dimensions.paddingSmall)
+                            .testTag(SearchScreenTestTag.BACK_BUTTON.name)
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(id = R.string.Back),
+                            tint = colors.kds_black
+                        )
+                    }
                     Text(
                         text = stringResource(R.string.Category),
-                        style = KSTheme.typographyV2.headingXL,
+                        style = typographyV2.headingXL,
                         modifier = Modifier.weight(1f),
                         color = colors.textPrimary
                     )

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/CategorySelectionSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/CategorySelectionSheet.kt
@@ -48,7 +48,7 @@ private fun CategorySelectionSheetPreview() {
     KSTheme {
         CategorySelectionSheet(
             categories = CategoryFactory.rootCategories(),
-            onApply = {},
+            onApply = { a, b -> },
             onDismiss = {},
             isLoading = false
         )
@@ -60,7 +60,7 @@ fun CategorySelectionSheet(
     currentCategory: Category? = null,
     categories: List<Category>,
     onDismiss: () -> Unit,
-    onApply: (Category) -> Unit,
+    onApply: (Category?, Boolean?) -> Unit,
     isLoading: Boolean,
     onNavigate: () -> Unit = {},
 ) {
@@ -123,7 +123,7 @@ fun CategorySelectionSheet(
                         contentAlignment = Alignment.Center
                     ) {
                         CircularProgressIndicator(
-                            color = KSTheme.colors.textPrimary,
+                            color = colors.textPrimary,
                             modifier = Modifier.size(48.dp)
                         )
                     }
@@ -138,6 +138,8 @@ fun CategorySelectionSheet(
                                         selectedCategory.value =
                                             categories.find { it.name() == category.name() }!!
                                     }
+
+                                    onApply(selectedCategory.value, null)
                                 }
                             )
                         }
@@ -148,10 +150,11 @@ fun CategorySelectionSheet(
                 KSSearchBottomSheetFooter(
                     isLoading = isLoading,
                     resetOnclickAction = {
-                        selectedCategory.value = Category.builder().name(resetCategoryName).build()
+                        selectedCategory.value = null
+                        onApply(selectedCategory.value, false)
                     },
                     onApply = {
-                        selectedCategory.value?.let { onApply(it) }
+                        selectedCategory.value?.let { onApply(it, true) }
                     }
                 )
             }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -72,8 +71,6 @@ fun FilterMenuBottomSheet(
 
     Surface(
         modifier = Modifier
-            .fillMaxWidth()
-            .navigationBarsPadding()
             .testTag(FilterMenuTestTags.SHEET),
         color = colors.backgroundSurfacePrimary
     ) {
@@ -86,7 +83,7 @@ fun FilterMenuBottomSheet(
                 modifier = Modifier.testTag(FilterMenuTestTags.DISMISS_ROW)
             )
 
-            LazyColumn {
+            LazyColumn(modifier = Modifier.weight(1f)) {
                 items(availableFilters) { filter ->
                     when (filter) {
                         FilterType.CATEGORIES -> FilterRow(
@@ -95,7 +92,6 @@ fun FilterMenuBottomSheet(
                             icon = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                             modifier = Modifier.testTag(FilterMenuTestTags.CATEGORY_ROW)
                         )
-
                         FilterType.PROJECT_STATUS -> ProjectStatusRow(
                             text = titleForFilter(filter),
                             callback = { status -> projStatus.value = status },

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
@@ -64,7 +64,7 @@ fun FilterMenuBottomSheet(
     selectedProjectStatus: DiscoveryParams.State? = null,
     availableFilters: List<FilterType> = FilterType.values().asList(),
     onDismiss: () -> Unit = {},
-    onApply: (DiscoveryParams.State?) -> Unit = {},
+    onApply: (DiscoveryParams.State?, Boolean?) -> Unit = { a, b -> },
     onNavigate: () -> Unit = {}
 ) {
     val projStatus = remember { mutableStateOf(selectedProjectStatus) }
@@ -94,7 +94,10 @@ fun FilterMenuBottomSheet(
                         )
                         FilterType.PROJECT_STATUS -> ProjectStatusRow(
                             text = titleForFilter(filter),
-                            callback = { status -> projStatus.value = status },
+                            callback = { status ->
+                                projStatus.value = status
+                                onApply(projStatus.value, null)
+                            },
                             selectedStatus = projStatus,
                             modifier = Modifier.testTag(FilterMenuTestTags.PROJECT_STATUS_ROW)
                         )
@@ -106,10 +109,10 @@ fun FilterMenuBottomSheet(
                 modifier = Modifier.testTag(FilterMenuTestTags.FOOTER),
                 resetOnclickAction = {
                     projStatus.value = null
-                    onApply(projStatus.value)
+                    onApply(projStatus.value, false)
                 },
                 onApply = {
-                    onApply(projStatus.value)
+                    onApply(projStatus.value, true)
                 }
             )
         }
@@ -286,7 +289,7 @@ private fun FilterMenuSheetPreview() {
     KSTheme {
         FilterMenuBottomSheet(
             selectedProjectStatus = DiscoveryParams.State.LIVE,
-            onApply = {},
+            onApply = { a, b -> },
             onDismiss = {}
         )
     }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
@@ -65,7 +65,8 @@ fun FilterMenuBottomSheet(
     selectedProjectStatus: DiscoveryParams.State? = null,
     availableFilters: List<FilterType> = FilterType.values().asList(),
     onDismiss: () -> Unit = {},
-    onApply: (DiscoveryParams.State?) -> Unit = {}
+    onApply: (DiscoveryParams.State?) -> Unit = {},
+    onNavigate: () -> Unit = {}
 ) {
     val projStatus = remember { mutableStateOf(selectedProjectStatus) }
 
@@ -90,7 +91,7 @@ fun FilterMenuBottomSheet(
                     when (filter) {
                         FilterType.CATEGORIES -> FilterRow(
                             text = titleForFilter(filter),
-                            callback = onDismiss,
+                            callback = onNavigate,
                             icon = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                             modifier = Modifier.testTag(FilterMenuTestTags.CATEGORY_ROW)
                         )

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
@@ -78,7 +78,7 @@ fun FilterMenuBottomSheet(
             modifier = Modifier.background(color = colors.backgroundSurfacePrimary)
         ) {
             FilterRow(
-                callback = onDismiss,
+                onClickAction = onDismiss,
                 icon = Icons.Filled.Close,
                 modifier = Modifier.testTag(FilterMenuTestTags.DISMISS_ROW)
             )
@@ -88,7 +88,7 @@ fun FilterMenuBottomSheet(
                     when (filter) {
                         FilterType.CATEGORIES -> FilterRow(
                             text = titleForFilter(filter),
-                            callback = onNavigate,
+                            onClickAction = onNavigate,
                             icon = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                             modifier = Modifier.testTag(FilterMenuTestTags.CATEGORY_ROW)
                         )
@@ -214,7 +214,7 @@ private fun ProjectStatusRow(
 private fun FilterRow(
     modifier: Modifier = Modifier,
     text: String = stringResource(R.string.Filter_fpo),
-    callback: () -> Unit,
+    onClickAction: () -> Unit,
     icon: ImageVector
 ) {
     val backgroundDisabledColor = colors.backgroundDisabled
@@ -251,7 +251,10 @@ private fun FilterRow(
             color = colors.textPrimary
         )
         IconButton(
-            onClick = { callback.invoke() }
+            modifier = Modifier.testTag(text),
+            onClick = {
+                onClickAction.invoke()
+            }
         ) {
             Icon(
                 imageVector = icon,

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
@@ -491,6 +491,7 @@ fun FilterAndCategoryPagerSheet(
                 onApply = { selectedProjectState, applyAndDismiss ->
                     projectState.value = selectedProjectState
                     if (applyAndDismiss != null) {
+                        // - Reset to default values
                         if (applyAndDismiss.isFalse()) {
                             category.value = null
                         }
@@ -518,6 +519,7 @@ fun FilterAndCategoryPagerSheet(
                 onApply = { selectedCategory, applyAndDismiss ->
                     category.value = selectedCategory
                     if (applyAndDismiss != null) {
+                        // - Reset to default values
                         if (applyAndDismiss.isFalse()) {
                             projectState.value = null
                         }
@@ -537,6 +539,13 @@ fun FilterAndCategoryPagerSheet(
     }
 }
 
+/**
+ * Applies user selection.
+ * @param shouldDismiss the context for this value refers to which button in the footer the user has pressed,
+ * it applies to both FilterMenu screen and CategorySelection screen
+ *  shouldDismiss = false -> user has pressed "Reset" button on the footer. (Not dismiss bottomSheet).
+ *  shouldDismiss = true -> user has pressed "See results" button on the footer. (Should dismiss bottomSheet).
+ */
 private fun applyUserSelection(
     onApply: (DiscoveryParams.State?, Category?) -> Unit,
     projectState: DiscoveryParams.State?,

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
@@ -219,7 +219,7 @@ fun SearchScreen(
 
     val mainFilterMenuState = rememberModalBottomSheetState(
         initialValue = Hidden,
-        skipHalfExpanded = false
+        skipHalfExpanded = true
     )
 
     ModalBottomSheetLayout(

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
@@ -62,6 +62,7 @@ import com.kickstarter.libs.utils.extensions.isFalse
 import com.kickstarter.libs.utils.extensions.isLatePledgesActive
 import com.kickstarter.libs.utils.extensions.isTrue
 import com.kickstarter.libs.utils.extensions.toDiscoveryParamsList
+import com.kickstarter.mock.factories.CategoryFactory
 import com.kickstarter.models.Category
 import com.kickstarter.models.Photo
 import com.kickstarter.models.Project
@@ -82,6 +83,44 @@ import com.kickstarter.ui.views.compose.search.SearchEmptyView
 import com.kickstarter.ui.views.compose.search.SearchTopBar
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+@Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+fun PagerPreview() {
+    KSTheme {
+        val testPagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
+        val testSheetState = rememberModalBottomSheetState(
+            initialValue = Hidden,
+            skipHalfExpanded = true
+        )
+
+        val categories = CategoryFactory.rootCategories()
+        val selectedStatus = DiscoveryParams.State.LIVE
+
+        val appliedFilters = mutableListOf<Pair<DiscoveryParams.State?, Category?>>()
+        val dismissed = mutableListOf<Boolean>()
+        val selectedCounts = mutableListOf<Pair<Int?, Int?>>()
+
+        Box(modifier = Modifier.size(400.dp)) {
+            FilterAndCategoryPagerSheet(
+                selectedProjectStatus = selectedStatus,
+                currentCategory = categories[0],
+                categories = categories,
+                onDismiss = { dismissed.add(true) },
+                onApply = { state, category -> appliedFilters.add(Pair(state, category)) },
+                updateSelectedCounts = { statusCount, categoryCount ->
+                    selectedCounts.add(
+                        statusCount to categoryCount
+                    )
+                },
+                pagerState = testPagerState,
+                sheetState = testSheetState
+            )
+        }
+    }
+}
 
 @Composable
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
@@ -439,7 +478,7 @@ fun FilterAndCategoryPagerSheet(
         modifier = Modifier
             .fillMaxWidth()
             .navigationBarsPadding()
-            .heightIn(min = 200.dp, max = 770.dp),
+            .heightIn(min = dimensions.bottomSheetMinHeight, max = dimensions.bottomSheetMaxHeight),
         state = pagerState,
 
     ) { page ->

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSDimensions.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSDimensions.kt
@@ -74,6 +74,8 @@ data class KSDimensions(
     val searchBottomSheetFooter: Dp = Dp.Unspecified,
     val activityFeedProjectImageWidth: Dp = Dp.Unspecified,
     val activityFeedProjectImageHeight: Dp = Dp.Unspecified,
+    val bottomSheetMinHeight: Dp = Dp.Unspecified,
+    val bottomSheetMaxHeight: Dp = Dp.Unspecified
 )
 
 val LocalKSCustomDimensions = staticCompositionLocalOf {
@@ -146,5 +148,7 @@ val KSStandardDimensions = KSDimensions(
     projectCardImageAspectRatio = 16f / 9f,
     searchBottomSheetFooter = 88.dp,
     activityFeedProjectImageWidth = 96.dp,
-    activityFeedProjectImageHeight = 54.dp
+    activityFeedProjectImageHeight = 54.dp,
+    bottomSheetMinHeight = 200.dp,
+    bottomSheetMaxHeight = 770.dp
 )

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/CategorySelectionSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/CategorySelectionSheetTest.kt
@@ -21,7 +21,9 @@ class CategorySelectionSheetTest : KSRobolectricTestCase() {
                 CategorySelectionSheet(
                     categories = listOf(),
                     onDismiss = { dismissClickCount++ },
-                    onApply = { applyClickCount++ },
+                    onApply = { selected, from ->
+                        applyClickCount++
+                    },
                     isLoading = false
                 )
             }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheetTest.kt
@@ -49,13 +49,15 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 FilterMenuBottomSheet(
-                    onApply = { publicState: DiscoveryParams.State? ->
+                    onApply = { publicState: DiscoveryParams.State?, from: Boolean? ->
                         counter++
                         if (counter == 1)
                             assertEquals(publicState, DiscoveryParams.State.LIVE)
 
                         if (counter == 2)
                             assertEquals(publicState, null)
+
+                        assertNull(from)
                     }
                 )
             }
@@ -63,23 +65,20 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
 
         val livePill = composeTestRule.onNodeWithTag(FilterMenuTestTags.pillTag(DiscoveryParams.State.LIVE))
         livePill.performClick() // Select
-        composeTestRule
-            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name) // apply
-            .performClick()
 
         livePill.performClick() // Unselect (toggle off)
-        composeTestRule
-            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name) // apply
-            .performClick()
     }
 
     @Test
     fun filterMenu_onApplyCallbackReceivesSelection() {
         var selected: DiscoveryParams.State? = null
-
+        var contextFrom: Boolean? = null
         composeTestRule.setContent {
             KSTheme {
-                FilterMenuBottomSheet(onApply = { selected = it })
+                FilterMenuBottomSheet(onApply = { state, from ->
+                    selected = state
+                    contextFrom = from
+                })
             }
         }
 
@@ -92,17 +91,22 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
             .performClick()
 
         assertEquals(DiscoveryParams.State.LIVE, selected)
+        assertEquals(contextFrom, true)
     }
 
     @Test
     fun filterMenu_resetClearsSelection() {
         var selected: DiscoveryParams.State? = DiscoveryParams.State.LIVE
+        var contextFrom: Boolean? = null
 
         composeTestRule.setContent {
             KSTheme {
                 FilterMenuBottomSheet(
                     selectedProjectStatus = selected,
-                    onApply = { selected = it }
+                    onApply = { state, from ->
+                        selected = state
+                        contextFrom = from
+                    }
                 )
             }
         }
@@ -112,5 +116,6 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
             .performClick()
 
         assertNull(selected)
+        assertEquals(contextFrom, false)
     }
 }


### PR DESCRIPTION
# 📲 What

- Now the user can navigate between menu options within the same bottomSheet, 
- pressing the filter pillButton, can navigate to the categories screen.
- pressing the categories pillButton,  can navigate back to the main filter menu screen.
- pressing the project status pillButton, has the same behaviour as the filter button.

# 🤔 Why
- Improve filtering experience.

# 👀 See
- Feature working on Emulator (MBL-2225)

https://github.com/user-attachments/assets/b2e97fa0-7a31-4dbe-bd8b-f441ae01a084

- Compose preview interactive mode supports the navigation as well (MBL-2223)

https://github.com/user-attachments/assets/5485a33e-f979-4794-b98f-01777eb1b3f5



|  |  |

# 📋 QA

All related to category selection keeps working exactly as in Phase 1, except for reset button updates.
- Select 1 category
- Apply 1 category
- Reset 1 category (it does not dismiss bottomSheet automatically, but the query with results with default category is executed, and projects list updated accordingly)

Single project status selection keeps working as usual
- Select 1 project status
- Apply 1 project status
- Reset 1 project status (it does not dismiss bottomSheet automatically, but the query with results with default project state is executed, and projects list updated accordingly)

Double selection with navigation:
- Select category and project status (regardless the order of the selection, navigate back and forth and use the filter pill button and the project status pill button).
- Apply the category and project status
- Reset button return to the default state both category and project status, it does not dismiss bottomSheet.

# Story 📖

[MBL-2225](https://kickstarter.atlassian.net/browse/MBL-2225)
[MBL-2223](https://kickstarter.atlassian.net/browse/MBL-2223)


[MBL-2225]: https://kickstarter.atlassian.net/browse/MBL-2225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ