### PR TITLE
MBL-2490 Secret Rewards - limited:The secret reward is not available and the system shows it as available

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
@@ -193,13 +193,23 @@ fun RewardCarouselScreen(
 
                     val ctaButtonEnabled = when {
                         RewardUtils.isNoReward(reward) -> true
-                        !reward.hasAddons() && backing?.isBacked(reward) != true -> true
-                        backing?.rewardId() != reward.id() && RewardUtils.isAvailable(
-                            project,
-                            reward
-                        ) && reward.isAvailable() -> true
 
-                        reward.hasAddons() && backing?.rewardId() == reward.id() && (project.isLive || (project.postCampaignPledgingEnabled() ?: false && project.isInPostCampaignPledgingPhase() ?: false)) && reward.isAvailable() -> true
+                        !reward.isAvailable() -> false
+
+                        !reward.hasAddons() && backing?.isBacked(reward) != true -> true
+
+                        backing?.rewardId() != reward.id() &&
+                            RewardUtils.isAvailable(project, reward) -> true
+
+                        reward.hasAddons() &&
+                            backing?.rewardId() == reward.id() &&
+                            (
+                                project.isLive || (
+                                    project.postCampaignPledgingEnabled() == true &&
+                                        project.isInPostCampaignPledgingPhase() == true
+                                    )
+
+                                ) -> true
 
                         else -> false
                     }


### PR DESCRIPTION
# 📲 What

Ensure the reward selection CTA button is disabled for unavailable rewards, except for the “No Reward” option which is always enabled.

# 🤔 Why

Previously, some edge cases allowed users to interact with rewards that were marked as unavailable, which led to confusing UX and potential errors during pledge flow. Also, the “No Reward” option could be incorrectly disabled depending on availability status.

# 🛠 How

Updated the ctaButtonEnabled logic to:
- Always enable the button for No Reward .
- Ensure all other rewards are disabled when reward.isAvailable() returns false, regardless of other conditions.
- Reordered the when branches to prioritize No Reward before availability checks.

# 👀 See


[Screen_recording_20250609_132438.webm](https://github.com/user-attachments/assets/ddc299f1-4291-425e-860e-fa7b2dfcfe2b)

# 📋 QA

Open a project in staging that has rewards in different availability states (including a “No Reward”).
- Confirm that:
- Rewards with isAvailable = false have a disabled CTA.
- “No Reward” is always selectable, regardless of its availability status.
- Example deeplink:
https://staging.kickstarter.com/projects/1768690592/plot-secret-rewards?secret_reward_token=d57addc8

# Story 📖

[MBL-2490](https://kickstarter.atlassian.net/browse/MBL-2490)


[MBL-2490]: https://kickstarter.atlassian.net/browse/MBL-2490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ