### PR TITLE
[no-jira]: Keep current user selection while navigating back-forth

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
@@ -486,7 +486,7 @@ fun FilterAndCategoryPagerSheet(
     ) { page ->
         when (page) {
             FilterPages.MAIN_FILTER.ordinal -> FilterMenuBottomSheet(
-                selectedProjectStatus = selectedProjectStatus,
+                selectedProjectStatus = projectState.value,
                 onDismiss = {
                     onDismiss.invoke()
                 },
@@ -515,7 +515,7 @@ fun FilterAndCategoryPagerSheet(
                 onNavigate = {
                     coroutineScope.launch { pagerState.animateScrollToPage(FilterPages.MAIN_FILTER.ordinal) }
                 },
-                currentCategory = currentCategory,
+                currentCategory = category.value,
                 onDismiss = onDismiss,
                 categories = categories,
                 onApply = { selectedCategory, applyAndDismiss ->


### PR DESCRIPTION
# 📲 What

- Navigating back-forth between filter screens did not persisted the user selection 

# 🤔 Why

# 👀 See

| Before 🐛 |

https://github.com/user-attachments/assets/2bb5ec64-3000-48c6-a948-6520a6a4e31e



| After 🦋 |



https://github.com/user-attachments/assets/9c32356e-9540-4854-8644-eee32c7ed9e1



| --- | --- |
|  |  |

# 📋 QA

- Select one project status, select 1 category, navigate back a forth several times within screens.

