### PR TITLE
[MBL-3093, MBL-3094, MBL-3095]: Add support for image captions & linked images to Project Story

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -332,6 +332,7 @@ dependencies {
     testImplementation "io.mockk:mockk-android:$mockkVersion"
     testImplementation "io.mockk:mockk-agent:$mockkVersion"
     testImplementation "com.squareup.okhttp3:mockwebserver:5.1.0"
+    testImplementation("io.coil-kt:coil-test:2.5.0")
 
     def espresso = '3.4.0'
     androidTestImplementation ('androidx.test.espresso:espresso-contrib:' + espresso) {

--- a/app/src/main/java/com/kickstarter/features/projectstory/ProjectStoryActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/projectstory/ProjectStoryActivity.kt
@@ -82,6 +82,7 @@ class ProjectStoryActivity : ComponentActivity() {
                     val txtState = projectStoryViewModel.txt
                     CompositionLocalProvider(LocalUriHandler provides uriHandler) {
                         CampaignScreen(uiState, txtState)
+//                        CaptionedImageScreen()
                     }
                 }
             }
@@ -172,10 +173,13 @@ class ProjectStoryActivity : ComponentActivity() {
                                 is RichTextItem.Text -> {
                                     when (item) {
                                         is RichTextItem.Text.Paragraph -> {
-                                            if (item.children?.any { it is RichTextItem.Photo } == true) {
-                                                Timber.w("MISSING LINKED IMAGE")
-                                            } else {
-                                                RichTextItemTextComponent(item as RichTextItem.Text)
+                                            val childPhoto = item.children?.firstOrNull { it is RichTextItem.Photo } as? RichTextItem.Photo
+                                            when {
+                                                childPhoto != null -> {
+                                                    val link = item.link
+                                                    RichTextItemPhotoComponent(childPhoto, link)
+                                                }
+                                                else -> RichTextItemTextComponent(item)
                                             }
                                         }
                                         else -> {

--- a/app/src/main/java/com/kickstarter/features/projectstory/ProjectStoryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/projectstory/ProjectStoryViewModel.kt
@@ -38,7 +38,8 @@ class ProjectStoryViewModel(
 
     private var project: Project? = null
 
-    val txt = mutableStateOf("https://www.kickstarter.com/projects/peak-design/roller-pro-carry-on-luggage-by-peak-design")
+//    val txt = mutableStateOf("https://www.kickstarter.com/projects/peak-design/roller-pro-carry-on-luggage-by-peak-design")
+    val txt = mutableStateOf("https://www.kickstarter.com/projects/glennf/flong-time-no-see")
 
     private var job: Job? = null
 

--- a/app/src/main/java/com/kickstarter/features/projectstory/ui/ConstraintsSizeResolver.kt
+++ b/app/src/main/java/com/kickstarter/features/projectstory/ui/ConstraintsSizeResolver.kt
@@ -1,0 +1,93 @@
+package com.kickstarter.features.projectstory.ui
+
+import android.content.Context
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.layout.LayoutModifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.unit.Constraints
+import coil.size.Dimension
+import coil.size.Size
+import coil.size.SizeResolver
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.mapNotNull
+
+/*
+ * These `SizeResolver`s and utility functions are lifted directly from the same version of the
+ * Coil library that is used in this project (2.7.0). In this version they are marked `internal`,
+ * but they are needed to match the behavior of `AsyncImage` when using `rememberAsyncImagePainter()`.
+ *
+ * This file should be removed upon upgrading to Coil 3.+.
+ *
+ * See:
+ * - https://github.com/coil-kt/coil/blob/2.7.0/coil-compose-base/src/main/java/coil/compose/ConstraintsSizeResolver.kt
+ * - https://github.com/coil-kt/coil/blob/2.7.0/coil-compose-base/src/main/java/coil/compose/utils.kt
+ */
+
+private val ZeroConstraints = Constraints.fixed(0, 0)
+
+@Stable
+private fun Constraints.toSizeOrNull(): Size? {
+    if (isZero) {
+        return null
+    } else {
+        val width = if (hasBoundedWidth) Dimension(maxWidth) else Dimension.Undefined
+        val height = if (hasBoundedHeight) Dimension(maxHeight) else Dimension.Undefined
+        return Size(width, height)
+    }
+}
+
+/**
+ * A [SizeResolver] that computes the size from the constraints passed during the layout phase.
+ */
+class ConstraintsSizeResolver : SizeResolver, LayoutModifier {
+
+    private val currentConstraints = MutableStateFlow(ZeroConstraints)
+
+    override suspend fun size(): Size {
+        return currentConstraints
+            .mapNotNull(Constraints::toSizeOrNull)
+            .first()
+    }
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints,
+    ): MeasureResult {
+        // Cache the current constraints.
+        currentConstraints.value = constraints
+
+        // Measure and layout the content.
+        val placeable = measurable.measure(constraints)
+        return layout(placeable.width, placeable.height) {
+            placeable.place(0, 0)
+        }
+    }
+
+    fun setConstraints(constraints: Constraints) {
+        currentConstraints.value = constraints
+    }
+}
+
+/* In Coil 2.7.0, this is the default SizeResolver when using `rememberAsyncImagePainter()`,
+ * a surprising difference from `AsyncImage`, which uses a `ConstraintsSizeResolver` by default when
+ * when `ContentScale` is anything but `None`. Moreover, there is a bug in 2.7.0 that prevents the
+ * default resolver from being activated in certain conditions, so it's more reliable to pass in an
+ * instance regardless. */
+class DisplaySizeResolver(private val context: Context) : SizeResolver {
+
+    override suspend fun size(): Size {
+        val metrics = context.resources.displayMetrics
+        val maxDimension = Dimension(maxOf(metrics.widthPixels, metrics.heightPixels))
+        return Size(maxDimension, maxDimension)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is DisplaySizeResolver && context == other.context
+    }
+
+    override fun hashCode() = context.hashCode()
+}

--- a/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryCaptionedImage.kt
+++ b/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryCaptionedImage.kt
@@ -1,0 +1,229 @@
+package com.kickstarter.features.projectstory.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import coil.compose.AsyncImagePainter
+import coil.compose.rememberAsyncImagePainter
+import coil.imageLoader
+import coil.request.ImageRequest
+import coil.size.SizeResolver
+import com.kickstarter.ui.compose.designsystem.KSTheme
+import com.kickstarter.ui.compose.designsystem.grey_04
+import org.joda.time.DateTime
+
+enum class ProjectStoryCaptionedImageTestTag {
+    CAPTION,
+}
+
+private val placeholderPainter = object : Painter() {
+    override val intrinsicSize = Size(100f, 50f)
+    override fun DrawScope.onDraw() {
+        drawRect(grey_04)
+    }
+}
+
+@Preview(
+    device = Devices.PIXEL_3
+)
+@Composable
+private fun CaptionedImageScreenPreview() {
+    KSTheme {
+        CaptionedImageScreen()
+    }
+}
+
+@Composable
+fun CaptionedImageScreen() {
+    Box(
+        modifier = Modifier
+            .background(Color(0xFFECE4DA))
+            .fillMaxSize()
+            .systemBarsPadding(),
+    ) {
+        ProjectStoryCaptionedImage(
+            image = "https://picsum.photos/1120/630?random=${DateTime.now().millis}",
+            caption = "The above image shows the Special Editions of Book 3, Book 2 and Book 1 at the front.",
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ProjectStoryCaptionedImagePreview() {
+    ProjectStoryCaptionedImage(
+        image = "https://picsum.photos/1120/630?random=${DateTime.now().millis}",
+        caption = "The above image shows the Special Editions of Book 3, Book 2 and Book 1 at the front."
+    )
+}
+
+@Composable
+fun ProjectStoryCaptionedImage(
+    modifier: Modifier = Modifier,
+    image: String?,
+    caption: String?,
+    link: String? = null,
+    onSuccess: ((AsyncImagePainter.State.Success) -> Unit)? = null
+) {
+    val context = LocalContext.current
+    val defaults = context.imageLoader.defaults
+
+    val contentScale = remember {
+        ContentScale.FillWidth
+    }
+
+    val sizeResolver = remember {
+        ConstraintsSizeResolver()
+    }
+
+    val imageRequest = remember {
+        ImageRequest.Builder(context)
+            .data(image)
+            .size(sizeResolver)
+            .defaults(defaults)
+            .crossfade(true)
+            .build()
+    }
+
+    val inPreview = LocalInspectionMode.current
+    val previewPlaceholder = remember {
+        if (inPreview) placeholderPainter else null
+    }
+
+    val painter = rememberAsyncImagePainter(
+        model = imageRequest,
+        contentScale = contentScale,
+        onSuccess = onSuccess,
+        placeholder = previewPlaceholder
+    )
+
+    ProjectStoryCaptionedImage(
+        modifier,
+        painter,
+        contentScale,
+        sizeResolver,
+        caption,
+        link,
+    )
+}
+
+@Composable
+fun ProjectStoryCaptionedImage(
+    modifier: Modifier = Modifier,
+    asyncPainter: AsyncImagePainter,
+    contentScale: ContentScale,
+    sizeResolver: SizeResolver,
+    caption: String?,
+    link: String? = null,
+) {
+    val uriHandler = LocalUriHandler.current
+
+    val clickableModifier =
+        if (link.isNullOrBlank())
+            Modifier
+        else
+            Modifier.clickable {
+                uriHandler.openUri(link)
+            }
+
+    Column(
+        modifier = Modifier
+            .then(modifier)
+            .then(clickableModifier)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+        ) {
+            ConstrainedImage(
+                modifier = Modifier.fillMaxWidth(),
+                painter = asyncPainter,
+                contentDescription = caption,
+                contentScale = contentScale,
+                sizeResolver = sizeResolver,
+                wrapContentHeightUnbounded = true
+            )
+            if (asyncPainter.state is AsyncImagePainter.State.Empty ||
+                asyncPainter.state is AsyncImagePainter.State.Loading
+            ) {
+                LinearProgressIndicator(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .fillMaxWidth(),
+                    color = grey_04,
+                    trackColor = Color.Transparent
+                )
+            }
+        }
+        caption?.let {
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(ProjectStoryCaptionedImageTestTag.CAPTION.name),
+                text = caption,
+                color = if (link.isNullOrBlank()) Color.Unspecified else StoryTheme.InlineStyles.link.color,
+                fontStyle = FontStyle.Italic,
+                textDecoration = if (link.isNullOrBlank()) null else TextDecoration.Underline,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+/* A Modified `Image` component that is mean to be paired with
+ * the use of `rememberAsyncImagePainter()` to enable behavior that
+ * more closely matches `AsyncImage` in both constrained an unconstrained environments
+ * (unconstrainted as in a LazyList or parent with a vertical/horizontalScroll modifier. */
+@Composable
+private fun ConstrainedImage(
+    painter: Painter,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    sizeResolver: SizeResolver, /* Probably make this nullable */
+    wrapContentHeightUnbounded: Boolean = true
+) {
+    Image(
+        modifier = Modifier
+            .run { if (wrapContentHeightUnbounded) wrapContentHeight(unbounded = true) else this }
+            .then(modifier)
+            .then(sizeResolver as? ConstraintsSizeResolver ?: Modifier),
+        painter = painter,
+        contentDescription = contentDescription,
+        alignment = alignment,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter
+    )
+}

--- a/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryCaptionedImage.kt
+++ b/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryCaptionedImage.kt
@@ -41,7 +41,7 @@ import com.kickstarter.ui.compose.designsystem.grey_04
 import org.joda.time.DateTime
 
 enum class ProjectStoryCaptionedImageTestTag {
-    CAPTION,
+    IMAGE, CAPTION, LOADING_INDICATOR
 }
 
 private val placeholderPainter = object : Painter() {
@@ -160,11 +160,12 @@ fun ProjectStoryCaptionedImage(
             .then(clickableModifier)
     ) {
         Box(
-            modifier = Modifier
-                .fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
         ) {
             ConstrainedImage(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(ProjectStoryCaptionedImageTestTag.IMAGE.name),
                 painter = asyncPainter,
                 contentDescription = caption,
                 contentScale = contentScale,
@@ -177,7 +178,8 @@ fun ProjectStoryCaptionedImage(
                 LinearProgressIndicator(
                     modifier = Modifier
                         .align(Alignment.Center)
-                        .fillMaxWidth(),
+                        .fillMaxWidth()
+                        .testTag(ProjectStoryCaptionedImageTestTag.LOADING_INDICATOR.name),
                     color = grey_04,
                     trackColor = Color.Transparent
                 )

--- a/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryComponents.kt
+++ b/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryComponents.kt
@@ -5,14 +5,10 @@ import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.painter.ColorPainter
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.LocalPinnableContainer
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.Bullet
@@ -26,15 +22,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
-import coil.compose.AsyncImage
 import com.kickstarter.features.projectstory.data.RichTextItem
 import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.libs.utils.extensions.getEnvironment
-import com.kickstarter.ui.compose.designsystem.grey_03
 import com.kickstarter.ui.compose.designsystem.kds_create_700
 import timber.log.Timber
 
@@ -182,14 +175,15 @@ private fun parseRichTextChildrenOfRichText(children: List<RichTextItem.Text.Chi
 }
 
 @Composable
-fun RichTextItemPhotoComponent(item: RichTextItem.Photo) {
+fun RichTextItemPhotoComponent(item: RichTextItem.Photo, link: String? = null) {
+    // Consider special handling of empty image url
     val imageUrl = item.asset?.url ?: item.url
-    AsyncImage(
-        model = imageUrl,
-        contentDescription = item.altText,
-        modifier = Modifier.fillMaxWidth().defaultMinSize(minHeight = 30.dp),
-        placeholder = ColorPainter(color = grey_03),
-        contentScale = ContentScale.FillWidth
+    // `item.caption` can be empty
+    val caption = item.caption.ifBlank { null }
+    ProjectStoryCaptionedImage(
+        image = imageUrl,
+        caption = caption,
+        link = link
     )
 }
 

--- a/app/src/test/java/com/kickstarter/TestKSApplication.java
+++ b/app/src/test/java/com/kickstarter/TestKSApplication.java
@@ -2,6 +2,13 @@ package com.kickstarter;
 
 import com.facebook.FacebookSdk;
 
+import org.jetbrains.annotations.NotNull;
+
+import coil.ComponentRegistry;
+import coil.ImageLoader;
+import coil.request.ErrorResult;
+import coil.test.FakeImageLoaderEngine;
+
 public class TestKSApplication extends KSApplication {
 
   @Override
@@ -23,6 +30,20 @@ public class TestKSApplication extends KSApplication {
   @Override
   public boolean isInUnitTests() {
     return true;
+  }
+
+  @Override
+  public @NotNull ImageLoader newImageLoader() {
+    final FakeImageLoaderEngine engine = new FakeImageLoaderEngine.Builder()
+            .addInterceptor((chain, continuation) ->
+                    new ErrorResult(null, chain.getRequest(), new Throwable()))
+            .build();
+    final ComponentRegistry componentRegistry = new ComponentRegistry.Builder()
+            .add(engine)
+            .build();
+    return new ImageLoader.Builder(this)
+            .components(componentRegistry)
+            .build();
   }
 }
 

--- a/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryCaptionedImageTest.kt
+++ b/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryCaptionedImageTest.kt
@@ -10,13 +10,14 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.printToString
 import androidx.test.core.app.ApplicationProvider
 import coil.Coil
 import coil.ImageLoader
@@ -34,7 +35,6 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import org.joda.time.DateTime
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -124,18 +124,18 @@ class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
 
         assertEquals(1, onSuccessCount)
 
-        composeTestRule.onNode(
-            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image)
-                and hasContentDescription(caption)
-        ).assertIsDisplayed()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.IMAGE.name))
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image))
+            .assertContentDescriptionEquals(caption)
+            .assertIsDisplayed()
 
         composeTestRule.onNode(
             SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
         ).assertDoesNotExist()
 
-        composeTestRule.onNode(
-            hasText(caption)
-        ).assertIsDisplayed()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name))
+            .assertTextEquals(caption)
+            .assertIsDisplayed()
     }
 
     @Test
@@ -149,18 +149,18 @@ class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
             )
         }
 
-        composeTestRule.onNode(
-            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image)
-                and hasContentDescription(caption)
-        ).assertIsNotDisplayed()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.IMAGE.name))
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image))
+            .assertContentDescriptionEquals(caption)
+            .assertIsNotDisplayed()
 
         composeTestRule.onNode(
             SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
         ).assertDoesNotExist()
 
-        composeTestRule.onNode(
-            hasText(caption)
-        ).assertIsDisplayed()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name))
+            .assertTextEquals(caption)
+            .assertIsDisplayed()
     }
 
     @Test /* For Reference */
@@ -224,11 +224,9 @@ class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
             )
         }
 
-        println("${DateTime.now()} ${composeTestRule.onRoot().printToString()}")
-
-        composeTestRule.onNode(
-            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
-        ).assertIsDisplayed()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.LOADING_INDICATOR.name))
+            .assert(SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo))
+            .assertIsDisplayed()
 
         /* Using `advanceTimeBy()` + `runCurrent()` just to make the explicit connection to `requestDelay`.
          * These can be replaced with a single call to `advanceUntilIdle()`. */
@@ -237,20 +235,18 @@ class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
 
         composeTestRule.waitForIdle()
 
-        println("${DateTime.now()} ${composeTestRule.onRoot().printToString()}")
-
         composeTestRule.onNode(
             SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
         ).assertDoesNotExist()
 
-        composeTestRule.onNode(
-            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image)
-                and hasContentDescription(caption)
-        ).assertIsDisplayed()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.IMAGE.name))
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image))
+            .assertContentDescriptionEquals(caption)
+            .assertIsDisplayed()
 
-        composeTestRule.onNode(
-            hasText(caption)
-        ).assertIsDisplayed()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name))
+            .assertTextEquals(caption)
+            .assertIsDisplayed()
     }
 
     @Test
@@ -264,9 +260,9 @@ class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
             )
         }
 
-        composeTestRule.onNode(
-            hasText(caption)
-        ).assertIsDisplayed()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name))
+            .assertTextEquals(caption)
+            .assertIsDisplayed()
     }
 
     @Test
@@ -278,9 +274,8 @@ class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
             )
         }
 
-        composeTestRule.onNode(
-            hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name)
-        ).assertDoesNotExist()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name))
+            .assertDoesNotExist()
     }
 
     companion object {

--- a/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryCaptionedImageTest.kt
+++ b/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryCaptionedImageTest.kt
@@ -1,0 +1,289 @@
+package com.kickstarter.features.projecstory.ui
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.GradientDrawable
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.printToString
+import androidx.test.core.app.ApplicationProvider
+import coil.Coil
+import coil.ImageLoader
+import coil.annotation.ExperimentalCoilApi
+import coil.decode.DataSource
+import coil.request.ErrorResult
+import coil.request.SuccessResult
+import coil.test.FakeImageLoaderEngine
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.features.projectstory.ui.ProjectStoryCaptionedImage
+import com.kickstarter.features.projectstory.ui.ProjectStoryCaptionedImageTestTag
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.joda.time.DateTime
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoilApi::class)
+class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private fun gradientDrawable(color: Int, width: Int = 100, height: Int = 50) =
+        GradientDrawable().apply {
+            shape = GradientDrawable.RECTANGLE
+            setColor(color)
+            setSize(width, height)
+        }
+
+    private fun bitmapDrawable(width: Int = 100, height: Int = 50): Drawable {
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        return BitmapDrawable(context.resources, bitmap)
+    }
+
+    private fun fakeImageLoaderEngine() =
+        FakeImageLoaderEngine.Builder()
+            .intercept(
+                "https://www.example.com/image.png",
+                bitmapDrawable()
+            )
+            .intercept(
+                { it == "https://www.example.com/red.jpg" },
+                { ErrorResult(null, it.request, Throwable("Bad request: red")) }
+            )
+            .intercept(
+                { it is String && it.contains("green") },
+                gradientDrawable(Color.GREEN)
+            )
+            .intercept(
+                { it == "https://www.example.com/blue.jpg" },
+                {
+                    /* The `ImageRequest` for `rememberAsyncImagePainter` is executed explicitly on
+                     * `Dispatchers.Main.immediate`. But this suspending `intercept` method is run on
+                     * the `ImageRequest.interceptorDispatcher`, which we can set to a test dispatcher,
+                     * and then introduce a delay to witness AsyncImagePainter's `Loading` state.
+                     *
+                     * An alternative would be to call `Dispatchers.setMain()` with a test dispatcher.
+                     * But on the current versions of the the current set of test libraries, this does
+                     * not work as expected, and requires coordinating with Robolectric. */
+                    delay(REQUEST_DELAY)
+                    SuccessResult(gradientDrawable(Color.BLUE), it.request, DataSource.MEMORY)
+                }
+            )
+            .default { ErrorResult(null, it.request, Throwable("Default interceptor error")) }
+            .build()
+
+    private fun setUpImageLoader(imageLoader: ImageLoader) {
+        Coil.setImageLoader(imageLoader)
+    }
+
+    @Before
+    fun before() {
+        setUpImageLoader(
+            ImageLoader.Builder(context)
+                .components { add(fakeImageLoaderEngine()) }
+                .build()
+        )
+    }
+
+    @After
+    fun after() {
+        Coil.reset()
+    }
+
+    @Test
+    fun `test image success with caption`() {
+        val caption = "Aye aye, Caption"
+
+        var onSuccessCount = 0
+
+        composeTestRule.setContent {
+            ProjectStoryCaptionedImage(
+                image = "https://www.example.com/green.jpg",
+                caption = caption,
+                link = null,
+                onSuccess = {
+                    onSuccessCount++
+                }
+            )
+        }
+
+        assertEquals(1, onSuccessCount)
+
+        composeTestRule.onNode(
+            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image)
+                and hasContentDescription(caption)
+        ).assertIsDisplayed()
+
+        composeTestRule.onNode(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
+        ).assertDoesNotExist()
+
+        composeTestRule.onNode(
+            hasText(caption)
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun `test image error with caption`() {
+        val caption = "Aye aye, Caption"
+
+        composeTestRule.setContent {
+            ProjectStoryCaptionedImage(
+                image = "https://www.example.com/red.jpg",
+                caption = caption,
+            )
+        }
+
+        composeTestRule.onNode(
+            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image)
+                and hasContentDescription(caption)
+        ).assertIsNotDisplayed()
+
+        composeTestRule.onNode(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
+        ).assertDoesNotExist()
+
+        composeTestRule.onNode(
+            hasText(caption)
+        ).assertIsDisplayed()
+    }
+
+    @Test /* For Reference */
+    @OptIn(ExperimentalTestApi::class)
+    fun `test image loading with caption (mainClock)`() {
+        val caption = "Aye aye, Caption"
+
+        composeTestRule.mainClock.autoAdvance = false
+
+        composeTestRule.setContent {
+            ProjectStoryCaptionedImage(
+                image = "https://www.example.com/green.jpg",
+                caption = caption,
+            )
+        }
+
+        composeTestRule.waitUntilExactlyOneExists(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
+        )
+
+        composeTestRule.onNode(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
+        ).assertIsDisplayed()
+
+        composeTestRule.mainClock.autoAdvance = true
+
+        composeTestRule.waitUntilDoesNotExist(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
+        )
+
+        composeTestRule.onNode(
+            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image)
+                and hasContentDescription(caption)
+        ).assertIsDisplayed()
+
+        composeTestRule.onNode(
+            hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name)
+                and hasText(caption)
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `test image loading with caption`() = runTest {
+        val standardDispatcher = StandardTestDispatcher(testScheduler)
+
+        setUpImageLoader(
+            ImageLoader.Builder(context)
+                .components { add(fakeImageLoaderEngine()) }
+                .dispatcher(standardDispatcher)
+                .interceptorDispatcher(standardDispatcher)
+                .build()
+        )
+
+        val caption = "Aye aye, Caption"
+
+        composeTestRule.setContent {
+            ProjectStoryCaptionedImage(
+                image = "https://www.example.com/blue.jpg",
+                caption = caption,
+            )
+        }
+
+        println("${DateTime.now()} ${composeTestRule.onRoot().printToString()}")
+
+        composeTestRule.onNode(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
+        ).assertIsDisplayed()
+
+        /* Using `advanceTimeBy()` + `runCurrent()` just to make the explicit connection to `requestDelay`.
+         * These can be replaced with a single call to `advanceUntilIdle()`. */
+        advanceTimeBy(REQUEST_DELAY)
+        runCurrent()
+
+        composeTestRule.waitForIdle()
+
+        println("${DateTime.now()} ${composeTestRule.onRoot().printToString()}")
+
+        composeTestRule.onNode(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
+        ).assertDoesNotExist()
+
+        composeTestRule.onNode(
+            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image)
+                and hasContentDescription(caption)
+        ).assertIsDisplayed()
+
+        composeTestRule.onNode(
+            hasText(caption)
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun `test empty caption still displayed`() {
+        val caption = ""
+
+        composeTestRule.setContent {
+            ProjectStoryCaptionedImage(
+                image = null,
+                caption = caption,
+            )
+        }
+
+        composeTestRule.onNode(
+            hasText(caption)
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun `test null caption not displayed`() {
+        composeTestRule.setContent {
+            ProjectStoryCaptionedImage(
+                image = null,
+                caption = null,
+            )
+        }
+
+        composeTestRule.onNode(
+            hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name)
+        ).assertDoesNotExist()
+    }
+
+    companion object {
+        private const val REQUEST_DELAY = 1500L
+    }
+}

--- a/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryComponentsTest.kt
+++ b/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryComponentsTest.kt
@@ -1,0 +1,228 @@
+package com.kickstarter.features.projecstory.ui
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.printToString
+import androidx.test.core.app.ApplicationProvider
+import coil.Coil
+import coil.ImageLoader
+import coil.annotation.ExperimentalCoilApi
+import coil.decode.DataSource
+import coil.request.ErrorResult
+import coil.request.SuccessResult
+import coil.test.FakeImageLoaderEngine
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.features.projectstory.data.RichTextItem
+import com.kickstarter.features.projectstory.ui.ProjectStoryCaptionedImageTestTag
+import com.kickstarter.features.projectstory.ui.RichTextItemPhotoComponent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.joda.time.DateTime
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoilApi::class)
+class ProjectStoryComponentsTest : KSRobolectricTestCase() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private fun fakeImageLoaderEngine() =
+        FakeImageLoaderEngine.Builder()
+            .intercept(
+                { it == "https://www.example.com/blue.jpg" },
+                {
+                    delay(1500L)
+
+                    SuccessResult(
+                        GradientDrawable().apply {
+                            shape = GradientDrawable.RECTANGLE
+                            setColor(Color.BLUE)
+                            setSize(100, 50)
+                        },
+                        it.request,
+                        DataSource.MEMORY
+                    )
+                }
+            )
+            .default { ErrorResult(null, it.request, Throwable("Default interceptor error")) }
+            .build()
+
+    private fun setUpImageLoader(imageLoader: ImageLoader) {
+        Coil.setImageLoader(imageLoader)
+    }
+
+    @Before
+    fun before() {
+        setUpImageLoader(
+            ImageLoader.Builder(context)
+                .components { add(fakeImageLoaderEngine()) }
+                .build()
+        )
+    }
+
+    @After
+    fun after() {
+        Coil.reset()
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `test image loading + success with caption`() = runTest {
+        val standardDispatcher = StandardTestDispatcher(testScheduler)
+
+        setUpImageLoader(
+            ImageLoader.Builder(context)
+                .components { add(fakeImageLoaderEngine()) }
+                .dispatcher(standardDispatcher)
+                .interceptorDispatcher(standardDispatcher)
+                .build()
+        )
+
+        val caption = "Aye aye, Caption"
+
+        val imageUrl = "https://www.example.com/blue.jpg"
+        val richTextItemPhoto = RichTextItem.Photo(
+            __typename = "",
+            url = imageUrl,
+            altText = caption,
+            caption = caption,
+            asset = RichTextItem.Photo.Asset(
+                url = imageUrl,
+                altText = caption
+            ),
+        )
+
+        composeTestRule.setContent {
+            RichTextItemPhotoComponent(
+                richTextItemPhoto
+            )
+        }
+
+        println("${DateTime.now()} ${composeTestRule.onRoot().printToString()}")
+
+        composeTestRule.onNode(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
+        ).assertIsDisplayed()
+
+        composeTestRule.onNode(
+            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image)
+                and hasContentDescription(caption)
+        ).assertExists()
+
+        composeTestRule.onNode(
+            hasText(caption)
+        ).assertIsDisplayed()
+
+        advanceUntilIdle()
+
+        composeTestRule.waitForIdle()
+
+        println("${DateTime.now()} ${composeTestRule.onRoot().printToString()}")
+
+        composeTestRule.onNode(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
+        ).assertDoesNotExist()
+
+        composeTestRule.onNode(
+            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image)
+                and hasContentDescription(caption)
+        ).assertIsDisplayed()
+
+        composeTestRule.onNode(
+            hasText(caption)
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun `test empty caption does not render`() {
+        val caption = ""
+
+        val imageUrl = ""
+        val richTextItemPhoto = RichTextItem.Photo(
+            __typename = "",
+            url = imageUrl,
+            altText = caption,
+            caption = caption,
+            asset = RichTextItem.Photo.Asset(
+                url = imageUrl,
+                altText = caption
+            ),
+        )
+
+        composeTestRule.setContent {
+            RichTextItemPhotoComponent(
+                richTextItemPhoto
+            )
+        }
+
+        composeTestRule.onAllNodes(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.Text)
+        ).assertCountEquals(0)
+    }
+
+    @Test
+    fun `test link + click`() {
+        val caption = "Aye aye, Caption"
+
+        val imageUrl = ""
+        val richTextItemPhoto = RichTextItem.Photo(
+            __typename = "",
+            url = imageUrl,
+            altText = caption,
+            caption = caption,
+            asset = RichTextItem.Photo.Asset(
+                url = imageUrl,
+                altText = caption
+            ),
+        )
+
+        val link = "https://www.example.com"
+        var clickCount = 0
+        val uriHandler = object : UriHandler {
+            override fun openUri(uri: String) {
+                clickCount++
+            }
+        }
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalUriHandler provides uriHandler) {
+                RichTextItemPhotoComponent(
+                    richTextItemPhoto,
+                    link
+                )
+            }
+        }
+
+        println("${DateTime.now()} ${composeTestRule.onRoot(true).printToString()}")
+
+        composeTestRule.onNode(
+            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image)
+                and hasContentDescription(caption),
+            true
+        ).performClick()
+
+        composeTestRule.onNode(
+            hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name),
+            true
+        ).performClick()
+
+        assertEquals(2, clickCount)
+    }
+}

--- a/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryComponentsTest.kt
+++ b/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryComponentsTest.kt
@@ -9,14 +9,13 @@ import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.printToString
 import androidx.test.core.app.ApplicationProvider
 import coil.Coil
 import coil.ImageLoader
@@ -34,7 +33,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.joda.time.DateTime
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -115,39 +113,34 @@ class ProjectStoryComponentsTest : KSRobolectricTestCase() {
             )
         }
 
-        println("${DateTime.now()} ${composeTestRule.onRoot().printToString()}")
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.LOADING_INDICATOR.name))
+            .assert(SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo))
+            .assertIsDisplayed()
 
-        composeTestRule.onNode(
-            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
-        ).assertIsDisplayed()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.IMAGE.name))
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image))
+            .assertContentDescriptionEquals(caption)
+            .assertIsNotDisplayed()
 
-        composeTestRule.onNode(
-            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image)
-                and hasContentDescription(caption)
-        ).assertExists()
-
-        composeTestRule.onNode(
-            hasText(caption)
-        ).assertIsDisplayed()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name))
+            .assertTextEquals(caption)
+            .assertIsDisplayed()
 
         advanceUntilIdle()
 
         composeTestRule.waitForIdle()
 
-        println("${DateTime.now()} ${composeTestRule.onRoot().printToString()}")
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.LOADING_INDICATOR.name))
+            .assertDoesNotExist()
 
-        composeTestRule.onNode(
-            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
-        ).assertDoesNotExist()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.IMAGE.name))
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image))
+            .assertContentDescriptionEquals(caption)
+            .assertIsDisplayed()
 
-        composeTestRule.onNode(
-            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image)
-                and hasContentDescription(caption)
-        ).assertIsDisplayed()
-
-        composeTestRule.onNode(
-            hasText(caption)
-        ).assertIsDisplayed()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name))
+            .assertTextEquals(caption)
+            .assertIsDisplayed()
     }
 
     @Test
@@ -172,9 +165,8 @@ class ProjectStoryComponentsTest : KSRobolectricTestCase() {
             )
         }
 
-        composeTestRule.onAllNodes(
-            SemanticsMatcher.keyIsDefined(SemanticsProperties.Text)
-        ).assertCountEquals(0)
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name))
+            .assertDoesNotExist()
     }
 
     @Test
@@ -210,18 +202,11 @@ class ProjectStoryComponentsTest : KSRobolectricTestCase() {
             }
         }
 
-        println("${DateTime.now()} ${composeTestRule.onRoot(true).printToString()}")
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.IMAGE.name), true)
+            .performClick()
 
-        composeTestRule.onNode(
-            SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image)
-                and hasContentDescription(caption),
-            true
-        ).performClick()
-
-        composeTestRule.onNode(
-            hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name),
-            true
-        ).performClick()
+        composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name), true)
+            .performClick()
 
         assertEquals(2, clickCount)
     }


### PR DESCRIPTION
# 📲 What

Add support for image captions & linked images to the SDUI-powered Project Story component.

# 🤔 Why

Images in Project stories can be captioned, linked, or both. The Project Story display in the app should support these aspects for parity with the web experience.

# 🛠 How

### Context for image-related data structures

From an SDUI perspective, the base image structure is really a "captioned image", as reflected in both the GraphQL `RichTextPhoto` type and the internal `RichTextItem.Photo` data model (see the [transformer](https://github.com/kickstarter/android-oss/blob/8c7e2a5938407301560cb739dd485a445f585f87/app/src/main/java/com/kickstarter/services/transformers/extensions/RichTextTransformers.kt#L137)). 

```json
{
  "__typename": "RichTextPhoto",
  "url": "",
  "altText": "",
  "caption": "",
  "asset": {
    "url": "",
    "altText": ""
  }
}
```

Furthermore, when a linked image is parsed, the API returns a `RichTextPhoto` as a child of a `RichText` item, which is internally mapped to a `RichTextItem.Photo` child of a `RichTextItem.Text.Paragraph` (see the [transformer](https://github.com/kickstarter/android-oss/blob/8c7e2a5938407301560cb739dd485a445f585f87/app/src/main/java/com/kickstarter/services/transformers/extensions/RichTextTransformers.kt#L72)). 

```json
{
  "__typename": "RichText",
  "text": null,
  "link": "",
  "styles": [],
  "children": [
    {
      "__typename": "RichTextPhoto",
      "url": "",
      "altText": "",
      "caption": "",
      "asset": {
        "url": "",
        "altText": ""
      }
    }
  ]
}
```

In the current implementation, we consider a `Paragraph` to represent a link for a `Photo` if _any_ of its children is a `Photo` (see [L176](https://github.com/kickstarter/android-oss/pull/2493/changes#diff-4a424c260bb8a242a073e12b976dacddc5f9e91e7b6882e999040ad859b6a4faR176) in ProjectStoryActivity). We take that link, and the first child `Photo`, and pass them to `RichTextItemPhotoComponent()`. In practice, a linked image should always return the same structure of a `RichText` wrapping a _single_ `RichTextPhoto`.

### Details

- Create a `ProjectStoryCaptionedImage` composable that loads and displays a network image alongside an optional caption.
  - Internally, use the `AsyncImagePainter.State` to display a loading indicator.
  - To ensure images are handled comparably to `AsyncImage`, lift the internal `ConstraintsSizeResolver` class and associated utility functions from the Coil library.
    - In Coil 2.7.0, the version used in this project, these components are `internal`. However, they are exposed in 3.+ and recommended to be used as such (see [coil/coil-compose at 3.0.0 · coil-kt/coil](https://github.com/coil-kt/coil/tree/3.0.0/coil-compose#rememberasyncimagepainter), [Compose - Coil](https://coil-kt.github.io/coil/compose/#rememberasyncimagepainter)).
  - If a link is passed in, add a `clickable` Modifier that delegates to the same CompositionLocal `UriHandler` used for text links (see #2483).
- Replace the implementation of `RichTextItemPhotoComponent` with a direct emission of `ProjectStoryCaptionedImage`.
- Add Coil's test library (`io.coil-kt:coil-test:2.5.0`) to access `FakeImageLoaderEngine` ([2.7.0 docs](https://github.com/coil-kt/coil/tree/2.7.0/coil-test))
  - When added to an `ImageLoader`, this engine intercepts all `ImageRequest`s and returns custom, specified `ImageResult`s, synchronously and on the main thread (note that the `interceptorDispatcher` can overriden for additional test control, as is done in `ProjectStoryCaptionedImageTest.kt`).
- To simplify and protect future tests, update `TestKSApplication` to override `newImageLoader()` and return an instance of an `ImageLoader` that only registers a `FakeImageLoaderEngine`.

# 👀 See

### Before 🐛

No captions, and linked images aren't displayed at all.

https://github.com/user-attachments/assets/4aa1e209-1bc2-400b-89a9-c13b7bf04fe1

### After 🦋 |

Captions, linked images are displayed and clickable. If the image is both captioned and linked, the caption is styled to match the pre-existing implementation.

https://github.com/user-attachments/assets/1f1b1ba2-f12e-423b-b27c-91f0363c68d5

# 📋 QA

(Note: You can simulate a slow network connection with the 'Network download rate limit' setting in Developer Options, in order to dutifully witness the loading state.)

1. Navigate to Internal Tools > Project Story Activity
2. Submit a Project url to fetch and display the Story data.
  - The default project is now [Flong Time, No See: Forgotten Stories of Printing and Labor by Glenn Fleishman — Kickstarter](https://www.kickstarter.com/projects/glennf/flong-time-no-see), with examples of both regular captioned images and linked captioned images.
  - The project in the video: [Draw Like a Boss 2 — Final Print Run by Ash DLAB — Kickstarter](https://www.kickstarter.com/projects/ashdrawsthings/draw-like-a-boss-2-sold-out-final-print-run)

# Story 📖

[\[MBL-3093\] Support image captions - Jira](https://kickstarter.atlassian.net/browse/MBL-3093)
[\[MBL-3094\] Handle linked image structure & component click event - Jira](https://kickstarter.atlassian.net/browse/MBL-3094)
[\[MBL-3095\] Add placeholders and loading indicators for image components - Jira](https://kickstarter.atlassian.net/browse/MBL-3095)
