### PR TITLE
MBL-2675: Android16 exoplayer videoplayer not loading video url's

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ContextExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ContextExt.kt
@@ -21,8 +21,8 @@ import com.stripe.android.paymentsheet.PaymentSheet
 const val header = "User-Agent"
 const val ua = "Custom-UA"
 
-fun userAgent(context: Context) = if (context.applicationContext.isKSApplication()) {
-    val build = requireNotNull(context.applicationContext.getEnvironment()?.build())
+fun Context.userAgent() = if (this.applicationContext.isKSApplication()) {
+    val build = requireNotNull(this.applicationContext.getEnvironment()?.build())
     WebUtils.userAgent(build)
 } else ua
 

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ContextExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ContextExt.kt
@@ -13,9 +13,18 @@ import com.kickstarter.KSApplication
 import com.kickstarter.R
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.featureflag.FlagKey
+import com.kickstarter.libs.utils.WebUtils
 import com.kickstarter.ui.SharedPreferenceKey
 import com.kickstarter.ui.activities.AppThemes
 import com.stripe.android.paymentsheet.PaymentSheet
+
+const val header = "User-Agent"
+const val ua = "Custom-UA"
+
+fun userAgent(context: Context) = if (context.applicationContext.isKSApplication()) {
+    val build = requireNotNull(context.applicationContext.getEnvironment()?.build())
+    WebUtils.userAgent(build)
+} else ua
 
 fun Context.isKSApplication() = (this is KSApplication) && !this.isInUnitTests
 

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -38,7 +38,7 @@ fun ImageView.loadCircleImage(url: String?) {
                 val glideUrl = GlideUrl(
                     it,
                     LazyHeaders.Builder()
-                        .addHeader(header, userAgent(context))
+                        .addHeader(header, context.userAgent())
                         .build()
                 )
                 Glide.with(context)
@@ -63,7 +63,7 @@ fun ImageView.loadImage(url: String?) {
             val glideUrl = GlideUrl(
                 it,
                 LazyHeaders.Builder()
-                    .addHeader(header, userAgent(context))
+                    .addHeader(header, context.userAgent())
                     .build()
             )
             Glide.with(context)
@@ -90,7 +90,7 @@ fun ImageView.loadImageWithResize(
             val glideUrl = GlideUrl(
                 it,
                 LazyHeaders.Builder()
-                    .addHeader(header, userAgent(context))
+                    .addHeader(header, context.userAgent())
                     .build()
             )
             Glide.with(context)
@@ -115,7 +115,7 @@ fun ImageView.loadImage(url: String?, context: Context, imageZoomablePlaceholder
                 val glideUrl = GlideUrl(
                     it,
                     LazyHeaders.Builder()
-                        .addHeader(header, userAgent(context))
+                        .addHeader(header, context.userAgent())
                         .build()
                 )
                 Glide.with(context)
@@ -164,7 +164,7 @@ fun ImageView.loadWebp(url: String?, context: Context) {
             val glideUrl = GlideUrl(
                 it,
                 LazyHeaders.Builder()
-                    .addHeader(header, userAgent(context))
+                    .addHeader(header, context.userAgent())
                     .build()
             )
             val roundedCorners = RoundedCorners(1)
@@ -191,7 +191,7 @@ fun ImageView.loadGifImage(url: String?, context: Context) {
                 val glideUrl = GlideUrl(
                     it,
                     LazyHeaders.Builder()
-                        .addHeader(header, userAgent(context))
+                        .addHeader(header, context.userAgent())
                         .build()
                 )
                 Glide.with(context)

--- a/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
+++ b/app/src/main/java/com/kickstarter/ui/extensions/ImageViewExt.kt
@@ -21,17 +21,9 @@ import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.Target
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.R
-import com.kickstarter.libs.utils.WebUtils
-import com.kickstarter.libs.utils.extensions.getEnvironment
+import com.kickstarter.libs.utils.extensions.header
 import com.kickstarter.libs.utils.extensions.isKSApplication
-
-const val header = "User-Agent"
-const val ua = "Custom-UA"
-
-fun userAgent(context: Context) = if (context.applicationContext.isKSApplication()) {
-    val build = requireNotNull(context.applicationContext.getEnvironment()?.build())
-    WebUtils.userAgent(build)
-} else ua
+import com.kickstarter.libs.utils.extensions.userAgent
 
 fun ImageView.loadCircleImage(url: String?) {
 

--- a/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/VideoElementViewHolder.kt
+++ b/app/src/main/java/com/kickstarter/ui/viewholders/projectcampaign/VideoElementViewHolder.kt
@@ -129,7 +129,7 @@ class VideoElementViewHolder(
 
     private fun getMediaSource(videoUrl: String): MediaSource {
         val headers = mapOf(
-            header to userAgent(context())
+            header to context().userAgent()
         )
 
         val dataSourceFactory = DefaultHttpDataSource.Factory()

--- a/app/src/main/java/com/kickstarter/ui/views/VideoPlayerViewer.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/VideoPlayerViewer.kt
@@ -1,12 +1,12 @@
 package com.kickstarter.ui.views
 
 import android.content.Context
-import android.net.Uri
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.ImageView
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.ExoPlayer
@@ -21,6 +21,8 @@ import com.google.android.exoplayer2.upstream.DefaultHttpDataSource
 import com.google.android.exoplayer2.util.Util
 import com.kickstarter.R
 import com.kickstarter.databinding.VideoPlayerLayoutBinding
+import com.kickstarter.libs.utils.extensions.header
+import com.kickstarter.libs.utils.extensions.userAgent
 import com.kickstarter.ui.data.VideoModelElement
 
 class VideoPlayerViewer @JvmOverloads constructor(
@@ -121,8 +123,14 @@ class VideoPlayerViewer @JvmOverloads constructor(
     }
 
     private fun getMediaSource(videoUrl: String): MediaSource {
+        val headers = mapOf(
+            header to userAgent(context)
+        )
+
         val dataSourceFactory = DefaultHttpDataSource.Factory()
-        val videoUri = Uri.parse(videoUrl)
+            .setDefaultRequestProperties(headers)
+
+        val videoUri = videoUrl.toUri()
         val fileType = Util.inferContentType(videoUri)
 
         return if (fileType == C.TYPE_HLS) {

--- a/app/src/main/java/com/kickstarter/ui/views/VideoPlayerViewer.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/VideoPlayerViewer.kt
@@ -124,7 +124,7 @@ class VideoPlayerViewer @JvmOverloads constructor(
 
     private fun getMediaSource(videoUrl: String): MediaSource {
         val headers = mapOf(
-            header to userAgent(context)
+            header to context.userAgent()
         )
 
         val dataSourceFactory = DefaultHttpDataSource.Factory()


### PR DESCRIPTION
# 📲 What

- Added custom user agent header 

# 🤔 Why

- On Android 16 devices the url fails with an error if no user agent header is found.

# 🛠 How

- Utilizing same extension method as for glide images, moved from `ImageExtension` to `ContextExtension`

# 👀 See
| Before 🐛 |

https://github.com/user-attachments/assets/4b41f8d8-e24d-489c-ac8d-c7cee9a1aed9

| After 🦋 |

https://github.com/user-attachments/assets/5ed9c601-473d-4d1a-b51b-758c15b6c7d6

| --- | --- |
|  |  |

# 📋 QA

- Using an android 16 device play any video on project header or project campaign, do go to full screen in both scenarios

# Story 📖

[MBL-2675](https://kickstarter.atlassian.net/browse/MBL-2675)


[MBL-2675]: https://kickstarter.atlassian.net/browse/MBL-2675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ