### PR TITLE
MBL- 2489 Late pledges Regression for Android 3.32.0

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -669,7 +669,10 @@ class ProjectPageActivity :
 
                     ProjectPledgeButtonAndFragmentContainer(
                         expanded = expanded,
-                        onContinueClicked = { checkoutFlowViewModel.onBackThisProjectClicked() },
+                        onContinueClicked = {     checkoutFlowViewModel.onContinueClicked(
+                            logInCallback = { startLoginToutActivity() },
+                            continueCallback = {checkoutFlowViewModel.onBackThisProjectClicked() }
+                        )},
                         onBackClicked = {
                             checkoutFlowViewModel.onBackPressed(pagerState.currentPage)
                         },

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -671,7 +671,10 @@ class ProjectPageActivity :
                         expanded = expanded,
                         onContinueClicked = {     checkoutFlowViewModel.onContinueClicked(
                             logInCallback = { startLoginToutActivity() },
-                            continueCallback = {checkoutFlowViewModel.onBackThisProjectClicked() }
+                            continueCallback = {
+                                rewardsSelectionViewModel.provideProjectData(projectData)
+                                checkoutFlowViewModel.onBackThisProjectClicked()
+                                }
                         )},
                         onBackClicked = {
                             checkoutFlowViewModel.onBackPressed(pagerState.currentPage)

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -669,13 +669,15 @@ class ProjectPageActivity :
 
                     ProjectPledgeButtonAndFragmentContainer(
                         expanded = expanded,
-                        onContinueClicked = {     checkoutFlowViewModel.onContinueClicked(
-                            logInCallback = { startLoginToutActivity() },
-                            continueCallback = {
-                                rewardsSelectionViewModel.provideProjectData(projectData)
-                                checkoutFlowViewModel.onBackThisProjectClicked()
+                        onContinueClicked = {
+                            checkoutFlowViewModel.onContinueClicked(
+                                logInCallback = { startLoginToutActivity() },
+                                continueCallback = {
+                                    rewardsSelectionViewModel.provideProjectData(projectData)
+                                    checkoutFlowViewModel.onBackThisProjectClicked()
                                 }
-                        )},
+                            )
+                        },
                         onBackClicked = {
                             checkoutFlowViewModel.onBackPressed(pagerState.currentPage)
                         },

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CheckoutFlowViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CheckoutFlowViewModel.kt
@@ -110,6 +110,10 @@ class CheckoutFlowViewModel(val environment: Environment) : ViewModel() {
     }
 
     fun onContinueClicked(continueCallback: () -> Unit) {
+        viewModelScope.launch {
+            mutableFlowUIState.emit(FlowUIState(currentPage = 4, expanded = true))
+            continueCallback()
+        }
     }
 
     class Factory(private val environment: Environment) :

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ProjectPageViewModel.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.viewModelScope
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.R
 import com.kickstarter.libs.ActivityRequestCodes
-import com.kickstarter.libs.CurrentUserV2
 import com.kickstarter.libs.Either
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.ProjectPagerTabs
@@ -694,7 +693,6 @@ interface ProjectPageViewModel {
                             FirebaseCrashlytics.getInstance().recordException(e)
                         }
                     }
-
             }
             currentProject
                 .compose(takeWhenV2(this.shareButtonClicked))

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
@@ -79,6 +79,7 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
             .asSharedFlow()
 
     fun provideProjectData(projectData: ProjectData) {
+        shippingRulesUseCase = null
         currentProjectData = projectData
         previousUserBacking =
             if (projectData.backing() != null) projectData.backing()

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
@@ -1,5 +1,6 @@
 package com.kickstarter.viewmodels.projectpage
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -224,6 +225,19 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
         }
 
         return false
+    }
+
+    /**
+     * Used for testing purposes.
+     *TODO:
+     * Remove this method when refactoring the view model so no need to use shippingRulesUseCase = null on provideProjectData
+     */
+    @VisibleForTesting
+    fun overrideShippingRulesUseCase(testUseCase: GetShippingRulesUseCase) {
+        shippingRulesUseCase = testUseCase
+        viewModelScope.launch {
+            emitShippingUIState()
+        }
     }
 
     class Factory(private val environment: Environment, private var shippingRulesUseCase: GetShippingRulesUseCase? = null) :

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
@@ -92,7 +92,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         }
 
         assert(uiState.size == 2)
-        assert(flowState.size == 0)
+        assert(flowState.isEmpty())
         assertEquals(
             uiState.last(),
             RewardSelectionUIState(
@@ -135,7 +135,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         }
 
         assert(uiState.size == 2)
-        assert(flowState.size == 0)
+        assert(flowState.isEmpty())
         assertEquals(
             uiState.last(),
             RewardSelectionUIState(
@@ -182,7 +182,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         }
 
         assert(uiState.size == 2)
-        assert(flowState.size == 0)
+        assert(flowState.isEmpty())
         assertEquals(
             uiState.last(),
             RewardSelectionUIState(
@@ -229,7 +229,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         }
 
         assert(uiState.size == 2)
-        assert(flowState.size == 0)
+        assert(flowState.isEmpty())
         assertEquals(
             uiState.last(),
             RewardSelectionUIState(
@@ -276,7 +276,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         }
 
         assert(uiState.size == 2)
-        assert(flowState.size == 0)
+        assert(flowState.isEmpty())
         assertEquals(
             uiState.last(),
             RewardSelectionUIState(
@@ -352,10 +352,11 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         val shippingUiState = mutableListOf<ShippingRulesState>()
 
         backgroundScope.launch(dispatcher) {
-            val useCase = GetShippingRulesUseCase(testProject, config, testRewards, this, dispatcher)
-            createViewModel(env, useCase)
+            createViewModel(env)
             viewModel.provideProjectData(testProjectData)
 
+            val useCase = GetShippingRulesUseCase(testProject, config, testRewards, this, dispatcher)
+            viewModel.overrideShippingRulesUseCase(useCase)
             viewModel.shippingUIState.toList(shippingUiState)
         }
 
@@ -473,9 +474,11 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val shippingUiState = mutableListOf<ShippingRulesState>()
         backgroundScope.launch(dispatcher) {
-            val useCase = GetShippingRulesUseCase(project, config, rwList, this, dispatcher)
-            createViewModel(env, useCase)
+            createViewModel(env)
             viewModel.provideProjectData(projectData)
+
+            val useCase = GetShippingRulesUseCase(project, config, rwList, this, dispatcher)
+            viewModel.overrideShippingRulesUseCase(useCase)
             viewModel.shippingUIState.toList(shippingUiState)
         }
 
@@ -515,9 +518,10 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val shippingUiState = mutableListOf<ShippingRulesState>()
         backgroundScope.launch(dispatcher) {
-            val useCase = GetShippingRulesUseCase(project, config, rwList, this, dispatcher)
-            createViewModel(env, useCase)
+            createViewModel(env)
             viewModel.provideProjectData(projectData)
+            val useCase = GetShippingRulesUseCase(project, config, rwList, this, dispatcher)
+            viewModel.overrideShippingRulesUseCase(useCase)
             viewModel.shippingUIState.toList(shippingUiState)
         }
 


### PR DESCRIPTION
# 📲 What

 Refactored the onContinueClicked method in CheckoutFlowViewModel to support a simplified use case where only a continueCallback is needed. This is now used in ProjectPageActivity when login flow is already guaranteed to be completed.

# 🤔 Why

The original onContinueClicked required both logInCallback and continueCallback, even in cases where the user is already logged in and the login check was redundant. This change adds a simpler, cleaner path for flows where login gating is handled earlier in the UI flow, improving readability and responsibility separation.

# 🛠 How

Implemented the onContinueClicked(continueCallback: () -> Unit) method to:
- Emit the next UI state (currentPage = 4, expanded = true)
- Immediately invoke the provided continueCallback
- Updated ProjectPageActivity to use this simplified version when login is already guaranteed.

# 👀 See

[latepledgefix.webm](https://github.com/user-attachments/assets/30db794a-5dce-44d5-a31c-cd944782b273)


# 📋 QA

1.	Launch the app and navigate to a late pledge project.
	2.	Do the checkout flow
	3.	Select a reward and proceed to add addons.
	4.	Addons selection should then send you the final checkout step
	5.	Verify pledge submission still works correctly.

# Story 📖

[MBL- 2489 Late pledges Regression for Android 3.32.0](https://kickstarter.atlassian.net/browse/MBL-2489)
