### PR TITLE
MBL-2580: Polish locations query params

### DIFF
--- a/app/src/main/graphql/locations.graphql
+++ b/app/src/main/graphql/locations.graphql
@@ -1,6 +1,6 @@
 
-query GetLocations($useSessionLocation: Boolean, $term: String, $lat: Float, $long: Float, $radius: Float, $filterByCoordinates: Boolean, $first: Int) {
-    locations(useSessionLocation: $useSessionLocation, term: $term, lat: $lat, long: $long, radius: $radius, filterByCoordinates: $filterByCoordinates, discoverable: true, assignable: true, first: $first){
+query GetLocations($useSessionLocation: Boolean, $term: String, $lat: Float, $long: Float, $radius: Float, $filterByCoordinates: Boolean, $first: Int, $discoverable: Boolean) {
+    locations(useSessionLocation: $useSessionLocation, term: $term, lat: $lat, long: $long, radius: $radius, filterByCoordinates: $filterByCoordinates, discoverable: $discoverable, assignable: true, first: $first){
         nodes {
             latitude
             longitude

--- a/app/src/main/graphql/locations.graphql
+++ b/app/src/main/graphql/locations.graphql
@@ -1,6 +1,6 @@
 
 query GetLocations($useSessionLocation: Boolean, $term: String, $lat: Float, $long: Float, $radius: Float, $filterByCoordinates: Boolean, $first: Int, $discoverable: Boolean) {
-    locations(useSessionLocation: $useSessionLocation, term: $term, lat: $lat, long: $long, radius: $radius, filterByCoordinates: $filterByCoordinates, discoverable: $discoverable, assignable: true, first: $first){
+    locations(useSessionLocation: $useSessionLocation, term: $term, lat: $lat, long: $long, radius: $radius, filterByCoordinates: $filterByCoordinates, discoverable: $discoverable, first: $first){
         nodes {
             latitude
             longitude

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -1952,7 +1952,8 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
             first = if (useDefault) Optional.Present(5) else Optional.present(10),
             radius = if (radius == null) Optional.absent() else Optional.present(radius.toDouble()),
             long = if (long == null) Optional.absent() else Optional.present(long.toDouble()),
-            lat = if (lat == null) Optional.absent() else Optional.present(lat.toDouble())
+            lat = if (lat == null) Optional.absent() else Optional.present(lat.toDouble()),
+            discoverable = if (useDefault.isTrue()) Optional.present(true) else Optional.absent()
         )
 
         val response = this.service.query(query).execute()

--- a/app/src/test/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModelTest.kt
@@ -2,6 +2,8 @@ package com.kickstarter.features.search.viewmodel
 
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.extensions.isFalse
+import com.kickstarter.libs.utils.extensions.isTrue
 import com.kickstarter.mock.factories.CategoryFactory
 import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.mock.services.MockApolloClientV2
@@ -91,6 +93,8 @@ class FilterMenuViewModelTest : KSRobolectricTestCase() {
         val searched = listOf(LocationFactory.vancouver())
         val default = listOf(LocationFactory.unitedStates())
 
+        var useDefaultParam = mutableListOf<Boolean>()
+        var termParam = mutableListOf<String?>()
         var timesCalled = 0
         val environment = environment()
             .toBuilder()
@@ -104,6 +108,8 @@ class FilterMenuViewModelTest : KSRobolectricTestCase() {
                         radius: Float?,
                         filterByCoordinates: Boolean?
                     ): Result<List<Location>> {
+                        termParam.add(term)
+                        useDefaultParam.add(useDefault)
                         timesCalled++
                         return if (!useDefault && term == "Vancouver") {
                             Result.success(searched)
@@ -116,14 +122,16 @@ class FilterMenuViewModelTest : KSRobolectricTestCase() {
         val state = mutableListOf<LocationsUIState>()
         backgroundScope.launch(dispatcher) {
             setUpEnvironment(environment, dispatcher)
-
             viewModel.updateQuery("Vancouver")
-
             viewModel.locationsUIState.toList(state)
         }
         advanceUntilIdle()
 
         assertEquals(timesCalled, 2)
+        assertNull(termParam.first()) // - Default locations = null term
+        assertEquals(termParam.last(), "Vancouver")
+        assertTrue(useDefaultParam.first().isTrue())
+        //assertFalse(useDefaultParam.last().isFalse())
         assertEquals(state.size, 3)
         assertEquals(state.last().nearLocations.last(), default.last())
         assertEquals(state.last().searchedLocations.last(), searched.last())

--- a/app/src/test/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModelTest.kt
@@ -131,7 +131,7 @@ class FilterMenuViewModelTest : KSRobolectricTestCase() {
         assertNull(termParam.first()) // - Default locations = null term
         assertEquals(termParam.last(), "Vancouver")
         assertTrue(useDefaultParam.first().isTrue())
-        //assertFalse(useDefaultParam.last().isFalse())
+        assertTrue(useDefaultParam.last().isFalse())
         assertEquals(state.size, 3)
         assertEquals(state.last().nearLocations.last(), default.last())
         assertEquals(state.last().searchedLocations.last(), searched.last())


### PR DESCRIPTION
# 📲 What

- `assignable` param removed, before was always true
- `discoverable` param true only when trying to retrieve default locations, in tandem with `useSessionLocation`

# 🤔 Why

- Improve results for location searching, results aren't showing state or country level results, only cities. So if you search for "United" you might get "United, Toledo, OH" but never "United States". 

# 🛠 How

```
locations(term: $term) //for searching for a location name
locations(useSessionLocation: true, discoverable: true) //for default locations
```

# 👀 See
-- Default locations parameters sent to the query
<img width="1066" alt="defaultLocations" src="https://github.com/user-attachments/assets/bf66d276-fb27-4081-a5d3-b2bb51f8b116" />

--- Searched term locations parameter sent to the query

<img width="1040" alt="searchedTermLocation" src="https://github.com/user-attachments/assets/9e855178-6e14-46f6-88a6-1ddfd3d2c381" />


|  |  |

# 📋 QA
- Use the network profiler, or datadog, to double check the parameter sent to the `locations` query.
- when you search "United" you get  "United States", as one of the possible results

# Story 📖

[MBL-2580](https://kickstarter.atlassian.net/browse/MBL-2580)


[MBL-2580]: https://kickstarter.atlassian.net/browse/MBL-2580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ