### PR TITLE
MBL-2511: Polish details on Location screen

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
@@ -36,8 +34,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kickstarter.R
+import com.kickstarter.models.Location
 import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.ui.compose.designsystem.KSDimensions
+import com.kickstarter.ui.compose.designsystem.KSIconButton
 import com.kickstarter.ui.compose.designsystem.KSPillButton
 import com.kickstarter.ui.compose.designsystem.KSSearchBottomSheetFooter
 import com.kickstarter.ui.compose.designsystem.KSTheme
@@ -72,6 +72,8 @@ fun FilterMenuBottomSheet(
     onDismiss: () -> Unit = {},
     onApply: (DiscoveryParams.State?, Boolean?) -> Unit = { a, b -> },
     onNavigate: (FilterType) -> Unit = {},
+    selectedLocation: Location? = null,
+    selectedPercentage: DiscoveryParams.RaisedBuckets? = null,
 ) {
     val projStatus = remember { mutableStateOf(selectedProjectStatus) }
 
@@ -111,13 +113,15 @@ fun FilterMenuBottomSheet(
                             text = titleForFilter(filter),
                             onClickAction = { onNavigate(FilterType.LOCATION) },
                             icon = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                            modifier = Modifier.testTag(FilterMenuTestTags.LOCATION_ROW)
+                            modifier = Modifier.testTag(FilterMenuTestTags.LOCATION_ROW),
+                            subText = selectedLocation?.displayableName()
                         )
                         FilterType.PERCENTAGE_RAISED -> FilterRow(
                             text = titleForFilter(filter),
                             onClickAction = { onNavigate(FilterType.PERCENTAGE_RAISED) },
                             icon = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                            modifier = Modifier.testTag(FilterMenuTestTags.PERCENTAGE_RAISED_ROW)
+                            modifier = Modifier.testTag(FilterMenuTestTags.PERCENTAGE_RAISED_ROW),
+                            subText = selectedPercentage?.let { textForBucket(it) }
                         )
                     }
                 }
@@ -234,7 +238,8 @@ private fun FilterRow(
     modifier: Modifier = Modifier,
     text: String = stringResource(R.string.Filter),
     onClickAction: () -> Unit,
-    icon: ImageVector
+    icon: ImageVector,
+    subText: String? = null
 ) {
     val backgroundDisabledColor = colors.backgroundDisabled
     val dimensions: KSDimensions = KSTheme.dimensions
@@ -264,26 +269,31 @@ private fun FilterRow(
             typographyV2.headingLG
         }
 
-        Text(
-            text = text,
-            style = style,
-            modifier = Modifier.weight(1f),
-            color = colors.textPrimary
-        )
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(
+                text = text,
+                style = style,
+                color = colors.textPrimary
+            )
 
-        // TODO: change to KSIconButton
-        IconButton(
+            if (subText != null) {
+                Text(
+                    text = subText,
+                    style = typographyV2.bodyMD,
+                    color = colors.textPrimary
+                )
+            }
+        }
+
+        KSIconButton(
             modifier = Modifier.testTag(text),
             onClick = {
                 onClickAction.invoke()
-            }
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = "Dismiss Filter Menu",
-                tint = colors.icon
-            )
-        }
+            },
+            imageVector = icon
+        )
     }
 }
 
@@ -316,8 +326,8 @@ private fun FilterMenuSheetPreview() {
     KSTheme {
         FilterMenuBottomSheet(
             selectedProjectStatus = DiscoveryParams.State.LIVE,
-            onApply = { a, b -> },
-            onDismiss = {}
+            onDismiss = {},
+            onApply = { a, b -> }
         )
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheet.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kickstarter.R
+import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.models.Location
 import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.ui.compose.designsystem.KSDimensions
@@ -280,9 +281,12 @@ private fun FilterRow(
 
             if (subText != null) {
                 Text(
+                    modifier = Modifier.padding(
+                        top = dimensions.paddingSmall
+                    ),
                     text = subText,
                     style = typographyV2.bodyMD,
-                    color = colors.textPrimary
+                    color = colors.textSecondary
                 )
             }
         }
@@ -327,7 +331,8 @@ private fun FilterMenuSheetPreview() {
         FilterMenuBottomSheet(
             selectedProjectStatus = DiscoveryParams.State.LIVE,
             onDismiss = {},
-            onApply = { a, b -> }
+            onApply = { a, b -> },
+            selectedLocation = LocationFactory.vancouver(),
         )
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/LocationSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/LocationSheet.kt
@@ -267,7 +267,6 @@ fun LocationSheet(
                 }
 
                 val isFocused = remember { mutableStateOf(false) }
-                val selectedLocation = remember { mutableStateOf(currentLocation.value) }
                 var inputValue = remember { mutableStateOf("") }
 
                 InputSearchComposable(
@@ -276,6 +275,7 @@ fun LocationSheet(
                     searchCallback = { term -> viewModel.updateQuery(term) },
                     cancelCallback = {
                         currentLocation.value = null
+                        inputValue.value = ""
                         viewModel.clearQuery()
                     }
                 )
@@ -284,14 +284,10 @@ fun LocationSheet(
                     DefaultLocationComposable(
                         modifier = Modifier.weight(1f),
                         defaultLocations = defaultLocations,
-                        currentLocation = selectedLocation,
+                        currentLocation = currentLocation,
                         onclickCallback = { locationClicked ->
                             if (locationClicked.isNotNull()) {
                                 currentLocation.value = locationClicked
-                                inputValue.value = locationClicked?.displayableName() ?: ""
-                                locationClicked?.displayableName()?.let {
-                                    viewModel.updateQuery(locationClicked.displayableName())
-                                }
                             } else {
                                 currentLocation.value = null
                                 inputValue.value = ""
@@ -310,7 +306,7 @@ fun LocationSheet(
                     SuggestedLocationsComposable(
                         modifier = Modifier.weight(1f),
                         suggestedLocations = searched,
-                        currentLocation = selectedLocation,
+                        currentLocation = currentLocation,
                         onclickCallback = { clickedLocation ->
                             currentLocation.value = clickedLocation
                             inputValue.value = clickedLocation?.displayableName() ?: ""
@@ -325,7 +321,7 @@ fun LocationSheet(
                         inputValue.value = ""
                         onApply(currentLocation.value, false)
                     },
-                    rightButtonIsEnabled = currentLocation.value.isNotNull(),
+                    rightButtonIsEnabled = currentLocation.value.isNotNull() || (currentLocation.value.isNull() && inputValue.value.isNullOrEmpty()),
                     rightButtonOnClickAction = {
                         onApply(currentLocation.value, true)
                     }
@@ -437,6 +433,7 @@ private fun InputSearchComposable(
                     KSIconButton(
                         onClick = {
                             input.value = ""
+                            cancelCallback()
                         },
                         imageVector = Icons.Filled.Clear,
                         contentDescription = stringResource(id = R.string.social_buttons_cancel)
@@ -483,6 +480,8 @@ private fun DefaultLocationComposable(
     val backgroundDisabledColor = colors.backgroundDisabled
     val dimensions: KSDimensions = KSTheme.dimensions
 
+    val isSelectedId = currentLocation.value?.id()
+
     LazyColumn(
         modifier = modifier
             .testTag(LocationTestTags.DEFAULT_LOCATION_LIST)
@@ -515,7 +514,7 @@ private fun DefaultLocationComposable(
                     horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
                 ) {
                     RadioButton(
-                        selected = currentLocation.value.isNull(),
+                        selected = isSelectedId == null,
                         onClick = null,
                         colors = RadioButtonDefaults.colors(
                             unselectedColor = colors.backgroundSelected,
@@ -544,7 +543,7 @@ private fun DefaultLocationComposable(
                 horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
             ) {
                 RadioButton(
-                    selected = currentLocation.value?.id() == location.id(),
+                    selected = isSelectedId == location.id(),
                     onClick = null,
                     colors = RadioButtonDefaults.colors(
                         unselectedColor = colors.backgroundSelected,

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
@@ -518,6 +518,8 @@ fun FilterPagerSheet(
     ) { page ->
         when (page) {
             FilterPages.MAIN_FILTER.ordinal -> FilterMenuBottomSheet(
+                selectedLocation = currentLocation,
+                selectedPercentage = currentPercentage,
                 selectedProjectStatus = projectState.value,
                 onDismiss = {
                     onDismiss.invoke()

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheetTest.kt
@@ -20,10 +20,7 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 Surface {
-                    FilterMenuBottomSheet(
-                        selectedLocation = currentLocation,
-                        selectedPercentage = currentPercentage
-                    )
+                    FilterMenuBottomSheet()
                 }
             }
         }
@@ -45,9 +42,7 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
                     else FilterType.values().asList().filter { it != FilterType.PERCENTAGE_RAISED },
                     onDismiss = {},
                     onApply = { a, b -> },
-                    onNavigate = {},
-                    selectedLocation = currentLocation,
-                    selectedPercentage = currentPercentage
+                    onNavigate = {}
                 )
             }
         }
@@ -69,9 +64,7 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
                     else FilterType.values().asList().filter { it != FilterType.PERCENTAGE_RAISED },
                     onDismiss = {},
                     onApply = { a, b -> },
-                    onNavigate = {},
-                    selectedLocation = currentLocation,
-                    selectedPercentage = currentPercentage
+                    onNavigate = {}
                 )
             }
         }
@@ -103,9 +96,7 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
                             assertEquals(publicState, null)
 
                         assertNull(from)
-                    },
-                    selectedLocation = currentLocation,
-                    selectedPercentage = currentPercentage
+                    }
                 )
             }
         }
@@ -125,7 +116,7 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
                 FilterMenuBottomSheet(onApply = { state, from ->
                     selected = state
                     contextFrom = from
-                }, selectedLocation = currentLocation, selectedPercentage = currentPercentage)
+                })
             }
         }
 
@@ -153,9 +144,7 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
                     onApply = { state, from ->
                         selected = state
                         contextFrom = from
-                    },
-                    selectedLocation = currentLocation,
-                    selectedPercentage = currentPercentage
+                    }
                 )
             }
         }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuBottomSheetTest.kt
@@ -20,7 +20,10 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 Surface {
-                    FilterMenuBottomSheet()
+                    FilterMenuBottomSheet(
+                        selectedLocation = currentLocation,
+                        selectedPercentage = currentPercentage
+                    )
                 }
             }
         }
@@ -38,11 +41,13 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 FilterMenuBottomSheet(
-                    onApply = { a, b -> },
-                    onDismiss = {},
-                    onNavigate = {},
                     availableFilters = if (shouldShowPhase) FilterType.values().asList()
-                    else FilterType.values().asList().filter { it != FilterType.PERCENTAGE_RAISED }
+                    else FilterType.values().asList().filter { it != FilterType.PERCENTAGE_RAISED },
+                    onDismiss = {},
+                    onApply = { a, b -> },
+                    onNavigate = {},
+                    selectedLocation = currentLocation,
+                    selectedPercentage = currentPercentage
                 )
             }
         }
@@ -60,11 +65,13 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
             KSTheme {
                 FilterMenuBottomSheet(
                     selectedProjectStatus = DiscoveryParams.State.LIVE,
-                    onApply = { a, b -> },
-                    onDismiss = {},
-                    onNavigate = {},
                     availableFilters = if (shouldShowPhase) FilterType.values().asList()
-                    else FilterType.values().asList().filter { it != FilterType.PERCENTAGE_RAISED }
+                    else FilterType.values().asList().filter { it != FilterType.PERCENTAGE_RAISED },
+                    onDismiss = {},
+                    onApply = { a, b -> },
+                    onNavigate = {},
+                    selectedLocation = currentLocation,
+                    selectedPercentage = currentPercentage
                 )
             }
         }
@@ -96,7 +103,9 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
                             assertEquals(publicState, null)
 
                         assertNull(from)
-                    }
+                    },
+                    selectedLocation = currentLocation,
+                    selectedPercentage = currentPercentage
                 )
             }
         }
@@ -116,7 +125,7 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
                 FilterMenuBottomSheet(onApply = { state, from ->
                     selected = state
                     contextFrom = from
-                })
+                }, selectedLocation = currentLocation, selectedPercentage = currentPercentage)
             }
         }
 
@@ -144,7 +153,9 @@ class FilterMenuBottomSheetTest : KSRobolectricTestCase() {
                     onApply = { state, from ->
                         selected = state
                         contextFrom = from
-                    }
+                    },
+                    selectedLocation = currentLocation,
+                    selectedPercentage = currentPercentage
                 )
             }
         }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/LocationSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/LocationSheetTest.kt
@@ -6,8 +6,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
-import androidx.compose.ui.test.isDisplayed
-import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/LocationSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/LocationSheetTest.kt
@@ -3,6 +3,8 @@ package com.kickstarter.ui.activities.compose.search
 import android.content.Context
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isNotDisplayed
@@ -22,6 +24,7 @@ import com.kickstarter.models.Location
 import com.kickstarter.ui.activities.compose.search.LocationTestTags.INPUT_BUTTON
 import com.kickstarter.ui.activities.compose.search.LocationTestTags.INPUT_SEARCH
 import com.kickstarter.ui.activities.compose.search.LocationTestTags.SUGGESTED_LOCATIONS_LIST
+import com.kickstarter.ui.compose.designsystem.BottomSheetFooterTestTags
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -190,7 +193,7 @@ class LocationSheetTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `Input text contains text, cancel button will clean up and go back to default locations`() {
+    fun `default state when opening Location Sheet, when pressing default location buttons states updates`() {
 
         val env = Environment.builder().apolloClientV2(
             object : MockApolloClientV2() {
@@ -229,28 +232,32 @@ class LocationSheetTest : KSRobolectricTestCase() {
             .assertIsDisplayed()
 
         composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name)
+            .assertIsEnabled()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.RESET.name)
+            .assertIsNotEnabled()
+
+        composeTestRule
             .onNodeWithTag(LocationTestTags.locationTag(LocationFactory.vancouver()))
             .performClick()
 
         composeTestRule
-            .onNodeWithTag(INPUT_SEARCH)
-            .assertTextContains(LocationFactory.vancouver().displayableName())
+            .onNodeWithTag(BottomSheetFooterTestTags.RESET.name)
+            .assertIsDisplayed()
 
         composeTestRule
-            .onNodeWithTag(LocationTestTags.locationTag(LocationFactory.vancouver()))
-            .isNotDisplayed() // Default locations no visible if text on input
+            .onNodeWithTag(BottomSheetFooterTestTags.RESET.name)
+            .assertIsEnabled()
 
         composeTestRule
-            .onNodeWithTag(INPUT_BUTTON)
-            .assertExists()
+            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name)
+            .assertIsDisplayed()
 
         composeTestRule
-            .onNodeWithTag(INPUT_BUTTON)
-            .performClick()
-
-        composeTestRule
-            .onNodeWithTag(LocationTestTags.locationTag(LocationFactory.vancouver()))
-            .isDisplayed() // Default locations visible after input cancel button
+            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name)
+            .assertIsEnabled()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- When a location other than “anywhere” is selected, "Reset" becomes active.
- When "anywhere" is selected, "See Results" button becomes active.
- When selecting a location from default locations, no changes happens to the search input.
- When clearing the search input with "X" it clears text input + resets location.
- When "anywhere" is selected, "Reset" button is disabled.
- The Main menu now holds a text with the selected Category/Location/Percentage raised bucket.

# 👀 See
| Before 🐛 | After 🦋 |


https://github.com/user-attachments/assets/c7024015-2213-49ed-800e-7e4de65b8cb8



| --- | --- |
|  |  |

# 📋 QA

- Look at reset, see results buttons states on initial load.
- Check that selecting a location/category/percentage raised bucket the Main menu now has a string with the name of the selected item

# Story 📖
[MBL-2511](https://kickstarter.atlassian.net/browse/MBL-2511)


[MBL-2511]: https://kickstarter.atlassian.net/browse/MBL-2511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ