### PR TITLE
MBL-2524: AddOns page was failing due timeout exception

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: ./gradlew lintExternalRelease -Dorg.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64
       - run:
           name: Jacoco External Debug Report
-          command: ./gradlew jacocoExternalDebugReport -PdisablePreDex -Dorg.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64
+          command: ./gradlew jacocoExternalDebugReport cleanTest --rerun-tasks -PdisablePreDex -Dorg.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64
           no_output_timeout: 30m
       - store_artifacts:
           path: app/build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: ./gradlew lintExternalRelease -Dorg.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64
       - run:
           name: Jacoco External Debug Report
-          command: ./gradlew jacocoExternalDebugReport cleanTest --rerun-tasks -PdisablePreDex -Dorg.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64
+          command: ./gradlew jacocoExternalDebugReport cleanTest -PdisablePreDex -Dorg.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64
           no_output_timeout: 30m
       - store_artifacts:
           path: app/build/reports

--- a/app/src/main/graphql/rewards.graphql
+++ b/app/src/main/graphql/rewards.graphql
@@ -12,28 +12,24 @@ query GetShippingRulesForRewardId($rewardId: ID!) {
     }
 }
 
-query GetRewardAllowedAddOns($slug: String!, $locationId: ID! , $rewardImageWidth: Int = 1024) {
-    project(slug: $slug) {
-        rewards {
-            nodes {
-                id
-                allowedAddons {
-                    edges {
-                        node {
-                            shippingRulesExpanded(forLocation: $locationId) {
-                                nodes {
-                                    ... shippingRule
-                                }
+query GetRewardAllowedAddOns($locationId: ID! , $rewardImageWidth: Int = 1024, $rewardId: ID!) {
+    node(id: $rewardId) {
+        ... on Reward {
+            allowedAddons {
+                edges {
+                    node {
+                        shippingRulesExpanded(forLocation: $locationId) {
+                            nodes {
+                                ... shippingRule
                             }
-                            ... reward
-                            items {
-                                ... rewardItems
-                            }
-                            ...rewardImage
                         }
+                        ... reward
+                        items {
+                            ... rewardItems
+                        }
+                        ...rewardImage
                     }
                 }
-
             }
         }
     }

--- a/app/src/main/graphql/rewards.graphql
+++ b/app/src/main/graphql/rewards.graphql
@@ -12,11 +12,12 @@ query GetShippingRulesForRewardId($rewardId: ID!) {
     }
 }
 
-query GetRewardAllowedAddOns($locationId: ID! , $rewardImageWidth: Int = 1024, $rewardId: ID!) {
+query GetRewardAllowedAddOns($locationId: ID! , $rewardImageWidth: Int = 1024, $rewardId: ID!, $first: Int = 5, $cursor: String) {
     node(id: $rewardId) {
         ... on Reward {
-            allowedAddons {
+            allowedAddons(first: $first, after:$cursor) {
                 edges {
+                    cursor
                     node {
                         shippingRulesExpanded(forLocation: $locationId) {
                             nodes {
@@ -29,6 +30,9 @@ query GetRewardAllowedAddOns($locationId: ID! , $rewardImageWidth: Int = 1024, $
                         }
                         ...rewardImage
                     }
+                }
+                pageInfo {
+                    ... pageInfo
                 }
             }
         }

--- a/app/src/main/java/com/kickstarter/features/checkout/data/AddOnsEnvelope.kt
+++ b/app/src/main/java/com/kickstarter/features/checkout/data/AddOnsEnvelope.kt
@@ -1,0 +1,9 @@
+package com.kickstarter.features.checkout.data
+
+import com.kickstarter.models.Reward
+import com.kickstarter.services.apiresponses.commentresponse.PageInfoEnvelope
+
+data class AddOnsEnvelope(
+    val addOnsList: List<Reward> = emptyList(),
+    val pageInfo: PageInfoEnvelope? = null,
+)

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
@@ -7,6 +7,7 @@ import com.kickstarter.SendEmailVerificationMutation
 import com.kickstarter.UpdateUserCurrencyMutation
 import com.kickstarter.UpdateUserEmailMutation
 import com.kickstarter.UpdateUserPasswordMutation
+import com.kickstarter.features.checkout.data.AddOnsEnvelope
 import com.kickstarter.features.pledgedprojectsoverview.data.PledgedProjectsOverviewEnvelope
 import com.kickstarter.features.pledgedprojectsoverview.data.PledgedProjectsOverviewQueryData
 import com.kickstarter.features.search.data.SearchEnvelope
@@ -195,8 +196,8 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
         return io.reactivex.Observable.empty()
     }
 
-    override fun getRewardAllowedAddOns(locationId: Location, rewardId: Reward, cursor: String?): io.reactivex.Observable<List<Reward>> {
-        return io.reactivex.Observable.empty()
+    override suspend fun getRewardAllowedAddOns(locationId: Location, rewardId: Reward, cursor: String?): Result<AddOnsEnvelope> {
+        return Result.success(AddOnsEnvelope())
     }
 
     override fun updateBacking(updateBackingData: UpdateBackingData): io.reactivex.Observable<Checkout> {

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
@@ -195,7 +195,7 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
         return io.reactivex.Observable.empty()
     }
 
-    override fun getRewardAllowedAddOns(slug: String, locationId: Location, rewardId: Long): io.reactivex.Observable<List<Reward>> {
+    override fun getRewardAllowedAddOns(locationId: Location, rewardId: Reward, cursor: String?): io.reactivex.Observable<List<Reward>> {
         return io.reactivex.Observable.empty()
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt
@@ -194,8 +194,7 @@ class AddOnsViewModel(val environment: Environment, bundle: Bundle? = null) : Vi
             scope.launch(dispatcher) {
                 apolloClient
                     .getRewardAllowedAddOns(
-                        slug = project.slug() ?: "",
-                        rewardId = currentUserReward.id(),
+                        rewardId = currentUserReward,
                         locationId = selectedShippingRule.location() ?: Location.builder().build()
                     )
                     .asFlow()

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
@@ -156,7 +156,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
             .build()
         setup(env, dispatcher)
 
-        backgroundScope.launch(dispatcher) {
+        backgroundScope.launch {
             viewModel.userRewardSelection(rw)
             viewModel.provideSelectedShippingRule(ShippingRuleFactory.canadaShippingRule())
 
@@ -387,7 +387,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
             .build()
         createViewModel(env, dispatcher)
 
-        backgroundScope.launch(dispatcher) {
+        backgroundScope.launch {
             viewModel.provideBundle(bundle)
             viewModel.updateSelection(addOnReward.id(), 4)
             viewModel.addOnsUIState.toList(uiState)

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
@@ -6,7 +6,6 @@ import com.kickstarter.features.checkout.data.AddOnsEnvelope
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUserV2
 import com.kickstarter.libs.utils.EventName
-import com.kickstarter.libs.utils.extensions.pledgeAmountTotal
 import com.kickstarter.mock.factories.BackingFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.RewardFactory

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
@@ -113,74 +113,74 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         this.segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
     }
 
-//    @Test
-//    fun `test amount of backed addOns has been increased plus loads second addOns page`() = runTest {
-//        val addOnReward = RewardFactory.addOn().toBuilder().id(1L).build()
-//        val aDifferentAddOnReward = RewardFactory.addOnSingle().toBuilder().id(2L).build()
-//        val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
-//
-//        val addOnReward2 = RewardFactory.addOn().toBuilder().id(7L).build()
-//        val aDifferentAddOnReward2 = RewardFactory.addOnSingle().toBuilder().id(8L).build()
-//        val secondPageAddOns = listOf(addOnReward2, aDifferentAddOnReward2)
-//
-//        var page = 0
-//
-//        val rw = RewardFactory.reward().toBuilder()
-//            .hasAddons(true)
-//            .id(99L)
-//            .pledgeAmount(20.0)
-//            .build()
-//
-//        val uiState = mutableListOf<AddOnsUIState>()
-//        val dispatcher = UnconfinedTestDispatcher(testScheduler)
-//
-//        val apolloClient = object : MockApolloClientV2() {
-//            override suspend fun getRewardAllowedAddOns(
-//                locationId: Location,
-//                rewardId: Reward,
-//                cursor: String?
-//            ): Result<AddOnsEnvelope> {
-//                page++
-//                assertEquals(99L, rewardId.id())
-//                val returnedList = if (page == 1) addOnsList else secondPageAddOns
-//                return Result.success(AddOnsEnvelope(addOnsList = returnedList))
-//            }
-//        }
-//
-//        val env = environment().toBuilder()
-//            .apolloClientV2(apolloClient)
-//            .build()
-//        setup(env, dispatcher)
-//
-//        var total = 0.0
-//        backgroundScope.launch(dispatcher) {
-//            viewModel.userRewardSelection(rw)
-//            viewModel.provideSelectedShippingRule(ShippingRuleFactory.canadaShippingRule())
-//
-//            viewModel.updateSelection(addOnsList.first().id(), 3)
-//
-//            advanceUntilIdle()
-//            //viewModel.loadMore()
-//
-//            total = viewModel.getPledgeDataAndReason()?.first?.pledgeAmountTotal()?.toDouble() ?: 0.0
-//            viewModel.addOnsUIState.toList(uiState)
-//        }
-//
-//        advanceUntilIdle()
-//
-//        val paginatedList = addOnsList + secondPageAddOns
-//        assertTrue(page == 2)
-//        assertEquals(
-//            uiState.last(),
-//            AddOnsUIState(
-//                addOns = addOnsList,
-//                totalCount = 3,
-//                isLoading = false,
-//                shippingRule = ShippingRuleFactory.canadaShippingRule(),
-//                totalPledgeAmount = total
-//            )
-//        )
-//    }
+    @Test
+    fun `test amount of backed addOns has been increased plus loads second addOns page`() = runTest {
+        val addOnReward = RewardFactory.addOn().toBuilder().id(1L).build()
+        val aDifferentAddOnReward = RewardFactory.addOnSingle().toBuilder().id(2L).build()
+        val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
+
+        val addOnReward2 = RewardFactory.addOn().toBuilder().id(7L).build()
+        val aDifferentAddOnReward2 = RewardFactory.addOnSingle().toBuilder().id(8L).build()
+        val secondPageAddOns = listOf(addOnReward2, aDifferentAddOnReward2)
+
+        var page = 0
+
+        val rw = RewardFactory.reward().toBuilder()
+            .hasAddons(true)
+            .id(99L)
+            .pledgeAmount(20.0)
+            .build()
+
+        val uiState = mutableListOf<AddOnsUIState>()
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+
+        val apolloClient = object : MockApolloClientV2() {
+            override suspend fun getRewardAllowedAddOns(
+                locationId: Location,
+                rewardId: Reward,
+                cursor: String?
+            ): Result<AddOnsEnvelope> {
+                page++
+                assertEquals(99L, rewardId.id())
+                val returnedList = if (page == 1) addOnsList else secondPageAddOns
+                return Result.success(AddOnsEnvelope(addOnsList = returnedList))
+            }
+        }
+
+        val env = environment().toBuilder()
+            .apolloClientV2(apolloClient)
+            .build()
+        setup(env, dispatcher)
+
+        var total = 0.0
+        backgroundScope.launch(dispatcher) {
+            viewModel.userRewardSelection(rw)
+            viewModel.provideSelectedShippingRule(ShippingRuleFactory.canadaShippingRule())
+
+            viewModel.updateSelection(addOnsList.first().id(), 3)
+
+            advanceUntilIdle()
+            viewModel.loadMore()
+
+            total = viewModel.getPledgeDataAndReason()?.first?.pledgeAmountTotal()?.toDouble() ?: 0.0
+            viewModel.addOnsUIState.toList(uiState)
+        }
+
+        advanceUntilIdle()
+
+        val paginatedList = addOnsList + secondPageAddOns
+        assertTrue(page == 2)
+        assertEquals(
+            uiState.last(),
+            AddOnsUIState(
+                addOns = paginatedList,
+                totalCount = 3,
+                isLoading = false,
+                shippingRule = ShippingRuleFactory.canadaShippingRule(),
+                totalPledgeAmount = total
+            )
+        )
+    }
 
     @Test
     fun `test amount of backed addOns has been increased`() = runTest {

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.kickstarter.viewmodels
 
 import android.os.Bundle
 import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.features.checkout.data.AddOnsEnvelope
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUserV2
 import com.kickstarter.libs.utils.EventName
@@ -122,13 +123,13 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
 
         val apolloClient = object : MockApolloClientV2() {
-            override fun getRewardAllowedAddOns(
-                slug: String,
+            override suspend fun getRewardAllowedAddOns(
                 locationId: Location,
-                rewardId: Long
-            ): Observable<List<Reward>> {
+                rewardId: Reward,
+                cursor: String?
+            ): Result<AddOnsEnvelope> {
                 assertEquals(99L, rewardId)
-                return Observable.just(addOnsList)
+                return Result.success(AddOnsEnvelope(addOnsList = addOnsList))
             }
         }
 
@@ -190,13 +191,13 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
 
         val apolloClient = object : MockApolloClientV2() {
-            override fun getRewardAllowedAddOns(
-                slug: String,
+            override suspend fun getRewardAllowedAddOns(
                 locationId: Location,
-                rewardId: Long
-            ): Observable<List<Reward>> {
+                rewardId: Reward,
+                cursor: String?
+            ): Result<AddOnsEnvelope> {
                 assertEquals(99L, rewardId)
-                return Observable.just(addOnsList)
+                return Result.success(AddOnsEnvelope(addOnsList = addOnsList))
             }
         }
 
@@ -263,13 +264,13 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val backedAddOnq = aDifferentAddOnReward.toBuilder().quantity(4).build()
 
         val apolloClient = object : MockApolloClientV2() {
-            override fun getRewardAllowedAddOns(
-                slug: String,
+            override suspend fun getRewardAllowedAddOns(
                 locationId: Location,
-                rewardId: Long,
-            ): Observable<List<Reward>> {
+                rewardId: Reward,
+                cursor: String?
+            ): Result<AddOnsEnvelope> {
                 assertEquals(99L, rewardId)
-                return Observable.just(listOf(aDifferentAddOnReward))
+                return Result.success(AddOnsEnvelope(addOnsList = listOf(aDifferentAddOnReward)))
             }
         }
 
@@ -342,13 +343,13 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
 
         val apolloClient = object : MockApolloClientV2() {
-            override fun getRewardAllowedAddOns(
-                slug: String,
+            override suspend fun getRewardAllowedAddOns(
                 locationId: Location,
-                rewardId: Long
-            ): Observable<List<Reward>> {
+                rewardId: Reward,
+                cursor: String?
+            ): Result<AddOnsEnvelope> {
                 assertEquals(99L, rewardId)
-                return Observable.just(addOnsList)
+                return Result.success(AddOnsEnvelope(addOnsList = addOnsList))
             }
         }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
@@ -118,72 +118,72 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         this.segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
     }
 
-    @Test
-    fun `test amount of backed addOns has been increased plus loads second addOns page`() = runTest {
-        val addOnReward = RewardFactory.addOn().toBuilder().id(1L).build()
-        val aDifferentAddOnReward = RewardFactory.addOnSingle().toBuilder().id(2L).build()
-        val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
-
-        val addOnReward2 = RewardFactory.addOn().toBuilder().id(7L).build()
-        val aDifferentAddOnReward2 = RewardFactory.addOnSingle().toBuilder().id(8L).build()
-        val secondPageAddOns = listOf(addOnReward2, aDifferentAddOnReward2)
-
-        var page = 0
-
-        val rw = RewardFactory.reward().toBuilder()
-            .hasAddons(true)
-            .id(99L)
-            .pledgeAmount(20.0)
-            .build()
-
-        val uiState = mutableListOf<AddOnsUIState>()
-        val dispatcher = UnconfinedTestDispatcher(testScheduler)
-
-        val apolloClient = object : MockApolloClientV2() {
-            override suspend fun getRewardAllowedAddOns(
-                locationId: Location,
-                rewardId: Reward,
-                cursor: String?
-            ): Result<AddOnsEnvelope> {
-                page++
-                assertEquals(99L, rewardId.id())
-                val returnedList = if (page == 1) addOnsList else secondPageAddOns
-                return Result.success(AddOnsEnvelope(addOnsList = returnedList))
-            }
-        }
-
-        val env = environment().toBuilder()
-            .apolloClientV2(apolloClient)
-            .build()
-        setup(env, dispatcher)
-
-        backgroundScope.launch(dispatcher) {
-            viewModel.userRewardSelection(rw)
-            viewModel.provideSelectedShippingRule(ShippingRuleFactory.canadaShippingRule())
-
-            viewModel.updateSelection(addOnsList.first().id(), 3)
-
-            viewModel.loadMore()
-            viewModel.addOnsUIState.toList(uiState)
-        }
-
-        advanceUntilIdle()
-
-        val total = viewModel.getPledgeDataAndReason()?.first?.pledgeAmountTotal()?.toDouble() ?: 0.0
-
-        val paginatedList = addOnsList + secondPageAddOns
-        assertTrue(page == 2)
-        assertEquals(
-            uiState.last(),
-            AddOnsUIState(
-                addOns = paginatedList,
-                totalCount = 3,
-                isLoading = false,
-                shippingRule = ShippingRuleFactory.canadaShippingRule(),
-                totalPledgeAmount = total
-            )
-        )
-    }
+//    @Test
+//    fun `test amount of backed addOns has been increased plus loads second addOns page`() = runTest {
+//        val addOnReward = RewardFactory.addOn().toBuilder().id(1L).build()
+//        val aDifferentAddOnReward = RewardFactory.addOnSingle().toBuilder().id(2L).build()
+//        val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
+//
+//        val addOnReward2 = RewardFactory.addOn().toBuilder().id(7L).build()
+//        val aDifferentAddOnReward2 = RewardFactory.addOnSingle().toBuilder().id(8L).build()
+//        val secondPageAddOns = listOf(addOnReward2, aDifferentAddOnReward2)
+//
+//        var page = 0
+//
+//        val rw = RewardFactory.reward().toBuilder()
+//            .hasAddons(true)
+//            .id(99L)
+//            .pledgeAmount(20.0)
+//            .build()
+//
+//        val uiState = mutableListOf<AddOnsUIState>()
+//        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+//
+//        val apolloClient = object : MockApolloClientV2() {
+//            override suspend fun getRewardAllowedAddOns(
+//                locationId: Location,
+//                rewardId: Reward,
+//                cursor: String?
+//            ): Result<AddOnsEnvelope> {
+//                page++
+//                assertEquals(99L, rewardId.id())
+//                val returnedList = if (page == 1) addOnsList else secondPageAddOns
+//                return Result.success(AddOnsEnvelope(addOnsList = returnedList))
+//            }
+//        }
+//
+//        val env = environment().toBuilder()
+//            .apolloClientV2(apolloClient)
+//            .build()
+//        setup(env, dispatcher)
+//
+//        backgroundScope.launch(dispatcher) {
+//            viewModel.userRewardSelection(rw)
+//            viewModel.provideSelectedShippingRule(ShippingRuleFactory.canadaShippingRule())
+//
+//            viewModel.updateSelection(addOnsList.first().id(), 3)
+//
+//            viewModel.loadMore()
+//            viewModel.addOnsUIState.toList(uiState)
+//        }
+//
+//        advanceUntilIdle()
+//
+//        val total = viewModel.getPledgeDataAndReason()?.first?.pledgeAmountTotal()?.toDouble() ?: 0.0
+//
+//        val paginatedList = addOnsList + secondPageAddOns
+//        assertTrue(page == 2)
+//        assertEquals(
+//            uiState.last(),
+//            AddOnsUIState(
+//                addOns = paginatedList,
+//                totalCount = 3,
+//                isLoading = false,
+//                shippingRule = ShippingRuleFactory.canadaShippingRule(),
+//                totalPledgeAmount = total
+//            )
+//        )
+//    }
 
     @Test
     fun `test add bonus Support without selecting addOns`() = runTest {
@@ -331,85 +331,85 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         assertEquals(backedAddOnq.quantity(), pledgeData?.addOns()?.first()?.quantity())
     }
 
-    @Test
-    fun `test backed addOns total amount when the amount has been updated`() = runTest {
-        val addOnReward = RewardFactory.addOn().toBuilder().id(1L).build()
-        val aDifferentAddOnReward = RewardFactory.addOnSingle().toBuilder().id(2L).build()
-        val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
-
-        val backedAddOnq = aDifferentAddOnReward.toBuilder().quantity(4).build()
-        val shippingRule = ShippingRuleFactory.canadaShippingRule()
-        val backedReward = RewardFactory.reward().toBuilder()
-            .hasAddons(true)
-            .id(99L)
-            .build()
-
-        val backing = BackingFactory.backing(reward = backedReward)
-            .toBuilder()
-            .addOns(listOf(backedAddOnq))
-            .build()
-
-        val testProject = ProjectFactory.project()
-            .toBuilder()
-            .rewards(listOf(backedReward))
-            .backing(backing)
-            .build()
-
-        val testProjectData = ProjectData.builder().project(testProject).build()
-
-        val bundle = Bundle()
-        bundle.putParcelable(
-            ArgumentsKey.PLEDGE_PLEDGE_DATA,
-            PledgeData.with(
-                PledgeFlowContext.CHANGE_REWARD,
-                testProjectData,
-                backedReward,
-                shippingRule = shippingRule
-            )
-        )
-        bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.UPDATE_PLEDGE)
-
-        val uiState = mutableListOf<AddOnsUIState>()
-        val dispatcher = UnconfinedTestDispatcher(testScheduler)
-
-        val apolloClient = object : MockApolloClientV2() {
-            override suspend fun getRewardAllowedAddOns(
-                locationId: Location,
-                rewardId: Reward,
-                cursor: String?
-            ): Result<AddOnsEnvelope> {
-                assertEquals(99L, backedReward.id())
-                return Result.success(AddOnsEnvelope(addOnsList = addOnsList))
-            }
-        }
-
-        val env = environment().toBuilder()
-            .apolloClientV2(apolloClient)
-            .build()
-        createViewModel(env, dispatcher)
-
-        backgroundScope.launch(dispatcher) {
-            viewModel.provideBundle(bundle)
-            viewModel.updateSelection(addOnReward.id(), 4)
-            viewModel.addOnsUIState.toList(uiState)
-        }
-        advanceUntilIdle()
-
-        val pledgeDataAndReason = viewModel.getPledgeDataAndReason()
-        val pledgeData = pledgeDataAndReason?.first
-
-        assertEquals(8, uiState.last().totalCount)
-        assertEquals(2, pledgeData?.addOns()?.size)
-
-        val firstAddOn = pledgeData?.addOns()?.first()
-        val secondAddOn = pledgeData?.addOns()?.last()
-
-        assertEquals(addOnReward.id(), firstAddOn?.id())
-        assertEquals(4, firstAddOn?.quantity())
-
-        assertEquals(backedAddOnq.id(), secondAddOn?.id())
-        assertEquals(backedAddOnq.quantity(), secondAddOn?.quantity())
-    }
+//    @Test
+//    fun `test backed addOns total amount when the amount has been updated`() = runTest {
+//        val addOnReward = RewardFactory.addOn().toBuilder().id(1L).build()
+//        val aDifferentAddOnReward = RewardFactory.addOnSingle().toBuilder().id(2L).build()
+//        val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
+//
+//        val backedAddOnq = aDifferentAddOnReward.toBuilder().quantity(4).build()
+//        val shippingRule = ShippingRuleFactory.canadaShippingRule()
+//        val backedReward = RewardFactory.reward().toBuilder()
+//            .hasAddons(true)
+//            .id(99L)
+//            .build()
+//
+//        val backing = BackingFactory.backing(reward = backedReward)
+//            .toBuilder()
+//            .addOns(listOf(backedAddOnq))
+//            .build()
+//
+//        val testProject = ProjectFactory.project()
+//            .toBuilder()
+//            .rewards(listOf(backedReward))
+//            .backing(backing)
+//            .build()
+//
+//        val testProjectData = ProjectData.builder().project(testProject).build()
+//
+//        val bundle = Bundle()
+//        bundle.putParcelable(
+//            ArgumentsKey.PLEDGE_PLEDGE_DATA,
+//            PledgeData.with(
+//                PledgeFlowContext.CHANGE_REWARD,
+//                testProjectData,
+//                backedReward,
+//                shippingRule = shippingRule
+//            )
+//        )
+//        bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.UPDATE_PLEDGE)
+//
+//        val uiState = mutableListOf<AddOnsUIState>()
+//        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+//
+//        val apolloClient = object : MockApolloClientV2() {
+//            override suspend fun getRewardAllowedAddOns(
+//                locationId: Location,
+//                rewardId: Reward,
+//                cursor: String?
+//            ): Result<AddOnsEnvelope> {
+//                assertEquals(99L, backedReward.id())
+//                return Result.success(AddOnsEnvelope(addOnsList = addOnsList))
+//            }
+//        }
+//
+//        val env = environment().toBuilder()
+//            .apolloClientV2(apolloClient)
+//            .build()
+//        createViewModel(env, dispatcher)
+//
+//        backgroundScope.launch(dispatcher) {
+//            viewModel.provideBundle(bundle)
+//            viewModel.updateSelection(addOnReward.id(), 4)
+//            viewModel.addOnsUIState.toList(uiState)
+//        }
+//        advanceUntilIdle()
+//
+//        val pledgeDataAndReason = viewModel.getPledgeDataAndReason()
+//        val pledgeData = pledgeDataAndReason?.first
+//
+//        assertEquals(8, uiState.last().totalCount)
+//        assertEquals(2, pledgeData?.addOns()?.size)
+//
+//        val firstAddOn = pledgeData?.addOns()?.first()
+//        val secondAddOn = pledgeData?.addOns()?.last()
+//
+//        assertEquals(addOnReward.id(), firstAddOn?.id())
+//        assertEquals(4, firstAddOn?.quantity())
+//
+//        assertEquals(backedAddOnq.id(), secondAddOn?.id())
+//        assertEquals(backedAddOnq.quantity(), secondAddOn?.quantity())
+//    }
 
     @Test
     fun `test if the VM has being reached by a loggedOut user`() = runTest {

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
@@ -38,21 +38,8 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var viewModel: AddOnsViewModel
 
-    private fun createViewModel(environment: Environment, dispatcher: CoroutineDispatcher? = null) {
-        viewModel =
-            AddOnsViewModel.Factory(environment, testDispatcher = dispatcher).create(AddOnsViewModel::class.java)
-    }
-
     fun setup(environment: Environment = environment(), dispatcher: CoroutineDispatcher? = null) {
-        createViewModel(environment, dispatcher)
-
-        val testRewards = (0..5).map { Reward.builder().hasAddons(true).title("$it").id(it.toLong()).build() }
-        val testBacking =
-            Backing.builder().reward(testRewards[2]).rewardId(testRewards[2].id()).build()
-        val testProject = Project.builder().rewards(testRewards).backing(testBacking).build()
-        val testProjectData = ProjectData.builder().project(testProject).build()
-
-        viewModel.provideProjectData(testProjectData)
+        viewModel = AddOnsViewModel.Factory(environment, testDispatcher = dispatcher).create(AddOnsViewModel::class.java)
     }
 
     @Test
@@ -82,7 +69,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val testProject = ProjectFactory.project().toBuilder().rewards(listOf(backedReward)).backing(backing).build()
         val testProjectData = ProjectData.builder().project(testProject).build()
 
-        createViewModel(env)
+        setup(env)
 
         val bundle = Bundle()
         bundle.putParcelable(ArgumentsKey.PLEDGE_PLEDGE_DATA, PledgeData.with(PledgeFlowContext.CHANGE_REWARD, testProjectData, backedReward, shippingRule = shippingRule))
@@ -113,6 +100,14 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
             .build()
 
         setup(env)
+
+        val testRewards = (0..5).map { Reward.builder().hasAddons(true).title("$it").id(it.toLong()).build() }
+        val testBacking =
+            Backing.builder().reward(testRewards[2]).rewardId(testRewards[2].id()).build()
+        val testProject = Project.builder().rewards(testRewards).backing(testBacking).build()
+        val testProjectData = ProjectData.builder().project(testProject).build()
+
+        viewModel.provideProjectData(testProjectData)
 
         viewModel.sendEvent()
         this.segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
@@ -189,6 +184,12 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun `test amount of backed addOns has been increased`() = runTest {
+        val testRewards = (0..5).map { Reward.builder().hasAddons(true).title("$it").id(it.toLong()).build() }
+        val testBacking =
+            Backing.builder().reward(testRewards[2]).rewardId(testRewards[2].id()).build()
+        val testProject = Project.builder().rewards(testRewards).backing(testBacking).build()
+        val testProjectData = ProjectData.builder().project(testProject).build()
+
         val addOnReward = RewardFactory.addOn().toBuilder().id(1L).build()
         val aDifferentAddOnReward = RewardFactory.addOnSingle().toBuilder().id(2L).build()
         val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
@@ -220,6 +221,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         setup(env, dispatcher)
 
         backgroundScope.launch(dispatcher) {
+            viewModel.provideProjectData(testProjectData)
             viewModel.userRewardSelection(rw)
             viewModel.provideSelectedShippingRule(ShippingRuleFactory.canadaShippingRule())
 
@@ -256,6 +258,12 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
 
     @Test
     fun `test add bonus Support without selecting addOns`() = runTest {
+        val testRewards = (0..5).map { Reward.builder().hasAddons(true).title("$it").id(it.toLong()).build() }
+        val testBacking =
+            Backing.builder().reward(testRewards[2]).rewardId(testRewards[2].id()).build()
+        val testProject = Project.builder().rewards(testRewards).backing(testBacking).build()
+        val testProjectData = ProjectData.builder().project(testProject).build()
+
         val addOnReward = RewardFactory.addOn().toBuilder().id(1L).build()
         val aDifferentAddOnReward = RewardFactory.addOnSingle().toBuilder().id(2L).build()
         val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
@@ -286,6 +294,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
 
         setup(env, dispatcher)
         backgroundScope.launch(dispatcher) {
+            viewModel.provideProjectData(testProjectData)
             viewModel.userRewardSelection(rw)
             viewModel.provideSelectedShippingRule(ShippingRuleFactory.canadaShippingRule())
             viewModel.addOnsUIState.toList(uiState)
@@ -378,8 +387,9 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val env = environment().toBuilder()
             .apolloClientV2(apolloClient)
             .build()
-        createViewModel(env, dispatcher)
+
         backgroundScope.launch(dispatcher) {
+            setup(env, dispatcher)
             viewModel.provideBundle(bundle)
             viewModel.addOnsUIState.toList(uiState)
         }
@@ -455,9 +465,9 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val env = environment().toBuilder()
             .apolloClientV2(apolloClient)
             .build()
-        createViewModel(env, dispatcher)
 
         backgroundScope.launch(dispatcher) {
+            setup(env, dispatcher)
             viewModel.provideBundle(bundle)
             viewModel.updateSelection(addOnReward.id(), 4)
             viewModel.addOnsUIState.toList(uiState)
@@ -486,7 +496,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
             .currentUserV2(MockCurrentUserV2()) // empty user
             .build()
 
-        createViewModel(env)
+        setup(env)
         assertFalse(viewModel.isUserLoggedIn())
     }
 
@@ -496,7 +506,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
             .currentUserV2(MockCurrentUserV2(UserFactory.user())) // empty user
             .build()
 
-        createViewModel(env)
+        setup(env)
         assertTrue(viewModel.isUserLoggedIn())
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
@@ -389,7 +389,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
 
         backgroundScope.launch(dispatcher) {
             viewModel.provideBundle(bundle)
-            viewModel.updateSelection(addOnReward.id(), 3)
+            viewModel.updateSelection(addOnReward.id(), 4)
             viewModel.addOnsUIState.toList(uiState)
         }
         advanceUntilIdle()
@@ -397,14 +397,14 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val pledgeDataAndReason = viewModel.getPledgeDataAndReason()
         val pledgeData = pledgeDataAndReason?.first
 
-        assertEquals(7, uiState.last().totalCount)
+        assertEquals(8, uiState.last().totalCount)
         assertEquals(2, pledgeData?.addOns()?.size)
 
         val firstAddOn = pledgeData?.addOns()?.first()
         val secondAddOn = pledgeData?.addOns()?.last()
 
         assertEquals(addOnReward.id(), firstAddOn?.id())
-        assertEquals(3, firstAddOn?.quantity())
+        assertEquals(4, firstAddOn?.quantity())
 
         assertEquals(backedAddOnq.id(), secondAddOn?.id())
         assertEquals(backedAddOnq.quantity(), secondAddOn?.quantity())

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
@@ -24,7 +24,6 @@ import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.projectpage.AddOnsUIState
 import com.kickstarter.viewmodels.projectpage.AddOnsViewModel
-import io.reactivex.Observable
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
@@ -63,11 +62,12 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
 
         val apolloClient = object : MockApolloClientV2() {
-            override fun getProjectAddOns(
-                slug: String,
-                locationId: Location
-            ): Observable<List<Reward>> {
-                return Observable.just(addOnsList)
+            override suspend fun getRewardAllowedAddOns(
+                locationId: Location,
+                rewardId: Reward,
+                cursor: String?
+            ): Result<AddOnsEnvelope> {
+                return Result.success(AddOnsEnvelope(addOnsList = addOnsList))
             }
         }
 
@@ -99,11 +99,12 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
 
         val apolloClient = object : MockApolloClientV2() {
-            override fun getProjectAddOns(
-                slug: String,
-                locationId: Location
-            ): Observable<List<Reward>> {
-                return Observable.just(addOnsList)
+            override suspend fun getRewardAllowedAddOns(
+                locationId: Location,
+                rewardId: Reward,
+                cursor: String?
+            ): Result<AddOnsEnvelope> {
+                return Result.success(AddOnsEnvelope(addOnsList = addOnsList))
             }
         }
 
@@ -156,7 +157,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
             .build()
         setup(env, dispatcher)
 
-        backgroundScope.launch {
+        backgroundScope.launch(dispatcher) {
             viewModel.userRewardSelection(rw)
             viewModel.provideSelectedShippingRule(ShippingRuleFactory.canadaShippingRule())
 
@@ -387,7 +388,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
             .build()
         createViewModel(env, dispatcher)
 
-        backgroundScope.launch {
+        backgroundScope.launch(dispatcher) {
             viewModel.provideBundle(bundle)
             viewModel.updateSelection(addOnReward.id(), 4)
             viewModel.addOnsUIState.toList(uiState)

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
@@ -114,7 +114,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `test amount of backed addOns has been increased plus loads second addOns page`() = runTest {
+    fun `test amount of backed addOns has been increased for page 1 loads second page, and increase addon from second page`() = runTest {
         val addOnReward = RewardFactory.addOn().toBuilder().id(1L).build()
         val aDifferentAddOnReward = RewardFactory.addOnSingle().toBuilder().id(2L).build()
         val addOnsList = listOf(addOnReward, aDifferentAddOnReward)
@@ -162,6 +162,9 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
             advanceUntilIdle()
             viewModel.loadMore()
 
+            advanceUntilIdle()
+            viewModel.updateSelection(secondPageAddOns.first().id(), 3)
+
             total = viewModel.getPledgeDataAndReason()?.first?.pledgeAmountTotal()?.toDouble() ?: 0.0
             viewModel.addOnsUIState.toList(uiState)
         }
@@ -174,7 +177,7 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
             uiState.last(),
             AddOnsUIState(
                 addOns = paginatedList,
-                totalCount = 3,
+                totalCount = 6,
                 isLoading = false,
                 shippingRule = ShippingRuleFactory.canadaShippingRule(),
                 totalPledgeAmount = total

--- a/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/AddOnsViewModelTest.kt
@@ -254,81 +254,81 @@ class AddOnsViewModelTest : KSRobolectricTestCase() {
         )
     }
 
-    @Test
-    fun `test backed addOns total amount on start`() = runTest {
-        val aDifferentAddOnReward = RewardFactory.addOnSingle().toBuilder().id(2L).build()
-
-        val backedAddOnq = aDifferentAddOnReward.toBuilder().quantity(4).build()
-
-        val shippingRule = ShippingRuleFactory.canadaShippingRule()
-        val backedReward = RewardFactory.reward().toBuilder()
-            .hasAddons(true)
-            .id(99L)
-            .build()
-
-        val backing = BackingFactory.backing(reward = backedReward)
-            .toBuilder()
-            .addOns(listOf(backedAddOnq))
-            .build()
-
-        val testProject = ProjectFactory.project()
-            .toBuilder()
-            .rewards(listOf(backedReward))
-            .backing(backing)
-            .build()
-
-        val testProjectData = ProjectData.builder().project(testProject).build()
-
-        val bundle = Bundle()
-        bundle.putParcelable(
-            ArgumentsKey.PLEDGE_PLEDGE_DATA,
-            PledgeData.with(
-                PledgeFlowContext.CHANGE_REWARD,
-                testProjectData,
-                backedReward,
-                shippingRule = shippingRule
-            )
-        )
-        bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.UPDATE_PLEDGE)
-
-        val uiState = mutableListOf<AddOnsUIState>()
-        val dispatcher = UnconfinedTestDispatcher(testScheduler)
-
-        val apolloClient = object : MockApolloClientV2() {
-            override suspend fun getRewardAllowedAddOns(
-                locationId: Location,
-                rewardId: Reward,
-                cursor: String?
-            ): Result<AddOnsEnvelope> {
-                assertEquals(99L, rewardId.id())
-                return Result.success(AddOnsEnvelope(addOnsList = listOf(aDifferentAddOnReward)))
-            }
-        }
-
-        val env = environment().toBuilder()
-            .apolloClientV2(apolloClient)
-            .build()
-        createViewModel(env, dispatcher)
-        backgroundScope.launch(dispatcher) {
-            viewModel.provideBundle(bundle)
-            viewModel.addOnsUIState.toList(uiState)
-        }
-
-        advanceUntilIdle()
-
-        val pledgeDataAndReason = viewModel.getPledgeDataAndReason()
-        val pledgeData = pledgeDataAndReason?.first
-
-        assertEquals(1, uiState.last().addOns.size)
-        assertEquals(aDifferentAddOnReward.id(), uiState.last().addOns.first().id())
-
-        assertEquals(4, uiState.last().totalCount)
-
-        assertEquals(shippingRule, pledgeData?.shippingRule())
-        assertEquals(1, pledgeData?.addOns()?.size)
-        assertEquals(backedAddOnq.id(), pledgeData?.addOns()?.first()?.id())
-        assertEquals(backedAddOnq.quantity(), pledgeData?.addOns()?.first()?.quantity())
-    }
+//    @Test
+//    fun `test backed addOns total amount on start`() = runTest {
+//        val aDifferentAddOnReward = RewardFactory.addOnSingle().toBuilder().id(2L).build()
+//
+//        val backedAddOnq = aDifferentAddOnReward.toBuilder().quantity(4).build()
+//
+//        val shippingRule = ShippingRuleFactory.canadaShippingRule()
+//        val backedReward = RewardFactory.reward().toBuilder()
+//            .hasAddons(true)
+//            .id(99L)
+//            .build()
+//
+//        val backing = BackingFactory.backing(reward = backedReward)
+//            .toBuilder()
+//            .addOns(listOf(backedAddOnq))
+//            .build()
+//
+//        val testProject = ProjectFactory.project()
+//            .toBuilder()
+//            .rewards(listOf(backedReward))
+//            .backing(backing)
+//            .build()
+//
+//        val testProjectData = ProjectData.builder().project(testProject).build()
+//
+//        val bundle = Bundle()
+//        bundle.putParcelable(
+//            ArgumentsKey.PLEDGE_PLEDGE_DATA,
+//            PledgeData.with(
+//                PledgeFlowContext.CHANGE_REWARD,
+//                testProjectData,
+//                backedReward,
+//                shippingRule = shippingRule
+//            )
+//        )
+//        bundle.putSerializable(ArgumentsKey.PLEDGE_PLEDGE_REASON, PledgeReason.UPDATE_PLEDGE)
+//
+//        val uiState = mutableListOf<AddOnsUIState>()
+//        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+//
+//        val apolloClient = object : MockApolloClientV2() {
+//            override suspend fun getRewardAllowedAddOns(
+//                locationId: Location,
+//                rewardId: Reward,
+//                cursor: String?
+//            ): Result<AddOnsEnvelope> {
+//                assertEquals(99L, rewardId.id())
+//                return Result.success(AddOnsEnvelope(addOnsList = listOf(aDifferentAddOnReward)))
+//            }
+//        }
+//
+//        val env = environment().toBuilder()
+//            .apolloClientV2(apolloClient)
+//            .build()
+//        createViewModel(env, dispatcher)
+//        backgroundScope.launch(dispatcher) {
+//            viewModel.provideBundle(bundle)
+//            viewModel.addOnsUIState.toList(uiState)
+//        }
+//
+//        advanceUntilIdle()
+//
+//        val pledgeDataAndReason = viewModel.getPledgeDataAndReason()
+//        val pledgeData = pledgeDataAndReason?.first
+//
+//        assertEquals(1, uiState.last().addOns.size)
+//        assertEquals(aDifferentAddOnReward.id(), uiState.last().addOns.first().id())
+//
+//        assertEquals(4, uiState.last().totalCount)
+//
+//        assertEquals(shippingRule, pledgeData?.shippingRule())
+//        assertEquals(1, pledgeData?.addOns()?.size)
+//        assertEquals(backedAddOnq.id(), pledgeData?.addOns()?.first()?.id())
+//        assertEquals(backedAddOnq.quantity(), pledgeData?.addOns()?.first()?.quantity())
+//    }
 
 //    @Test
 //    fun `test backed addOns total amount when the amount has been updated`() = runTest {


### PR DESCRIPTION
# 📲 What

- Performance improvements on query, now we query `allowedAddOns` for an specific reward, before all rewards + allowed addOns were queried and filtered afterwards the result for an specific reward.
- Added pagination to the AddOns Screen, each page retrieves only 10 addOns

# 🤔 Why
- A needed performance update

# 🛠 How
- New query with pagination
- Migrated to suspend method 
- Added pagination
- VM now receives the coroutineDispatcher as builder paramenter

# 👀 See


| Before 🐛 | 


https://github.com/user-attachments/assets/a0bf6208-d431-4b54-b677-67d3314d5075



|After 🦋 |


https://github.com/user-attachments/assets/8579ba07-b08e-45ef-8c26-f10a9481a7f5



| --- | --- |
|  |  |

# 📋 QA

- Load projects with addOns (for example this one in production before was returning the timeout https://www.kickstarter.com/projects/comicuno/aces-and-aros-an-asexual-and-aromantic-comic-book-anthology ) try to load addons select some of them and add bonus support, you should be able to reach checkout screen with the correct selection regardless of what page provided the addOn 

- Test editing a pledge (once already a backer). Change the selected addOns and/or adding bonus support. In this use case when the addOns screen loads the previusly backed quantity of addOns is displayed (attached video). In staging this project (https://staging.kickstarter.com/projects/isabel-martin/tween-podcast-sandwich) on the second reward there will be near 17 addons (:fyi the project is completed therefore if hitting update pledge will show that as error message, if you wanna test the hole checkout flow look for a project in staging with an ongoing campaign).

https://github.com/user-attachments/assets/ef5a4a6a-8254-4d3b-8691-3639239e4c42

- Test late pledges! late pledges rewards can have addOns! (video attached) 

https://github.com/user-attachments/assets/0953afce-9b75-4760-96e8-fbd1a6e575ab





# Story 📖

[MBL-2524](https://kickstarter.atlassian.net/browse/MBL-2524)


[MBL-2524]: https://kickstarter.atlassian.net/browse/MBL-2524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ