### PR TITLE
MBL-2570 && MBL-2568 && MBL-2572: (Phase 7) Goal filter

### DIFF
--- a/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
@@ -115,7 +115,7 @@ class SearchAndFilterActivity : ComponentActivity() {
                                     startProjectActivity(projAndRef)
                                 }
                             },
-                            onDismissBottomSheet = { category, sort, projectState, percentageBucket, location, amountRaisedBucket ->
+                            onDismissBottomSheet = { category, sort, projectState, percentageBucket, location, amountRaisedBucket, goalBucket ->
                                 viewModel.updateParamsToSearchWith(
                                     category = category,
                                     projectSort = sort
@@ -123,7 +123,8 @@ class SearchAndFilterActivity : ComponentActivity() {
                                     projectState = projectState,
                                     percentageBucket = percentageBucket,
                                     location = location,
-                                    amountBucket = amountRaisedBucket
+                                    amountBucket = amountRaisedBucket,
+                                    goalBucket = goalBucket
                                 )
                             },
                             shouldShowPhase = phaseff

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
@@ -110,7 +110,8 @@ class SearchAndFilterViewModel(
         projectState: DiscoveryParams.State? = null,
         percentageBucket: DiscoveryParams.RaisedBuckets? = null,
         location: Location? = null,
-        amountBucket: DiscoveryParams.AmountBuckets? = null
+        amountBucket: DiscoveryParams.AmountBuckets? = null,
+        goalBucket: DiscoveryParams.GoalBuckets? = null
     ) {
         val update = params.value.toBuilder()
             .apply {
@@ -120,6 +121,7 @@ class SearchAndFilterViewModel(
                 this.raisedBucket(percentageBucket)
                 this.location(location)
                 this.amountBucket(amountBucket)
+                this.goalBucket(goalBucket)
             }
             .build()
 

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/DiscoveryParamsExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/DiscoveryParamsExt.kt
@@ -6,6 +6,7 @@ import com.kickstarter.libs.utils.ListUtils
 import com.kickstarter.models.Category
 import com.kickstarter.models.User
 import com.kickstarter.services.DiscoveryParams
+import com.kickstarter.type.GoalBuckets
 import com.kickstarter.type.PledgedBuckets
 import com.kickstarter.type.ProjectSort
 import com.kickstarter.type.PublicProjectState
@@ -281,5 +282,15 @@ fun DiscoveryParams.AmountBuckets.toPledgedBucket(): PledgedBuckets {
         DiscoveryParams.AmountBuckets.BUCKET_3 -> PledgedBuckets.BUCKET_3
         DiscoveryParams.AmountBuckets.BUCKET_4 -> PledgedBuckets.BUCKET_4
         DiscoveryParams.AmountBuckets.BUCKET_0 -> PledgedBuckets.BUCKET_0
+    }
+}
+
+fun DiscoveryParams.GoalBuckets.toGoalBucket(): GoalBuckets {
+    return when (this) {
+        DiscoveryParams.GoalBuckets.BUCKET_1 -> GoalBuckets.BUCKET_1
+        DiscoveryParams.GoalBuckets.BUCKET_2 -> GoalBuckets.BUCKET_2
+        DiscoveryParams.GoalBuckets.BUCKET_3 -> GoalBuckets.BUCKET_3
+        DiscoveryParams.GoalBuckets.BUCKET_4 -> GoalBuckets.BUCKET_4
+        DiscoveryParams.GoalBuckets.BUCKET_0 -> GoalBuckets.BUCKET_0
     }
 }

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -67,6 +67,7 @@ import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.libs.utils.extensions.isPresent
 import com.kickstarter.libs.utils.extensions.isTrue
 import com.kickstarter.libs.utils.extensions.toBoolean
+import com.kickstarter.libs.utils.extensions.toGoalBucket
 import com.kickstarter.libs.utils.extensions.toPledgedBucket
 import com.kickstarter.libs.utils.extensions.toProjectSort
 import com.kickstarter.libs.utils.extensions.toProjectState
@@ -343,7 +344,8 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
             state = if (discoveryParams.state() == null) Optional.absent() else Optional.present(discoveryParams.state()?.toProjectState()),
             raised = if (discoveryParams.raisedBucket() == null) Optional.absent() else Optional.present(discoveryParams.raisedBucket()?.toRaisedBucket()),
             location = if (discoveryParams.location() == null) Optional.absent() else Optional.present(discoveryParams.location()?.let { encodeRelayId(it) }),
-            amountRaisedBucket = if (discoveryParams.amountBucket() == null) Optional.absent() else Optional.present(discoveryParams.amountBucket()?.toPledgedBucket())
+            amountRaisedBucket = if (discoveryParams.amountBucket() == null) Optional.absent() else Optional.present(discoveryParams.amountBucket()?.toPledgedBucket()),
+            goalBucket = if (discoveryParams.goalBucket() == null) Optional.absent() else Optional.present(discoveryParams.goalBucket()?.toGoalBucket())
         )
     }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheet.kt
@@ -60,6 +60,7 @@ object FilterMenuTestTags {
     const val AMOUNT_RAISED_ROW = "amount_raised_row"
     const val LOCATION_ROW = "location_row"
     const val OTHERS_ROW = "others_row"
+    const val GOAL_ROW = "goal_row"
     const val FOOTER = "footer"
 
     fun pillTag(state: DiscoveryParams.State?) = "pill_${state?.name ?: "ALL"}"
@@ -72,6 +73,7 @@ enum class FilterType {
     LOCATION,
     PERCENTAGE_RAISED,
     AMOUNT_RAISED,
+    GOAL,
     OTHERS
 }
 
@@ -86,7 +88,8 @@ fun FilterMenuSheet(
     selectedLocation: Location? = null,
     selectedPercentage: DiscoveryParams.RaisedBuckets? = null,
     selectedAmount: DiscoveryParams.AmountBuckets? = null,
-    selectedCategory: Category? = null
+    selectedCategory: Category? = null,
+    selectedGoal: DiscoveryParams.GoalBuckets? = null
 ) {
     val projStatus = remember { mutableStateOf(selectedProjectStatus) }
 
@@ -143,6 +146,13 @@ fun FilterMenuSheet(
                             icon = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                             modifier = Modifier.testTag(FilterMenuTestTags.AMOUNT_RAISED_ROW),
                             subText = selectedAmount?.let { textForBucket(it) }
+                        )
+                        FilterType.GOAL -> FilterRow(
+                            text = titleForFilter(filter),
+                            onClickAction = { onNavigate(FilterType.GOAL) },
+                            icon = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            modifier = Modifier.testTag(FilterMenuTestTags.GOAL_ROW),
+                            subText = selectedGoal?.let { textForBucket(it) }
                         )
                         FilterType.OTHERS -> OtherFiltersRow()
                     }
@@ -471,6 +481,7 @@ private fun titleForFilter(filter: FilterType): String {
         FilterType.LOCATION -> stringResource(R.string.Location_fpo)
         FilterType.PERCENTAGE_RAISED -> stringResource(R.string.Percentage_raised)
         FilterType.AMOUNT_RAISED -> stringResource(R.string.Amount_raised_fpo)
+        FilterType.GOAL -> stringResource(R.string.Goal_fpo)
         FilterType.OTHERS -> stringResource(R.string.Show_only_fpo)
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchTopBar.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchTopBar.kt
@@ -60,6 +60,7 @@ fun SearchTopBarLocationActiveFilterPreview() {
                 FilterRowPillType.PERCENTAGE_RAISED.name to 0,
                 FilterRowPillType.LOCATION.name to 1,
                 FilterRowPillType.AMOUNT_RAISED.name to 0,
+                FilterRowPillType.GOAL.name to 0
             ),
             onPillPressed = {},
             shouldShowPhase = true
@@ -82,6 +83,28 @@ fun SearchTopBarAmountRaisedActiveFilterPreview() {
                 FilterRowPillType.FILTER.name to 1,
                 FilterRowPillType.PERCENTAGE_RAISED.name to 0,
                 FilterRowPillType.AMOUNT_RAISED.name to 1,
+            ),
+            onPillPressed = {},
+            shouldShowPhase = true
+        )
+    }
+}
+
+@Composable
+@Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+fun SearchTopBarGoalActiveFilterPreview() {
+    KSTheme {
+        SearchTopBar(
+            onBackPressed = {},
+            onValueChanged = {},
+            selectedFilterCounts = mapOf(
+                FilterRowPillType.SORT.name to 0,
+                FilterRowPillType.CATEGORY.name to 0,
+                FilterRowPillType.PROJECT_STATUS.name to 0,
+                FilterRowPillType.FILTER.name to 1,
+                FilterRowPillType.PERCENTAGE_RAISED.name to 0,
+                FilterRowPillType.GOAL.name to 1,
             ),
             onPillPressed = {},
             shouldShowPhase = true
@@ -172,6 +195,7 @@ fun SearchTopBarAllActiveFiltersPreview() {
                 FilterRowPillType.PERCENTAGE_RAISED.name to 1,
                 FilterRowPillType.LOCATION.name to 1,
                 FilterRowPillType.AMOUNT_RAISED.name to 1,
+                FilterRowPillType.GOAL.name to 1
             ),
             onPillPressed = {},
             shouldShowPhase = true
@@ -188,6 +212,7 @@ fun SearchTopBar(
     percentageRaisedText: String = stringResource(R.string.Percentage_raised),
     locationText: String = stringResource(R.string.Location_fpo),
     amountRaisedText: String = stringResource(R.string.Amount_raised_fpo),
+    goalText: String = stringResource(R.string.Goal_fpo),
     onBackPressed: () -> Unit,
     onValueChanged: (String) -> Unit,
     selectedFilterCounts: Map<String, Int>,
@@ -286,6 +311,7 @@ fun SearchTopBar(
             amountRaisedText = amountRaisedText,
             percentageRaisedText = percentageRaisedText,
             locationText = locationText,
+            goalText = goalText,
             selectedFilterCounts = selectedFilterCounts,
             onPillPressed = onPillPressed,
             shouldShowPhase = shouldShowPhase,
@@ -305,6 +331,7 @@ fun PillBar(
     percentageRaisedText: String = stringResource(R.string.Percentage_raised),
     locationText: String = stringResource(R.string.Location_fpo),
     amountRaisedText: String = stringResource(R.string.Amount_raised_fpo),
+    goalText: String = stringResource(R.string.Goal_fpo),
     selectedFilterCounts: Map<String, Int>,
     onPillPressed: (FilterRowPillType) -> Unit,
     shouldShowPhase: Boolean = true
@@ -334,7 +361,8 @@ fun PillBar(
                 selectedFilterCounts.getOrDefault(FilterRowPillType.CATEGORY.name, 0) +
                 selectedFilterCounts.getOrDefault(FilterRowPillType.PERCENTAGE_RAISED.name, 0) +
                 selectedFilterCounts.getOrDefault(FilterRowPillType.LOCATION.name, 0) +
-                selectedFilterCounts.getOrDefault(FilterRowPillType.AMOUNT_RAISED.name, 0)
+                selectedFilterCounts.getOrDefault(FilterRowPillType.AMOUNT_RAISED.name, 0) +
+                selectedFilterCounts.getOrDefault(FilterRowPillType.GOAL.name, 0)
 
         KSIconPillButton(
             modifier = Modifier.testTag(pillTag(FilterRowPillType.FILTER)),
@@ -413,6 +441,20 @@ fun PillBar(
                 ),
                 onClick = { onPillPressed(FilterRowPillType.AMOUNT_RAISED) }
             )
+            KSPillButton(
+                modifier = Modifier.testTag(pillTag(FilterRowPillType.GOAL)),
+                countApiIsReady = countApiIsReady,
+                text = goalText,
+                isSelected = selectedFilterCounts.getOrDefault(
+                    FilterRowPillType.GOAL.name,
+                    0
+                ) > 0,
+                count = selectedFilterCounts.getOrDefault(
+                    FilterRowPillType.GOAL.name,
+                    0
+                ),
+                onClick = { onPillPressed(FilterRowPillType.GOAL) }
+            )
         }
     }
 }
@@ -424,5 +466,6 @@ enum class FilterRowPillType {
     PROJECT_STATUS,
     PERCENTAGE_RAISED,
     LOCATION,
-    AMOUNT_RAISED
+    AMOUNT_RAISED,
+    GOAL
 }

--- a/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
@@ -272,7 +272,7 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `test for searching with clean user selection no category, no sorting, no term options, no projectStatus, no percentage raised, no location, no amount raised`() = runTest {
+    fun `test for searching with clean user selection no category, no sorting, no term options, no projectStatus, no percentage raised, no location, no amount raised, no goal`() = runTest {
         var params: DiscoveryParams? = null
         val projectList = listOf(ProjectFactory.project(), ProjectFactory.prelaunchProject(""))
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
@@ -308,10 +308,11 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         assertEquals(params?.raisedBucket(), null)
         assertEquals(params?.amountBucket(), null)
         assertEquals(params?.location(), null)
+        assertEquals(params?.goalBucket(), null)
     }
 
     @Test
-    fun `test for searching with clean user selection no category, no sorting, no term options, no projectStatus, no percentage raised, no location, no amount raised, load two pages`() = runTest {
+    fun `test for searching with clean user selection no category, no sorting, no term options, no projectStatus, no percentage raised, no location, no amount raised, no goal, load two pages`() = runTest {
         var params: DiscoveryParams? = null
         val projectList = listOf(ProjectFactory.project(), ProjectFactory.prelaunchProject(""))
         val secondPageList = listOf(ProjectFactory.caProject(), ProjectFactory.mxProject())
@@ -353,6 +354,8 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         assertEquals(params?.state(), null)
         assertEquals(params?.raisedBucket(), null)
         assertEquals(params?.amountBucket(), null)
+        assertEquals(params?.goalBucket(), null)
+        assertEquals(params?.location(), null)
         assertEquals(searchState.size, 3)
         assertEquals(pageCounter, 2)
 
@@ -360,7 +363,7 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `test for searching a tem with category, sorting, projectStatus, percentage raised, amount raised, and location, load two pages`() = runTest {
+    fun `test for searching a tem with category, sorting, projectStatus, percentage raised, amount raised, goal, and location, load two pages`() = runTest {
         var params: DiscoveryParams? = null
         val projectList = listOf(ProjectFactory.project(), ProjectFactory.prelaunchProject(""))
 
@@ -397,7 +400,8 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
                 DiscoveryParams.State.LIVE,
                 DiscoveryParams.RaisedBuckets.BUCKET_2,
                 LocationFactory.vancouver(),
-                DiscoveryParams.AmountBuckets.BUCKET_4
+                DiscoveryParams.AmountBuckets.BUCKET_4,
+                DiscoveryParams.GoalBuckets.BUCKET_2
             )
             viewModel.updateSearchTerm("cats")
             viewModel.loadMore()
@@ -412,6 +416,7 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         assertEquals(params?.raisedBucket(), DiscoveryParams.RaisedBuckets.BUCKET_2)
         assertEquals(params?.location(), LocationFactory.vancouver())
         assertEquals(params?.amountBucket(), DiscoveryParams.AmountBuckets.BUCKET_4)
+        assertEquals(params?.goalBucket(), DiscoveryParams.GoalBuckets.BUCKET_2)
         assertEquals(searchState.size, 3)
         assertEquals(pageCounter, 2)
         assertEquals(errorNumber, 0)

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchScreenTest.kt
@@ -337,8 +337,8 @@ class SearchScreenTest : KSRobolectricTestCase() {
                     currentCategory = categories[0],
                     categories = categories,
                     onDismiss = { dismissed.add(true) },
-                    onApply = { state, category, _, _, _ -> appliedFilters.add(Pair(state, category)) },
-                    updateSelectedCounts = { statusCount, categoryCount, _, _, _ ->
+                    onApply = { state, category, _, _, _, _ -> appliedFilters.add(Pair(state, category)) },
+                    updateSelectedCounts = { statusCount, categoryCount, _, _, _, _ ->
                         selectedCounts.add(
                             statusCount to categoryCount
                         )
@@ -394,19 +394,21 @@ class SearchScreenTest : KSRobolectricTestCase() {
                     categories = categories,
                     currentPercentage = DiscoveryParams.RaisedBuckets.BUCKET_2,
                     onDismiss = { dismissed.add(true) },
-                    onApply = { state, category, bucket, location, amountBucket ->
+                    onApply = { state, category, bucket, location, amountBucket, goalBucket ->
                         appliedFilters.add(state)
                         appliedFilters.add(category)
                         appliedFilters.add(bucket)
                         appliedFilters.add(location)
                         appliedFilters.add(amountBucket)
+                        appliedFilters.add(goalBucket)
                     },
-                    updateSelectedCounts = { statusCount, categoryCount, bucket, location, amountCount ->
+                    updateSelectedCounts = { statusCount, categoryCount, bucket, location, amountCount, goal ->
                         selectedCounts.add(statusCount)
                         selectedCounts.add(categoryCount)
                         selectedCounts.add(bucket)
                         appliedFilters.add(location)
                         appliedFilters.add(amountCount)
+                        appliedFilters.add(goal)
                     },
                     pagerState = testPagerState,
                     sheetState = testSheetState,
@@ -451,8 +453,8 @@ class SearchScreenTest : KSRobolectricTestCase() {
                     currentCategory = categories[0],
                     categories = categories,
                     onDismiss = { },
-                    onApply = { _, _, _, _, _ -> },
-                    updateSelectedCounts = { _, _, _, _, _ ->
+                    onApply = { _, _, _, _, _, _ -> },
+                    updateSelectedCounts = { _, _, _, _, _, _ ->
                     },
                     pagerState = testPagerState,
                     sheetState = testSheetState,

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchTopBarTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchTopBarTest.kt
@@ -227,4 +227,38 @@ class SearchTopBarTest : KSRobolectricTestCase() {
         composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.FILTER))
             .assertTextEquals("1")
     }
+
+    @Test
+    fun `SearchTopBar pillBar Goal filter active`() {
+        composeTestRule.setContent {
+            KSTheme {
+                SearchTopBar(
+                    onBackPressed = {},
+                    onValueChanged = {},
+                    projectStatusText = "Live",
+                    selectedFilterCounts = mapOf(
+                        FilterRowPillType.SORT.name to 0,
+                        FilterRowPillType.CATEGORY.name to 0,
+                        FilterRowPillType.FILTER.name to 1,
+                        FilterRowPillType.PROJECT_STATUS.name to 0,
+                        FilterRowPillType.PERCENTAGE_RAISED.name to 0,
+                        FilterRowPillType.AMOUNT_RAISED.name to 0,
+                        FilterRowPillType.GOAL.name to 1,
+                    ),
+                    onPillPressed = {},
+                    shouldShowPhase = true
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(SearchScreenTestTag.BACK_BUTTON.name).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.PROJECT_STATUS)).assertExists()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.CATEGORY)).assertExists()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.AMOUNT_RAISED)).assertExists()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.GOAL)).assertExists()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.FILTER)).assertExists()
+
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.FILTER))
+            .assertTextEquals("1")
+    }
 }


### PR DESCRIPTION
# 📲 What

- MBL-2570: Adds pillbar for new goal filter to SearchTopBar
- MBL-2568: Adds new page to the pager + navigation(opens bottomSheet on GoalSheet page when pressing pillbar and new row added on FilterMenuSheet for Goal Filter)
- MBL-2570:  SearchAndFilterVM handles now a new parameter on DiscoveryParams, and projects query has been extended to support the new parameter
- Added some tests and modified others to consider goal filter

# 🤔 Why

- Adding new filtering options for goal amount(Phase 7)


# 👀 See

[Goal filter.webm](https://github.com/user-attachments/assets/b85fbfc5-5674-4a01-a850-aeb31d6a00d5)

# 📋 QA

- Click Goal pillBar -> should open goal screen, navigate back to the menu, dismiss ... etc.
- Click Goal row ->  should open goal screen, navigate back to the menu, dismiss ... etc
- Execute some searches with several filters

# Story 📖

[MBL-2570](https://kickstarter.atlassian.net/browse/MBL-2570)
[MBL-2572](https://kickstarter.atlassian.net/browse/MBL-2572)
[MBL-2568](https://kickstarter.atlassian.net/browse/MBL-2568)



[MBL-2570]: https://kickstarter.atlassian.net/browse/MBL-2570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MBL-2572]: https://kickstarter.atlassian.net/browse/MBL-2572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MBL-2568]: https://kickstarter.atlassian.net/browse/MBL-2568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ