### PR TITLE
PF-118: Upgrade Compose direct dependencies + align with BOM

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -209,7 +209,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.8.0'
 
     // Fonts
-    implementation 'androidx.compose.ui:ui-text-google-fonts:1.8.3'
+    implementation 'androidx.compose.ui:ui-text-google-fonts:1.10.6'
     implementation 'com.google.android.gms:play-services-base:18.7.2'
     implementation 'androidx.navigation:navigation-compose:2.9.6'
 
@@ -283,16 +283,15 @@ dependencies {
     implementation 'com.google.firebase:firebase-config'
 
     // Compose
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling:1.8.3"
-    debugImplementation "androidx.compose.ui:ui-tooling:1.8.3"
-    implementation "androidx.compose.runtime:runtime-rxjava2:$compose_version"
+    implementation "androidx.compose.ui:ui:1.10.6"
+    implementation "androidx.compose.ui:ui-tooling:1.10.6"
+    implementation "androidx.compose.runtime:runtime-rxjava2:1.10.6"
     implementation 'androidx.activity:activity-compose:1.10.1'
     implementation 'androidx.constraintlayout:constraintlayout-compose:1.1.1'
     implementation "com.google.accompanist:accompanist-systemuicontroller:0.36.0"
     implementation "androidx.lifecycle:lifecycle-runtime-compose:2.10.0"
-    implementation "androidx.compose.foundation:foundation:$compose_version"
-    implementation 'androidx.compose.ui:ui-util:1.10.5'
+    implementation "androidx.compose.foundation:foundation:1.10.6"
+    implementation 'androidx.compose.ui:ui-util:1.10.6'
 
     implementation "dev.chrisbanes.haze:haze:1.7.2"
 
@@ -327,8 +326,8 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.15.1'
     testImplementation "androidx.test:core:1.7.0"
     androidTestImplementation 'androidx.annotation:annotation:1.9.1'
-    testImplementation 'androidx.compose.ui:ui-test-junit4:1.8.3'
-    debugImplementation 'androidx.compose.ui:ui-test-manifest:1.8.3'
+    testImplementation 'androidx.compose.ui:ui-test-junit4:1.10.6'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest:1.10.6'
     def mockkVersion = '1.13.4'
     testImplementation "io.mockk:mockk-android:$mockkVersion"
     testImplementation "io.mockk:mockk-agent:$mockkVersion"
@@ -343,7 +342,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-intents:' + espresso
     androidTestImplementation "androidx.test.ext:junit:1.3.0"
     androidTestImplementation 'androidx.test:rules:1.7.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.10.6"
 
     // Desugaring Java 8 to < API 26
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -197,6 +197,13 @@ repositories {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
+
+    // Compose BOM
+    Dependency composeBom = platform('androidx.compose:compose-bom:2026.03.01')
+    implementation composeBom
+    testImplementation composeBom
+    androidTestImplementation composeBom
+
     implementation 'androidx.core:core-ktx:1.16.0'
     implementation 'androidx.annotation:annotation:1.9.1'
     implementation 'androidx.appcompat:appcompat:1.7.1'
@@ -209,7 +216,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.8.0'
 
     // Fonts
-    implementation 'androidx.compose.ui:ui-text-google-fonts:1.10.6'
+    implementation 'androidx.compose.ui:ui-text-google-fonts'
     implementation 'com.google.android.gms:play-services-base:18.7.2'
     implementation 'androidx.navigation:navigation-compose:2.9.6'
 
@@ -283,15 +290,15 @@ dependencies {
     implementation 'com.google.firebase:firebase-config'
 
     // Compose
-    implementation "androidx.compose.ui:ui:1.10.6"
-    implementation "androidx.compose.ui:ui-tooling:1.10.6"
-    implementation "androidx.compose.runtime:runtime-rxjava2:1.10.6"
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.ui:ui-tooling"
+    implementation "androidx.compose.runtime:runtime-rxjava2"
     implementation 'androidx.activity:activity-compose:1.10.1'
     implementation 'androidx.constraintlayout:constraintlayout-compose:1.1.1'
     implementation "com.google.accompanist:accompanist-systemuicontroller:0.36.0"
     implementation "androidx.lifecycle:lifecycle-runtime-compose:2.10.0"
-    implementation "androidx.compose.foundation:foundation:1.10.6"
-    implementation 'androidx.compose.ui:ui-util:1.10.6'
+    implementation "androidx.compose.foundation:foundation"
+    implementation 'androidx.compose.ui:ui-util'
 
     implementation "dev.chrisbanes.haze:haze:1.7.2"
 
@@ -317,8 +324,8 @@ dependencies {
 
     // Material
     implementation 'com.google.android.material:material:1.6.1'
-    implementation 'androidx.compose.material:material-icons-core:1.7.8'
-    implementation 'androidx.compose.material3:material3:1.4.0'
+    implementation 'androidx.compose.material:material-icons-core'
+    implementation 'androidx.compose.material3:material3'
 
     // Testing
     testImplementation "junit:junit:4.13.2"
@@ -326,8 +333,8 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.15.1'
     testImplementation "androidx.test:core:1.7.0"
     androidTestImplementation 'androidx.annotation:annotation:1.9.1'
-    testImplementation 'androidx.compose.ui:ui-test-junit4:1.10.6'
-    debugImplementation 'androidx.compose.ui:ui-test-manifest:1.10.6'
+    testImplementation 'androidx.compose.ui:ui-test-junit4'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest'
     def mockkVersion = '1.13.4'
     testImplementation "io.mockk:mockk-android:$mockkVersion"
     testImplementation "io.mockk:mockk-agent:$mockkVersion"
@@ -342,7 +349,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-intents:' + espresso
     androidTestImplementation "androidx.test.ext:junit:1.3.0"
     androidTestImplementation 'androidx.test:rules:1.7.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.10.6"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4"
 
     // Desugaring Java 8 to < API 26
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'


### PR DESCRIPTION
# 📲 What

This PR technically does two things:

1) Upgrades all of the direct Compose dependencies to the latest versions

2) Introduces the Compose Bill of Materials (BOM) and declares that the versions of those dependencies should come from there.

These two steps can be seen in the individual commits.

# 🤔 Why

As described in platform documentation: going forward, Compose libraries will be versioned independently, which means version numbers will start to be incremented at their own pace.

Importantly however, the latest stable releases of each library are tested together. Therefore, using the BOM helps verify that the versions of any Compose libraries in the app are compatible, and helps us to automatically use these latest versions.

Reference: [Use a Bill of Materials  |  Jetpack Compose  |  Android Developers](https://developer.android.com/develop/ui/compose/bom#groovy)

# 🛠 How

- Import the Compose BOM using Gradle's [Platform](https://docs.gradle.org/current/userguide/platforms.html#sec:bom-import) component.
  - See [BOM to library version mapping  |  Android Developers](https://developer.android.com/develop/ui/compose/bom/bom-mapping) for BOM version `2026.03.01`
- Notably, the BOM doesn't actually add libraries to the project, so we (re-)declare the Compose dependencies _without_ specifying a version, indicating that Gradle should rely on the version constraints from the BOM.
- Remove the declaration `debugImplementation "androidx.compose.ui:ui-tooling:1.8.3"` as it is redundant with the `implementation` declaration.

Result:

| Configuration             | Library                                       | Current                 | BOM Version (2026.03.01) |
|---------------------------|-----------------------------------------------|-------------------------|--------------------------|
| implementation            | androidx.compose.ui:ui-text-google-fonts      | 1.8.3                   | 1.10.6                   |
| implementation            | androidx.compose.ui:ui                        | 1.4.3 (compose_version) | 1.10.6                   |
| implementation            | androidx.compose.ui:ui-tooling                | 1.8.3                   | 1.10.6                   |
| implementation            | androidx.compose.runtime:runtime-rxjava2      | 1.4.3 (compose_version) | 1.10.6                   |
| implementation            | androidx.compose.foundation:foundation        | 1.4.3 (compose_version) | 1.10.6                   |
| implementation            | androidx.compose.ui:ui-util                   | 1.10.5                  | 1.10.6                   |
| implementation            | androidx.compose.material:material-icons-core | 1.7.8                   | 1.7.8                    |
| implementation            | androidx.compose.material3:material3          | 1.4.0                   | 1.4.0                    |
| testImplementation        | androidx.compose.ui:ui-test-junit4            | 1.8.3                   | 1.10.6                   |
| debugImplementation       | androidx.compose.ui:ui-test-manifest          | 1.8.3                   | 1.10.6                   |
| androidTestImplementation | androidx.compose.ui:ui-test-junit4            | 1.4.3 (compose_version) | 1.10.6                   |


# 👀 See

N/A

# 📋 QA

Use the app.

# Story 📖

[\[PF-118\] Upgrade direct Compose dependencies and align them with BOM - Jira](https://kickstarter.atlassian.net/browse/PF-118)
