### PR TITLE
Mask the KSWebView `userAgentString` on Android 16+

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/StringExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/StringExt.kt
@@ -22,6 +22,8 @@ import javax.crypto.spec.IvParameterSpec
 
 const val MINIMUM_PASSWORD_LENGTH = 6
 
+private val NON_WORD_REGEXP = Pattern.compile("[^\\w]")
+
 fun String.encrypt(secretKey: Key?): String? {
     return try {
         val cipher = Cipher.getInstance("AES/CBC/PKCS7PADDING")
@@ -294,4 +296,12 @@ fun String.createValidUrl(): String {
     return this
 }
 
-private val NON_WORD_REGEXP = Pattern.compile("[^\\w]")
+/*
+ * See https://android-developers.googleblog.com/2024/12/user-agent-reduction-on-android-webview.html
+ * Currently only a _partial_ mask. Consider moving this closer to WebView-related code.
+ */
+fun String.maskUserAgent() =
+    this.replace(
+        Regex("""\(Linux; Android \d+; [^)]+? Build/[^;]+; wv\)"""),
+        "(Linux; Android 10; K; wv)"
+    )

--- a/app/src/main/java/com/kickstarter/ui/views/KSWebView.kt
+++ b/app/src/main/java/com/kickstarter/ui/views/KSWebView.kt
@@ -13,11 +13,11 @@ import com.kickstarter.KSApplication
 import com.kickstarter.databinding.WebViewBinding
 import com.kickstarter.libs.Build
 import com.kickstarter.libs.WebViewJavascriptInterface
+import com.kickstarter.libs.utils.extensions.maskUserAgent
 import com.kickstarter.services.KSWebViewClient
 import com.kickstarter.services.RequestHandler
 import javax.inject.Inject
 
-private const val LOGTAG = "KSWebView"
 class KSWebView@JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -53,6 +53,14 @@ class KSWebView@JvmOverloads constructor(
             binding.internalWebView.settings.javaScriptEnabled = true
             binding.internalWebView.settings.allowFileAccess = false
             binding.internalWebView.settings.domStorageEnabled = true
+
+            // TODO: Replace `36` with `Build.VERSION_CODES.BAKLAVA` after updating `compileSdkVersion`.
+            // TODO: Consider upperbound. See link in `String.maskUserAgent()`.
+            if (android.os.Build.VERSION.SDK_INT >= 36) {
+                binding.internalWebView.settings.apply {
+                    userAgentString = userAgentString.maskUserAgent()
+                }
+            }
 
             this.client.setDelegate(this)
 

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/StringExtKtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/StringExtKtTest.kt
@@ -280,6 +280,31 @@ class StringExtKtTest : KSRobolectricTestCase() {
         assertNull(index)
     }
 
+    @Test
+    fun maskUserAgent() {
+        val ua1 = "Mozilla/5.0 (Linux; Android 16; Pixel 8 Build/BP2A.250705.008; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/138.0.7204.179 Mobile Safari/537.36"
+        val ua2 = "Mozilla/5.0 (Linux; Android 15; SM-S931B Build/AP3A.240905.015.A2; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/127.0.6533.103 Mobile Safari/537.36"
+        val ua3 = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36,gzip(gfe)"
+        val ua4 = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59"
+        val ua5 = "Opera/9.80 (Macintosh; Intel Mac OS X; U; en) Presto/2.2.15 Version/10.00"
+        val ua6 = "Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1"
+        assertEquals(
+            "Mozilla/5.0 (Linux; Android 10; K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/138.0.7204.179 Mobile Safari/537.36",
+            ua1.maskUserAgent()
+        )
+        assertEquals(
+            "Mozilla/5.0 (Linux; Android 10; K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/127.0.6533.103 Mobile Safari/537.36",
+            ua2.maskUserAgent()
+        )
+        assertEquals(
+            "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36,gzip(gfe)",
+            ua3.maskUserAgent()
+        )
+        assertEquals(ua4, ua4.maskUserAgent())
+        assertEquals(ua5, ua5.maskUserAgent())
+        assertEquals(ua6, ua6.maskUserAgent())
+    }
+
     companion object {
         private const val VALID_EMAIL = "hello@kickstarter.com"
         private const val VALID_GIF_URL = "https://i.kickstarter.com/assets/035/272/960/eae68383730822ffe949f3825600a80a_original.gif?origin=ugc-qa&q=92&sig=C1dWB6NvmlwKGw4lty6s4FGU6Dn3rzNv%2F3p%2B4bhSpzk%3D"


### PR DESCRIPTION
# 📲 What

Mask the KSWebView `userAgentString` on Android 16+.

# 🤔 Why

Since around July 27, 2025, KSR hosted assets (among a few other things) started failing to load for requests that included a User-Agent header associated with at least some—if not all—devices running Android 16. By partially masking the User-Agent string, assets successfully load.

# 🛠 How

See [Android Developers Blog: User-Agent Reduction on Android WebView](https://android-developers.googleblog.com/2024/12/user-agent-reduction-on-android-webview.html) for details on the choice of mask.

# 👀 See

### Before 🐛

https://github.com/user-attachments/assets/743a7055-4197-4ba3-a2f4-58671d111544

### After 🦋

https://github.com/user-attachments/assets/855da892-7678-4c4f-97e5-822dc3271e1b

# 📋 QA

On a physical device running Android 16, all pages opened with a KSWebView should load normally, including:
- Project Update
- Creator Bio

# Story 📖

[[MBL-2673] WebViews stopped loading assets on Android 16 - Jira](https://kickstarter.atlassian.net/browse/MBL-2673)


[MBL-2673]: https://kickstarter.atlassian.net/browse/MBL-2673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ