### PR TITLE
MBL-2648: Projects we love needs to be shown when user logged out

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheet.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheet.kt
@@ -108,7 +108,6 @@ fun FilterMenuSheet(
 ) {
     val viewModel = LocalFilterMenuViewModel.current
     val loggedInUser by viewModel.loggedInUser.collectAsStateWithLifecycle()
-    val filteredFilters = if (loggedInUser) availableFilters else availableFilters.filter { it != FilterType.OTHERS }
 
     val projStatus = remember { mutableStateOf(selectedProjectStatus) }
 
@@ -127,7 +126,7 @@ fun FilterMenuSheet(
             )
 
             LazyColumn(modifier = Modifier.weight(1f).testTag(FilterMenuTestTags.LIST)) {
-                items(filteredFilters) { filter ->
+                items(availableFilters) { filter ->
                     when (filter) {
                         FilterType.CATEGORIES -> FilterRow(
                             text = titleForFilter(filter),
@@ -171,6 +170,7 @@ fun FilterMenuSheet(
                             selectedRecommended = selectedRecommended,
                             selectedStarred = selectedSaved,
                             selectedSocial = selectedSocial,
+                            isUserloggedIn = loggedInUser,
                             callbackRecommended = { recommended ->
                                 selectedRecommended.value = recommended
                                 onApply(projStatus.value, selectedRecommended.value, selectedProjectsLoved.value, selectedSaved.value, selectedSocial.value, null)
@@ -231,6 +231,7 @@ private fun OtherFiltersRow(
     callbackSocial: (Boolean) -> Unit = {},
     selectedRecommended: MutableState<Boolean> = mutableStateOf(false),
     callbackRecommended: (Boolean) -> Unit = {},
+    isUserloggedIn: Boolean,
 ) {
     val backgroundDisabledColor = colors.backgroundDisabled
     val dimensions: KSDimensions = KSTheme.dimensions
@@ -262,28 +263,30 @@ private fun OtherFiltersRow(
                 color = colors.textPrimary
             )
 
-            Row(
-                modifier = Modifier.testTag(DiscoveryParams::recommended.name),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
-            ) {
-                Text(
-                    modifier = Modifier
-                        .weight(1f),
-                    text = stringResource(R.string.Recommended),
-                    style = typographyV2.bodyMD,
-                    color = colors.textSecondary
-                )
+            if (isUserloggedIn) {
+                Row(
+                    modifier = Modifier.testTag(DiscoveryParams::recommended.name),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
+                ) {
+                    Text(
+                        modifier = Modifier
+                            .weight(1f),
+                        text = stringResource(R.string.Recommended),
+                        style = typographyV2.bodyMD,
+                        color = colors.textSecondary
+                    )
 
-                KSSwitch(
-                    modifier = Modifier.testTag(switchTag(DiscoveryParams::recommended.name)),
-                    checked = selectedRecommended.value,
-                    onCheckChanged = {
-                        selectedRecommended.value = it
-                        if (it)
-                            callbackRecommended(it)
-                    }
-                )
+                    KSSwitch(
+                        modifier = Modifier.testTag(switchTag(DiscoveryParams::recommended.name)),
+                        checked = selectedRecommended.value,
+                        onCheckChanged = {
+                            selectedRecommended.value = it
+                            if (it)
+                                callbackRecommended(it)
+                        }
+                    )
+                }
             }
             Row(
                 modifier = Modifier.testTag(DiscoveryParams::staffPicks.name),
@@ -307,49 +310,51 @@ private fun OtherFiltersRow(
                     }
                 )
             }
-            Row(
-                modifier = Modifier.testTag(DiscoveryParams::starred.name),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
-            ) {
-                Text(
-                    modifier = Modifier
-                        .weight(1f),
-                    text = stringResource(R.string.Saved_projects),
-                    style = typographyV2.bodyMD,
-                    color = colors.textSecondary
-                )
+            if (isUserloggedIn) {
+                Row(
+                    modifier = Modifier.testTag(DiscoveryParams::starred.name),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
+                ) {
+                    Text(
+                        modifier = Modifier
+                            .weight(1f),
+                        text = stringResource(R.string.Saved_projects),
+                        style = typographyV2.bodyMD,
+                        color = colors.textSecondary
+                    )
 
-                KSSwitch(
-                    modifier = Modifier.testTag(switchTag(DiscoveryParams::starred.name)),
-                    checked = selectedStarred.value,
-                    onCheckChanged = {
-                        selectedStarred.value = it
-                        callbackStarred(it)
-                    }
-                )
-            }
-            Row(
-                modifier = Modifier.testTag(DiscoveryParams::social.name),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
-            ) {
-                Text(
-                    modifier = Modifier
-                        .weight(1f),
-                    text = stringResource(R.string.Following),
-                    style = typographyV2.bodyMD,
-                    color = colors.textSecondary
-                )
+                    KSSwitch(
+                        modifier = Modifier.testTag(switchTag(DiscoveryParams::starred.name)),
+                        checked = selectedStarred.value,
+                        onCheckChanged = {
+                            selectedStarred.value = it
+                            callbackStarred(it)
+                        }
+                    )
+                }
+                Row(
+                    modifier = Modifier.testTag(DiscoveryParams::social.name),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(dimensions.paddingSmall),
+                ) {
+                    Text(
+                        modifier = Modifier
+                            .weight(1f),
+                        text = stringResource(R.string.Following),
+                        style = typographyV2.bodyMD,
+                        color = colors.textSecondary
+                    )
 
-                KSSwitch(
-                    modifier = Modifier.testTag(switchTag(DiscoveryParams::social.name)),
-                    checked = selectedSocial.value.isTrue(),
-                    onCheckChanged = {
-                        selectedSocial.value = it
-                        callbackSocial(it)
-                    }
-                )
+                    KSSwitch(
+                        modifier = Modifier.testTag(switchTag(DiscoveryParams::social.name)),
+                        checked = selectedSocial.value.isTrue(),
+                        onCheckChanged = {
+                            selectedSocial.value = it
+                            callbackSocial(it)
+                        }
+                    )
+                }
             }
         }
     }
@@ -543,7 +548,8 @@ private fun OthersRowPreview() {
     KSTheme {
         OtherFiltersRow(
             modifier = Modifier.background(color = colors.backgroundSurfacePrimary),
-            text = titleForFilter(FilterType.OTHERS)
+            text = titleForFilter(FilterType.OTHERS),
+            isUserloggedIn = true
         )
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchTopBar.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchTopBar.kt
@@ -63,8 +63,34 @@ import io.reactivex.Observable
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun SearchTopBarLocationActiveFilterPreview() {
+    // Mocked user holder
+    val mockUser = object : CurrentUserTypeV2() {
+        override fun setToken(accessToken: String) {
+        }
+
+        override fun login(newUser: User) {
+        }
+
+        override fun logout() {
+        }
+
+        override val accessToken: String?
+            get() = null
+
+        override fun refresh(freshUser: User) {
+        }
+
+        override fun observable(): Observable<KsOptional<User>> {
+            return Observable.just(KsOptional.empty())
+        }
+
+        override fun getUser(): User? {
+            return null
+        }
+    }
     val env = Environment.builder()
         .apolloClientV2(MockApolloClientV2())
+        .currentUserV2(mockUser)
         .build()
 
     val fakeViewModel = FilterMenuViewModel(environment = env)
@@ -98,8 +124,34 @@ fun SearchTopBarLocationActiveFilterPreview() {
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun SearchTopBarAmountRaisedActiveFilterPreview() {
+    // Mocked user holder
+    val mockUser = object : CurrentUserTypeV2() {
+        override fun setToken(accessToken: String) {
+        }
+
+        override fun login(newUser: User) {
+        }
+
+        override fun logout() {
+        }
+
+        override val accessToken: String?
+            get() = null
+
+        override fun refresh(freshUser: User) {
+        }
+
+        override fun observable(): Observable<KsOptional<User>> {
+            return Observable.just(KsOptional.empty())
+        }
+
+        override fun getUser(): User? {
+            return null
+        }
+    }
     val env = Environment.builder()
         .apolloClientV2(MockApolloClientV2())
+        .currentUserV2(mockUser)
         .build()
 
     val fakeViewModel = FilterMenuViewModel(environment = env)
@@ -131,8 +183,34 @@ fun SearchTopBarAmountRaisedActiveFilterPreview() {
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun SearchTopBarGoalActiveFilterPreview() {
+    // Mocked user holder
+    val mockUser = object : CurrentUserTypeV2() {
+        override fun setToken(accessToken: String) {
+        }
+
+        override fun login(newUser: User) {
+        }
+
+        override fun logout() {
+        }
+
+        override val accessToken: String?
+            get() = null
+
+        override fun refresh(freshUser: User) {
+        }
+
+        override fun observable(): Observable<KsOptional<User>> {
+            return Observable.just(KsOptional.empty())
+        }
+
+        override fun getUser(): User? {
+            return null
+        }
+    }
     val env = Environment.builder()
         .apolloClientV2(MockApolloClientV2())
+        .currentUserV2(mockUser)
         .build()
 
     val fakeViewModel = FilterMenuViewModel(environment = env)
@@ -160,8 +238,34 @@ fun SearchTopBarGoalActiveFilterPreview() {
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun SearchTopBarPercentageRaisedActiveFilterPreview() {
+    // Mocked user holder
+    val mockUser = object : CurrentUserTypeV2() {
+        override fun setToken(accessToken: String) {
+        }
+
+        override fun login(newUser: User) {
+        }
+
+        override fun logout() {
+        }
+
+        override val accessToken: String?
+            get() = null
+
+        override fun refresh(freshUser: User) {
+        }
+
+        override fun observable(): Observable<KsOptional<User>> {
+            return Observable.just(KsOptional.empty())
+        }
+
+        override fun getUser(): User? {
+            return null
+        }
+    }
     val env = Environment.builder()
         .apolloClientV2(MockApolloClientV2())
+        .currentUserV2(mockUser)
         .build()
 
     val fakeViewModel = FilterMenuViewModel(environment = env)
@@ -192,8 +296,34 @@ fun SearchTopBarPercentageRaisedActiveFilterPreview() {
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun SearchTopBarProjectStatusActiveFilterPreview() {
+    // Mocked user holder
+    val mockUser = object : CurrentUserTypeV2() {
+        override fun setToken(accessToken: String) {
+        }
+
+        override fun login(newUser: User) {
+        }
+
+        override fun logout() {
+        }
+
+        override val accessToken: String?
+            get() = null
+
+        override fun refresh(freshUser: User) {
+        }
+
+        override fun observable(): Observable<KsOptional<User>> {
+            return Observable.just(KsOptional.empty())
+        }
+
+        override fun getUser(): User? {
+            return null
+        }
+    }
     val env = Environment.builder()
         .apolloClientV2(MockApolloClientV2())
+        .currentUserV2(mockUser)
         .build()
 
     val fakeViewModel = FilterMenuViewModel(environment = env)
@@ -225,8 +355,34 @@ fun SearchTopBarProjectStatusActiveFilterPreview() {
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun SearchTopBarCategoryActiveFilterPreview() {
+    // Mocked user holder
+    val mockUser = object : CurrentUserTypeV2() {
+        override fun setToken(accessToken: String) {
+        }
+
+        override fun login(newUser: User) {
+        }
+
+        override fun logout() {
+        }
+
+        override val accessToken: String?
+            get() = null
+
+        override fun refresh(freshUser: User) {
+        }
+
+        override fun observable(): Observable<KsOptional<User>> {
+            return Observable.just(KsOptional.empty())
+        }
+
+        override fun getUser(): User? {
+            return null
+        }
+    }
     val env = Environment.builder()
         .apolloClientV2(MockApolloClientV2())
+        .currentUserV2(mockUser)
         .build()
 
     val fakeViewModel = FilterMenuViewModel(environment = env)
@@ -254,8 +410,34 @@ fun SearchTopBarCategoryActiveFilterPreview() {
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun SearchTopBarAllActiveFiltersPreviewLoggedOutUser() {
+    // Mocked user holder
+    val mockUser = object : CurrentUserTypeV2() {
+        override fun setToken(accessToken: String) {
+        }
+
+        override fun login(newUser: User) {
+        }
+
+        override fun logout() {
+        }
+
+        override val accessToken: String?
+            get() = null
+
+        override fun refresh(freshUser: User) {
+        }
+
+        override fun observable(): Observable<KsOptional<User>> {
+            return Observable.just(KsOptional.empty())
+        }
+
+        override fun getUser(): User? {
+            return null
+        }
+    }
     val env = Environment.builder()
         .apolloClientV2(MockApolloClientV2())
+        .currentUserV2(mockUser)
         .build()
 
     val fakeViewModel = FilterMenuViewModel(environment = env)
@@ -646,25 +828,23 @@ fun PillBar(
         )
 
         if (shouldShowPhase) {
-            if (loggedInUser) {
-                KSPillButton(
-                    shouldShowLeadingIcon = true,
-                    modifier = Modifier.testTag(pillTag(FilterRowPillType.PROJECTS_LOVED)),
-                    text = projectsLovedText,
-                    isSelected = projectsLovedStatus.value,
-                    count = selectedFilterCounts.getOrDefault(
-                        FilterRowPillType.PROJECTS_LOVED.name,
-                        0
-                    ),
-                    onClick = {
-                        projectsLovedStatus.value = !projectsLovedStatus.value
-                        onPillPressedShowOnlyToggles(
-                            FilterRowPillType.PROJECTS_LOVED,
-                            projectsLovedStatus.value
-                        )
-                    }
-                )
-            }
+            KSPillButton(
+                shouldShowLeadingIcon = true,
+                modifier = Modifier.testTag(pillTag(FilterRowPillType.PROJECTS_LOVED)),
+                text = projectsLovedText,
+                isSelected = projectsLovedStatus.value,
+                count = selectedFilterCounts.getOrDefault(
+                    FilterRowPillType.PROJECTS_LOVED.name,
+                    0
+                ),
+                onClick = {
+                    projectsLovedStatus.value = !projectsLovedStatus.value
+                    onPillPressedShowOnlyToggles(
+                        FilterRowPillType.PROJECTS_LOVED,
+                        projectsLovedStatus.value
+                    )
+                }
+            )
             KSPillButton(
                 shouldShowTrailingIcon = true,
                 modifier = Modifier.testTag(pillTag(FilterRowPillType.GOAL)),

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/FilterMenuSheetTest.kt
@@ -95,6 +95,42 @@ class FilterMenuSheetTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun `test FilterMenuSheet renders all options within OthersRow when logged out user`() {
+
+        val env = environment()
+            .toBuilder()
+            .currentUserV2(MockCurrentUserV2())
+            .build()
+        val fakeViewModel = FilterMenuViewModel(env)
+        composeTestRule.setContent {
+            KSTheme {
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    Surface {
+                        FilterMenuSheet()
+                    }
+                }
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(FilterMenuTestTags.LIST)
+            .performScrollToNode(hasTestTag(FilterMenuTestTags.OTHERS_ROW))
+        composeTestRule.onNodeWithText(context.resources.getString(R.string.Show_only)).assertIsDisplayed()
+
+        // Recommended
+        composeTestRule.onNodeWithTag(DiscoveryParams::recommended.name).assertDoesNotExist()
+
+        // Projects we love is displayed with logged off user
+        composeTestRule.onNodeWithTag(DiscoveryParams::staffPicks.name).assertIsDisplayed()
+
+        // Saved
+        composeTestRule.onNodeWithTag(DiscoveryParams::starred.name).assertDoesNotExist()
+
+        // Social
+        composeTestRule.onNodeWithTag(DiscoveryParams::social.name).assertDoesNotExist()
+    }
+
+    @Test
     fun `test FilterMenuSheet renders all available filter Rows with ffOff`() {
         val shouldShowPhase = false
         val env = environment()

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchTopBarTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchTopBarTest.kt
@@ -148,7 +148,7 @@ class SearchTopBarTest : KSRobolectricTestCase() {
         composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.AMOUNT_RAISED)).assertExists() // exists instead of display to avoid having to scroll
         composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.FILTER)).assertIsDisplayed()
         composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.RECOMMENDED)).assertDoesNotExist()
-        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.PROJECTS_LOVED)).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.PROJECTS_LOVED)).assertExists()
         composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.SAVED)).assertDoesNotExist()
         composeTestRule.onNodeWithTag(pillTag(FilterRowPillType.FOLLOWING)).assertDoesNotExist()
     }


### PR DESCRIPTION
# 📲 What

- Projects we love should be visible when the user is logged out.

# 👀 See

https://github.com/user-attachments/assets/b0ae4555-a4bd-4ae4-b7e5-0556b6560434


| --- | --- |
|  |  |

# 📋 QA

- logout for the app or fresh install, go to search, you should see the projects we love pillBar and on the filter menu -> show only section the toggle should be available

# Story 📖

[MBL-2648](https://kickstarter.atlassian.net/browse/MBL-2648)


[MBL-2648]: https://kickstarter.atlassian.net/browse/MBL-2648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ