### PR TITLE
MBL-2389: "Reset All" button disabled when the selected project status is "All"

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kickstarter.R
+import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.ui.compose.designsystem.KSDimensions
 import com.kickstarter.ui.compose.designsystem.KSSearchBottomSheetFooter
@@ -106,6 +107,7 @@ fun FilterMenuBottomSheet(
 
             KSSearchBottomSheetFooter(
                 modifier = Modifier.testTag(FilterMenuTestTags.FOOTER),
+                leftButtonIsEnabled = projStatus.value.isNotNull(),
                 leftButtonClickAction = {
                     projStatus.value = null
                     onApply(projStatus.value, false)


### PR DESCRIPTION
# 📲 What

- "Reset All" button disabled when the selected project status is "All".

# 👀 See


https://github.com/user-attachments/assets/6f90c76f-28e2-4fae-9d0a-7e03cb62c2a7



| --- | --- |
|  |  |

# 📋 QA

- When "All" filter for project status us selected, "Reset All" button is disabled.

# Story 📖

[MBL-2389](https://kickstarter.atlassian.net/browse/MBL-2389)


[MBL-2389]: https://kickstarter.atlassian.net/browse/MBL-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ