### PR TITLE
MBL-3145: Vertical Pager with Snapping scroll behaviour

### DIFF
--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
@@ -12,8 +12,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kickstarter.features.videofeed.data.KSVideoBadgeType
@@ -54,18 +57,30 @@ class VideoFeedActivity : ComponentActivity() {
 
                 // TODO: Following vm lines are for qa/demo purposes as of now!!! aiming here to avoid videoURL expiration real VM still to come
                 val videoFeedUIState = viewModel.videoFeedUIState.collectAsStateWithLifecycle()
-                val videoUrl = videoFeedUIState.value.project?.video()?.hls() ?: ""
-                val profileImage = videoFeedUIState.value.project?.creator()?.avatar()?.medium() ?: ""
-                val projectTitle = videoFeedUIState.value.project?.name() ?: "Ringo Move - The Ultimate Workout Bottle"
-                val percentageFounded = videoFeedUIState.value.project?.percentageFunded() ?: 0f
+                val projectsList = videoFeedUIState.value.projects
 
-                val pagerState = rememberPagerState(pageCount = { 5 })
+                val pagerState = rememberPagerState(pageCount = { projectsList.size })
+
+//                val pool = remember { VideoPlayerPool(this) }
+//                DisposableEffect(pool) { onDispose { pool.releaseAll() } }
 
                 VerticalPager(
                     modifier = Modifier.fillMaxSize(),
                     state = pagerState,
-                    beyondViewportPageCount = 1
+                    beyondViewportPageCount = 1,
+                    key = { index -> projectsList[index].id() }
                 ) { page ->
+
+                    val project = projectsList[page]
+                    val videoUrl = project.video()?.hls() ?: ""
+                    val profileImage = project.creator()?.avatar()?.medium() ?: ""
+                    val projectTitle = project.name()
+                    val percentageFounded = project.percentageFunded()
+
+//                    val player = remember(page, videoUrl) {
+//                        pool.getPlayer(page, videoUrl, pagerState.currentPage)
+//                    }
+
                     KSVideoPlayer(
                         videoUrl = videoUrl,
                         isActive = pagerState.currentPage == page,

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
@@ -6,9 +6,12 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.VerticalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -56,43 +59,51 @@ class VideoFeedActivity : ComponentActivity() {
                 val projectTitle = videoFeedUIState.value.project?.name() ?: "Ringo Move - The Ultimate Workout Bottle"
                 val percentageFounded = videoFeedUIState.value.project?.percentageFunded() ?: 0f
 
-                KSVideoPlayer(
-                    videoUrl = videoUrl,
-                    isActive = true,
-                    overlayContent = { hazeState ->
-                        Column(
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            KSVideoActionsColumn(
-                                modifier = Modifier
-                                    .align(Alignment.End)
-                                    .padding(end = dimensions.paddingMediumLarge),
-                                profileImageUrl = profileImage,
-                                bookmarkCount = "1k",
-                                shareCount = "50",
-                                onProfileClick = { },
-                                onBookmarkClick = { },
-                                onShareClick = { },
-                                onMoreOptionsClick = { }
-                            )
+                val pagerState = rememberPagerState(pageCount = { 5 })
 
-                            Spacer(modifier = Modifier.height(24.dp))
+                VerticalPager(
+                    modifier = Modifier.fillMaxSize(),
+                    state = pagerState,
+                    beyondViewportPageCount = 1
+                ) { page ->
+                    KSVideoPlayer(
+                        videoUrl = videoUrl,
+                        isActive = pagerState.currentPage == page,
+                        overlayContent = { hazeState ->
+                            Column(
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                KSVideoActionsColumn(
+                                    modifier = Modifier
+                                        .align(Alignment.End)
+                                        .padding(end = dimensions.paddingMediumLarge),
+                                    profileImageUrl = profileImage,
+                                    bookmarkCount = "1k",
+                                    shareCount = "50",
+                                    onProfileClick = { },
+                                    onBookmarkClick = { },
+                                    onShareClick = { },
+                                    onMoreOptionsClick = { }
+                                )
 
-                            KSVideoBadgesRow(
-                                badges = badges,
-                                hazeState = hazeState
-                            )
+                                Spacer(modifier = Modifier.height(24.dp))
 
-                            KSVideoCampaignCard(
-                                title = projectTitle,
-                                subtitle = "$50,134 pledged • Join 431 backers",
-                                buttonText = "Back this project",
-                                onButtonClick = { },
-                                progress = percentageFounded
-                            )
+                                KSVideoBadgesRow(
+                                    badges = badges,
+                                    hazeState = hazeState
+                                )
+
+                                KSVideoCampaignCard(
+                                    title = projectTitle,
+                                    subtitle = "$50,134 pledged • Join 431 backers",
+                                    buttonText = "Back this project",
+                                    onButtonClick = { },
+                                    progress = percentageFounded
+                                )
+                            }
                         }
-                    }
-                )
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
@@ -4,29 +4,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.pager.VerticalPager
-import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.kickstarter.features.videofeed.data.KSVideoBadgeType
-import com.kickstarter.features.videofeed.ui.components.KSVideoActionsColumn
-import com.kickstarter.features.videofeed.ui.components.KSVideoBadgesRow
-import com.kickstarter.features.videofeed.ui.components.KSVideoCampaignCard
 import com.kickstarter.features.videofeed.viewmodel.VideoFeedViewModel
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.utils.extensions.getEnvironment
 import com.kickstarter.ui.compose.designsystem.KSTheme
-import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
-import com.kickstarter.ui.compose.designsystem.videoplayer.KSVideoPlayer
-import kotlin.getValue
 
 class VideoFeedActivity : ComponentActivity() {
 
@@ -44,78 +27,8 @@ class VideoFeedActivity : ComponentActivity() {
 
         setContent {
             KSTheme {
-                // TODO: In future tickets this hardcoded list will be substituted by the result of a query
-                val badges = listOf(
-                    KSVideoBadgeType.ProjectWeLove,
-                    KSVideoBadgeType.DaysLeft("3 days left"),
-                    KSVideoBadgeType.JustLaunched,
-                    KSVideoBadgeType.Trending
-                )
-
-                // TODO: Following vm lines are for qa/demo purposes as of now!!! aiming here to avoid videoURL expiration real VM still to come
-                val videoFeedUIState = viewModel.videoFeedUIState.collectAsStateWithLifecycle()
-                val projectsList = videoFeedUIState.value.projects
-
-                val pagerState = rememberPagerState(pageCount = { projectsList.size })
-
-//                val pool = remember { VideoPlayerPool(this) }
-//                DisposableEffect(pool) { onDispose { pool.releaseAll() } }
-
-                VerticalPager(
-                    modifier = Modifier.fillMaxSize(),
-                    state = pagerState,
-                    beyondViewportPageCount = 1,
-                    key = { index -> projectsList[index].id() }
-                ) { page ->
-
-                    val project = projectsList[page]
-                    val videoUrl = project.video()?.hls() ?: ""
-                    val profileImage = project.creator()?.avatar()?.medium() ?: ""
-                    val projectTitle = project.name()
-                    val percentageFounded = project.percentageFunded()
-
-//                    val player = remember(page, videoUrl) {
-//                        pool.getPlayer(page, videoUrl, pagerState.currentPage)
-//                    }
-
-                    KSVideoPlayer(
-                        videoUrl = videoUrl,
-                        isActive = pagerState.currentPage == page,
-                        overlayContent = { hazeState ->
-                            Column(
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                KSVideoActionsColumn(
-                                    modifier = Modifier
-                                        .align(Alignment.End)
-                                        .padding(end = dimensions.paddingMediumLarge),
-                                    profileImageUrl = profileImage,
-                                    bookmarkCount = "1k",
-                                    shareCount = "50",
-                                    onProfileClick = { },
-                                    onBookmarkClick = { },
-                                    onShareClick = { },
-                                    onMoreOptionsClick = { }
-                                )
-
-                                Spacer(modifier = Modifier.height(24.dp))
-
-                                KSVideoBadgesRow(
-                                    badges = badges,
-                                    hazeState = hazeState
-                                )
-
-                                KSVideoCampaignCard(
-                                    title = projectTitle,
-                                    subtitle = "$50,134 pledged • Join 431 backers",
-                                    buttonText = "Back this project",
-                                    onButtonClick = { },
-                                    progress = percentageFounded
-                                )
-                            }
-                        }
-                    )
-                }
+                val videoFeedUIState by viewModel.videoFeedUIState.collectAsStateWithLifecycle()
+                VideoFeedScreen(projectsList = videoFeedUIState.projects)
             }
         }
     }

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
@@ -12,11 +12,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kickstarter.features.videofeed.data.KSVideoBadgeType

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
@@ -1,0 +1,115 @@
+package com.kickstarter.features.videofeed.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.VerticalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kickstarter.features.videofeed.data.KSVideoBadgeType
+import com.kickstarter.features.videofeed.ui.components.KSVideoActionsColumn
+import com.kickstarter.features.videofeed.ui.components.KSVideoBadgesRow
+import com.kickstarter.features.videofeed.ui.components.KSVideoCampaignCard
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.models.Project
+import com.kickstarter.ui.compose.designsystem.KSTheme
+import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
+import com.kickstarter.ui.compose.designsystem.videoplayer.KSVideoPlayer
+
+enum class VideoFeedScreenTestTag {
+    VIDEO_FEED_PAGER,
+    VIDEO_FEED_OVERLAY_CONTAINER
+}
+
+@Composable
+fun VideoFeedScreen(
+    projectsList: List<Project>
+) {
+    // TODO: In future tickets this hardcoded list will be substituted by the result of a query
+    val badges = listOf(
+        KSVideoBadgeType.ProjectWeLove,
+        KSVideoBadgeType.DaysLeft("3 days left"),
+        KSVideoBadgeType.JustLaunched,
+        KSVideoBadgeType.Trending
+    )
+
+    val pagerState = rememberPagerState(pageCount = { projectsList.size })
+
+    VerticalPager(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag(VideoFeedScreenTestTag.VIDEO_FEED_PAGER.name),
+        state = pagerState,
+        beyondViewportPageCount = 1,
+        key = { index -> projectsList[index].id() }
+    ) { page ->
+
+        val project = projectsList[page]
+        val videoUrl = project.video()?.hls() ?: ""
+        val profileImage = project.creator().avatar().medium()
+        val projectTitle = project.name()
+        val percentageFounded = project.percentageFunded()
+
+        KSVideoPlayer(
+            videoUrl = videoUrl,
+            isActive = pagerState.currentPage == page,
+            overlayContent = { hazeState ->
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_${project.id()}")
+                ) {
+                    KSVideoActionsColumn(
+                        modifier = Modifier
+                            .align(Alignment.End)
+                            .padding(end = dimensions.paddingMediumLarge),
+                        profileImageUrl = profileImage,
+                        bookmarkCount = "1k",
+                        shareCount = "50",
+                        onProfileClick = { },
+                        onBookmarkClick = { },
+                        onShareClick = { },
+                        onMoreOptionsClick = { }
+                    )
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    KSVideoBadgesRow(
+                        badges = badges,
+                        hazeState = hazeState
+                    )
+
+                    KSVideoCampaignCard(
+                        title = projectTitle,
+                        subtitle = "$50,134 pledged • Join 431 backers",
+                        buttonText = "Back this project",
+                        onButtonClick = { },
+                        progress = percentageFounded
+                    )
+                }
+            }
+        )
+    }
+}
+
+@Preview
+@Composable
+fun VideoFeedScreenPreview() {
+    KSTheme {
+        VideoFeedScreen(
+            projectsList = listOf(
+                ProjectFactory.project(),
+                ProjectFactory.caProject(),
+                ProjectFactory.ukProject()
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModel.kt
@@ -7,11 +7,9 @@ import com.kickstarter.libs.Environment
 import com.kickstarter.models.Project
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
@@ -20,7 +18,7 @@ import timber.log.Timber
 import kotlin.coroutines.EmptyCoroutineContext
 
 data class VideoFeedUIState(
-    val project: Project? = null,
+    val projects: List<Project> = emptyList()
 )
 
 class VideoFeedViewModel(
@@ -32,29 +30,34 @@ class VideoFeedViewModel(
     private val apolloClient = requireNotNull(environment.apolloClientV2())
 
     private val _videoFeedUIState = MutableStateFlow(VideoFeedUIState())
-    val videoFeedUIState: StateFlow<VideoFeedUIState>
-        get() = _videoFeedUIState
-            .asStateFlow()
-            .stateIn(
-                scope = scope,
-                started = SharingStarted.WhileSubscribed(),
-                initialValue = VideoFeedUIState()
-            )
+
+    val videoFeedUIState: StateFlow<VideoFeedUIState> = _videoFeedUIState.asStateFlow()
 
     init {
-        // getProject("wowfactories/the-combine-driver-2-in-1-ratchet-and-torque-screwdriver")
-        getProject("ringobottle/ringo-move")
+        loadDemoProjects()
+    }
+
+    private fun loadDemoProjects() {
+        // TODO: replace with a single paginated feed query.
+        listOf(
+            "ringobottle/ringo-move",
+            "cameraintelligence/caira-worlds-first-ai-native-mirrorless-camera",
+            "rollbed/roll-real-bed-in-an-unreal-size",
+            "wowfactories/the-combine-driver-2-in-1-ratchet-and-torque-screwdriver",
+            "hyodo/magbasetm-swappable-wallet-for-magsafe-designed-by-hyodo",
+            "kode/kode-dot-the-all-in-one-pocket-size-maker-device",
+        ).forEach { getProject(it) }
     }
 
     private fun getProject(slug: String) {
         scope.launch {
             apolloClient.getProject(slug)
                 .asFlow()
-                .catch {
-                    Timber.d(it)
-                }
+                .catch { Timber.d(it) }
                 .collect { project ->
-                    _videoFeedUIState.update { it.copy(project = project) }
+                    _videoFeedUIState.update { state ->
+                        state.copy(projects = state.projects + project)
+                    }
                 }
         }
     }

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ContextExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ContextExt.kt
@@ -13,6 +13,7 @@ import androidx.core.content.ContextCompat
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import com.kickstarter.KSApplication
@@ -39,13 +40,43 @@ fun Context.getEnvironment(): Environment? {
 }
 
 /**
+ * Returns true if the current device is an emulator.
+ */
+fun isEmulator(): Boolean {
+    return (
+        Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic") ||
+            Build.FINGERPRINT.startsWith("generic") ||
+            Build.FINGERPRINT.startsWith("unknown") ||
+            Build.HARDWARE.contains("goldfish") ||
+            Build.HARDWARE.contains("ranchu") ||
+            Build.MODEL.contains("google_sdk") ||
+            Build.MODEL.contains("Emulator") ||
+            Build.MODEL.contains("Android SDK built for x86") ||
+            Build.MANUFACTURER.contains("Genymotion") ||
+            Build.PRODUCT.contains("sdk_google") ||
+            Build.PRODUCT.contains("google_sdk") ||
+            Build.PRODUCT.contains("sdk") ||
+            Build.PRODUCT.contains("sdk_x86") ||
+            Build.PRODUCT.contains("vbox86p") ||
+            Build.PRODUCT.contains("emulator") ||
+            Build.PRODUCT.contains("simulator")
+        )
+}
+
+/**
  * Initializes and returns a configured [ExoPlayer] instance.
  *
  * This player is preconfigured with KS custom User-Agent and uses a [DefaultDataSource.Factory]
  * to support media playback over HTTP(S).
  *
- * Note: This method opts into Media3's [UnstableApi] due to the usage of [setMediaSourceFactory],
- * which is required for setting custom HTTP headers such as User-Agent.
+ * It also configures the [DefaultRenderersFactory] to disable asynchronous codec queuing
+ * specifically when running on an emulator. This helps avoid
+ * [androidx.media3.exoplayer.mediacodec.MediaCodecRenderer.DecoderInitializationException]
+ * (specifically "Decoder init failed: c2.goldfish.h264.decoder") which is a known issue
+ * with the emulator's H.264 decoder and Media3's asynchronous implementation.
+ *
+ * Note: This method opts into Media3's [UnstableApi] due to the usage of [setMediaSourceFactory] and
+ * [setRenderersFactory], which are required for setting custom HTTP headers and codec configurations.
  */
 @OptIn(UnstableApi::class)
 fun Context.initializeExoplayer(): ExoPlayer {
@@ -54,7 +85,13 @@ fun Context.initializeExoplayer(): ExoPlayer {
 
     val dataSourceFactory = DefaultDataSource.Factory(this, httpDataSourceFactory)
 
-    val player = ExoPlayer.Builder(this)
+    val renderersFactory = DefaultRenderersFactory(this)
+    if (isEmulator()) {
+        // - Disable asynchronous codec queuing to avoid "Decoder init failed: c2.goldfish.h264.decoder" on emulators
+        renderersFactory.forceDisableMediaCodecAsynchronousQueueing()
+    }
+
+    val player = ExoPlayer.Builder(this, renderersFactory)
         .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
         .build()
 

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
@@ -139,9 +139,7 @@ fun KSVideoPlayer(
 ) {
     if (videoUrl.isEmpty()) return // TODO: Check video format of the url on the VM
     val context = LocalContext.current
-    // When an external player is provided, key on the player instance so that the pool can
-    // recycle it across pages without triggering spurious recomputations. When managed
-    // internally, key on videoUrl so the player is replaced if the URL changes.
+
     val exoPlayer = remember(player ?: videoUrl) {
         player ?: context.initializeExoplayer().apply {
             setMediaItem(MediaItem.fromUri(videoUrl))

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
@@ -236,6 +236,7 @@ fun KSVideoPlayer(
             },
             onRelease = { view ->
                 (view.tag as? Player.Listener)?.let { exoPlayer.removeListener(it) }
+                exoPlayer.clearVideoTextureView(view)
             },
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
@@ -139,7 +139,10 @@ fun KSVideoPlayer(
 ) {
     if (videoUrl.isEmpty()) return // TODO: Check video format of the url on the VM
     val context = LocalContext.current
-    val exoPlayer = remember(videoUrl) { // - TODO will be extracted to a videoplayer pool, and the pool will be pass as dependency
+    // When an external player is provided, key on the player instance so that the pool can
+    // recycle it across pages without triggering spurious recomputations. When managed
+    // internally, key on videoUrl so the player is replaced if the URL changes.
+    val exoPlayer = remember(player ?: videoUrl) {
         player ?: context.initializeExoplayer().apply {
             setMediaItem(MediaItem.fromUri(videoUrl))
             repeatMode = Player.REPEAT_MODE_ONE
@@ -152,12 +155,9 @@ fun KSVideoPlayer(
     var showControls by remember { mutableStateOf(false) }
     val hazeState = rememberHazeState()
 
-    LaunchedEffect(isActive) {
-        exoPlayer.playWhenReady = isActive
-    }
-
     // - Updated progress bar only when active
     LaunchedEffect(isActive) {
+        exoPlayer.playWhenReady = isActive
         if (isActive) {
             while (true) {
                 val duration = exoPlayer.duration
@@ -215,22 +215,27 @@ fun KSVideoPlayer(
             }
     ) {
         AndroidView(
-            factory = {
-                // - Required TextureView to work in tandem with haze to achieve glassmorphism on control buttons/badges
-                TextureView(context).apply {
+            // - Required TextureView to work in tandem with haze to achieve glassmorphism on control buttons/badges
+            factory = { ctx ->
+                TextureView(ctx).apply {
                     layoutParams = ViewGroup.LayoutParams(
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.MATCH_PARENT
                     )
-                    exoPlayer.setVideoTextureView(this)
-                    exoPlayer.addListener(object : Player.Listener {
+                    val listener = object : Player.Listener {
                         override fun onVideoSizeChanged(videoSize: VideoSize) {
                             if (videoSize.width > 0 && videoSize.height > 0) {
                                 this@apply.applyZoomMatrix(videoSize.width, videoSize.height)
                             }
                         }
-                    })
+                    }
+                    tag = listener
+                    exoPlayer.setVideoTextureView(this)
+                    exoPlayer.addListener(listener)
                 }
+            },
+            onRelease = { view ->
+                (view.tag as? Player.Listener)?.let { exoPlayer.removeListener(it) }
             },
             modifier = Modifier
                 .fillMaxSize()
@@ -271,7 +276,9 @@ fun KSVideoPlayer(
         }
     }
 
-    DisposableEffect(videoUrl) {
+    // Key on the player instance: release only when the internal player is replaced or disposed.
+    // External (pool) players are never released here — the pool owns their lifecycle.
+    DisposableEffect(exoPlayer) {
         onDispose { if (player == null) exoPlayer.release() }
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
@@ -40,6 +40,11 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.setProgress
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -47,6 +52,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
 import androidx.media3.exoplayer.ExoPlayer
+import com.kickstarter.R
 import com.kickstarter.libs.utils.extensions.initializeExoplayer
 import com.kickstarter.ui.compose.designsystem.KSControlIcon
 import com.kickstarter.ui.compose.designsystem.KSLinearProgressIndicator
@@ -207,7 +213,8 @@ fun KSVideoPlayer(
             .testTag(KSVideoPlayerTestTag.VIDEO_PLAYER_SURFACE.name)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
-                indication = null // Remove ripple for the background tap
+                indication = null, // Remove ripple for the background tap
+                onClickLabel = stringResource(id = if (showControls) R.string.accessibility_discovery_buttons_close else R.string.fpo_Play)
             ) {
                 onToggleControls()
             }
@@ -307,6 +314,14 @@ private fun ProgressBarContainer(
             .fillMaxWidth()
             .height(48.dp) // Standard touch target height
             .testTag(KSVideoPlayerTestTag.VIDEO_PLAYER_PROGRESS_BAR.name)
+            .semantics {
+                val progress = progressProvider()
+                progressBarRangeInfo = ProgressBarRangeInfo(progress, 0f..1f)
+                setProgress { targetProgress ->
+                    onSeek(targetProgress)
+                    true
+                }
+            }
             .pointerInput(Unit) {
                 detectTapGestures { offset ->
                     val tappedProgress = offset.x / size.width
@@ -368,7 +383,8 @@ private fun ControlsContainer(
                     playPauseCallback.invoke()
                 },
                 hazeState = hazeState,
-                modifier = Modifier.testTag(KSVideoPlayerTestTag.VIDEO_PLAYER_PLAY_BUTTON.name)
+                modifier = Modifier.testTag(KSVideoPlayerTestTag.VIDEO_PLAYER_PLAY_BUTTON.name),
+                contentDescription = stringResource(id = R.string.fpo_Play)
             )
 
             KSControlIcon(

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
@@ -47,6 +47,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
 import androidx.media3.exoplayer.ExoPlayer
+import com.kickstarter.libs.utils.extensions.initializeExoplayer
 import com.kickstarter.ui.compose.designsystem.KSControlIcon
 import com.kickstarter.ui.compose.designsystem.KSLinearProgressIndicator
 import com.kickstarter.ui.compose.designsystem.KSTheme
@@ -139,7 +140,7 @@ fun KSVideoPlayer(
     if (videoUrl.isEmpty()) return // TODO: Check video format of the url on the VM
     val context = LocalContext.current
     val exoPlayer = remember(videoUrl) { // - TODO will be extracted to a videoplayer pool, and the pool will be pass as dependency
-        player ?: ExoPlayer.Builder(context).build().apply {
+        player ?: context.initializeExoplayer().apply {
             setMediaItem(MediaItem.fromUri(videoUrl))
             repeatMode = Player.REPEAT_MODE_ONE
             prepare()

--- a/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
@@ -1,0 +1,66 @@
+package com.kickstarter.features.videofeed.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeUp
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.ui.compose.designsystem.KSTheme
+import org.junit.Test
+
+class VideoFeedScreenTest : KSRobolectricTestCase() {
+
+    @Test
+    fun `VideoFeedScreen displays pager and verifies beyondViewportPageCount and key usage`() {
+        val project1Id = 101L
+        val project2Id = 102L
+        val project3Id = 103L
+
+        val projects = listOf(
+            ProjectFactory.project().toBuilder().id(project1Id).build(),
+            ProjectFactory.caProject().toBuilder().id(project2Id).build(),
+            ProjectFactory.ukProject().toBuilder().id(project3Id).build()
+        )
+
+        composeTestRule.setContent {
+            KSTheme {
+                VideoFeedScreen(projectsList = projects)
+            }
+        }
+
+        // --- Initial State (Page 0) ---
+        // Verify Pager exists
+        composeTestRule.onNodeWithTag(VideoFeedScreenTestTag.VIDEO_FEED_PAGER.name)
+            .assertIsDisplayed()
+
+        // Verify Page 0 is displayed and associated with correct Project ID
+        composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project1Id", useUnmergedTree = true)
+            .assertIsDisplayed()
+
+        // Verify beyondViewportPageCount = 1: Page 1 should exist in composition but not necessarily be fully displayed
+        composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project2Id", useUnmergedTree = true)
+            .assertExists()
+
+        // 3. Verify Page 2 does NOT exist (it's beyond the viewport + 1)
+        composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project3Id", useUnmergedTree = true)
+            .assertDoesNotExist()
+
+        // --- Swipe to Page 1 ---
+        composeTestRule.onNodeWithTag(VideoFeedScreenTestTag.VIDEO_FEED_PAGER.name)
+            .performTouchInput { swipeUp() }
+        composeTestRule.waitForIdle()
+
+        // 4. Verify Page 1 is now "displayed" (active page)
+        composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project2Id", useUnmergedTree = true)
+            .assertExists()
+
+        // 5. Verify Page 0 still exists (it's 1 page behind now)
+        composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project1Id", useUnmergedTree = true)
+            .assertExists()
+
+        // 6. Verify Page 2 now exists (it's 1 page ahead)
+        composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project3Id", useUnmergedTree = true)
+            .assertExists()
+    }
+}

--- a/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
@@ -1,11 +1,13 @@
 package com.kickstarter.features.videofeed.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeUp
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.mock.factories.VideoFactory
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import org.junit.Test
 
@@ -17,10 +19,13 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         val project2Id = 102L
         val project3Id = 103L
 
+        // KSVideoPlayer needs a valid hls url
+        val video = VideoFactory.hlsVideo()
+
         val projects = listOf(
-            ProjectFactory.project().toBuilder().id(project1Id).build(),
-            ProjectFactory.caProject().toBuilder().id(project2Id).build(),
-            ProjectFactory.ukProject().toBuilder().id(project3Id).build()
+            ProjectFactory.project().toBuilder().id(project1Id).video(video).build(),
+            ProjectFactory.caProject().toBuilder().id(project2Id).video(video).build(),
+            ProjectFactory.ukProject().toBuilder().id(project3Id).video(video).build()
         )
 
         composeTestRule.setContent {
@@ -29,38 +34,40 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
             }
         }
 
-        // --- Initial State (Page 0) ---
-        // Verify Pager exists
         composeTestRule.onNodeWithTag(VideoFeedScreenTestTag.VIDEO_FEED_PAGER.name)
-            .assertIsDisplayed()
-
-        // Verify Page 0 is displayed and associated with correct Project ID
-        composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project1Id", useUnmergedTree = true)
-            .assertIsDisplayed()
-
-        // Verify beyondViewportPageCount = 1: Page 1 should exist in composition but not necessarily be fully displayed
-        composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project2Id", useUnmergedTree = true)
             .assertExists()
 
-        // 3. Verify Page 2 does NOT exist (it's beyond the viewport + 1)
+        // Page 0 is in the tree and associated with correct Project ID (key test), and displayed
+        composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project1Id", useUnmergedTree = true)
+            .assertExists()
+            .assertIsDisplayed()
+
+        // beyondViewportPageCount = 1: Page 1 should exist in composition, not yet displayed
+        composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project2Id", useUnmergedTree = true)
+            .assertExists()
+            .assertIsNotDisplayed()
+
+        // Page 2 does NOT exist (it's beyond the viewport + 1)
         composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project3Id", useUnmergedTree = true)
             .assertDoesNotExist()
 
-        // --- Swipe to Page 1 ---
         composeTestRule.onNodeWithTag(VideoFeedScreenTestTag.VIDEO_FEED_PAGER.name)
             .performTouchInput { swipeUp() }
         composeTestRule.waitForIdle()
 
-        // 4. Verify Page 1 is now "displayed" (active page)
+        // Page 1 exists and displayed
         composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project2Id", useUnmergedTree = true)
             .assertExists()
+            .assertIsDisplayed()
 
-        // 5. Verify Page 0 still exists (it's 1 page behind now)
+        // Page 0 still exists (1 page behind) and not displayed
         composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project1Id", useUnmergedTree = true)
             .assertExists()
+            .assertIsNotDisplayed()
 
-        // 6. Verify Page 2 now exists (it's 1 page ahead)
+        // Page 2 now exists (1 page ahead)
         composeTestRule.onNodeWithTag("${VideoFeedScreenTestTag.VIDEO_FEED_OVERLAY_CONTAINER.name}_$project3Id", useUnmergedTree = true)
             .assertExists()
+            .assertIsNotDisplayed()
     }
 }

--- a/app/src/test/java/com/kickstarter/features/videofeed/ui/components/KSVideoActionsColumnTest.kt
+++ b/app/src/test/java/com/kickstarter/features/videofeed/ui/components/KSVideoActionsColumnTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.kickstarter.KSRobolectricTestCase
@@ -36,11 +37,15 @@ class KSVideoActionsColumnTest : KSRobolectricTestCase() {
         val bookmarkDesc = context().getString(R.string.fpo_Bookmark)
         composeTestRule.onNodeWithContentDescription(bookmarkDesc).assertIsDisplayed()
         composeTestRule.onNodeWithText("1.2k").assertIsDisplayed()
+        composeTestRule.onNodeWithTag(KSVideoActionsColumnTestTag.BOOKMARK_BUTTON.name, useUnmergedTree = true)
+            .assertExists()
 
         // Verify share button and count
         val shareDesc = context().getString(R.string.fpo_Share)
         composeTestRule.onNodeWithContentDescription(shareDesc).assertIsDisplayed()
         composeTestRule.onNodeWithText("45").assertIsDisplayed()
+        composeTestRule.onNodeWithTag(KSVideoActionsColumnTestTag.SHARE_BUTTON.name, useUnmergedTree = true)
+            .assertExists()
 
         // Verify more options button
         val moreDesc = context().getString(R.string.fpo_More_options)

--- a/app/src/test/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayerTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayerTest.kt
@@ -189,6 +189,10 @@ class KSVideoPlayerTest() : KSRobolectricTestCase() {
         composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_CONTROLS.name).assertDoesNotExist()
 
         verify(mockPlayer).play()
+
+        // Check Video Player Surface has click label
+        composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_SURFACE.name)
+            .assertExists()
     }
 
     @Test
@@ -236,6 +240,10 @@ class KSVideoPlayerTest() : KSRobolectricTestCase() {
 
         // - Should seek to 25% of 100000L = 25000L
         verify(mockPlayer).seekTo(25000L)
+
+        // Check Progress Bar semantics
+        composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_PROGRESS_BAR.name, useUnmergedTree = true)
+            .assertExists()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Implemented a scrollable video discovery feed. This PR introduces the VideoFeedScreen with vertical paging, refactors the video player for better lifecycle management, and enhances accessibility.

# 🤔 Why

To provide an immersive, video-first discovery experience for Kickstarter projects. This work sets the foundation for the video feed feature by moving from a single-video test implementation to a multi-project pager. Part of the initiative [MBL-3070](https://kickstarter.atlassian.net/browse/MBL-3070)

# 🛠 How

• New Screen: Created `VideoFeedScreen.kt` using Compose's VerticalPager. It manages the state and layout for the full-screen video experience, added equivalent previews and tests. 
• Improved KSVideoPlayer resource management by utilizing AndroidView's onRelease callback to clear listeners and texture views.
◦ Small accesibility improvements
◦ Centralized ExoPlayer initialization logic into a new Context extension.

# 👀 See

https://github.com/user-attachments/assets/6748f61f-3d3e-4fb0-960e-54e6323ff835



|  |  |

# 📋 QA

- Launch the app and navigate to the Video Feed.
- Verify that you can scroll vertically through the list of projects.
- Confirm that videos auto-play when they are the primary focused item in the pager.
- Scroll up/down several time quickly

# Story 📖

[MBL-3145](https://kickstarter.atlassian.net/browse/MBL-3145)


[MBL-3070]: https://kickstarter.atlassian.net/browse/MBL-3070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MBL-3145]: https://kickstarter.atlassian.net/browse/MBL-3145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ