### PR TITLE
no-jira: PPO timeout errors, paging crash, and total alerts bug for hotfix

### DIFF
--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewActivity.kt
@@ -80,7 +80,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                 val ppoUIState by viewModel.ppoUIState.collectAsStateWithLifecycle()
 
                 val lazyListState = rememberLazyListState()
-                val totalAlerts = viewModel.totalAlertsState.collectAsStateWithLifecycle().value
+                val totalAlerts = ppoUIState.totalAlerts
 
                 val ppoCardPagingSource = viewModel.ppoCardsState.collectAsLazyPagingItems()
 
@@ -99,7 +99,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                         lazyColumnListState = lazyListState,
                         errorSnackBarHostState = snackbarHostState,
                         ppoCards = ppoCardPagingSource,
-                        totalAlerts = totalAlerts,
+                        totalAlerts = totalAlerts ?: 0,
                         onAddressConfirmed = { addressID, backingID -> viewModel.confirmAddress(backingID = backingID, addressID = addressID) },
                         onSendMessageClick = { projectName, projectID, ppoCards, totalAlerts, creatorID -> viewModel.onMessageCreatorClicked(projectName = projectName, projectId = projectID, creatorID = creatorID, ppoCards = ppoCards, totalAlerts = totalAlerts) },
                         onProjectPledgeSummaryClick = { projectSlug ->
@@ -115,7 +115,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                         onPrimaryActionButtonClicked = { PPOCard ->
                             when (PPOCard.viewType()) {
                                 PPOCardViewType.AUTHENTICATE_CARD -> {
-                                    env.analytics()?.trackPPOFixPaymentCTAClicked(PPOCard.projectId ?: "", ppoCardPagingSource.itemSnapshotList.items, totalAlerts)
+                                    env.analytics()?.trackPPOFixPaymentCTAClicked(PPOCard.projectId ?: "", ppoCardPagingSource.itemSnapshotList.items, totalAlerts ?: 0)
                                     lifecycleScope.launch {
                                         viewModel.showLoadingState(true)
                                     }
@@ -123,7 +123,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                                 }
 
                                 PPOCardViewType.FIX_PAYMENT -> {
-                                    env.analytics()?.trackPPOFixPaymentCTAClicked(PPOCard.projectId ?: "", ppoCardPagingSource.itemSnapshotList.items, totalAlerts)
+                                    env.analytics()?.trackPPOFixPaymentCTAClicked(PPOCard.projectId ?: "", ppoCardPagingSource.itemSnapshotList.items, totalAlerts ?: 0)
                                     openManagePledge(
                                         PPOCard.projectSlug ?: "",
                                         resultLauncher = startForResult
@@ -131,7 +131,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                                 }
 
                                 PPOCardViewType.OPEN_SURVEY -> {
-                                    env.analytics()?.trackPPOOpenSurveyCTAClicked(PPOCard.projectId ?: "", ppoCardPagingSource.itemSnapshotList.items, totalAlerts, PPOCard.surveyID ?: "")
+                                    env.analytics()?.trackPPOOpenSurveyCTAClicked(PPOCard.projectId ?: "", ppoCardPagingSource.itemSnapshotList.items, totalAlerts ?: 0, PPOCard.surveyID ?: "")
                                     openBackingDetailsWebView(
                                         url = PPOCard.backingDetailsUrl ?: "",
                                         toolbarTitle = R.string.Backing_details,
@@ -140,7 +140,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                                 }
 
                                 PPOCardViewType.PLEDGE_MANAGEMENT -> {
-                                    viewModel.sendFinalizePledgeCTAEvent(PPOCard.projectId ?: "", ppoCardPagingSource.itemSnapshotList.items, totalAlerts)
+                                    viewModel.sendFinalizePledgeCTAEvent(PPOCard.projectId ?: "", ppoCardPagingSource.itemSnapshotList.items, totalAlerts ?: 0)
                                     openBackingDetailsWebView(
                                         url = PPOCard.webviewUrl ?: "",
                                         toolbarTitle = R.string.Pledge_manager,
@@ -157,7 +157,7 @@ class PledgedProjectsOverviewActivity : AppCompatActivity() {
                                 PPOCardViewType.ADDRESS_CONFIRMED,
                                 PPOCardViewType.SURVEY_SUBMITTED_SHIPPABLE,
                                 -> {
-                                    env.analytics()?.trackPPOConfirmAddressEditCTAClicked(PPOCard.projectId ?: "", ppoCardPagingSource.itemSnapshotList.items, totalAlerts)
+                                    env.analytics()?.trackPPOConfirmAddressEditCTAClicked(PPOCard.projectId ?: "", ppoCardPagingSource.itemSnapshotList.items, totalAlerts ?: 0)
                                     openBackingDetailsWebView(
                                         url = PPOCard.backingDetailsUrl ?: "",
                                         toolbarTitle = R.string.Backing_details,

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
@@ -321,17 +321,19 @@ fun PledgedProjectsOverviewScreen(
                         item {
                             if (!totalAlerts.isNullOrZero()) {
                                 Text(
+                                    modifier = Modifier.testTag(PledgedProjectsOverviewScreenTestTag.ALERT_COUNT.name),
                                     text = stringResource(id = R.string.Alerts_count).format("count", totalAlerts.toString()),
                                     style = typographyV2.headingXL,
                                     color = colors.textPrimary
                                 )
+                            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
                             }
                         }
+
 
                         items(
                             count = ppoCards.itemCount
                         ) { index ->
-                            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
 
                             ppoCards[index]?.let { ppoData ->
                                 PPOCardView(
@@ -493,4 +495,5 @@ enum class PledgedProjectsOverviewScreenTestTag {
     BACK_BUTTON,
     INFO_BUTTON,
     BOTTOM_SHEET,
+    ALERT_COUNT
 }

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreen.kt
@@ -326,10 +326,9 @@ fun PledgedProjectsOverviewScreen(
                                     style = typographyV2.headingXL,
                                     color = colors.textPrimary
                                 )
-                            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                                Spacer(modifier = Modifier.height(dimensions.paddingMedium))
                             }
                         }
-
 
                         items(
                             count = ppoCards.itemCount

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
@@ -113,7 +113,7 @@ class PledgedProjectsOverviewViewModel(
     private var isV1Enabled = environment.featureFlagClient()?.getBoolean(FlagKey.ANDROID_PLEDGED_PROJECTS_OVERVIEW) ?: false
     private val currentUser = environment.currentUserV2()
 
-    private var totalAlerts : Int? = null
+    private var totalAlerts: Int? = null
 
     private val mutablePPOUIState = MutableStateFlow(PledgedProjectsOverviewUIState())
     val ppoCardsState: StateFlow<PagingData<PPOCard>> = mutablePpoCards.asStateFlow()

--- a/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModel.kt
@@ -111,7 +111,7 @@ class PledgedProjectsOverviewViewModel(
     private val analyticEvents = requireNotNull(environment.analytics())
     private var isV2Enabled = environment.featureFlagClient()?.getBoolean(FlagKey.ANDROID_PLEDGED_PROJECTS_OVERVIEW_V2) ?: false
     private var isV1Enabled = environment.featureFlagClient()?.getBoolean(FlagKey.ANDROID_PLEDGED_PROJECTS_OVERVIEW) ?: false
-    private val currentUser = environment.currentUserV2()
+    private val currentUser = requireNotNull(environment.currentUserV2())
 
     private var totalAlerts: Int? = null
 
@@ -149,8 +149,8 @@ class PledgedProjectsOverviewViewModel(
     init {
         viewModelScope.launch(ioDispatcher) {
             emitCurrentState(isLoading = true)
-            currentUser?.observable()?.asFlow()
-                ?.collectLatest {
+            currentUser.observable().asFlow()
+                .collectLatest {
                     totalAlerts = it.getValue()?.backingActionCount()
                 }
         }

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/ui/PledgedProjectsOverviewScreenTest.kt
@@ -3,6 +3,7 @@ package com.kickstarter.features.pledgedprojectsoverview.ui
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.onNodeWithTag
@@ -24,6 +25,8 @@ PledgedProjectsOverviewScreenTest : KSRobolectricTestCase() {
         composeTestRule.onNodeWithTag(PledgedProjectsOverviewScreenTestTag.INFO_BUTTON.name)
     private val bottomSheet =
         composeTestRule.onNodeWithTag(PledgedProjectsOverviewScreenTestTag.BOTTOM_SHEET.name)
+    private val alertCount =
+        composeTestRule.onNodeWithTag(PledgedProjectsOverviewScreenTestTag.ALERT_COUNT.name)
     @Test
     fun testBackButtonClick() {
         var backClickedCount = 0
@@ -117,5 +120,68 @@ PledgedProjectsOverviewScreenTest : KSRobolectricTestCase() {
         }
 
         infoButton.assertDoesNotExist()
+    }
+
+    @Test
+    fun `when total alert count 0, should not show alert count in header`() {
+        composeTestRule.setContent {
+            val ppoCardList = (0..10).map {
+                PPOCardFactory.confirmAddressCard()
+            }
+            val ppoCardPagingList = flowOf(PagingData.from(ppoCardList)).collectAsLazyPagingItems()
+
+            KSTheme {
+                PledgedProjectsOverviewScreen(
+                    modifier = Modifier,
+                    onBackPressed = { },
+                    lazyColumnListState = rememberLazyListState(),
+                    ppoCards = ppoCardPagingList,
+                    errorSnackBarHostState = SnackbarHostState(),
+                    onSendMessageClick = { _, _, _, _, _ -> },
+                    onAddressConfirmed = { _, _ -> },
+                    onRewardReceivedChanged = { _, _ -> },
+                    onProjectPledgeSummaryClick = { _ -> },
+                    onSeeAllBackedProjectsClick = {},
+                    onPrimaryActionButtonClicked = {},
+                    onSecondaryActionButtonClicked = {},
+                    totalAlerts = 0,
+                    v2Enabled = false
+                )
+            }
+        }
+
+        alertCount.assertDoesNotExist()
+    }
+
+    @Test
+    fun `when total alert count more than 0, should show alert count in header`() {
+        composeTestRule.setContent {
+            val ppoCardList = (0..10).map {
+                PPOCardFactory.confirmAddressCard()
+            }
+            val ppoCardPagingList = flowOf(PagingData.from(ppoCardList)).collectAsLazyPagingItems()
+
+            KSTheme {
+                PledgedProjectsOverviewScreen(
+                    modifier = Modifier,
+                    onBackPressed = { },
+                    lazyColumnListState = rememberLazyListState(),
+                    ppoCards = ppoCardPagingList,
+                    errorSnackBarHostState = SnackbarHostState(),
+                    onSendMessageClick = { _, _, _, _, _ -> },
+                    onAddressConfirmed = { _, _ -> },
+                    onRewardReceivedChanged = { _, _ -> },
+                    onProjectPledgeSummaryClick = { _ -> },
+                    onSeeAllBackedProjectsClick = {},
+                    onPrimaryActionButtonClicked = {},
+                    onSecondaryActionButtonClicked = {},
+                    totalAlerts = 10,
+                    v2Enabled = false
+                )
+            }
+        }
+
+        alertCount.assertExists()
+        alertCount.assertIsDisplayed()
     }
 }

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
@@ -432,7 +432,6 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
             )
         }
 
-
 // TODO will add tests back after spike MBL-1638 completed
 //    @Test
 //    fun `emits_error_state_when_errored`() =

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import kotlin.properties.Delegates.observable
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
@@ -315,7 +316,6 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
             val pagingSource = PledgedProjectsPagingSource(
                 mockApolloClientV2,
                 AnalyticEvents(listOf(trackingClient)),
-                mutableTotalAlerts,
                 tierTypes = listOf(),
             )
 
@@ -339,8 +339,6 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
     @Test
     fun `pager result returns list network call is successful`() {
         runTest {
-            val mutableTotalAlerts = MutableStateFlow<Int>(0)
-            val totalAlertsList = mutableListOf<Int>()
             val user = UserFactory.user()
             val trackingClient = MockTrackingClient(
                 MockCurrentUserV2(user),
@@ -364,7 +362,6 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
             val pagingSource = PledgedProjectsPagingSource(
                 mockApolloClientV2,
                 AnalyticEvents(listOf(trackingClient)),
-                mutableTotalAlerts,
                 tierTypes = listOf()
             )
 
@@ -373,10 +370,6 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
                 environment = environment()
             )
                 .create(PledgedProjectsOverviewViewModel::class.java)
-
-            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-                mutableTotalAlerts.toList(totalAlertsList)
-            }
 
             val pager = TestPager(
                 PagingConfig(
@@ -393,11 +386,6 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
 
             val page = pager.getLastLoadedPage()
             assert(page?.data?.size == 1)
-
-            assertEquals(
-                totalAlertsList,
-                listOf(0, 10)
-            )
 
             segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
             subscription.dispose()
@@ -419,6 +407,31 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
             segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
         }
     }
+
+    @Test
+    fun `emits correct total alert count from user object when available`() =
+        runTest {
+            val currentUserV2 = UserFactory.user().toBuilder().backingActionCount(8).build()
+            val viewModel = PledgedProjectsOverviewViewModel.Factory(
+                ioDispatcher = UnconfinedTestDispatcher(testScheduler),
+                environment = environment().toBuilder()
+                    .currentUserV2(MockCurrentUserV2(currentUserV2)).build()
+            ).create(PledgedProjectsOverviewViewModel::class.java)
+
+            val uiState = mutableListOf<PledgedProjectsOverviewUIState>()
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.ppoUIState.toList(uiState)
+            }
+
+            assertEquals(
+                uiState,
+                listOf(
+                    PledgedProjectsOverviewUIState(isLoading = false, isErrored = false, totalAlerts = null),
+                    PledgedProjectsOverviewUIState(isLoading = false, isErrored = false, totalAlerts = 8),
+                )
+            )
+        }
+
 
 // TODO will add tests back after spike MBL-1638 completed
 //    @Test


### PR DESCRIPTION
# 📲 What

1. The PPO query was taking a long time, and would timeout after 10 seconds, causing the page to show an error. 
2. [Firebase showing a crash for the paging 3 library](https://console.firebase.google.com/u/1/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/5526eaecfe0ff800288b2cd9275387a8?time=last-seven-days&types=crash&sessionEventKey=68AF33BA02150001485D4A17B253CE50_2121752419153019001)
3. Total alerts in the header was displaying the incorrect number

# 🛠 How

1. Changed the ppo page size from 25 to 10, making the call run much faster (<half the time)
2. Added the `cachedIn(viewModelScope)` to the pledged projects overview paging flow
3. Changed the value we display from `totalAlerts` on the ppo query, to `backingActionsCount` on the user object. hide count when user has no tier 1 alerts

# 👀 See

1 Alert:
<img width="252" height="546" alt="Screenshot_20250827_133418" src="https://github.com/user-attachments/assets/adafca20-4f53-45c6-a871-392ccf0481ed" />

No Alerts: 
<img width="252" height="546" alt="Screenshot_20250827_130752" src="https://github.com/user-attachments/assets/659f1da6-42dc-40b2-9d1a-debdad86382c" />

# 📋 QA

1. Open backings dashboard. Paginate, pull to refresh, reload the page, scroll down a few pages. Make sure there are no errors or timeouts
2. Couldnt reproduce the crash, but if you could, then please make sure the crash is no longer happening
3. Make sure the "Alerts()" displayed at the top of the screen is reflective of all tier 1 alerts

# Story 📖

no-jira
