### PR TITLE
MBL-2290, 2295, 2296, and 2297: Remaining work for reward shipped cards in activity feed

### DIFF
--- a/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
+++ b/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
@@ -121,7 +121,7 @@ fun RewardTrackingModal(
         Row {
             TextWithStartIcon(
                 modifier = Modifier,
-                text = stringResource(id = R.string.fpo_your_reward_has_shipped),
+                text = stringResource(id = R.string.Your_reward_has_shipped),
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_shipping),
                 style = when (pageType) {
                     RewardTrackingPageType.VIEW_YOUR_PLEDGE -> typographyV2.headingMD
@@ -137,7 +137,7 @@ fun RewardTrackingModal(
         Spacer(modifier = Modifier.height(dimensions.paddingXSmall))
 
         Text(
-            text = stringResource(R.string.fpo_tracking_number).format(key1 = "tracking_number", value1 = trackingNumber),
+            text = stringResource(R.string.Tracking_number).format(key1 = "number", value1 = trackingNumber),
             style = typographyV2.bodyMD,
             color = colors.textSecondary
         )
@@ -150,7 +150,7 @@ fun RewardTrackingModal(
             textColor = colors.kds_white,
             onClickAction = trackShipmentClicked,
             shape = RoundedCornerShape(size = KSTheme.dimensions.radiusExtraSmall),
-            text = stringResource(R.string.fpo_track_shipment),
+            text = stringResource(R.string.Track_shipment),
             textStyle = typographyV2.buttonLabel,
             isEnabled = true
         )

--- a/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
+++ b/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
@@ -2,6 +2,7 @@ package com.kickstarter.features.rewardtracking
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -39,7 +40,6 @@ fun RewardTrackingActivityPreview() {
             trackingNumber = "123291242342",
             modifier = Modifier.background(color = colors.backgroundSurfacePrimary),
             projectName = "This is a project name",
-            publishedAt = "2 days ago",
         )
     }
 }
@@ -62,14 +62,16 @@ fun RewardTrackingActivityFeed(
     trackingNumber: String,
     photo: Photo? = null,
     projectName: String,
-    publishedAt: String,
+    projectClicked: () -> Unit = {},
+    trackShipmentClicked: () -> Unit = {},
 ) {
     Column(
         modifier = modifier.fillMaxWidth()
     ) {
         ProjectInfoHeader(
             photo = photo,
-            projectName = projectName
+            projectName = projectName,
+            projectClicked = projectClicked,
         )
 
         Spacer(modifier = Modifier.height(dimensions.paddingMediumSmall))
@@ -80,17 +82,12 @@ fun RewardTrackingActivityFeed(
 
         Spacer(modifier = Modifier.height(dimensions.paddingMediumSmall))
 
-        Text(
-            text = publishedAt,
-            style = typographyV2.bodyBoldXXS,
-            color = colors.textSecondary
-        )
-
         Spacer(modifier = Modifier.height(dimensions.paddingMediumSmall))
 
         RewardTrackingModal(
             trackingNumber,
             RewardTrackingPageType.ACTIVITY_FEED,
+            trackShipmentClicked,
         )
     }
 }
@@ -118,7 +115,7 @@ fun RewardTrackingViewYourPledge(
 fun RewardTrackingModal(
     trackingNumber: String,
     pageType: RewardTrackingPageType,
-    onClick: () -> Unit = {},
+    trackShipmentClicked: () -> Unit = {},
 ) {
     Column {
         Row {
@@ -151,7 +148,7 @@ fun RewardTrackingModal(
             modifier = Modifier,
             backgroundColor = colors.kds_black,
             textColor = colors.kds_white,
-            onClickAction = onClick,
+            onClickAction = trackShipmentClicked,
             shape = RoundedCornerShape(size = KSTheme.dimensions.radiusExtraSmall),
             text = stringResource(R.string.fpo_track_shipment),
             textStyle = typographyV2.buttonLabel,
@@ -164,9 +161,11 @@ fun RewardTrackingModal(
 fun ProjectInfoHeader(
     photo: Photo?,
     projectName: String,
+    projectClicked: () -> Unit = {},
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.clickable { projectClicked.invoke() }
     ) {
         KSAsyncImage(
             image = photo,

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/StringExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/StringExt.kt
@@ -287,4 +287,11 @@ fun String.replace(substitutions: Map<String, String?>): String {
     return buffer.toString()
 }
 
+fun String.createValidUrl(): String {
+    if (!this.startsWith("http://") && !this.startsWith("https://")) {
+        return "http://$this"
+    }
+    return this
+}
+
 private val NON_WORD_REGEXP = Pattern.compile("[^\\w]")

--- a/app/src/main/java/com/kickstarter/mock/factories/ActivityFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/ActivityFactory.kt
@@ -37,6 +37,16 @@ object ActivityFactory {
     }
 
     @JvmStatic
+    fun rewardShippedActivity(): Activity {
+        return activity().toBuilder()
+            .category(Activity.CATEGORY_SHIPPED)
+            .project(project())
+            .trackingUrl("www.trackingnumbertest.com")
+            .trackingNumber("22342gdfg2341")
+            .build()
+    }
+
+    @JvmStatic
     fun projectStateChangedPositiveActivity(): Activity {
         return activity().toBuilder()
             .category(Activity.CATEGORY_SUCCESS)

--- a/app/src/main/java/com/kickstarter/models/Activity.kt
+++ b/app/src/main/java/com/kickstarter/models/Activity.kt
@@ -17,12 +17,16 @@ class Activity internal constructor(
     private val project: Project?,
     private val update: Update?,
     private val updatedAt: DateTime?,
+    private val trackingNumber: String?,
+    private val trackingUrl: String?,
     private val user: User?
 ) : Parcelable {
     fun category() = this.category
     fun createdAt() = this.createdAt
     fun id() = this.id
     fun project() = this.project
+    fun trackingNumber() = this.trackingNumber
+    fun trackingUrl() = this.trackingUrl
     fun update() = this.update
     fun updatedAt() = this.updatedAt
     fun user() = this.user
@@ -33,6 +37,8 @@ class Activity internal constructor(
         private var createdAt: DateTime = DateTime.now(),
         private var id: Long = 0L,
         private var project: Project? = null,
+        private var trackingNumber: String? = "",
+        private var trackingUrl: String? = "",
         private var update: Update? = null,
         private var updatedAt: DateTime? = null,
         private var user: User? = null
@@ -41,6 +47,8 @@ class Activity internal constructor(
         fun createdAt(createdAt: DateTime?) = apply { createdAt?.let { this.createdAt = it } }
         fun id(id: Long?) = apply { this.id = id ?: 0L }
         fun project(project: Project?) = apply { this.project = project }
+        fun trackingNumber(trackingNumber: String?) = apply { this.trackingNumber = trackingNumber }
+        fun trackingUrl(trackingUrl: String?) = apply { this.trackingUrl = trackingUrl }
         fun update(update: Update?) = apply { this.update = update }
         fun updatedAt(updatedAt: DateTime?) = apply { this.updatedAt = updatedAt }
         fun user(user: User?) = apply { this.user = user }
@@ -49,6 +57,8 @@ class Activity internal constructor(
             createdAt = createdAt,
             id = id,
             project = project,
+            trackingNumber = trackingNumber,
+            trackingUrl = trackingUrl,
             update = update,
             updatedAt = updatedAt,
             user = user
@@ -60,6 +70,8 @@ class Activity internal constructor(
         createdAt = createdAt,
         id = id,
         project = project,
+        trackingNumber = trackingNumber,
+        trackingUrl = trackingUrl,
         update = update,
         updatedAt = updatedAt,
         user = user
@@ -72,6 +84,8 @@ class Activity internal constructor(
                 createdAt() == other.createdAt() &&
                 id() == other.id() &&
                 project() == other.project() &&
+                trackingNumber() == other.trackingNumber() &&
+                trackingUrl() == other.trackingUrl() &&
                 update() == other.update() &&
                 updatedAt() == other.updatedAt() &&
                 user() == other.user()
@@ -101,7 +115,8 @@ class Activity internal constructor(
         CATEGORY_BACKING_REWARD,
         CATEGORY_BACKING_AMOUNT,
         CATEGORY_COMMENT_PROPOSAL,
-        CATEGORY_FOLLOW
+        CATEGORY_FOLLOW,
+        CATEGORY_SHIPPED,
     )
     annotation class Category
 
@@ -132,6 +147,7 @@ class Activity internal constructor(
         const val CATEGORY_BACKING_REWARD = "backing-reward"
         const val CATEGORY_BACKING_AMOUNT = "backing-amount"
         const val CATEGORY_COMMENT_PROPOSAL = "comment-proposal"
+        const val CATEGORY_SHIPPED = "shipped"
         const val CATEGORY_FOLLOW = "follow"
     }
 }

--- a/app/src/main/java/com/kickstarter/services/ApiClientV2.java
+++ b/app/src/main/java/com/kickstarter/services/ApiClientV2.java
@@ -87,7 +87,8 @@ public final class ApiClientV2 implements ApiClientTypeV2 {
       Activity.CATEGORY_LAUNCH,
       Activity.CATEGORY_SUCCESS,
       Activity.CATEGORY_UPDATE,
-      Activity.CATEGORY_FOLLOW
+      Activity.CATEGORY_FOLLOW,
+      Activity.CATEGORY_SHIPPED
     );
 
     return this.service

--- a/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ActivityFeedActivity.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.ui.activities
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.addCallback
 import androidx.activity.viewModels
@@ -14,6 +15,7 @@ import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.recyclerviewpagination.RecyclerViewPaginatorV2
 import com.kickstarter.libs.utils.ApplicationUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.libs.utils.extensions.createValidUrl
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.getProjectIntent
 import com.kickstarter.models.Activity
@@ -126,6 +128,11 @@ class ActivityFeedActivity : AppCompatActivity() {
             .subscribe { startUpdateActivity(it) }
             .addToDisposable(disposables)
 
+        viewModel.outputs.trackShipmentClicked()
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe { openShipmentTrackingUrl(it) }
+            .addToDisposable(disposables)
+
         viewModel.outputs.loggedOutEmptyStateIsVisible()
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { adapter?.showLoggedOutEmptyState(it) }
@@ -200,5 +207,10 @@ class ActivityFeedActivity : AppCompatActivity() {
             .putExtra(IntentKey.PROJECT_PARAM, activity.project()?.slug())
             .putExtra(IntentKey.UPDATE, activity.update())
         startActivityWithTransition(intent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
+    }
+
+    private fun openShipmentTrackingUrl(url: String) {
+        val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url.createValidUrl()))
+        startActivityWithTransition(browserIntent, R.anim.slide_in_right, R.anim.fade_out_slide_out_left)
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/adapters/ActivityFeedAdapter.kt
+++ b/app/src/main/java/com/kickstarter/ui/adapters/ActivityFeedAdapter.kt
@@ -9,6 +9,7 @@ import com.kickstarter.databinding.ActivityFriendFollowViewBinding
 import com.kickstarter.databinding.ActivityProjectStateChangedPositiveViewBinding
 import com.kickstarter.databinding.ActivityProjectStateChangedViewBinding
 import com.kickstarter.databinding.ActivityProjectUpdateViewBinding
+import com.kickstarter.databinding.ActivityRewardShippedViewBinding
 import com.kickstarter.databinding.ActivitySurveyHeaderViewBinding
 import com.kickstarter.databinding.ActivitySurveyViewBinding
 import com.kickstarter.databinding.EmptyActivityFeedViewBinding
@@ -27,6 +28,7 @@ import com.kickstarter.ui.viewholders.KSViewHolder
 import com.kickstarter.ui.viewholders.ProjectStateChangedPositiveViewHolder
 import com.kickstarter.ui.viewholders.ProjectStateChangedViewHolder
 import com.kickstarter.ui.viewholders.ProjectUpdateViewHolder
+import com.kickstarter.ui.viewholders.RewardShippedViewHolder
 import com.kickstarter.ui.viewholders.SurveyHeaderViewHolder
 import com.kickstarter.ui.viewholders.SurveyViewHolder
 
@@ -37,7 +39,8 @@ class ActivityFeedAdapter(private val delegate: Delegate?) : KSAdapter() {
         ProjectStateChangedPositiveViewHolder.Delegate,
         ProjectStateChangedViewHolder.Delegate,
         ProjectUpdateViewHolder.Delegate,
-        EmptyActivityFeedViewHolder.Delegate
+        EmptyActivityFeedViewHolder.Delegate,
+        RewardShippedViewHolder.Delegate
 
     fun takeActivities(activities: List<Activity?>) {
         setSection(SECTION_ACTIVITIES_VIEW, activities)
@@ -99,6 +102,7 @@ class ActivityFeedAdapter(private val delegate: Delegate?) : KSAdapter() {
                 Activity.CATEGORY_FAILURE, Activity.CATEGORY_CANCELLATION, Activity.CATEGORY_SUSPENSION -> return R.layout.activity_project_state_changed_view
                 Activity.CATEGORY_LAUNCH, Activity.CATEGORY_SUCCESS -> return R.layout.activity_project_state_changed_positive_view
                 Activity.CATEGORY_UPDATE -> return R.layout.activity_project_update_view
+                Activity.CATEGORY_SHIPPED -> return R.layout.activity_reward_shipped_view
             }
         }
         return R.layout.empty_view
@@ -141,6 +145,7 @@ class ActivityFeedAdapter(private val delegate: Delegate?) : KSAdapter() {
             )
 
             R.layout.activity_project_update_view -> ProjectUpdateViewHolder(ActivityProjectUpdateViewBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false), delegate)
+            R.layout.activity_reward_shipped_view -> RewardShippedViewHolder(ActivityRewardShippedViewBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false), delegate)
             R.layout.empty_activity_feed_view -> EmptyActivityFeedViewHolder(EmptyActivityFeedViewBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false), delegate)
             R.layout.item_errored_backing -> ErroredBackingViewHolder(ItemErroredBackingBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false), delegate)
             else -> EmptyViewHolder(EmptyViewBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false))

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -315,6 +315,21 @@ fun Activity.startDisclaimerChromeTab(disclaimerItem: DisclaimerItems, environme
     ChromeTabsHelperActivity.openCustomTab(this, UrlUtils.baseCustomTabsIntent(this), uri, fallback)
 }
 
+fun Activity.get(url: String) {
+
+    val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+
+    val uri = Uri.parse(url)
+
+    val fallback = object : ChromeTabsHelperActivity.CustomTabFallback {
+        override fun openUri(activity: Activity, uri: Uri) {
+            activity.startActivity(browserIntent)
+        }
+    }
+
+    ChromeTabsHelperActivity.openCustomTab(this, UrlUtils.baseCustomTabsIntent(this), uri, fallback)
+}
+
 fun Activity.startCreatorMessageActivity(project: Project, previousScreen: MessagePreviousScreenType) {
     startActivity(
         Intent(this, MessagesActivity::class.java)

--- a/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ActivityExt.kt
@@ -314,22 +314,6 @@ fun Activity.startDisclaimerChromeTab(disclaimerItem: DisclaimerItems, environme
 
     ChromeTabsHelperActivity.openCustomTab(this, UrlUtils.baseCustomTabsIntent(this), uri, fallback)
 }
-
-fun Activity.get(url: String) {
-
-    val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-
-    val uri = Uri.parse(url)
-
-    val fallback = object : ChromeTabsHelperActivity.CustomTabFallback {
-        override fun openUri(activity: Activity, uri: Uri) {
-            activity.startActivity(browserIntent)
-        }
-    }
-
-    ChromeTabsHelperActivity.openCustomTab(this, UrlUtils.baseCustomTabsIntent(this), uri, fallback)
-}
-
 fun Activity.startCreatorMessageActivity(project: Project, previousScreen: MessagePreviousScreenType) {
     startActivity(
         Intent(this, MessagesActivity::class.java)

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardShippedViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardShippedViewHolder.kt
@@ -1,0 +1,41 @@
+package com.kickstarter.ui.viewholders
+
+import androidx.compose.ui.Modifier
+import com.kickstarter.databinding.ActivityRewardShippedViewBinding
+import com.kickstarter.features.rewardtracking.RewardTrackingActivityFeed
+import com.kickstarter.models.Activity
+import com.kickstarter.ui.compose.designsystem.KSTheme
+
+class RewardShippedViewHolder(
+    private val binding: ActivityRewardShippedViewBinding,
+    private val delegate: Delegate?
+) : ActivityListViewHolder(binding.root) {
+
+    interface Delegate {
+        fun projectClicked(viewHolder: RewardShippedViewHolder?, activity: Activity?)
+        fun trackingNumberClicked(url: String)
+    }
+
+    override fun onBind() {
+        binding.rewardShippedComposeView.setContent {
+            KSTheme {
+                RewardTrackingActivityFeed(
+                    modifier = Modifier,
+                    trackingNumber = activity().trackingNumber() ?: "",
+                    projectName = activity().project()?.name() ?: "",
+                    photo = activity().project()?.photo(),
+                    projectClicked = { projectOnClick() },
+                    trackShipmentClicked = { trackingNumberClicked() }
+                )
+        }
+        }
+    }
+
+    private fun projectOnClick() {
+        delegate?.projectClicked(this, activity())
+    }
+
+    private fun trackingNumberClicked() {
+        delegate?.trackingNumberClicked(activity().trackingUrl() ?: "")
+    }
+}

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardShippedViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardShippedViewHolder.kt
@@ -27,7 +27,7 @@ class RewardShippedViewHolder(
                     projectClicked = { projectOnClick() },
                     trackShipmentClicked = { trackingNumberClicked() }
                 )
-        }
+            }
         }
     }
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardShippedViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardShippedViewHolder.kt
@@ -3,6 +3,7 @@ package com.kickstarter.ui.viewholders
 import androidx.compose.ui.Modifier
 import com.kickstarter.databinding.ActivityRewardShippedViewBinding
 import com.kickstarter.features.rewardtracking.RewardTrackingActivityFeed
+import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.models.Activity
 import com.kickstarter.ui.compose.designsystem.KSTheme
 
@@ -17,16 +18,18 @@ class RewardShippedViewHolder(
     }
 
     override fun onBind() {
-        binding.rewardShippedComposeView.setContent {
-            KSTheme {
-                RewardTrackingActivityFeed(
-                    modifier = Modifier,
-                    trackingNumber = activity().trackingNumber() ?: "",
-                    projectName = activity().project()?.name() ?: "",
-                    photo = activity().project()?.photo(),
-                    projectClicked = { projectOnClick() },
-                    trackShipmentClicked = { trackingNumberClicked() }
-                )
+        if(!activity().trackingUrl().isNullOrEmpty() && !activity().trackingNumber().isNullOrEmpty() && activity().project().isNotNull()) {
+            binding.rewardShippedComposeView.setContent {
+                KSTheme {
+                    RewardTrackingActivityFeed(
+                        modifier = Modifier,
+                        trackingNumber = activity().trackingNumber() ?: "",
+                        projectName = activity().project()?.name() ?: "",
+                        photo = activity().project()?.photo(),
+                        projectClicked = { projectOnClick() },
+                        trackShipmentClicked = { trackingNumberClicked() }
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardShippedViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardShippedViewHolder.kt
@@ -18,7 +18,7 @@ class RewardShippedViewHolder(
     }
 
     override fun onBind() {
-        if(!activity().trackingUrl().isNullOrEmpty() && !activity().trackingNumber().isNullOrEmpty() && activity().project().isNotNull()) {
+        if (!activity().trackingUrl().isNullOrEmpty() && !activity().trackingNumber().isNullOrEmpty() && activity().project().isNotNull()) {
             binding.rewardShippedComposeView.setContent {
                 KSTheme {
                     RewardTrackingActivityFeed(

--- a/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.kt
@@ -212,7 +212,7 @@ interface ActivityFeedViewModel {
             paginator.paginatedData()
                 .subscribe {
                     if (!environment.featureFlagClient()
-                            ?.getBoolean(FlagKey.ANDROID_REWARD_SHIPMENT_TRACKING).isTrue()
+                        ?.getBoolean(FlagKey.ANDROID_REWARD_SHIPMENT_TRACKING).isTrue()
                     ) {
                         activityList.onNext(it.filter { it.category() != CATEGORY_SHIPPED })
                     } else {

--- a/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ActivityFeedViewModel.kt
@@ -27,6 +27,7 @@ import com.kickstarter.ui.viewholders.FriendBackingViewHolder
 import com.kickstarter.ui.viewholders.ProjectStateChangedPositiveViewHolder
 import com.kickstarter.ui.viewholders.ProjectStateChangedViewHolder
 import com.kickstarter.ui.viewholders.ProjectUpdateViewHolder
+import com.kickstarter.ui.viewholders.RewardShippedViewHolder
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subjects.BehaviorSubject
@@ -78,6 +79,9 @@ interface ActivityFeedViewModel {
         /** Emits when we should start the [com.kickstarter.ui.activities.UpdateActivity].  */
         fun startUpdateActivity(): Observable<Activity>
 
+        /** Emits when we should open the browser to view shipment tracking.  */
+        fun trackShipmentClicked(): Observable<String>
+
         /** Emits a list of unanswered surveys to be shown in the user's activity feed  */
         fun surveys(): Observable<List<SurveyResponse>>
     }
@@ -93,6 +97,7 @@ interface ActivityFeedViewModel {
         private val friendBackingClick = PublishSubject.create<Activity>()
         private val loginClick = PublishSubject.create<Unit>()
         private val managePledgeClicked = PublishSubject.create<String>()
+        private val trackShipmentClicked = PublishSubject.create<String>()
         private val nextPage = PublishSubject.create<Unit>()
         private val projectStateChangedClick = PublishSubject.create<Activity>()
         private val projectStateChangedPositiveClick = PublishSubject.create<Activity>()
@@ -258,6 +263,18 @@ interface ActivityFeedViewModel {
             loginClick.onNext(Unit)
         }
 
+        override fun projectClicked(viewHolder: RewardShippedViewHolder?, activity: Activity?) {
+            if (activity != null) {
+                projectUpdateProjectClick.onNext(activity)
+            }
+        }
+
+        override fun trackingNumberClicked(
+            url: String
+        ) {
+            trackShipmentClicked.onNext(url)
+        }
+
         override fun managePledgeClicked(projectSlug: String) {
             managePledgeClicked.onNext(projectSlug)
         }
@@ -330,6 +347,7 @@ interface ActivityFeedViewModel {
         override fun loggedOutEmptyStateIsVisible(): Observable<Boolean> = loggedOutEmptyStateIsVisible
         override fun startFixPledge(): Observable<String> = startFixPledge
         override fun startUpdateActivity(): Observable<Activity> = startUpdateActivity
+        override fun trackShipmentClicked(): Observable<String> = trackShipmentClicked
         override fun surveys(): Observable<List<SurveyResponse>> = surveys
     }
 

--- a/app/src/main/res/layout/activity_reward_shipped_view.xml
+++ b/app/src/main/res/layout/activity_reward_shipped_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/reward_shipped_compose_view"
+        android:padding="@dimen/grid_2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_backing.xml
+++ b/app/src/main/res/layout/fragment_backing.xml
@@ -145,14 +145,14 @@
                         layout="@layout/fragment_backing_section_delivery_date_reminder"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/grid_3" />
+                        android:layout_marginTop="@dimen/grid_3"
+                        android:layout_marginBottom="@dimen/grid_4" />
 
                     <include
                         android:id="@+id/fragment_pledge_section_summary_pledge"
                         layout="@layout/fragment_pledge_section_summary_pledge"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/grid_4"
                         android:layout_marginBottom="@dimen/grid_3"
                         android:visibility="visible" />
 

--- a/app/src/test/java/com/kickstarter/ui/adapters/ActivityFeedAdapterTest.java
+++ b/app/src/test/java/com/kickstarter/ui/adapters/ActivityFeedAdapterTest.java
@@ -74,8 +74,9 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
     final Activity activity0 = ActivityFactory.projectStateChangedPositiveActivity();
     final Activity activity1 = ActivityFactory.friendBackingActivity();
     final Activity activity2 = ActivityFactory.projectStateChangedActivity();
+    final Activity activity3 = ActivityFactory.rewardShippedActivity();
 
-    this.adapter.takeActivities(Arrays.asList(activity0, activity1, activity2));
+    this.adapter.takeActivities(Arrays.asList(activity0, activity1, activity2, activity3));
     this.adapter.showLoggedOutEmptyState(true);
 
     final List<List<Object>> data = Arrays.asList(
@@ -88,7 +89,8 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
       Arrays.asList(
         activity0,
         activity1,
-        activity2
+        activity2,
+        activity3
       )
     );
 
@@ -140,11 +142,12 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
     final Activity activity0 = ActivityFactory.projectStateChangedPositiveActivity();
     final Activity activity1 = ActivityFactory.friendBackingActivity();
     final Activity activity2 = ActivityFactory.projectStateChangedActivity();
+    final Activity activity3 = ActivityFactory.rewardShippedActivity();
     final ErroredBacking erroredBacking = ErroredBackingFactory.erroredBacking();
     final SurveyResponse surveyResponse0 = SurveyResponseFactory.surveyResponse();
     final SurveyResponse surveyResponse1 = SurveyResponseFactory.surveyResponse();
 
-    this.adapter.takeActivities(Arrays.asList(activity0, activity1, activity2));
+    this.adapter.takeActivities(Arrays.asList(activity0, activity1, activity2, activity3));
     this.adapter.takeErroredBackings(Collections.singletonList(erroredBacking));
     this.adapter.takeSurveys(Arrays.asList(surveyResponse0, surveyResponse1));
     this.adapter.showLoggedInEmptyState(true);
@@ -162,7 +165,8 @@ public class ActivityFeedAdapterTest extends KSRobolectricTestCase {
       Arrays.asList(
         activity0,
         activity1,
-        activity2
+        activity2,
+        activity3
       )
     );
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ActivityFeedViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ActivityFeedViewModelTest.kt
@@ -422,6 +422,5 @@ class ActivityFeedViewModelTest : KSRobolectricTestCase() {
 
         vm.inputs.trackingNumberClicked("www.google.com")
         trackShipment.assertValue("www.google.com")
-
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ActivityFeedViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ActivityFeedViewModelTest.kt
@@ -44,6 +44,7 @@ class ActivityFeedViewModelTest : KSRobolectricTestCase() {
     private val startUpdateActivity = TestSubscriber<Activity>()
     private val surveys = TestSubscriber<List<SurveyResponse>>()
     private val user = TestSubscriber<User>()
+    private val trackShipment = TestSubscriber<String>()
     private val disposables = CompositeDisposable()
 
     private fun setUpEnvironment(environment: Environment) {
@@ -69,6 +70,8 @@ class ActivityFeedViewModelTest : KSRobolectricTestCase() {
         vm.outputs.startUpdateActivity().subscribe { startUpdateActivity.onNext(it) }
             .addToDisposable(disposables)
         vm.outputs.surveys().subscribe { surveys.onNext(it) }
+            .addToDisposable(disposables)
+        vm.trackShipmentClicked().subscribe { trackShipment.onNext(it) }
             .addToDisposable(disposables)
     }
 
@@ -407,5 +410,18 @@ class ActivityFeedViewModelTest : KSRobolectricTestCase() {
 
         vm.inputs.resume()
         user.assertValues(initialUser, updatedUser)
+    }
+
+    @Test
+    fun testTrackShipment_whenButtonClicked_emitsUrl() {
+        val environment = environment()
+            .toBuilder()
+            .apiClientV2(MockApiClientV2())
+            .build()
+        setUpEnvironment(environment)
+
+        vm.inputs.trackingNumberClicked("www.google.com")
+        trackShipment.assertValue("www.google.com")
+
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ActivityFeedViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ActivityFeedViewModelTest.kt
@@ -8,7 +8,6 @@ import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.mock.MockFeatureFlagClient
-import com.kickstarter.mock.factories.ActivityFactory
 import com.kickstarter.mock.factories.ActivityFactory.activity
 import com.kickstarter.mock.factories.ActivityFactory.friendBackingActivity
 import com.kickstarter.mock.factories.ActivityFactory.projectStateChangedActivity
@@ -18,7 +17,6 @@ import com.kickstarter.mock.factories.ActivityFactory.updateActivity
 import com.kickstarter.mock.factories.SurveyResponseFactory.surveyResponse
 import com.kickstarter.mock.factories.UserFactory.user
 import com.kickstarter.mock.services.MockApiClientV2
-import com.kickstarter.mock.services.MockApolloClientV2
 import com.kickstarter.models.Activity
 import com.kickstarter.models.ErroredBacking
 import com.kickstarter.models.Project
@@ -396,7 +394,7 @@ class ActivityFeedViewModelTest : KSRobolectricTestCase() {
             })
             .apiClientV2(object : MockApiClientV2() {
                 override fun fetchActivities(): Observable<ActivityEnvelope> {
-                    return  Observable.just(ActivityEnvelope.builder().activities(listOf(projectStateChangedPositiveActivity(), friendBackingActivity(), rewardShippedActivity(), updateActivity())).build())
+                    return Observable.just(ActivityEnvelope.builder().activities(listOf(projectStateChangedPositiveActivity(), friendBackingActivity(), rewardShippedActivity(), updateActivity())).build())
                 }
             })
             .build()
@@ -424,7 +422,7 @@ class ActivityFeedViewModelTest : KSRobolectricTestCase() {
             })
             .apiClientV2(object : MockApiClientV2() {
                 override fun fetchActivities(): Observable<ActivityEnvelope> {
-                    return  Observable.just(ActivityEnvelope.builder().activities(listOf(projectStateChangedPositiveActivity(), friendBackingActivity(), rewardShippedActivity(), updateActivity())).build())
+                    return Observable.just(ActivityEnvelope.builder().activities(listOf(projectStateChangedPositiveActivity(), friendBackingActivity(), rewardShippedActivity(), updateActivity())).build())
                 }
             })
             .build()


### PR DESCRIPTION
# 📲 What

After updates to backend, we are now able to support showing tracking numbers in the activity feed! 

# 🤔 Why

PM tracking

# 🛠 How

Updated `Activity` with new optional fields for tracking number and tracking url
Added support for the `shipped` category in activity feed
Tracking url opens in external browser
Update fpo strings to use localized strings
All gated behind feature flag

# 👀 See

https://github.com/user-attachments/assets/fcaa5faa-3817-4211-99da-64663fd8f6b5

# 📋 QA

Ping me for test account details if you want to QA. 
Feature flag on: 
Go to activity feed and confirm shipped reward card appears, and track shipment opens external browser. 
Feature flag off:
Go to activity feed and confirm shipped reward card does NOT appear. all other cards are still there

# Story 📖

[MBL-2295: Show tracking number cards in activity feed list when available](https://kickstarter.atlassian.net/browse/MBL-2295)
[MBL-2296: Track shipment button in activity feed opens browser](https://kickstarter.atlassian.net/browse/MBL-2296)
[MBL-2290: Sub in localized strings once translations are complete](https://kickstarter.atlassian.net/browse/MBL-2290)
[MBL-2297: API - Extend networking functionality to tracking number cards in activity feed](https://kickstarter.atlassian.net/browse/MBL-2297)