### PR TITLE
MBL-2636 Implement new "Refunded" badge for PaymentSchedule component

### DIFF
--- a/app/src/main/java/com/kickstarter/mock/factories/PaymentIncrementFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/PaymentIncrementFactory.kt
@@ -69,6 +69,17 @@ class PaymentIncrementFactory {
             )
         }
 
+        fun incrementUsdRefunded(dateTime: DateTime, formattedAmount: String): PaymentIncrement {
+            return paymentIncrement(
+                paymentIncrementAmount = PaymentIncrementFactory.amount(formattedAmount = formattedAmount, formattedAmountWithCode = "USD $99.75", amountAsFloat = "99.75", amountAsCents = "9975", currencyCode = CurrencyCode.USD.rawValue, amountFormattedInProjectNativeCurrency = "99.75$"),
+                scheduledCollection = dateTime,
+                paymentIncrementableId = "",
+                paymentIncrementableType = "",
+                state = PaymentIncrementState.REFUNDED,
+                stateReason = PaymentIncrementStateReason.UNKNOWN__
+            )
+        }
+
         fun samplePaymentIncrements(): List<PaymentIncrement> {
             val now = DateTime.now()
 
@@ -112,8 +123,15 @@ class PaymentIncrementFactory {
                     paymentIncrementableType = "pledge",
                     scheduledCollection = now.plusDays(60),
                     stateReason = PaymentIncrementStateReason.UNKNOWN__
-                )
-
+                ),
+                PaymentIncrementFactory.paymentIncrement(
+                    paymentIncrementAmount = PaymentIncrementFactory.amount(formattedAmount = "$60.00", formattedAmountWithCode = "USD $99.75", amountAsFloat = "99.75", amountAsCents = "9975", currencyCode = CurrencyCode.USD.rawValue, amountFormattedInProjectNativeCurrency = "99.75$"),
+                    state = PaymentIncrementState.REFUNDED,
+                    paymentIncrementableId = "4",
+                    paymentIncrementableType = "pledge",
+                    scheduledCollection = now.plusDays(60),
+                    stateReason = PaymentIncrementStateReason.UNKNOWN__
+                ),
             )
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSColors.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSColors.kt
@@ -151,7 +151,6 @@ data class KSCustomColors(
     val textAccentYellow: Color = Color.Unspecified,
     val textAccentYellowBold: Color = Color.Unspecified,
 
-    // Add these two new purples
     val purple_03: Color = Color.Unspecified,
     val purple_08: Color = Color.Unspecified,
     val yellow_03: Color = Color.Unspecified,
@@ -285,7 +284,6 @@ val KSLightCustomColors = KSCustomColors(
     textAccentYellow = yellow_06,
     textAccentYellowBold = yellow_08,
 
-    // Add new purples
     purple_03 = purple_03,
     purple_08 = purple_08,
     yellow_03 = yellow_03,
@@ -416,7 +414,6 @@ val KSDarkCustomColors = KSCustomColors(
     textAccentYellow = yellow_05,
     textAccentYellowBold = yellow_02,
 
-    // Add new purples
     purple_03 = purple_03,
     purple_08 = purple_08,
     yellow_03 = yellow_03,

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSColors.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSColors.kt
@@ -128,6 +128,8 @@ val blue_08 = Color(0xFF0F0FBD)
 val blue_09 = Color(0xFF0B0B89)
 val blue_10 = Color(0xFF050543)
 
+val red_light = Color(0xFFF5E8E9)
+
 @Immutable
 data class KSCustomColors(
     // NEW COLORS
@@ -148,6 +150,12 @@ data class KSCustomColors(
     val textAccentPurpleBold: Color = Color.Unspecified,
     val textAccentYellow: Color = Color.Unspecified,
     val textAccentYellowBold: Color = Color.Unspecified,
+
+    // Add these two new purples
+    val purple_03: Color = Color.Unspecified,
+    val purple_08: Color = Color.Unspecified,
+    val yellow_03: Color = Color.Unspecified,
+    val yellow_08: Color = Color.Unspecified,
 
     // Background Colors
     val backgroundSurfacePrimary: Color = Color.Unspecified,
@@ -240,6 +248,17 @@ data class KSCustomColors(
     val kds_warn: Color = Color.Unspecified,
     val kds_inform: Color = Color.Unspecified,
     val facebook_blue: Color = Color.Unspecified,
+    val red_light: Color = Color.Unspecified,
+    val red_03: Color = Color.Unspecified,
+    val red_07: Color = Color.Unspecified,
+    val grey_03: Color = Color.Unspecified,
+    val grey_05: Color = Color.Unspecified,
+    val grey_10: Color = Color.Unspecified,
+    val blue_03: Color = Color.Unspecified,
+    val blue_09: Color = Color.Unspecified,
+    val green_02: Color = Color.Unspecified,
+    val green_07: Color = Color.Unspecified,
+    val green_06: Color = Color.Unspecified,
 )
 
 val LocalKSCustomColors = staticCompositionLocalOf {
@@ -265,6 +284,12 @@ val KSLightCustomColors = KSCustomColors(
     textAccentPurpleBold = purple_08,
     textAccentYellow = yellow_06,
     textAccentYellowBold = yellow_08,
+
+    // Add new purples
+    purple_03 = purple_03,
+    purple_08 = purple_08,
+    yellow_03 = yellow_03,
+    yellow_08 = yellow_08,
 
     // Background Colors
     backgroundSurfacePrimary = white,
@@ -357,6 +382,17 @@ val KSLightCustomColors = KSCustomColors(
     kds_warn = kds_warn,
     kds_inform = kds_inform,
     facebook_blue = facebook_blue,
+    red_light = red_light,
+    red_03 = red_03,
+    red_07 = red_07,
+    grey_03 = grey_03,
+    grey_05 = grey_05,
+    grey_10 = grey_10,
+    blue_03 = blue_03,
+    blue_09 = blue_09,
+    green_02 = green_02,
+    green_07 = green_07,
+    green_06 = green_06,
 )
 
 // TODO: Change colors to reflect actual dark theme when available
@@ -379,6 +415,12 @@ val KSDarkCustomColors = KSCustomColors(
     textAccentPurpleBold = purple_02,
     textAccentYellow = yellow_05,
     textAccentYellowBold = yellow_02,
+
+    // Add new purples
+    purple_03 = purple_03,
+    purple_08 = purple_08,
+    yellow_03 = yellow_03,
+    yellow_08 = yellow_08,
 
     // Background Colors
     backgroundSurfacePrimary = grey_10,
@@ -471,4 +513,15 @@ val KSDarkCustomColors = KSCustomColors(
     kds_warn = kds_warn,
     kds_inform = kds_inform,
     facebook_blue = facebook_blue,
+    red_light = red_light,
+    red_03 = red_03,
+    red_07 = red_07,
+    grey_03 = grey_03,
+    grey_05 = grey_05,
+    grey_10 = grey_10,
+    blue_03 = blue_03,
+    blue_09 = blue_09,
+    green_02 = green_02,
+    green_07 = green_07,
+    green_06 = green_06,
 )

--- a/app/src/main/java/com/kickstarter/ui/views/compose/checkout/PaymentSchedule.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/compose/checkout/PaymentSchedule.kt
@@ -1,6 +1,7 @@
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -261,10 +262,13 @@ fun StatusBadge(state: PaymentIncrementState, stateReason: PaymentIncrementState
     when (state) {
         PaymentIncrementState.ERRORED -> {
             if (stateReason == PaymentIncrementStateReason.REQUIRES_ACTION) {
+                val isLight = !isSystemInDarkTheme()
+                val backgroundColor = if (isLight) colors.backgroundWarningSubtle else colors.yellow_03
+                val textColor = if (isLight) colors.textAccentYellowBold else colors.yellow_08
                 Box(
                     modifier = Modifier
                         .background(
-                            color = colors.backgroundAccentOrangeSubtle,
+                            color = backgroundColor,
                             shape = RoundedCornerShape(
                                 topStart = dimensions.radiusSmall,
                                 topEnd = dimensions.radiusSmall,
@@ -281,14 +285,17 @@ fun StatusBadge(state: PaymentIncrementState, stateReason: PaymentIncrementState
                         modifier = Modifier.testTag(PaymentScheduleTestTags.BADGE_TEXT.name),
                         text = stringResource(id = R.string.Authentication_required),
                         style = typographyV2.headingSM,
-                        color = colors.kds_support_400
+                        color = textColor
                     )
                 }
             } else {
+                val isLight = !isSystemInDarkTheme()
+                val backgroundColor = if (isLight) colors.red_light else colors.red_03
+                val textColor = if (isLight) colors.kds_alert else colors.red_07
                 Box(
                     modifier = Modifier
                         .background(
-                            color = colors.backgroundDangerSubtle,
+                            color = backgroundColor,
                             shape = RoundedCornerShape(
                                 topStart = dimensions.radiusSmall,
                                 topEnd = dimensions.radiusSmall,
@@ -305,17 +312,20 @@ fun StatusBadge(state: PaymentIncrementState, stateReason: PaymentIncrementState
                         modifier = Modifier.testTag(PaymentScheduleTestTags.BADGE_TEXT.name),
                         text = stringResource(id = R.string.Errored_payment),
                         style = typographyV2.headingSM,
-                        color = colors.textAccentRedBold
+                        color = textColor
                     )
                 }
             }
         }
 
         PaymentIncrementState.COLLECTED -> {
+            val isLight = !isSystemInDarkTheme()
+            val backgroundColor = if (isLight) colors.green_06.copy(alpha = 0.06f) else colors.green_02
+            val textColor = if (isLight) colors.green_06 else colors.green_07
             Box(
                 modifier = Modifier
                     .background(
-                        color = colors.textAccentGreen.copy(alpha = 0.2f),
+                        color = backgroundColor,
                         shape = RoundedCornerShape(
                             topStart = dimensions.radiusSmall,
                             topEnd = dimensions.radiusSmall,
@@ -332,7 +342,7 @@ fun StatusBadge(state: PaymentIncrementState, stateReason: PaymentIncrementState
                     modifier = Modifier.testTag(PaymentScheduleTestTags.BADGE_TEXT.name),
                     text = stringResource(id = R.string.project_view_pledge_status_collected),
                     style = typographyV2.headingSM,
-                    color = colors.textAccentGreen
+                    color = textColor
                 )
             }
         }
@@ -341,7 +351,7 @@ fun StatusBadge(state: PaymentIncrementState, stateReason: PaymentIncrementState
             Box(
                 modifier = Modifier
                     .background(
-                        color = colors.kds_support_200,
+                        color = colors.blue_03,
                         shape = RoundedCornerShape(
                             topStart = dimensions.radiusSmall,
                             topEnd = dimensions.radiusSmall,
@@ -358,16 +368,19 @@ fun StatusBadge(state: PaymentIncrementState, stateReason: PaymentIncrementState
                     modifier = Modifier.testTag(PaymentScheduleTestTags.BADGE_TEXT.name),
                     text = stringResource(id = R.string.Scheduled),
                     style = typographyV2.headingSM,
-                    color = colors.kds_support_400
+                    color = colors.blue_09
                 )
             }
         }
 
         PaymentIncrementState.CANCELLED -> {
+            val isLight = !isSystemInDarkTheme()
+            val backgroundColor = if (isLight) colors.grey_03 else colors.grey_05
+            val textColor = colors.grey_10
             Box(
                 modifier = Modifier
                     .background(
-                        color = colors.kds_support_200,
+                        color = backgroundColor,
                         shape = RoundedCornerShape(
                             topStart = dimensions.radiusSmall,
                             topEnd = dimensions.radiusSmall,
@@ -384,12 +397,36 @@ fun StatusBadge(state: PaymentIncrementState, stateReason: PaymentIncrementState
                     modifier = Modifier.testTag(PaymentScheduleTestTags.BADGE_TEXT.name),
                     text = stringResource(id = R.string.project_view_pledge_status_canceled),
                     style = typographyV2.headingSM,
-                    color = colors.kds_support_400
+                    color = textColor
+                )
+            }
+        }
+        PaymentIncrementState.REFUNDED -> {
+            Box(
+                modifier = Modifier
+                    .background(
+                        color = colors.purple_03,
+                        shape = RoundedCornerShape(
+                            topStart = dimensions.radiusSmall,
+                            topEnd = dimensions.radiusSmall,
+                            bottomStart = dimensions.radiusSmall,
+                            bottomEnd = dimensions.radiusSmall
+                        ),
+                    )
+                    .padding(
+                        horizontal = dimensions.paddingSmall,
+                        vertical = dimensions.paddingXSmall
+                    )
+            ) {
+                Text(
+                    modifier = Modifier.testTag(PaymentScheduleTestTags.BADGE_TEXT.name),
+                    text = stringResource(id = R.string.fpo_refunded),
+                    style = typographyV2.headingSM,
+                    color = colors.purple_08
                 )
             }
         }
         PaymentIncrementState.UNKNOWN__ -> {}
         PaymentIncrementState.CHARGEBACK_LOST -> {}
-        PaymentIncrementState.REFUNDED -> {}
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,4 +117,8 @@
   <string name="fpo_tracking_number" formatted="false">Tracking #: %{tracking_number}</string>
   <string name="fpo_track_shipment" formatted="false">Track shipment</string>
 
+  <!-- FPO's for PLOT refund -->
+  <string name="fpo_refunded" formatted="false">Refunded</string>
+
+
 </resources>

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/PaymentScheduleTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/PaymentScheduleTest.kt
@@ -206,6 +206,45 @@ class PaymentScheduleTest : KSRobolectricTestCase() {
         )
     )
 
+    private val samplePaymentIncrementsWithRefundedState = listOf(
+        PaymentIncrement(
+            paymentIncrementAmount = PaymentIncrementAmount.builder().formattedAmount("$25")
+                .build(),
+            state = PaymentIncrementState.REFUNDED,
+            paymentIncrementableId = "1",
+            paymentIncrementableType = "pledge",
+            scheduledCollection = DateTime.parse("2024-10-14T18:12:00Z"),
+            stateReason = PaymentIncrementStateReason.REQUIRES_ACTION
+        ),
+        PaymentIncrement(
+            paymentIncrementAmount = PaymentIncrementAmount.builder().formattedAmount("$25")
+                .build(),
+            state = PaymentIncrementState.REFUNDED,
+            paymentIncrementableId = "2",
+            paymentIncrementableType = "pledge",
+            scheduledCollection = DateTime.parse("2024-10-15T14:00:00Z"),
+            stateReason = PaymentIncrementStateReason.REQUIRES_ACTION
+        ),
+        PaymentIncrement(
+            paymentIncrementAmount = PaymentIncrementAmount.builder().formattedAmount("$25")
+                .build(),
+            state = PaymentIncrementState.REFUNDED,
+            paymentIncrementableId = "3",
+            paymentIncrementableType = "pledge",
+            scheduledCollection = DateTime.parse("2024-10-16T10:00:00Z"),
+            stateReason = PaymentIncrementStateReason.REQUIRES_ACTION
+        ),
+        PaymentIncrement(
+            paymentIncrementAmount = PaymentIncrementAmount.builder().formattedAmount("$25")
+                .build(),
+            state = PaymentIncrementState.REFUNDED,
+            paymentIncrementableId = "4",
+            paymentIncrementableType = "pledge",
+            scheduledCollection = DateTime.parse("2024-10-17T16:30:00Z"),
+            stateReason = PaymentIncrementStateReason.REQUIRES_ACTION
+        )
+    )
+
     private val samplePaymentIncrementsWithErroredStateAndRequiresActionStateReason = listOf(
         PaymentIncrement(
             paymentIncrementAmount = PaymentIncrementAmount.builder().formattedAmount("$25")
@@ -422,6 +461,23 @@ class PaymentScheduleTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun testRefundedBadge() {
+        composeTestRule.setContent {
+            KSTheme {
+                PaymentSchedule(
+                    isExpanded = true,
+                    onExpandChange = {},
+                    paymentIncrements = samplePaymentIncrementsWithRefundedState
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        badgeText.assertCountEquals(samplePaymentIncrementsWithRefundedState.size)
+        badgeText.assertAll(hasText(context.getString(R.string.fpo_refunded)))
+    }
+
+    @Test
     fun testPaymentScheduleAmountsText() {
         composeTestRule.setContent {
             KSTheme {
@@ -440,7 +496,7 @@ class PaymentScheduleTest : KSRobolectricTestCase() {
         }
 
         composeTestRule.waitForIdle()
-        amountText.assertCountEquals(5)
+        amountText.assertCountEquals(6)
 
         // Assert Currency text
         amountText.assertAll(hasText("99.75$", ignoreCase = true))


### PR DESCRIPTION
# 📲 What

- Created new badge for refunded increments for payment schedule
- Updated other badges colors to match [new Designs ](https://www.figma.com/design/hnl7NkgWvAYfXc4oHyyqk3/--PLOT-V2-Designs?node-id=1969-71716&m=dev)

# 🤔 Why

- It would be needed for refund payments on PLOT
- When given the new design for Refunded badge colors of the others badge where updated too

# 🛠 How

- On `PaymentSchedule` component render a new badge for `PaymentIncrementState.REFUNDED`
- Changed the colors for other badged adding validations for ligh/dark theme to match new designs
- added necessary colors to `KSColors`

# 👀 See

<img width="813" height="477" alt="Screenshot 2025-07-17 at 4 27 03 a m" src="https://github.com/user-attachments/assets/37eb2b4e-5777-40fd-b79c-fdf799928712" />



# 📋 QA

Right now there is no functionality is just the compose component so just go to `PaymentSchedule.kt` and verify that badges designs matches the new designs from the figma attached above
# Story 📖

[MBL-2636](https://kickstarter.atlassian.net/browse/MBL-2636)


[MBL-2636]: https://kickstarter.atlassian.net/browse/MBL-2636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ