### PR TITLE
MBL-2483 Secret Rewards - limited (Secret reward no longer available should be visible)

### DIFF
--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
@@ -372,7 +372,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
             testRewards[6], // available, unrestricted
             testRewards[8], // available, unrestricted
             testRewards[1], // unavailable
-            testRewards[7]  // unavailable
+            testRewards[7] // unavailable
         )
 
         val obtained = shippingUiState.last().filteredRw

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
@@ -300,37 +300,38 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
     @Test
     fun `Test rewards list filtered when given a Germany location and a Project with unavailable rewards and mixed types of shipping`() = runTest {
         val testShippingRulesList = ShippingRulesEnvelopeFactory.shippingRules()
+
         val testRewards: List<Reward> = (0..8).map {
-            if (it == 5)
-                Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(it != 2)
+            when (it) {
+                0 -> RewardFactory.noReward()
+                3 -> Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(true)
                     .pledgeAmount(3.0)
                     .shippingPreference(Reward.ShippingPreference.RESTRICTED.name)
                     .shippingPreferenceType(Reward.ShippingPreference.RESTRICTED)
-                    .shippingRules((listOf(ShippingRuleFactory.mexicoShippingRule())))
+                    .shippingRules(listOf(ShippingRuleFactory.germanyShippingRule()))
                     .build()
-            else if (it == 3)
-                Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(it != 2)
+                5 -> Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(true)
                     .pledgeAmount(3.0)
                     .shippingPreference(Reward.ShippingPreference.RESTRICTED.name)
                     .shippingPreferenceType(Reward.ShippingPreference.RESTRICTED)
-                    .shippingRules((listOf(ShippingRuleFactory.germanyShippingRule())))
+                    .shippingRules(listOf(ShippingRuleFactory.mexicoShippingRule()))
                     .build()
-            else if (it == 0)
-                RewardFactory.noReward()
-            else if (it % 2 == 0)
-                Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(it != 2)
-                    .pledgeAmount(3.0)
-                    .shippingPreference(Reward.ShippingPreference.UNRESTRICTED.name)
-                    .shippingRules(testShippingRulesList.shippingRules())
-                    .shippingPreferenceType(Reward.ShippingPreference.UNRESTRICTED)
-                    .build()
-            else
-                Reward.builder().title("$it").id(it.toLong()).isAvailable(false).hasAddons(it != 2)
-                    .pledgeAmount(3.0)
-                    .shippingPreference(Reward.ShippingPreference.RESTRICTED.name)
-                    .shippingPreferenceType(Reward.ShippingPreference.RESTRICTED)
-                    .shippingRules((listOf(ShippingRuleFactory.mexicoShippingRule())))
-                    .build()
+                else -> {
+                    val isEven = it % 2 == 0
+                    Reward.builder().title("$it").id(it.toLong()).isAvailable(isEven).hasAddons(true)
+                        .pledgeAmount(3.0)
+                        .shippingPreference(
+                            if (isEven) Reward.ShippingPreference.UNRESTRICTED.name
+                            else Reward.ShippingPreference.RESTRICTED.name
+                        )
+                        .shippingPreferenceType(
+                            if (isEven) Reward.ShippingPreference.UNRESTRICTED
+                            else Reward.ShippingPreference.RESTRICTED
+                        )
+                        .shippingRules(testShippingRulesList.shippingRules())
+                        .build()
+                }
+            }
         }
 
         val testProject = Project.builder().rewards(testRewards).build()
@@ -357,35 +358,36 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
 
             viewModel.shippingUIState.toList(shippingUiState)
         }
-        advanceUntilIdle() // wait until all state emissions completed
-        viewModel.selectedShippingRule(ShippingRuleFactory.germanyShippingRule())
-        advanceTimeBy(600) // account for de delay within GetShippingRulesUseCase.filterBySelectedRule
 
-        // - Available rewards should be those available AND able to ship to germany
-        val filteredRewards = mutableListOf(
-            testRewards[0],
-            testRewards[2],
-            testRewards[3],
-            testRewards[4],
-            testRewards[6],
-            testRewards[8]
+        advanceUntilIdle()
+        viewModel.selectedShippingRule(ShippingRuleFactory.germanyShippingRule())
+        advanceTimeBy(600)
+
+        // Construct expected filtered list
+        val filteredRewards = listOf(
+            testRewards[0], // noReward (always first)
+            testRewards[2], // available, unrestricted
+            testRewards[3], // available, restricted to Germany
+            testRewards[4], // available, unrestricted
+            testRewards[6], // available, unrestricted
+            testRewards[8], // available, unrestricted
+            testRewards[1], // unavailable
+            testRewards[7]  // unavailable
         )
 
+        val obtained = shippingUiState.last().filteredRw
+
+        // Assertions
         assertEquals(shippingUiState.size, 4)
         assertEquals(shippingUiState[2].loading, true)
         assertEquals(shippingUiState[3].loading, false)
 
-        // - make sure the uiState output reward list is filtered
-        assertEquals(shippingUiState.last().filteredRw.size, filteredRewards.size)
+        assertEquals(filteredRewards.size, obtained.size)
+        assertEquals(filteredRewards, obtained)
 
-        val obtained = shippingUiState.last().filteredRw
-        assertEquals(
-            obtained,
-            filteredRewards
-        )
-
-        assertEquals(obtained.first(), RewardFactory.noReward())
-        assertEquals(obtained[2].shippingRules()?.first(), ShippingRuleFactory.germanyShippingRule())
+        // Optional: Verify that "no reward" is first and Germany-shipping reward is correctly placed
+        assertEquals(obtained.first(), testRewards[0]) // noReward
+        assertEquals(obtained[2], testRewards[3]) // restricted Germany reward
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCaseTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCaseTest.kt
@@ -92,4 +92,174 @@ class GetShippingRulesUseCaseTest : KSRobolectricTestCase() {
         assertEquals(state.last().filteredRw.size, 1)
         assertEquals(state.last().filteredRw.first(), reward2)
     }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `no reward is always added first even if unavailable`() = runTest {
+        val config = ConfigFactory.configForUSUser()
+        val noReward = RewardFactory.noReward().toBuilder()
+            .isAvailable(false) // Force it to be unavailable
+            .build()
+
+        val regularReward = RewardFactory.reward().toBuilder()
+            .isAvailable(true)
+            .shippingPreference(Reward.ShippingPreference.RESTRICTED.name)
+            .shippingRules(listOf(ShippingRuleFactory.usShippingRule()))
+            .build()
+
+        val project = ProjectFactory.project()
+            .toBuilder()
+            .rewards(listOf(regularReward, noReward))
+            .isInPostCampaignPledgingPhase(true)
+            .postCampaignPledgingEnabled(true)
+            .build()
+
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = backgroundScope
+
+        val useCase = GetShippingRulesUseCase(project, config, project.rewards() ?: emptyList(), scope, dispatcher)
+
+        val state = mutableListOf<ShippingRulesState>()
+        scope.launch(dispatcher) {
+            useCase.invoke()
+            useCase.shippingRulesState.toList(state)
+        }
+        advanceUntilIdle()
+
+        val filtered = state.last().filteredRw
+        assertTrue(filtered.isNotEmpty())
+        assertEquals(noReward, filtered.first())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `unavailable rewards are appended at the end`() = runTest {
+        val config = ConfigFactory.configForUSUser()
+        val availableReward = RewardFactory.reward().toBuilder()
+            .isAvailable(true)
+            .shippingPreference(Reward.ShippingPreference.UNRESTRICTED.name)
+            .build()
+
+        val unavailableReward = RewardFactory.reward().toBuilder()
+            .isAvailable(false)
+            .build()
+
+        val project = ProjectFactory.project()
+            .toBuilder()
+            .rewards(listOf(availableReward, unavailableReward))
+            .isInPostCampaignPledgingPhase(true)
+            .postCampaignPledgingEnabled(true)
+            .build()
+
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = backgroundScope
+
+        val useCase = GetShippingRulesUseCase(project, config, project.rewards() ?: emptyList(), scope, dispatcher)
+
+        val state = mutableListOf<ShippingRulesState>()
+        scope.launch(dispatcher) {
+            useCase.invoke()
+            useCase.shippingRulesState.toList(state)
+        }
+        advanceUntilIdle()
+
+        val filtered = state.last().filteredRw
+        assertEquals(2, filtered.size)
+        assertEquals(unavailableReward, filtered.last())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `secret rewards are included if available and sorted by minimum pledge`() = runTest {
+        val config = ConfigFactory.configForUSUser()
+
+        val noReward = RewardFactory.noReward().toBuilder()
+            .isAvailable(true)
+            .build()
+
+        val secretReward1 = RewardFactory.reward().toBuilder()
+            .isSecretReward(true)
+            .minimum(30.0)
+            .isAvailable(true)
+            .build()
+
+        val secretReward2 = RewardFactory.reward().toBuilder()
+            .isSecretReward(true)
+            .minimum(10.0)
+            .isAvailable(true)
+            .build()
+
+        val regularReward = RewardFactory.reward().toBuilder()
+            .isAvailable(true)
+            .shippingPreference(Reward.ShippingPreference.UNRESTRICTED.name)
+            .build()
+
+        val project = ProjectFactory.project()
+            .toBuilder()
+            .rewards(listOf(regularReward, secretReward1, secretReward2, noReward))
+            .isInPostCampaignPledgingPhase(true)
+            .postCampaignPledgingEnabled(true)
+            .build()
+
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = backgroundScope
+
+        val useCase = GetShippingRulesUseCase(project, config, project.rewards() ?: emptyList(), scope, dispatcher)
+
+        val state = mutableListOf<ShippingRulesState>()
+        scope.launch(dispatcher) {
+            useCase.invoke()
+            useCase.shippingRulesState.toList(state)
+        }
+        advanceUntilIdle()
+
+        val filtered = state.last().filteredRw
+        assertEquals(4, filtered.size)
+        assertEquals(noReward, filtered[0]) // "no reward" first
+        assertEquals(secretReward2, filtered[1]) // secret reward with min = 10
+        assertEquals(secretReward1, filtered[2]) // secret reward with min = 30
+        assertEquals(regularReward, filtered[3]) // available regular reward at the end
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `unavailable secret rewards are added at the end with other unavailable rewards`() = runTest {
+        val config = ConfigFactory.configForUSUser()
+
+        val secretUnavailable = RewardFactory.reward().toBuilder()
+            .isSecretReward(true)
+            .isAvailable(false)
+            .minimum(50.0)
+            .build()
+
+        val regularAvailable = RewardFactory.reward().toBuilder()
+            .isAvailable(true)
+            .shippingPreference(Reward.ShippingPreference.UNRESTRICTED.name)
+            .build()
+
+        val project = ProjectFactory.project()
+            .toBuilder()
+            .rewards(listOf(regularAvailable, secretUnavailable))
+            .isInPostCampaignPledgingPhase(true)
+            .postCampaignPledgingEnabled(true)
+            .build()
+
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = backgroundScope
+
+        val useCase = GetShippingRulesUseCase(project, config, project.rewards() ?: emptyList(), scope, dispatcher)
+
+        val state = mutableListOf<ShippingRulesState>()
+        scope.launch(dispatcher) {
+            useCase.invoke()
+            useCase.shippingRulesState.toList(state)
+        }
+        advanceUntilIdle()
+
+        val filtered = state.last().filteredRw
+
+        assertEquals(2, filtered.size)
+        assertEquals(regularAvailable, filtered[0]) // Eligible reward comes first
+        assertEquals(secretUnavailable, filtered[1]) // Unavailable secret reward at the end
+    }
 }


### PR DESCRIPTION
# 📲 What

Updated the reward filtering logic to ensure unavailable rewards are included in the final list, regardless of reward type, and are displayed with proper UI feedback.

# 🤔 Why

Previously, unavailable rewards (including secret rewards) were excluded entirely from the list, which led to confusion and missing context for users. According to [MBL-2843](https://kickstarter.atlassian.net/browse/MBL-2483), rewards that are no longer available should still be shown at the end(just marked as such) to preserve transparency and provide context for backers.
# 🛠 How

- Modified filterRewardsByLocation() to:
	•	Always add "no reward" first
	•	Add available secret rewards, sorted by minimum.
	•	Add all other available eligible rewards (per shipping rules).
	•	Append all unavailable rewards at the end, regardless of whether they are secret or not.
- Unavailable rewards now:
	•	Display a disabled CTA button with“No longer available” message instead of “Select”
- Refactored and added unit tests to cover:
	•	Reward grouping by availability and type.
	•	Proper ordering and edge case handling (e.g., restricted shipping).
	•	Inclusion of unavailable secret rewards.
# 👀 See

[secret_rewards_not_available.webm](https://github.com/user-attachments/assets/096cd1f9-fe9c-4575-9f09-b67fd80d0ce9)


# 📋 QA

1.	Open this deep link in the app:
[Staging Project with Unavailable Secret Reward](https://staging.kickstarter.com/projects/1466322202/sustainable-hot-sauce-restoration?secret_reward_token=10f09ac1)
	2.	This staging project includes a secret reward that is no longer available.
	3.	Verify that:
	•	The “no reward” option appears first in the list.
	•	All available secret and eligible rewards appear next, sorted by minimum pledge amount.
	•	The unavailable secret reward is shown at the end of the list, not hidden.
	•	It displays:
	•	A “No longer available” label.
	•	A disabled CTA button instead of “Select”.
	4.	Confirm that there are no regressions in reward display, selection behavior, or pledge flow.

# Story 📖

[MBL-2843 Secret Rewards - limited (Secret reward no longer available should be visible)](https://kickstarter.atlassian.net/browse/MBL-2483)
