### PR TITLE
MBL-2566: Goal Screen (phase 7) UI

### DIFF
--- a/app/src/main/graphql/project.graphql
+++ b/app/src/main/graphql/project.graphql
@@ -11,7 +11,8 @@ query FetchProjects(
   $searchTerm: String,
   $raised: RaisedBuckets,
   $location: ID,
-  $amountRaisedBucket: PledgedBuckets
+  $amountRaisedBucket: PledgedBuckets,
+  $goalBucket: GoalBuckets
 ) {
     projects(
       first: $first,
@@ -26,7 +27,8 @@ query FetchProjects(
       term: $searchTerm,
       raised: $raised,
       locationId: $location,
-      pledged: $amountRaisedBucket
+      pledged: $amountRaisedBucket,
+      goal: $goalBucket
       ) {
         edges {
           cursor

--- a/app/src/main/java/com/kickstarter/services/DiscoveryParams.kt
+++ b/app/src/main/java/com/kickstarter/services/DiscoveryParams.kt
@@ -41,7 +41,8 @@ class DiscoveryParams private constructor(
     private val tagId: Int?,
     private val term: String?,
     private val raisedbucket: RaisedBuckets?,
-    private val amountRaisedBucket: AmountBuckets?
+    private val amountRaisedBucket: AmountBuckets?,
+    private val goalBucket: GoalBuckets?
 ) : Parcelable {
 
     fun backed() = this.backed
@@ -63,6 +64,7 @@ class DiscoveryParams private constructor(
     fun term() = this.term
     fun raisedBucket() = this.raisedbucket
     fun amountBucket() = this.amountRaisedBucket
+    fun goalBucket() = this.goalBucket
     fun nextPage(): DiscoveryParams {
         val page = page()
         return if (page != null) toBuilder().page(page + 1).build() else this
@@ -88,7 +90,8 @@ class DiscoveryParams private constructor(
                 tagId() == other.tagId() &&
                 term() == other.term() &&
                 raisedBucket() == other.raisedBucket() &&
-                amountBucket() == other.amountBucket()
+                amountBucket() == other.amountBucket() &&
+                goalBucket() == other.goalBucket()
         }
         return equals
     }
@@ -113,7 +116,8 @@ class DiscoveryParams private constructor(
         private var tagId: Int? = null,
         private var term: String? = null,
         private var raisedBucket: RaisedBuckets? = null,
-        private var amountBucket: AmountBuckets? = null
+        private var amountBucket: AmountBuckets? = null,
+        private var goalBucket: GoalBuckets? = null
     ) : Parcelable {
         fun backed(backed: Int?) = apply { this.backed = backed }
         fun category(category: Category?) = apply { this.category = category }
@@ -132,6 +136,7 @@ class DiscoveryParams private constructor(
         fun state(state: State?) = apply { this.state = state }
         fun raisedBucket(raisedbucket: RaisedBuckets?) = apply { this.raisedBucket = raisedbucket }
         fun amountBucket(amountRaisedBucket: AmountBuckets?) = apply { this.amountBucket = amountRaisedBucket }
+        fun goalBucket(goalBucket: GoalBuckets?) = apply { this.goalBucket = goalBucket }
         fun tagId(tagId: Int?) = apply { this.tagId = tagId }
         fun term(term: String?) = apply { this.term = term }
         fun build() = DiscoveryParams(
@@ -153,7 +158,8 @@ class DiscoveryParams private constructor(
             tagId = tagId,
             term = term,
             raisedbucket = raisedBucket,
-            amountRaisedBucket = amountBucket
+            amountRaisedBucket = amountBucket,
+            goalBucket = goalBucket
         )
 
         /**
@@ -234,7 +240,8 @@ class DiscoveryParams private constructor(
         tagId = tagId,
         term = term,
         raisedBucket = raisedbucket,
-        amountBucket = amountRaisedBucket
+        amountBucket = amountRaisedBucket,
+        goalBucket = goalBucket
     )
 
     fun queryParams(): Map<String, String> {
@@ -608,6 +615,33 @@ class DiscoveryParams private constructor(
                     "BUCKET_3" -> BUCKET_3
                     "BUCKET_4" -> BUCKET_4
                     else -> { null }
+                }
+            }
+        }
+    }
+    /**
+     * Buckets of goals
+     */
+    enum class GoalBuckets {
+        BUCKET_0,
+        BUCKET_1,
+        BUCKET_2,
+        BUCKET_3,
+        BUCKET_4;
+
+        override fun toString(): String {
+            return name.lowercase(Locale.getDefault())
+        }
+
+        companion object {
+            fun fromString(string: String?): GoalBuckets? {
+                return when (string) {
+                    "BUCKET_0" -> BUCKET_0
+                    "BUCKET_1" -> BUCKET_1
+                    "BUCKET_2" -> BUCKET_2
+                    "BUCKET_3" -> BUCKET_3
+                    "BUCKET_4" -> BUCKET_4
+                    else -> null
                 }
             }
         }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/GoalSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/GoalSheet.kt
@@ -28,8 +28,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.kickstarter.R
 import com.kickstarter.services.DiscoveryParams
-import com.kickstarter.ui.activities.compose.search.AmountRaisedTestTags.BUCKETS_LIST
-import com.kickstarter.ui.activities.compose.search.AmountRaisedTestTags.bucketTag
 import com.kickstarter.ui.compose.designsystem.KSDimensions
 import com.kickstarter.ui.compose.designsystem.KSIconButton
 import com.kickstarter.ui.compose.designsystem.KSSearchBottomSheetFooter
@@ -40,9 +38,9 @@ import com.kickstarter.ui.compose.designsystem.KSTheme.typographyV2
 @Composable
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
-private fun AmountRaisedPreview() {
+private fun GoalSheetPreview() {
     KSTheme {
-        AmountRaisedSheet(
+        GoalSheet(
             onNavigate = {},
             onDismiss = {},
             onApply = { bucket, applyAndDismiss ->
@@ -54,10 +52,10 @@ private fun AmountRaisedPreview() {
 @Composable
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
-private fun AmountRaisedSelectedPreview() {
+private fun GoalSelectedPreview() {
     KSTheme {
-        AmountRaisedSheet(
-            currentBucket = DiscoveryParams.AmountBuckets.BUCKET_3,
+        GoalSheet(
+            currentGoalBucket = DiscoveryParams.GoalBuckets.BUCKET_2,
             onNavigate = {},
             onDismiss = {},
             onApply = { bucket, applyAndDismiss ->
@@ -66,31 +64,26 @@ private fun AmountRaisedSelectedPreview() {
     }
 }
 
-object AmountRaisedTestTags {
-    const val BUCKETS_LIST = "buckets_list"
-    fun bucketTag(bucket: DiscoveryParams.AmountBuckets) = "bucket_${bucket.name}"
+object GoalTestTags {
+    const val BUCKETS_LIST = "goal_buckets_list"
+    fun bucketTag(bucket: DiscoveryParams.GoalBuckets) = "bucket_${bucket.name}"
 }
 
 @Composable
-fun AmountRaisedSheet(
-    currentBucket: DiscoveryParams.AmountBuckets? = null,
+fun GoalSheet(
+    currentGoalBucket: DiscoveryParams.GoalBuckets? = null,
     onDismiss: () -> Unit = {},
-    onApply: (DiscoveryParams.AmountBuckets?, Boolean?) -> Unit = { a, b -> },
-    onNavigate: () -> Unit = {},
+    onApply: (DiscoveryParams.GoalBuckets?, Boolean?) -> Unit = { _, _ -> },
+    onNavigate: () -> Unit = {}
 ) {
     val backgroundDisabledColor = colors.backgroundDisabled
     val dimensions: KSDimensions = KSTheme.dimensions
 
-    val selectedBucket = remember { mutableStateOf(currentBucket) }
+    val selectedGoalBucket = remember { mutableStateOf(currentGoalBucket) }
 
     KSTheme {
-        Surface(
-            color = colors.backgroundSurfacePrimary
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-            ) {
+        Surface(color = colors.backgroundSurfacePrimary) {
+            Column(modifier = Modifier.fillMaxWidth()) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -103,27 +96,24 @@ fun AmountRaisedSheet(
                             )
                         }
                         .padding(top = dimensions.paddingLarge, bottom = dimensions.paddingLarge, end = dimensions.paddingMediumSmall),
-
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     KSIconButton(
                         modifier = Modifier
-                            .padding(start = dimensions.paddingSmall)
-                            .testTag(SearchScreenTestTag.BACK_BUTTON.name),
+                            .padding(start = dimensions.paddingSmall),
                         onClick = onNavigate,
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = stringResource(id = R.string.Back)
                     )
 
                     Text(
-                        text = stringResource(R.string.Amount_raised_fpo),
+                        text = stringResource(R.string.Goal_fpo),
                         style = typographyV2.headingXL,
                         modifier = Modifier.weight(1f),
                         color = colors.textPrimary
                     )
 
                     KSIconButton(
-                        modifier = Modifier.testTag(CategorySelectionSheetTestTag.DISMISS_BUTTON.name),
                         onClick = onDismiss,
                         imageVector = Icons.Filled.Close,
                         contentDescription = stringResource(id = R.string.accessibility_discovery_buttons_close)
@@ -132,7 +122,7 @@ fun AmountRaisedSheet(
 
                 LazyColumn(
                     modifier = Modifier
-                        .testTag(BUCKETS_LIST)
+                        .testTag(GoalTestTags.BUCKETS_LIST)
                         .fillMaxWidth()
                         .weight(1f)
                         .drawBehind {
@@ -143,28 +133,31 @@ fun AmountRaisedSheet(
                                 strokeWidth = dimensions.dividerThickness.toPx()
                             )
                         }
-                        .padding(horizontal = dimensions.paddingLarge, vertical = dimensions.paddingMedium),
+                        .padding(horizontal = dimensions.paddingLarge, vertical = dimensions.paddingMedium)
                 ) {
-                    val validBuckets = DiscoveryParams.AmountBuckets.values()
+                    val validBuckets = DiscoveryParams.GoalBuckets.values()
                     items(validBuckets) { bucket ->
                         Row(
-                            modifier = Modifier.testTag(bucketTag(bucket))
+                            modifier = Modifier
+                                .testTag(GoalTestTags.bucketTag(bucket))
                                 .padding(top = dimensions.paddingMediumSmall, bottom = dimensions.paddingMediumSmall)
                                 .clickable {
-                                    selectedBucket.value = bucket
-                                    onApply(selectedBucket.value, null)
+                                    selectedGoalBucket.value = bucket
+                                    onApply(selectedGoalBucket.value, null)
                                 },
                             verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
+                            horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall)
                         ) {
                             RadioButton(
-                                selected = selectedBucket.value == bucket,
+                                selected = selectedGoalBucket.value == bucket,
                                 onClick = null,
-                                colors = RadioButtonDefaults.colors(unselectedColor = colors.backgroundSelected, selectedColor = colors.backgroundSelected)
+                                colors = RadioButtonDefaults.colors(
+                                    unselectedColor = colors.backgroundSelected,
+                                    selectedColor = colors.backgroundSelected
+                                )
                             )
                             Text(
-                                modifier = Modifier
-                                    .weight(1f),
+                                modifier = Modifier.weight(1f),
                                 color = colors.textPrimary,
                                 text = textForBucket(bucket),
                                 style = typographyV2.headingLG
@@ -174,13 +167,13 @@ fun AmountRaisedSheet(
                 }
 
                 KSSearchBottomSheetFooter(
-                    leftButtonIsEnabled = selectedBucket.value != null,
+                    leftButtonIsEnabled = selectedGoalBucket.value != null,
                     leftButtonClickAction = {
-                        selectedBucket.value = null
-                        onApply(selectedBucket.value, false)
+                        selectedGoalBucket.value = null
+                        onApply(null, false)
                     },
                     rightButtonOnClickAction = {
-                        onApply(selectedBucket.value, true)
+                        onApply(selectedGoalBucket.value, true)
                     }
                 )
             }
@@ -189,10 +182,10 @@ fun AmountRaisedSheet(
 }
 
 @Composable
-fun textForBucket(bucket: DiscoveryParams.AmountBuckets) = when (bucket) {
-    DiscoveryParams.AmountBuckets.BUCKET_2 -> stringResource(R.string.Bucket_2_fpo)
-    DiscoveryParams.AmountBuckets.BUCKET_1 -> stringResource(R.string.Bucket_1_fpo)
-    DiscoveryParams.AmountBuckets.BUCKET_0 -> stringResource(R.string.Bucket_0_fpo)
-    DiscoveryParams.AmountBuckets.BUCKET_3 -> stringResource(R.string.Bucket_3_fpo)
-    DiscoveryParams.AmountBuckets.BUCKET_4 -> stringResource(R.string.Bucket_4_fpo)
+fun textForBucket(bucket: DiscoveryParams.GoalBuckets): String = when (bucket) {
+    DiscoveryParams.GoalBuckets.BUCKET_0 -> stringResource(R.string.Bucket_0_fpo)
+    DiscoveryParams.GoalBuckets.BUCKET_1 -> stringResource(R.string.Bucket_1_fpo)
+    DiscoveryParams.GoalBuckets.BUCKET_2 -> stringResource(R.string.Bucket_2_fpo)
+    DiscoveryParams.GoalBuckets.BUCKET_3 -> stringResource(R.string.Bucket_3_fpo)
+    DiscoveryParams.GoalBuckets.BUCKET_4 -> stringResource(R.string.Bucket_4_fpo)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,13 +96,13 @@
   <string name="Location_fpo" formatted="false">Location</string>
   <string name="Location_Anywhere" formatted="false">Anywhere</string>
 
-  <!-- FPO's for search&filter phase 5 -->
+  <!-- FPO's for search&filter phase 5 & 7 -->
   <string name="Amount_raised_fpo" formatted="false">Amount raised</string>
-  <string name="Amount_raised_bucket_0_fpo" formatted="false">Under $1,000</string>
-  <string name="Amount_raised_bucket_1_fpo" formatted="false">$1,000 to $10,000</string>
-  <string name="Amount_raised_bucket_2_fpo" formatted="false">$10,000 to $100,000</string>
-  <string name="Amount_raised_bucket_3_fpo" formatted="false">$100,000 to $1,000,000</string>
-  <string name="Amount_raised_bucket_4_fpo" formatted="false">More than $1,000,000</string>
+  <string name="Bucket_0_fpo" formatted="false">Under $1,000</string>
+  <string name="Bucket_1_fpo" formatted="false">$1,000 to $10,000</string>
+  <string name="Bucket_2_fpo" formatted="false">$10,000 to $100,000</string>
+  <string name="Bucket_3_fpo" formatted="false">$100,000 to $1,000,000</string>
+  <string name="Bucket_4_fpo" formatted="false">More than $1,000,000</string>
 
   <!-- FPO's for reward shipment tracking -->
   <string name="fpo_your_reward_has_shipped" formatted="false">Your reward has shipped!</string>

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/AmountRaisedSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/AmountRaisedSheetTest.kt
@@ -40,7 +40,7 @@ class AmountRaisedSheetTest : KSRobolectricTestCase() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onNodeWithText(context.resources.getString(R.string.Amount_raised_bucket_0_fpo))
+            .onNodeWithText(context.resources.getString(R.string.Bucket_0_fpo))
             .isDisplayed()
 
         composeTestRule
@@ -50,7 +50,7 @@ class AmountRaisedSheetTest : KSRobolectricTestCase() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onNodeWithText(context.resources.getString(R.string.Amount_raised_bucket_1_fpo))
+            .onNodeWithText(context.resources.getString(R.string.Bucket_1_fpo))
             .isDisplayed()
 
         composeTestRule
@@ -60,7 +60,7 @@ class AmountRaisedSheetTest : KSRobolectricTestCase() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onNodeWithText(context.resources.getString(R.string.Amount_raised_bucket_2_fpo))
+            .onNodeWithText(context.resources.getString(R.string.Bucket_2_fpo))
             .isDisplayed()
 
         composeTestRule
@@ -70,7 +70,7 @@ class AmountRaisedSheetTest : KSRobolectricTestCase() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onNodeWithText(context.resources.getString(R.string.Amount_raised_bucket_3_fpo))
+            .onNodeWithText(context.resources.getString(R.string.Bucket_3_fpo))
             .isDisplayed()
 
         composeTestRule
@@ -80,7 +80,7 @@ class AmountRaisedSheetTest : KSRobolectricTestCase() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onNodeWithText(context.resources.getString(R.string.Amount_raised_bucket_4_fpo))
+            .onNodeWithText(context.resources.getString(R.string.Bucket_4_fpo))
             .isDisplayed()
     }
 

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/GoalSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/GoalSheetTest.kt
@@ -40,12 +40,12 @@ class GoalSheetTest : KSRobolectricTestCase() {
             composeTestRule
                 .onNodeWithText(
                     context.resources.getString(
-                    context.resources.getIdentifier(
-                        "Bucket_${bucket.name.last().digitToInt()}_fpo",
-                        "string",
-                        context.packageName
+                        context.resources.getIdentifier(
+                            "Bucket_${bucket.name.last().digitToInt()}_fpo",
+                            "string",
+                            context.packageName
+                        )
                     )
-                )
                 )
                 .isDisplayed()
         }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/GoalSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/GoalSheetTest.kt
@@ -1,0 +1,145 @@
+package com.kickstarter.ui.activities.compose.search
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.R
+import com.kickstarter.services.DiscoveryParams
+import com.kickstarter.ui.compose.designsystem.BottomSheetFooterTestTags
+import com.kickstarter.ui.compose.designsystem.KSTheme
+import org.junit.Test
+
+class GoalSheetTest : KSRobolectricTestCase() {
+
+    val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun `All goal buckets displayed and showing proper text`() {
+        composeTestRule.setContent {
+            KSTheme {
+                GoalSheet()
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText(context.resources.getString(R.string.Goal_fpo))
+            .assertIsDisplayed()
+
+        DiscoveryParams.GoalBuckets.values().forEach { bucket ->
+            composeTestRule
+                .onNodeWithTag(GoalTestTags.bucketTag(bucket))
+                .assertIsDisplayed()
+
+            composeTestRule
+                .onNodeWithText(
+                    context.resources.getString(
+                    context.resources.getIdentifier(
+                        "Bucket_${bucket.name.last().digitToInt()}_fpo",
+                        "string",
+                        context.packageName
+                    )
+                )
+                )
+                .isDisplayed()
+        }
+    }
+
+    @Test
+    fun `Initial buttons state`() {
+        composeTestRule.setContent {
+            KSTheme {
+                GoalSheet()
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name)
+            .assertIsEnabled()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.RESET.name)
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun `Buttons state when one goal bucket is selected`() {
+        composeTestRule.setContent {
+            KSTheme {
+                GoalSheet()
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(GoalTestTags.bucketTag(DiscoveryParams.GoalBuckets.BUCKET_3))
+            .assertIsDisplayed()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name)
+            .assertIsEnabled()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.RESET.name)
+            .assertIsEnabled()
+    }
+
+    @Test
+    fun `Buttons actions for left button (reset)`() {
+        var selectedBucket: DiscoveryParams.GoalBuckets? = null
+
+        composeTestRule.setContent {
+            KSTheme {
+                GoalSheet(
+                    onApply = { bucket, _ ->
+                        selectedBucket = bucket
+                    }
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(GoalTestTags.bucketTag(DiscoveryParams.GoalBuckets.BUCKET_2))
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.RESET.name)
+            .performClick()
+
+        assertEquals(null, selectedBucket)
+    }
+
+    @Test
+    fun `Buttons actions for right button (see results)`() {
+        var selectedBucket: DiscoveryParams.GoalBuckets? = null
+        var shouldApply: Boolean? = null
+
+        composeTestRule.setContent {
+            KSTheme {
+                GoalSheet(
+                    onApply = { bucket, apply ->
+                        selectedBucket = bucket
+                        shouldApply = apply
+                    }
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(GoalTestTags.bucketTag(DiscoveryParams.GoalBuckets.BUCKET_4))
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(BottomSheetFooterTestTags.SEE_RESULTS.name)
+            .performClick()
+
+        assertEquals(DiscoveryParams.GoalBuckets.BUCKET_4, selectedBucket)
+        assertEquals(true, shouldApply)
+    }
+}


### PR DESCRIPTION
# 📲 What

- New screen with the UI for Goal, on follow up tickets this UI will be integrated within the Pager + BottomSheet on search.

# 🤔 Why

- Adding a new filter for Goal

# 🛠 How

- Created Compose screen for GoalSheet
- Created Test for GoalSheet screen
- Changed string names from Amount raised to be used in both of them
- Created enum for GoalBuckets
- Added goalBucket for fetch project

# 👀 See
![Screenshot 2025-07-07 at 4 17 20 p m](https://github.com/user-attachments/assets/3bc5ea2e-0784-4015-ae31-933d0e5bc6cd)

# 📋 QA

No qa available as of now, is just the Scren UI not connected yet to the pager + bottomSheet

# Story 📖

[MBL-2566](https://kickstarter.atlassian.net/browse/MBL-2566)


[MBL-2566]: https://kickstarter.atlassian.net/browse/MBL-2566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ