### PR TITLE
MBL-2585 [Edit PLOT- FF disabled] The standard promise does not display the edit option

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -1109,26 +1109,23 @@ class ProjectPageActivity :
         binding.pledgeContainerLayout.pledgeToolbar.setOnMenuItemClickListener {
             when (it.itemId) {
                 R.id.rewards,
-                R.id.edit_pledge -> {
+                R.id.edit_pledge,
+                R.id.choose_another_reward -> {
                     this.viewModel.inputs.viewRewardsClicked()
                     true
                 }
-
                 R.id.update_payment -> {
                     this.viewModel.inputs.updatePaymentClicked()
                     true
                 }
-
                 R.id.cancel_pledge -> {
                     this.viewModel.inputs.cancelPledgeClicked()
                     true
                 }
-
                 R.id.contact_creator -> {
                     this.viewModel.inputs.contactCreatorClicked()
                     true
                 }
-
                 else -> false
             }
         }
@@ -1417,12 +1414,17 @@ class ProjectPageActivity :
         super.onDestroy()
     }
 
+    /**
+     * Updates the visibility of the items in the Manage Pledge menu based on the provided options.
+     *
+     * @param options The options for managing the pledge.
+     */
     private fun updateManagePledgeMenuVisibility(options: ManagePledgeMenuOptions) {
         val menu = binding.pledgeContainerLayout.pledgeToolbar.menu
-
         menu.findItem(R.id.edit_pledge)?.isVisible = options.showEditPledge
-        menu.findItem(R.id.update_payment)?.isVisible = options.showUpdatePayment
+        menu.findItem(R.id.choose_another_reward)?.isVisible = options.showChooseAnotherReward
         menu.findItem(R.id.rewards)?.isVisible = options.showSeeRewards
+        menu.findItem(R.id.update_payment)?.isVisible = options.showUpdatePayment
         menu.findItem(R.id.cancel_pledge)?.isVisible = options.showCancelPledge
         menu.findItem(R.id.contact_creator)?.isVisible = options.showContactCreator
     }

--- a/app/src/main/java/com/kickstarter/ui/data/ManagePledgeMenuOptions.kt
+++ b/app/src/main/java/com/kickstarter/ui/data/ManagePledgeMenuOptions.kt
@@ -2,6 +2,7 @@ package com.kickstarter.ui.data
 
 data class ManagePledgeMenuOptions(
     val showEditPledge: Boolean,
+    val showChooseAnotherReward: Boolean,
     val showUpdatePayment: Boolean,
     val showSeeRewards: Boolean,
     val showCancelPledge: Boolean,

--- a/app/src/main/java/com/kickstarter/ui/helpers/ManagePledgeMenuOptionsFactory.kt
+++ b/app/src/main/java/com/kickstarter/ui/helpers/ManagePledgeMenuOptionsFactory.kt
@@ -1,7 +1,5 @@
 package com.kickstarter.ui.helpers
 
-import android.annotation.SuppressLint
-import android.util.Log
 import com.kickstarter.libs.featureflag.FeatureFlagClientType
 import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.models.Backing
@@ -16,7 +14,6 @@ import com.kickstarter.ui.data.ManagePledgeMenuOptions
  * @param ffClient The feature flag client used to check feature flag s statuses.
  * @return A [ManagePledgeMenuOptions] instance with the appropriate visibility settings for each menu item.
  */
-@SuppressLint("LogNotTimber")
 fun createManagePledgeMenuOptions(
     project: Project,
     ffClient: FeatureFlagClientType
@@ -27,7 +24,6 @@ fun createManagePledgeMenuOptions(
     val isFeatureFlagOn = ffClient.getBoolean(FlagKey.ANDROID_PLOT_EDIT_PLEDGE)
     val isPlotProject = project.isPledgeOverTimeAllowed() == true // If the project allows pledge over time, it is considered a plot project.
     val isPledgeOverTime = !backing?.paymentIncrements.isNullOrEmpty() // If the backing has payment increments, it is considered a pledge over time.
-Log.d("ManagePledgeMenuOptions", "isFeatureFlagOn: $isFeatureFlagOn, isPlotProject: $isPlotProject, isPledgeOverTime: $isPledgeOverTime")
     val showEditPledge = when {
         isFeatureFlagOn && (isPlotProject || isPledgeOverTime) -> project.isLive && !isBackingStatusPreAuth
         else -> false

--- a/app/src/main/java/com/kickstarter/ui/helpers/ManagePledgeMenuOptionsFactory.kt
+++ b/app/src/main/java/com/kickstarter/ui/helpers/ManagePledgeMenuOptionsFactory.kt
@@ -1,5 +1,7 @@
 package com.kickstarter.ui.helpers
 
+import android.annotation.SuppressLint
+import android.util.Log
 import com.kickstarter.libs.featureflag.FeatureFlagClientType
 import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.models.Backing
@@ -14,17 +16,32 @@ import com.kickstarter.ui.data.ManagePledgeMenuOptions
  * @param ffClient The feature flag client used to check feature flag s statuses.
  * @return A [ManagePledgeMenuOptions] instance with the appropriate visibility settings for each menu item.
  */
+@SuppressLint("LogNotTimber")
 fun createManagePledgeMenuOptions(
     project: Project,
     ffClient: FeatureFlagClientType
 ): ManagePledgeMenuOptions {
     val backing = project.backing()
-
     val isBackingStatusPreAuth = backing?.status() == Backing.STATUS_PREAUTH
 
-    val isEditPledgeAllowed = ffClient.getBoolean(FlagKey.ANDROID_PLOT_EDIT_PLEDGE)
+    val isFeatureFlagOn = ffClient.getBoolean(FlagKey.ANDROID_PLOT_EDIT_PLEDGE)
+    val isPlotProject = project.isPledgeOverTimeAllowed() == true // If the project allows pledge over time, it is considered a plot project.
+    val isPledgeOverTime = !backing?.paymentIncrements.isNullOrEmpty() // If the backing has payment increments, it is considered a pledge over time.
+Log.d("ManagePledgeMenuOptions", "isFeatureFlagOn: $isFeatureFlagOn, isPlotProject: $isPlotProject, isPledgeOverTime: $isPledgeOverTime")
+    val showEditPledge = when {
+        isFeatureFlagOn && (isPlotProject || isPledgeOverTime) -> project.isLive && !isBackingStatusPreAuth
+        else -> false
+    }
+
+    val showChooseAnotherReward = when {
+        !isFeatureFlagOn -> !isPledgeOverTime || !isPlotProject
+        isFeatureFlagOn -> !(isPlotProject || isPledgeOverTime)
+        else -> false
+    }
+
     return ManagePledgeMenuOptions(
-        showEditPledge = project.isLive && !isBackingStatusPreAuth && isEditPledgeAllowed,
+        showEditPledge = showEditPledge,
+        showChooseAnotherReward = showChooseAnotherReward,
         showUpdatePayment = project.isLive && !isBackingStatusPreAuth,
         showSeeRewards = !project.isLive,
         showCancelPledge = project.isLive && !isBackingStatusPreAuth,

--- a/app/src/main/res/menu/manage_pledge.xml
+++ b/app/src/main/res/menu/manage_pledge.xml
@@ -4,6 +4,9 @@
   <item android:id="@+id/edit_pledge"
       android:title="@string/Edit_pledge"
       app:showAsAction="never"/>
+  <item android:id="@+id/choose_another_reward"
+      android:title="@string/Choose_another_reward"
+      app:showAsAction="never"/>
   <item android:id="@+id/update_payment"
     android:title="@string/Change_payment_method"
     app:showAsAction="never"/>


### PR DESCRIPTION
# 📲 What

Fix the choose another reward option on new manage pledge menu to be shown when FF is off

# 🤔 Why

On the refactor of the menu for manage pledge the choose another reward was deleted in order to use the Edit Pledge option, but when feature flag is off it should appear and when ff is on it should appear for non-plot projects

# 🛠 How

- Added choose another reward option to xml menu
- Add validations to show it or not matchin iOS behavior


# 👀 See

- FEATURE FLAG OFF NO-PLOT PROJECT

[ff_off_non_plot.webm](https://github.com/user-attachments/assets/401dc5fc-72a8-491c-8792-c95aa4555e37)


- FEATURE FLAG OFF PLOT PROJECT

[ff_off_plot.webm](https://github.com/user-attachments/assets/afd06db1-27cf-4e27-bf92-64734a339e96)


- FEATURE FLAG ON NO-PLOT PROJECT

[ff_on_non_plot_project.webm](https://github.com/user-attachments/assets/855aa9ce-782f-47e2-ae3c-cfab66736c67)


- FEATURE FLAG ON PLOT PROJECT

[ff_on_plot_project.webm](https://github.com/user-attachments/assets/c227d08a-3bdf-4728-bad9-1d264d5b8b11)



# 📋 QA

Check the render of the menu depending on the feature flag status. This is the matrix:


Feature Flag: OFF
-----------------
Pledge Type                      | Choose Another Reward | Edit Pledge
------------------------------- | ---------------------- | -------------
Standard pledge (non-PLOT)      | ✅ YES                 | ❌ NO
Standard pledge (PLOT)          | ✅ YES                 | ❌ NO
Pledge Over Time                | ❌ NO                  | ❌ NO

Feature Flag: ON
----------------
Pledge Type                      | Choose Another Reward | Edit Pledge
------------------------------- | ---------------------- | -------------
Standard pledge (non-PLOT)      | ✅ YES                 | ❌ NO
Standard pledge (PLOT)          | ❌ NO                  | ✅ YES (if project is live && not preauth)
Pledge Over Time                | ❌ NO                  | ✅ YES (if project is live && not preauth)

# Story 📖

[MBL-2585](https://kickstarter.atlassian.net/browse/MBL-2585)


[MBL-2585]: https://kickstarter.atlassian.net/browse/MBL-2585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ