### PR TITLE
MBL-2732: Re-enable K2 mode of KAPT compiler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@ android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 #android.debug.obsoleteApi=true
 
-kapt.use.k2=false
+kapt.use.k2=true


### PR DESCRIPTION
# 📲 What

Re-enable K2 mode of KAPT compiler

# 🤔 Why

Modernization & optimization!

The K2 compiler has been enabled by default for the general codebase since the update to Kotlin 2.1.21. However, K2 mode of the KAPT compiler was previous [disabled](https://kotlinlang.org/docs/whatsnew2120.html#new-default-kapt-plugin) due to build issues stemming from a compatibility issue with the older version of Dagger. Now that our libraries have been updated, these issues have been resolved.

In-depth reads about the benefits of the K2 compiler:
- [K2 compiler migration guide | Kotlin Documentation](https://kotlinlang.org/docs/k2-compiler-migration-guide.html)
- [The K2 Compiler Is Going Stable in Kotlin 2.0 | The Kotlin Blog](https://blog.jetbrains.com/kotlin/2023/02/k2-kotlin-2-0/)

# 🛠 How

Set `kapt.use.k2=true` in `gradle.properties`.

Assembled and ran all variants and test suites locally.

# 📋 QA

No visible changes. Ensure you can continue to assemble the project locally.

# Story 📖

[\[MBL-2732\] Re-enable K2 mode of KAPT compiler - Jira](https://kickstarter.atlassian.net/browse/MBL-2732)
