### PR TITLE
MBL-2431: Insets fix for SurveyResponseActivity, BackingDetailsActivity

### DIFF
--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/BackingDetailsActivity.kt
@@ -1,9 +1,15 @@
 package com.kickstarter.features.pledgedprojectsoverview.ui
 
 import android.os.Bundle
+import android.view.ViewGroup
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -11,7 +17,6 @@ import com.kickstarter.databinding.ActivityBackingDetailsBinding
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.ui.IntentKey
 import com.kickstarter.ui.extensions.finishWithAnimation
-import com.kickstarter.utils.WindowInsetsUtil
 import com.kickstarter.viewmodels.BackingDetailsViewModel
 import kotlinx.coroutines.launch
 
@@ -25,17 +30,30 @@ class BackingDetailsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
         binding = ActivityBackingDetailsBinding.inflate(layoutInflater)
-        WindowInsetsUtil.manageEdgeToEdge(
-            window,
-            binding.root,
-        )
+        setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                leftMargin = insets.left
+                bottomMargin = insets.bottom
+                rightMargin = insets.right
+                topMargin = insets.top
+            }
+
+            val imeInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime())
+            v.updatePadding(bottom = imeInsets.bottom)
+
+            WindowInsetsCompat.CONSUMED
+        }
+
         this.getEnvironment()?.let { env ->
             viewModelFactory = BackingDetailsViewModel.Factory(env, intent = intent)
             env
         }
-
-        setContentView(binding.root)
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/app/src/main/java/com/kickstarter/ui/activities/SurveyResponseActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/SurveyResponseActivity.kt
@@ -3,10 +3,16 @@ package com.kickstarter.ui.activities
 import android.content.DialogInterface
 import android.net.Uri
 import android.os.Bundle
+import android.view.ViewGroup
 import android.webkit.WebView
 import androidx.activity.ComponentActivity
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import com.kickstarter.R
 import com.kickstarter.databinding.SurveyResponseLayoutBinding
 import com.kickstarter.libs.rx.transformers.Transformers
@@ -15,7 +21,6 @@ import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.isProjectSurveyUri
 import com.kickstarter.libs.utils.extensions.isProjectUri
 import com.kickstarter.services.RequestHandler
-import com.kickstarter.utils.WindowInsetsUtil
 import com.kickstarter.viewmodels.SurveyResponseViewModel
 import io.reactivex.disposables.CompositeDisposable
 import okhttp3.Request
@@ -39,15 +44,29 @@ class SurveyResponseActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        binding = SurveyResponseLayoutBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                leftMargin = insets.left
+                bottomMargin = insets.bottom
+                rightMargin = insets.right
+                topMargin = insets.top
+            }
+
+            val imeInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime())
+            v.updatePadding(bottom = imeInsets.bottom)
+
+            WindowInsetsCompat.CONSUMED
+        }
+
         getEnvironment()?.let { env ->
             factory = SurveyResponseViewModel.Factory(environment = env, intent = intent)
         }
-        binding = SurveyResponseLayoutBinding.inflate(layoutInflater)
-        WindowInsetsUtil.manageEdgeToEdge(
-            window,
-            binding.root
-        )
-        setContentView(binding.root)
 
         binding.surveyResponseWebView.registerRequestHandlers(
             Arrays.asList(


### PR DESCRIPTION
# 📲 What

MBL-2431: Apply window insets fix to `SurveyResponseActivity` & `BackingDetailsActivity`

# 👀 See

### BackingDetailsActivity

#### Before 🐛

https://github.com/user-attachments/assets/7c73da99-2b60-492f-b93a-124afba1b6dd

#### After 🦋 

https://github.com/user-attachments/assets/3bf6bb88-fef7-4033-a3fd-5d2b0ee807f8

# 📋 QA

Respond to a Survey that requires keyboard entry in two scenarios:

- `BackingDetailsActivity` is launched from the Backings Dashboard. Open the Backings Dashboard and click 'Take Survey'.
- `SurveyResponseActivity` is launched from a deep link. Visit the Project's backing details  in a browser, and click the 'Open' in app banner at the top of the website.

# Story 📖

[\[MBL-2431\] Keyboard hides Survey response form - Jira](https://kickstarter.atlassian.net/browse/MBL-2431)