### PR TITLE
MBL-2398 Display SEPA payment method type on mobile

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -178,7 +178,7 @@ fragment backing on Backing {
         ... amount
     }
     paymentSource {
-        ... payment
+        ... paymentSourceFragment
     }
     paymentIncrements {
         ...paymentIncrement
@@ -476,13 +476,20 @@ fragment pageInfo on PageInfo {
       endCursor
 }
 
-fragment payment on CreditCard {
-    id
-    lastFour
-    expirationDate
-    type
-    state
-    stripeCardId
+fragment paymentSourceFragment on PaymentSource {
+    ... on CreditCard {
+        id
+        lastFour
+        expirationDate
+        type
+        state
+        stripeCardId
+    }
+    ... on BankAccount {
+        id
+        lastFour
+        bankName
+    }
 }
 
 fragment freeformPost on FreeformPost {

--- a/app/src/main/java/com/kickstarter/models/PaymentSource.kt
+++ b/app/src/main/java/com/kickstarter/models/PaymentSource.kt
@@ -11,7 +11,8 @@ class PaymentSource private constructor(
     private val state: String,
     private val type: String?,
     private val lastFour: String?,
-    private val expirationDate: Date?
+    private val expirationDate: Date?,
+    private val bankName: String?
 ) : Parcelable {
     fun id() = this.id
     fun paymentType() = this.paymentType
@@ -19,6 +20,7 @@ class PaymentSource private constructor(
     fun type() = this.type
     fun lastFour() = this.lastFour
     fun expirationDate() = this.expirationDate
+    fun bankName() = this.bankName
 
     @Parcelize
     data class Builder(
@@ -27,7 +29,8 @@ class PaymentSource private constructor(
         private var state: String = "",
         private var type: String? = "",
         private var lastFour: String? = "",
-        private var expirationDate: Date? = null
+        private var expirationDate: Date? = null,
+        private var bankName: String? = ""
     ) : Parcelable {
         fun id(id: String?) = apply { this.id = id ?: "" }
         fun paymentType(type: String?) = apply { this.paymentType = type ?: "" }
@@ -35,13 +38,15 @@ class PaymentSource private constructor(
         fun type(type: String?) = apply { this.type = type ?: "" }
         fun lastFour(lastFour: String?) = apply { this.lastFour = lastFour }
         fun expirationDate(expirationDate: Date?) = apply { this.expirationDate = expirationDate }
+        fun bankName(bankName: String?) = apply { this.bankName = bankName }
         fun build() = PaymentSource(
             id = id,
             paymentType = paymentType,
             state = state,
             type = type,
             lastFour = lastFour,
-            expirationDate = expirationDate
+            expirationDate = expirationDate,
+            bankName = bankName
         )
     }
 
@@ -56,7 +61,8 @@ class PaymentSource private constructor(
         state = state,
         type = type,
         lastFour = lastFour,
-        expirationDate = expirationDate
+        expirationDate = expirationDate,
+        bankName = bankName
     )
 
     override fun equals(other: Any?): Boolean {
@@ -67,7 +73,8 @@ class PaymentSource private constructor(
             this.state() == other.state() &&
                 this.type() == other.type() &&
                 this.lastFour() == other.lastFour() &&
-                this.expirationDate() == other.expirationDate()
+                this.expirationDate() == other.expirationDate() &&
+                this.bankName() == other.bankName()
         }
         return equals
     }

--- a/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
@@ -60,10 +60,12 @@ import com.kickstarter.services.mutations.CreateAttributionEventData
 import com.kickstarter.services.mutations.CreateOrUpdateBackingAddressData
 import com.kickstarter.services.mutations.UpdateBackerCompletedData
 import com.kickstarter.type.AppDataInput
+import com.kickstarter.type.BankAccount
 import com.kickstarter.type.CheckoutStateEnum
 import com.kickstarter.type.CollaboratorPermission
 import com.kickstarter.type.CreateAttributionEventInput
 import com.kickstarter.type.CreateOrUpdateBackingAddressInput
+import com.kickstarter.type.CreditCard
 import com.kickstarter.type.CreditCardPaymentType
 import com.kickstarter.type.CurrencyCode
 import com.kickstarter.type.Feature
@@ -752,15 +754,24 @@ fun commentTransformer(commentFr: com.kickstarter.fragment.Comment?): Comment {
  * @return Backing
  */
 fun backingTransformer(backingGr: com.kickstarter.fragment.Backing?): Backing {
-    val payment = backingGr?.paymentSource?.payment?.let { payment ->
-        PaymentSource.builder()
-            .state(payment.state.toString())
-            .type(payment.type.rawValue)
-            .paymentType(CreditCardPaymentType.CREDIT_CARD.rawValue)
-            .id(payment.id)
-            .expirationDate(payment.expirationDate)
-            .lastFour(payment.lastFour)
-            .build()
+    val payment = backingGr?.paymentSource?.paymentSourceFragment?.let { paymentSource ->
+        if (paymentSource.onBankAccount != null) {
+            PaymentSource.builder()
+                .paymentType(CreditCardPaymentType.BANK_ACCOUNT.rawValue)
+                .id(paymentSource.onBankAccount.id)
+                .lastFour(paymentSource.onBankAccount.lastFour)
+                .bankName(paymentSource.onBankAccount.bankName)
+                .build()
+        } else if (paymentSource.onCreditCard != null) {
+            PaymentSource.builder()
+                .state(paymentSource.onCreditCard.state.toString())
+                .type(paymentSource.onCreditCard.type.rawValue)
+                .paymentType(CreditCardPaymentType.CREDIT_CARD.rawValue)
+                .id(paymentSource.onCreditCard.id)
+                .expirationDate(paymentSource.onCreditCard.expirationDate)
+                .lastFour(paymentSource.onCreditCard.lastFour)
+                .build()
+        } else { null }
     }
 
     val addOns = backingGr?.addOns?.let {

--- a/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
@@ -60,12 +60,10 @@ import com.kickstarter.services.mutations.CreateAttributionEventData
 import com.kickstarter.services.mutations.CreateOrUpdateBackingAddressData
 import com.kickstarter.services.mutations.UpdateBackerCompletedData
 import com.kickstarter.type.AppDataInput
-import com.kickstarter.type.BankAccount
 import com.kickstarter.type.CheckoutStateEnum
 import com.kickstarter.type.CollaboratorPermission
 import com.kickstarter.type.CreateAttributionEventInput
 import com.kickstarter.type.CreateOrUpdateBackingAddressInput
-import com.kickstarter.type.CreditCard
 import com.kickstarter.type.CreditCardPaymentType
 import com.kickstarter.type.CurrencyCode
 import com.kickstarter.type.Feature

--- a/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/BackingFragment.kt
@@ -435,11 +435,14 @@ class BackingFragment : Fragment() {
     }
 
     private fun setCardExpirationText(expiration: String) {
-        binding?.rewardCardDetails?.rewardCardExpirationDate?.text =
-            this.viewModel.ksString?.format(
-                getString(R.string.Credit_card_expiration),
-                "expiration_date", expiration
-            )
+        if (expiration.isNotEmpty()) {
+            binding?.rewardCardDetails?.rewardCardExpirationDate?.visibility = View.VISIBLE
+            binding?.rewardCardDetails?.rewardCardExpirationDate?.text =
+                this.viewModel.ksString?.format(
+                    getString(R.string.Credit_card_expiration),
+                    "expiration_date", expiration
+                )
+        }
     }
 
     private fun setCardIssuerContentDescription(cardIssuerOrStringRes: Either<String, Int>) {

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -367,7 +367,7 @@ interface BackingFragmentViewModel {
 
             backing
                 .map { CreditCardPaymentType.safeValueOf(it.paymentSource()?.paymentType() ?: "") }
-                .map { it == CreditCardPaymentType.ANDROID_PAY || it == CreditCardPaymentType.APPLE_PAY || it == CreditCardPaymentType.CREDIT_CARD }
+                .map { it == CreditCardPaymentType.ANDROID_PAY || it == CreditCardPaymentType.APPLE_PAY || it == CreditCardPaymentType.CREDIT_CARD || it == CreditCardPaymentType.BANK_ACCOUNT }
                 .map { it.negate() }
                 .distinctUntilChanged()
                 .subscribe { this.paymentMethodIsGone.onNext(it) }
@@ -575,6 +575,7 @@ interface BackingFragmentViewModel {
                 CreditCardPaymentType.ANDROID_PAY -> R.drawable.google_pay_mark
                 CreditCardPaymentType.APPLE_PAY -> R.drawable.apple_pay_mark
                 CreditCardPaymentType.CREDIT_CARD -> paymentSource.getCardTypeDrawable()
+                CreditCardPaymentType.BANK_ACCOUNT -> R.drawable.generic_bank_md
                 else -> R.drawable.generic_bank_md
             }
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/BackingFragmentViewModel.kt
@@ -575,7 +575,7 @@ interface BackingFragmentViewModel {
                 CreditCardPaymentType.ANDROID_PAY -> R.drawable.google_pay_mark
                 CreditCardPaymentType.APPLE_PAY -> R.drawable.apple_pay_mark
                 CreditCardPaymentType.CREDIT_CARD -> paymentSource.getCardTypeDrawable()
-                CreditCardPaymentType.BANK_ACCOUNT -> R.drawable.generic_bank_md
+                CreditCardPaymentType.BANK_ACCOUNT -> R.drawable.credit_card
                 else -> R.drawable.generic_bank_md
             }
         }

--- a/app/src/main/res/drawable/credit_card.xml
+++ b/app/src/main/res/drawable/credit_card.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M19,5H5C3.343,5 2,6.343 2,8V16C2,17.657 3.343,19 5,19H19C20.657,19 22,17.657 22,16V8C22,6.343 20.657,5 19,5ZM4,8C4,7.448 4.448,7 5,7H19C19.552,7 20,7.448 20,8V9H4V8ZM4,11V16C4,16.552 4.448,17 5,17H19C19.552,17 20,16.552 20,16V11H4Z"
+      android:fillColor="#3C3C3C"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/layout/reward_card_details.xml
+++ b/app/src/main/res/layout/reward_card_details.xml
@@ -13,7 +13,7 @@
     android:layout_width="@dimen/credit_card_logo_width"
     android:layout_height="@dimen/credit_card_logo_height"
     android:contentDescription="@null"
-    android:scaleType="fitXY"
+    android:scaleType="fitCenter"
     tools:src="@drawable/mastercard_md" />
 
   <LinearLayout

--- a/app/src/main/res/layout/reward_card_details.xml
+++ b/app/src/main/res/layout/reward_card_details.xml
@@ -36,8 +36,8 @@
       style="@style/CreditCardExpiration"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      tools:text="Expires in 03/2020"
-      tools:visibility="visible"  />
+      android:visibility="gone"
+      tools:text="Expires in 03/2020" />
   </LinearLayout>
 
 </LinearLayout>

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -328,7 +328,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testPaymentMethodIsGone_whenNotCardType() {
+    fun testPaymentMethodIsGone_whenBankAccount() {
         val paymentSource = PaymentSourceFactory.bankAccount()
         val backing = BackingFactory.backing()
             .toBuilder()
@@ -342,7 +342,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment)
         this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.backedProject()))
 
-        this.paymentMethodIsGone.assertValue(true)
+        this.paymentMethodIsGone.assertValue(false)
     }
 
     @Test
@@ -397,6 +397,24 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.backedProject()))
 
         this.cardLogo.assertValue(R.drawable.visa_md)
+    }
+
+    @Test
+    fun testCardLogo_whenBankAccount() {
+        val paymentSource = PaymentSourceFactory.bankAccount()
+        val backing = BackingFactory.backing()
+            .toBuilder()
+            .paymentSource(paymentSource)
+            .build()
+
+        val environment = environment()
+            .toBuilder()
+            .apolloClientV2(mockApolloClientForBacking(backing))
+            .build()
+        setUpEnvironment(environment)
+        this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.backedProject()))
+
+        this.cardLogo.assertValue(R.drawable.generic_bank_md)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/BackingFragmentViewModelTest.kt
@@ -414,7 +414,7 @@ class BackingFragmentViewModelTest : KSRobolectricTestCase() {
         setUpEnvironment(environment)
         this.vm.inputs.configureWith(ProjectDataFactory.project(ProjectFactory.backedProject()))
 
-        this.cardLogo.assertValue(R.drawable.generic_bank_md)
+        this.cardLogo.assertValue(R.drawable.credit_card)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Copy pasta'ed from @ifosli's [iOS PR](https://github.com/kickstarter/ios-oss/pull/2423): 
SEPA is a bank account payment method type in the EU that's available to backers on web (possibly only for backers in Germany). On mobile, in the "manage pledge" screen, we should be able to show SEPA payment methods. This PR does not aim to add SEPA as a payment method during pledge in the app.

# 🛠 How

Data changes:
PaymentSource can have type BankAccount or CreditCard, so I edited the PaymentSource graphql fragment to grab the fields of both.  I updated the PaymentSource data model with the bankName field that is unique to BankAccount type. And finally updated the GraphQLTransformers class to transform appropriately.

UI changes:
Hid the expiration date TextView and used the "credit card" icon (from the new design system, per @matthewfamularo's request) for the logo when payment type is bank account.

Tests:
Updated tests appropriately

# 👀 See

| Before 🐛 | After 🦋 | Credit Card payment for comparison |
| --- | --- | --- |
| ![Screenshot_20250512_171433](https://github.com/user-attachments/assets/fa11fa82-bacb-4fd2-ad04-6e1c0bbc37be) | ![Screenshot_20250513_123913](https://github.com/user-attachments/assets/d2490bd9-1417-4fb0-a2d2-0f353d16cb0a) | ![Screenshot_20250512_171412](https://github.com/user-attachments/assets/8b28d714-1ff8-4e87-b089-50971c8326fd)  |

# 📋 QA

Here's a SEPA enabled project to pledge to ON WEB (again, SEPA payment method is not available on app for pledging):
https://staging.kickstarter.com/projects/1768690592/sepa-mobile-emoji-games
Input a bank account from https://docs.stripe.com/testing?payment-method=sepa-direct-debit for IBAN

View your pledge on app and verify the bank account payment method is displayed. Verify pledges paid with credit cards look the same as before.

# Story 📖

https://kickstarter.atlassian.net/browse/MBL-2398
