### PR TITLE
MBL-2671:  Android16 Glide not loading images

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -21,10 +21,20 @@ import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.Target
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.R
+import com.kickstarter.libs.utils.WebUtils
+import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.libs.utils.extensions.isKSApplication
 
 const val header = "User-Agent"
-fun ImageView.loadCircleImage(url: String?, userAgent: String = "") {
+const val ua = "Custom-UA"
+
+fun userAgent(context: Context) = if (context.applicationContext.isKSApplication()) {
+    val build = requireNotNull(context.applicationContext.getEnvironment()?.build())
+    WebUtils.userAgent(build)
+} else ua
+
+fun ImageView.loadCircleImage(url: String?) {
+
     url?.let {
         try {
             if (it.isBlank()) { // - load with drawable
@@ -36,7 +46,7 @@ fun ImageView.loadCircleImage(url: String?, userAgent: String = "") {
                 val glideUrl = GlideUrl(
                     it,
                     LazyHeaders.Builder()
-                        .addHeader(header, userAgent)
+                        .addHeader(header, userAgent(context))
                         .build()
                 )
                 Glide.with(context)
@@ -55,13 +65,13 @@ fun ImageView.loadCircleImage(url: String?, userAgent: String = "") {
     }
 }
 
-fun ImageView.loadImage(url: String?, userAgent: String = "") {
+fun ImageView.loadImage(url: String?) {
     url?.let {
         try {
             val glideUrl = GlideUrl(
                 it,
                 LazyHeaders.Builder()
-                    .addHeader(header, userAgent)
+                    .addHeader(header, userAgent(context))
                     .build()
             )
             Glide.with(context)
@@ -81,15 +91,14 @@ fun ImageView.loadImageWithResize(
     url: String?,
     targetImageWidth: Int,
     targetImageHeight: Int,
-    placeholder: Drawable,
-    userAgent: String = ""
+    placeholder: Drawable
 ) {
     url?.let {
         try {
             val glideUrl = GlideUrl(
                 it,
                 LazyHeaders.Builder()
-                    .addHeader(header, userAgent)
+                    .addHeader(header, userAgent(context))
                     .build()
             )
             Glide.with(context)
@@ -106,7 +115,7 @@ fun ImageView.loadImageWithResize(
         }
     }
 }
-fun ImageView.loadImage(url: String?, context: Context, imageZoomablePlaceholder: AppCompatImageView? = null, userAgent: String = "") {
+fun ImageView.loadImage(url: String?, context: Context, imageZoomablePlaceholder: AppCompatImageView? = null) {
     url?.let {
         val targetView = this
         if (context.applicationContext.isKSApplication()) {
@@ -114,7 +123,7 @@ fun ImageView.loadImage(url: String?, context: Context, imageZoomablePlaceholder
                 val glideUrl = GlideUrl(
                     it,
                     LazyHeaders.Builder()
-                        .addHeader(header, userAgent)
+                        .addHeader(header, userAgent(context))
                         .build()
                 )
                 Glide.with(context)
@@ -157,13 +166,13 @@ fun ImageView.loadImage(url: String?, context: Context, imageZoomablePlaceholder
     }
 }
 
-fun ImageView.loadWebp(url: String?, context: Context, userAgent: String = "") {
+fun ImageView.loadWebp(url: String?, context: Context) {
     url?.let {
         try {
             val glideUrl = GlideUrl(
                 it,
                 LazyHeaders.Builder()
-                    .addHeader(header, userAgent)
+                    .addHeader(header, userAgent(context))
                     .build()
             )
             val roundedCorners = RoundedCorners(1)
@@ -183,14 +192,14 @@ fun ImageView.loadWebp(url: String?, context: Context, userAgent: String = "") {
     }
 }
 
-fun ImageView.loadGifImage(url: String?, context: Context, userAgent: String = "") {
+fun ImageView.loadGifImage(url: String?, context: Context) {
     url?.let {
         if (context.applicationContext.isKSApplication()) {
             try {
                 val glideUrl = GlideUrl(
                     it,
                     LazyHeaders.Builder()
-                        .addHeader(header, userAgent)
+                        .addHeader(header, userAgent(context))
                         .build()
                 )
                 Glide.with(context)

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -21,8 +21,6 @@ import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.Target
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.R
-import com.kickstarter.libs.Build
-import com.kickstarter.libs.utils.WebUtils
 import com.kickstarter.libs.utils.extensions.isKSApplication
 
 const val header = "User-Agent"

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -12,6 +12,8 @@ import com.bumptech.glide.integration.webp.decoder.WebpDrawable
 import com.bumptech.glide.integration.webp.decoder.WebpDrawableTransformation
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.load.model.GlideUrl
+import com.bumptech.glide.load.model.LazyHeaders
 import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.request.RequestListener
@@ -19,9 +21,12 @@ import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.Target
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.R
+import com.kickstarter.libs.Build
+import com.kickstarter.libs.utils.WebUtils
 import com.kickstarter.libs.utils.extensions.isKSApplication
 
-fun ImageView.loadCircleImage(url: String?) {
+const val header = "User-Agent"
+fun ImageView.loadCircleImage(url: String?, userAgent: String = "") {
     url?.let {
         try {
             if (it.isBlank()) { // - load with drawable
@@ -30,8 +35,14 @@ fun ImageView.loadCircleImage(url: String?) {
                     .circleCrop()
                     .into(this)
             } else { // - load with url string
+                val glideUrl = GlideUrl(
+                    it,
+                    LazyHeaders.Builder()
+                        .addHeader(header, userAgent)
+                        .build()
+                )
                 Glide.with(context)
-                    .load(it)
+                    .load(glideUrl)
                     .placeholder(ColorDrawable(Color.TRANSPARENT))
                     .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                     .circleCrop()
@@ -46,11 +57,17 @@ fun ImageView.loadCircleImage(url: String?) {
     }
 }
 
-fun ImageView.loadImage(url: String?) {
+fun ImageView.loadImage(url: String?, userAgent: String = "") {
     url?.let {
         try {
+            val glideUrl = GlideUrl(
+                it,
+                LazyHeaders.Builder()
+                    .addHeader(header, userAgent)
+                    .build()
+            )
             Glide.with(context)
-                .load(url)
+                .load(glideUrl)
                 .placeholder(ColorDrawable(Color.TRANSPARENT))
                 .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                 .into(this)
@@ -66,12 +83,19 @@ fun ImageView.loadImageWithResize(
     url: String?,
     targetImageWidth: Int,
     targetImageHeight: Int,
-    placeholder: Drawable
+    placeholder: Drawable,
+    userAgent: String = ""
 ) {
     url?.let {
         try {
+            val glideUrl = GlideUrl(
+                it,
+                LazyHeaders.Builder()
+                    .addHeader(header, userAgent)
+                    .build()
+            )
             Glide.with(context)
-                .load(url)
+                .load(glideUrl)
                 .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                 .apply(RequestOptions().override(targetImageWidth, targetImageHeight))
                 .centerCrop()
@@ -84,13 +108,19 @@ fun ImageView.loadImageWithResize(
         }
     }
 }
-fun ImageView.loadImage(url: String?, context: Context, imageZoomablePlaceholder: AppCompatImageView? = null) {
+fun ImageView.loadImage(url: String?, context: Context, imageZoomablePlaceholder: AppCompatImageView? = null, userAgent: String = "") {
     url?.let {
         val targetView = this
         if (context.applicationContext.isKSApplication()) {
             try {
+                val glideUrl = GlideUrl(
+                    it,
+                    LazyHeaders.Builder()
+                        .addHeader(header, userAgent)
+                        .build()
+                )
                 Glide.with(context)
-                    .load(url)
+                    .load(glideUrl)
                     .listener(object : RequestListener<Drawable> {
                         override fun onResourceReady(
                             resource: Drawable,
@@ -129,12 +159,18 @@ fun ImageView.loadImage(url: String?, context: Context, imageZoomablePlaceholder
     }
 }
 
-fun ImageView.loadWebp(url: String?, context: Context) {
+fun ImageView.loadWebp(url: String?, context: Context, userAgent: String = "") {
     url?.let {
         try {
+            val glideUrl = GlideUrl(
+                it,
+                LazyHeaders.Builder()
+                    .addHeader(header, userAgent)
+                    .build()
+            )
             val roundedCorners = RoundedCorners(1)
             Glide.with(this)
-                .load(it)
+                .load(glideUrl)
                 .downsample(DownsampleStrategy.AT_LEAST)
                 .override(Resources.getSystem().displayMetrics.widthPixels, Resources.getSystem().displayMetrics.heightPixels)
                 .optionalTransform(roundedCorners)
@@ -149,13 +185,19 @@ fun ImageView.loadWebp(url: String?, context: Context) {
     }
 }
 
-fun ImageView.loadGifImage(url: String?, context: Context) {
+fun ImageView.loadGifImage(url: String?, context: Context, userAgent: String = "") {
     url?.let {
         if (context.applicationContext.isKSApplication()) {
             try {
+                val glideUrl = GlideUrl(
+                    it,
+                    LazyHeaders.Builder()
+                        .addHeader(header, userAgent)
+                        .build()
+                )
                 Glide.with(context)
                     .asGif()
-                    .load(it)
+                    .load(glideUrl)
                     .downsample(DownsampleStrategy.AT_LEAST)
                     .override(Resources.getSystem().displayMetrics.widthPixels, Resources.getSystem().displayMetrics.heightPixels)
                     .diskCacheStrategy(DiskCacheStrategy.AUTOMATIC)

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectCardViewHolder.kt
@@ -17,7 +17,6 @@ import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.DateTimeUtils
 import com.kickstarter.libs.utils.SocialUtils
 import com.kickstarter.libs.utils.ViewUtils
-import com.kickstarter.libs.utils.WebUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.deadlineCountdownDetail
 import com.kickstarter.libs.utils.extensions.isProjectNamePunctuated
@@ -160,9 +159,7 @@ class ProjectCardViewHolder(
 
         viewModel.outputs.photoUrl()
             .compose(Transformers.observeForUIV2())
-            .subscribe {
-                resizeProjectImage(it, WebUtils.userAgent(build))
-            }
+            .subscribe { resizeProjectImage(it) }
             .addToDisposable(disposables)
 
         viewModel.outputs.projectCanceledAt()
@@ -318,7 +315,7 @@ class ProjectCardViewHolder(
         binding.nameAndBlurbTextView.text = styledString
     }
 
-    private fun resizeProjectImage(avatarUrl: String?, userAgent: String) {
+    private fun resizeProjectImage(avatarUrl: String?) {
         val targetImageWidth = getProjectImageWidth()
         val targetImageHeight = photoHeightFromWidthRatio(targetImageWidth)
 
@@ -326,7 +323,7 @@ class ProjectCardViewHolder(
         avatarUrl?.let {
             ResourcesCompat.getDrawable(context().resources, R.drawable.gray_gradient, null)
                 ?.let { placeholder ->
-                    binding.projectCardPhoto.photo.loadImageWithResize(it, targetImageWidth, targetImageHeight, placeholder, userAgent = userAgent)
+                    binding.projectCardPhoto.photo.loadImageWithResize(it, targetImageWidth, targetImageHeight, placeholder)
                 }
         }
     }

--- a/app/src/main/java/com/kickstarter/ui/viewholders/ProjectCardViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/ProjectCardViewHolder.kt
@@ -17,6 +17,7 @@ import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.DateTimeUtils
 import com.kickstarter.libs.utils.SocialUtils
 import com.kickstarter.libs.utils.ViewUtils
+import com.kickstarter.libs.utils.WebUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.deadlineCountdownDetail
 import com.kickstarter.libs.utils.extensions.isProjectNamePunctuated
@@ -35,6 +36,7 @@ class ProjectCardViewHolder(
 ) : KSViewHolder(binding.root) {
     private val viewModel = ProjectCardHolderViewModel.ViewModel()
     private val ksString = requireNotNull(environment().ksString())
+    private val build = requireNotNull(environment().build())
     private val disposables = CompositeDisposable()
 
     interface Delegate {
@@ -158,7 +160,9 @@ class ProjectCardViewHolder(
 
         viewModel.outputs.photoUrl()
             .compose(Transformers.observeForUIV2())
-            .subscribe { resizeProjectImage(it) }
+            .subscribe {
+                resizeProjectImage(it, WebUtils.userAgent(build))
+            }
             .addToDisposable(disposables)
 
         viewModel.outputs.projectCanceledAt()
@@ -314,7 +318,7 @@ class ProjectCardViewHolder(
         binding.nameAndBlurbTextView.text = styledString
     }
 
-    private fun resizeProjectImage(avatarUrl: String?) {
+    private fun resizeProjectImage(avatarUrl: String?, userAgent: String) {
         val targetImageWidth = getProjectImageWidth()
         val targetImageHeight = photoHeightFromWidthRatio(targetImageWidth)
 
@@ -322,7 +326,7 @@ class ProjectCardViewHolder(
         avatarUrl?.let {
             ResourcesCompat.getDrawable(context().resources, R.drawable.gray_gradient, null)
                 ?.let { placeholder ->
-                    binding.projectCardPhoto.photo.loadImageWithResize(it, targetImageWidth, targetImageHeight, placeholder)
+                    binding.projectCardPhoto.photo.loadImageWithResize(it, targetImageWidth, targetImageHeight, placeholder, userAgent = userAgent)
                 }
         }
     }


### PR DESCRIPTION
# 📲 What

- On android 16 devices, Glide seems to require the header userAgent to load images 

# 🤔 Why

- Images not loading on Android 16 devices

# 🛠 How
- Added a lazyHeader containing the custom user agent we use for the apps

# 👀 See

| Before 🐛 | 


https://github.com/user-attachments/assets/8cf089aa-6b34-40f9-88ef-2c2619e36206




| After 🦋 |


https://github.com/user-attachments/assets/7c5c4fbf-3574-40b4-b97e-d08ef26f1420



| --- | --- |
|  |  |

# 📋 QA

- You need an android 16 device, or a simulator, then just open the app, images with this branch should load again without issues

# Story 📖

[MBL-2671](https://kickstarter.atlassian.net/browse/MBL-2671)


[MBL-2671]: https://kickstarter.atlassian.net/browse/MBL-2671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ