### PR TITLE
[no-jira] Disable track shipment button when tracking url null

### DIFF
--- a/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
+++ b/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
@@ -64,7 +64,7 @@ fun RewardTrackingActivityFeed(
     photo: Photo? = null,
     projectName: String,
     projectClicked: () -> Unit = {},
-    trackingButtonEnabled : Boolean = false,
+    trackingButtonEnabled: Boolean = false,
     trackShipmentClicked: () -> Unit = {},
 ) {
     Column(
@@ -119,8 +119,8 @@ fun RewardTrackingModal(
     trackingNumber: String,
     pageType: RewardTrackingPageType,
     trackShipmentClicked: () -> Unit = {},
-    trackingButtonEnabled : Boolean = false,
-    ) {
+    trackingButtonEnabled: Boolean = false,
+) {
     Column {
         Row {
             TextWithStartIcon(

--- a/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
+++ b/app/src/main/java/com/kickstarter/features/rewardtracking/RewardTrackingViews.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -63,6 +64,7 @@ fun RewardTrackingActivityFeed(
     photo: Photo? = null,
     projectName: String,
     projectClicked: () -> Unit = {},
+    trackingButtonEnabled : Boolean = false,
     trackShipmentClicked: () -> Unit = {},
 ) {
     Column(
@@ -88,6 +90,7 @@ fun RewardTrackingActivityFeed(
             trackingNumber,
             RewardTrackingPageType.ACTIVITY_FEED,
             trackShipmentClicked,
+            trackingButtonEnabled
         )
     }
 }
@@ -116,7 +119,8 @@ fun RewardTrackingModal(
     trackingNumber: String,
     pageType: RewardTrackingPageType,
     trackShipmentClicked: () -> Unit = {},
-) {
+    trackingButtonEnabled : Boolean = false,
+    ) {
     Column {
         Row {
             TextWithStartIcon(
@@ -145,14 +149,14 @@ fun RewardTrackingModal(
         Spacer(modifier = Modifier.height(dimensions.paddingMediumSmall))
 
         KSButton(
-            modifier = Modifier,
+            modifier = Modifier.testTag(RewardTrackingTestTag.TRACK_SHIPMENT_BUTTON.name),
             backgroundColor = colors.kds_black,
             textColor = colors.kds_white,
             onClickAction = trackShipmentClicked,
             shape = RoundedCornerShape(size = KSTheme.dimensions.radiusExtraSmall),
             text = stringResource(R.string.Track_shipment),
             textStyle = typographyV2.buttonLabel,
-            isEnabled = true
+            isEnabled = trackingButtonEnabled
         )
     }
 }
@@ -165,7 +169,7 @@ fun ProjectInfoHeader(
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.clickable { projectClicked.invoke() }
+        modifier = Modifier.clickable { projectClicked.invoke() }.testTag(RewardTrackingTestTag.PROJECT_CARD_MODAL.name)
     ) {
         KSAsyncImage(
             image = photo,
@@ -182,6 +186,10 @@ fun ProjectInfoHeader(
             color = colors.textPrimary
         )
     }
+}
+enum class RewardTrackingTestTag(name: String) {
+    TRACK_SHIPMENT_BUTTON("track_shipment_button"),
+    PROJECT_CARD_MODAL("project_card_modal")
 }
 
 enum class RewardTrackingPageType(name: String) {

--- a/app/src/main/java/com/kickstarter/ui/viewholders/RewardShippedViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/RewardShippedViewHolder.kt
@@ -18,7 +18,7 @@ class RewardShippedViewHolder(
     }
 
     override fun onBind() {
-        if (!activity().trackingUrl().isNullOrEmpty() && !activity().trackingNumber().isNullOrEmpty() && activity().project().isNotNull()) {
+        if (!activity().trackingNumber().isNullOrEmpty() && activity().project().isNotNull()) {
             binding.rewardShippedComposeView.setContent {
                 KSTheme {
                     RewardTrackingActivityFeed(
@@ -27,6 +27,7 @@ class RewardShippedViewHolder(
                         projectName = activity().project()?.name() ?: "",
                         photo = activity().project()?.photo(),
                         projectClicked = { projectOnClick() },
+                        trackingButtonEnabled = !activity().trackingUrl().isNullOrEmpty(),
                         trackShipmentClicked = { trackingNumberClicked() }
                     )
                 }

--- a/app/src/test/java/com/kickstarter/features/rewardtracking/RewardTrackingViewsKtTest.kt
+++ b/app/src/test/java/com/kickstarter/features/rewardtracking/RewardTrackingViewsKtTest.kt
@@ -8,7 +8,7 @@ import com.kickstarter.mock.factories.ActivityFactory
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import org.junit.Test
 
-class RewardTrackingViewsKtTest: KSRobolectricTestCase() {
+class RewardTrackingViewsKtTest : KSRobolectricTestCase() {
 
     private val trackingButton =
         composeTestRule.onNodeWithTag(RewardTrackingTestTag.TRACK_SHIPMENT_BUTTON.name)
@@ -25,13 +25,13 @@ class RewardTrackingViewsKtTest: KSRobolectricTestCase() {
 
             KSTheme {
                 RewardTrackingActivityFeed(
-                        trackingNumber = activity.trackingNumber() ?: "",
-                        projectName = activity.project()?.name() ?: "",
-                        photo = activity.project()?.photo(),
-                        projectClicked = { projectClicks++ },
-                        trackingButtonEnabled = !activity.trackingUrl().isNullOrEmpty(),
-                        trackShipmentClicked = { trackShipmentClicks++ }
-                    )
+                    trackingNumber = activity.trackingNumber() ?: "",
+                    projectName = activity.project()?.name() ?: "",
+                    photo = activity.project()?.photo(),
+                    projectClicked = { projectClicks++ },
+                    trackingButtonEnabled = !activity.trackingUrl().isNullOrEmpty(),
+                    trackShipmentClicked = { trackShipmentClicks++ }
+                )
             }
         }
 

--- a/app/src/test/java/com/kickstarter/features/rewardtracking/RewardTrackingViewsKtTest.kt
+++ b/app/src/test/java/com/kickstarter/features/rewardtracking/RewardTrackingViewsKtTest.kt
@@ -1,0 +1,65 @@
+package com.kickstarter.features.rewardtracking
+
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.mock.factories.ActivityFactory
+import com.kickstarter.ui.compose.designsystem.KSTheme
+import org.junit.Test
+
+class RewardTrackingViewsKtTest: KSRobolectricTestCase() {
+
+    private val trackingButton =
+        composeTestRule.onNodeWithTag(RewardTrackingTestTag.TRACK_SHIPMENT_BUTTON.name)
+
+    private val projectCardModal =
+        composeTestRule.onNodeWithTag(RewardTrackingTestTag.PROJECT_CARD_MODAL.name)
+
+    @Test
+    fun `test tracking activity card clicks`() {
+        var trackShipmentClicks = 0
+        var projectClicks = 0
+        composeTestRule.setContent {
+            val activity = ActivityFactory.rewardShippedActivity()
+
+            KSTheme {
+                RewardTrackingActivityFeed(
+                        trackingNumber = activity.trackingNumber() ?: "",
+                        projectName = activity.project()?.name() ?: "",
+                        photo = activity.project()?.photo(),
+                        projectClicked = { projectClicks++ },
+                        trackingButtonEnabled = !activity.trackingUrl().isNullOrEmpty(),
+                        trackShipmentClicked = { trackShipmentClicks++ }
+                    )
+            }
+        }
+
+        trackingButton.performClick()
+        projectCardModal.performClick()
+        assertEquals(1, trackShipmentClicks)
+        assertEquals(1, projectClicks)
+    }
+
+    @Test
+    fun `test tracking button disabled when false`() {
+        var trackShipmentClicks = 0
+        var projectClicks = 0
+        composeTestRule.setContent {
+            val activity = ActivityFactory.rewardShippedActivity().toBuilder().trackingUrl(null).build()
+
+            KSTheme {
+                RewardTrackingActivityFeed(
+                    trackingNumber = activity.trackingNumber() ?: "",
+                    projectName = activity.project()?.name() ?: "",
+                    photo = activity.project()?.photo(),
+                    projectClicked = { projectClicks++ },
+                    trackingButtonEnabled = !activity.trackingUrl().isNullOrEmpty(),
+                    trackShipmentClicked = { trackShipmentClicks++ }
+                )
+            }
+        }
+
+        trackingButton.assertIsNotEnabled()
+    }
+}


### PR DESCRIPTION
# 📲 What

Previously, we would hide the tracking card in activity feed when the project, tracking number, or tracking url were null. now, we only hide when project or tracking number are null, and just disable the track shipment button when tracking url null. 

Also added tests for the activity tracking modal

# 🤔 Why

Users should still be able to see the tracking number card if the tracking url is null

# 👀 See

| Enabled 🐛 | Disabled 🦋 |
| --- | --- |
| ![button enabled](https://github.com/user-attachments/assets/a151eaea-1eac-4dcf-bb24-2406cdfc3dff) | ![disabled button](https://github.com/user-attachments/assets/0ae335fc-7434-4d05-b3b2-8430b017a70a) |

# 📋 QA

Ping me if you need credentials for a test account with reward shipping cards available in the activity.  
If you set the tracking number to null in the `RewardShippedViewHolder` and run the app, you should see that the button is disabled. 

# Story 📖

no-jira
