### PR TITLE
MBL-2615: Logged in/out user logic

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheet.kt
@@ -33,7 +33,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kickstarter.R
+import com.kickstarter.features.search.ui.LocalFilterMenuViewModel
 import com.kickstarter.libs.utils.extensions.isTrue
 import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.models.Category
@@ -73,8 +75,8 @@ enum class FilterType {
     LOCATION,
     PERCENTAGE_RAISED,
     AMOUNT_RAISED,
+    OTHERS,
     GOAL,
-    OTHERS
 }
 
 @Composable
@@ -95,6 +97,10 @@ fun FilterMenuSheet(
     selectedSocial: Boolean = false,
     selectedGoal: DiscoveryParams.GoalBuckets? = null
 ) {
+    val viewModel = LocalFilterMenuViewModel.current
+    val loggedInUser by viewModel.loggedInUser.collectAsStateWithLifecycle()
+    val filteredFilters = if (loggedInUser) availableFilters else availableFilters.filter { it != FilterType.OTHERS }
+
     val projStatus = remember { mutableStateOf(selectedProjectStatus) }
 
     val currentStaffPicked = remember { mutableStateOf(selectedProjectsLoved) }
@@ -117,7 +123,7 @@ fun FilterMenuSheet(
             )
 
             LazyColumn(modifier = Modifier.weight(1f).testTag(FilterMenuTestTags.LIST)) {
-                items(availableFilters) { filter ->
+                items(filteredFilters) { filter ->
                     when (filter) {
                         FilterType.CATEGORIES -> FilterRow(
                             text = titleForFilter(filter),

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchTopBar.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchTopBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -39,38 +40,53 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kickstarter.R
 import com.kickstarter.features.search.ui.LocalFilterMenuViewModel
+import com.kickstarter.features.search.viewmodel.FilterMenuViewModel
+import com.kickstarter.libs.CurrentUserTypeV2
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.KsOptional
+import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.mock.services.MockApolloClientV2
+import com.kickstarter.models.User
 import com.kickstarter.ui.activities.compose.search.PillBarTestTags.pillTag
 import com.kickstarter.ui.compose.designsystem.KSIconPillButton
 import com.kickstarter.ui.compose.designsystem.KSPillButton
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
+import io.reactivex.Observable
 
 @Composable
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun SearchTopBarLocationActiveFilterPreview() {
+    val env = Environment.builder()
+        .apolloClientV2(MockApolloClientV2())
+        .build()
+
+    val fakeViewModel = FilterMenuViewModel(environment = env)
     KSTheme {
-        SearchTopBar(
-            onBackPressed = {},
-            onValueChanged = {},
-            selectedFilterCounts = mapOf(
-                FilterRowPillType.SORT.name to 0,
-                FilterRowPillType.CATEGORY.name to 0,
-                FilterRowPillType.PROJECT_STATUS.name to 0,
-                FilterRowPillType.FILTER.name to 1,
-                FilterRowPillType.PERCENTAGE_RAISED.name to 0,
-                FilterRowPillType.LOCATION.name to 1,
-                FilterRowPillType.AMOUNT_RAISED.name to 0,
-                FilterRowPillType.RECOMMENDED.name to 0,
-                FilterRowPillType.PROJECTS_LOVED.name to 0,
-                FilterRowPillType.SAVED.name to 0,
-                FilterRowPillType.FOLLOWING.name to 0,
-                FilterRowPillType.GOAL.name to 0
-            ),
-            onPillPressed = {},
-            shouldShowPhase = true
-        )
+        CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+            SearchTopBar(
+                onBackPressed = {},
+                onValueChanged = {},
+                selectedFilterCounts = mapOf(
+                    FilterRowPillType.SORT.name to 0,
+                    FilterRowPillType.CATEGORY.name to 0,
+                    FilterRowPillType.PROJECT_STATUS.name to 0,
+                    FilterRowPillType.FILTER.name to 1,
+                    FilterRowPillType.PERCENTAGE_RAISED.name to 0,
+                    FilterRowPillType.LOCATION.name to 1,
+                    FilterRowPillType.AMOUNT_RAISED.name to 0,
+                    FilterRowPillType.RECOMMENDED.name to 0,
+                    FilterRowPillType.PROJECTS_LOVED.name to 0,
+                    FilterRowPillType.SAVED.name to 0,
+                    FilterRowPillType.FOLLOWING.name to 0,
+                    FilterRowPillType.GOAL.name to 0
+                ),
+                onPillPressed = {},
+                shouldShowPhase = true
+            )
+        }
     }
 }
 
@@ -78,25 +94,32 @@ fun SearchTopBarLocationActiveFilterPreview() {
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun SearchTopBarAmountRaisedActiveFilterPreview() {
+    val env = Environment.builder()
+        .apolloClientV2(MockApolloClientV2())
+        .build()
+
+    val fakeViewModel = FilterMenuViewModel(environment = env)
     KSTheme {
-        SearchTopBar(
-            onBackPressed = {},
-            onValueChanged = {},
-            selectedFilterCounts = mapOf(
-                FilterRowPillType.SORT.name to 0,
-                FilterRowPillType.CATEGORY.name to 0,
-                FilterRowPillType.PROJECT_STATUS.name to 0,
-                FilterRowPillType.FILTER.name to 1,
-                FilterRowPillType.PERCENTAGE_RAISED.name to 0,
-                FilterRowPillType.AMOUNT_RAISED.name to 1,
-                FilterRowPillType.RECOMMENDED.name to 0,
-                FilterRowPillType.PROJECTS_LOVED.name to 0,
-                FilterRowPillType.SAVED.name to 0,
-                FilterRowPillType.FOLLOWING.name to 0,
-            ),
-            onPillPressed = {},
-            shouldShowPhase = true
-        )
+        CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+            SearchTopBar(
+                onBackPressed = {},
+                onValueChanged = {},
+                selectedFilterCounts = mapOf(
+                    FilterRowPillType.SORT.name to 0,
+                    FilterRowPillType.CATEGORY.name to 0,
+                    FilterRowPillType.PROJECT_STATUS.name to 0,
+                    FilterRowPillType.FILTER.name to 1,
+                    FilterRowPillType.PERCENTAGE_RAISED.name to 0,
+                    FilterRowPillType.AMOUNT_RAISED.name to 1,
+                    FilterRowPillType.RECOMMENDED.name to 0,
+                    FilterRowPillType.PROJECTS_LOVED.name to 0,
+                    FilterRowPillType.SAVED.name to 0,
+                    FilterRowPillType.FOLLOWING.name to 0,
+                ),
+                onPillPressed = {},
+                shouldShowPhase = true
+            )
+        }
     }
 }
 
@@ -104,21 +127,28 @@ fun SearchTopBarAmountRaisedActiveFilterPreview() {
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun SearchTopBarGoalActiveFilterPreview() {
+    val env = Environment.builder()
+        .apolloClientV2(MockApolloClientV2())
+        .build()
+
+    val fakeViewModel = FilterMenuViewModel(environment = env)
     KSTheme {
-        SearchTopBar(
-            onBackPressed = {},
-            onValueChanged = {},
-            selectedFilterCounts = mapOf(
-                FilterRowPillType.SORT.name to 0,
-                FilterRowPillType.CATEGORY.name to 0,
-                FilterRowPillType.PROJECT_STATUS.name to 0,
-                FilterRowPillType.FILTER.name to 1,
-                FilterRowPillType.PERCENTAGE_RAISED.name to 0,
-                FilterRowPillType.GOAL.name to 1,
-            ),
-            onPillPressed = {},
-            shouldShowPhase = true
-        )
+        CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+            SearchTopBar(
+                onBackPressed = {},
+                onValueChanged = {},
+                selectedFilterCounts = mapOf(
+                    FilterRowPillType.SORT.name to 0,
+                    FilterRowPillType.CATEGORY.name to 0,
+                    FilterRowPillType.PROJECT_STATUS.name to 0,
+                    FilterRowPillType.FILTER.name to 1,
+                    FilterRowPillType.PERCENTAGE_RAISED.name to 0,
+                    FilterRowPillType.GOAL.name to 1,
+                ),
+                onPillPressed = {},
+                shouldShowPhase = true
+            )
+        }
     }
 }
 
@@ -126,24 +156,31 @@ fun SearchTopBarGoalActiveFilterPreview() {
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun SearchTopBarPercentageRaisedActiveFilterPreview() {
+    val env = Environment.builder()
+        .apolloClientV2(MockApolloClientV2())
+        .build()
+
+    val fakeViewModel = FilterMenuViewModel(environment = env)
     KSTheme {
-        SearchTopBar(
-            onBackPressed = {},
-            onValueChanged = {},
-            selectedFilterCounts = mapOf(
-                FilterRowPillType.SORT.name to 0,
-                FilterRowPillType.CATEGORY.name to 0,
-                FilterRowPillType.PROJECT_STATUS.name to 0,
-                FilterRowPillType.FILTER.name to 1,
-                FilterRowPillType.PERCENTAGE_RAISED.name to 1,
-                FilterRowPillType.RECOMMENDED.name to 0,
-                FilterRowPillType.PROJECTS_LOVED.name to 0,
-                FilterRowPillType.SAVED.name to 0,
-                FilterRowPillType.FOLLOWING.name to 0,
-            ),
-            onPillPressed = {},
-            shouldShowPhase = true
-        )
+        CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+            SearchTopBar(
+                onBackPressed = {},
+                onValueChanged = {},
+                selectedFilterCounts = mapOf(
+                    FilterRowPillType.SORT.name to 0,
+                    FilterRowPillType.CATEGORY.name to 0,
+                    FilterRowPillType.PROJECT_STATUS.name to 0,
+                    FilterRowPillType.FILTER.name to 1,
+                    FilterRowPillType.PERCENTAGE_RAISED.name to 1,
+                    FilterRowPillType.RECOMMENDED.name to 0,
+                    FilterRowPillType.PROJECTS_LOVED.name to 0,
+                    FilterRowPillType.SAVED.name to 0,
+                    FilterRowPillType.FOLLOWING.name to 0,
+                ),
+                onPillPressed = {},
+                shouldShowPhase = true
+            )
+        }
     }
 }
 
@@ -151,25 +188,32 @@ fun SearchTopBarPercentageRaisedActiveFilterPreview() {
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun SearchTopBarProjectStatusActiveFilterPreview() {
+    val env = Environment.builder()
+        .apolloClientV2(MockApolloClientV2())
+        .build()
+
+    val fakeViewModel = FilterMenuViewModel(environment = env)
     KSTheme {
-        SearchTopBar(
-            onBackPressed = {},
-            onValueChanged = {},
-            categoryPillText = "Art",
-            projectStatusText = "Live",
-            selectedFilterCounts = mapOf(
-                FilterRowPillType.SORT.name to 0,
-                FilterRowPillType.CATEGORY.name to 0,
-                FilterRowPillType.PROJECT_STATUS.name to 1,
-                FilterRowPillType.FILTER.name to 1,
-                FilterRowPillType.RECOMMENDED.name to 0,
-                FilterRowPillType.PROJECTS_LOVED.name to 0,
-                FilterRowPillType.SAVED.name to 0,
-                FilterRowPillType.FOLLOWING.name to 0,
-            ),
-            onPillPressed = {},
-            shouldShowPhase = true
-        )
+        CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+            SearchTopBar(
+                onBackPressed = {},
+                onValueChanged = {},
+                categoryPillText = "Art",
+                projectStatusText = "Live",
+                selectedFilterCounts = mapOf(
+                    FilterRowPillType.SORT.name to 0,
+                    FilterRowPillType.CATEGORY.name to 0,
+                    FilterRowPillType.PROJECT_STATUS.name to 1,
+                    FilterRowPillType.FILTER.name to 1,
+                    FilterRowPillType.RECOMMENDED.name to 0,
+                    FilterRowPillType.PROJECTS_LOVED.name to 0,
+                    FilterRowPillType.SAVED.name to 0,
+                    FilterRowPillType.FOLLOWING.name to 0,
+                ),
+                onPillPressed = {},
+                shouldShowPhase = true
+            )
+        }
     }
 }
 
@@ -177,51 +221,130 @@ fun SearchTopBarProjectStatusActiveFilterPreview() {
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun SearchTopBarCategoryActiveFilterPreview() {
+    val env = Environment.builder()
+        .apolloClientV2(MockApolloClientV2())
+        .build()
+
+    val fakeViewModel = FilterMenuViewModel(environment = env)
     KSTheme {
-        SearchTopBar(
-            onBackPressed = {},
-            onValueChanged = {},
-            categoryPillText = "Art",
-            projectStatusText = "Live",
-            selectedFilterCounts = mapOf(
-                FilterRowPillType.SORT.name to 0,
-                FilterRowPillType.CATEGORY.name to 1,
-                FilterRowPillType.PROJECT_STATUS.name to 0,
-                FilterRowPillType.FILTER.name to 1,
-            ),
-            onPillPressed = {},
-            shouldShowPhase = true
-        )
+        CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+            SearchTopBar(
+                onBackPressed = {},
+                onValueChanged = {},
+                categoryPillText = "Art",
+                projectStatusText = "Live",
+                selectedFilterCounts = mapOf(
+                    FilterRowPillType.SORT.name to 0,
+                    FilterRowPillType.CATEGORY.name to 1,
+                    FilterRowPillType.PROJECT_STATUS.name to 0,
+                    FilterRowPillType.FILTER.name to 1,
+                ),
+                onPillPressed = {},
+                shouldShowPhase = true
+            )
+        }
     }
 }
 
 @Composable
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
-fun SearchTopBarAllActiveFiltersPreview() {
+fun SearchTopBarAllActiveFiltersPreviewLoggedOutUser() {
+    val env = Environment.builder()
+        .apolloClientV2(MockApolloClientV2())
+        .build()
+
+    val fakeViewModel = FilterMenuViewModel(environment = env)
     KSTheme {
-        SearchTopBar(
-            onBackPressed = {},
-            onValueChanged = {},
-            categoryPillText = "Art",
-            projectStatusText = "Live",
-            selectedFilterCounts = mapOf(
-                FilterRowPillType.SORT.name to 0,
-                FilterRowPillType.CATEGORY.name to 1,
-                FilterRowPillType.PROJECT_STATUS.name to 1,
-                FilterRowPillType.FILTER.name to 1,
-                FilterRowPillType.PERCENTAGE_RAISED.name to 1,
-                FilterRowPillType.LOCATION.name to 1,
-                FilterRowPillType.AMOUNT_RAISED.name to 1,
-                FilterRowPillType.RECOMMENDED.name to 1,
-                FilterRowPillType.PROJECTS_LOVED.name to 1,
-                FilterRowPillType.SAVED.name to 1,
-                FilterRowPillType.FOLLOWING.name to 1,
-                FilterRowPillType.GOAL.name to 1
-            ),
-            onPillPressed = {},
-            shouldShowPhase = true
-        )
+        CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+            SearchTopBar(
+                onBackPressed = {},
+                onValueChanged = {},
+                categoryPillText = "Art",
+                projectStatusText = "Live",
+                selectedFilterCounts = mapOf(
+                    FilterRowPillType.SORT.name to 0,
+                    FilterRowPillType.CATEGORY.name to 1,
+                    FilterRowPillType.PROJECT_STATUS.name to 1,
+                    FilterRowPillType.FILTER.name to 1,
+                    FilterRowPillType.PERCENTAGE_RAISED.name to 1,
+                    FilterRowPillType.LOCATION.name to 1,
+                    FilterRowPillType.AMOUNT_RAISED.name to 1,
+                    FilterRowPillType.RECOMMENDED.name to 1,
+                    FilterRowPillType.PROJECTS_LOVED.name to 1,
+                    FilterRowPillType.SAVED.name to 1,
+                    FilterRowPillType.FOLLOWING.name to 1,
+                    FilterRowPillType.GOAL.name to 1
+                ),
+                onPillPressed = {},
+                shouldShowPhase = true
+            )
+        }
+    }
+}
+
+@Composable
+@Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+fun SearchTopBarAllActiveFiltersPreviewLoggedInUser() {
+    // Mocked user holder
+    val mockUser = object : CurrentUserTypeV2() {
+        private var user = UserFactory.user()
+        override fun setToken(accessToken: String) {
+        }
+
+        override fun login(newUser: User) {
+        }
+
+        override fun logout() {
+        }
+
+        override val accessToken: String?
+            get() = "Token"
+
+        override fun refresh(freshUser: User) {
+            user = freshUser
+        }
+
+        override fun observable(): Observable<KsOptional<User>> {
+            return Observable.just(KsOptional.of(user))
+        }
+
+        override fun getUser(): User? {
+            return null
+        }
+    }
+    val env = Environment.builder()
+        .apolloClientV2(MockApolloClientV2())
+        .currentUserV2(mockUser)
+        .build()
+
+    val fakeViewModel = FilterMenuViewModel(environment = env)
+    KSTheme {
+        CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+            SearchTopBar(
+                onBackPressed = {},
+                onValueChanged = {},
+                categoryPillText = "Art",
+                projectStatusText = "Live",
+                selectedFilterCounts = mapOf(
+                    FilterRowPillType.SORT.name to 0,
+                    FilterRowPillType.CATEGORY.name to 1,
+                    FilterRowPillType.PROJECT_STATUS.name to 1,
+                    FilterRowPillType.FILTER.name to 1,
+                    FilterRowPillType.PERCENTAGE_RAISED.name to 1,
+                    FilterRowPillType.LOCATION.name to 1,
+                    FilterRowPillType.AMOUNT_RAISED.name to 1,
+                    FilterRowPillType.RECOMMENDED.name to 1,
+                    FilterRowPillType.PROJECTS_LOVED.name to 1,
+                    FilterRowPillType.SAVED.name to 1,
+                    FilterRowPillType.FOLLOWING.name to 1,
+                    FilterRowPillType.GOAL.name to 1
+                ),
+                onPillPressed = {},
+                shouldShowPhase = true
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchTopBar.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchTopBar.kt
@@ -36,7 +36,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kickstarter.R
+import com.kickstarter.features.search.ui.LocalFilterMenuViewModel
 import com.kickstarter.ui.activities.compose.search.PillBarTestTags.pillTag
 import com.kickstarter.ui.compose.designsystem.KSIconPillButton
 import com.kickstarter.ui.compose.designsystem.KSPillButton
@@ -368,6 +370,9 @@ fun PillBar(
     onPillPressed: (FilterRowPillType) -> Unit,
     shouldShowPhase: Boolean = true
 ) {
+    val viewModel = LocalFilterMenuViewModel.current
+    val loggedInUser by viewModel.loggedInUser.collectAsStateWithLifecycle()
+
     val scrollState = rememberScrollState()
     Row(
         modifier = Modifier
@@ -447,6 +452,22 @@ fun PillBar(
             ),
             onClick = { onPillPressed(FilterRowPillType.LOCATION) }
         )
+        if (shouldShowPhase && loggedInUser) {
+            KSPillButton(
+                modifier = Modifier.testTag(pillTag(FilterRowPillType.RECOMMENDED)),
+                text = recommendedText,
+                isSelected = selectedFilterCounts.getOrDefault(
+                    FilterRowPillType.RECOMMENDED.name,
+                    0
+                ) > 0,
+                count = selectedFilterCounts.getOrDefault(
+                    FilterRowPillType.RECOMMENDED.name,
+                    0
+                ),
+                onClick = { onPillPressed(FilterRowPillType.RECOMMENDED) }
+            )
+        }
+
         KSPillButton(
             shouldShowTrailingIcon = true,
             modifier = Modifier.testTag(pillTag(FilterRowPillType.PERCENTAGE_RAISED)),
@@ -480,59 +501,22 @@ fun PillBar(
         )
 
         if (shouldShowPhase) {
-            KSPillButton(
-                modifier = Modifier.testTag(pillTag(FilterRowPillType.RECOMMENDED)),
-                text = recommendedText,
-                isSelected = selectedFilterCounts.getOrDefault(
-                    FilterRowPillType.RECOMMENDED.name,
-                    0
-                ) > 0,
-                count = selectedFilterCounts.getOrDefault(
-                    FilterRowPillType.RECOMMENDED.name,
-                    0
-                ),
-                onClick = { onPillPressed(FilterRowPillType.RECOMMENDED) }
-            )
-            KSPillButton(
-                shouldShowLeadingIcon = true,
-                modifier = Modifier.testTag(pillTag(FilterRowPillType.PROJECTS_LOVED)),
-                text = projectsLovedText,
-                isSelected = selectedFilterCounts.getOrDefault(
-                    FilterRowPillType.PROJECTS_LOVED.name,
-                    0
-                ) > 0,
-                count = selectedFilterCounts.getOrDefault(
-                    FilterRowPillType.PROJECTS_LOVED.name,
-                    0
-                ),
-                onClick = { onPillPressed(FilterRowPillType.PROJECTS_LOVED) }
-            )
-            KSPillButton(
-                modifier = Modifier.testTag(pillTag(FilterRowPillType.SAVED)),
-                text = savedProjectsText,
-                isSelected = selectedFilterCounts.getOrDefault(
-                    FilterRowPillType.SAVED.name,
-                    0
-                ) > 0,
-                count = selectedFilterCounts.getOrDefault(
-                    FilterRowPillType.SAVED.name,
-                    0
-                ),
-                onClick = { onPillPressed(FilterRowPillType.SAVED) }
-            )
-            KSPillButton(
-                modifier = Modifier.testTag(pillTag(FilterRowPillType.FOLLOWING)),
-                text = followingText,
-                isSelected = selectedFilterCounts.getOrDefault(
-                    FilterRowPillType.FOLLOWING.name,
-                    0
-                ) > 0,
-                count = selectedFilterCounts.getOrDefault(
-                    FilterRowPillType.FOLLOWING.name,
-                    0
-                ),
-                onClick = { onPillPressed(FilterRowPillType.FOLLOWING) }
-            )
+            if (loggedInUser) {
+                KSPillButton(
+                    shouldShowLeadingIcon = true,
+                    modifier = Modifier.testTag(pillTag(FilterRowPillType.PROJECTS_LOVED)),
+                    text = projectsLovedText,
+                    isSelected = selectedFilterCounts.getOrDefault(
+                        FilterRowPillType.PROJECTS_LOVED.name,
+                        0
+                    ) > 0,
+                    count = selectedFilterCounts.getOrDefault(
+                        FilterRowPillType.PROJECTS_LOVED.name,
+                        0
+                    ),
+                    onClick = { onPillPressed(FilterRowPillType.PROJECTS_LOVED) }
+                )
+            }
             KSPillButton(
                 shouldShowTrailingIcon = true,
                 modifier = Modifier.testTag(pillTag(FilterRowPillType.GOAL)),
@@ -548,6 +532,35 @@ fun PillBar(
                 ),
                 onClick = { onPillPressed(FilterRowPillType.GOAL) }
             )
+
+            if (loggedInUser) {
+                KSPillButton(
+                    modifier = Modifier.testTag(pillTag(FilterRowPillType.SAVED)),
+                    text = savedProjectsText,
+                    isSelected = selectedFilterCounts.getOrDefault(
+                        FilterRowPillType.SAVED.name,
+                        0
+                    ) > 0,
+                    count = selectedFilterCounts.getOrDefault(
+                        FilterRowPillType.SAVED.name,
+                        0
+                    ),
+                    onClick = { onPillPressed(FilterRowPillType.SAVED) }
+                )
+                KSPillButton(
+                    modifier = Modifier.testTag(pillTag(FilterRowPillType.FOLLOWING)),
+                    text = followingText,
+                    isSelected = selectedFilterCounts.getOrDefault(
+                        FilterRowPillType.FOLLOWING.name,
+                        0
+                    ) > 0,
+                    count = selectedFilterCounts.getOrDefault(
+                        FilterRowPillType.FOLLOWING.name,
+                        0
+                    ),
+                    onClick = { onPillPressed(FilterRowPillType.FOLLOWING) }
+                )
+            }
         }
     }
 }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheetTest.kt
@@ -16,13 +16,10 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.features.search.ui.LocalFilterMenuViewModel
 import com.kickstarter.features.search.viewmodel.FilterMenuViewModel
-import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUserV2
 import com.kickstarter.mock.factories.CategoryFactory
 import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.mock.factories.UserFactory
-import com.kickstarter.mock.services.MockApolloClientV2
-import com.kickstarter.models.Location
 import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.ui.compose.designsystem.BottomSheetFooterTestTags
 import com.kickstarter.ui.compose.designsystem.KSTheme
@@ -141,18 +138,18 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
             .build()
         val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
-                KSTheme {
-                    CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
-                        FilterMenuSheet(
-                            selectedProjectStatus = DiscoveryParams.State.LIVE,
-                            availableFilters = if (shouldShowPhase) FilterType.values().asList()
-                            else FilterType.values().asList().filter { it != FilterType.OTHERS },
-                            onDismiss = {},
-                            onApply = { a, b, c, d, e, f -> },
-                            onNavigate = {}
-                        )
-                    }
+            KSTheme {
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    FilterMenuSheet(
+                        selectedProjectStatus = DiscoveryParams.State.LIVE,
+                        availableFilters = if (shouldShowPhase) FilterType.values().asList()
+                        else FilterType.values().asList().filter { it != FilterType.OTHERS },
+                        onDismiss = {},
+                        onApply = { a, b, c, d, e, f -> },
+                        onNavigate = {}
+                    )
                 }
+            }
         }
 
         composeTestRule.onNodeWithTag(FilterMenuTestTags.SHEET).assertIsDisplayed()
@@ -303,7 +300,6 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
                         selectedPercentage = DiscoveryParams.RaisedBuckets.BUCKET_2
                     )
                 }
-
             }
         }
 
@@ -326,13 +322,13 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
-                        FilterMenuSheet(
-                            onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
-                            },
-                            selectedLocation = LocationFactory.vancouver()
-                        )
-                    }
+                    FilterMenuSheet(
+                        onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
+                        },
+                        selectedLocation = LocationFactory.vancouver()
+                    )
                 }
+            }
         }
 
         // - As working with LazyColumns, not all elements of the list are composed until the elements is visible
@@ -374,5 +370,4 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
             .onNodeWithText(textForBucket)
             .assertIsDisplayed()
     }
-
 }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheetTest.kt
@@ -2,6 +2,7 @@ package com.kickstarter.ui.activities.compose.search
 
 import android.content.Context
 import androidx.compose.material.Surface
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.hasTestTag
@@ -13,8 +14,15 @@ import androidx.compose.ui.test.performScrollToNode
 import androidx.test.platform.app.InstrumentationRegistry
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
+import com.kickstarter.features.search.ui.LocalFilterMenuViewModel
+import com.kickstarter.features.search.viewmodel.FilterMenuViewModel
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.MockCurrentUserV2
 import com.kickstarter.mock.factories.CategoryFactory
 import com.kickstarter.mock.factories.LocationFactory
+import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.mock.services.MockApolloClientV2
+import com.kickstarter.models.Location
 import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.ui.compose.designsystem.BottomSheetFooterTestTags
 import com.kickstarter.ui.compose.designsystem.KSTheme
@@ -27,9 +35,13 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
     fun `test FilterMenuSheet renders all pills within ProjectStatusRow`() {
 
         composeTestRule.setContent {
+            val env = environment()
+            val fakeViewModel = FilterMenuViewModel(env)
             KSTheme {
-                Surface {
-                    FilterMenuSheet()
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    Surface {
+                        FilterMenuSheet()
+                    }
                 }
             }
         }
@@ -42,12 +54,19 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `test FilterMenuSheet renders all options within OthersRow`() {
+    fun `test FilterMenuSheet renders all options within OthersRow when logged in user`() {
 
+        val env = environment()
+            .toBuilder()
+            .currentUserV2(MockCurrentUserV2(UserFactory.user()))
+            .build()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                Surface {
-                    FilterMenuSheet()
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    Surface {
+                        FilterMenuSheet()
+                    }
                 }
             }
         }
@@ -81,15 +100,19 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
     @Test
     fun `test FilterMenuSheet renders all available filter Rows with ffOff`() {
         val shouldShowPhase = false
+        val env = environment()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                FilterMenuSheet(
-                    availableFilters = if (shouldShowPhase) FilterType.values().asList()
-                    else FilterType.values().asList().filter { it != FilterType.OTHERS },
-                    onDismiss = {},
-                    onApply = { a, b, c, d, e, f -> },
-                    onNavigate = {}
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    FilterMenuSheet(
+                        availableFilters = if (shouldShowPhase) FilterType.values().asList()
+                        else FilterType.values().asList().filter { it != FilterType.OTHERS },
+                        onDismiss = {},
+                        onApply = { a, b, c, d, e, f -> },
+                        onNavigate = {}
+                    )
+                }
             }
         }
 
@@ -111,18 +134,25 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
 
     @Test
     fun `test FilterMenuSheet renders all available filter Rows with ffOn`() {
+        val shouldShowPhase = true
+        val env = environment()
+            .toBuilder()
+            .currentUserV2(MockCurrentUserV2(UserFactory.user()))
+            .build()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
-            val shouldShowPhase = true
-            KSTheme {
-                FilterMenuSheet(
-                    selectedProjectStatus = DiscoveryParams.State.LIVE,
-                    availableFilters = if (shouldShowPhase) FilterType.values().asList()
-                    else FilterType.values().asList().filter { it != FilterType.OTHERS },
-                    onDismiss = {},
-                    onApply = { a, b, c, d, e, f -> },
-                    onNavigate = {}
-                )
-            }
+                KSTheme {
+                    CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                        FilterMenuSheet(
+                            selectedProjectStatus = DiscoveryParams.State.LIVE,
+                            availableFilters = if (shouldShowPhase) FilterType.values().asList()
+                            else FilterType.values().asList().filter { it != FilterType.OTHERS },
+                            onDismiss = {},
+                            onApply = { a, b, c, d, e, f -> },
+                            onNavigate = {}
+                        )
+                    }
+                }
         }
 
         composeTestRule.onNodeWithTag(FilterMenuTestTags.SHEET).assertIsDisplayed()
@@ -148,20 +178,24 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
     @Test
     fun `test selected and unselected status for live pill`() {
         var counter = 0
+        val env = environment()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                FilterMenuSheet(
-                    onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
-                        counter++
-                        if (counter == 1)
-                            assertEquals(publicState, DiscoveryParams.State.LIVE)
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    FilterMenuSheet(
+                        onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
+                            counter++
+                            if (counter == 1)
+                                assertEquals(publicState, DiscoveryParams.State.LIVE)
 
-                        if (counter == 2)
-                            assertEquals(publicState, null)
+                            if (counter == 2)
+                                assertEquals(publicState, null)
 
-                        assertNull(from)
-                    }
-                )
+                            assertNull(from)
+                        }
+                    )
+                }
             }
         }
 
@@ -175,12 +209,16 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
     fun `test FilterMenu _onApplyCallback receives projectState when pressing footer right button`() {
         var selected: DiscoveryParams.State? = null
         var contextFrom: Boolean? = null
+        val env = environment()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                FilterMenuSheet(onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
-                    selected = publicState
-                    contextFrom = from
-                })
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    FilterMenuSheet(onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
+                        selected = publicState
+                        contextFrom = from
+                    })
+                }
             }
         }
 
@@ -201,15 +239,19 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
         var selected: DiscoveryParams.State? = DiscoveryParams.State.LIVE
         var contextFrom: Boolean? = null
 
+        val env = environment()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                FilterMenuSheet(
-                    selectedProjectStatus = selected,
-                    onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
-                        selected = publicState
-                        contextFrom = from
-                    }
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    FilterMenuSheet(
+                        selectedProjectStatus = selected,
+                        onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
+                            selected = publicState
+                            contextFrom = from
+                        }
+                    )
+                }
             }
         }
 
@@ -223,13 +265,17 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
 
     @Test
     fun `category row, selected category subtext is present`() {
+        val env = environment()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                FilterMenuSheet(
-                    selectedCategory = CategoryFactory.CeramicsCategory(),
-                    onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
-                    }
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    FilterMenuSheet(
+                        selectedCategory = CategoryFactory.CeramicsCategory(),
+                        onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
+                        }
+                    )
+                }
             }
         }
 
@@ -245,14 +291,19 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
     @Test
     fun `percentage raised row, selected percentage bucket, subtext is present`() {
         var textForBucket: String = ""
+        val env = environment()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                textForBucket = textForBucket(DiscoveryParams.RaisedBuckets.BUCKET_2)
-                FilterMenuSheet(
-                    onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
-                    },
-                    selectedPercentage = DiscoveryParams.RaisedBuckets.BUCKET_2
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    textForBucket = textForBucket(DiscoveryParams.RaisedBuckets.BUCKET_2)
+                    FilterMenuSheet(
+                        onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
+                        },
+                        selectedPercentage = DiscoveryParams.RaisedBuckets.BUCKET_2
+                    )
+                }
+
             }
         }
 
@@ -270,14 +321,18 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
 
     @Test
     fun `location row, selected location, subtext is present`() {
+        val env = environment()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                FilterMenuSheet(
-                    onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
-                    },
-                    selectedLocation = LocationFactory.vancouver()
-                )
-            }
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                        FilterMenuSheet(
+                            onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
+                            },
+                            selectedLocation = LocationFactory.vancouver()
+                        )
+                    }
+                }
         }
 
         // - As working with LazyColumns, not all elements of the list are composed until the elements is visible
@@ -294,14 +349,18 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
     @Test
     fun `amount raised row, selected amount bucket, subtext is present`() {
         var textForBucket: String = ""
+        val env = environment()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                textForBucket = textForBucket(DiscoveryParams.AmountBuckets.BUCKET_4)
-                FilterMenuSheet(
-                    onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
-                    },
-                    selectedAmount = DiscoveryParams.AmountBuckets.BUCKET_4
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    textForBucket = textForBucket(DiscoveryParams.AmountBuckets.BUCKET_4)
+                    FilterMenuSheet(
+                        onApply = { publicState: DiscoveryParams.State?, recommended: Boolean, projectsLoved: Boolean, saved: Boolean, social: Boolean, from: Boolean? ->
+                        },
+                        selectedAmount = DiscoveryParams.AmountBuckets.BUCKET_4
+                    )
+                }
             }
         }
 
@@ -315,4 +374,5 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
             .onNodeWithText(textForBucket)
             .assertIsDisplayed()
     }
+
 }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/LocationSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/LocationSheetTest.kt
@@ -16,6 +16,7 @@ import com.kickstarter.R
 import com.kickstarter.features.search.ui.LocalFilterMenuViewModel
 import com.kickstarter.features.search.viewmodel.FilterMenuViewModel
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.MockCurrentUserV2
 import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.mock.services.MockApolloClientV2
 import com.kickstarter.models.Location
@@ -49,7 +50,9 @@ class LocationSheetTest : KSRobolectricTestCase() {
                     return Result.success(listOf(LocationFactory.vancouver()))
                 }
             }
-        ).build()
+        )
+            .currentUserV2(MockCurrentUserV2())
+            .build()
         val fakeViewModel = FilterMenuViewModel(env)
 
         composeTestRule.setContent {
@@ -101,7 +104,9 @@ class LocationSheetTest : KSRobolectricTestCase() {
                     return Result.success(listOf(LocationFactory.vancouver()))
                 }
             }
-        ).build()
+        )
+            .currentUserV2(MockCurrentUserV2())
+            .build()
         val fakeViewModel = FilterMenuViewModel(env)
 
         composeTestRule.setContent {
@@ -154,7 +159,9 @@ class LocationSheetTest : KSRobolectricTestCase() {
                         }
                     }
                 }
-            ).build()
+            )
+                .currentUserV2(MockCurrentUserV2())
+                .build()
 
             val fakeViewModel = FilterMenuViewModel(env, testDispatcher = UnconfinedTestDispatcher(testScheduler))
 
@@ -206,7 +213,9 @@ class LocationSheetTest : KSRobolectricTestCase() {
                     return Result.success(listOf(LocationFactory.vancouver()))
                 }
             }
-        ).build()
+        )
+            .currentUserV2(MockCurrentUserV2())
+            .build()
         val fakeViewModel = FilterMenuViewModel(env)
 
         composeTestRule.setContent {
@@ -277,7 +286,9 @@ class LocationSheetTest : KSRobolectricTestCase() {
                     }
                 }
             }
-        ).build()
+        )
+            .currentUserV2(MockCurrentUserV2())
+            .build()
         val fakeViewModel = FilterMenuViewModel(env, testDispatcher = UnconfinedTestDispatcher(testScheduler))
 
         composeTestRule.setContent {
@@ -320,7 +331,9 @@ class LocationSheetTest : KSRobolectricTestCase() {
                     return Result.success(emptyList())
                 }
             }
-        ).build()
+        )
+            .currentUserV2(MockCurrentUserV2())
+            .build()
         val fakeViewModel = FilterMenuViewModel(env, testDispatcher = UnconfinedTestDispatcher(testScheduler))
 
         composeTestRule.setContent {
@@ -358,7 +371,9 @@ class LocationSheetTest : KSRobolectricTestCase() {
                     return Result.success(listOf(LocationFactory.vancouver()))
                 }
             }
-        ).build()
+        )
+            .currentUserV2(MockCurrentUserV2())
+            .build()
         val fakeViewModel = FilterMenuViewModel(env)
 
         composeTestRule.setContent {

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchScreenTest.kt
@@ -48,17 +48,21 @@ class SearchScreenTest : KSRobolectricTestCase() {
     @Test
     fun testEmptyComponentsVisible() {
         composeTestRule.setContent {
+            val env = environment()
+            val fakeViewModel = FilterMenuViewModel(env)
             KSTheme {
-                SearchScreen(
-                    onBackClicked = { },
-                    scaffoldState = rememberScaffoldState(),
-                    isLoading = false,
-                    lazyColumnListState = rememberLazyListState(),
-                    showEmptyView = true,
-                    categories = listOf(),
-                    onSearchTermChanged = {},
-                    onItemClicked = {}
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchScreen(
+                        onBackClicked = { },
+                        scaffoldState = rememberScaffoldState(),
+                        isLoading = false,
+                        lazyColumnListState = rememberLazyListState(),
+                        showEmptyView = true,
+                        categories = listOf(),
+                        onSearchTermChanged = {},
+                        onItemClicked = {}
+                    )
+                }
             }
         }
 
@@ -75,26 +79,30 @@ class SearchScreenTest : KSRobolectricTestCase() {
     @Test
     fun testPopularListComponentsVisible() {
         composeTestRule.setContent {
+            val env = environment()
+            val fakeViewModel = FilterMenuViewModel(env)
             KSTheme {
-                SearchScreen(
-                    onBackClicked = { },
-                    scaffoldState = rememberScaffoldState(),
-                    isLoading = false,
-                    lazyColumnListState = rememberLazyListState(),
-                    showEmptyView = false,
-                    isDefaultList = true,
-                    itemsList = List(20) {
-                        Project.builder()
-                            .name("This is a test $it")
-                            .pledged((it * 2).toDouble())
-                            .goal(20.0)
-                            .state(if (it in 10..20) Project.STATE_SUBMITTED else Project.STATE_LIVE)
-                            .build()
-                    },
-                    categories = listOf(),
-                    onSearchTermChanged = {},
-                    onItemClicked = {}
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchScreen(
+                        onBackClicked = { },
+                        scaffoldState = rememberScaffoldState(),
+                        isLoading = false,
+                        lazyColumnListState = rememberLazyListState(),
+                        showEmptyView = false,
+                        isDefaultList = true,
+                        itemsList = List(20) {
+                            Project.builder()
+                                .name("This is a test $it")
+                                .pledged((it * 2).toDouble())
+                                .goal(20.0)
+                                .state(if (it in 10..20) Project.STATE_SUBMITTED else Project.STATE_LIVE)
+                                .build()
+                        },
+                        categories = listOf(),
+                        onSearchTermChanged = {},
+                        onItemClicked = {}
+                    )
+                }
             }
         }
 
@@ -122,26 +130,30 @@ class SearchScreenTest : KSRobolectricTestCase() {
     @Test
     fun testSearchedListComponentsVisible() {
         composeTestRule.setContent {
+            val env = environment()
+            val fakeViewModel = FilterMenuViewModel(env)
             KSTheme {
-                SearchScreen(
-                    onBackClicked = { },
-                    scaffoldState = rememberScaffoldState(),
-                    isLoading = false,
-                    lazyColumnListState = rememberLazyListState(),
-                    showEmptyView = false,
-                    isDefaultList = false,
-                    itemsList = List(20) {
-                        Project.builder()
-                            .name("This is a test $it")
-                            .pledged((it * 2).toDouble())
-                            .goal(20.0)
-                            .state(if (it in 10..20) Project.STATE_SUBMITTED else Project.STATE_LIVE)
-                            .build()
-                    },
-                    categories = listOf(),
-                    onSearchTermChanged = {},
-                    onItemClicked = {}
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchScreen(
+                        onBackClicked = { },
+                        scaffoldState = rememberScaffoldState(),
+                        isLoading = false,
+                        lazyColumnListState = rememberLazyListState(),
+                        showEmptyView = false,
+                        isDefaultList = false,
+                        itemsList = List(20) {
+                            Project.builder()
+                                .name("This is a test $it")
+                                .pledged((it * 2).toDouble())
+                                .goal(20.0)
+                                .state(if (it in 10..20) Project.STATE_SUBMITTED else Project.STATE_LIVE)
+                                .build()
+                        },
+                        categories = listOf(),
+                        onSearchTermChanged = {},
+                        onItemClicked = {}
+                    )
+                }
             }
         }
 
@@ -166,17 +178,21 @@ class SearchScreenTest : KSRobolectricTestCase() {
     @Test
     fun testLoadingComponentsEmptyListVisible() {
         composeTestRule.setContent {
+            val env = environment()
+            val fakeViewModel = FilterMenuViewModel(env)
             KSTheme {
-                SearchScreen(
-                    onBackClicked = { },
-                    scaffoldState = rememberScaffoldState(),
-                    isLoading = true,
-                    lazyColumnListState = rememberLazyListState(),
-                    showEmptyView = false,
-                    categories = listOf(),
-                    onSearchTermChanged = {},
-                    onItemClicked = {}
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchScreen(
+                        onBackClicked = { },
+                        scaffoldState = rememberScaffoldState(),
+                        isLoading = true,
+                        lazyColumnListState = rememberLazyListState(),
+                        showEmptyView = false,
+                        categories = listOf(),
+                        onSearchTermChanged = {},
+                        onItemClicked = {}
+                    )
+                }
             }
         }
 

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetValue.Hidden
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material.rememberScaffoldState
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
@@ -19,6 +20,8 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.platform.app.InstrumentationRegistry
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
+import com.kickstarter.features.search.ui.LocalFilterMenuViewModel
+import com.kickstarter.features.search.viewmodel.FilterMenuViewModel
 import com.kickstarter.mock.factories.CategoryFactory
 import com.kickstarter.models.Category
 import com.kickstarter.models.Project
@@ -190,26 +193,30 @@ class SearchScreenTest : KSRobolectricTestCase() {
     @Test
     fun testLoadingComponentsWithListVisible() {
         composeTestRule.setContent {
+            val env = environment()
+            val fakeViewModel = FilterMenuViewModel(env)
             KSTheme {
-                SearchScreen(
-                    onBackClicked = { },
-                    scaffoldState = rememberScaffoldState(),
-                    isLoading = true,
-                    lazyColumnListState = rememberLazyListState(),
-                    showEmptyView = false,
-                    isDefaultList = false,
-                    itemsList = List(20) {
-                        Project.builder()
-                            .name("This is a test $it")
-                            .pledged((it * 2).toDouble())
-                            .goal(20.0)
-                            .state(if (it in 10..20) Project.STATE_SUBMITTED else Project.STATE_LIVE)
-                            .build()
-                    },
-                    categories = listOf(),
-                    onSearchTermChanged = {},
-                    onItemClicked = {}
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchScreen(
+                        onBackClicked = { },
+                        scaffoldState = rememberScaffoldState(),
+                        isLoading = true,
+                        lazyColumnListState = rememberLazyListState(),
+                        showEmptyView = false,
+                        isDefaultList = false,
+                        itemsList = List(20) {
+                            Project.builder()
+                                .name("This is a test $it")
+                                .pledged((it * 2).toDouble())
+                                .goal(20.0)
+                                .state(if (it in 10..20) Project.STATE_SUBMITTED else Project.STATE_LIVE)
+                                .build()
+                        },
+                        categories = listOf(),
+                        onSearchTermChanged = {},
+                        onItemClicked = {}
+                    )
+                }
             }
         }
 
@@ -238,26 +245,30 @@ class SearchScreenTest : KSRobolectricTestCase() {
         var itemClickedCount = 0
 
         composeTestRule.setContent {
+            val env = environment()
+            val fakeViewModel = FilterMenuViewModel(env)
             KSTheme {
-                SearchScreen(
-                    onBackClicked = { backClickedCount++ },
-                    scaffoldState = rememberScaffoldState(),
-                    isLoading = false,
-                    lazyColumnListState = rememberLazyListState(),
-                    showEmptyView = false,
-                    isDefaultList = false,
-                    itemsList = List(20) {
-                        Project.builder()
-                            .name("This is a test $it")
-                            .pledged((it * 2).toDouble())
-                            .goal(20.0)
-                            .state(if (it in 10..20) Project.STATE_SUBMITTED else Project.STATE_LIVE)
-                            .build()
-                    },
-                    categories = listOf(),
-                    onSearchTermChanged = {},
-                    onItemClicked = { itemClickedCount++ }
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchScreen(
+                        onBackClicked = { backClickedCount++ },
+                        scaffoldState = rememberScaffoldState(),
+                        isLoading = false,
+                        lazyColumnListState = rememberLazyListState(),
+                        showEmptyView = false,
+                        isDefaultList = false,
+                        itemsList = List(20) {
+                            Project.builder()
+                                .name("This is a test $it")
+                                .pledged((it * 2).toDouble())
+                                .goal(20.0)
+                                .state(if (it in 10..20) Project.STATE_SUBMITTED else Project.STATE_LIVE)
+                                .build()
+                        },
+                        categories = listOf(),
+                        onSearchTermChanged = {},
+                        onItemClicked = { itemClickedCount++ }
+                    )
+                }
             }
         }
 
@@ -282,28 +293,32 @@ class SearchScreenTest : KSRobolectricTestCase() {
         var currentSearchTerm = ""
 
         composeTestRule.setContent {
+            val env = environment()
+            val fakeViewModel = FilterMenuViewModel(env)
             KSTheme {
-                SearchScreen(
-                    onBackClicked = { },
-                    scaffoldState = rememberScaffoldState(),
-                    isLoading = false,
-                    lazyColumnListState = rememberLazyListState(),
-                    showEmptyView = false,
-                    isDefaultList = false,
-                    itemsList = List(20) {
-                        Project.builder()
-                            .name("This is a test $it")
-                            .pledged((it * 2).toDouble())
-                            .goal(20.0)
-                            .state(if (it in 10..20) Project.STATE_SUBMITTED else Project.STATE_LIVE)
-                            .build()
-                    },
-                    categories = listOf(),
-                    onSearchTermChanged = {
-                        currentSearchTerm = it
-                    },
-                    onItemClicked = { }
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchScreen(
+                        onBackClicked = { },
+                        scaffoldState = rememberScaffoldState(),
+                        isLoading = false,
+                        lazyColumnListState = rememberLazyListState(),
+                        showEmptyView = false,
+                        isDefaultList = false,
+                        itemsList = List(20) {
+                            Project.builder()
+                                .name("This is a test $it")
+                                .pledged((it * 2).toDouble())
+                                .goal(20.0)
+                                .state(if (it in 10..20) Project.STATE_SUBMITTED else Project.STATE_LIVE)
+                                .build()
+                        },
+                        categories = listOf(),
+                        onSearchTermChanged = {
+                            currentSearchTerm = it
+                        },
+                        onItemClicked = { }
+                    )
+                }
             }
         }
 
@@ -314,43 +329,50 @@ class SearchScreenTest : KSRobolectricTestCase() {
     @OptIn(ExperimentalMaterialApi::class)
     @Test
     fun `pager initial State, navigates to category row, then navigate back to filter menu page`() {
+        val categories = CategoryFactory.rootCategories()
+        val selectedStatus = DiscoveryParams.State.LIVE
 
+        val appliedFilters = mutableListOf<Pair<DiscoveryParams.State?, Category?>>()
+        val dismissed = mutableListOf<Boolean>()
+        val selectedCounts = mutableListOf<Pair<Int?, Int?>>()
         var page = 0
+        val env = environment()
+        val fakeViewModel = FilterMenuViewModel(env)
+
         composeTestRule.setContent {
-            val testPagerState = rememberPagerState(initialPage = FilterPages.MAIN_FILTER.ordinal, pageCount = { FilterPages.values().size })
+            val testPagerState = rememberPagerState(
+                initialPage = FilterPages.MAIN_FILTER.ordinal,
+                pageCount = { FilterPages.values().size }
+            )
             val testSheetState = rememberModalBottomSheetState(
                 initialValue = Hidden,
                 skipHalfExpanded = true
             )
-
-            val categories = CategoryFactory.rootCategories()
-            val selectedStatus = DiscoveryParams.State.LIVE
-
-            val appliedFilters = mutableListOf<Pair<DiscoveryParams.State?, Category?>>()
-            val dismissed = mutableListOf<Boolean>()
-            val selectedCounts = mutableListOf<Pair<Int?, Int?>>()
-
             KSTheme {
-
-                FilterPagerSheet(
-                    selectedProjectStatus = selectedStatus,
-                    currentCategory = categories[0],
-                    categories = categories,
-                    onDismiss = { dismissed.add(true) },
-                    onApply = { state, category, _, _, _, _, _, _, _, _ -> appliedFilters.add(Pair(state, category)) },
-                    updateSelectedCounts = { statusCount, categoryCount, _, _, _, _, _, _, _, _ ->
-                        selectedCounts.add(
-                            statusCount to categoryCount
-                        )
-                    },
-                    pagerState = testPagerState,
-                    sheetState = testSheetState,
-                    shouldShowPhase = true
-                )
-            }
-
-            LaunchedEffect(testPagerState.currentPage) { // Update page counter outside compose context
-                page = testPagerState.currentPage
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    FilterPagerSheet(
+                        selectedProjectStatus = selectedStatus,
+                        currentCategory = categories[0],
+                        categories = categories,
+                        onDismiss = { dismissed.add(true) },
+                        onApply = { state, category, _, _, _, _, _, _, _, _ ->
+                            appliedFilters.add(
+                                Pair(state, category)
+                            )
+                        },
+                        updateSelectedCounts = { statusCount, categoryCount, _, _, _, _, _, _, _, _ ->
+                            selectedCounts.add(
+                                statusCount to categoryCount
+                            )
+                        },
+                        pagerState = testPagerState,
+                        sheetState = testSheetState,
+                        shouldShowPhase = true
+                    )
+                }
+                LaunchedEffect(testPagerState.currentPage) { // Update page counter outside compose context
+                    page = testPagerState.currentPage
+                }
             }
         }
 
@@ -379,6 +401,9 @@ class SearchScreenTest : KSRobolectricTestCase() {
         val dismissed = mutableListOf<Boolean>()
         val selectedCounts = mutableListOf<Int?>()
 
+        val env = environment()
+        val fakeViewModel = FilterMenuViewModel(env)
+
         composeTestRule.setContent {
             val testPagerState = rememberPagerState(initialPage = FilterPages.MAIN_FILTER.ordinal, pageCount = { FilterPages.values().size })
             val testSheetState = rememberModalBottomSheetState(
@@ -387,41 +412,42 @@ class SearchScreenTest : KSRobolectricTestCase() {
             )
 
             KSTheme {
-
-                FilterPagerSheet(
-                    selectedProjectStatus = DiscoveryParams.State.LIVE,
-                    currentCategory = categories[0],
-                    categories = categories,
-                    currentPercentage = DiscoveryParams.RaisedBuckets.BUCKET_2,
-                    onDismiss = { dismissed.add(true) },
-                    onApply = { state, category, bucket, location, amountBucket, recommended, projectsLoved, saved, social, goalBucket ->
-                        appliedFilters.add(state)
-                        appliedFilters.add(category)
-                        appliedFilters.add(bucket)
-                        appliedFilters.add(location)
-                        appliedFilters.add(amountBucket)
-                        appliedFilters.add(recommended)
-                        appliedFilters.add(projectsLoved)
-                        appliedFilters.add(saved)
-                        appliedFilters.add(social)
-                        appliedFilters.add(goalBucket)
-                    },
-                    updateSelectedCounts = { statusCount, categoryCount, bucket, location, amountCount, recommended, projectsLoved, saved, social, goal ->
-                        selectedCounts.add(statusCount)
-                        selectedCounts.add(categoryCount)
-                        selectedCounts.add(bucket)
-                        appliedFilters.add(location)
-                        appliedFilters.add(amountCount)
-                        appliedFilters.add(goal)
-                        appliedFilters.add(recommended)
-                        appliedFilters.add(projectsLoved)
-                        appliedFilters.add(saved)
-                        appliedFilters.add(social)
-                    },
-                    pagerState = testPagerState,
-                    sheetState = testSheetState,
-                    shouldShowPhase = true
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    FilterPagerSheet(
+                        selectedProjectStatus = DiscoveryParams.State.LIVE,
+                        currentCategory = categories[0],
+                        categories = categories,
+                        currentPercentage = DiscoveryParams.RaisedBuckets.BUCKET_2,
+                        onDismiss = { dismissed.add(true) },
+                        onApply = { state, category, bucket, location, amountBucket, recommended, projectsLoved, saved, social, goalBucket ->
+                            appliedFilters.add(state)
+                            appliedFilters.add(category)
+                            appliedFilters.add(bucket)
+                            appliedFilters.add(location)
+                            appliedFilters.add(amountBucket)
+                            appliedFilters.add(recommended)
+                            appliedFilters.add(projectsLoved)
+                            appliedFilters.add(saved)
+                            appliedFilters.add(social)
+                            appliedFilters.add(goalBucket)
+                        },
+                        updateSelectedCounts = { statusCount, categoryCount, bucket, location, amountCount, recommended, projectsLoved, saved, social, goal ->
+                            selectedCounts.add(statusCount)
+                            selectedCounts.add(categoryCount)
+                            selectedCounts.add(bucket)
+                            appliedFilters.add(location)
+                            appliedFilters.add(amountCount)
+                            appliedFilters.add(goal)
+                            appliedFilters.add(recommended)
+                            appliedFilters.add(projectsLoved)
+                            appliedFilters.add(saved)
+                            appliedFilters.add(social)
+                        },
+                        pagerState = testPagerState,
+                        sheetState = testSheetState,
+                        shouldShowPhase = true
+                    )
+                }
             }
         }
 
@@ -446,6 +472,8 @@ class SearchScreenTest : KSRobolectricTestCase() {
         var page = 0
         val categories = CategoryFactory.rootCategories()
         val selectedStatus = DiscoveryParams.State.LIVE
+        val env = environment()
+        val fakeViewModel = FilterMenuViewModel(env)
 
         composeTestRule.setContent {
             val testPagerState = rememberPagerState(initialPage = FilterPages.MAIN_FILTER.ordinal, pageCount = { FilterPages.values().size })
@@ -455,19 +483,20 @@ class SearchScreenTest : KSRobolectricTestCase() {
             )
 
             KSTheme {
-
-                FilterPagerSheet(
-                    selectedProjectStatus = selectedStatus,
-                    currentCategory = categories[0],
-                    categories = categories,
-                    onDismiss = { },
-                    onApply = { _, _, _, _, _, _, _, _, _, _ -> },
-                    updateSelectedCounts = { _, _, _, _, _, _, _, _, _, _ ->
-                    },
-                    pagerState = testPagerState,
-                    sheetState = testSheetState,
-                    shouldShowPhase = true
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    FilterPagerSheet(
+                        selectedProjectStatus = selectedStatus,
+                        currentCategory = categories[0],
+                        categories = categories,
+                        onDismiss = { },
+                        onApply = { _, _, _, _, _, _, _, _, _, _ -> },
+                        updateSelectedCounts = { _, _, _, _, _, _, _, _, _, _ ->
+                        },
+                        pagerState = testPagerState,
+                        sheetState = testSheetState,
+                        shouldShowPhase = true
+                    )
+                }
             }
 
             LaunchedEffect(testPagerState.currentPage) { // Update page counter outside compose context

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchTopBarTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchTopBarTest.kt
@@ -1,9 +1,14 @@
 package com.kickstarter.ui.activities.compose.search
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.onNodeWithTag
 import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.features.search.ui.LocalFilterMenuViewModel
+import com.kickstarter.features.search.viewmodel.FilterMenuViewModel
+import com.kickstarter.libs.MockCurrentUserV2
+import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.ui.activities.compose.search.PillBarTestTags.pillTag
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import org.junit.Test
@@ -12,27 +17,34 @@ class SearchTopBarTest : KSRobolectricTestCase() {
 
     @Test
     fun `SearchTopBar when phase 6-7 feature flag is off`() {
+        val env = environment()
+            .toBuilder()
+            .currentUserV2(MockCurrentUserV2(UserFactory.user()))
+            .build()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                SearchTopBar(
-                    onBackPressed = {},
-                    onValueChanged = {},
-                    selectedFilterCounts = mapOf(
-                        FilterRowPillType.SORT.name to 0,
-                        FilterRowPillType.CATEGORY.name to 0,
-                        FilterRowPillType.PROJECT_STATUS.name to 0,
-                        FilterRowPillType.PERCENTAGE_RAISED.name to 0,
-                        FilterRowPillType.LOCATION.name to 0,
-                        FilterRowPillType.AMOUNT_RAISED.name to 0,
-                        FilterRowPillType.RECOMMENDED.name to 0,
-                        FilterRowPillType.PROJECTS_LOVED.name to 0,
-                        FilterRowPillType.SAVED.name to 0,
-                        FilterRowPillType.FOLLOWING.name to 0,
-                        FilterRowPillType.GOAL.name to 0,
-                    ),
-                    onPillPressed = {},
-                    shouldShowPhase = false
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchTopBar(
+                        onBackPressed = {},
+                        onValueChanged = {},
+                        selectedFilterCounts = mapOf(
+                            FilterRowPillType.SORT.name to 0,
+                            FilterRowPillType.CATEGORY.name to 0,
+                            FilterRowPillType.PROJECT_STATUS.name to 0,
+                            FilterRowPillType.PERCENTAGE_RAISED.name to 0,
+                            FilterRowPillType.LOCATION.name to 0,
+                            FilterRowPillType.AMOUNT_RAISED.name to 0,
+                            FilterRowPillType.RECOMMENDED.name to 0,
+                            FilterRowPillType.PROJECTS_LOVED.name to 0,
+                            FilterRowPillType.SAVED.name to 0,
+                            FilterRowPillType.FOLLOWING.name to 0,
+                            FilterRowPillType.GOAL.name to 0,
+                        ),
+                        onPillPressed = {},
+                        shouldShowPhase = false
+                    )
+                }
             }
         }
 
@@ -52,27 +64,34 @@ class SearchTopBarTest : KSRobolectricTestCase() {
 
     @Test
     fun `SearchTopBar when phase 6-7 feature flag is on`() {
+        val env = environment()
+            .toBuilder()
+            .currentUserV2(MockCurrentUserV2(UserFactory.user()))
+            .build()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                SearchTopBar(
-                    onBackPressed = {},
-                    onValueChanged = {},
-                    selectedFilterCounts = mapOf(
-                        FilterRowPillType.SORT.name to 0,
-                        FilterRowPillType.CATEGORY.name to 0,
-                        FilterRowPillType.PROJECT_STATUS.name to 0,
-                        FilterRowPillType.PERCENTAGE_RAISED.name to 0,
-                        FilterRowPillType.LOCATION.name to 0,
-                        FilterRowPillType.AMOUNT_RAISED.name to 0,
-                        FilterRowPillType.RECOMMENDED.name to 0,
-                        FilterRowPillType.PROJECTS_LOVED.name to 0,
-                        FilterRowPillType.SAVED.name to 0,
-                        FilterRowPillType.FOLLOWING.name to 0,
-                        FilterRowPillType.GOAL.name to 0,
-                    ),
-                    onPillPressed = {},
-                    shouldShowPhase = true
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchTopBar(
+                        onBackPressed = {},
+                        onValueChanged = {},
+                        selectedFilterCounts = mapOf(
+                            FilterRowPillType.SORT.name to 0,
+                            FilterRowPillType.CATEGORY.name to 0,
+                            FilterRowPillType.PROJECT_STATUS.name to 0,
+                            FilterRowPillType.PERCENTAGE_RAISED.name to 0,
+                            FilterRowPillType.LOCATION.name to 0,
+                            FilterRowPillType.AMOUNT_RAISED.name to 0,
+                            FilterRowPillType.RECOMMENDED.name to 0,
+                            FilterRowPillType.PROJECTS_LOVED.name to 0,
+                            FilterRowPillType.SAVED.name to 0,
+                            FilterRowPillType.FOLLOWING.name to 0,
+                            FilterRowPillType.GOAL.name to 0,
+                        ),
+                        onPillPressed = {},
+                        shouldShowPhase = true
+                    )
+                }
             }
         }
 
@@ -90,31 +109,81 @@ class SearchTopBarTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `SearchTopBar pillBar all filters active`() {
+    fun `SearchTopBar when phase 6-7 feature flag is on User is logged out`() {
+        val env = environment()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                SearchTopBar(
-                    onBackPressed = {},
-                    onValueChanged = {},
-                    categoryPillText = "Art",
-                    projectStatusText = "Live",
-                    selectedFilterCounts = mapOf(
-                        FilterRowPillType.SORT.name to 0,
-                        FilterRowPillType.CATEGORY.name to 1,
-                        FilterRowPillType.FILTER.name to 1,
-                        FilterRowPillType.PROJECT_STATUS.name to 1,
-                        FilterRowPillType.PERCENTAGE_RAISED.name to 1,
-                        FilterRowPillType.AMOUNT_RAISED.name to 1,
-                        FilterRowPillType.LOCATION.name to 1,
-                        FilterRowPillType.GOAL.name to 1,
-                        FilterRowPillType.RECOMMENDED.name to 1,
-                        FilterRowPillType.PROJECTS_LOVED.name to 1,
-                        FilterRowPillType.SAVED.name to 1,
-                        FilterRowPillType.FOLLOWING.name to 1,
-                    ),
-                    onPillPressed = {},
-                    shouldShowPhase = true
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchTopBar(
+                        onBackPressed = {},
+                        onValueChanged = {},
+                        selectedFilterCounts = mapOf(
+                            FilterRowPillType.SORT.name to 0,
+                            FilterRowPillType.CATEGORY.name to 0,
+                            FilterRowPillType.PROJECT_STATUS.name to 0,
+                            FilterRowPillType.PERCENTAGE_RAISED.name to 0,
+                            FilterRowPillType.LOCATION.name to 0,
+                            FilterRowPillType.AMOUNT_RAISED.name to 0,
+                            FilterRowPillType.RECOMMENDED.name to 0,
+                            FilterRowPillType.PROJECTS_LOVED.name to 0,
+                            FilterRowPillType.SAVED.name to 0,
+                            FilterRowPillType.FOLLOWING.name to 0,
+                            FilterRowPillType.GOAL.name to 0,
+                        ),
+                        onPillPressed = {},
+                        shouldShowPhase = true
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag(SearchScreenTestTag.BACK_BUTTON.name).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.PROJECT_STATUS)).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.CATEGORY)).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.PERCENTAGE_RAISED)).assertExists() // exists instead of display to avoid having to scroll
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.LOCATION)).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.AMOUNT_RAISED)).assertExists() // exists instead of display to avoid having to scroll
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.FILTER)).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.RECOMMENDED)).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.PROJECTS_LOVED)).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.SAVED)).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.FOLLOWING)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `SearchTopBar pillBar all filters active`() {
+        val env = environment()
+            .toBuilder()
+            .currentUserV2(MockCurrentUserV2(UserFactory.user()))
+            .build()
+        val fakeViewModel = FilterMenuViewModel(env)
+        composeTestRule.setContent {
+            KSTheme {
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchTopBar(
+                        onBackPressed = {},
+                        onValueChanged = {},
+                        categoryPillText = "Art",
+                        projectStatusText = "Live",
+                        selectedFilterCounts = mapOf(
+                            FilterRowPillType.SORT.name to 0,
+                            FilterRowPillType.CATEGORY.name to 1,
+                            FilterRowPillType.FILTER.name to 1,
+                            FilterRowPillType.PROJECT_STATUS.name to 1,
+                            FilterRowPillType.PERCENTAGE_RAISED.name to 1,
+                            FilterRowPillType.AMOUNT_RAISED.name to 1,
+                            FilterRowPillType.LOCATION.name to 1,
+                            FilterRowPillType.GOAL.name to 1,
+                            FilterRowPillType.RECOMMENDED.name to 1,
+                            FilterRowPillType.PROJECTS_LOVED.name to 1,
+                            FilterRowPillType.SAVED.name to 1,
+                            FilterRowPillType.FOLLOWING.name to 1,
+                        ),
+                        onPillPressed = {},
+                        shouldShowPhase = true
+                    )
+                }
             }
         }
 
@@ -137,23 +206,30 @@ class SearchTopBarTest : KSRobolectricTestCase() {
 
     @Test
     fun `SearchTopBar pillBar Category filter active`() {
+        val env = environment()
+            .toBuilder()
+            .currentUserV2(MockCurrentUserV2(UserFactory.user()))
+            .build()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                SearchTopBar(
-                    onBackPressed = {},
-                    onValueChanged = {},
-                    categoryPillText = "Art",
-                    projectStatusText = "Project Status",
-                    selectedFilterCounts = mapOf(
-                        FilterRowPillType.SORT.name to 0,
-                        FilterRowPillType.CATEGORY.name to 1,
-                        FilterRowPillType.FILTER.name to 1,
-                        FilterRowPillType.PROJECT_STATUS.name to 0,
-                        FilterRowPillType.PERCENTAGE_RAISED.name to 0
-                    ),
-                    onPillPressed = {},
-                    shouldShowPhase = true
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchTopBar(
+                        onBackPressed = {},
+                        onValueChanged = {},
+                        categoryPillText = "Art",
+                        projectStatusText = "Project Status",
+                        selectedFilterCounts = mapOf(
+                            FilterRowPillType.SORT.name to 0,
+                            FilterRowPillType.CATEGORY.name to 1,
+                            FilterRowPillType.FILTER.name to 1,
+                            FilterRowPillType.PROJECT_STATUS.name to 0,
+                            FilterRowPillType.PERCENTAGE_RAISED.name to 0
+                        ),
+                        onPillPressed = {},
+                        shouldShowPhase = true
+                    )
+                }
             }
         }
 
@@ -168,22 +244,29 @@ class SearchTopBarTest : KSRobolectricTestCase() {
 
     @Test
     fun `SearchTopBar pillBar ProjectStatus filter active`() {
+        val env = environment()
+            .toBuilder()
+            .currentUserV2(MockCurrentUserV2(UserFactory.user()))
+            .build()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                SearchTopBar(
-                    onBackPressed = {},
-                    onValueChanged = {},
-                    projectStatusText = "Live",
-                    selectedFilterCounts = mapOf(
-                        FilterRowPillType.SORT.name to 0,
-                        FilterRowPillType.CATEGORY.name to 0,
-                        FilterRowPillType.FILTER.name to 1,
-                        FilterRowPillType.PROJECT_STATUS.name to 1,
-                        FilterRowPillType.PERCENTAGE_RAISED.name to 0
-                    ),
-                    onPillPressed = {},
-                    shouldShowPhase = true
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchTopBar(
+                        onBackPressed = {},
+                        onValueChanged = {},
+                        projectStatusText = "Live",
+                        selectedFilterCounts = mapOf(
+                            FilterRowPillType.SORT.name to 0,
+                            FilterRowPillType.CATEGORY.name to 0,
+                            FilterRowPillType.FILTER.name to 1,
+                            FilterRowPillType.PROJECT_STATUS.name to 1,
+                            FilterRowPillType.PERCENTAGE_RAISED.name to 0
+                        ),
+                        onPillPressed = {},
+                        shouldShowPhase = true
+                    )
+                }
             }
         }
 
@@ -198,22 +281,29 @@ class SearchTopBarTest : KSRobolectricTestCase() {
 
     @Test
     fun `SearchTopBar pillBar PercentageRaised filter active`() {
+        val env = environment()
+            .toBuilder()
+            .currentUserV2(MockCurrentUserV2(UserFactory.user()))
+            .build()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                SearchTopBar(
-                    onBackPressed = {},
-                    onValueChanged = {},
-                    projectStatusText = "Live",
-                    selectedFilterCounts = mapOf(
-                        FilterRowPillType.SORT.name to 0,
-                        FilterRowPillType.CATEGORY.name to 0,
-                        FilterRowPillType.FILTER.name to 1,
-                        FilterRowPillType.PROJECT_STATUS.name to 0,
-                        FilterRowPillType.PERCENTAGE_RAISED.name to 1
-                    ),
-                    onPillPressed = {},
-                    shouldShowPhase = true
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchTopBar(
+                        onBackPressed = {},
+                        onValueChanged = {},
+                        projectStatusText = "Live",
+                        selectedFilterCounts = mapOf(
+                            FilterRowPillType.SORT.name to 0,
+                            FilterRowPillType.CATEGORY.name to 0,
+                            FilterRowPillType.FILTER.name to 1,
+                            FilterRowPillType.PROJECT_STATUS.name to 0,
+                            FilterRowPillType.PERCENTAGE_RAISED.name to 1
+                        ),
+                        onPillPressed = {},
+                        shouldShowPhase = true
+                    )
+                }
             }
         }
 
@@ -228,23 +318,30 @@ class SearchTopBarTest : KSRobolectricTestCase() {
 
     @Test
     fun `SearchTopBar pillBar AmountRaised filter active`() {
+        val env = environment()
+            .toBuilder()
+            .currentUserV2(MockCurrentUserV2(UserFactory.user()))
+            .build()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                SearchTopBar(
-                    onBackPressed = {},
-                    onValueChanged = {},
-                    projectStatusText = "Live",
-                    selectedFilterCounts = mapOf(
-                        FilterRowPillType.SORT.name to 0,
-                        FilterRowPillType.CATEGORY.name to 0,
-                        FilterRowPillType.FILTER.name to 1,
-                        FilterRowPillType.PROJECT_STATUS.name to 0,
-                        FilterRowPillType.PERCENTAGE_RAISED.name to 0,
-                        FilterRowPillType.AMOUNT_RAISED.name to 1,
-                    ),
-                    onPillPressed = {},
-                    shouldShowPhase = true
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchTopBar(
+                        onBackPressed = {},
+                        onValueChanged = {},
+                        projectStatusText = "Live",
+                        selectedFilterCounts = mapOf(
+                            FilterRowPillType.SORT.name to 0,
+                            FilterRowPillType.CATEGORY.name to 0,
+                            FilterRowPillType.FILTER.name to 1,
+                            FilterRowPillType.PROJECT_STATUS.name to 0,
+                            FilterRowPillType.PERCENTAGE_RAISED.name to 0,
+                            FilterRowPillType.AMOUNT_RAISED.name to 1,
+                        ),
+                        onPillPressed = {},
+                        shouldShowPhase = true
+                    )
+                }
             }
         }
 
@@ -260,24 +357,31 @@ class SearchTopBarTest : KSRobolectricTestCase() {
 
     @Test
     fun `SearchTopBar pillBar Goal filter active`() {
+        val env = environment()
+            .toBuilder()
+            .currentUserV2(MockCurrentUserV2(UserFactory.user()))
+            .build()
+        val fakeViewModel = FilterMenuViewModel(env)
         composeTestRule.setContent {
             KSTheme {
-                SearchTopBar(
-                    onBackPressed = {},
-                    onValueChanged = {},
-                    projectStatusText = "Live",
-                    selectedFilterCounts = mapOf(
-                        FilterRowPillType.SORT.name to 0,
-                        FilterRowPillType.CATEGORY.name to 0,
-                        FilterRowPillType.FILTER.name to 1,
-                        FilterRowPillType.PROJECT_STATUS.name to 0,
-                        FilterRowPillType.PERCENTAGE_RAISED.name to 0,
-                        FilterRowPillType.AMOUNT_RAISED.name to 0,
-                        FilterRowPillType.GOAL.name to 1,
-                    ),
-                    onPillPressed = {},
-                    shouldShowPhase = true
-                )
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchTopBar(
+                        onBackPressed = {},
+                        onValueChanged = {},
+                        projectStatusText = "Live",
+                        selectedFilterCounts = mapOf(
+                            FilterRowPillType.SORT.name to 0,
+                            FilterRowPillType.CATEGORY.name to 0,
+                            FilterRowPillType.FILTER.name to 1,
+                            FilterRowPillType.PROJECT_STATUS.name to 0,
+                            FilterRowPillType.PERCENTAGE_RAISED.name to 0,
+                            FilterRowPillType.AMOUNT_RAISED.name to 0,
+                            FilterRowPillType.GOAL.name to 1,
+                        ),
+                        onPillPressed = {},
+                        shouldShowPhase = true
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
# 📲 What

- Show only toggles and pills should be available only for logged in users
- The order of the pills and the "Show Only" row have changed

# 🛠 How
- `FilterMenuViewModel` now has a state for `loggedInUser`, on init we check if the current user is present or not.
- Now `FilterMenuSheet` and `SearchTopBar` both use `CompositionLocalProvider` to have access to `FilterMenuViewModel`


# 👀 See

| Logged In User | 


https://github.com/user-attachments/assets/608b93ea-524c-447d-91e6-ded7dfa42424



| Logged Out User |


https://github.com/user-attachments/assets/0866b067-0b77-4258-8915-37c516cfbd30



| --- | --- |
|  |  |

# 📋 QA

- Log in and check the "Show only" toggles and pills are visible
- Log out and make sure none of the "Show only" and pills are visible

# Story 📖

[MBL-2615](https://kickstarter.atlassian.net/browse/MBL-2615)


[MBL-2615]: https://kickstarter.atlassian.net/browse/MBL-2615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ