### PR TITLE
MBL-3074: KSVideoProgressIndicator with animation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -292,6 +292,7 @@ dependencies {
     implementation "com.google.accompanist:accompanist-systemuicontroller:0.36.0"
     implementation "androidx.lifecycle:lifecycle-runtime-compose:2.10.0"
     implementation "androidx.compose.foundation:foundation:$compose_version"
+    implementation 'androidx.compose.ui:ui-util:1.10.5'
 
     implementation "dev.chrisbanes.haze:haze:1.7.2"
 

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/components/KSVideoCampaignCard.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/components/KSVideoCampaignCard.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
@@ -23,6 +24,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.kickstarter.R
 import com.kickstarter.ui.compose.designsystem.KSOutlinedButton
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
@@ -100,7 +102,7 @@ fun KSVideoCampaignCard(
                 progress = progressValue,
                 icon = if (isComplete) Check else null,
                 text = if (!isComplete) progress.toInt().toString() else "",
-                contentDescription = if (isComplete) "Campaign goal reached" else "" // TODO extract to resources
+                contentDescription = if (isComplete) stringResource(id = R.string.fpo_Campaign_goal_reached) else ""
             )
         }
 

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSColors.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSColors.kt
@@ -49,6 +49,7 @@ val grey_02 = Color(0xFFF2F2F2)
 val grey_03 = Color(0xFFE0E0E0)
 val grey_04 = Color(0xFFC9C9C9)
 val grey_05 = Color(0xFFB3B3B3)
+val grey_055 = Color(0xFF6B6B6B)
 val grey_06 = Color(0xFF636363)
 val grey_07 = Color(0xFF4D4D4D)
 val grey_08 = Color(0xFF3C3C3C)
@@ -74,6 +75,7 @@ val green_09 = Color(0xFF01321D)
 val green_10 = Color(0xFF011E11)
 val green_100 = Color(0xFFDAFFBB)
 val green_200 = Color(0xFFA3FF55)
+val green_300 = Color(0xFF8CE71A)
 val green_400 = Color(0xFF71F701)
 val green_800 = Color(0xFF244F00)
 
@@ -237,6 +239,9 @@ data class KSCustomColors(
     val videoPlayerIconShadow: Color = Color.Unspecified,
     val videoPlayerButtonBorder: Color = Color.Unspecified,
     val videoPlayerButtonText: Color = Color.Unspecified,
+    val videoPlayerProgressBase: Color = Color.Unspecified,
+    val videoPlayerProgressComplete: Color = Color.Unspecified,
+    val videoPlayerProgressTrack: Color = Color.Unspecified,
 
     // OLD COLORS
     // Greens
@@ -385,6 +390,9 @@ val KSLightCustomColors = KSCustomColors(
     videoPlayerIconShadow = black.copy(alpha = 0.1f),
     videoPlayerButtonBorder = white,
     videoPlayerButtonText = white,
+    videoPlayerProgressBase = white,
+    videoPlayerProgressComplete = green_300,
+    videoPlayerProgressTrack = grey_055,
 
     // OLD COLORS
     // Greens
@@ -531,6 +539,9 @@ val KSDarkCustomColors = KSCustomColors(
     videoPlayerIconShadow = black.copy(alpha = 0.1f),
     videoPlayerButtonBorder = white,
     videoPlayerButtonText = white,
+    videoPlayerProgressBase = white,
+    videoPlayerProgressComplete = green_300,
+    videoPlayerProgressTrack = grey_055,
 
     // OLD COLORS
     // Greens

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -210,7 +211,10 @@ fun KSVideoProgressIndicator(
         modifier = modifier
             .size(44.dp)
             .semantics(mergeDescendants = true) {
-                this.contentDescription = contentDescription
+                if (contentDescription.isNotEmpty()) {
+                    this.contentDescription = contentDescription
+                }
+                this.stateDescription = text
                 this.progressBarRangeInfo = ProgressBarRangeInfo(progress, 0f..1f)
             },
         contentAlignment = Alignment.Center

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
@@ -211,12 +211,8 @@ fun KSVideoProgressIndicator(
         modifier = modifier
             .size(44.dp)
             .semantics(mergeDescendants = true) {
+                this.contentDescription = contentDescription
                 this.stateDescription = text
-
-                if (contentDescription.isNotEmpty()) {
-                    this.contentDescription = contentDescription
-                }
-
                 this.progressBarRangeInfo = ProgressBarRangeInfo(progress, 0f..1f)
             },
         contentAlignment = Alignment.Center

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
@@ -1,8 +1,6 @@
 package com.kickstarter.ui.compose.designsystem
 
 import android.content.res.Configuration
-import androidx.compose.animation.Crossfade
-import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -16,7 +14,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.Text
@@ -32,9 +29,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathMeasure
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.contentDescription
@@ -47,6 +47,9 @@ import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
 import com.kickstarter.ui.compose.designsystem.KSTheme.typographyV2
 import com.kickstarter.ui.compose.designsystem.videoplayer.icons.Check
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @Composable
 @Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
@@ -118,6 +121,15 @@ fun KSCircularProgressIndicator(
 
 /**
  * Progress indicator designed for use within the Video Player.
+ * Matches the Lottie animation (https://www.lottielab.com/editor?project=c2eeb8ac-3d34-4e47-9519-39f8d5ad9e85) frame-for-frame.
+ *
+ * Lottie timeline (100fps, 252 frames):
+ *   Frames 0-23:   Arc fades in (opacity 0→1)
+ *   Frames 0-130:  Arc sweeps 0→100%
+ *   Frames 130-187: Stroke turns white→green
+ *   Frames 125-150: Circle pulses up (638→680)
+ *   Frames 143-216: Checkmark draws in via trim path
+ *   Frames 216-252: Settle — green→white, circle 680→638
  */
 @Composable
 fun KSVideoProgressIndicator(
@@ -127,59 +139,85 @@ fun KSVideoProgressIndicator(
     text: String = "",
     contentDescription: String = "",
     baseColor: Color = Color.White,
-    completeColor: Color = Color(0xFF8CE71A), // [0.55, 0.906, 0.1] from JSON
-    trackColor: Color = Color.White.copy(alpha = 0.2f)
+    completeColor: Color = Color(0xFF8CE71A), // [0.55, 0.906, 0.1] from Lottie
+    trackColor: Color = Color(0xFF6B6B6B) // [0.42, 0.42, 0.42] from Lottie
 ) {
-    val lottieEasing = CubicBezierEasing(0.15f, 0f, 0.27f, 1f)
+    // ── Lottie-matched cubic-bezier easings ──
+    val arcSweepEasing = CubicBezierEasing(0.741f, 0f, 0.545f, 1f)
+    val fadeInEasing = CubicBezierEasing(0.5f, 0f, 0f, 1f)
+    val scaleUpEasing = CubicBezierEasing(0.5f, -0.5f, 0.2f, 1f)
+    val scaleDownEasing = CubicBezierEasing(0.8f, 0f, 0.5f, 1.5f)
+    val checkDrawEasing = CubicBezierEasing(0.271f, 0.307f, 0.153f, 1f)
 
-    // Animation States
-    var targetProgressValue by remember { mutableFloatStateOf(0f) }
-    val pulseScale = remember { Animatable(1f) }
-
-    // 0: Initial, 1: Success (Green), 2: Settle (White)
-    var completionPhase by remember { mutableIntStateOf(0) }
-
-    LaunchedEffect(progress) {
-        targetProgressValue = progress
-    }
+    // ── Animation state ──
+    val arcOpacity = remember { Animatable(0f) }
+    val circleScale = remember { Animatable(1f) }
+    val colorPhase = remember { Animatable(0f) } // 0 = baseColor, 1 = completeColor
+    val checkTrim = remember { Animatable(0f) } // 0..1 trim-end for checkmark path
+    var phase by remember { mutableIntStateOf(0) } // 0=progress, 1=success, 2=settled
+    var targetProgress by remember { mutableFloatStateOf(0f) }
 
     val animatedProgress by animateFloatAsState(
-        targetValue = targetProgressValue.coerceIn(0f, 1f),
-        animationSpec = tween(durationMillis = 800, easing = lottieEasing),
+        targetValue = targetProgress.coerceIn(0f, 1f),
+        animationSpec = tween(durationMillis = 1300, easing = arcSweepEasing),
         label = "ProgressSweep"
     )
 
-    // Sequence Trigger: Handles the Green -> White transition from frames 216-252
+    // Arc fades in over 230ms on mount (Lottie frames 0-23)
+    LaunchedEffect(Unit) {
+        arcOpacity.animateTo(1f, tween(230, easing = fadeInEasing))
+    }
+
+    LaunchedEffect(progress) {
+        targetProgress = progress
+    }
+
+    // Completion choreography — matches Lottie frames 130-252
     LaunchedEffect(animatedProgress >= 1f) {
         if (animatedProgress >= 1f) {
-            // Step 1: Hit Success Phase (Green + Pulse Up)
-            completionPhase = 1
-            pulseScale.animateTo(1.06f, tween(300, easing = lottieEasing))
-
-            // Step 2: Settle Phase (Back to White + Scale Down)
-            completionPhase = 2
-            pulseScale.animateTo(1f, tween(300, easing = lottieEasing))
+            phase = 1
+            // ── Success phase (frames 130-216, ~860ms) ──
+            coroutineScope {
+                // Circle pulse up: 638→680, 200ms (frames ~130-150)
+                launch {
+                    circleScale.animateTo(680f / 638f, tween(200, easing = scaleUpEasing))
+                }
+                // Stroke color: white→green, 570ms (frames 130-187)
+                launch {
+                    colorPhase.animateTo(1f, tween(570, easing = fadeInEasing))
+                }
+                // Checkmark trim: 0→100%, 730ms after 130ms delay (frames 143-216)
+                launch {
+                    delay(130)
+                    checkTrim.animateTo(1f, tween(730, easing = checkDrawEasing))
+                }
+            }
+            // ── Settle phase (frames 216-252, ~360ms) ──
+            phase = 2
+            coroutineScope {
+                // Circle pulse down: 680→638, 360ms
+                launch {
+                    circleScale.animateTo(1f, tween(360, easing = scaleDownEasing))
+                }
+                // Stroke color: green→white, 330ms after 30ms hold (frames 219-252)
+                launch {
+                    delay(30)
+                    colorPhase.animateTo(0f, tween(330, easing = fadeInEasing))
+                }
+            }
         } else {
-            completionPhase = 0
-            pulseScale.snapTo(1f)
+            phase = 0
+            circleScale.snapTo(1f)
+            colorPhase.snapTo(0f)
+            checkTrim.snapTo(0f)
         }
     }
 
-    // Color logic mapping to the JSON keyframes
-    val animatedColor by animateColorAsState(
-        targetValue = when (completionPhase) {
-            1 -> completeColor // Success Green
-            2 -> baseColor // Settles back to White
-            else -> baseColor
-        },
-        animationSpec = tween(500),
-        label = "ColorPhase"
-    )
+    val currentColor = lerp(baseColor, completeColor, colorPhase.value)
 
     Box(
         modifier = modifier
             .size(44.dp)
-            .graphicsLayer(scaleX = pulseScale.value, scaleY = pulseScale.value)
             .semantics(mergeDescendants = true) {
                 this.contentDescription = contentDescription
                 this.progressBarRangeInfo = ProgressBarRangeInfo(progress, 0f..1f)
@@ -187,61 +225,77 @@ fun KSVideoProgressIndicator(
         contentAlignment = Alignment.Center
     ) {
         Canvas(modifier = Modifier.fillMaxSize()) {
-            // 1. Calculate a consistent stroke width based on your design ratio
-            val strokeWidthPx = size.width * (120f / 638f)
+            // Scale to fit max pulsed outer circle (680 + 120 = 800 Lottie units)
+            val scale = size.minDimension / 800f
+            val strokeWidthPx = 120f * scale
+            val baseRadius = 319f * scale // 638 / 2
+            val currentRadius = baseRadius * circleScale.value
 
-            // 2. Calculate a shared radius that accounts for the stroke width
-            // to prevent the edges from being clipped at the Canvas bounds
-            val radius = (size.minDimension - strokeWidthPx) / 2f
-
-            // 3. Define the bounding box for the Arc so it matches the Circle's path
-            val arcSize = Size(radius * 2, radius * 2)
+            val arcSize = Size(currentRadius * 2, currentRadius * 2)
             val arcTopLeft = Offset(
-                x = (size.width / 2f) - radius,
-                y = (size.height / 2f) - radius
+                x = center.x - currentRadius,
+                y = center.y - currentRadius
             )
 
-            // TRACK: Draws the static background circle
+            // TRACK (Lottie layer 3): solid gray circle, always visible
             drawCircle(
                 color = trackColor,
-                radius = radius,
+                radius = currentRadius,
                 center = center,
                 style = Stroke(width = strokeWidthPx)
             )
 
-            // PROGRESS: Draws the moving arc on top using the animated values
+            // PROGRESS ARC (Lottie layer 2): sweeps with fade-in and color transition
             if (animatedProgress > 0f) {
                 drawArc(
-                    color = animatedColor, // Keeps your Green -> White transition
+                    color = currentColor,
                     startAngle = -90f,
-                    sweepAngle = 360f * animatedProgress, // Keeps your 0.0 -> 1.0 motion
+                    sweepAngle = 360f * animatedProgress,
                     useCenter = false,
                     topLeft = arcTopLeft,
                     size = arcSize,
+                    style = Stroke(width = strokeWidthPx, cap = StrokeCap.Round),
+                    alpha = arcOpacity.value
+                )
+            }
+
+            // CHECKMARK (Lottie layer 1): trim-path reveal
+            if (icon != null && checkTrim.value > 0f) {
+                val d = baseRadius * 2 // checkmark scaled to base diameter
+
+                // Path vertices from Lottie, normalized to circle diameter:
+                // Lottie path [-7.14,0.39]→[-2.12,5.49]→[6.94,-4.68]
+                // scaled by 1339.46%, offset to (601.31,444.59), relative to center (600,449.56)
+                val checkPath = Path().apply {
+                    moveTo(center.x - 0.1478f * d, center.y + 0.0004f * d)
+                    lineTo(center.x - 0.0424f * d, center.y + 0.1074f * d)
+                    lineTo(center.x + 0.1477f * d, center.y - 0.1060f * d)
+                }
+
+                val measure = PathMeasure().apply { setPath(checkPath, false) }
+                val trimmedPath = Path()
+                measure.getSegment(0f, measure.length * checkTrim.value, trimmedPath, true)
+
+                // Stroke width: Lottie 3 * 13.3946 / 638 ≈ 0.06295 of diameter
+                drawPath(
+                    path = trimmedPath,
+                    color = currentColor,
                     style = Stroke(
-                        width = strokeWidthPx,
-                        cap = StrokeCap.Round // Creates the rounded "pill" look
+                        width = d * 0.06295f,
+                        cap = StrokeCap.Round,
+                        join = StrokeJoin.Round
                     )
                 )
             }
         }
 
-        // Show Icon/Text based on the completion phase
-        Crossfade(targetState = completionPhase >= 1, label = "ContentFade") { isFinished ->
-            if (isFinished && icon != null) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    tint = animatedColor,
-                    modifier = Modifier.fillMaxSize(0.5f)
-                )
-            } else if (!isFinished && text.isNotEmpty()) {
-                Text(
-                    text = text,
-                    color = Color.White,
-                    style = typographyV2.bodyBoldXS.copy(fontSize = 12.sp)
-                )
-            }
+        // Text overlay (shown during progress phase only)
+        if (phase == 0 && text.isNotEmpty()) {
+            Text(
+                text = text,
+                color = baseColor,
+                style = typographyV2.bodyBoldXS.copy(fontSize = 12.sp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.graphics.PathMeasure
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.contentDescription
@@ -43,6 +42,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.util.lerp
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
 import com.kickstarter.ui.compose.designsystem.KSTheme.typographyV2
@@ -139,23 +139,27 @@ fun KSVideoProgressIndicator(
     text: String = "",
     contentDescription: String = "",
     baseColor: Color = Color.White,
-    completeColor: Color = Color(0xFF8CE71A), // [0.55, 0.906, 0.1] from Lottie
-    trackColor: Color = Color(0xFF6B6B6B) // [0.42, 0.42, 0.42] from Lottie
+    completeColor: Color = Color(0xFF8CE71A),
+    trackColor: Color = Color(0xFF6B6B6B)
 ) {
-    // ── Lottie-matched cubic-bezier easings ──
     val arcSweepEasing = CubicBezierEasing(0.741f, 0f, 0.545f, 1f)
     val fadeInEasing = CubicBezierEasing(0.5f, 0f, 0f, 1f)
     val scaleUpEasing = CubicBezierEasing(0.5f, -0.5f, 0.2f, 1f)
     val scaleDownEasing = CubicBezierEasing(0.8f, 0f, 0.5f, 1.5f)
     val checkDrawEasing = CubicBezierEasing(0.271f, 0.307f, 0.153f, 1f)
 
-    // ── Animation state ──
     val arcOpacity = remember { Animatable(0f) }
     val circleScale = remember { Animatable(1f) }
-    val colorPhase = remember { Animatable(0f) } // 0 = baseColor, 1 = completeColor
-    val checkTrim = remember { Animatable(0f) } // 0..1 trim-end for checkmark path
-    var phase by remember { mutableIntStateOf(0) } // 0=progress, 1=success, 2=settled
+    val colorPhase = remember { Animatable(0f) }
+    val checkTrim = remember { Animatable(0f) }
+
+    var phase by remember { mutableIntStateOf(0) }
     var targetProgress by remember { mutableFloatStateOf(0f) }
+
+    // Pre-allocate path objects to avoid GC pressure in DrawScope
+    val checkPath = remember { Path() }
+    val trimmedPath = remember { Path() }
+    val pathMeasure = remember { PathMeasure() }
 
     val animatedProgress by animateFloatAsState(
         targetValue = targetProgress.coerceIn(0f, 1f),
@@ -178,15 +182,8 @@ fun KSVideoProgressIndicator(
             phase = 1
             // ── Success phase (frames 130-216, ~860ms) ──
             coroutineScope {
-                // Circle pulse up: 638→680, 200ms (frames ~130-150)
-                launch {
-                    circleScale.animateTo(680f / 638f, tween(200, easing = scaleUpEasing))
-                }
-                // Stroke color: white→green, 570ms (frames 130-187)
-                launch {
-                    colorPhase.animateTo(1f, tween(570, easing = fadeInEasing))
-                }
-                // Checkmark trim: 0→100%, 730ms after 130ms delay (frames 143-216)
+                launch { circleScale.animateTo(680f / 638f, tween(200, easing = scaleUpEasing)) }
+                launch { colorPhase.animateTo(1f, tween(570, easing = fadeInEasing)) }
                 launch {
                     delay(130)
                     checkTrim.animateTo(1f, tween(730, easing = checkDrawEasing))
@@ -195,11 +192,7 @@ fun KSVideoProgressIndicator(
             // ── Settle phase (frames 216-252, ~360ms) ──
             phase = 2
             coroutineScope {
-                // Circle pulse down: 680→638, 360ms
-                launch {
-                    circleScale.animateTo(1f, tween(360, easing = scaleDownEasing))
-                }
-                // Stroke color: green→white, 330ms after 30ms hold (frames 219-252)
+                launch { circleScale.animateTo(1f, tween(360, easing = scaleDownEasing)) }
                 launch {
                     delay(30)
                     colorPhase.animateTo(0f, tween(330, easing = fadeInEasing))
@@ -213,8 +206,6 @@ fun KSVideoProgressIndicator(
         }
     }
 
-    val currentColor = lerp(baseColor, completeColor, colorPhase.value)
-
     Box(
         modifier = modifier
             .size(44.dp)
@@ -224,18 +215,25 @@ fun KSVideoProgressIndicator(
             },
         contentAlignment = Alignment.Center
     ) {
-        Canvas(modifier = Modifier.fillMaxSize()) {
             // Scale to fit max pulsed outer circle (680 + 120 = 800 Lottie units)
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+        ) {
+            val currentColor = Color(
+                red = lerp(baseColor.red, completeColor.red, colorPhase.value),
+                green = lerp(baseColor.green, completeColor.green, colorPhase.value),
+                blue = lerp(baseColor.blue, completeColor.blue, colorPhase.value),
+                alpha = lerp(baseColor.alpha, completeColor.alpha, colorPhase.value)
+            )
+
             val scale = size.minDimension / 800f
             val strokeWidthPx = 120f * scale
-            val baseRadius = 319f * scale // 638 / 2
+            val baseRadius = 319f * scale
             val currentRadius = baseRadius * circleScale.value
 
             val arcSize = Size(currentRadius * 2, currentRadius * 2)
-            val arcTopLeft = Offset(
-                x = center.x - currentRadius,
-                y = center.y - currentRadius
-            )
+            val arcTopLeft = Offset(center.x - currentRadius, center.y - currentRadius)
 
             // TRACK (Lottie layer 3): solid gray circle, always visible
             drawCircle(
@@ -261,22 +259,17 @@ fun KSVideoProgressIndicator(
 
             // CHECKMARK (Lottie layer 1): trim-path reveal
             if (icon != null && checkTrim.value > 0f) {
-                val d = baseRadius * 2 // checkmark scaled to base diameter
+                val d = baseRadius * 2
 
-                // Path vertices from Lottie, normalized to circle diameter:
-                // Lottie path [-7.14,0.39]→[-2.12,5.49]→[6.94,-4.68]
-                // scaled by 1339.46%, offset to (601.31,444.59), relative to center (600,449.56)
-                val checkPath = Path().apply {
-                    moveTo(center.x - 0.1478f * d, center.y + 0.0004f * d)
-                    lineTo(center.x - 0.0424f * d, center.y + 0.1074f * d)
-                    lineTo(center.x + 0.1477f * d, center.y - 0.1060f * d)
-                }
+                checkPath.reset()
+                checkPath.moveTo(center.x - 0.1478f * d, center.y + 0.0004f * d)
+                checkPath.lineTo(center.x - 0.0424f * d, center.y + 0.1074f * d)
+                checkPath.lineTo(center.x + 0.1477f * d, center.y - 0.1060f * d)
 
-                val measure = PathMeasure().apply { setPath(checkPath, false) }
-                val trimmedPath = Path()
-                measure.getSegment(0f, measure.length * checkTrim.value, trimmedPath, true)
+                pathMeasure.setPath(checkPath, false)
+                trimmedPath.reset()
+                pathMeasure.getSegment(0f, pathMeasure.length * checkTrim.value, trimmedPath, true)
 
-                // Stroke width: Lottie 3 * 13.3946 / 638 ≈ 0.06295 of diameter
                 drawPath(
                     path = trimmedPath,
                     color = currentColor,

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
@@ -219,7 +219,7 @@ fun KSVideoProgressIndicator(
             },
         contentAlignment = Alignment.Center
     ) {
-            // Scale to fit max pulsed outer circle (680 + 120 = 800 Lottie units)
+        // Scale to fit max pulsed outer circle (680 + 120 = 800 Lottie units)
         Canvas(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -123,51 +124,57 @@ fun KSCircularProgressIndicator(
  */
 @Composable
 fun KSVideoProgressIndicator(
-    progress: Float, // Expected 0.0 to 1.0 from the Card
+    progress: Float,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
     text: String = "",
     contentDescription: String = "",
     baseColor: Color = Color.White,
-    completeColor: Color = Color(0xFF8CE71A), // JSON Green
+    completeColor: Color = Color(0xFF8CE71A), // [0.55, 0.906, 0.1] from JSON
     trackColor: Color = Color.White.copy(alpha = 0.2f)
 ) {
-    // 1. Technical Constants from JSON
     val lottieEasing = CubicBezierEasing(0.15f, 0f, 0.27f, 1f)
-    val strokeRatio = 120f / 638f
 
-    // 2. Animation State Management
-    var targetProgress by remember { mutableFloatStateOf(0f) }
+    // Animation States
+    var targetProgressValue by remember { mutableFloatStateOf(0f) }
     val pulseScale = remember { Animatable(1f) }
-    var isAnimationComplete by remember { mutableStateOf(false) }
+
+    // 0: Initial, 1: Success (Green), 2: Settle (White)
+    var completionPhase by remember { mutableIntStateOf(0) }
 
     LaunchedEffect(progress) {
-        targetProgress = progress
+        targetProgressValue = progress
     }
 
-    // The "Running" Sweep Animation
     val animatedProgress by animateFloatAsState(
-        targetValue = targetProgress.coerceIn(0f, 1f),
+        targetValue = targetProgressValue.coerceIn(0f, 1f),
         animationSpec = tween(durationMillis = 800, easing = lottieEasing),
         label = "ProgressSweep"
     )
 
-    // 3. Phase Trigger: Run Pulse and Color shift once sweep hits 100%
+    // Sequence Trigger: Handles the Green -> White transition from frames 216-252
     LaunchedEffect(animatedProgress >= 1f) {
         if (animatedProgress >= 1f) {
-            isAnimationComplete = true
-            // Pulse Up (Frames 125-150 in JSON)
+            // Step 1: Hit Success Phase (Green + Pulse Up)
+            completionPhase = 1
             pulseScale.animateTo(1.06f, tween(300, easing = lottieEasing))
-            // Settle Down (Frames 216-252 in JSON)
+
+            // Step 2: Settle Phase (Back to White + Scale Down)
+            completionPhase = 2
             pulseScale.animateTo(1f, tween(300, easing = lottieEasing))
         } else {
-            isAnimationComplete = false
+            completionPhase = 0
             pulseScale.snapTo(1f)
         }
     }
 
+    // Color logic mapping to the JSON keyframes
     val animatedColor by animateColorAsState(
-        targetValue = if (isAnimationComplete) completeColor else baseColor,
+        targetValue = when (completionPhase) {
+            1 -> completeColor // Success Green
+            2 -> baseColor     // Settles back to White
+            else -> baseColor
+        },
         animationSpec = tween(500),
         label = "ColorPhase"
     )
@@ -183,42 +190,34 @@ fun KSVideoProgressIndicator(
         contentAlignment = Alignment.Center
     ) {
         Canvas(modifier = Modifier.fillMaxSize()) {
-            val strokeWidthPx = size.width * strokeRatio
+            val strokeWidthPx = size.width * (120f / 638f)
             val radius = (size.width - strokeWidthPx) / 2
 
-            // Background Track (Layer 3)
-            drawCircle(
-                color = trackColor,
-                radius = radius,
-                style = Stroke(width = strokeWidthPx)
-            )
+            // Track
+            drawCircle(color = trackColor, radius = radius, style = Stroke(width = strokeWidthPx))
 
-            // Progress Arc (Layer 2)
+            // Progress Arc
             if (animatedProgress > 0f) {
                 drawArc(
                     color = animatedColor,
                     startAngle = -90f,
                     sweepAngle = 360f * animatedProgress,
                     useCenter = false,
-                    style = Stroke(
-                        width = strokeWidthPx,
-                        cap = StrokeCap.Round,
-                        join = StrokeJoin.Round
-                    )
+                    style = Stroke(width = strokeWidthPx, cap = StrokeCap.Round, join = StrokeJoin.Round)
                 )
             }
         }
 
-        // Layer 1: Icon/Text Reveal
-        Crossfade(targetState = isAnimationComplete, label = "ContentFade") { completed ->
-            if (completed && icon != null) {
+        // Show Icon/Text based on the completion phase
+        Crossfade(targetState = completionPhase >= 1, label = "ContentFade") { isFinished ->
+            if (isFinished && icon != null) {
                 Icon(
                     imageVector = icon,
                     contentDescription = null,
                     tint = animatedColor,
                     modifier = Modifier.fillMaxSize(0.5f)
                 )
-            } else if (!completed && text.isNotEmpty()) {
+            } else if (!isFinished && text.isNotEmpty()) {
                 Text(
                     text = text,
                     color = Color.White,

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
@@ -139,9 +139,9 @@ fun KSVideoProgressIndicator(
     icon: ImageVector? = null,
     text: String = "",
     contentDescription: String = "",
-    baseColor: Color = Color.White,
-    completeColor: Color = Color(0xFF8CE71A),
-    trackColor: Color = Color(0xFF6B6B6B)
+    baseColor: Color = colors.videoPlayerProgressBase,
+    completeColor: Color = colors.videoPlayerProgressComplete,
+    trackColor: Color = colors.videoPlayerProgressTrack
 ) {
     val arcSweepEasing = CubicBezierEasing(0.741f, 0f, 0.545f, 1f)
     val fadeInEasing = CubicBezierEasing(0.5f, 0f, 0f, 1f)

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
@@ -211,10 +211,12 @@ fun KSVideoProgressIndicator(
         modifier = modifier
             .size(44.dp)
             .semantics(mergeDescendants = true) {
+                this.stateDescription = text
+
                 if (contentDescription.isNotEmpty()) {
                     this.contentDescription = contentDescription
                 }
-                this.stateDescription = text
+
                 this.progressBarRangeInfo = ProgressBarRangeInfo(progress, 0f..1f)
             },
         contentAlignment = Alignment.Center

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
@@ -1,6 +1,13 @@
 package com.kickstarter.ui.compose.designsystem
 
 import android.content.res.Configuration
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -15,11 +22,20 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.contentDescription
@@ -107,47 +123,108 @@ fun KSCircularProgressIndicator(
  */
 @Composable
 fun KSVideoProgressIndicator(
+    progress: Float, // Expected 0.0 to 1.0 from the Card
     modifier: Modifier = Modifier,
-    progress: Float,
-    text: String = "",
     icon: ImageVector? = null,
+    text: String = "",
     contentDescription: String = "",
+    baseColor: Color = Color.White,
+    completeColor: Color = Color(0xFF8CE71A), // JSON Green
+    trackColor: Color = Color.White.copy(alpha = 0.2f)
 ) {
+    // 1. Technical Constants from JSON
+    val lottieEasing = CubicBezierEasing(0.15f, 0f, 0.27f, 1f)
+    val strokeRatio = 120f / 638f
+
+    // 2. Animation State Management
+    var targetProgress by remember { mutableFloatStateOf(0f) }
+    val pulseScale = remember { Animatable(1f) }
+    var isAnimationComplete by remember { mutableStateOf(false) }
+
+    LaunchedEffect(progress) {
+        targetProgress = progress
+    }
+
+    // The "Running" Sweep Animation
+    val animatedProgress by animateFloatAsState(
+        targetValue = targetProgress.coerceIn(0f, 1f),
+        animationSpec = tween(durationMillis = 800, easing = lottieEasing),
+        label = "ProgressSweep"
+    )
+
+    // 3. Phase Trigger: Run Pulse and Color shift once sweep hits 100%
+    LaunchedEffect(animatedProgress >= 1f) {
+        if (animatedProgress >= 1f) {
+            isAnimationComplete = true
+            // Pulse Up (Frames 125-150 in JSON)
+            pulseScale.animateTo(1.06f, tween(300, easing = lottieEasing))
+            // Settle Down (Frames 216-252 in JSON)
+            pulseScale.animateTo(1f, tween(300, easing = lottieEasing))
+        } else {
+            isAnimationComplete = false
+            pulseScale.snapTo(1f)
+        }
+    }
+
+    val animatedColor by animateColorAsState(
+        targetValue = if (isAnimationComplete) completeColor else baseColor,
+        animationSpec = tween(500),
+        label = "ColorPhase"
+    )
+
     Box(
         modifier = modifier
             .size(44.dp)
-            .clip(CircleShape)
+            .graphicsLayer(scaleX = pulseScale.value, scaleY = pulseScale.value)
             .semantics(mergeDescendants = true) {
                 this.contentDescription = contentDescription
-                this.stateDescription = text
                 this.progressBarRangeInfo = ProgressBarRangeInfo(progress, 0f..1f)
             },
         contentAlignment = Alignment.Center
     ) {
-        CircularProgressIndicator(
-            progress = { progress },
-            modifier = Modifier
-                .padding(4.dp)
-                .fillMaxSize(),
-            color = Color.White,
-            trackColor = Color.White.copy(alpha = 0.15f),
-            strokeWidth = 5.dp,
-            strokeCap = StrokeCap.Round
-        )
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val strokeWidthPx = size.width * strokeRatio
+            val radius = (size.width - strokeWidthPx) / 2
 
-        if (icon != null) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = Color.White,
-                modifier = Modifier.size(dimensions.iconSizeMedium)
+            // Background Track (Layer 3)
+            drawCircle(
+                color = trackColor,
+                radius = radius,
+                style = Stroke(width = strokeWidthPx)
             )
+
+            // Progress Arc (Layer 2)
+            if (animatedProgress > 0f) {
+                drawArc(
+                    color = animatedColor,
+                    startAngle = -90f,
+                    sweepAngle = 360f * animatedProgress,
+                    useCenter = false,
+                    style = Stroke(
+                        width = strokeWidthPx,
+                        cap = StrokeCap.Round,
+                        join = StrokeJoin.Round
+                    )
+                )
+            }
         }
 
-        Text(
-            text = text,
-            color = Color.White,
-            style = typographyV2.bodyBoldXS.copy(fontSize = 12.sp)
-        )
+        // Layer 1: Icon/Text Reveal
+        Crossfade(targetState = isAnimationComplete, label = "ContentFade") { completed ->
+            if (completed && icon != null) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = animatedColor,
+                    modifier = Modifier.fillMaxSize(0.5f)
+                )
+            } else if (!completed && text.isNotEmpty()) {
+                Text(
+                    text = text,
+                    color = Color.White,
+                    style = typographyV2.bodyBoldXS.copy(fontSize = 12.sp)
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
@@ -26,15 +25,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -42,7 +40,6 @@ import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -172,7 +169,7 @@ fun KSVideoProgressIndicator(
     val animatedColor by animateColorAsState(
         targetValue = when (completionPhase) {
             1 -> completeColor // Success Green
-            2 -> baseColor     // Settles back to White
+            2 -> baseColor // Settles back to White
             else -> baseColor
         },
         animationSpec = tween(500),
@@ -190,20 +187,41 @@ fun KSVideoProgressIndicator(
         contentAlignment = Alignment.Center
     ) {
         Canvas(modifier = Modifier.fillMaxSize()) {
+            // 1. Calculate a consistent stroke width based on your design ratio
             val strokeWidthPx = size.width * (120f / 638f)
-            val radius = (size.width - strokeWidthPx) / 2
 
-            // Track
-            drawCircle(color = trackColor, radius = radius, style = Stroke(width = strokeWidthPx))
+            // 2. Calculate a shared radius that accounts for the stroke width
+            // to prevent the edges from being clipped at the Canvas bounds
+            val radius = (size.minDimension - strokeWidthPx) / 2f
 
-            // Progress Arc
+            // 3. Define the bounding box for the Arc so it matches the Circle's path
+            val arcSize = Size(radius * 2, radius * 2)
+            val arcTopLeft = Offset(
+                x = (size.width / 2f) - radius,
+                y = (size.height / 2f) - radius
+            )
+
+            // TRACK: Draws the static background circle
+            drawCircle(
+                color = trackColor,
+                radius = radius,
+                center = center,
+                style = Stroke(width = strokeWidthPx)
+            )
+
+            // PROGRESS: Draws the moving arc on top using the animated values
             if (animatedProgress > 0f) {
                 drawArc(
-                    color = animatedColor,
+                    color = animatedColor, // Keeps your Green -> White transition
                     startAngle = -90f,
-                    sweepAngle = 360f * animatedProgress,
+                    sweepAngle = 360f * animatedProgress, // Keeps your 0.0 -> 1.0 motion
                     useCenter = false,
-                    style = Stroke(width = strokeWidthPx, cap = StrokeCap.Round, join = StrokeJoin.Round)
+                    topLeft = arcTopLeft,
+                    size = arcSize,
+                    style = Stroke(
+                        width = strokeWidthPx,
+                        cap = StrokeCap.Round // Creates the rounded "pill" look
+                    )
                 )
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,5 +132,6 @@
   <string name="fpo_Rewind_10_seconds">Rewind 5 seconds</string>
   <string name="fpo_Play">Play</string>
   <string name="fpo_Forward">Forward 5 seconds</string>
+  <string name="fpo_Campaign_goal_reached" formatted="false">Campaign goal reached</string>
 
 </resources>

--- a/app/src/test/java/com/kickstarter/features/videofeed/ui/components/KSVideoCampaignCardTest.kt
+++ b/app/src/test/java/com/kickstarter/features/videofeed/ui/components/KSVideoCampaignCardTest.kt
@@ -63,9 +63,9 @@ class KSVideoCampaignCardTest : KSRobolectricTestCase() {
             }
         }
 
-        // Verify progress indicator tag and its state/range info
         composeTestRule.onNodeWithTag(KSVideoCampaignCardTestTag.PROGRESS_INDICATOR.name)
             .assertIsDisplayed()
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.ContentDescription, listOf(""))) // No content description when not fully funded
             .assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "50"))
             .assert(SemanticsMatcher.expectValue(SemanticsProperties.ProgressBarRangeInfo, ProgressBarRangeInfo(0.5f, 0f..1f)))
     }
@@ -85,7 +85,6 @@ class KSVideoCampaignCardTest : KSRobolectricTestCase() {
             }
         }
 
-        // Verify content description for completion and state description is empty
         composeTestRule.onNodeWithTag(KSVideoCampaignCardTestTag.PROGRESS_INDICATOR.name)
             .assertIsDisplayed()
             .assert(SemanticsMatcher.expectValue(SemanticsProperties.ContentDescription, listOf("Campaign goal reached")))


### PR DESCRIPTION
# 📲 What

This PR enhances the component's accessibility and animation to match design specifications for the component `KSVideoProgressIndicator`

# 🤔 Why

To provide users with immediate project context and a way to support creators directly from the new Video Feed interface, as part of the MBL-3070 initiative.

# 🛠 How

**Theme Integration:**
◦ Added primitive colors grey_055 (#6B6B6B) and green_300 (#8CE71A) to KSColors.kt.
◦ Defined new semantic color variables videoPlayerProgressBase, videoPlayerProgressComplete, and videoPlayerProgressTrack in KSCustomColors.
◦ Mapped these variables in both KSLightCustomColors and KSDarkCustomColors.

**Component Refactoring:**
◦ Updated KSVideoProgressIndicator to use androidx.compose.ui.util.lerp for color transitions.
◦ Replaced hardcoded parameter defaults with KSTheme.colors references.
◦ Implemented full custom drawing logic using Canvas to match Lottie animation frame-for-frame, including a pulsing success effect and trim-path checkmark reveal.

# 👀 See


https://github.com/user-attachments/assets/8662da8a-8d15-4cde-a7f3-b3de87b79941


|  |  |

# 📋 QA

- Open the Video Feed activity.
- Observe the progress indicators on campaign cards in both Light and Dark modes.
- Observe the animation when a campaign reaches 100%; it should pulse and draw a checkmark.

# Story 📖

[MBL-3074](https://kickstarter.atlassian.net/browse/MBL-3074)


[MBL-3074]: https://kickstarter.atlassian.net/browse/MBL-3074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ