### PR TITLE
MBL-2727 Refactor onboarding flow tests to avoid calling Thread.sleep()

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/SystemClock.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/SystemClock.kt
@@ -1,0 +1,22 @@
+package com.kickstarter.libs.utils
+
+/**
+ * An injectable clock interface with two implementations - SystemClock and FakeClock.
+ * The real SystemClock is used in code to avoid hardcoding System.currentTimeMillis().
+ * The FakeClock is injected in tests and can be used to advance the time manually using the
+ * advanceBy() method. Use this FakeClock instead of calling Thread.sleep() which slows tests down.
+ */
+
+fun interface Clock {
+    fun now(): Long
+}
+
+object SystemClock : Clock {
+    override fun now(): Long = System.currentTimeMillis()
+}
+
+class FakeClock(start: Long = 0L) : Clock {
+    private var current = start
+    override fun now(): Long = current
+    fun advanceBy(millis: Long) { current += millis }
+}

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/OnboardingFlowScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/OnboardingFlowScreen.kt
@@ -234,7 +234,6 @@ fun OnboardingScreen(
                 KSPrimaryBlackButton(
                     text = filteredPages[currentPage].buttonText,
                     onClickAction = {
-
                         val currentTime = clock.now()
                         if (currentTime - lastClickTime > debounceInterval) {
                             lastClickTime = currentTime

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/OnboardingFlowScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/OnboardingFlowScreen.kt
@@ -52,9 +52,11 @@ import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.kickstarter.R
 import com.kickstarter.libs.AnalyticEvents
+import com.kickstarter.libs.utils.Clock
 import com.kickstarter.libs.utils.EventContextValues.ContextSectionName.ACTIVITY_TRACKING_PROMPT
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.ALLOW
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.DENY
+import com.kickstarter.libs.utils.SystemClock
 import com.kickstarter.ui.compose.designsystem.KSButton
 import com.kickstarter.ui.compose.designsystem.KSButtonType
 import com.kickstarter.ui.compose.designsystem.KSIconButton
@@ -99,6 +101,7 @@ fun OnboardingScreenPreview() {
 
 @Composable
 fun OnboardingScreen(
+    clock: Clock = SystemClock,
     isUserLoggedIn: Boolean = false,
     deviceNeedsNotificationPermissions: Boolean = false,
     onboardingCompleted: () -> Unit = {},
@@ -231,7 +234,8 @@ fun OnboardingScreen(
                 KSPrimaryBlackButton(
                     text = filteredPages[currentPage].buttonText,
                     onClickAction = {
-                        val currentTime = System.currentTimeMillis()
+
+                        val currentTime = clock.now()
                         if (currentTime - lastClickTime > debounceInterval) {
                             lastClickTime = currentTime
 

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/OnboardingFlowScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/OnboardingFlowScreenTest.kt
@@ -170,9 +170,9 @@ class OnboardingFlowScreenTest : KSRobolectricTestCase() {
 
         primaryButton.performClick() // Welcome -> Save
         fakeClock.advanceBy(600)
-        primaryButton.performClick() // Save -> Notifications
+        primaryButton.performClick() // Save -> Activity Tracking
         fakeClock.advanceBy(600)
-        secondaryButton.performClick() // Notifications -> Activity Tracking
+        secondaryButton.performClick() // Activity Tracking -> Notifications
         fakeClock.advanceBy(600)
 
         pageTitle.assertIsDisplayed()
@@ -195,11 +195,11 @@ class OnboardingFlowScreenTest : KSRobolectricTestCase() {
 
         primaryButton.performClick() // Welcome -> Save
         fakeClock.advanceBy(600)
-        primaryButton.performClick() // Save -> Notifications
+        primaryButton.performClick() // Save -> Activity Tracking
         fakeClock.advanceBy(600)
-        secondaryButton.performClick() // Notifications -> Activity Tracking
+        secondaryButton.performClick() // Activity Tracking -> Notifications
         fakeClock.advanceBy(600)
-        secondaryButton.performClick() // Activity Tracking -> Login/Signup
+        secondaryButton.performClick() // Notifications -> Login/Signup
         fakeClock.advanceBy(600)
 
         pageTitle.assertIsDisplayed()
@@ -220,14 +220,13 @@ class OnboardingFlowScreenTest : KSRobolectricTestCase() {
     fun `Test activity tracking page secondary button click navigates to Discovery page if user is already logged in`() {
         setupOnboardingScreen(isUserLoggedIn = true)
 
-        // Navigate to Notifications Page (Welcome -> Save -> Notifications)
         primaryButton.performClick() // Welcome -> Save
         fakeClock.advanceBy(600)
-        primaryButton.performClick() // Save -> Notifications
+        primaryButton.performClick() // Save -> Activity Tracking
         fakeClock.advanceBy(600)
-        secondaryButton.performClick() // Notifications -> Activity Tracking
+        secondaryButton.performClick() // Activity Tracking -> Notifications
         fakeClock.advanceBy(600)
-        secondaryButton.performClick() // Activity Tracking -> Login/Signup
+        secondaryButton.performClick() // Notifications -> Login/Signup
         fakeClock.advanceBy(600)
 
         // Assert that signupOrLogin callback was NOT called

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/OnboardingFlowScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/OnboardingFlowScreenTest.kt
@@ -226,7 +226,7 @@ class OnboardingFlowScreenTest : KSRobolectricTestCase() {
         fakeClock.advanceBy(600)
         secondaryButton.performClick() // Activity Tracking -> Notifications
         fakeClock.advanceBy(600)
-        secondaryButton.performClick() // Notifications -> Login/Signup
+        secondaryButton.performClick() // Notifications -> Discovery page
         fakeClock.advanceBy(600)
 
         // Assert that signupOrLogin callback was NOT called

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/OnboardingFlowScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/OnboardingFlowScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
+import com.kickstarter.libs.utils.FakeClock
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import org.junit.Test
 
@@ -30,6 +31,8 @@ class OnboardingFlowScreenTest : KSRobolectricTestCase() {
     private var turnOnNotificationsCalled = false
     private var allowTrackingCalled = false
     private var signupOrLoginCalled = false
+
+    private val fakeClock = FakeClock(12345) // Start at some greater than 0 time
 
     private val welcomePageTitleText by lazy { context.getString(R.string.onboarding_welcome_to_kickstarter_title) }
     private val welcomePageDescriptionText by lazy { context.getString(R.string.onboarding_welcome_to_kickstarter_subtitle) }
@@ -64,6 +67,7 @@ class OnboardingFlowScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 OnboardingScreen(
+                    clock = fakeClock,
                     isUserLoggedIn = isUserLoggedIn,
                     deviceNeedsNotificationPermissions = deviceNeedsNotificationPermissions,
                     onboardingCompleted = { onboardingCompletedCalled = true },
@@ -121,9 +125,9 @@ class OnboardingFlowScreenTest : KSRobolectricTestCase() {
         setupOnboardingScreen()
 
         primaryButton.performClick() // Welcome -> Save
-        Thread.sleep(500)
+        fakeClock.advanceBy(600)
         primaryButton.performClick() // Save -> Activity Tracking
-        Thread.sleep(500)
+        fakeClock.advanceBy(600)
 
         pageTitle.assertIsDisplayed()
         pageTitle.assertTextEquals(activityTrackingPageTitleText)
@@ -144,9 +148,9 @@ class OnboardingFlowScreenTest : KSRobolectricTestCase() {
         setupOnboardingScreen(deviceNeedsNotificationPermissions = false)
 
         primaryButton.performClick() // Welcome -> Save
-        Thread.sleep(500)
+        fakeClock.advanceBy(600)
         primaryButton.performClick() // Save -> Activity Tracking
-        Thread.sleep(500)
+        fakeClock.advanceBy(600)
         secondaryButton.performClick() // Activity Tracking -> Login/Signup
 
         pageTitle.assertIsDisplayed()
@@ -165,11 +169,11 @@ class OnboardingFlowScreenTest : KSRobolectricTestCase() {
         setupOnboardingScreen()
 
         primaryButton.performClick() // Welcome -> Save
-        Thread.sleep(500)
-        primaryButton.performClick() // Save -> Activity Tracking
-        Thread.sleep(500)
-        secondaryButton.performClick() // Activity Tracking -> Notifications
-        Thread.sleep(500)
+        fakeClock.advanceBy(600)
+        primaryButton.performClick() // Save -> Notifications
+        fakeClock.advanceBy(600)
+        secondaryButton.performClick() // Notifications -> Activity Tracking
+        fakeClock.advanceBy(600)
 
         pageTitle.assertIsDisplayed()
         pageTitle.assertTextEquals(notificationsPageTitleText)
@@ -190,13 +194,13 @@ class OnboardingFlowScreenTest : KSRobolectricTestCase() {
         setupOnboardingScreen(isUserLoggedIn = false)
 
         primaryButton.performClick() // Welcome -> Save
-        Thread.sleep(500)
-        primaryButton.performClick() // Save -> Activity Tracking
-        Thread.sleep(500)
-        secondaryButton.performClick() // Activity Tracking -> Notifications
-        Thread.sleep(500)
-        secondaryButton.performClick() // Notifications -> Login/Signup
-        Thread.sleep(500)
+        fakeClock.advanceBy(600)
+        primaryButton.performClick() // Save -> Notifications
+        fakeClock.advanceBy(600)
+        secondaryButton.performClick() // Notifications -> Activity Tracking
+        fakeClock.advanceBy(600)
+        secondaryButton.performClick() // Activity Tracking -> Login/Signup
+        fakeClock.advanceBy(600)
 
         pageTitle.assertIsDisplayed()
         pageTitle.assertTextEquals(loginOrSignupPageTitleText)
@@ -218,13 +222,13 @@ class OnboardingFlowScreenTest : KSRobolectricTestCase() {
 
         // Navigate to Notifications Page (Welcome -> Save -> Notifications)
         primaryButton.performClick() // Welcome -> Save
-        Thread.sleep(500)
+        fakeClock.advanceBy(600)
         primaryButton.performClick() // Save -> Notifications
-        Thread.sleep(500)
+        fakeClock.advanceBy(600)
         secondaryButton.performClick() // Notifications -> Activity Tracking
-        Thread.sleep(500)
+        fakeClock.advanceBy(600)
         secondaryButton.performClick() // Activity Tracking -> Login/Signup
-        Thread.sleep(500)
+        fakeClock.advanceBy(600)
 
         // Assert that signupOrLogin callback was NOT called
         assertFalse("signupOrLogin callback should NOT have been called", signupOrLoginCalled)


### PR DESCRIPTION
# 📲 What

Refactor the onboarding flow logic and tests to use an injectable Clock, with a FakeClock implementation that can be manually advanced in time so that we don't have to call Thread.sleep() in tests.

# 🤔 Why

The button debounce in the onboarding flow was implemented using the real clock System.currentTimeMillis(), which required us to call Thread.sleep() to pass real time. But Thread.sleep() slows down our tests because it uses real time and can sometimes cause flakey behavior. 

# 🛠 How

Create an injectable clock interface with two implementations - SystemClock and FakeClock.
 - The real SystemClock is used in code to avoid hardcoding System.currentTimeMillis().
 - The FakeClock is injected in tests and can be used to advance the time manually using the advanceBy() method. Use this FakeClock instead of calling Thread.sleep() which slows tests down.

# 👀 See

No user facing changes.

# 📋 QA

Tests in OnboardingFlowScreenTest.kt should continue to pass as they did before.

# Story 📖

https://kickstarter.atlassian.net/browse/MBL-2727
