### PR TITLE
MBL-2555: Show only toggles UI

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheet.kt
@@ -39,6 +39,8 @@ import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.models.Category
 import com.kickstarter.models.Location
 import com.kickstarter.services.DiscoveryParams
+import com.kickstarter.ui.activities.compose.search.FilterMenuTestTags.OTHERS_ROW
+import com.kickstarter.ui.activities.compose.search.FilterMenuTestTags.switchTag
 import com.kickstarter.ui.compose.designsystem.KSDimensions
 import com.kickstarter.ui.compose.designsystem.KSIconButton
 import com.kickstarter.ui.compose.designsystem.KSPillButton
@@ -57,9 +59,11 @@ object FilterMenuTestTags {
     const val PERCENTAGE_RAISED_ROW = "percentage_raised_row"
     const val AMOUNT_RAISED_ROW = "amount_raised_row"
     const val LOCATION_ROW = "location_row"
+    const val OTHERS_ROW = "others_row"
     const val FOOTER = "footer"
 
     fun pillTag(state: DiscoveryParams.State?) = "pill_${state?.name ?: "ALL"}"
+    fun switchTag(param: String) = "switch_$param"
 }
 
 enum class FilterType {
@@ -175,10 +179,6 @@ private fun OtherFiltersRow(
     selectedRecommended: MutableState<Boolean> = mutableStateOf(false),
     callbackRecommended: (Boolean?) -> Unit = {},
 ) {
-    // private val staffPicks: Boolean?, -> Projects we love
-    // private val starred: Int?, -> Saved projects
-    // private val social: Int?, -> following
-    // private val recommended: Boolean?, -> recommended for you
     val backgroundDisabledColor = colors.backgroundDisabled
     val dimensions: KSDimensions = KSTheme.dimensions
 
@@ -205,7 +205,9 @@ private fun OtherFiltersRow(
                 end = dimensions.paddingMediumSmall
             )
     ) {
-        Column {
+        Column(
+            modifier = Modifier.testTag(OTHERS_ROW)
+        ) {
             Text(
                 text = text,
                 style = typographyV2.headingLG,
@@ -213,7 +215,7 @@ private fun OtherFiltersRow(
             )
 
             Row(
-                modifier = Modifier.testTag("TODO_TAG"),
+                modifier = Modifier.testTag(DiscoveryParams::recommended.name),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
             ) {
@@ -226,6 +228,7 @@ private fun OtherFiltersRow(
                 )
 
                 KSSwitch(
+                    modifier = Modifier.testTag(switchTag(DiscoveryParams::recommended.name)),
                     checked = currentRecommended.value,
                     onCheckChanged = {
                         currentRecommended.value = it
@@ -234,9 +237,7 @@ private fun OtherFiltersRow(
                 )
             }
             Row(
-                modifier = Modifier.testTag("TODO_TAG")
-                    .clickable {
-                    },
+                modifier = Modifier.testTag(DiscoveryParams::staffPicks.name),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
             ) {
@@ -249,6 +250,7 @@ private fun OtherFiltersRow(
                 )
 
                 KSSwitch(
+                    modifier = Modifier.testTag(switchTag(DiscoveryParams::staffPicks.name)),
                     checked = currentStaffPicked.value.isTrue(),
                     onCheckChanged = {
                         currentStaffPicked.value = it
@@ -257,7 +259,7 @@ private fun OtherFiltersRow(
                 )
             }
             Row(
-                modifier = Modifier.testTag("TODO_TAG"),
+                modifier = Modifier.testTag(DiscoveryParams::starred.name),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
             ) {
@@ -270,6 +272,7 @@ private fun OtherFiltersRow(
                 )
 
                 KSSwitch(
+                    modifier = Modifier.testTag(switchTag(DiscoveryParams::starred.name)),
                     checked = currentStarred.value,
                     onCheckChanged = {
                         currentStarred.value = it
@@ -278,7 +281,7 @@ private fun OtherFiltersRow(
                 )
             }
             Row(
-                modifier = Modifier.testTag("TODO_TAG"),
+                modifier = Modifier.testTag(DiscoveryParams::social.name),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
             ) {
@@ -291,6 +294,7 @@ private fun OtherFiltersRow(
                 )
 
                 KSSwitch(
+                    modifier = Modifier.testTag(switchTag(DiscoveryParams::social.name)),
                     checked = currentSocial.value.isTrue(),
                     onCheckChanged = {
                         currentSocial.value = it
@@ -479,6 +483,18 @@ private fun ProjectStatusRowPreview() {
         ProjectStatusRow(
             modifier = Modifier.background(color = colors.backgroundSurfacePrimary),
             text = titleForFilter(FilterType.PROJECT_STATUS)
+        )
+    }
+}
+
+@Composable
+@Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+private fun OthersRowPreview() {
+    KSTheme {
+        OtherFiltersRow(
+            modifier = Modifier.background(color = colors.backgroundSurfacePrimary),
+            text = titleForFilter(FilterType.OTHERS)
         )
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheet.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kickstarter.R
+import com.kickstarter.libs.utils.extensions.isTrue
 import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.models.Category
 import com.kickstarter.models.Location
@@ -42,6 +43,7 @@ import com.kickstarter.ui.compose.designsystem.KSDimensions
 import com.kickstarter.ui.compose.designsystem.KSIconButton
 import com.kickstarter.ui.compose.designsystem.KSPillButton
 import com.kickstarter.ui.compose.designsystem.KSSearchBottomSheetFooter
+import com.kickstarter.ui.compose.designsystem.KSSwitch
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.typographyV2
@@ -65,7 +67,8 @@ enum class FilterType {
     PROJECT_STATUS,
     LOCATION,
     PERCENTAGE_RAISED,
-    AMOUNT_RAISED
+    AMOUNT_RAISED,
+    OTHERS
 }
 
 @Composable
@@ -137,6 +140,7 @@ fun FilterMenuSheet(
                             modifier = Modifier.testTag(FilterMenuTestTags.AMOUNT_RAISED_ROW),
                             subText = selectedAmount?.let { textForBucket(it) }
                         )
+                        FilterType.OTHERS -> OtherFiltersRow()
                     }
                 }
             }
@@ -153,6 +157,147 @@ fun FilterMenuSheet(
                 },
                 leftButtonText = stringResource(R.string.Reset_all_filters)
             )
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun OtherFiltersRow(
+    modifier: Modifier = Modifier,
+    text: String = stringResource(R.string.Show_only_fpo),
+    selectedStaffPicked: MutableState<Boolean> = mutableStateOf(false),
+    callbackStaffPicked: (Boolean?) -> Unit = {},
+    selectedStarred: MutableState<Boolean> = mutableStateOf(false),
+    callbackStarred: (Boolean?) -> Unit = {},
+    selectedSocial: MutableState<Boolean> = mutableStateOf(false),
+    callbackSocial: (Boolean?) -> Unit = {},
+    selectedRecommended: MutableState<Boolean> = mutableStateOf(false),
+    callbackRecommended: (Boolean?) -> Unit = {},
+) {
+    // private val staffPicks: Boolean?, -> Projects we love
+    // private val starred: Int?, -> Saved projects
+    // private val social: Int?, -> following
+    // private val recommended: Boolean?, -> recommended for you
+    val backgroundDisabledColor = colors.backgroundDisabled
+    val dimensions: KSDimensions = KSTheme.dimensions
+
+    val currentStaffPicked = remember { selectedStaffPicked }
+    val currentStarred = remember { selectedStarred }
+    val currentSocial = remember { selectedSocial }
+    val currentRecommended = remember { selectedRecommended }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .drawBehind {
+                drawLine(
+                    color = backgroundDisabledColor,
+                    start = Offset(0f, size.height),
+                    end = Offset(size.width, size.height),
+                    strokeWidth = dimensions.dividerThickness.toPx()
+                )
+            }
+            .padding(
+                start = dimensions.paddingLarge,
+                top = dimensions.paddingLarge,
+                bottom = dimensions.paddingLarge,
+                end = dimensions.paddingMediumSmall
+            )
+    ) {
+        Column {
+            Text(
+                text = text,
+                style = typographyV2.headingLG,
+                color = colors.textPrimary
+            )
+
+            Row(
+                modifier = Modifier.testTag("TODO_TAG"),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
+            ) {
+                Text(
+                    modifier = Modifier
+                        .weight(1f),
+                    text = stringResource(R.string.Recommended_fpo),
+                    style = typographyV2.bodyMD,
+                    color = colors.textSecondary
+                )
+
+                KSSwitch(
+                    checked = currentRecommended.value,
+                    onCheckChanged = {
+                        currentRecommended.value = it
+                        callbackRecommended(it)
+                    }
+                )
+            }
+            Row(
+                modifier = Modifier.testTag("TODO_TAG")
+                    .clickable {
+                    },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
+            ) {
+                Text(
+                    modifier = Modifier
+                        .weight(1f),
+                    text = stringResource(R.string.Projects_We_Love_fpo),
+                    style = typographyV2.bodyMD,
+                    color = colors.textSecondary
+                )
+
+                KSSwitch(
+                    checked = currentStaffPicked.value.isTrue(),
+                    onCheckChanged = {
+                        currentStaffPicked.value = it
+                        callbackStaffPicked(it)
+                    }
+                )
+            }
+            Row(
+                modifier = Modifier.testTag("TODO_TAG"),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
+            ) {
+                Text(
+                    modifier = Modifier
+                        .weight(1f),
+                    text = stringResource(R.string.Saved_projects_fpo),
+                    style = typographyV2.bodyMD,
+                    color = colors.textSecondary
+                )
+
+                KSSwitch(
+                    checked = currentStarred.value,
+                    onCheckChanged = {
+                        currentStarred.value = it
+                        callbackStarred(it)
+                    }
+                )
+            }
+            Row(
+                modifier = Modifier.testTag("TODO_TAG"),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
+            ) {
+                Text(
+                    modifier = Modifier
+                        .weight(1f),
+                    text = stringResource(R.string.Following_fpo),
+                    style = typographyV2.bodyMD,
+                    color = colors.textSecondary
+                )
+
+                KSSwitch(
+                    checked = currentSocial.value.isTrue(),
+                    onCheckChanged = {
+                        currentSocial.value = it
+                        callbackSocial(it)
+                    }
+                )
+            }
         }
     }
 }
@@ -322,6 +467,7 @@ private fun titleForFilter(filter: FilterType): String {
         FilterType.LOCATION -> stringResource(R.string.Location_fpo)
         FilterType.PERCENTAGE_RAISED -> stringResource(R.string.Percentage_raised)
         FilterType.AMOUNT_RAISED -> stringResource(R.string.Amount_raised_fpo)
+        FilterType.OTHERS -> stringResource(R.string.Show_only_fpo)
     }
 }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
@@ -586,7 +586,7 @@ fun FilterPagerSheet(
                     }
                 },
                 availableFilters = if (shouldShowPhase) FilterType.values().asList()
-                else FilterType.values().asList().filter { it != FilterType.LOCATION && it != FilterType.AMOUNT_RAISED }
+                else FilterType.values().asList().filter { it != FilterType.OTHERS }
             )
             FilterPages.CATEGORIES.ordinal -> CategorySelectionSheet(
                 onNavigate = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,6 +104,13 @@
   <string name="Amount_raised_bucket_3_fpo" formatted="false">$100,000 to $1,000,000</string>
   <string name="Amount_raised_bucket_4_fpo" formatted="false">More than $1,000,000</string>
 
+  <!-- FPO's for search&filter phase 7 -->
+  <string name="Show_only_fpo" formatted="false">Show only</string>
+  <string name="Recommended_fpo" formatted="false">Recommended for you</string>
+  <string name="Projects_We_Love_fpo" formatted="false">Projects We Love</string>
+  <string name="Saved_projects_fpo" formatted="false">Saved projects</string>
+  <string name="Following_fpo" formatted="false">Following</string>
+
   <!-- FPO's for reward shipment tracking -->
   <string name="fpo_your_reward_has_shipped" formatted="false">Your reward has shipped!</string>
   <string name="fpo_tracking_number" formatted="false">Tracking #: %{tracking_number}</string>

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheetTest.kt
@@ -1,14 +1,18 @@
 package com.kickstarter.ui.activities.compose.search
 
+import android.content.Context
 import androidx.compose.material.Surface
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
+import androidx.test.platform.app.InstrumentationRegistry
 import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.R
 import com.kickstarter.mock.factories.CategoryFactory
 import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.services.DiscoveryParams
@@ -17,6 +21,7 @@ import com.kickstarter.ui.compose.designsystem.KSTheme
 import org.junit.Test
 
 class FilterMenuSheetTest : KSRobolectricTestCase() {
+    val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
 
     @Test
     fun `test FilterMenuSheet renders all pills within ProjectStatusRow`() {
@@ -37,13 +42,50 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun `test FilterMenuSheet renders all options within OthersRow`() {
+
+        composeTestRule.setContent {
+            KSTheme {
+                Surface {
+                    FilterMenuSheet()
+                }
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(FilterMenuTestTags.LIST)
+            .performScrollToNode(hasTestTag(FilterMenuTestTags.OTHERS_ROW))
+        composeTestRule.onNodeWithText(context.resources.getString(R.string.Show_only_fpo)).assertIsDisplayed()
+
+        // Recommended
+        composeTestRule.onNodeWithTag(DiscoveryParams::recommended.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.resources.getString(R.string.Recommended_fpo)).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FilterMenuTestTags.switchTag(DiscoveryParams::recommended.name)).assertIsOff()
+
+        // Projects we love
+        composeTestRule.onNodeWithTag(DiscoveryParams::staffPicks.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.resources.getString(R.string.Projects_We_Love_fpo)).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FilterMenuTestTags.switchTag(DiscoveryParams::staffPicks.name)).assertIsOff()
+
+        // Saved
+        composeTestRule.onNodeWithTag(DiscoveryParams::starred.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.resources.getString(R.string.Saved_projects_fpo)).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FilterMenuTestTags.switchTag(DiscoveryParams::starred.name)).assertIsOff()
+
+        // Social
+        composeTestRule.onNodeWithTag(DiscoveryParams::social.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.resources.getString(R.string.Following_fpo)).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FilterMenuTestTags.switchTag(DiscoveryParams::social.name)).assertIsOff()
+    }
+
+    @Test
     fun `test FilterMenuSheet renders all available filter Rows with ffOff`() {
         val shouldShowPhase = false
         composeTestRule.setContent {
             KSTheme {
                 FilterMenuSheet(
                     availableFilters = if (shouldShowPhase) FilterType.values().asList()
-                    else FilterType.values().asList().filter { it != FilterType.LOCATION && it != FilterType.AMOUNT_RAISED },
+                    else FilterType.values().asList().filter { it != FilterType.OTHERS },
                     onDismiss = {},
                     onApply = { a, b -> },
                     onNavigate = {}
@@ -62,8 +104,9 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
             .performScrollToNode(hasTestTag(FilterMenuTestTags.PERCENTAGE_RAISED_ROW))
 
         composeTestRule.onNodeWithTag(FilterMenuTestTags.PERCENTAGE_RAISED_ROW).assertIsDisplayed()
-        composeTestRule.onNodeWithTag(FilterMenuTestTags.LOCATION_ROW).assertDoesNotExist()
-        composeTestRule.onNodeWithTag(FilterMenuTestTags.AMOUNT_RAISED_ROW).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(FilterMenuTestTags.LOCATION_ROW).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FilterMenuTestTags.AMOUNT_RAISED_ROW).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(FilterMenuTestTags.OTHERS_ROW).assertDoesNotExist()
     }
 
     @Test
@@ -74,7 +117,7 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
                 FilterMenuSheet(
                     selectedProjectStatus = DiscoveryParams.State.LIVE,
                     availableFilters = if (shouldShowPhase) FilterType.values().asList()
-                    else FilterType.values().asList().filter { it != FilterType.LOCATION && it != FilterType.AMOUNT_RAISED },
+                    else FilterType.values().asList().filter { it != FilterType.OTHERS },
                     onDismiss = {},
                     onApply = { a, b -> },
                     onNavigate = {}
@@ -95,6 +138,11 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
         composeTestRule.onNodeWithTag(FilterMenuTestTags.PERCENTAGE_RAISED_ROW).assertIsDisplayed()
         composeTestRule.onNodeWithTag(FilterMenuTestTags.AMOUNT_RAISED_ROW).assertIsDisplayed()
         composeTestRule.onNodeWithTag(FilterMenuTestTags.LOCATION_ROW).assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(FilterMenuTestTags.LIST)
+            .performScrollToNode(hasTestTag(FilterMenuTestTags.OTHERS_ROW))
+        composeTestRule.onNodeWithTag(FilterMenuTestTags.OTHERS_ROW).assertIsDisplayed()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

- Added new row `OthersRow` that contains the UI toggles for `recomended`, `Projects we love`, `saved`, and `following`
- Feature flag logic moved to gate keep now phase 6.

# 🛠 How

More in-depth discussion of the change or implementation.

# 👀 See
- With feature flag enabled, the new row with all the toggles is visible


https://github.com/user-attachments/assets/0fcbc600-d460-4f68-a715-3f15896a82c3


- With Feature flag disabled, the functionality remains exactly the same as when released 

https://github.com/user-attachments/assets/a61ab76d-3524-44a2-a0f2-6a202fe427c1

- Compose preview, of the new row added

<img width="452" alt="Screenshot 2025-07-07 at 2 52 58 PM" src="https://github.com/user-attachments/assets/537029fd-3067-4364-b9c6-b0ccd629bd61" />


|  |  |

# 📋 QA

- No need to qa anything else yet appart from the ff on/off, that can be done by "hardcoding" the value on `SearchAndFilterActivity:70` or turning on/off on remote config

# Story 📖

[Name of Trello Story](Trello link)
