### PR TITLE
MBL-2469: Empty content when PM loads on webview.

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/views/KSWebView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/KSWebView.kt
@@ -51,7 +51,9 @@ class KSWebView@JvmOverloads constructor(
             binding.internalWebView.webViewClient = this.client
             binding.internalWebView.webChromeClient = WebChromeClient()
             binding.internalWebView.settings.javaScriptEnabled = true
-            binding.internalWebView.settings.allowFileAccess = false
+            binding.internalWebView.settings.allowFileAccess = true
+            binding.internalWebView.settings.domStorageEnabled = true
+            binding.internalWebView.settings.allowContentAccess = true
             this.client.setDelegate(this)
 
             if (Build.isInternal() || build.isDebug) {

--- a/app/src/main/java/com/kickstarter/ui/views/KSWebView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/KSWebView.kt
@@ -51,9 +51,9 @@ class KSWebView@JvmOverloads constructor(
             binding.internalWebView.webViewClient = this.client
             binding.internalWebView.webChromeClient = WebChromeClient()
             binding.internalWebView.settings.javaScriptEnabled = true
-            binding.internalWebView.settings.allowFileAccess = true
+            binding.internalWebView.settings.allowFileAccess = false
             binding.internalWebView.settings.domStorageEnabled = true
-            binding.internalWebView.settings.allowContentAccess = true
+
             this.client.setDelegate(this)
 
             if (Build.isInternal() || build.isDebug) {


### PR DESCRIPTION
# 📲 What
- Enable the use of DOM Storage (like localStorage). ⚠️  what is shown on the Before video was completely unable to be reproduced until added for the first time an addOn, afterwards it never loaded the PM content again.

# 🤔 Why
<img width="1692" alt="Screenshot 2025-05-23 at 2 42 59 PM" src="https://github.com/user-attachments/assets/5dd212d5-6d62-4b2f-a8bd-ea328711b5a3" />


# 🛠 How

- DOM Storage (which includes localStorage and sessionStorage) allows web pages to store key-value pairs locally within the user's browser. Enabling it is often necessary for modern web applications that use these features for saving user preferences, offline data, or caching.
- How to enable it on a webview -> https://developer.android.com/reference/android/webkit/WebSettings#setDomStorageEnabled(boolean)

# 👀 See
| Before 🐛 |

https://github.com/user-attachments/assets/d4b5cebc-b18a-4af5-88ac-a4e60615b075





| After 🦋 |

https://github.com/user-attachments/assets/80d33af2-49b0-418f-9773-58c6cdaebb6c



| --- | --- |
|  |  |

# 📋 QA

- Take this project for example -> https://www.kickstarter.com/projects/skellig-games/click-a-tree
- Try to complete PM or at least reach the last step. Make sure you add AddOns and answer survey questios.

# Story 📖

[MBL-2469](https://kickstarter.atlassian.net/browse/MBL-2469)


[MBL-2469]: https://kickstarter.atlassian.net/browse/MBL-2469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ