### PR TITLE
MBL-2311: Apply window insets fix to BackingActivity

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/BackingActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/BackingActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.kickstarter.R
+import com.kickstarter.databinding.BackingLayoutBinding
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
@@ -14,6 +15,7 @@ import com.kickstarter.ui.extensions.finishWithAnimation
 import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.ui.fragments.BackingFragment
 import com.kickstarter.ui.fragments.BackingFragment.BackingDelegate
+import com.kickstarter.utils.WindowInsetsUtil
 import com.kickstarter.viewmodels.BackingViewModel.BackingViewModel
 import com.kickstarter.viewmodels.BackingViewModel.Factory
 import io.reactivex.disposables.CompositeDisposable
@@ -30,7 +32,12 @@ class BackingActivity : AppCompatActivity(), BackingDelegate {
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        setContentView(R.layout.backing_layout)
+        val binding = BackingLayoutBinding.inflate(layoutInflater)
+        WindowInsetsUtil.manageEdgeToEdge(
+            window,
+            binding.root
+        )
+        setContentView(binding.root)
 
         setUpConnectivityStatusCheck(lifecycle)
 


### PR DESCRIPTION
# 📲 What

Apply window insets fix to BackingActivity to account for Android 15 forced edge-to-edge.
tion.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Screenshot_20250423_113007](https://github.com/user-attachments/assets/c7c42b65-971b-41f1-a6dd-c87c42417642) | ![Screenshot_20250423_113228](https://github.com/user-attachments/assets/ea13e152-006c-4edf-8747-c22325a9703c) |

# 📋 QA

Navigate to the View Pledge screen (`BackingActivity`) from the Messaging w/ a creator screen  (`MessagesActivity`). See the following document for various flows: [🤖 Investigating issues Messaging with Creators - Mobile Team - Confluence](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/3623845895/Investigating+issues+Messaging+with+Creators)

# Story 📖

[[MBL-2311] View Pledge screen does not fit when opened from MessagesActivity - Jira](https://kickstarter.atlassian.net/browse/MBL-2311)


[MBL-2311]: https://kickstarter.atlassian.net/browse/MBL-2311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ