### PR TITLE
MBL-2263: [PLOT]The "Change payment method" should enable 

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
@@ -469,7 +469,7 @@ class CrowdfundCheckoutViewModel(val environment: Environment, bundle: Bundle? =
                             pMethod = selectedPaymentMethod
                         )
                     } else {
-                        // Non-PLOT: fallback to legacy behavior
+                        // Non-PLOT: send the payment method, locationId, and rewards
                         val locationId = backing.locationId()?.toString()
                         val rwl = mutableListOf<Reward>()
                         backing.reward()?.let {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
@@ -457,24 +457,38 @@ class CrowdfundCheckoutViewModel(val environment: Environment, bundle: Bundle? =
         project.backing()?.let { backing ->
             val backingData = when (pledgeReason) {
                 PledgeReason.UPDATE_PAYMENT -> {
-                    // - Update payment should NOT send amounts
-                    val locationId = backing.locationId() ?: 0
-                    val rwl = mutableListOf<Reward>()
-                    backing.reward()?.let {
-                        rwl.add(it)
-                    }
-                    backing.addOns()?.let {
-                        rwl.addAll(RewardUtils.extendAddOns(it))
-                    }
+                    if (project.isPledgeOverTimeAllowed().isTrue()) {
+                        // PLOT projects: Only send the payment method
+                        // Backend expects NO amount, NO rewards, NO location — sending any of these
+                        // may result in 'Feature unavailable' error.
+                        getUpdateBackingData(
+                            backing,
+                            amount = null,
+                            locationId = null,
+                            rewardsList = null,
+                            pMethod = selectedPaymentMethod
+                        )
+                    } else {
+                        // Non-PLOT: fallback to legacy behavior
+                        val locationId = backing.locationId()?.toString()
+                        val rwl = mutableListOf<Reward>()
+                        backing.reward()?.let {
+                            rwl.add(it)
+                        }
+                        backing.addOns()?.let {
+                            rwl.addAll(RewardUtils.extendAddOns(it))
+                        }
 
-                    getUpdateBackingData(
-                        backing,
-                        null,
-                        locationId.toString(),
-                        rwl,
-                        selectedPaymentMethod
-                    )
+                        getUpdateBackingData(
+                            backing,
+                            amount = null,
+                            locationId = locationId,
+                            rwl,
+                            pMethod = selectedPaymentMethod
+                        )
+                    }
                 }
+
                 PledgeReason.UPDATE_REWARD,
                 PledgeReason.UPDATE_PLEDGE -> {
                     // - Update Reward/Pledge should send ALL newly selected rewards/Locations

--- a/app/src/main/res/menu/manage_pledge_plot_selected.xml
+++ b/app/src/main/res/menu/manage_pledge_plot_selected.xml
@@ -8,6 +8,9 @@
         android:layout_height="wrap_content"
         android:title="@string/Cancel_pledge"
         app:showAsAction="never" />
+    <item android:id="@+id/update_payment"
+        android:title="@string/Change_payment_method"
+        app:showAsAction="never"/>
     <item
         android:id="@+id/contact_creator"
         android:layout_width="wrap_content"


### PR DESCRIPTION
# 📲 What

Added conditional logic to correctly update the payment method for PLOT (Pledge Over Time) projects and enabled the "Change payment method" option in the manage_pledge_plot_selected.xml menu for such projects.

# 🤔 Why

PLOT projects have strict backend requirements that disallow sending extra pledge data (like amount, reward IDs, or location) when updating the payment method — doing so results in a "Feature unavailable" error. Additionally, the UI previously didn’t offer a way to trigger payment method changes for PLOT pledges, so this needed to be addressed.

# 🛠 How

In CrowdfundCheckoutViewModel, updated updateBacking() logic for PledgeReason.UPDATE_PAYMENT:

- If the project is PLOT: only the paymentSourceId is sent.

- If the project is not PLOT: legacy behavior remains, sending reward IDs, location, and null amount.

Updated the XML menu:

- Enabled the "Change payment method" option for PLOT projects by adding the corresponding item in manage_pledge_plot_selected.xml.


# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| [Before change payment method available ](https://github.com/user-attachments/assets/a255a869-2d91-4265-a61d-b676c1baa085) | [After change payment method available](https://github.com/user-attachments/assets/42ce4276-428d-4f8c-992a-1fb59d04e5ad) |

# 📋 QA

- Back a PLOT-enabled project.

- Navigate to Manage Pledge.

- Verify the "Change payment method" option appears in the menu (manage_pledge_plot_selected.xml).

- Select a different payment method and complete the flow.

Confirm:

- The app sends only the paymentSourceId in the GraphQL mutation.

- No errors or validation failures from backend.

- New method is persisted correctly.

Also verify:

- Non-PLOT projects still send full backing info (reward IDs, location, etc.).

- All other pledge/update flows are unaffected.


# Story 📖

[MBL-2263](https://kickstarter.atlassian.net/browse/MBL-2263)


[MBL-2263]: https://kickstarter.atlassian.net/browse/MBL-2263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ