### PR TITLE
PF-121: Upgrade Compose testing libraries + swap in createComposeRule() v2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -212,7 +212,7 @@ dependencies {
     /* Compose BOM */
     Dependency composeBom = platform('androidx.compose:compose-bom:2026.03.01')
     // BOM version override for `androidx.compose.ui:ui-test-junit4` and `androidx.compose.ui:ui-test-manifest`
-    def androidxComposeUiTestVersion = "1.11.0-beta02"
+    def androidxComposeUiTestVersion = "1.11.0-rc01"
     implementation composeBom
     testImplementation composeBom
     androidTestImplementation composeBom

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -198,12 +198,6 @@ repositories {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
-    // Compose BOM
-    Dependency composeBom = platform('androidx.compose:compose-bom:2026.03.01')
-    implementation composeBom
-    testImplementation composeBom
-    androidTestImplementation composeBom
-
     implementation 'androidx.core:core-ktx:1.16.0'
     implementation 'androidx.annotation:annotation:1.9.1'
     implementation 'androidx.appcompat:appcompat:1.7.1'
@@ -214,6 +208,14 @@ dependencies {
     implementation 'androidx.work:work-runtime-ktx:2.10.3'
     // Chrome Tabs library
     implementation 'androidx.browser:browser:1.8.0'
+
+    /* Compose BOM */
+    Dependency composeBom = platform('androidx.compose:compose-bom:2026.03.01')
+    // BOM version override for `androidx.compose.ui:ui-test-junit4` and `androidx.compose.ui:ui-test-manifest`
+    def androidxComposeUiTestVersion = "1.11.0-beta02"
+    implementation composeBom
+    testImplementation composeBom
+    androidTestImplementation composeBom
 
     // Fonts
     implementation 'androidx.compose.ui:ui-text-google-fonts'
@@ -333,8 +335,8 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.15.1'
     testImplementation "androidx.test:core:1.7.0"
     androidTestImplementation 'androidx.annotation:annotation:1.9.1'
-    testImplementation 'androidx.compose.ui:ui-test-junit4'
-    debugImplementation 'androidx.compose.ui:ui-test-manifest'
+    testImplementation "androidx.compose.ui:ui-test-junit4:$androidxComposeUiTestVersion"
+    debugImplementation "androidx.compose.ui:ui-test-manifest:$androidxComposeUiTestVersion"
     def mockkVersion = '1.13.4'
     testImplementation "io.mockk:mockk-android:$mockkVersion"
     testImplementation "io.mockk:mockk-agent:$mockkVersion"

--- a/app/src/test/java/com/kickstarter/KSRobolectricTestCase.kt
+++ b/app/src/test/java/com/kickstarter/KSRobolectricTestCase.kt
@@ -2,7 +2,7 @@ package com.kickstarter
 
 import android.app.Application
 import android.content.Context
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.core.app.ApplicationProvider
 import com.kickstarter.libs.AnalyticEvents
 import com.kickstarter.libs.AttributionEvents

--- a/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryCaptionedImageTest.kt
+++ b/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryCaptionedImageTest.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.test.core.app.ApplicationProvider
 import coil.Coil
 import coil.ImageLoader
@@ -163,9 +164,12 @@ class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
             .assertIsDisplayed()
     }
 
-    @Test /* For Reference */
+    @Test
     @OptIn(ExperimentalTestApi::class)
     fun `test image loading with caption (mainClock)`() {
+        /* This test exists for educational purposes.
+         * It verifies the same behavior as the two tests below.
+         * If this test breaks, delete it. */
         val caption = "Aye aye, Caption"
 
         composeTestRule.mainClock.autoAdvance = false
@@ -177,9 +181,9 @@ class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
             )
         }
 
-        composeTestRule.waitUntilExactlyOneExists(
+        composeTestRule.onNode(
             SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
-        )
+        ).assertIsDisplayed()
 
         composeTestRule.onNode(
             SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
@@ -204,7 +208,10 @@ class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
-    fun `test image loading with caption`() = runTest {
+    fun `test image loading with caption (runTest)`() = runTest {
+        /* This test exists for educational purposes.
+         * It verifies the same behavior as the test above and test below.
+         * If this test breaks, delete it. */
         val standardDispatcher = StandardTestDispatcher(testScheduler)
 
         setUpImageLoader(
@@ -233,8 +240,6 @@ class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
         advanceTimeBy(REQUEST_DELAY)
         runCurrent()
 
-        composeTestRule.waitForIdle()
-
         composeTestRule.onNode(
             SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
         ).assertDoesNotExist()
@@ -245,6 +250,48 @@ class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
             .assertIsDisplayed()
 
         composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name))
+            .assertTextEquals(caption)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    @OptIn(ExperimentalTestApi::class)
+    fun `test image loading with caption (runComposeUiTest)`() = runComposeUiTest {
+        val standardDispatcher = StandardTestDispatcher(mainClock.scheduler)
+
+        setUpImageLoader(
+            ImageLoader.Builder(context)
+                .components { add(fakeImageLoaderEngine()) }
+                .dispatcher(standardDispatcher)
+                .interceptorDispatcher(standardDispatcher)
+                .build()
+        )
+
+        val caption = "Aye aye, Caption"
+
+        setContent {
+            ProjectStoryCaptionedImage(
+                image = "https://www.example.com/blue.jpg",
+                caption = caption,
+            )
+        }
+
+        onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.LOADING_INDICATOR.name))
+            .assert(SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo))
+            .assertIsDisplayed()
+
+        mainClock.advanceTimeBy(REQUEST_DELAY)
+
+        onNode(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
+        ).assertDoesNotExist()
+
+        onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.IMAGE.name))
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image))
+            .assertContentDescriptionEquals(caption)
+            .assertIsDisplayed()
+
+        onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name))
             .assertTextEquals(caption)
             .assertIsDisplayed()
     }


### PR DESCRIPTION
# 📲 What

Upgrade the Compose libraries for local UI tests to `1.11.0-rc01`, overriding the version provided by the BOM.

# 🤔 Why

The v1 versions of the core Compose testing APIs ([createComposeRule](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/junit4/v2/package-summary#createComposeRule(kotlin.coroutines.CoroutineContext)), [createAndroidComposeRule](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/junit4/v2/package-summary#createAndroidComposeRule(java.lang.Class,kotlin.coroutines.CoroutineContext)), [runComposeUiTest](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/v2/package-summary#runComposeUiTest%28kotlin.coroutines.CoroutineContext,kotlin.coroutines.CoroutineContext,kotlin.time.Duration,kotlin.coroutines.SuspendFunction1%29), [runAndroidComposeUiTest](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/v2/package-summary#runAndroidComposeUiTest%28kotlin.coroutines.CoroutineContext,kotlin.coroutines.CoroutineContext,kotlin.time.Duration,kotlin.coroutines.SuspendFunction1%29), etc) are deprecated.

The v2 APIs, which improve control over coroutine execution, are now past beta.

From the documentation:

> [I]t's strongly recommended to migrate to the new APIs. Migrating verifies your tests align with standard coroutine behavior and avoids future compatibility issues.

Reference: [Migrate to v2 testing APIs  |  Jetpack Compose  |  Android Developers](https://developer.android.com/develop/ui/compose/testing/migrate-v2) (Please read)

# 🛠 How

The v1 APIs remain in the same packages, so upgrading these libraries does not automatically upgrade usages. The v2 APIs are generally available under a `.v2` sub-package. 

Virtually all local UI tests rely on the `composeTestRule` property of the abstract class `KSRobolectricTestCase`, defined by a call to `createComposeRule()`. We take advantage of this by simply updating the import declaration in that file to bring `createComposeRule` from `.v2`, thus upgrading all of the tests at the same time.

In addition, we leverage the new version of `runComposeUiTest` to test `AsyncImagePainter` with a custom `ImageLoader`, but avoid the "two clock problem" introduced by using the v1 `createComposeRule` with `runTest` (as [recommended](https://developer.android.com/develop/ui/compose/testing/migrate-v2#previous-approach-2)).

# 👀 See

N/A

# 📋 QA

(CircleCI checks pass)

# Story 📖

[\[PF-121\] Upgrade Compose testing libraries & use createComposeRule() v2 - Jira](https://kickstarter.atlassian.net/browse/PF-121)
