### PR TITLE
[no-jira] Fix project video player not working when loaded from search

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -52,6 +52,9 @@ fragment projectCard on Project {
     pledgeOverTimeCollectionPlanChargeExplanation
     pledgeOverTimeCollectionPlanChargedAsNPayments
     pledgeOverTimeCollectionPlanShortPitch
+    video {
+        ...video
+    }
 }
 
 # Fragment used to load all the Project information on Project Page

--- a/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
@@ -618,6 +618,7 @@ fun projectTransformer(projectFragment: ProjectCard?): Project {
         .rewards("$url/rewards")
         .build()
     val urls = Urls.builder().web(urlsWeb).build()
+    val video = videoTransformer(projectFragment?.video?.video)
     val displayPrelaunch = (projectFragment?.isLaunched ?: false).negate()
     val isInPostCampaignPledgingPhase = projectFragment?.isInPostCampaignPledgingPhase ?: false
     val postCampaignPledgingEnabled = projectFragment?.postCampaignPledgingEnabled ?: false
@@ -654,6 +655,7 @@ fun projectTransformer(projectFragment: ProjectCard?): Project {
         .urls(urls)
         .stateChangedAt(stateChangedAt)
         .isInPostCampaignPledgingPhase(isInPostCampaignPledgingPhase)
+        .video(video)
         .postCampaignPledgingEnabled(postCampaignPledgingEnabled)
         .build()
 }


### PR DESCRIPTION
# 📲 What

Videos were unable to be played on the project page when the entry point was from search.

# 🤔 Why

This was caused by omitting the video fragment from the project list calls made from search, causing the video urls to be null.

# 🛠 How

Added the video object to the project card fragment

# 👀 See

**Before** 🐛 

https://github.com/user-attachments/assets/ac0b3918-ad0c-4b9b-8917-8149683e62b9

**After** 🦋 

https://github.com/user-attachments/assets/6fcbaeab-d573-4020-9378-fcaec16965a0

# 📋 QA

Open search screen, tap on a project and observe that video playback is working correctly, search for a project and observe that video is working correctly

# Story 📖

[no-jira]
