### PR TITLE
MBL-2335: location menu screen

### DIFF
--- a/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -18,6 +19,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -43,6 +45,11 @@ import com.kickstarter.ui.compose.designsystem.KSSnackbarTypes
 import com.kickstarter.ui.compose.designsystem.KickstarterApp
 import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import kotlinx.coroutines.launch
+
+// TODO: Improve error message
+val LocalFilterMenuViewModel = staticCompositionLocalOf<FilterMenuViewModel> {
+    error("No FilterMenuViewModel provided")
+}
 
 class SearchAndFilterActivity : ComponentActivity() {
 
@@ -80,43 +87,46 @@ class SearchAndFilterActivity : ComponentActivity() {
 
                 val darModeEnabled = this.isDarkModeEnabled(env = env)
                 KickstarterApp(useDarkTheme = darModeEnabled) {
-                    SearchScreen(
-                        environment = env,
-                        onBackClicked = { onBackPressedDispatcher.onBackPressed() },
-                        scaffoldState = rememberScaffoldState(),
-                        errorSnackBarHostState = snackbarHostState,
-                        isLoading = isLoading,
-                        isDefaultList = currentSearchTerm.isTrimmedEmpty(),
-                        itemsList = if (currentSearchTerm.isTrimmedEmpty()) {
-                            popularProjects
-                        } else {
-                            searchedProjects
-                        },
-                        lazyColumnListState = lazyListState,
-                        showEmptyView = !isLoading && (searchedProjects.isEmpty() && popularProjects.isEmpty()),
-                        categories = categories,
-                        onSearchTermChanged = { searchTerm ->
-                            currentSearchTerm = searchTerm
-                            viewModel.updateSearchTerm(searchTerm)
-                        },
-                        onItemClicked = { project ->
-                            val projAndRef = viewModel.getProjectAndRefTag(project)
-                            if (project.displayPrelaunch().isTrue()) {
-                                startPreLaunchProjectActivity(project, projAndRef.second)
+                    CompositionLocalProvider(LocalFilterMenuViewModel provides filterMenuViewModel) {
+                        SearchScreen(
+                            environment = env,
+                            onBackClicked = { onBackPressedDispatcher.onBackPressed() },
+                            scaffoldState = rememberScaffoldState(),
+                            errorSnackBarHostState = snackbarHostState,
+                            isLoading = isLoading,
+                            isDefaultList = currentSearchTerm.isTrimmedEmpty(),
+                            itemsList = if (currentSearchTerm.isTrimmedEmpty()) {
+                                popularProjects
                             } else {
-                                startProjectActivity(projAndRef)
-                            }
-                        },
-                        onDismissBottomSheet = { category, sort, projectState, bucket ->
-                            viewModel.updateParamsToSearchWith(
-                                category = category,
-                                projectSort = sort ?: DiscoveryParams.Sort.MAGIC, // magic is the default sort
-                                projectState = projectState,
-                                raisedBucket = bucket
-                            )
-                        },
-                        shouldShowPhase = phaseff
-                    )
+                                searchedProjects
+                            },
+                            lazyColumnListState = lazyListState,
+                            showEmptyView = !isLoading && (searchedProjects.isEmpty() && popularProjects.isEmpty()),
+                            categories = categories,
+                            onSearchTermChanged = { searchTerm ->
+                                currentSearchTerm = searchTerm
+                                viewModel.updateSearchTerm(searchTerm)
+                            },
+                            onItemClicked = { project ->
+                                val projAndRef = viewModel.getProjectAndRefTag(project)
+                                if (project.displayPrelaunch().isTrue()) {
+                                    startPreLaunchProjectActivity(project, projAndRef.second)
+                                } else {
+                                    startProjectActivity(projAndRef)
+                                }
+                            },
+                            onDismissBottomSheet = { category, sort, projectState, bucket ->
+                                viewModel.updateParamsToSearchWith(
+                                    category = category,
+                                    projectSort = sort
+                                        ?: DiscoveryParams.Sort.MAGIC, // magic is the default sort
+                                    projectState = projectState,
+                                    raisedBucket = bucket
+                                )
+                            },
+                            shouldShowPhase = phaseff
+                        )
+                    }
                 }
 
                 // Load more when scroll to the end

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
@@ -67,7 +67,6 @@ open class FilterMenuViewModel(
     private var nearbyLocations = emptyList<Location>()
     private var suggestedLocations = emptyList<Location>()
 
-
     private lateinit var searchJob: Job
 
     init {
@@ -123,8 +122,7 @@ open class FilterMenuViewModel(
         if (response.isSuccess) {
             if (default) nearbyLocations = response.getOrDefault(emptyList())
             if (!term.isNullOrEmpty()) suggestedLocations = response.getOrDefault(emptyList())
-        }
-        else
+        } else
             errorAction.invoke(response.exceptionOrNull()?.message)
 
         emitLocationsCurrentState(isLoading = false, nearBy = nearbyLocations, searched = suggestedLocations)

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
@@ -32,7 +32,8 @@ data class LocationsUIState(
 
 open class FilterMenuViewModel(
     private val environment: Environment,
-    private val testDispatcher: CoroutineDispatcher? = null
+    private val testDispatcher: CoroutineDispatcher? = null,
+    private val isInPreview: Boolean = false
 ) : ViewModel() {
 
     private val scope = viewModelScope + (testDispatcher ?: EmptyCoroutineContext)
@@ -61,8 +62,10 @@ open class FilterMenuViewModel(
     private var categoriesList = emptyList<Category>()
 
     init {
-        scope.launch {
-            getNearByLocations()
+        if (isInPreview) {
+            scope.launch {
+                getNearByLocations()
+            }
         }
     }
 
@@ -84,7 +87,7 @@ open class FilterMenuViewModel(
     suspend fun getNearByLocations() {
         emitCurrentState(isLoading = true)
 
-        val locationsHardcodedList = listOf(LocationFactory.vancouver(), LocationFactory.mexico(), LocationFactory.sydney(), LocationFactory.germany(), LocationFactory.unitedStates())
+        val locationsHardcodedList = listOf(LocationFactory.vancouver())
         emitLocationsCurrentState(
             isLoading = false,
             nearBy = locationsHardcodedList

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
@@ -70,19 +70,21 @@ open class FilterMenuViewModel(
     private lateinit var searchJob: Job
 
     init {
-        scope.launch {
-            // - This call can potentially be moved to the Activity
-            getLocations(default = true)
+        if (isInPreview) {
+            scope.launch {
+                // - This call can potentially be moved to the Activity
+                getLocations(default = true)
 
-            searchJob = scope.launch {
-                _searchQuery
-                    .debounce(300L)
-                    .distinctUntilChanged()
-                    .collectLatest { query ->
-                        if (query.isNotBlank()) {
-                            getLocations(default = false, term = query)
+                searchJob = scope.launch {
+                    _searchQuery
+                        .debounce(300L)
+                        .distinctUntilChanged()
+                        .collectLatest { query ->
+                            if (query.isNotBlank()) {
+                                getLocations(default = false, term = query)
+                            }
                         }
-                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
@@ -61,14 +61,6 @@ open class FilterMenuViewModel(
 
     private var categoriesList = emptyList<Category>()
 
-    init {
-        if (isInPreview) {
-            scope.launch {
-                getNearByLocations()
-            }
-        }
-    }
-
     fun getRootCategories() {
         scope.launch {
             emitCurrentState(isLoading = true)
@@ -84,17 +76,35 @@ open class FilterMenuViewModel(
         }
     }
 
+    init {
+        if (isInPreview) {
+            viewModelScope.launch {
+                getNearByLocations()
+                // getSearchedLocations("")
+            }
+        }
+    }
+
+    val defaultHardcodedList = listOf(LocationFactory.vancouver())
+    val suggestedHardcodedList = listOf(LocationFactory.sydney(), LocationFactory.mexico(), LocationFactory.canada(), LocationFactory.germany())
     suspend fun getNearByLocations() {
         emitCurrentState(isLoading = true)
 
-        val locationsHardcodedList = listOf(LocationFactory.vancouver())
         emitLocationsCurrentState(
             isLoading = false,
-            nearBy = locationsHardcodedList
+            nearBy = defaultHardcodedList,
+            searched = suggestedHardcodedList
         )
     }
 
     suspend fun getSearchedLocations(term: String) {
+        emitCurrentState(isLoading = true)
+
+        emitLocationsCurrentState(
+            isLoading = false,
+            searched = suggestedHardcodedList,
+            nearBy = defaultHardcodedList
+        )
     }
 
     fun provideErrorAction(errorAction: (message: String?) -> Unit) {
@@ -111,7 +121,7 @@ open class FilterMenuViewModel(
     }
 
     // - the lists should probably be stored and not update every time, for now it's ok as it is hardcoded when real query is called change this
-    private suspend fun emitLocationsCurrentState(isLoading: Boolean = false, nearBy: List<Location> = emptyList(), searched: List<Location> = emptyList()) {
+    private suspend fun emitLocationsCurrentState(isLoading: Boolean = false, nearBy: List<Location>, searched: List<Location>) {
         _locations.emit(
             LocationsUIState(
                 isLoading = isLoading,

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
@@ -94,7 +94,7 @@ open class FilterMenuViewModel(
         )
     }
 
-    suspend fun getSearchedLocations(term: String){
+    suspend fun getSearchedLocations(term: String) {
     }
 
     fun provideErrorAction(errorAction: (message: String?) -> Unit) {

--- a/app/src/main/java/com/kickstarter/mock/factories/LocationFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/LocationFactory.kt
@@ -74,17 +74,7 @@ object LocationFactory {
             .expandedCountry("Canada")
             .build()
     }
-
-//    "id": "TG9jYXRpb24tOTgwNw==",
-//    "latitude": 49.254648208619,
-//    "longitude": -123.130176544185,
-//    "name": "Vancouver",
-//    "county": "Greater Vancouver",
-//    "state": "BC",
-//    "countryName": "Canada",
-//    "displayableName": "Vancouver, Canada",
-//    "discoverUrl": "https://staging.kickstarter.com/discover/places/vancouver-ca"
-
+    
     fun vancouver(): Location {
         return builder()
             .id(9807)

--- a/app/src/main/java/com/kickstarter/mock/factories/LocationFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/LocationFactory.kt
@@ -75,6 +75,26 @@ object LocationFactory {
             .build()
     }
 
+//    "id": "TG9jYXRpb24tOTgwNw==",
+//    "latitude": 49.254648208619,
+//    "longitude": -123.130176544185,
+//    "name": "Vancouver",
+//    "county": "Greater Vancouver",
+//    "state": "BC",
+//    "countryName": "Canada",
+//    "displayableName": "Vancouver, Canada",
+//    "discoverUrl": "https://staging.kickstarter.com/discover/places/vancouver-ca"
+
+    fun vancouver(): Location {
+        return builder()
+            .id(9807)
+            .displayableName("Vancouver, Canada")
+            .name("Vancouver")
+            .country("Canada")
+            .state("BC")
+            .build()
+    }
+
     fun empty(): Location {
         return builder()
             .id(-1L)

--- a/app/src/main/java/com/kickstarter/mock/factories/LocationFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/LocationFactory.kt
@@ -74,7 +74,7 @@ object LocationFactory {
             .expandedCountry("Canada")
             .build()
     }
-    
+
     fun vancouver(): Location {
         return builder()
             .id(9807)

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
@@ -363,6 +363,10 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
         return Result.success(emptyList())
     }
 
+    override suspend fun getLocations(useDefault: Boolean, term: String?): Result<List<Location>> {
+        return Result.success(emptyList())
+    }
+
     override suspend fun getSearchProjects(discoveryParams: DiscoveryParams, cursor: String?): Result<SearchEnvelope> {
         return Result.success(SearchEnvelope())
     }

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -66,6 +66,7 @@ import com.kickstarter.libs.utils.extensions.toBoolean
 import com.kickstarter.libs.utils.extensions.toProjectSort
 import com.kickstarter.libs.utils.extensions.toProjectState
 import com.kickstarter.libs.utils.extensions.toRaisedBucket
+import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.models.Backing
 import com.kickstarter.models.BuildPaymentPlanData
@@ -240,6 +241,7 @@ interface ApolloClientTypeV2 {
     suspend fun getSearchProjects(discoveryParams: DiscoveryParams, cursor: String? = null): Result<SearchEnvelope>
     suspend fun fetchSimilarProjects(pid: Long): Result<List<Project>>
     suspend fun getCategories(): Result<List<Category>>
+    suspend fun getLocations(useDefault: Boolean = true, term: String?): Result<List<Location>>
     fun cleanDisposables()
 }
 
@@ -1921,6 +1923,27 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
                 projectTransformer(it?.similarProject)
             }
         } ?: emptyList()
+    }
+
+    override suspend fun getLocations(useDefault: Boolean, term: String?): Result<List<Location>> = executeForResult {
+        if (useDefault) Result.success(listOf(LocationFactory.vancouver()))
+        val searched = listOf(
+            LocationFactory.sydney(),
+            LocationFactory.mexico(),
+            LocationFactory.canada(),
+            LocationFactory.germany(),
+            LocationFactory.unitedStates(),
+            LocationFactory.nigeria(),
+            LocationFactory.sydney(),
+            LocationFactory.mexico(),
+            LocationFactory.canada(),
+            LocationFactory.germany(),
+            LocationFactory.unitedStates(),
+            LocationFactory.nigeria(),
+        )
+        if (term.isNotNull()) Result.success(searched)
+
+        emptyList()
     }
 
     sealed class KSApolloClientV2Exception(

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/LocationSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/LocationSheet.kt
@@ -1,0 +1,282 @@
+package com.kickstarter.ui.activities.compose.search
+
+import android.content.res.Configuration
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.RadioButton
+import androidx.compose.material.RadioButtonDefaults
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kickstarter.R
+import com.kickstarter.features.search.ui.LocalFilterMenuViewModel
+import com.kickstarter.features.search.viewmodel.FilterMenuViewModel
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.extensions.isTrue
+import com.kickstarter.mock.factories.LocationFactory
+import com.kickstarter.mock.services.MockApolloClientV2
+import com.kickstarter.models.Location
+import com.kickstarter.ui.activities.compose.search.LocationTestTags.LOCATION_ANYWHERE
+import com.kickstarter.ui.activities.compose.search.LocationTestTags.locationTag
+import com.kickstarter.ui.compose.designsystem.KSDimensions
+import com.kickstarter.ui.compose.designsystem.KSIconButton
+import com.kickstarter.ui.compose.designsystem.KSSearchBottomSheetFooter
+import com.kickstarter.ui.compose.designsystem.KSTheme
+import com.kickstarter.ui.compose.designsystem.KSTheme.colors
+import com.kickstarter.ui.compose.designsystem.KSTheme.typographyV2
+
+@Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun LocationSheetPreview() {
+    val env = Environment.builder().apolloClientV2(MockApolloClientV2()).build()
+    val fakeViewModel= FilterMenuViewModel(env)
+
+    KSTheme {
+        CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+            LocationSheet(
+                selectedLocation = LocationFactory.vancouver()
+            )
+        }
+    }
+}
+
+object LocationTestTags {
+    const val LOCATION_LIST = "location_list"
+    const val LOCATION_ANYWHERE = "location_anywhere"
+    const val LOCATION_CITY = "location_city"
+    fun locationTag(location: Location) = "location_${location.displayableName()}"
+}
+
+@Composable
+fun LocationSheet(
+    selectedLocation: Location? = null,
+    onDismiss: () -> Unit = {},
+    onApply: (Location?, Boolean?) -> Unit = { a, b -> },
+    onNavigate: () -> Unit = {},
+){
+    val viewModel = LocalFilterMenuViewModel.current
+    val locationsUIState by viewModel.locationsUIState.collectAsStateWithLifecycle()
+    val defaultLocations = locationsUIState.nearLocations
+    val searched = locationsUIState.searchedLocations
+    val isLoading = locationsUIState.isLoading
+
+    val backgroundDisabledColor = colors.backgroundDisabled
+    val dimensions: KSDimensions = KSTheme.dimensions
+
+    val currentLocation = remember { mutableStateOf(selectedLocation) }
+    KSTheme {
+        Surface(
+            color = colors.backgroundSurfacePrimary
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+            ) {
+                // TODO: extract this row as a title re-usable composable can be used with Category as well same UI, just changes the title
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .drawBehind {
+                            drawLine(
+                                color = backgroundDisabledColor,
+                                start = Offset(0f, size.height),
+                                end = Offset(size.width, size.height),
+                                strokeWidth = dimensions.dividerThickness.toPx()
+                            )
+                        }
+                        .padding(
+                            top = dimensions.paddingLarge,
+                            bottom = dimensions.paddingLarge,
+                            end = dimensions.paddingMediumSmall
+                        ),
+
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    KSIconButton(
+                        modifier = Modifier
+                            .padding(start = dimensions.paddingSmall)
+                            .testTag(SearchScreenTestTag.BACK_BUTTON.name),
+                        onClick = onNavigate,
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(id = R.string.Back)
+                    )
+
+                    Text(
+                        text = stringResource(R.string.Location),
+                        style = typographyV2.headingXL,
+                        modifier = Modifier.weight(1f),
+                        color = colors.textPrimary
+                    )
+
+                    KSIconButton(
+                        modifier = Modifier.testTag(CategorySelectionSheetTestTag.DISMISS_BUTTON.name),
+                        onClick = onDismiss,
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = stringResource(id = R.string.accessibility_discovery_buttons_close)
+                    )
+                }
+
+                // OutlinedTextField can be extracted as input-text design system piece
+                OutlinedTextField(
+                    modifier = Modifier
+                        .testTag(SearchScreenTestTag.SEARCH_TEXT_INPUT.name)
+                        .padding(
+                            horizontal = dimensions.paddingLarge,
+                            vertical = dimensions.paddingMedium
+                        )
+                        .fillMaxWidth(),
+                    value = "",
+                    onValueChange = {
+//                        value = it
+//                        onValueChanged(value)
+                    },
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(
+                        onSearch = {
+//                            keyboardController?.hide()
+//                            focusManager.clearFocus()
+                        }
+                    ),
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        backgroundColor = colors.backgroundSurfacePrimary,
+                        errorLabelColor = colors.kds_alert,
+                        unfocusedLabelColor = colors.textSecondary,
+                        focusedLabelColor = colors.borderActive,
+                        cursorColor = colors.kds_create_700,
+                        errorCursorColor = colors.kds_alert,
+                        textColor = colors.textAccentGrey,
+                        disabledTextColor = colors.textDisabled,
+                        focusedBorderColor = colors.borderActive,
+                        unfocusedBorderColor = colors.borderBold
+                    ),
+                    label = {
+                        Text(text = stringResource(id = R.string.Location_searchbox_placeholder))
+                    },
+                    singleLine = true
+                )
+
+                Column(
+                    modifier = Modifier
+                        .testTag(LocationTestTags.LOCATION_LIST)
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .drawBehind {
+                            drawLine(
+                                color = backgroundDisabledColor,
+                                start = Offset(0f, size.height),
+                                end = Offset(size.width, size.height),
+                                strokeWidth = dimensions.dividerThickness.toPx()
+                            )
+                        }
+                        .padding(
+                            horizontal = dimensions.paddingLarge,
+                            vertical = dimensions.paddingMedium
+                        ),
+                ) {
+                    defaultLocations.forEachIndexed { index, location ->
+                        if (index == 0) {
+                            Row(
+                                modifier = Modifier.testTag(LOCATION_ANYWHERE)
+                                    .padding(
+                                        top = dimensions.paddingMediumSmall,
+                                        bottom = dimensions.paddingMediumSmall
+                                    )
+                                    .clickable {
+                                        onApply(currentLocation.value, null)
+                                    },
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
+                            ) {
+                                RadioButton(
+                                    selected = currentLocation.value == null || currentLocation.value?.displayableName()?.isEmpty().isTrue(),
+                                    onClick = null,
+                                    colors = RadioButtonDefaults.colors(
+                                        unselectedColor = colors.backgroundSelected,
+                                        selectedColor = colors.backgroundSelected
+                                    )
+                                )
+                                Text(
+                                    modifier = Modifier
+                                        .weight(1f),
+                                    color = colors.textPrimary,
+                                    text = stringResource(R.string.Location_Anywhere),
+                                    style = typographyV2.headingLG
+                                )
+                            }
+                        }
+                        Row(
+                            modifier = Modifier.testTag(locationTag(location))
+                                .padding(
+                                    top = dimensions.paddingMediumSmall,
+                                    bottom = dimensions.paddingMediumSmall
+                                )
+                                .clickable {
+                                    onApply(currentLocation.value, null)
+                                },
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
+                        ) {
+                            RadioButton(
+                                selected = currentLocation.value?.id() == location.id(),
+                                onClick = null,
+                                colors = RadioButtonDefaults.colors(
+                                    unselectedColor = colors.backgroundSelected,
+                                    selectedColor = colors.backgroundSelected
+                                )
+                            )
+                            Text(
+                                modifier = Modifier
+                                    .weight(1f),
+                                color = colors.textPrimary,
+                                text = location.displayableName(),
+                                style = typographyV2.headingLG
+                            )
+                        }
+
+                    }
+                }
+
+                KSSearchBottomSheetFooter(
+                    leftButtonIsEnabled = false,
+                    leftButtonClickAction = {
+                        currentLocation.value = null
+                        onApply(currentLocation.value, false)
+                    },
+                    rightButtonOnClickAction = {
+                        onApply(currentLocation.value, true)
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/LocationSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/LocationSheet.kt
@@ -75,7 +75,7 @@ import com.kickstarter.ui.compose.designsystem.KSTheme.typographyV2
 @Composable
 fun LocationSheetPreview() {
     val env = Environment.builder().apolloClientV2(
-        object: MockApolloClientV2(){
+        object : MockApolloClientV2() {
             override suspend fun getLocations(
                 useDefault: Boolean,
                 term: String?

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/LocationSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/LocationSheet.kt
@@ -71,6 +71,23 @@ fun LocationSheetPreview() {
     }
 }
 
+@Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun DefaultLocationComposablePreview() {
+
+    KSTheme {
+        Surface(
+            color = colors.backgroundSurfacePrimary
+        ) {
+            DefaultLocationComposable(
+                defaultLocations = listOf(LocationFactory.vancouver()),
+                currentLocation = remember { mutableStateOf(LocationFactory.sydney()) }
+            )
+        }
+    }
+}
+
 object LocationTestTags {
     const val LOCATION_LIST = "location_list"
     const val LOCATION_ANYWHERE = "location_anywhere"

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/LocationSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/LocationSheet.kt
@@ -53,6 +53,7 @@ import com.kickstarter.R
 import com.kickstarter.features.search.ui.LocalFilterMenuViewModel
 import com.kickstarter.features.search.viewmodel.FilterMenuViewModel
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.libs.utils.extensions.isNull
 import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.mock.services.MockApolloClientV2
@@ -73,7 +74,33 @@ import com.kickstarter.ui.compose.designsystem.KSTheme.typographyV2
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun LocationSheetPreview() {
-    val env = Environment.builder().apolloClientV2(MockApolloClientV2()).build()
+    val env = Environment.builder().apolloClientV2(
+        object: MockApolloClientV2(){
+            override suspend fun getLocations(
+                useDefault: Boolean,
+                term: String?
+            ): Result<List<Location>> {
+                if (useDefault) return Result.success(listOf(LocationFactory.vancouver()))
+                val searched = listOf(
+                    LocationFactory.sydney(),
+                    LocationFactory.mexico(),
+                    LocationFactory.canada(),
+                    LocationFactory.germany(),
+                    LocationFactory.unitedStates(),
+                    LocationFactory.nigeria(),
+                    LocationFactory.sydney(),
+                    LocationFactory.mexico(),
+                    LocationFactory.canada(),
+                    LocationFactory.germany(),
+                    LocationFactory.unitedStates(),
+                    LocationFactory.nigeria(),
+                )
+                if (term.isNotNull()) return Result.success(searched)
+
+                return Result.success(emptyList())
+            }
+        }
+    ).build()
     val fakeViewModel = FilterMenuViewModel(env, isInPreview = true)
 
     KSTheme {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,11 @@
   <string name="Amount_pledged_fpo" formatted="false">Amount Pledged</string>
   <string name="Goal_fpo" formatted="false">Goal</string>
 
+  <!-- FPO's for phase 3 -->
+  <string name="Location_fpo" formatted="false">Location</string>
+  <string name="Location_searchbox_placeholder" formatted="false">Search by city, state, country...</string>
+  <string name="Location_Anywhere" formatted="false">Anywhere</string>
+
   <!-- FPO's for reward shipment tracking -->
   <string name="fpo_your_reward_has_shipped" formatted="false">Your reward has shipped!</string>
   <string name="fpo_tracking_number" formatted="false">Tracking #: %{tracking_number}</string>

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/LocationSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/LocationSheetTest.kt
@@ -3,6 +3,7 @@ package com.kickstarter.ui.activities.compose.search
 import android.content.Context
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry
 import com.kickstarter.KSRobolectricTestCase
@@ -25,7 +26,7 @@ class LocationSheetTest : KSRobolectricTestCase() {
     fun `Initial setUp with Empty InputText, Anywhere + default Location`() {
 
         val env = Environment.builder().apolloClientV2(
-            object: MockApolloClientV2(){
+            object : MockApolloClientV2() {
                 override suspend fun getLocations(
                     useDefault: Boolean,
                     term: String?
@@ -59,18 +60,18 @@ class LocationSheetTest : KSRobolectricTestCase() {
                     LocationSheet()
                 }
             }
-
-            composeTestRule
-                .onNodeWithText(context.resources.getString(R.string.Location))
-                .assertIsDisplayed()
-
-            composeTestRule
-                .onNodeWithText(context.resources.getString(R.string.Location_Anywhere))
-                .assertIsDisplayed()
-
-            composeTestRule
-                .onNodeWithText(LocationTestTags.locationTag(LocationFactory.vancouver()))
-                .assertIsDisplayed()
         }
+
+        composeTestRule
+            .onNodeWithText(context.resources.getString(R.string.Location))
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(context.resources.getString(R.string.Location_Anywhere))
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(LocationTestTags.locationTag(LocationFactory.vancouver()))
+            .assertIsDisplayed()
     }
 }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/LocationSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/LocationSheetTest.kt
@@ -1,0 +1,76 @@
+package com.kickstarter.ui.activities.compose.search
+
+import android.content.Context
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.R
+import com.kickstarter.features.search.ui.LocalFilterMenuViewModel
+import com.kickstarter.features.search.viewmodel.FilterMenuViewModel
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.extensions.isNotNull
+import com.kickstarter.mock.factories.LocationFactory
+import com.kickstarter.mock.services.MockApolloClientV2
+import com.kickstarter.models.Location
+import com.kickstarter.ui.compose.designsystem.KSTheme
+import org.junit.Test
+
+class LocationSheetTest : KSRobolectricTestCase() {
+
+    val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun `Initial setUp with Empty InputText, Anywhere + default Location`() {
+
+        val env = Environment.builder().apolloClientV2(
+            object: MockApolloClientV2(){
+                override suspend fun getLocations(
+                    useDefault: Boolean,
+                    term: String?
+                ): Result<List<Location>> {
+                    if (useDefault) return Result.success(listOf(LocationFactory.vancouver()))
+                    val searched = listOf(
+                        LocationFactory.sydney(),
+                        LocationFactory.mexico(),
+                        LocationFactory.canada(),
+                        LocationFactory.germany(),
+                        LocationFactory.unitedStates(),
+                        LocationFactory.nigeria(),
+                        LocationFactory.sydney(),
+                        LocationFactory.mexico(),
+                        LocationFactory.canada(),
+                        LocationFactory.germany(),
+                        LocationFactory.unitedStates(),
+                        LocationFactory.nigeria(),
+                    )
+                    if (term.isNotNull()) return Result.success(searched)
+
+                    return Result.success(emptyList())
+                }
+            }
+        ).build()
+        val fakeViewModel = FilterMenuViewModel(env, isInPreview = true)
+
+        composeTestRule.setContent {
+            KSTheme {
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    LocationSheet()
+                }
+            }
+
+            composeTestRule
+                .onNodeWithText(context.resources.getString(R.string.Location))
+                .assertIsDisplayed()
+
+            composeTestRule
+                .onNodeWithText(context.resources.getString(R.string.Location_Anywhere))
+                .assertIsDisplayed()
+
+            composeTestRule
+                .onNodeWithText(LocationTestTags.locationTag(LocationFactory.vancouver()))
+                .assertIsDisplayed()
+        }
+    }
+}


### PR DESCRIPTION
# 📲 What

- `LocationScreen` UI . For now data is hardcoded, on following tickets this new screen will be integrated within search with real network calls.
- This screen is not yet integrated with the app, it is working for compose preview, is able to interact with UI + VM (no real networking yet but hardcoded data).
- 📥  None of the new additions to `FilterMenuViewModel` affects the running app as of today, this is the very first attempt to use `CompositionLocalProvider` to have the VM accessible to individual composables.

# 🤔 Why

- Keep adding filtering options to search experience.

# 👀 See

https://github.com/user-attachments/assets/2a169a9f-2bcf-43c7-bc9d-01967c2bcf9c

| --- | --- |
|  |  |

# 📋 QA
- Play around with the interactive mode and run the preview if you like it, but for now this is juts the UI, on following tickets the integrations will be made.

# Story 📖

[MBL-2335](https://kickstarter.atlassian.net/browse/MBL-2335)


[MBL-2335]: https://kickstarter.atlassian.net/browse/MBL-2335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ