### PR TITLE
MBL-2799 Remove consent management feature flag

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -174,7 +174,7 @@ public class ApplicationModule {
   @Nonnull
   @Singleton
   static FirebaseAnalyticsClientType provideFirebaseAnalyticsClientType(final @NonNull FeatureFlagClientType ffClient, final @NonNull SharedPreferences sharedPreferences, final @ApplicationContext @NonNull Context context) {
-    return new FirebaseAnalyticsClient(ffClient, sharedPreferences, FirebaseAnalytics.getInstance(context));
+    return new FirebaseAnalyticsClient(sharedPreferences, FirebaseAnalytics.getInstance(context));
   }
 
   @Provides

--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -14,12 +14,14 @@ import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.kickstarter.libs.AnalyticEvents;
 import com.kickstarter.libs.ApiEndpoint;
 import com.kickstarter.libs.AttributionEvents;
 import com.kickstarter.libs.Build;
-import com.kickstarter.libs.CurrentConfigV2;
 import com.kickstarter.libs.CurrentConfigTypeV2;
+import com.kickstarter.libs.CurrentConfigV2;
 import com.kickstarter.libs.CurrentUserTypeV2;
+import com.kickstarter.libs.CurrentUserV2;
 import com.kickstarter.libs.DateTimeTypeConverter;
 import com.kickstarter.libs.DeviceRegistrar;
 import com.kickstarter.libs.DeviceRegistrarType;
@@ -30,8 +32,6 @@ import com.kickstarter.libs.Font;
 import com.kickstarter.libs.InternalToolsType;
 import com.kickstarter.libs.KSCurrency;
 import com.kickstarter.libs.KSString;
-import com.kickstarter.libs.AnalyticEvents;
-import com.kickstarter.libs.CurrentUserV2;
 import com.kickstarter.libs.Logout;
 import com.kickstarter.libs.PushNotifications;
 import com.kickstarter.libs.SegmentTrackingClient;
@@ -415,9 +415,8 @@ public class ApplicationModule {
           final @ApplicationContext @NonNull Context context,
           final @NonNull CurrentUserTypeV2 currentUser,
           final @NonNull Build build,
-          final @NonNull CurrentConfigTypeV2 currentConfig,
-          final @NonNull FeatureFlagClientType featureFlagClient) {
-    return new SegmentTrackingClient(build, context, currentConfig, currentUser, featureFlagClient, PreferenceManager.getDefaultSharedPreferences(context));
+          final @NonNull CurrentConfigTypeV2 currentConfig) {
+    return new SegmentTrackingClient(build, context, currentConfig, currentUser, PreferenceManager.getDefaultSharedPreferences(context));
   }
 
   @Provides

--- a/app/src/main/java/com/kickstarter/libs/FirebaseAnalyticsClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/FirebaseAnalyticsClient.kt
@@ -3,8 +3,6 @@ package com.kickstarter.libs
 import android.content.SharedPreferences
 import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
-import com.kickstarter.libs.featureflag.FeatureFlagClientType
-import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.models.User
 import com.kickstarter.ui.SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE
 
@@ -17,12 +15,11 @@ interface FirebaseAnalyticsClientType {
 }
 
 open class FirebaseAnalyticsClient(
-    private var ffClient: FeatureFlagClientType,
     private var preference: SharedPreferences,
     private val firebaseAnalytics: FirebaseAnalytics?,
 ) : FirebaseAnalyticsClientType {
 
-    override fun isEnabled() = preference.getBoolean(CONSENT_MANAGEMENT_PREFERENCE, false) && ffClient.getBoolean(FlagKey.ANDROID_CONSENT_MANAGEMENT)
+    override fun isEnabled() = preference.getBoolean(CONSENT_MANAGEMENT_PREFERENCE, false)
 
     override fun trackEvent(eventName: String, parameters: Bundle) {
         firebaseAnalytics?.let {

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -3,7 +3,6 @@ package com.kickstarter.libs
 import android.content.Context
 import android.content.SharedPreferences
 import com.kickstarter.libs.braze.BrazeClient
-import com.kickstarter.libs.featureflag.FeatureFlagClientType
 import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.libs.utils.extensions.isKSApplication
 import com.kickstarter.models.User
@@ -27,9 +26,8 @@ open class SegmentTrackingClient(
     private val context: Context,
     currentConfig: CurrentConfigTypeV2,
     currentUser: CurrentUserTypeV2,
-    ffClient: FeatureFlagClientType,
     preference: SharedPreferences
-) : TrackingClient(context, currentUser, build, currentConfig, ffClient, preference) {
+) : TrackingClient(context, currentUser, build, currentConfig, preference) {
 
     override var isInitialized = false
     override var loggedInUser: User? = null

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -11,7 +11,6 @@ import com.google.android.gms.common.GoogleApiAvailabilityLight
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.BuildConfig
 import com.kickstarter.R
-import com.kickstarter.libs.featureflag.FeatureFlagClientType
 import com.kickstarter.libs.qualifiers.ApplicationContext
 import com.kickstarter.libs.utils.WebUtils
 import com.kickstarter.libs.utils.extensions.currentVariants
@@ -26,7 +25,6 @@ abstract class TrackingClient(
     @set:Inject var currentUser: CurrentUserTypeV2,
     @set:Inject var build: Build,
     @set:Inject var currentConfig: CurrentConfigTypeV2,
-    @set:Inject var ffClient: FeatureFlagClientType,
     @set:Inject var sharedPreferences: SharedPreferences
 ) : TrackingClientType() {
 

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -12,7 +12,6 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.BuildConfig
 import com.kickstarter.R
 import com.kickstarter.libs.featureflag.FeatureFlagClientType
-import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.libs.qualifiers.ApplicationContext
 import com.kickstarter.libs.utils.WebUtils
 import com.kickstarter.libs.utils.extensions.currentVariants
@@ -59,9 +58,7 @@ abstract class TrackingClient(
     }
 
     override fun isEnabled(): Boolean {
-        return if (ffClient.getBoolean(FlagKey.ANDROID_CONSENT_MANAGEMENT)) {
-            sharedPreferences.getBoolean(CONSENT_MANAGEMENT_PREFERENCE, false)
-        } else true
+        return sharedPreferences.getBoolean(CONSENT_MANAGEMENT_PREFERENCE, false)
     }
 
     override fun reset() {

--- a/app/src/main/java/com/kickstarter/libs/featureflag/FeatureFlagClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/FeatureFlagClient.kt
@@ -70,7 +70,6 @@ enum class FlipperFlagKey(val key: String) {
 enum class FlagKey(val key: String) {
     ANDROID_FACEBOOK_LOGIN_REMOVE("android_facebook_login_remove"),
     ANDROID_HIDE_APP_RATING_DIALOG("android_hide_app_rating_dialog"),
-    ANDROID_CONSENT_MANAGEMENT("android_consent_management"),
     ANDROID_CAPI_INTEGRATION("android_capi_integration"),
     ANDROID_GOOGLE_ANALYTICS("android_google_analytics"),
     ANDROID_DARK_MODE_ENABLED("android_dark_mode_enabled"),

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryViewModel.kt
@@ -454,7 +454,6 @@ interface DiscoveryViewModel {
 
             Observable.just(sharedPreferences.contains(CONSENT_MANAGEMENT_PREFERENCE))
                 .filter { !it }
-                .filter { ffClient?.getBoolean(FlagKey.ANDROID_CONSENT_MANAGEMENT) ?: false }
                 .subscribe { showConsentManagementDialog.onNext(Unit) }
                 .addToDisposable(disposables)
         }

--- a/app/src/main/java/com/kickstarter/viewmodels/usecases/SendThirdPartyEventUseCaseV2.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/usecases/SendThirdPartyEventUseCaseV2.kt
@@ -19,8 +19,7 @@ class SendThirdPartyEventUseCaseV2(
     ffClient: FeatureFlagClientType,
 ) : BuildInput {
     private val canSendEventFlag = (
-        ffClient.getBoolean(FlagKey.ANDROID_CONSENT_MANAGEMENT) &&
-            sharedPreferences.getBoolean(SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE, false) &&
+        sharedPreferences.getBoolean(SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE, false) &&
             (ffClient.getBoolean(FlagKey.ANDROID_CAPI_INTEGRATION) || ffClient.getBoolean(FlagKey.ANDROID_GOOGLE_ANALYTICS))
         )
 

--- a/app/src/test/java/com/kickstarter/KSRobolectricTestCase.kt
+++ b/app/src/test/java/com/kickstarter/KSRobolectricTestCase.kt
@@ -30,7 +30,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import kotlin.jvm.Throws
+
 @RunWith(KSRobolectricGradleTestRunner::class)
 @Config(
     shadows = [ShadowAndroidXMultiDex::class],
@@ -102,8 +102,7 @@ abstract class KSRobolectricTestCase : TestCase() {
         val segmentTrackingClient = MockTrackingClient(
             MockCurrentUserV2(),
             mockCurrentConfig,
-            TrackingClientType.Type.SEGMENT,
-            ffClient
+            TrackingClientType.Type.SEGMENT
         )
         segmentTrackingClient.eventNames.subscribe { segmentTrack.onNext(it) }.addToDisposable(disposables)
         segmentTrackingClient.identifiedUser.subscribe { segmentIdentify.onNext(it) }.addToDisposable(disposables)

--- a/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/pledgedprojectsoverview/viewmodel/PledgedProjectsOverviewViewModelTest.kt
@@ -14,7 +14,6 @@ import com.kickstarter.libs.MockTrackingClient
 import com.kickstarter.libs.TrackingClientType
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.mock.MockCurrentConfigV2
-import com.kickstarter.mock.MockFeatureFlagClient
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClientV2
@@ -31,7 +30,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import kotlin.properties.Delegates.observable
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
@@ -303,8 +301,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
             val trackingClient = MockTrackingClient(
                 MockCurrentUserV2(user),
                 MockCurrentConfigV2(),
-                TrackingClientType.Type.SEGMENT,
-                MockFeatureFlagClient()
+                TrackingClientType.Type.SEGMENT
             )
 
             val mockApolloClientV2 = object : MockApolloClientV2() {
@@ -343,8 +340,7 @@ class PledgedProjectsOverviewViewModelTest : KSRobolectricTestCase() {
             val trackingClient = MockTrackingClient(
                 MockCurrentUserV2(user),
                 MockCurrentConfigV2(),
-                TrackingClientType.Type.SEGMENT,
-                MockFeatureFlagClient()
+                TrackingClientType.Type.SEGMENT
             )
             val mockApolloClientV2 = object : MockApolloClientV2() {
 

--- a/app/src/test/java/com/kickstarter/libs/FirebaseAnalyticsClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/FirebaseAnalyticsClientTest.kt
@@ -6,6 +6,7 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.featureflag.FeatureFlagClientType
 import com.kickstarter.libs.featureflag.FlagKey
 import com.kickstarter.mock.MockFeatureFlagClient
+import com.kickstarter.ui.SharedPreferenceKey
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subjects.PublishSubject
@@ -28,7 +29,7 @@ class FirebaseAnalyticsClientTest : KSRobolectricTestCase() {
     private class MockFirebaseClient(
         ffClient: FeatureFlagClientType,
         sharedPreferences: SharedPreferences
-    ) : FirebaseAnalyticsClient(ffClient, sharedPreferences, null) {
+    ) : FirebaseAnalyticsClient(sharedPreferences, null) {
 
         private val events = PublishSubject.create<Event>()
 
@@ -66,39 +67,7 @@ class FirebaseAnalyticsClientTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testIsEnabled_whenFeatureFlagOnButNoConsent_returnFalse() {
-        val mockFeatureFlagClient = object : MockFeatureFlagClient() {
-            override fun getBoolean(FlagKey: FlagKey): Boolean {
-                return true
-            }
-        }
-
-        val mockSharedPreferences: SharedPreferences = MockSharedPreferences()
-
-        val mockFirebaseClient = MockFirebaseClient(mockFeatureFlagClient, mockSharedPreferences)
-
-        assertFalse(mockFirebaseClient.isEnabled())
-    }
-
-    @Test
-    fun testIsEnabled_whenConsentTrueButFeatureFlagOff_returnFalse() {
-        val mockFeatureFlagClient = object : MockFeatureFlagClient() {
-            override fun getBoolean(FlagKey: FlagKey): Boolean {
-                return false
-            }
-        }
-
-        val mockSharedPreferences: SharedPreferences = MockSharedPreferences()
-        mockSharedPreferences.edit()
-            .putBoolean(FlagKey.ANDROID_CONSENT_MANAGEMENT.toString(), true).commit()
-
-        val mockFirebaseClient = MockFirebaseClient(mockFeatureFlagClient, mockSharedPreferences)
-
-        assertFalse(mockFirebaseClient.isEnabled())
-    }
-
-    @Test
-    fun testIsEnabled_whenConsentFalseButFeatureFlagOn_returnFalse() {
+    fun testIsEnabled_whenConsentFalse_returnFalse() {
         val mockFeatureFlagClient = object : MockFeatureFlagClient() {
             override fun getBoolean(FlagKey: FlagKey): Boolean {
                 return true
@@ -107,7 +76,7 @@ class FirebaseAnalyticsClientTest : KSRobolectricTestCase() {
 
         val mockSharedPreferences: SharedPreferences = MockSharedPreferences()
         mockSharedPreferences.edit()
-            .putBoolean(FlagKey.ANDROID_CONSENT_MANAGEMENT.toString(), false).commit()
+            .putBoolean(SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE, false).commit()
 
         val mockFirebaseClient = MockFirebaseClient(mockFeatureFlagClient, mockSharedPreferences)
 
@@ -115,7 +84,7 @@ class FirebaseAnalyticsClientTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testIsEnabled_whenConsentTrueButFeatureFlagOn_returnTrue() {
+    fun testIsEnabled_whenConsentTrue_returnTrue() {
         val mockFeatureFlagClient = object : MockFeatureFlagClient() {
             override fun getBoolean(FlagKey: FlagKey): Boolean {
                 return true
@@ -124,11 +93,11 @@ class FirebaseAnalyticsClientTest : KSRobolectricTestCase() {
 
         val mockSharedPreferences: SharedPreferences = MockSharedPreferences()
         mockSharedPreferences.edit()
-            .putBoolean(FlagKey.ANDROID_CONSENT_MANAGEMENT.toString(), true).commit()
+            .putBoolean(SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE, true).commit()
 
         val mockFirebaseClient = MockFirebaseClient(mockFeatureFlagClient, mockSharedPreferences)
 
-        assertFalse(mockFirebaseClient.isEnabled())
+        assertTrue(mockFirebaseClient.isEnabled())
     }
 
     @After

--- a/app/src/test/java/com/kickstarter/libs/MockTrackingClient.kt
+++ b/app/src/test/java/com/kickstarter/libs/MockTrackingClient.kt
@@ -1,6 +1,5 @@
 package com.kickstarter.libs
 
-import com.kickstarter.libs.featureflag.FeatureFlagClientType
 import com.kickstarter.libs.utils.extensions.currentVariants
 import com.kickstarter.mock.factories.ConfigFactory.config
 import com.kickstarter.models.User
@@ -12,7 +11,6 @@ class MockTrackingClient(
     currentUser: CurrentUserTypeV2,
     currentConfig: CurrentConfigTypeV2,
     private val type: Type,
-    private val ffClient: FeatureFlagClientType
 ) : TrackingClientType() {
     override var loggedInUser: User? = null
     override var config: Config? = config()

--- a/app/src/test/java/com/kickstarter/viewmodels/ChangePasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ChangePasswordViewModelTest.kt
@@ -8,7 +8,6 @@ import com.kickstarter.libs.MockCurrentUserV2
 import com.kickstarter.libs.MockTrackingClient
 import com.kickstarter.libs.TrackingClientType
 import com.kickstarter.mock.MockCurrentConfigV2
-import com.kickstarter.mock.MockFeatureFlagClient
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClientV2
 import com.kickstarter.models.User
@@ -201,8 +200,7 @@ class ChangePasswordViewModelTest : KSRobolectricTestCase() {
     private fun getMockClientWithUser(user: User) = MockTrackingClient(
         MockCurrentUserV2(user),
         MockCurrentConfigV2(),
-        TrackingClientType.Type.SEGMENT,
-        MockFeatureFlagClient()
+        TrackingClientType.Type.SEGMENT
     ).apply {
         this.identifiedUser.subscribe { currentUser.onNext(it) }
     }

--- a/app/src/test/java/com/kickstarter/viewmodels/CreatePasswordViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CreatePasswordViewModelTest.kt
@@ -9,7 +9,6 @@ import com.kickstarter.libs.MockTrackingClient
 import com.kickstarter.libs.TrackingClientType
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.mock.MockCurrentConfigV2
-import com.kickstarter.mock.MockFeatureFlagClient
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClientV2
 import com.kickstarter.models.User
@@ -147,8 +146,7 @@ class CreatePasswordViewModelTest : KSRobolectricTestCase() {
     private fun getMockClientWithUser(user: User) = MockTrackingClient(
         MockCurrentUserV2(user),
         MockCurrentConfigV2(),
-        TrackingClientType.Type.SEGMENT,
-        MockFeatureFlagClient()
+        TrackingClientType.Type.SEGMENT
     ).apply {
         this.identifiedUser.subscribe { currentUser.onNext(it) }
     }

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryViewModelTest.kt
@@ -810,53 +810,14 @@ class DiscoveryViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun testConsentManagementDialog_whenFFOff_shouldNotEmit() {
+    fun testConsentManagementDialog_preferenceDoesNotContainKeyValue_shouldEmit() {
         val sharedPreferences: SharedPreferences = Mockito.mock(SharedPreferences::class.java)
         Mockito.`when`(sharedPreferences.contains(SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE)).thenReturn(false)
-
-        val mockFeatureFlagClient: MockFeatureFlagClient =
-            object : MockFeatureFlagClient() {
-                override fun getBoolean(FlagKey: FlagKey): Boolean {
-                    return false
-                }
-            }
 
         setUpEnvironment(
             environment()
                 .toBuilder()
                 .sharedPreferences(sharedPreferences)
-                .featureFlagClient(mockFeatureFlagClient)
-                .build()
-        )
-
-        vm.outputs.showConsentManagementDialog().subscribe { showConsentManagementDialog.onNext(it) }.addToDisposable(disposables)
-
-        showConsentManagementDialog.assertNoValues()
-    }
-
-    @Test
-    fun testConsentManagementDialog_preferenceDoesNotContainKeyValueAndFFOn_shouldEmit() {
-        val sharedPreferences: SharedPreferences = Mockito.mock(SharedPreferences::class.java)
-        Mockito.`when`(sharedPreferences.contains(SharedPreferenceKey.CONSENT_MANAGEMENT_PREFERENCE)).thenReturn(false)
-
-        val mockFeatureFlagClient: MockFeatureFlagClient =
-            object : MockFeatureFlagClient() {
-                override fun getBoolean(FlagKey: FlagKey): Boolean {
-                    if (FlagKey == com.kickstarter.libs.featureflag.FlagKey.ANDROID_CONSENT_MANAGEMENT) {
-                        return true
-                    } else if (FlagKey == com.kickstarter.libs.featureflag.FlagKey.ANDROID_NATIVE_ONBOARDING_FLOW) {
-                        return false
-                    } else {
-                        return false
-                    }
-                }
-            }
-
-        setUpEnvironment(
-            environment()
-                .toBuilder()
-                .sharedPreferences(sharedPreferences)
-                .featureFlagClient(mockFeatureFlagClient)
                 .build()
         )
 
@@ -877,8 +838,6 @@ class DiscoveryViewModelTest : KSRobolectricTestCase() {
             object : MockFeatureFlagClient() {
                 override fun getBoolean(FlagKey: FlagKey): Boolean {
                     return if (FlagKey == com.kickstarter.libs.featureflag.FlagKey.ANDROID_NATIVE_ONBOARDING_FLOW) {
-                        true
-                    } else if (FlagKey == com.kickstarter.libs.featureflag.FlagKey.ANDROID_CONSENT_MANAGEMENT) {
                         true
                     } else {
                         false
@@ -911,8 +870,6 @@ class DiscoveryViewModelTest : KSRobolectricTestCase() {
             object : MockFeatureFlagClient() {
                 override fun getBoolean(FlagKey: FlagKey): Boolean {
                     return if (FlagKey == com.kickstarter.libs.featureflag.FlagKey.ANDROID_NATIVE_ONBOARDING_FLOW) {
-                        true
-                    } else if (FlagKey == com.kickstarter.libs.featureflag.FlagKey.ANDROID_CONSENT_MANAGEMENT) {
                         true
                     } else {
                         false

--- a/app/src/test/java/com/kickstarter/viewmodels/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/SettingsViewModelTest.kt
@@ -8,7 +8,6 @@ import com.kickstarter.libs.MockTrackingClient
 import com.kickstarter.libs.TrackingClientType
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.mock.MockCurrentConfigV2
-import com.kickstarter.mock.MockFeatureFlagClient
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.models.User
 import io.reactivex.disposables.CompositeDisposable
@@ -101,8 +100,7 @@ class SettingsViewModelTest : KSRobolectricTestCase() {
     private fun getMockClientWithUser(user: User) = MockTrackingClient(
         MockCurrentUserV2(user),
         MockCurrentConfigV2(),
-        TrackingClientType.Type.SEGMENT,
-        MockFeatureFlagClient()
+        TrackingClientType.Type.SEGMENT
     ).apply {
         this.identifiedUser.subscribe { currentUser }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@
 # org.gradle.parallel=true
 #Mon Sep 23 14:36:55 EDT 2019
 android.enableJetifier=true
-org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.jvmargs=-Xmx4096m -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 android.useAndroidX=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@
 # org.gradle.parallel=true
 #Mon Sep 23 14:36:55 EDT 2019
 android.enableJetifier=true
-org.gradle.jvmargs=-Xmx4096m -Dkotlin.daemon.jvm.options\="-Xmx4096M"
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
# 📲 What

Remove  FlagKey.ANDROID_CONSENT_MANAGEMENT and its usages

# 🤔 Why

It's an old flag that's existed for years. 

Plus this logic for tracking caused `isEnabled()` to return true if the feature flags aren't initialized in time:
```
   override fun isEnabled(): Boolean {
        return if (ffClient.getBoolean(FlagKey.ANDROID_CONSENT_MANAGEMENT)) {
            sharedPreferences.getBoolean(CONSENT_MANAGEMENT_PREFERENCE, false)
        } else true
    }
```
Remove this feature flag check to ensure correct tracking behavior for onboarding in particular.

# 🛠 How


# 👀 See


# 📋 QA

Ensure unit tests all pass.

Do a fresh install of this branch on device. Verify no onboarding analytics are seen in https://app.segment.com/kickstarter/sources/kickstarter/debugger until AFTER you've consented to tracking. You should see no analytics for the following onboarding screens: WELCOME, SAVE PROJECTS,  APP TRACKING

# Story 📖

https://kickstarter.atlassian.net/browse/MBL-2779
