### PR TITLE
MBL-2414: Fix android v2 buttons for darkmode

### DIFF
--- a/app/src/internal/java/com/kickstarter/ui/activities/DesignSystemActivity.kt
+++ b/app/src/internal/java/com/kickstarter/ui/activities/DesignSystemActivity.kt
@@ -376,14 +376,14 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Filled,
+            type = KSButtonType.FILLED,
             text = "Filled",
             imageId = R.drawable.icon_eye_gray
         )
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Filled,
+            type = KSButtonType.FILLED,
             text = "Pressed",
             isPressed = true,
             imageId = R.drawable.icon_eye_gray
@@ -391,14 +391,14 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Filled,
+            type = KSButtonType.FILLED,
             text = "Disabled",
             isEnabled = false,
         )
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Filled,
+            type = KSButtonType.FILLED,
             text = "Loading",
             isLoading = true,
             imageId = R.drawable.icon_eye_gray
@@ -409,14 +409,14 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Green,
+            type = KSButtonType.GREEN,
             text = "Green",
             imageId = R.drawable.icon_eye_gray
         )
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Green,
+            type = KSButtonType.GREEN,
             text = "Pressed",
             isPressed = true,
             imageId = R.drawable.icon_eye_gray
@@ -424,7 +424,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Green,
+            type = KSButtonType.GREEN,
             text = "Disabled",
             isEnabled = false,
             imageId = R.drawable.icon_eye_gray
@@ -432,7 +432,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Green,
+            type = KSButtonType.GREEN,
             text = "Loading",
             isLoading = true,
             imageId = R.drawable.icon_eye_gray
@@ -443,14 +443,14 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.FilledInverted,
+            type = KSButtonType.FILLED_INVERTED,
             text = "Inverted",
             imageId = R.drawable.icon_eye_gray
         )
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.FilledInverted,
+            type = KSButtonType.FILLED_INVERTED,
             text = "Pressed",
             isPressed = true,
             imageId = R.drawable.icon_eye_gray
@@ -458,7 +458,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.FilledInverted,
+            type = KSButtonType.FILLED_INVERTED,
             text = "Disabled",
             isEnabled = false,
             imageId = R.drawable.icon_eye_gray
@@ -466,7 +466,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.FilledInverted,
+            type = KSButtonType.FILLED_INVERTED,
             text = "Loading",
             isLoading = true,
             imageId = R.drawable.icon_eye_gray
@@ -477,14 +477,14 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.FilledDestructive,
+            type = KSButtonType.FILLED_DESTRUCTIVE,
             text = "Destructive",
             imageId = R.drawable.icon_eye_gray
         )
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.FilledDestructive,
+            type = KSButtonType.FILLED_DESTRUCTIVE,
             text = "Pressed",
             isPressed = true,
             imageId = R.drawable.icon_eye_gray
@@ -492,7 +492,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.FilledDestructive,
+            type = KSButtonType.FILLED_DESTRUCTIVE,
             text = "Disabled",
             isEnabled = false,
             imageId = R.drawable.icon_eye_gray
@@ -500,7 +500,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.FilledDestructive,
+            type = KSButtonType.FILLED_DESTRUCTIVE,
             text = "Loading",
             isLoading = true,
             imageId = R.drawable.icon_eye_gray
@@ -511,14 +511,14 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Borderless,
+            type = KSButtonType.BORDERLESS,
             text = "Borderless",
             imageId = R.drawable.icon_eye_gray
         )
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Borderless,
+            type = KSButtonType.BORDERLESS,
             text = "Pressed",
             isPressed = true,
             imageId = R.drawable.icon_eye_gray
@@ -526,7 +526,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Borderless,
+            type = KSButtonType.BORDERLESS,
             text = "Disabled",
             isEnabled = false,
             imageId = R.drawable.icon_eye_gray
@@ -534,7 +534,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Borderless,
+            type = KSButtonType.BORDERLESS,
             text = "Loading",
             isLoading = true,
             imageId = R.drawable.icon_eye_gray
@@ -544,14 +544,14 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Outlined,
+            type = KSButtonType.OUTLINED,
             text = "Outlined",
             imageId = R.drawable.icon_eye_gray
         )
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Outlined,
+            type = KSButtonType.OUTLINED,
             text = "Pressed",
             isPressed = true,
             imageId = R.drawable.icon_eye_gray
@@ -559,7 +559,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Outlined,
+            type = KSButtonType.OUTLINED,
             text = "Disabled",
             isEnabled = false,
             imageId = R.drawable.icon_eye_gray
@@ -567,7 +567,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.Outlined,
+            type = KSButtonType.OUTLINED,
             text = "Loading",
             isLoading = true,
             imageId = R.drawable.icon_eye_gray
@@ -578,14 +578,14 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.OutlinedDestructive,
+            type = KSButtonType.OUTLINED_DESTRUCTIVE,
             text = "Outlined Destructive",
             imageId = R.drawable.icon_eye_gray
         )
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.OutlinedDestructive,
+            type = KSButtonType.OUTLINED_DESTRUCTIVE,
             text = "Pressed",
             isPressed = true,
             imageId = R.drawable.icon_eye_gray
@@ -593,7 +593,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.OutlinedDestructive,
+            type = KSButtonType.OUTLINED_DESTRUCTIVE,
             text = "Disabled",
             isEnabled = false,
             imageId = R.drawable.icon_eye_gray
@@ -601,7 +601,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.OutlinedDestructive,
+            type = KSButtonType.OUTLINED_DESTRUCTIVE,
             text = "Loading",
             isLoading = true,
             imageId = R.drawable.icon_eye_gray
@@ -612,14 +612,14 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.BorderlessDestructive,
+            type = KSButtonType.BORDERLESS_DESTRUCTIVE,
             text = "Borderless Destructive",
             imageId = R.drawable.icon_eye_gray
         )
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.BorderlessDestructive,
+            type = KSButtonType.BORDERLESS_DESTRUCTIVE,
             text = "Pressed",
             isPressed = true,
             imageId = R.drawable.icon_eye_gray
@@ -627,7 +627,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.BorderlessDestructive,
+            type = KSButtonType.BORDERLESS_DESTRUCTIVE,
             text = "Disabled",
             isEnabled = false,
             imageId = R.drawable.icon_eye_gray
@@ -635,7 +635,7 @@ fun NewDesignSystemButtonsVisuals() {
         KSButton(
             modifier = Modifier.fillMaxWidth(),
             onClickAction = {},
-            type = KSButtonType.BorderlessDestructive,
+            type = KSButtonType.BORDERLESS_DESTRUCTIVE,
             text = "Loading",
             isLoading = true,
             imageId = R.drawable.icon_eye_gray

--- a/app/src/internal/java/com/kickstarter/ui/activities/DesignSystemActivity.kt
+++ b/app/src/internal/java/com/kickstarter/ui/activities/DesignSystemActivity.kt
@@ -116,6 +116,25 @@ fun DesignSystemViewPreview() {
     }
 }
 
+@Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO, showSystemUi = true)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES, showSystemUi = true)
+@Composable
+fun DesignSystemButtonsV2Preview() {
+    val currentTheme = isSystemInDarkTheme()
+    var darkMode = remember { mutableStateOf(currentTheme) }
+    KSTheme(
+        useDarkTheme = darkMode.value
+    ) {
+        Column(
+            Modifier
+                .background(color = colors.backgroundSurfacePrimary)
+                .padding(all = dimensions.paddingSmall)
+        ) {
+            NewDesignSystemButtonsVisuals()
+        }
+    }
+}
+
 @SuppressLint("UnrememberedMutableInteractionSource")
 @Composable
 fun DesignSystemView(darkMode: MutableState<Boolean>, onBackClicked: () -> Unit) {
@@ -141,13 +160,13 @@ fun DesignSystemView(darkMode: MutableState<Boolean>, onBackClicked: () -> Unit)
                         )
                     }
                 },
-                backgroundColor = colors.kds_white
+                backgroundColor = colors.backgroundSurfaceSecondary
             )
         }
     ) { padding ->
         LazyColumn(
             Modifier
-                .background(color = colors.kds_support_100)
+                .background(color = colors.backgroundSurfacePrimary)
                 .fillMaxSize()
                 .padding(padding)
                 .clickable(

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/MultiCategorySelectionSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/MultiCategorySelectionSheet.kt
@@ -154,14 +154,14 @@ fun MultiCategorySelectionSheet(
                             onClickAction = {
                                 selectedCategories = selectedCategories.mapValues { false }
                             },
-                            type = KSButtonType.Outlined,
+                            type = KSButtonType.OUTLINED,
                             text = stringResource(R.string.Reset_filters),
                             isEnabled = !isLoading
                         )
                         KSButton(
                             modifier = Modifier.weight(1f),
                             onClickAction = { onApply(totalSelectedResults) },
-                            type = KSButtonType.Filled,
+                            type = KSButtonType.FILLED,
                             text = "See $totalSelectedResults results",
                             isEnabled = totalSelectedResults > 0 && !isLoading,
                         )

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSButtonColorVariables.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSButtonColorVariables.kt
@@ -21,7 +21,7 @@ data class ButtonColorVariables(
 @Composable
 fun filledButtonColors(
     color: KSButtonColors,
-) : ButtonColorVariables {
+): ButtonColorVariables {
 
     val buttonColors = ButtonColorVariables(
         backgroundColor = color.filledBackgroundAction,
@@ -42,7 +42,7 @@ fun filledButtonColors(
 @Composable
 fun greenButtonColors(
     color: KSButtonColors,
-) : ButtonColorVariables {
+): ButtonColorVariables {
 
     val buttonColors = ButtonColorVariables(
         backgroundColor = color.greenBackgroundAccentBold,
@@ -63,7 +63,7 @@ fun greenButtonColors(
 @Composable
 fun filledInvertedButtonColors(
     color: KSButtonColors,
-) : ButtonColorVariables {
+): ButtonColorVariables {
 
     val buttonColors = ButtonColorVariables(
         backgroundColor = color.filledInvertedBackgroundSurfacePrimary,
@@ -84,7 +84,7 @@ fun filledInvertedButtonColors(
 @Composable
 fun filledDestructiveButtonColors(
     color: KSButtonColors,
-) : ButtonColorVariables {
+): ButtonColorVariables {
 
     val buttonColors = ButtonColorVariables(
         backgroundColor = color.destructiveBackgroundBold,
@@ -105,7 +105,7 @@ fun filledDestructiveButtonColors(
 @Composable
 fun borderlessButtonColors(
     color: KSButtonColors,
-) : ButtonColorVariables {
+): ButtonColorVariables {
 
     val buttonColors = ButtonColorVariables(
         backgroundColor = Color.Transparent,
@@ -126,7 +126,7 @@ fun borderlessButtonColors(
 @Composable
 fun outlinedButtonColors(
     color: KSButtonColors,
-) : ButtonColorVariables {
+): ButtonColorVariables {
 
     val buttonColors = ButtonColorVariables(
         backgroundColor = Color.Transparent,
@@ -147,7 +147,7 @@ fun outlinedButtonColors(
 @Composable
 fun outlinedDestructiveButtonColors(
     color: KSButtonColors,
-) : ButtonColorVariables {
+): ButtonColorVariables {
 
     val buttonColors = ButtonColorVariables(
         backgroundColor = Color.Transparent,
@@ -168,7 +168,7 @@ fun outlinedDestructiveButtonColors(
 @Composable
 fun borderLessDestructiveButtonColors(
     color: KSButtonColors,
-) : ButtonColorVariables {
+): ButtonColorVariables {
 
     val buttonColors = ButtonColorVariables(
         backgroundColor = Color.Transparent,
@@ -189,7 +189,7 @@ fun borderLessDestructiveButtonColors(
 @Composable
 fun fbLoginButtonColors(
     colors: KSButtonColors,
-) : ButtonColorVariables {
+): ButtonColorVariables {
 
     val buttonColors = ButtonColorVariables(
         backgroundColor = colors.fbLoginButtonBackgroundColor,

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSButtonColorVariables.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSButtonColorVariables.kt
@@ -1,0 +1,208 @@
+package com.kickstarter.ui.compose.designsystem
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.kickstarter.ui.compose.designsystem.KSTheme.colors
+
+data class ButtonColorVariables(
+    val backgroundColor: Color,
+    val pressedColor: Color,
+    val disabledColor: Color,
+    val textColor: Color,
+    val disabledTextColor: Color,
+    val loadingSpinnerColor: Color,
+    val borderColor: Color,
+    val borderColorPressed: Color,
+    val borderColorDisabled: Color,
+    val iconEnabled: Color,
+    val iconDisabled: Color,
+)
+
+@Composable
+fun filledButtonColors(
+    color: KSButtonColors,
+) : ButtonColorVariables {
+
+    val buttonColors = ButtonColorVariables(
+        backgroundColor = color.filledBackgroundAction,
+        pressedColor = color.filledBackgroundActionPressed,
+        disabledColor = color.filledBackgroundActionDisabled,
+        textColor = colors.textInversePrimary,
+        disabledTextColor = color.filledTextInverseDisabled,
+        loadingSpinnerColor = color.filledLoadingSpinner,
+        borderColor = Color.Transparent,
+        borderColorPressed = Color.Transparent,
+        borderColorDisabled = Color.Transparent,
+        iconEnabled = color.iconFilled,
+        iconDisabled = color.iconFilled
+    )
+    return buttonColors
+}
+
+@Composable
+fun greenButtonColors(
+    color: KSButtonColors,
+) : ButtonColorVariables {
+
+    val buttonColors = ButtonColorVariables(
+        backgroundColor = color.greenBackgroundAccentBold,
+        pressedColor = color.greenBackgroundAccentBoldPressed,
+        disabledColor = color.greenBackgroundAccentDisabled,
+        textColor = colors.textInversePrimary,
+        disabledTextColor = color.greenTextDisabled,
+        loadingSpinnerColor = color.greenLoadingSpinner,
+        borderColor = Color.Transparent,
+        borderColorPressed = Color.Transparent,
+        borderColorDisabled = Color.Transparent,
+        iconEnabled = color.iconGreen,
+        iconDisabled = color.iconGreenDisabled
+    )
+    return buttonColors
+}
+
+@Composable
+fun filledInvertedButtonColors(
+    color: KSButtonColors,
+) : ButtonColorVariables {
+
+    val buttonColors = ButtonColorVariables(
+        backgroundColor = color.filledInvertedBackgroundSurfacePrimary,
+        pressedColor = color.filledInvertedBackgroundInversePressed,
+        disabledColor = color.filledInvertedBackgroundInverseDisabled,
+        textColor = colors.textPrimary,
+        disabledTextColor = color.filledInvertedTextDisabled,
+        loadingSpinnerColor = color.filledInvertedTextDisabled,
+        borderColor = Color.Transparent,
+        borderColorPressed = Color.Transparent,
+        borderColorDisabled = Color.Transparent,
+        iconEnabled = color.iconFilledInverted,
+        iconDisabled = color.iconFilledInvertedDisabled
+    )
+    return buttonColors
+}
+
+@Composable
+fun filledDestructiveButtonColors(
+    color: KSButtonColors,
+) : ButtonColorVariables {
+
+    val buttonColors = ButtonColorVariables(
+        backgroundColor = color.destructiveBackgroundBold,
+        pressedColor = color.destructiveBackgroundPressed,
+        disabledColor = color.destructiveBackgroundDisabled,
+        textColor = colors.textInversePrimary,
+        disabledTextColor = color.destructiveTextAccentRedInverseDisabled,
+        loadingSpinnerColor = color.destructiveLoadingSpinner,
+        borderColor = Color.Transparent,
+        borderColorPressed = Color.Transparent,
+        borderColorDisabled = Color.Transparent,
+        iconEnabled = color.iconFilledDestructive,
+        iconDisabled = color.iconFilledDestructiveDisabled,
+    )
+    return buttonColors
+}
+
+@Composable
+fun borderlessButtonColors(
+    color: KSButtonColors,
+) : ButtonColorVariables {
+
+    val buttonColors = ButtonColorVariables(
+        backgroundColor = Color.Transparent,
+        pressedColor = color.borderlessBackgroundInversePressed,
+        disabledColor = Color.Transparent,
+        textColor = colors.textPrimary,
+        disabledTextColor = color.borderlessTextDisabled,
+        loadingSpinnerColor = color.borderlessLoadingSpinner,
+        borderColor = Color.Transparent,
+        borderColorPressed = Color.Transparent,
+        borderColorDisabled = Color.Transparent,
+        iconEnabled = color.iconBorderless,
+        iconDisabled = color.iconBorderlessDisabled,
+    )
+    return buttonColors
+}
+
+@Composable
+fun outlinedButtonColors(
+    color: KSButtonColors,
+) : ButtonColorVariables {
+
+    val buttonColors = ButtonColorVariables(
+        backgroundColor = Color.Transparent,
+        pressedColor = color.outlinedBackgroundInversePressed,
+        disabledColor = Color.Transparent,
+        textColor = colors.textPrimary,
+        disabledTextColor = color.outlinedTextDisabled,
+        loadingSpinnerColor = color.outlinedLoadingSpinner,
+        borderColor = color.outlinedBorderBold,
+        borderColorPressed = color.outlinedBackgroundInversePressed,
+        borderColorDisabled = color.outlinedBorderSubtle,
+        iconEnabled = color.iconOutlined,
+        iconDisabled = color.iconOutlinedDisabled
+    )
+    return buttonColors
+}
+
+@Composable
+fun outlinedDestructiveButtonColors(
+    color: KSButtonColors,
+) : ButtonColorVariables {
+
+    val buttonColors = ButtonColorVariables(
+        backgroundColor = Color.Transparent,
+        pressedColor = color.outlinedDestructiveBackgroundAccentRedSubtle,
+        disabledColor = Color.Transparent,
+        textColor = colors.textAccentRed,
+        disabledTextColor = color.outlinedDestructiveTextAccentRedDisabled,
+        loadingSpinnerColor = color.outlinedDestructiveLoadingSpinner,
+        borderColor = color.outlinedDestructiveBorderBold,
+        borderColorPressed = color.outlinedDestructiveBorderPressedBold,
+        borderColorDisabled = color.outlinedDestructiveTextAccentRedDisabled,
+        iconEnabled = color.iconOutlinedDestructive,
+        iconDisabled = color.iconOutlinedDestructiveDisabled
+    )
+    return buttonColors
+}
+
+@Composable
+fun borderLessDestructiveButtonColors(
+    color: KSButtonColors,
+) : ButtonColorVariables {
+
+    val buttonColors = ButtonColorVariables(
+        backgroundColor = Color.Transparent,
+        pressedColor = color.borderlessDestructiveBackgroundAccentRedSubtle,
+        disabledColor = Color.Transparent,
+        textColor = colors.textAccentRed,
+        disabledTextColor = color.borderlessDestructiveTextAccentRedDisabled,
+        loadingSpinnerColor = color.borderlessDestructiveLoadingSpinner,
+        borderColor = Color.Transparent,
+        borderColorPressed = Color.Transparent,
+        borderColorDisabled = Color.Transparent,
+        iconEnabled = color.iconBorderlessDestructive,
+        iconDisabled = color.iconBorderlessDestructiveDisabled
+    )
+    return buttonColors
+}
+
+@Composable
+fun fbLoginButtonColors(
+    colors: KSButtonColors,
+) : ButtonColorVariables {
+
+    val buttonColors = ButtonColorVariables(
+        backgroundColor = colors.fbLoginButtonBackgroundColor,
+        pressedColor = colors.fbLoginButtonPressedColor,
+        disabledColor = colors.fbLoginButtonBackgroundColor,
+        textColor = colors.fbLoginButtonTextColor,
+        disabledTextColor = colors.fbLoginButtonTextColor,
+        loadingSpinnerColor = Color.Transparent,
+        borderColor = Color.Transparent,
+        borderColorPressed = Color.Transparent,
+        borderColorDisabled = Color.Transparent,
+        iconEnabled = Color.White,
+        iconDisabled = Color.White
+    )
+    return buttonColors
+}

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSButtonsColors.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSButtonsColors.kt
@@ -70,7 +70,7 @@ data class KSButtonColors(
     val fbLoginButtonTextColor: Color = Color.Unspecified,
     val fbLoginButtonPressedColor: Color = Color.Unspecified,
 
-    //Icon Colors
+    // Icon Colors
     val iconFilled: Color = Color.Unspecified,
     val iconGreen: Color = Color.Unspecified,
     val iconGreenDisabled: Color = Color.Unspecified,
@@ -174,7 +174,7 @@ val KSDefaultButtonColors = KSButtonColors(
 
 val KSDarkButtonColors = KSButtonColors(
     // Filled Button Colors – reuse common neutral colors
-    filledBackgroundAction =  Color(0xFFFAFAFA),
+    filledBackgroundAction = Color(0xFFFAFAFA),
     filledBackgroundActionPressed = Color(0xFFE0E0E0),
     filledBackgroundActionDisabled = Color(0xFF636363),
     filledTextInverseDisabled = Color(0xFF2C2C2C),

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSButtonsColors.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSButtonsColors.kt
@@ -31,6 +31,7 @@ data class KSButtonColors(
     // Filled Destructive Button Colors
     val destructiveBackgroundBold: Color = Color.Unspecified,
     val destructiveBackgroundDisabled: Color = Color.Unspecified,
+    val destructiveBackgroundPressed: Color = Color.Unspecified,
     val destructiveTextInversePrimary: Color = Color.Unspecified,
     val destructiveTextAccentRedInverseDisabled: Color = Color.Unspecified,
     val destructiveLoadingSpinner: Color = Color.Unspecified,
@@ -50,10 +51,10 @@ data class KSButtonColors(
     val outlinedLoadingSpinner: Color = Color.Unspecified,
 
     // Outlined Destructive Button Colors
-    val outlinedDestructiveBackgroundBold: Color = Color.Unspecified,
+    val outlinedDestructiveBorderBold: Color = Color.Unspecified,
     val outlinedDestructiveTextAccentRed: Color = Color.Unspecified,
     val outlinedDestructiveBackgroundAccentRedSubtle: Color = Color.Unspecified,
-    val outlinedDestructiveBorderDangerBold: Color = Color.Unspecified,
+    val outlinedDestructiveBorderPressedBold: Color = Color.Unspecified,
     val outlinedDestructiveTextAccentRedDisabled: Color = Color.Unspecified,
     val outlinedDestructiveLoadingSpinner: Color = Color.Unspecified,
 
@@ -68,6 +69,23 @@ data class KSButtonColors(
     val fbLoginButtonBackgroundColor: Color = Color.Unspecified,
     val fbLoginButtonTextColor: Color = Color.Unspecified,
     val fbLoginButtonPressedColor: Color = Color.Unspecified,
+
+    //Icon Colors
+    val iconFilled: Color = Color.Unspecified,
+    val iconGreen: Color = Color.Unspecified,
+    val iconGreenDisabled: Color = Color.Unspecified,
+    val iconFilledInverted: Color = Color.Unspecified,
+    val iconFilledInvertedDisabled: Color = Color.Unspecified,
+    val iconFilledDestructive: Color = Color.Unspecified,
+    val iconFilledDestructiveDisabled: Color = Color.Unspecified,
+    val iconBorderless: Color = Color.Unspecified,
+    val iconBorderlessDisabled: Color = Color.Unspecified,
+    val iconOutlined: Color = Color.Unspecified,
+    val iconOutlinedDisabled: Color = Color.Unspecified,
+    val iconOutlinedDestructive: Color = Color.Unspecified,
+    val iconOutlinedDestructiveDisabled: Color = Color.Unspecified,
+    val iconBorderlessDestructive: Color = Color.Unspecified,
+    val iconBorderlessDestructiveDisabled: Color = Color.Unspecified,
 )
 
 val LocalKSButtonColors = staticCompositionLocalOf { KSButtonColors() }
@@ -97,6 +115,7 @@ val KSDefaultButtonColors = KSButtonColors(
 
     // Filled Destructive Button Colors
     destructiveBackgroundBold = Color(0xFFB81F14),
+    destructiveBackgroundPressed = Color(0xFF73140D),
     destructiveBackgroundDisabled = Color(0xFFF7BBB7),
     destructiveTextInversePrimary = Color(0xFFFFFFFF),
     destructiveTextAccentRedInverseDisabled = Color(0xFFFEF2F1),
@@ -117,10 +136,10 @@ val KSDefaultButtonColors = KSButtonColors(
     outlinedLoadingSpinner = Color(0xFF3C3C3C),
 
     // Outlined Destructive Button Colors
-    outlinedDestructiveBackgroundBold = Color(0xFFB81F14),
+    outlinedDestructiveBorderBold = Color(0xFFB81F14),
     outlinedDestructiveTextAccentRed = Color(0xFF73140D),
     outlinedDestructiveBackgroundAccentRedSubtle = Color(0xFFFEF2F1),
-    outlinedDestructiveBorderDangerBold = Color(0xFF73140D),
+    outlinedDestructiveBorderPressedBold = Color(0xFF73140D),
     outlinedDestructiveTextAccentRedDisabled = Color(0xFFF7BBB7),
     outlinedDestructiveLoadingSpinner = Color(0xFF931910),
 
@@ -134,5 +153,101 @@ val KSDefaultButtonColors = KSButtonColors(
     // Facebook Login Button Colors
     fbLoginButtonBackgroundColor = Color(0xFF1877F2),
     fbLoginButtonTextColor = Color.White,
-    fbLoginButtonPressedColor = Color(0xFF135ABE)
+    fbLoginButtonPressedColor = Color(0xFF135ABE),
+
+    iconFilled = Color(0xFFE0E0E0),
+    iconGreen = Color(0xFFD2FEEB),
+    iconGreenDisabled = Color(0xFFB3B3B3),
+    iconFilledInverted = Color(0xFF3C3C3C),
+    iconFilledInvertedDisabled = Color(0xFFB3B3B3),
+    iconFilledDestructive = Color(0xFFFEF2F1),
+    iconFilledDestructiveDisabled = Color(0xFFFEF2F1),
+    iconBorderless = Color(0xFF3C3C3C),
+    iconBorderlessDisabled = Color(0xFFB3B3B3),
+    iconOutlined = Color(0xFF3C3C3C),
+    iconOutlinedDisabled = Color(0xFFB3B3B3),
+    iconOutlinedDestructive = Color(0xFF931910),
+    iconOutlinedDestructiveDisabled = Color(0xFFF7BBB7),
+    iconBorderlessDestructive = Color(0xFF931910),
+    iconBorderlessDestructiveDisabled = Color(0xFFF7BBB7),
+)
+
+val KSDarkButtonColors = KSButtonColors(
+    // Filled Button Colors – reuse common neutral colors
+    filledBackgroundAction =  Color(0xFFFAFAFA),
+    filledBackgroundActionPressed = Color(0xFFE0E0E0),
+    filledBackgroundActionDisabled = Color(0xFF636363),
+    filledTextInverseDisabled = Color(0xFF2C2C2C),
+    filledLoadingSpinner = Color(0xFFF2F2F2),
+
+    // Green Button Colors
+    greenBackgroundAccentBold = Color(0xFF05CE78),
+    greenBackgroundAccentBoldPressed = Color(0xFF79FCC3),
+    greenBackgroundAccentDisabled = Color(0xFF01321D),
+    greenTextDisabled = Color(0xFF636363),
+    greenLoadingSpinner = Color(0xFF79FCC3),
+
+    // Filled Inverted Button Colors
+    filledInvertedBackgroundSurfacePrimary = Color(0xFF171717),
+    filledInvertedBackgroundInversePressed = Color(0xFF3C3C3C),
+    filledInvertedBackgroundInverseDisabled = Color(0xFF363636),
+    filledInvertedTextDisabled = Color(0xFF636363),
+    filledInvertedLoadingSpinner = Color(0xFFF2F2F2),
+
+    // Filled Destructive Button Colors
+    destructiveBackgroundBold = Color(0xFFF39C95),
+    destructiveBackgroundDisabled = Color(0xFF2E0805),
+    destructiveBackgroundPressed = Color(0xFFFBDDDB),
+    destructiveTextAccentRedInverseDisabled = Color(0xFF73140D),
+    destructiveLoadingSpinner = Color(0xFFF7BBB7),
+
+    // Borderless Button Colors
+    borderlessTextPrimary = Color(0xFF171717),
+    borderlessBackgroundInversePressed = Color(0xFF3C3C3C),
+    borderlessTextDisabled = Color(0xFF636363),
+    borderlessLoadingSpinner = Color(0xFFF2F2F2),
+
+    // Outlined Button Colors
+    outlinedBorderBold = Color(0xFF858585),
+    outlinedBackgroundInversePressed = Color(0xFF3C3C3C),
+    outlinedBorderSubtle = Color(0xFF4D4D4D),
+    outlinedTextDisabled = Color(0xFF636363),
+    outlinedLoadingSpinner = Color(0xFFF2F2F2),
+
+    // Outlined Destructive Button Colors
+    outlinedDestructiveBorderBold = Color(0xFFF39C95),
+    outlinedDestructiveTextAccentRed = Color(0xFF73140D),
+    outlinedDestructiveBackgroundAccentRedSubtle = Color(0xFF530E09),
+    outlinedDestructiveBorderPressedBold = Color(0xFFFBDDDB),
+    outlinedDestructiveTextAccentRedDisabled = Color(0xFF931910),
+    outlinedDestructiveLoadingSpinner = Color(0xFFF7BBB7),
+
+    // Borderless Destructive Button Colors
+    borderlessDestructiveTextAccentRed = Color(0xFFB81F14),
+    borderlessDestructiveTextAccentRedBolder = Color(0xFF73140D),
+    borderlessDestructiveTextAccentRedDisabled = Color(0xFF931910),
+    borderlessDestructiveBackgroundAccentRedSubtle = Color(0xFF530E09),
+    borderlessDestructiveLoadingSpinner = Color(0xFFF7BBB7),
+
+    // Facebook Login Button Colors
+    fbLoginButtonBackgroundColor = Color(0xFF1877F2),
+    fbLoginButtonTextColor = Color.White,
+    fbLoginButtonPressedColor = Color(0xFF135ABE),
+
+    iconFilled = Color(0xFF3C3C3C),
+    iconGreen = Color(0xFF024629),
+    iconGreenDisabled = Color(0xFF636363),
+    iconFilledInverted = Color(0xFFF2F2F2),
+    iconFilledInvertedDisabled = Color(0xFF636363),
+    iconFilledDestructive = Color(0xFF73140D),
+    iconFilledDestructiveDisabled = Color(0xFF73140D),
+    iconBorderless = Color(0xFFF2F2F2),
+    iconBorderlessDisabled = Color(0xFF636363),
+    iconOutlined = Color(0xFFF2F2F2),
+    iconOutlinedDisabled = Color(0xFF3C3C3C),
+    iconOutlinedDestructive = Color(0xFFF7BBB7),
+    iconOutlinedDestructiveDisabled = Color(0xFF931910),
+    iconBorderlessDestructive = Color(0xFFF7BBB7),
+    iconBorderlessDestructiveDisabled = Color(0xFF931910),
+
 )

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSButtonsV2.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSButtonsV2.kt
@@ -1,9 +1,11 @@
 package com.kickstarter.ui.compose.designsystem
 
 import android.content.res.Configuration
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -29,145 +32,16 @@ import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
 import com.kickstarter.ui.compose.designsystem.KSTheme.typographyV2
 
-data class ButtonColorVariables(
-    val backgroundColor: Color,
-    val pressedColor: Color,
-    val disabledColor: Color,
-    val textColor: Color,
-    val disabledTextColor: Color,
-    val loadingSpinnerColor: Color,
-    val borderColor: Color,
-    val borderColorPressed: Color,
-    val borderColorDisabled: Color,
-)
-
-val FilledButtonColors = ButtonColorVariables(
-    backgroundColor = KSDefaultButtonColors.filledBackgroundAction,
-    pressedColor = KSDefaultButtonColors.filledBackgroundActionPressed,
-    disabledColor = KSDefaultButtonColors.filledBackgroundActionDisabled,
-    textColor = Color.White,
-    disabledTextColor = KSDefaultButtonColors.filledTextInverseDisabled,
-    loadingSpinnerColor = KSDefaultButtonColors.filledLoadingSpinner,
-    borderColor = Color.Transparent,
-    borderColorPressed = Color.Transparent,
-    borderColorDisabled = Color.Transparent
-)
-
-// For Green buttons, enabled text is also white.
-val GreenButtonColors = ButtonColorVariables(
-    backgroundColor = KSDefaultButtonColors.greenBackgroundAccentBold,
-    pressedColor = KSDefaultButtonColors.greenBackgroundAccentBoldPressed,
-    disabledColor = KSDefaultButtonColors.greenBackgroundAccentDisabled,
-    textColor = Color.White,
-    disabledTextColor = KSDefaultButtonColors.greenTextDisabled,
-    loadingSpinnerColor = KSDefaultButtonColors.greenLoadingSpinner,
-    borderColor = Color.Transparent,
-    borderColorPressed = Color.Transparent,
-    borderColorDisabled = Color.Transparent
-)
-
-// For Filled Inverted buttons, we use the inverted color palette.
-val FilledInvertedButtonColors = ButtonColorVariables(
-    backgroundColor = KSDefaultButtonColors.filledInvertedBackgroundSurfacePrimary,
-    pressedColor = KSDefaultButtonColors.filledInvertedBackgroundInversePressed,
-    disabledColor = KSDefaultButtonColors.filledInvertedBackgroundInverseDisabled,
-    textColor = KSDefaultButtonColors.filledInvertedTextPrimary,
-    disabledTextColor = KSDefaultButtonColors.filledInvertedTextDisabled,
-    loadingSpinnerColor = KSDefaultButtonColors.filledInvertedLoadingSpinner,
-    borderColor = Color.Transparent,
-    borderColorPressed = Color.Transparent,
-    borderColorDisabled = Color.Transparent
-)
-
-// For Filled Destructive buttons.
-val FilledDestructiveButtonColors = ButtonColorVariables(
-    backgroundColor = KSDefaultButtonColors.destructiveBackgroundBold,
-    pressedColor = KSDefaultButtonColors.destructiveBackgroundBold, // Using the same as background for pressed.
-    disabledColor = KSDefaultButtonColors.destructiveBackgroundDisabled,
-    textColor = KSDefaultButtonColors.destructiveTextInversePrimary,
-    disabledTextColor = KSDefaultButtonColors.destructiveTextAccentRedInverseDisabled,
-    loadingSpinnerColor = KSDefaultButtonColors.destructiveLoadingSpinner,
-    borderColor = Color.Transparent,
-    borderColorPressed = Color.Transparent,
-    borderColorDisabled = Color.Transparent
-)
-
-// For Borderless buttons, we use a transparent background.
-val BorderlessButtonColors = ButtonColorVariables(
-    backgroundColor = Color.Transparent,
-    pressedColor = KSDefaultButtonColors.borderlessBackgroundInversePressed,
-    disabledColor = Color.Transparent,
-    textColor = KSDefaultButtonColors.borderlessTextPrimary,
-    disabledTextColor = KSDefaultButtonColors.borderlessTextDisabled,
-    loadingSpinnerColor = KSDefaultButtonColors.borderlessLoadingSpinner,
-    borderColor = Color.Transparent,
-    borderColorPressed = Color.Transparent,
-    borderColorDisabled = Color.Transparent
-)
-
-// For Outlined buttons.
-val OutlinedButtonColors = ButtonColorVariables(
-    backgroundColor = Color.Transparent,
-    pressedColor = KSDefaultButtonColors.outlinedBackgroundInversePressed,
-    disabledColor = Color.Transparent,
-    textColor = KSDefaultButtonColors.outlinedTextPrimary,
-    disabledTextColor = KSDefaultButtonColors.outlinedTextDisabled,
-    loadingSpinnerColor = KSDefaultButtonColors.outlinedLoadingSpinner,
-    borderColor = KSDefaultButtonColors.outlinedBorderBold,
-    borderColorPressed = KSDefaultButtonColors.outlinedBackgroundInversePressed,
-    borderColorDisabled = KSDefaultButtonColors.outlinedBorderSubtle
-)
-
-// For Outlined Destructive buttons.
-val OutlinedDestructiveButtonColors = ButtonColorVariables(
-    backgroundColor = Color.Transparent,
-    pressedColor = KSDefaultButtonColors.outlinedDestructiveBackgroundAccentRedSubtle,
-    disabledColor = Color.Transparent,
-    textColor = KSDefaultButtonColors.outlinedDestructiveTextAccentRed,
-    disabledTextColor = KSDefaultButtonColors.outlinedDestructiveTextAccentRedDisabled,
-    loadingSpinnerColor = KSDefaultButtonColors.outlinedDestructiveLoadingSpinner,
-    borderColor = KSDefaultButtonColors.outlinedDestructiveBackgroundBold,
-    borderColorPressed = KSDefaultButtonColors.outlinedDestructiveTextAccentRed,
-    borderColorDisabled = KSDefaultButtonColors.outlinedDestructiveTextAccentRedDisabled
-)
-
-// For Borderless Destructive buttons.
-val BorderlessDestructiveButtonColors = ButtonColorVariables(
-    backgroundColor = Color.Transparent,
-    pressedColor = KSDefaultButtonColors.borderlessDestructiveBackgroundAccentRedSubtle,
-    disabledColor = Color.Transparent,
-    textColor = KSDefaultButtonColors.borderlessDestructiveTextAccentRed,
-    disabledTextColor = KSDefaultButtonColors.borderlessDestructiveTextAccentRedDisabled,
-    loadingSpinnerColor = KSDefaultButtonColors.borderlessDestructiveLoadingSpinner,
-    borderColor = Color.Transparent,
-    borderColorPressed = Color.Transparent,
-    borderColorDisabled = Color.Transparent
-)
-
-// For Facebook Login buttons.
-val FBLoginButtonColors = ButtonColorVariables(
-    backgroundColor = KSDefaultButtonColors.fbLoginButtonBackgroundColor,
-    pressedColor = KSDefaultButtonColors.fbLoginButtonPressedColor,
-    disabledColor = KSDefaultButtonColors.fbLoginButtonBackgroundColor,
-    textColor = KSDefaultButtonColors.fbLoginButtonTextColor,
-    disabledTextColor = KSDefaultButtonColors.fbLoginButtonTextColor,
-    loadingSpinnerColor = Color.Transparent,
-    borderColor = Color.Transparent,
-    borderColorPressed = Color.Transparent,
-    borderColorDisabled = Color.Transparent
-)
-
-// Define a sealed class for different button types
-sealed class KSButtonType(val colors: ButtonColorVariables) {
-    object Filled : KSButtonType(FilledButtonColors)
-    object Green : KSButtonType(GreenButtonColors)
-    object FilledInverted : KSButtonType(FilledInvertedButtonColors)
-    object FilledDestructive : KSButtonType(FilledDestructiveButtonColors)
-    object Borderless : KSButtonType(BorderlessButtonColors)
-    object Outlined : KSButtonType(OutlinedButtonColors)
-    object OutlinedDestructive : KSButtonType(OutlinedDestructiveButtonColors)
-    object BorderlessDestructive : KSButtonType(BorderlessDestructiveButtonColors)
-    object Facebook : KSButtonType(FBLoginButtonColors)
+enum class KSButtonType {
+    FILLED,
+    GREEN,
+    FILLED_INVERTED,
+    FILLED_DESTRUCTIVE,
+    BORDERLESS,
+    OUTLINED,
+    OUTLINED_DESTRUCTIVE,
+    BORDERLESS_DESTRUCTIVE,
+    FACEBOOK,
 }
 
 @Composable
@@ -182,59 +56,35 @@ fun KSButton(
     imageId: Int? = null,
     imageContentDescription: String? = null,
 ) {
-    CreateButton(
-        modifier = if (type is KSButtonType.Outlined || type is KSButtonType.OutlinedDestructive) {
-            modifier.border(
-                width = dimensions.dividerThickness,
-                color = when {
-                    isPressed -> type.colors.borderColorPressed
-                    !isEnabled -> type.colors.borderColorDisabled
-                    else -> type.colors.borderColor
-                },
-                shape = RoundedCornerShape(size = dimensions.radiusExtraSmall)
-            )
-        } else modifier,
-        onClickAction = onClickAction,
-        text = text,
-        colors = type.colors,
-        imageId = imageId,
-        imageContentDescription = imageContentDescription,
-        isEnabled = isEnabled,
-        isLoading = isLoading,
-        isPressed = isPressed,
-        isBorderless = type is KSButtonType.Borderless || type is KSButtonType.BorderlessDestructive
-    )
-}
+    val colors = if (!isSystemInDarkTheme()) {
+        KSDefaultButtonColors
+    } else {
+        KSDarkButtonColors
+    }
 
-@Composable
-fun CreateButton(
-    modifier: Modifier = Modifier,
-    onClickAction: () -> Unit,
-    text: String,
-    colors: ButtonColorVariables,
-    imageId: Int? = null,
-    imageContentDescription: String? = null,
-    isEnabled: Boolean = true,
-    isLoading: Boolean = false,
-    isPressed: Boolean = false,
-    isBorderless: Boolean = false,
-) {
+    val buttonColors = when(type) {
+        KSButtonType.FILLED -> filledButtonColors(colors)
+        KSButtonType.GREEN -> greenButtonColors(colors)
+        KSButtonType.FILLED_INVERTED -> filledInvertedButtonColors(colors)
+        KSButtonType.FILLED_DESTRUCTIVE -> filledDestructiveButtonColors(colors)
+        KSButtonType.BORDERLESS -> borderlessButtonColors(colors)
+        KSButtonType.OUTLINED -> outlinedButtonColors(colors)
+        KSButtonType.OUTLINED_DESTRUCTIVE -> outlinedDestructiveButtonColors(colors)
+        KSButtonType.BORDERLESS_DESTRUCTIVE -> borderLessDestructiveButtonColors(colors)
+        KSButtonType.FACEBOOK -> fbLoginButtonColors(colors)
+    }
+
     BaseButton(
         modifier = modifier,
         onClickAction = onClickAction,
         text = text,
-        backgroundColor = colors.backgroundColor,
-        pressedColor = colors.pressedColor,
-        disabledColor = colors.disabledColor,
-        textColor = colors.textColor,
-        disabledTextColor = colors.disabledTextColor,
-        loadingSpinnerColor = colors.loadingSpinnerColor,
+        buttonColors = buttonColors,
         imageId = imageId,
         imageContentDescription = imageContentDescription,
         isEnabled = isEnabled,
         isLoading = isLoading,
         isPressed = isPressed,
-        isBorderless = isBorderless
+        isBorderless = type == KSButtonType.BORDERLESS || type == KSButtonType.BORDERLESS_DESTRUCTIVE
     )
 }
 
@@ -243,12 +93,7 @@ fun BaseButton(
     modifier: Modifier = Modifier,
     onClickAction: () -> Unit,
     text: String,
-    backgroundColor: Color,
-    pressedColor: Color,
-    disabledColor: Color,
-    textColor: Color,
-    disabledTextColor: Color,
-    loadingSpinnerColor: Color,
+    buttonColors: ButtonColorVariables,
     imageId: Int? = null,
     imageContentDescription: String? = null,
     isEnabled: Boolean = true,
@@ -257,19 +102,30 @@ fun BaseButton(
     isBorderless: Boolean = false,
 ) {
     val currentBackgroundColor = when {
-        !isEnabled -> disabledColor
-        isPressed -> pressedColor
-        else -> backgroundColor
+        !isEnabled -> buttonColors.disabledColor
+        isPressed -> buttonColors.pressedColor
+        else -> buttonColors.backgroundColor
     }
 
-    val currentTextColor = if (isEnabled) textColor else disabledTextColor
+    val currentTextColor = if (isEnabled) buttonColors.textColor else buttonColors.disabledTextColor
 
     Button(
+        border = if (!isBorderless) {
+            BorderStroke(
+                width = dimensions.dividerThickness,
+                color = when {
+                    isPressed -> buttonColors.borderColorPressed
+                    !isEnabled -> buttonColors.borderColorDisabled
+                    isLoading -> buttonColors.borderColorDisabled
+                    else -> buttonColors.borderColor
+                },
+            )
+        } else BorderStroke(0.dp, Color.Transparent),
         modifier = modifier
             .defaultMinSize(minHeight = dimensions.minButtonHeight),
         colors = ButtonDefaults.buttonColors(
             backgroundColor = currentBackgroundColor,
-            disabledBackgroundColor = disabledColor
+            disabledBackgroundColor = buttonColors.disabledColor
         ),
         onClick = { onClickAction.invoke() },
         enabled = isEnabled && !isLoading,
@@ -282,15 +138,16 @@ fun BaseButton(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 if (imageId != null) {
-                    Image(
+                    Icon(
                         modifier = Modifier.size(dimensions.paddingMedium),
                         painter = painterResource(id = imageId),
-                        contentDescription = imageContentDescription
+                        contentDescription = imageContentDescription,
+                        tint = if (!isEnabled || isLoading) buttonColors.iconDisabled else buttonColors.iconEnabled
                     )
                 }
                 Text(
                     text = text,
-                    color = currentTextColor,
+                    color = if (isLoading) buttonColors.disabledTextColor else currentTextColor,
                     style = typographyV2.buttonLabel,
                     modifier = Modifier.padding(start = if (imageId != null) dimensions.paddingSmall else dimensions.none)
                 )
@@ -298,7 +155,7 @@ fun BaseButton(
             if (isLoading) {
                 CircularProgressIndicator(
                     modifier = Modifier.size(dimensions.loadingSpinnerSize),
-                    color = loadingSpinnerColor,
+                    color = buttonColors.loadingSpinnerColor,
                     strokeWidth = dimensions.strokeWidth
                 )
             }
@@ -313,8 +170,9 @@ fun FBLoginButton(
     text: String,
     isPressed: Boolean = false,
 ) {
+    val colors = fbLoginButtonColors(if (!isSystemInDarkTheme()) KSDefaultButtonColors else KSDarkButtonColors)
     val currentBackgroundColor =
-        if (isPressed) FBLoginButtonColors.pressedColor else FBLoginButtonColors.backgroundColor
+        if (isPressed) colors.pressedColor else colors.backgroundColor
 
     Button(
         onClick = { onClickAction.invoke() },
@@ -335,7 +193,7 @@ fun FBLoginButton(
             )
             Text(
                 text = text,
-                color = FBLoginButtonColors.textColor,
+                color = colors.textColor,
                 style = typographyV2.buttonLabel,
                 modifier = Modifier.padding(start = dimensions.paddingSmall)
             )
@@ -353,31 +211,31 @@ fun KSFilledButtonPreview() {
                 .padding(all = dimensions.paddingSmall)
                 .fillMaxWidth()
                 .background(color = colors.backgroundSurfacePrimary),
-            verticalArrangement = Arrangement.spacedBy(60.dp, Alignment.CenterVertically)
+            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically)
         ) {
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Filled,
+                type = KSButtonType.FILLED,
                 text = "Filled",
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Filled,
+                type = KSButtonType.FILLED,
                 text = "Pressed",
                 isPressed = true,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Filled,
+                type = KSButtonType.FILLED,
                 text = "Disabled",
                 isEnabled = false,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Filled,
+                type = KSButtonType.FILLED,
                 text = "Loading",
                 isLoading = true,
                 imageId = R.drawable.icon_eye_gray
@@ -396,31 +254,31 @@ fun KSGreenButtonPreview() {
                 .padding(all = dimensions.paddingSmall)
                 .fillMaxWidth()
                 .background(color = colors.backgroundSurfacePrimary),
-            verticalArrangement = Arrangement.spacedBy(60.dp, Alignment.CenterVertically)
+            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically)
         ) {
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Green,
+                type = KSButtonType.GREEN,
                 text = "Green",
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Green,
+                type = KSButtonType.GREEN,
                 text = "Pressed",
                 isPressed = true,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Green,
+                type = KSButtonType.GREEN,
                 text = "Disabled",
                 isEnabled = false,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Green,
+                type = KSButtonType.GREEN,
                 text = "Loading",
                 isLoading = true,
                 imageId = R.drawable.icon_eye_gray
@@ -439,31 +297,31 @@ fun KSFilledInvertedButtonPreview() {
                 .padding(all = dimensions.paddingSmall)
                 .fillMaxWidth()
                 .background(color = colors.backgroundSurfacePrimary),
-            verticalArrangement = Arrangement.spacedBy(60.dp, Alignment.CenterVertically)
+            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically)
         ) {
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.FilledInverted,
+                type = KSButtonType.FILLED_INVERTED,
                 text = "Inverted",
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.FilledInverted,
+                type = KSButtonType.FILLED_INVERTED,
                 text = "Pressed",
                 isPressed = true,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.FilledInverted,
+                type = KSButtonType.FILLED_INVERTED,
                 text = "Disabled",
                 isEnabled = false,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.FilledInverted,
+                type = KSButtonType.FILLED_INVERTED,
                 text = "Loading",
                 isLoading = true,
                 imageId = R.drawable.icon_eye_gray
@@ -482,31 +340,31 @@ fun KSFilledDestructiveButtonPreview() {
                 .padding(all = dimensions.paddingSmall)
                 .fillMaxWidth()
                 .background(color = colors.backgroundSurfacePrimary),
-            verticalArrangement = Arrangement.spacedBy(60.dp, Alignment.CenterVertically)
+            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically)
         ) {
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.FilledDestructive,
+                type = KSButtonType.FILLED_DESTRUCTIVE,
                 text = "Destructive",
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.FilledDestructive,
+                type = KSButtonType.FILLED_DESTRUCTIVE,
                 text = "Pressed",
                 isPressed = true,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.FilledDestructive,
+                type = KSButtonType.FILLED_DESTRUCTIVE,
                 text = "Disabled",
                 isEnabled = false,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.FilledDestructive,
+                type = KSButtonType.FILLED_DESTRUCTIVE,
                 text = "Loading",
                 isLoading = true,
                 imageId = R.drawable.icon_eye_gray
@@ -525,31 +383,31 @@ fun KSBorderlessButtonPreview() {
                 .padding(all = dimensions.paddingSmall)
                 .background(color = colors.backgroundSurfacePrimary)
                 .fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(60.dp, Alignment.CenterVertically)
+            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically)
         ) {
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Borderless,
+                type = KSButtonType.BORDERLESS,
                 text = "Borderless",
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Borderless,
+                type = KSButtonType.BORDERLESS,
                 text = "Pressed",
                 isPressed = true,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Borderless,
+                type = KSButtonType.BORDERLESS,
                 text = "Disabled",
                 isEnabled = false,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Borderless,
+                type = KSButtonType.BORDERLESS,
                 text = "Loading",
                 isLoading = true,
                 imageId = R.drawable.icon_eye_gray
@@ -568,31 +426,31 @@ fun KSOutlinedButtonPreview() {
                 .padding(all = dimensions.paddingSmall)
                 .background(color = colors.backgroundSurfacePrimary)
                 .fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(60.dp, Alignment.CenterVertically)
+            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically)
         ) {
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Outlined,
+                type = KSButtonType.OUTLINED,
                 text = "Outlined",
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Outlined,
+                type = KSButtonType.OUTLINED,
                 text = "Pressed",
                 isPressed = true,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Outlined,
+                type = KSButtonType.OUTLINED,
                 text = "Disabled",
                 isEnabled = false,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.Outlined,
+                type = KSButtonType.OUTLINED,
                 text = "Loading",
                 isLoading = true,
                 imageId = R.drawable.icon_eye_gray
@@ -611,31 +469,31 @@ fun KSOutlinedDestructiveButtonPreview() {
                 .padding(all = dimensions.paddingSmall)
                 .background(color = colors.backgroundSurfacePrimary)
                 .fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(60.dp, Alignment.CenterVertically)
+            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically)
         ) {
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.OutlinedDestructive,
+                type = KSButtonType.OUTLINED_DESTRUCTIVE,
                 text = "Outlined Destructive",
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.OutlinedDestructive,
+                type = KSButtonType.OUTLINED_DESTRUCTIVE,
                 text = "Pressed",
                 isPressed = true,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.OutlinedDestructive,
+                type = KSButtonType.OUTLINED_DESTRUCTIVE,
                 text = "Disabled",
                 isEnabled = false,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.OutlinedDestructive,
+                type = KSButtonType.OUTLINED_DESTRUCTIVE,
                 text = "Loading",
                 isLoading = true,
                 imageId = R.drawable.icon_eye_gray
@@ -654,31 +512,31 @@ fun KSBorderlessDestructiveButtonPreview() {
                 .padding(all = dimensions.paddingSmall)
                 .background(color = colors.backgroundSurfacePrimary)
                 .fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(60.dp, Alignment.CenterVertically)
+            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically)
         ) {
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.BorderlessDestructive,
+                type = KSButtonType.BORDERLESS_DESTRUCTIVE,
                 text = "Borderless Destructive",
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.BorderlessDestructive,
+                type = KSButtonType.BORDERLESS_DESTRUCTIVE,
                 text = "Pressed",
                 isPressed = true,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.BorderlessDestructive,
+                type = KSButtonType.BORDERLESS_DESTRUCTIVE,
                 text = "Disabled",
                 isEnabled = false,
                 imageId = R.drawable.icon_eye_gray
             )
             KSButton(
                 onClickAction = {},
-                type = KSButtonType.BorderlessDestructive,
+                type = KSButtonType.BORDERLESS_DESTRUCTIVE,
                 text = "Loading",
                 isLoading = true,
                 imageId = R.drawable.icon_eye_gray
@@ -696,7 +554,7 @@ fun FBLoginButtonPreview() {
             Modifier
                 .background(colors.kds_white)
                 .padding(all = dimensions.paddingSmall),
-            verticalArrangement = Arrangement.spacedBy(60.dp, Alignment.CenterVertically),
+            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             FBLoginButton(onClickAction = {}, text = "Continue with Facebook")

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSButtonsV2.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSButtonsV2.kt
@@ -62,7 +62,7 @@ fun KSButton(
         KSDarkButtonColors
     }
 
-    val buttonColors = when(type) {
+    val buttonColors = when (type) {
         KSButtonType.FILLED -> filledButtonColors(colors)
         KSButtonType.GREEN -> greenButtonColors(colors)
         KSButtonType.FILLED_INVERTED -> filledInvertedButtonColors(colors)


### PR DESCRIPTION
# 📲 What

v2 buttons were not formatted for dark mode, and there were a few color mistakes that needed to be corrected. 
This PR fixes those issues. 

# 🛠 How

Added dark mode colors for v2 buttons

# 👀 See

https://github.com/user-attachments/assets/5e70f7ce-7e22-44f3-a1ad-ba0e265e1342 

https://github.com/user-attachments/assets/c4217312-3e31-46b1-9b9c-7f548aec1644

# 📋 QA
Dark and light mode figma designs are included in the ticket.
Compare dark mode and light mode buttons in the design system to the figma designs

**Note: the sun button in the tool bar changes the design system activity from light to dark, however this does not work for v2 buttons. You will have to manually set the phone to light/dark mode in the system settings to see the changes.** 

# Story 📖

[MBL-2414: Fix android v2 buttons for darkmode](https://kickstarter.atlassian.net/browse/MBL-2414)
