### PR TITLE
MBL-2513: Amount raised (phase 5) UI

### DIFF
--- a/app/src/main/java/com/kickstarter/services/DiscoveryParams.kt
+++ b/app/src/main/java/com/kickstarter/services/DiscoveryParams.kt
@@ -556,8 +556,7 @@ class DiscoveryParams private constructor(
             }
         }
     }
-
-    // TODO: rename to PercentageBuckets
+    
     enum class RaisedBuckets {
         BUCKET_0,
         BUCKET_1,

--- a/app/src/main/java/com/kickstarter/services/DiscoveryParams.kt
+++ b/app/src/main/java/com/kickstarter/services/DiscoveryParams.kt
@@ -557,6 +557,7 @@ class DiscoveryParams private constructor(
         }
     }
 
+    // TODO: rename to PercentageBuckets
     enum class RaisedBuckets {
         BUCKET_0,
         BUCKET_1,
@@ -572,6 +573,34 @@ class DiscoveryParams private constructor(
                     "BUCKET_0" -> BUCKET_0
                     "BUCKET_1" -> BUCKET_1
                     "BUCKET_2" -> BUCKET_2
+                    else -> { null }
+                }
+            }
+        }
+    }
+
+    /**
+     * Buckets of amount pledged
+     */
+    enum class AmountBuckets {
+        BUCKET_0,
+        BUCKET_1,
+        BUCKET_2,
+        BUCKET_3,
+        BUCKET_4;
+
+        override fun toString(): String {
+            return name.lowercase(Locale.getDefault())
+        }
+
+        companion object {
+            fun fromString(string: String?): AmountBuckets? {
+                return when (string) {
+                    "BUCKET_0" -> BUCKET_0
+                    "BUCKET_1" -> BUCKET_1
+                    "BUCKET_2" -> BUCKET_2
+                    "BUCKET_3" -> BUCKET_3
+                    "BUCKET_4" -> BUCKET_4
                     else -> { null }
                 }
             }

--- a/app/src/main/java/com/kickstarter/services/DiscoveryParams.kt
+++ b/app/src/main/java/com/kickstarter/services/DiscoveryParams.kt
@@ -556,7 +556,7 @@ class DiscoveryParams private constructor(
             }
         }
     }
-    
+
     enum class RaisedBuckets {
         BUCKET_0,
         BUCKET_1,

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/AmountRaisedSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/AmountRaisedSheet.kt
@@ -181,5 +181,4 @@ fun textForBucket(bucket: DiscoveryParams.AmountBuckets) = when (bucket) {
     DiscoveryParams.AmountBuckets.BUCKET_0 -> stringResource(R.string.Amount_raised_bucket_0_fpo)
     DiscoveryParams.AmountBuckets.BUCKET_3 -> stringResource(R.string.Amount_raised_bucket_3_fpo)
     DiscoveryParams.AmountBuckets.BUCKET_4 -> stringResource(R.string.Amount_raised_bucket_4_fpo)
-    else -> ""
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/AmountRaisedSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/AmountRaisedSheet.kt
@@ -51,6 +51,21 @@ private fun AmountRaisedPreview() {
     }
 }
 
+@Composable
+@Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+private fun AmountRaisedSelectedPreview() {
+    KSTheme {
+        AmountRaisedSheet(
+            currentBucket = DiscoveryParams.AmountBuckets.BUCKET_3,
+            onNavigate = {},
+            onDismiss = {},
+            onApply = { bucket, applyAndDismiss ->
+            }
+        )
+    }
+}
+
 object AmountRaisedTestTags {
     const val BUCKETS_LIST = "buckets_list"
     fun bucketTag(bucket: DiscoveryParams.AmountBuckets) = "bucket_${bucket.name}"
@@ -58,7 +73,7 @@ object AmountRaisedTestTags {
 
 @Composable
 fun AmountRaisedSheet(
-    currentPercentage: DiscoveryParams.AmountBuckets? = null,
+    currentBucket: DiscoveryParams.AmountBuckets? = null,
     onDismiss: () -> Unit = {},
     onApply: (DiscoveryParams.AmountBuckets?, Boolean?) -> Unit = { a, b -> },
     onNavigate: () -> Unit = {},
@@ -66,7 +81,7 @@ fun AmountRaisedSheet(
     val backgroundDisabledColor = colors.backgroundDisabled
     val dimensions: KSDimensions = KSTheme.dimensions
 
-    val selectedPercentage = remember { mutableStateOf(currentPercentage) }
+    val selectedPercentage = remember { mutableStateOf(currentBucket) }
 
     KSTheme {
         Surface(
@@ -76,7 +91,6 @@ fun AmountRaisedSheet(
                 modifier = Modifier
                     .fillMaxWidth()
             ) {
-                // TODO: extract this row as a title re-usable composable can be used with Category as well same UI, just changes the title
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/AmountRaisedSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/AmountRaisedSheet.kt
@@ -28,8 +28,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.kickstarter.R
 import com.kickstarter.services.DiscoveryParams
-import com.kickstarter.ui.activities.compose.search.PercentageRaisedTestTags.BUCKETS_LIST
-import com.kickstarter.ui.activities.compose.search.PercentageRaisedTestTags.bucketTag
+import com.kickstarter.ui.activities.compose.search.AmountRaisedTestTags.BUCKETS_LIST
+import com.kickstarter.ui.activities.compose.search.AmountRaisedTestTags.bucketTag
 import com.kickstarter.ui.compose.designsystem.KSDimensions
 import com.kickstarter.ui.compose.designsystem.KSIconButton
 import com.kickstarter.ui.compose.designsystem.KSSearchBottomSheetFooter
@@ -40,9 +40,9 @@ import com.kickstarter.ui.compose.designsystem.KSTheme.typographyV2
 @Composable
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
-private fun PercentageRaisedPreview() {
+private fun AmountRaisedPreview() {
     KSTheme {
-        PercentageRaisedSheet(
+        AmountRaisedSheet(
             onNavigate = {},
             onDismiss = {},
             onApply = { bucket, applyAndDismiss ->
@@ -51,16 +51,16 @@ private fun PercentageRaisedPreview() {
     }
 }
 
-object PercentageRaisedTestTags {
+object AmountRaisedTestTags {
     const val BUCKETS_LIST = "buckets_list"
-    fun bucketTag(bucket: DiscoveryParams.RaisedBuckets) = "bucket_${bucket.name}"
+    fun bucketTag(bucket: DiscoveryParams.AmountBuckets) = "bucket_${bucket.name}"
 }
 
 @Composable
-fun PercentageRaisedSheet(
-    currentPercentage: DiscoveryParams.RaisedBuckets? = null,
+fun AmountRaisedSheet(
+    currentPercentage: DiscoveryParams.AmountBuckets? = null,
     onDismiss: () -> Unit = {},
-    onApply: (DiscoveryParams.RaisedBuckets?, Boolean?) -> Unit = { a, b -> },
+    onApply: (DiscoveryParams.AmountBuckets?, Boolean?) -> Unit = { a, b -> },
     onNavigate: () -> Unit = {},
 ) {
     val backgroundDisabledColor = colors.backgroundDisabled
@@ -102,7 +102,7 @@ fun PercentageRaisedSheet(
                     )
 
                     Text(
-                        text = stringResource(R.string.Percentage_raised),
+                        text = stringResource(R.string.Amount_raised_fpo),
                         style = typographyV2.headingXL,
                         modifier = Modifier.weight(1f),
                         color = colors.textPrimary
@@ -131,7 +131,7 @@ fun PercentageRaisedSheet(
                         }
                         .padding(horizontal = dimensions.paddingLarge, vertical = dimensions.paddingMedium),
                 ) {
-                    val validBuckets = DiscoveryParams.RaisedBuckets.values()
+                    val validBuckets = DiscoveryParams.AmountBuckets.values()
                     items(validBuckets) { bucket ->
                         Row(
                             modifier = Modifier.testTag(bucketTag(bucket))
@@ -175,9 +175,11 @@ fun PercentageRaisedSheet(
 }
 
 @Composable
-fun textForBucket(bucket: DiscoveryParams.RaisedBuckets) = when (bucket) {
-    DiscoveryParams.RaisedBuckets.BUCKET_2 -> stringResource(R.string.Percentage_raised_bucket_2)
-    DiscoveryParams.RaisedBuckets.BUCKET_1 -> stringResource(R.string.Percentage_raised_bucket_1)
-    DiscoveryParams.RaisedBuckets.BUCKET_0 -> stringResource(R.string.Percentage_raised_bucket_0)
+fun textForBucket(bucket: DiscoveryParams.AmountBuckets) = when (bucket) {
+    DiscoveryParams.AmountBuckets.BUCKET_2 -> stringResource(R.string.Amount_raised_bucket_2_fpo)
+    DiscoveryParams.AmountBuckets.BUCKET_1 -> stringResource(R.string.Amount_raised_bucket_1_fpo)
+    DiscoveryParams.AmountBuckets.BUCKET_0 -> stringResource(R.string.Amount_raised_bucket_0_fpo)
+    DiscoveryParams.AmountBuckets.BUCKET_3 -> stringResource(R.string.Amount_raised_bucket_3_fpo)
+    DiscoveryParams.AmountBuckets.BUCKET_4 -> stringResource(R.string.Amount_raised_bucket_4_fpo)
     else -> ""
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,13 +105,20 @@
   <string name="fpo_introducing_the_backings_tab" formatted="false">Introducing the Backings tab</string>
 
 
-  <string name="Amount_pledged_fpo" formatted="false">Amount Pledged</string>
   <string name="Goal_fpo" formatted="false">Goal</string>
 
-  <!-- FPO's for phase 3 -->
+  <!-- FPO's for search&filter phase 3 -->
   <string name="Location_fpo" formatted="false">Location</string>
   <string name="Location_searchbox_placeholder" formatted="false">Search by city, state, country...</string>
   <string name="Location_Anywhere" formatted="false">Anywhere</string>
+
+  <!-- FPO's for search&filter phase 5 -->
+  <string name="Amount_raised_fpo" formatted="false">Amount raised</string>
+  <string name="Amount_raised_bucket_0_fpo" formatted="false">Under $1,000</string>
+  <string name="Amount_raised_bucket_1_fpo" formatted="false">$1,000 to $10,000</string>
+  <string name="Amount_raised_bucket_2_fpo" formatted="false">$10,000 to $100,000</string>
+  <string name="Amount_raised_bucket_3_fpo" formatted="false">$100,000 to $1,000,000</string>
+  <string name="Amount_raised_bucket_4_fpo" formatted="false">More than $1,000,000</string>
 
   <!-- FPO's for reward shipment tracking -->
   <string name="fpo_your_reward_has_shipped" formatted="false">Your reward has shipped!</string>

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/AmountRaisedSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/AmountRaisedSheetTest.kt
@@ -2,19 +2,24 @@ package com.kickstarter.ui.activities.compose.search
 
 import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.services.DiscoveryParams
+import com.kickstarter.ui.compose.designsystem.BottomSheetFooterTestTags
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import org.junit.Test
 
 class AmountRaisedSheetTest : KSRobolectricTestCase() {
 
     val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
     @Test
     fun `All buckets displayed and showing proper text`() {
 
@@ -77,5 +82,132 @@ class AmountRaisedSheetTest : KSRobolectricTestCase() {
         composeTestRule
             .onNodeWithText(context.resources.getString(R.string.Amount_raised_bucket_4_fpo))
             .isDisplayed()
+    }
+
+    @Test
+    fun `Initial buttons state`() {
+        composeTestRule.setContent {
+            KSTheme {
+                AmountRaisedSheet()
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name)
+            .assertIsEnabled()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.RESET.name)
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun `Buttons state when one bucket is selected`() {
+        composeTestRule.setContent {
+            KSTheme {
+                AmountRaisedSheet()
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(
+                AmountRaisedTestTags.bucketTag(DiscoveryParams.AmountBuckets.BUCKET_4)
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(
+                AmountRaisedTestTags.bucketTag(DiscoveryParams.AmountBuckets.BUCKET_4)
+            )
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name)
+            .assertIsEnabled()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.RESET.name)
+            .assertIsEnabled()
+    }
+
+    @Test
+    fun `Buttons actions for left button (reset)`() {
+
+        var bucket: DiscoveryParams.AmountBuckets? = null
+        composeTestRule.setContent {
+            KSTheme {
+                AmountRaisedSheet(
+                    onApply = { amountBucket, b ->
+                        bucket = amountBucket
+                    }
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(
+                AmountRaisedTestTags.bucketTag(DiscoveryParams.AmountBuckets.BUCKET_4)
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(
+                AmountRaisedTestTags.bucketTag(DiscoveryParams.AmountBuckets.BUCKET_4)
+            )
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.RESET.name)
+            .assertIsEnabled()
+
+        assertEquals(bucket, DiscoveryParams.AmountBuckets.BUCKET_4)
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.RESET.name)
+            .performClick()
+
+        assertEquals(bucket, null)
+    }
+
+    @Test
+    fun `Buttons actions for right button (see results)`() {
+
+        var bucket: DiscoveryParams.AmountBuckets? = null
+        var shouldPropagateUpwards: Boolean? = null
+        composeTestRule.setContent {
+            KSTheme {
+                AmountRaisedSheet(
+                    onApply = { amountBucket, b ->
+                        bucket = amountBucket
+                        shouldPropagateUpwards = b
+                    }
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(
+                AmountRaisedTestTags.bucketTag(DiscoveryParams.AmountBuckets.BUCKET_4)
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(
+                AmountRaisedTestTags.bucketTag(DiscoveryParams.AmountBuckets.BUCKET_4)
+            )
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name)
+            .assertIsEnabled()
+
+        assertEquals(bucket, DiscoveryParams.AmountBuckets.BUCKET_4)
+        assertEquals(shouldPropagateUpwards, null)
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name)
+            .performClick()
+
+        assertEquals(shouldPropagateUpwards, true)
     }
 }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/AmountRaisedSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/AmountRaisedSheetTest.kt
@@ -1,0 +1,81 @@
+package com.kickstarter.ui.activities.compose.search
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.R
+import com.kickstarter.services.DiscoveryParams
+import com.kickstarter.ui.compose.designsystem.KSTheme
+import org.junit.Test
+
+class AmountRaisedSheetTest : KSRobolectricTestCase() {
+
+    val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+    @Test
+    fun `All buckets displayed and showing proper text`() {
+
+        composeTestRule.setContent {
+            KSTheme {
+                AmountRaisedSheet()
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText(context.resources.getString(R.string.Amount_raised_fpo))
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(
+                AmountRaisedTestTags.bucketTag(DiscoveryParams.AmountBuckets.BUCKET_0)
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(context.resources.getString(R.string.Amount_raised_bucket_0_fpo))
+            .isDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(
+                AmountRaisedTestTags.bucketTag(DiscoveryParams.AmountBuckets.BUCKET_1)
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(context.resources.getString(R.string.Amount_raised_bucket_1_fpo))
+            .isDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(
+                AmountRaisedTestTags.bucketTag(DiscoveryParams.AmountBuckets.BUCKET_2)
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(context.resources.getString(R.string.Amount_raised_bucket_2_fpo))
+            .isDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(
+                AmountRaisedTestTags.bucketTag(DiscoveryParams.AmountBuckets.BUCKET_3)
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(context.resources.getString(R.string.Amount_raised_bucket_3_fpo))
+            .isDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(
+                AmountRaisedTestTags.bucketTag(DiscoveryParams.AmountBuckets.BUCKET_4)
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(context.resources.getString(R.string.Amount_raised_bucket_4_fpo))
+            .isDisplayed()
+    }
+}

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/PercentageRaisedSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/PercentageRaisedSheetTest.kt
@@ -2,13 +2,17 @@ package com.kickstarter.ui.activities.compose.search
 
 import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.services.DiscoveryParams
+import com.kickstarter.ui.compose.designsystem.BottomSheetFooterTestTags
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import org.junit.Test
 
@@ -62,9 +66,47 @@ class PercentageRaisedSheetTest : KSRobolectricTestCase() {
 
     @Test
     fun `Initial buttons state`() {
+        composeTestRule.setContent {
+            KSTheme {
+                AmountRaisedSheet()
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name)
+            .assertIsEnabled()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.RESET.name)
+            .assertIsNotEnabled()
     }
 
     @Test
     fun `Buttons state when one bucket is selected`() {
+        composeTestRule.setContent {
+            KSTheme {
+                PercentageRaisedSheet()
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(
+                PercentageRaisedTestTags.bucketTag(DiscoveryParams.RaisedBuckets.BUCKET_2)
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(
+                PercentageRaisedTestTags.bucketTag(DiscoveryParams.RaisedBuckets.BUCKET_2)
+            )
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name)
+            .assertIsEnabled()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.RESET.name)
+            .assertIsEnabled()
     }
 }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/PercentageRaisedSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/PercentageRaisedSheetTest.kt
@@ -59,4 +59,12 @@ class PercentageRaisedSheetTest : KSRobolectricTestCase() {
             .onNodeWithText(context.resources.getString(R.string.Percentage_raised_bucket_2))
             .isDisplayed()
     }
+
+    @Test
+    fun `Initial buttons state`() {
+    }
+
+    @Test
+    fun `Buttons state when one bucket is selected`() {
+    }
 }


### PR DESCRIPTION
# 📲 What

- New screen with the UI for Amount raised, on follow up tickets this UI will be integrated within the Pager + BottomSheet on search.

# 🤔 Why

- Adding a new filter for Amount raised

# 🛠 How

- Take a look at https://kickstarter.atlassian.net/wiki/spaces/NT/pages/3469049914/Search+Sort+Filter#Phase-5%3A-Amount-Raised
- Almos identical UI to % raised 

# 👀 See
- Video running the compose preview


https://github.com/user-attachments/assets/21e071c9-94e9-4f29-be68-44e03b5551e8



<img width="496" alt="Screenshot 2025-06-23 at 7 46 53 PM" src="https://github.com/user-attachments/assets/f21885c7-1bba-42e1-abf7-2aa19754a514" />

|  |  |

# 📋 QA

- No qa available as of now, is just the Scren UI not connected yet to the pager + bottomSheet

# Story 📖

[MBL-2513](https://kickstarter.atlassian.net/browse/MBL-2513)


[MBL-2513]: https://kickstarter.atlassian.net/browse/MBL-2513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ