### PR TITLE
DISC-140: Feature flagging with statsig (feature gates)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -349,7 +349,7 @@ dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
 
     // Statsig
-    implementation 'com.github.statsig-io:android-sdk:4.37.0'
+    implementation 'com.statsig:android-sdk:4.45.6'
 }
 
 // SHA and timestamp caching courtesy of https://github.com/gdg-x/frisbee/blob/develop/app/build.gradle#L193-L218

--- a/app/src/main/java/com/kickstarter/KSApplication.kt
+++ b/app/src/main/java/com/kickstarter/KSApplication.kt
@@ -20,6 +20,7 @@ import com.kickstarter.libs.SegmentTrackingClient
 import com.kickstarter.libs.braze.RemotePushClientType
 import com.kickstarter.libs.featureflag.FeatureFlagClientType
 import com.kickstarter.libs.featureflag.StatsigClient
+import com.kickstarter.libs.featureflag.StatsigException
 import com.kickstarter.libs.utils.ApplicationLifecycleUtil
 import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.viewmodels.InitializationState
@@ -136,7 +137,7 @@ open class KSApplication : MultiDexApplication(), IKSApplicationComponent, Image
         statsigClient.initialize(
             scope = applicationScope,
             errorCallback = { exception ->
-                FirebaseCrashlytics.getInstance().recordException(exception)
+                FirebaseCrashlytics.getInstance().recordException(StatsigException(exception))
             }
         )
 

--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -7,7 +7,7 @@ import com.kickstarter.libs.CurrentUserTypeV2
 import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.libs.utils.extensions.isFalse
 import com.kickstarter.libs.utils.extensions.isTrue
-import com.statsig.androidsdk.InitializationDetails
+import com.statsig.androidsdk.FeatureGate
 import com.statsig.androidsdk.Statsig
 import com.statsig.androidsdk.StatsigOptions
 import com.statsig.androidsdk.StatsigUser
@@ -22,11 +22,26 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
 
+enum class StatsigGateKey(val key: String) {
+    ANDROID_VIDEO_FEED("android_video_feed")
+}
+
 class StatsigException(cause: Throwable) : Exception(cause)
 interface StatsigClientType {
     fun getSDKKey(): String
     fun isInitialized(): Boolean = Statsig.isInitialized()
-    fun checkGate(gateName: String) = Statsig.checkGate(gateName) // TODO: For feature flags, will expand in the future
+    fun checkGate(gateName: String) = Statsig.checkGate(gateName)
+
+    /**
+     * Returns the full [FeatureGate] object for [gateName], including the evaluated boolean value,
+     * the matched [com.statsig.androidsdk.FeatureGate.getRuleID] (which rule in the Statsig
+     * console was responsible for the result), and [com.statsig.androidsdk.EvaluationDetails]
+     * describing how the value was resolved (network, cache, etc.).
+     *
+     * Prefer this over [checkGate] when you need more than just the boolean — e.g. for logging
+     * which rule was evaluated or for debugging targeting behaviour.
+     */
+    fun getFeatureGate(gateName: String): FeatureGate = Statsig.getFeatureGate(gateName)
     fun getExperiment(experimentName: String) = Statsig.getExperiment(experimentName) // TODO: for test MOCK statsig DynamicConfig type or expose to the rest of the app just the json values, will explore in the future
     suspend fun updateUser(id: String) = Statsig.updateUser(StatsigUser(id))
     fun getStableId() = Statsig.getStableID()
@@ -44,21 +59,32 @@ open class StatsigClient(
         if (build.isRelease && Build.isExternal()) Secrets.Statsig.PRODUCTION
         else Secrets.Statsig.STAGING
 
-    fun initialize(scope: CoroutineScope, dispatcher: CoroutineDispatcher = Dispatchers.IO, errorCallback: (Throwable) -> Unit) {
+    /**
+     * Initializes the Statsig SDK using the recommended `async { }.await()` pattern from the
+     * Statsig Android documentation for structured concurrency.
+     *
+     * This method is `open` so that tests can override it to avoid calling the real [Statsig]
+     * singleton, which requires a live Application context and network access. Test subclasses
+     * should replace the body entirely to simulate success or failure scenarios.
+     *
+     * @param scope the [CoroutineScope] used to launch initialization; stored for later use by [updateExperimentUser]
+     * @param dispatcher the [CoroutineDispatcher] for the initialization coroutine, defaults to [Dispatchers.IO]
+     * @param errorCallback invoked with the error when initialization fails or throws
+     */
+    open fun initialize(scope: CoroutineScope, dispatcher: CoroutineDispatcher = Dispatchers.IO, errorCallback: (Throwable) -> Unit) {
         this.scope = scope
-        var details: InitializationDetails? = null
-        val options = StatsigOptions().apply {
-            setTier(
-                if (build.isRelease && Build.isExternal()) Tier.PRODUCTION
-                else Tier.STAGING
-            )
-        }
         scope.launch(context = dispatcher) {
             try {
-                async {
-                    details = Statsig.initialize(
+                val options = StatsigOptions().apply {
+                    setTier(
+                        if (build.isRelease && Build.isExternal()) Tier.PRODUCTION
+                        else Tier.STAGING
+                    )
+                }
+                val details = async {
+                    Statsig.initialize(
                         application = context as KSApplication,
-                        "client-gMosuzVPIQ4U1y6WTCjBM1HF3Y4nIouVqUfciWzH729",
+                        getSDKKey(),
                         StatsigUser(),
                         options = options
                     )

--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -9,18 +9,21 @@ import com.kickstarter.libs.utils.extensions.isFalse
 import com.kickstarter.libs.utils.extensions.isTrue
 import com.statsig.androidsdk.InitializationDetails
 import com.statsig.androidsdk.Statsig
+import com.statsig.androidsdk.StatsigOptions
 import com.statsig.androidsdk.StatsigUser
+import com.statsig.androidsdk.Tier
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
 
+class StatsigException(cause: Throwable) : Exception(cause)
 interface StatsigClientType {
-    suspend fun init(application: KSApplication, sdkKey: String): InitializationDetails? = Statsig.initialize(application, sdkKey)
     fun getSDKKey(): String
     fun isInitialized(): Boolean = Statsig.isInitialized()
     fun checkGate(gateName: String) = Statsig.checkGate(gateName) // TODO: For feature flags, will expand in the future
@@ -41,17 +44,28 @@ open class StatsigClient(
         if (build.isRelease && Build.isExternal()) Secrets.Statsig.PRODUCTION
         else Secrets.Statsig.STAGING
 
-    fun initialize(scope: CoroutineScope, dispatcher: CoroutineDispatcher = Dispatchers.IO, errorCallback: (Exception) -> Unit) {
+    fun initialize(scope: CoroutineScope, dispatcher: CoroutineDispatcher = Dispatchers.IO, errorCallback: (Throwable) -> Unit) {
         this.scope = scope
+        var details: InitializationDetails? = null
+        val options = StatsigOptions().apply {
+            setTier(
+                if (build.isRelease && Build.isExternal()) Tier.PRODUCTION
+                else Tier.STAGING
+            )
+        }
         scope.launch(context = dispatcher) {
             try {
-                val initDetails = init(
-                    application = context as KSApplication,
-                    sdkKey = getSDKKey()
-                )
+                async {
+                    details = Statsig.initialize(
+                        application = context as KSApplication,
+                        "client-gMosuzVPIQ4U1y6WTCjBM1HF3Y4nIouVqUfciWzH729",
+                        StatsigUser(),
+                        options = options
+                    )
+                }.await()
 
-                if (initDetails?.success.isFalse()) {
-                    initDetails?.failureDetails?.exception?.let { errorCallback.invoke(it) }
+                if (details?.success.isFalse()) {
+                    errorCallback.invoke(Throwable(details?.failureDetails?.exception))
                 }
             } catch (e: Exception) {
                 errorCallback.invoke(e)

--- a/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/DiscoveryActivity.kt
@@ -80,6 +80,15 @@ class DiscoveryActivity : AppCompatActivity(), SharedPreferences.OnSharedPrefere
             statsigClient = requireNotNull(env.statsigClient())
         }
 
+//        val gateValueExtended = statsigClient.getFeatureGate(StatsigGateKey.ANDROID_VIDEO_FEED.key)
+//        val gateValue = statsigClient.checkGate(StatsigGateKey.ANDROID_VIDEO_FEED.key)
+//
+//        if (gateValue) Timber.d("*** statsig gate open!")
+//        else Timber.d("*** statsig gate closed!")
+//
+//        if (gateValueExtended.getValue()) Timber.d("*** statsig gate open with group=${gateValueExtended.getName()} and rule${gateValueExtended.getRuleID()}")
+//        else Timber.d("*** statsig gate closed with group=${gateValueExtended.getName()} and rule${gateValueExtended.getRuleID()}")
+
         /*
          * Provide the Intent _after_ the view tree (most importantly the ViewPager)
          * has completed a first-pass render, ensuring that the Intent workflows begin

--- a/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
@@ -1,13 +1,22 @@
 package com.kickstarter.libs
 
-import com.kickstarter.KSApplication
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.featureflag.StatsigClient
+import com.statsig.androidsdk.EvaluationDetails
+import com.statsig.androidsdk.EvaluationReason
+import com.statsig.androidsdk.FeatureGate
 import com.statsig.androidsdk.InitializationDetails
+import com.statsig.androidsdk.InitializeFailReason
+import com.statsig.androidsdk.InitializeResponse
+import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -16,67 +25,184 @@ class StatsigClientTest : KSRobolectricTestCase() {
 
     private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
 
-    @Test
-    fun testInitialize_success() = runTest(testDispatcher) {
+    /**
+     * Creates a [StatsigClient] subclass that never touches the real [com.statsig.androidsdk.Statsig]
+     * singleton. Every SDK-facing method is overridden so tests run without a live Application
+     * context, network access, or Statsig initialization.
+     *
+     * @param initResult the [InitializationDetails] that [initialize] will return to simulate SDK responses
+     * @param initException when non-null, [initialize] will throw this instead of returning [initResult],
+     *                      simulating a crash during SDK initialization
+     * @param gateValues a map of gate names to their boolean values used by [checkGate];
+     *                   any gate not present in the map defaults to false
+     * @param featureGates a map of gate names to [FeatureGate] objects used by [getFeatureGate];
+     *                     gates absent from the map return a default disabled [FeatureGate] with
+     *                     an empty rule ID and [EvaluationReason.Unrecognized]
+     * @param initialized the value returned by [isInitialized], controlling whether the client
+     *                    reports itself as ready
+     */
+    fun buildClient(
+        initResult: InitializationDetails? = null,
+        initException: Exception? = null,
+        gateValues: Map<String, Boolean> = emptyMap(),
+        featureGates: Map<String, FeatureGate> = emptyMap(),
+        initialized: Boolean = true
+    ): StatsigClient {
         val mockCurrentUser: CurrentUserTypeV2 = requireNotNull(environment().currentUserV2())
-        val mockBuildObject = mockk<Build>()
-
-        val initDet = InitializationDetails(2, true)
-
-        val stClient = object : StatsigClient(build = mockBuildObject, context = application(), currentUser = mockCurrentUser) {
-            override suspend fun init(
-                application: KSApplication,
-                sdkKey: String
-            ): InitializationDetails? {
-                return initDet
-            }
-
-            override fun getSDKKey(): String {
-                return ""
-            }
+        val mockBuild = mockk<Build> {
+            every { isRelease } returns false
         }
 
-        var eCounter = 0
-        stClient.initialize(this, errorCallback = { eCounter++ })
+        return object : StatsigClient(
+            build = mockBuild,
+            context = application(),
+            currentUser = mockCurrentUser
+        ) {
+            override fun isInitialized(): Boolean = initialized
 
-        assertEquals(stClient.scope, this)
-        assertEquals(eCounter, 0)
+            override fun checkGate(gateName: String): Boolean =
+                gateValues[gateName] ?: false
+
+            override fun getFeatureGate(gateName: String): FeatureGate =
+                featureGates[gateName] ?: FeatureGate(
+                    gateName,
+                    EvaluationDetails(EvaluationReason.Unrecognized, lcut = 0),
+                    false
+                )
+
+            override fun getSDKKey(): String = "test-sdk-key"
+
+            override fun initialize(
+                scope: CoroutineScope,
+                dispatcher: CoroutineDispatcher,
+                errorCallback: (Throwable) -> Unit
+            ) {
+                this.scope = scope
+                scope.launch(context = dispatcher) {
+                    try {
+                        val details = initException?.let { throw it } ?: initResult
+                        if (details?.success == false) {
+                            errorCallback.invoke(Throwable(details.failureDetails?.exception))
+                        }
+                    } catch (e: Exception) {
+                        errorCallback.invoke(e)
+                    }
+                }
+            }
+        }
     }
 
-//    @Test
-//    fun testInitialize_error_callback() = runTest(testDispatcher) {
-//        val mockCurrentUser: CurrentUserTypeV2 = requireNotNull(environment().currentUserV2())
-//        val mockBuildObject = mockk<Build>()
-//
-//        val initDet = InitializationDetails(
-//            2,
-//            false,
-//            InitializeResponse.FailedInitializeResponse(InitializeFailReason.NetworkError, Exception("Something went wrong"))
-//        )
-//
-//        val stClient = object : StatsigClient(build = mockBuildObject, context = application(), currentUser = mockCurrentUser) {
-//            override suspend fun init(
-//                application: KSApplication,
-//                sdkKey: String
-//            ): InitializationDetails? {
-//                return initDet
-//            }
-//
-//            override fun getSDKKey(): String {
-//                return ""
-//            }
-//        }
-//
-//        var eCounter = 0
-//        var exception: Exception? = null
-//        stClient.initialize(this, errorCallback = { e ->
-//            exception = e
-//            eCounter++
-//        })
-//
-//        advanceUntilIdle()
-//        assertEquals(stClient.scope, this)
-//        assertEquals(eCounter, 1)
-//        assertEquals(exception?.message, "Something went wrong")
-//    }
+    @Test
+    fun `initialize - Sets scope and completes without error on success`() = runTest(testDispatcher) {
+        val initDetails = InitializationDetails(200L, true)
+        val client = buildClient(initResult = initDetails)
+
+        var errorCount = 0
+        client.initialize(this, testDispatcher) { errorCount++ }
+
+        advanceUntilIdle()
+
+        assertEquals(0, errorCount)
+        assertEquals(this, client.scope)
+    }
+
+    @Test
+    fun `initialize - Invokes error callback with failure details on SDK failure`() = runTest(testDispatcher) {
+        val failureDetails = InitializeResponse.FailedInitializeResponse(
+            reason = InitializeFailReason.NetworkError,
+            exception = Exception("Network unavailable")
+        )
+        val initDetails = InitializationDetails(100L, false, failureDetails)
+        val client = buildClient(initResult = initDetails)
+
+        var capturedError: Throwable? = null
+        client.initialize(this, testDispatcher) { capturedError = it }
+
+        advanceUntilIdle()
+
+        assertNotNull(capturedError)
+        assertEquals("Network unavailable", capturedError?.cause?.message)
+    }
+
+    @Test
+    fun `initialize - Invokes error callback when initialization throws an exception`() = runTest(testDispatcher) {
+        val client = buildClient(initException = RuntimeException("Init crashed"))
+
+        var capturedError: Throwable? = null
+        client.initialize(this, testDispatcher) { capturedError = it }
+
+        advanceUntilIdle()
+
+        assertNotNull(capturedError)
+        assertEquals("Init crashed", capturedError?.message)
+    }
+
+    @Test
+    fun `checkGate - Returns true for an enabled gate`() {
+        val client = buildClient(gateValues = mapOf("test_gate" to true))
+        assertTrue(client.checkGate("test_gate"))
+    }
+
+    @Test
+    fun `checkGate - Returns false for an unknown gate`() {
+        val client = buildClient(gateValues = mapOf("test_gate" to true))
+        assertFalse(client.checkGate("unknown_gate"))
+    }
+
+    @Test
+    fun `checkGate - Returns false for a disabled gate`() {
+        val client = buildClient(gateValues = mapOf("test_gate" to false))
+        assertFalse(client.checkGate("test_gate"))
+    }
+
+    @Test
+    fun `isInitialized - Returns true when initialized and false when not`() {
+        val initializedClient = buildClient(initialized = true)
+        assertTrue(initializedClient.isInitialized())
+
+        val uninitializedClient = buildClient(initialized = false)
+        assertFalse(uninitializedClient.isInitialized())
+    }
+
+    @Test
+    fun `getFeatureGate - Returns gate value and matching rule ID for a known gate`() {
+        val gate = FeatureGate(
+            "test_gate",
+            EvaluationDetails(EvaluationReason.Network, lcut = 0),
+            true,
+            "targeting_rule_us_users"
+        )
+        val client = buildClient(featureGates = mapOf("test_gate" to gate))
+
+        val result = client.getFeatureGate("test_gate")
+
+        assertTrue(result.getValue())
+        assertEquals("targeting_rule_us_users", result.getRuleID())
+        assertEquals("test_gate", result.getName())
+    }
+
+    @Test
+    fun `getFeatureGate - Returns disabled gate with empty rule ID for an unknown gate`() {
+        val client = buildClient()
+
+        val result = client.getFeatureGate("unknown_gate")
+
+        assertFalse(result.getValue())
+        assertEquals("", result.getRuleID())
+    }
+
+    @Test
+    fun `getFeatureGate - Returns correct evaluation reason from gate details`() {
+        val gate = FeatureGate(
+            "cached_gate",
+            EvaluationDetails(EvaluationReason.Cache, lcut = 0),
+            true,
+            "cache_rule"
+        )
+        val client = buildClient(featureGates = mapOf("cached_gate" to gate))
+
+        val result = client.getFeatureGate("cached_gate")
+
+        assertEquals(EvaluationReason.Cache, result.getEvaluationDetails()?.reason)
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' } // statsig
         maven { url 'https://s3-us-west-2.amazonaws.com/si-mobile-sdks/android/' }
         maven {
             url 'http://appboy.github.io/appboy-android-sdk/sdk'


### PR DESCRIPTION
# 📲 What

Upgraded the Statsig SDK from version 4.37.0 (JitPack) to 4.45.6 (MavenCentral) and refactored the StatsigClient to use modern initialization patterns and provide more granular gate evaluation.

# 🤔 Why

The upgrade was necessary to move away from the JitPack-hosted SDK and adopt the latest Statsig features. The refactor improves the reliability of the initialization flow using Kotlin Coroutines' structured concurrency and adds support for retrieving full FeatureGate objects, which includes metadata like rule IDs and evaluation reasons—essential for debugging targeting logic.

# 🛠 How

**Dependency Update:** Swapped com.github.statsig-io:android-sdk for com.statsig:android-sdk:4.45.6 in app/build.gradle and removed the JitPack repository from the project-level build.gradle.

**Initialization Flow:** Refactored StatsigClient.initialize to use the recommended async { ... }.await() pattern.

**Environment Tiers:** Introduced StatsigOptions to explicitly set the Tier (Production vs. Staging) based on the build configuration.

**New API:** Added getFeatureGate(gateName: String) to the StatsigClientType interface to allow access to the full FeatureGate object beyond just a boolean value.

**Type Safety:** Added a StatsigGateKey enum to centralize gate names (starting with ANDROID_VIDEO_FEED).

**Error Handling:** Wrapped SDK initialization errors in a custom StatsigException for clearer reporting in Crashlytics.

**Testing:** Completely overhauled StatsigClientTest.kt. Created a mockable test architecture that simulates the SDK behavior without requiring a live Application context or network calls, covering success, network failures, and crash scenarios.

# 👀 See
<img width="1484" height="292" alt="Screenshot 2026-04-07 at 9 36 51 AM" src="https://github.com/user-attachments/assets/f5349e05-8f80-47f4-9620-353aafa758ec" />

|  |  |

# 📋 QA

- There is a feature gate in both staging and production dashboards checking for app version 3.39.0
- - If you want to pass the gate change `internal_version_name` for staging or `external_version_name` (depending on build variant) to pass the gate, use current one to keep off the gate.
- Go to Discovery activity, and un-comment the follow up code snippets to see in logcat Statsig information:

```
        val gateValueExtended = statsigClient.getFeatureGate(ANDROID_VIDEO_FEED.key)
        val gateValue = statsigClient.checkGate(ANDROID_VIDEO_FEED.key)

        if (gateValue) Timber.d("*** statsig gate open!")
        else Timber.d("*** statsig gate closed!")

        if (gateValueExtended.getValue()) Timber.d("*** statsig gate open with group=${gateValueExtended.getName()} and rule${gateValueExtended.getRuleID()}")
        else Timber.d("*** statsig gate closed with group=${gateValueExtended.getName()} and rule${gateValueExtended.getRuleID()}")

```

# Story 📖

[DISC-140](https://kickstarter.atlassian.net/browse/DISC-140)


[DISC-140]: https://kickstarter.atlassian.net/browse/DISC-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ