### PR TITLE
MBL-2594 [Edit PLOT]. FF disabled- The choose another reward flow should not allow changing collection plans.

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
@@ -127,7 +127,7 @@ fun CheckoutScreenPreview() {
             onDisclaimerItemClicked = {},
             onAccountabilityLinkClicked = {},
             onChangedPaymentMethod = {},
-            isPlotEnabled = false,
+            plotIsVisible = false,
             showPaymentMethodSelection = true,
         )
     }
@@ -172,7 +172,7 @@ fun CheckoutScreenIsPlotEnabledPreview() {
             onDisclaimerItemClicked = {},
             onAccountabilityLinkClicked = {},
             onChangedPaymentMethod = {},
-            isPlotEnabled = true,
+            plotIsVisible = true,
             showPaymentMethodSelection = true,
         )
     }
@@ -201,7 +201,7 @@ fun CheckoutScreen(
     onAccountabilityLinkClicked: () -> Unit,
     onChangedPaymentMethod: (StoredCard?) -> Unit = {},
     onCollectionPlanSelected: (CollectionOptions) -> Unit = {},
-    isPlotEnabled: Boolean = false,
+    plotIsVisible: Boolean = false,
     isPlotEligible: Boolean = false,
     isIncrementalPledge: Boolean = false,
     paymentIncrements: List<PaymentIncrement>? = null,
@@ -388,7 +388,7 @@ fun CheckoutScreen(
                 )
 
                 Spacer(modifier = Modifier.height(dimensions.paddingMedium))
-                if (isPlotEnabled) {
+                if (plotIsVisible) {
                     Text(
                         modifier = Modifier.padding(
                             start = dimensions.paddingMediumLarge,

--- a/app/src/main/java/com/kickstarter/ui/fragments/CrowdfundCheckoutFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/CrowdfundCheckoutFragment.kt
@@ -135,10 +135,13 @@ class CrowdfundCheckoutFragment : Fragment() {
                                 (activity as PledgeDelegate?)?.pledgeSuccessfullyUpdated()
                         }
                     }
+                    val isEditPledgeFeatureFlagOn = environment?.featureFlagClient()?.getBoolean(FlagKey.ANDROID_PLOT_EDIT_PLEDGE) == true
 
-                    val plotIsVisible = showPlotWidget &&
-                        environment?.featureFlagClient()?.getBoolean(FlagKey.ANDROID_PLEDGE_OVER_TIME) ?: false &&
-                        pledgeReason in listOf(PledgeReason.PLEDGE, PledgeReason.UPDATE_REWARD) && project.isPledgeOverTimeAllowed() == true
+                    val plotIsVisible = when {
+                        pledgeReason == PledgeReason.PLEDGE -> showPlotWidget
+                        pledgeReason == PledgeReason.UPDATE_REWARD -> isEditPledgeFeatureFlagOn && showPlotWidget
+                        else -> false
+                    }
 
                     val isPostCampaignPhase = project.isInPostCampaignPledgingPhase() == true
                     val emailForCheckout = if (isPostCampaignPhase) email else null
@@ -179,7 +182,7 @@ class CrowdfundCheckoutFragment : Fragment() {
                                 viewModel.userChangedPaymentMethodSelected(paymentMethodSelected)
                             },
                             ksCurrency = environment.ksCurrency(),
-                            isPlotEnabled = plotIsVisible,
+                            plotIsVisible = plotIsVisible,
                             isPlotEligible = plotEligible,
                             paymentIncrements = paymentIncrements,
                             isIncrementalPledge = isIncremental == true,

--- a/app/src/main/java/com/kickstarter/ui/helpers/ManagePledgeMenuOptionsFactory.kt
+++ b/app/src/main/java/com/kickstarter/ui/helpers/ManagePledgeMenuOptionsFactory.kt
@@ -21,7 +21,7 @@ fun createManagePledgeMenuOptions(
     val backing = project.backing()
     val isBackingStatusPreAuth = backing?.status() == Backing.STATUS_PREAUTH
 
-    val isFeatureFlagOn = ffClient.getBoolean(FlagKey.ANDROID_PLOT_EDIT_PLEDGE)
+    val isFeatureFlagOn = ffClient.getBoolean(FlagKey.ANDROID_PLOT_EDIT_PLEDGE) == true
     val isPlotProject = project.isPledgeOverTimeAllowed() == true // If the project allows pledge over time, it is considered a plot project.
     val isPledgeOverTime = !backing?.paymentIncrements.isNullOrEmpty() // If the backing has payment increments, it is considered a pledge over time.
     val showEditPledge = when {


### PR DESCRIPTION
# 📲 What

Hide collection plan when FF off and choose another reward is selected for a pledge in full payment selected before

# 🤔 Why

The choose another reward flow should not allow changing collection plans.

# 🛠 How

Fixed the validation for show collection plan or not adding the FF for edit pledge to the equation

# SEE

[video_proof.webm](https://github.com/user-attachments/assets/62aea2b1-abdf-4cbc-a6a8-3184fa96ac80)

# 📋 QA

- Turn off feature flag for edit pledge
- Do the pledge flow on Crossfit Video Game Think Tank https://staging.kickstarter.com/projects/1466322202/crossfit-video-game-think-tank?ref=android_project_share

- on the manage pledge menu select choose another reward
- on the checkoutscreen collection plan should not be shown

# Story 📖

[MBL-2594](https://kickstarter.atlassian.net/browse/MBL-2594)


[MBL-2594]: https://kickstarter.atlassian.net/browse/MBL-2594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ