### PR TITLE
DISC-133: Search Entry point card

### DIFF
--- a/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
@@ -14,6 +14,7 @@ import com.kickstarter.ui.compose.designsystem.KickstarterApp
 import com.kickstarter.ui.extensions.setUpConnectivityStatusCheck
 import com.kickstarter.ui.extensions.startPreLaunchProjectActivity
 import com.kickstarter.ui.extensions.startProjectActivity
+import com.kickstarter.ui.extensions.startVideoFeed
 
 // TODO: Improve error message
 val LocalFilterMenuViewModel = staticCompositionLocalOf<FilterMenuViewModel> {
@@ -57,6 +58,7 @@ class SearchAndFilterActivity : ComponentActivity() {
                                 previousScreen = ThirdPartyEventValues.ScreenName.SEARCH.value
                             )
                         },
+                        onVideoFeedBannerClicked = { startVideoFeed() }
                     )
                 }
             }

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.RefTag
+import com.kickstarter.libs.featureflag.StatsigGateKey
 import com.kickstarter.libs.utils.extensions.isNull
 import com.kickstarter.libs.utils.extensions.isTrue
 import com.kickstarter.models.Category
@@ -44,6 +45,10 @@ class SearchAndFilterViewModel(
     private val scope = viewModelScope + (testDispatcher ?: EmptyCoroutineContext)
     private val apolloClient = requireNotNull(environment.apolloClientV2())
     private val analyticEvents = requireNotNull(environment.analytics())
+    private val statsigClient = requireNotNull(environment.statsigClient())
+
+    private val _isVideoFeedBannerVisible = MutableStateFlow(false)
+    val isVideoFeedBannerVisible: StateFlow<Boolean> = _isVideoFeedBannerVisible.asStateFlow()
 
     private val _searchUIState = MutableStateFlow(SearchUIState())
     val searchUIState: StateFlow<SearchUIState>
@@ -76,6 +81,8 @@ class SearchAndFilterViewModel(
     private var isLoadingMore = false
 
     init {
+        _isVideoFeedBannerVisible.value = statsigClient.checkGate(StatsigGateKey.ANDROID_VIDEO_FEED.key)
+
         scope.launch {
             val debounced = _searchTerm
                 .debounce(debouncePeriod)

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
@@ -3,6 +3,7 @@ package com.kickstarter.ui.activities.compose.search
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -88,6 +89,7 @@ import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
 import com.kickstarter.ui.compose.designsystem.KSTheme.typographyV2
+import com.kickstarter.ui.compose.designsystem.KSVideoFeedBanner
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -219,7 +221,8 @@ fun SearchAndFilterScreen(
     searchViewModel: SearchAndFilterViewModel,
     onBackClicked: () -> Unit = {},
     preLaunchedCallback: (project: Project, reftag: RefTag) -> Unit = { a, b -> },
-    projectCallback: (projAndRef: Pair<Project, RefTag>) -> Unit = { a -> }
+    projectCallback: (projAndRef: Pair<Project, RefTag>) -> Unit = { a -> },
+    onVideoFeedBannerClicked: () -> Unit = {}
 ) {
     val phaseff = env.featureFlagClient()?.getBoolean(FlagKey.ANDROID_SEARCH_FILTER) ?: false
     var currentSearchTerm by rememberSaveable { mutableStateOf("") }
@@ -231,6 +234,7 @@ fun SearchAndFilterScreen(
     val searchedProjects = searchUIState.searchList
     val isLoading = searchUIState.isLoading
     val hasMorePages = searchUIState.hasMore
+    val isVideoFeedBannerVisible by searchViewModel.isVideoFeedBannerVisible.collectAsStateWithLifecycle()
 
     val categoriesState by filterMenuVM.filterMenuUIState.collectAsStateWithLifecycle()
     val categories = categoriesState.categoriesList
@@ -290,7 +294,9 @@ fun SearchAndFilterScreen(
                     social = social
                 )
             },
-            shouldShowPhase = phaseff
+            shouldShowPhase = phaseff,
+            isVideoFeedBannerVisible = isVideoFeedBannerVisible,
+            onVideoFeedBannerClicked = onVideoFeedBannerClicked
         )
     }
 
@@ -361,7 +367,9 @@ fun SearchScreen(
         DiscoveryParams.GoalBuckets?
     ) -> Unit = { _, _, _, _, _, _, _, _, _, _, _ ->
     },
-    shouldShowPhase: Boolean = true
+    shouldShowPhase: Boolean = true,
+    isVideoFeedBannerVisible: Boolean = false,
+    onVideoFeedBannerClicked: () -> Unit = {}
 ) {
     var currentSearchTerm by rememberSaveable { mutableStateOf("") }
 
@@ -542,86 +550,104 @@ fun SearchScreen(
                 }
             )
         } else {
-            LazyColumn(
+            Column(
                 modifier = Modifier
-                    .testTag(SearchScreenTestTag.LIST_VIEW.name)
                     .padding(padding)
                     .background(colors.backgroundSurfacePrimary)
-                    .fillMaxWidth(),
-                contentPadding = PaddingValues(
-                    start = dimensions.paddingMediumLarge,
-                    end = dimensions.paddingMediumLarge
-                ),
-                state = lazyColumnListState,
-                horizontalAlignment = Alignment.CenterHorizontally,
+                    .fillMaxWidth()
             ) {
-                itemsIndexed(itemsList) { index, project ->
-                    if (index == 0 && isDefaultList) {
-                        Spacer(modifier = Modifier.height(dimensions.paddingMedium))
-
-                        Text(
-                            modifier = Modifier
-                                .testTag(SearchScreenTestTag.DISCOVER_PROJECTS_TITLE.name)
-                                .fillMaxWidth(),
-                            text = stringResource(id = R.string.activity_empty_state_logged_in_button),
-                            style = typographyV2.title2,
-                            color = colors.kds_support_700,
-                            textAlign = TextAlign.Start
-                        )
-                    }
-
-                    val state = getCardProjectState(project)
-                    val fundingInfoString = getFundingInfoString(state, environment, project)
-
-                    if (index == 0) {
-                        Spacer(modifier = Modifier.height(dimensions.paddingMedium))
-                        KSProjectCardLarge(
-                            modifier = Modifier
-                                .testTag(SearchScreenTestTag.FEATURED_PROJECT_VIEW.name),
-                            photo = project.photo(),
-                            title = project.name(),
-                            state = state,
-                            fundingInfoString = fundingInfoString,
-                            fundedPercentage = project.percentageFunded().toInt(),
-                        ) {
-                            onItemClicked(project)
-                        }
-
-                        if (itemsList.size > 1) {
-                            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
-                        }
-                    } else {
-                        KSProjectCardSmall(
-                            modifier = Modifier
-                                .testTag(SearchScreenTestTag.NORMAL_PROJECT_VIEW.name + index),
-                            photo = project.photo(),
-                            title = project.name(),
-                            state = state,
-                            fundingInfoString = fundingInfoString,
-                            fundedPercentage = project.percentageFunded().toInt(),
-                        ) {
-                            onItemClicked(project)
-                        }
-
-                        if (index < itemsList.size - 1) {
-                            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
-                        } else {
-                            Spacer(modifier = Modifier.height(dimensions.paddingMediumLarge))
-                        }
-                    }
+                if (isVideoFeedBannerVisible) {
+                    KSVideoFeedBanner(
+                        modifier = Modifier.padding(
+                            start = dimensions.paddingMediumLarge,
+                            end = dimensions.paddingMediumLarge,
+                            top = dimensions.paddingMedium,
+                            bottom = dimensions.paddingMedium
+                        ),
+                        onButtonClick = onVideoFeedBannerClicked
+                    )
                 }
 
-                item(isLoading) {
-                    if (isLoading && itemsList.isNotEmpty()) {
-                        Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                LazyColumn(
+                    modifier = Modifier
+                        .testTag(SearchScreenTestTag.LIST_VIEW.name)
+                        .background(colors.backgroundSurfacePrimary)
+                        .fillMaxWidth(),
+                    contentPadding = PaddingValues(
+                        start = dimensions.paddingMediumLarge,
+                        end = dimensions.paddingMediumLarge
+                    ),
+                    state = lazyColumnListState,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    itemsIndexed(itemsList) { index, project ->
+                        if (index == 0 && isDefaultList) {
+                            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
 
-                        KSCircularProgressIndicator(
-                            modifier = Modifier
-                                .testTag(SearchScreenTestTag.IN_LIST_LOADING_VIEW.name)
-                                .size(size = dimensions.imageSizeLarge)
-                        )
+                            Text(
+                                modifier = Modifier
+                                    .testTag(SearchScreenTestTag.DISCOVER_PROJECTS_TITLE.name)
+                                    .fillMaxWidth(),
+                                text = stringResource(id = R.string.activity_empty_state_logged_in_button),
+                                style = typographyV2.title2,
+                                color = colors.kds_support_700,
+                                textAlign = TextAlign.Start
+                            )
+                        }
 
-                        Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                        val state = getCardProjectState(project)
+                        val fundingInfoString = getFundingInfoString(state, environment, project)
+
+                        if (index == 0) {
+                            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                            KSProjectCardLarge(
+                                modifier = Modifier
+                                    .testTag(SearchScreenTestTag.FEATURED_PROJECT_VIEW.name),
+                                photo = project.photo(),
+                                title = project.name(),
+                                state = state,
+                                fundingInfoString = fundingInfoString,
+                                fundedPercentage = project.percentageFunded().toInt(),
+                            ) {
+                                onItemClicked(project)
+                            }
+
+                            if (itemsList.size > 1) {
+                                Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                            }
+                        } else {
+                            KSProjectCardSmall(
+                                modifier = Modifier
+                                    .testTag(SearchScreenTestTag.NORMAL_PROJECT_VIEW.name + index),
+                                photo = project.photo(),
+                                title = project.name(),
+                                state = state,
+                                fundingInfoString = fundingInfoString,
+                                fundedPercentage = project.percentageFunded().toInt(),
+                            ) {
+                                onItemClicked(project)
+                            }
+
+                            if (index < itemsList.size - 1) {
+                                Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                            } else {
+                                Spacer(modifier = Modifier.height(dimensions.paddingMediumLarge))
+                            }
+                        }
+                    }
+
+                    item(isLoading) {
+                        if (isLoading && itemsList.isNotEmpty()) {
+                            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+
+                            KSCircularProgressIndicator(
+                                modifier = Modifier
+                                    .testTag(SearchScreenTestTag.IN_LIST_LOADING_VIEW.name)
+                                    .size(size = dimensions.imageSizeLarge)
+                            )
+
+                            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/search/SearchScreen.kt
@@ -3,7 +3,6 @@ package com.kickstarter.ui.activities.compose.search
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -550,104 +549,94 @@ fun SearchScreen(
                 }
             )
         } else {
-            Column(
+            LazyColumn(
                 modifier = Modifier
+                    .testTag(SearchScreenTestTag.LIST_VIEW.name)
                     .padding(padding)
                     .background(colors.backgroundSurfacePrimary)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
+                contentPadding = PaddingValues(
+                    start = dimensions.paddingMediumLarge,
+                    end = dimensions.paddingMediumLarge
+                ),
+                state = lazyColumnListState,
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 if (isVideoFeedBannerVisible) {
-                    KSVideoFeedBanner(
-                        modifier = Modifier.padding(
-                            start = dimensions.paddingMediumLarge,
-                            end = dimensions.paddingMediumLarge,
-                            top = dimensions.paddingMedium,
-                            bottom = dimensions.paddingMedium
-                        ),
-                        onButtonClick = onVideoFeedBannerClicked
-                    )
+                    item {
+                        Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                        KSVideoFeedBanner(onButtonClick = onVideoFeedBannerClicked)
+                        Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                    }
                 }
 
-                LazyColumn(
-                    modifier = Modifier
-                        .testTag(SearchScreenTestTag.LIST_VIEW.name)
-                        .background(colors.backgroundSurfacePrimary)
-                        .fillMaxWidth(),
-                    contentPadding = PaddingValues(
-                        start = dimensions.paddingMediumLarge,
-                        end = dimensions.paddingMediumLarge
-                    ),
-                    state = lazyColumnListState,
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    itemsIndexed(itemsList) { index, project ->
-                        if (index == 0 && isDefaultList) {
-                            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                itemsIndexed(itemsList) { index, project ->
+                    if (index == 0 && isDefaultList) {
+                        Spacer(modifier = Modifier.height(dimensions.paddingMedium))
 
-                            Text(
-                                modifier = Modifier
-                                    .testTag(SearchScreenTestTag.DISCOVER_PROJECTS_TITLE.name)
-                                    .fillMaxWidth(),
-                                text = stringResource(id = R.string.activity_empty_state_logged_in_button),
-                                style = typographyV2.title2,
-                                color = colors.kds_support_700,
-                                textAlign = TextAlign.Start
-                            )
-                        }
-
-                        val state = getCardProjectState(project)
-                        val fundingInfoString = getFundingInfoString(state, environment, project)
-
-                        if (index == 0) {
-                            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
-                            KSProjectCardLarge(
-                                modifier = Modifier
-                                    .testTag(SearchScreenTestTag.FEATURED_PROJECT_VIEW.name),
-                                photo = project.photo(),
-                                title = project.name(),
-                                state = state,
-                                fundingInfoString = fundingInfoString,
-                                fundedPercentage = project.percentageFunded().toInt(),
-                            ) {
-                                onItemClicked(project)
-                            }
-
-                            if (itemsList.size > 1) {
-                                Spacer(modifier = Modifier.height(dimensions.paddingMedium))
-                            }
-                        } else {
-                            KSProjectCardSmall(
-                                modifier = Modifier
-                                    .testTag(SearchScreenTestTag.NORMAL_PROJECT_VIEW.name + index),
-                                photo = project.photo(),
-                                title = project.name(),
-                                state = state,
-                                fundingInfoString = fundingInfoString,
-                                fundedPercentage = project.percentageFunded().toInt(),
-                            ) {
-                                onItemClicked(project)
-                            }
-
-                            if (index < itemsList.size - 1) {
-                                Spacer(modifier = Modifier.height(dimensions.paddingMedium))
-                            } else {
-                                Spacer(modifier = Modifier.height(dimensions.paddingMediumLarge))
-                            }
-                        }
+                        Text(
+                            modifier = Modifier
+                                .testTag(SearchScreenTestTag.DISCOVER_PROJECTS_TITLE.name)
+                                .fillMaxWidth(),
+                            text = stringResource(id = R.string.activity_empty_state_logged_in_button),
+                            style = typographyV2.title2,
+                            color = colors.kds_support_700,
+                            textAlign = TextAlign.Start
+                        )
                     }
 
-                    item(isLoading) {
-                        if (isLoading && itemsList.isNotEmpty()) {
-                            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                    val state = getCardProjectState(project)
+                    val fundingInfoString = getFundingInfoString(state, environment, project)
 
-                            KSCircularProgressIndicator(
-                                modifier = Modifier
-                                    .testTag(SearchScreenTestTag.IN_LIST_LOADING_VIEW.name)
-                                    .size(size = dimensions.imageSizeLarge)
-                            )
+                    if (index == 0) {
+                        Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                        KSProjectCardLarge(
+                            modifier = Modifier
+                                .testTag(SearchScreenTestTag.FEATURED_PROJECT_VIEW.name),
+                            photo = project.photo(),
+                            title = project.name(),
+                            state = state,
+                            fundingInfoString = fundingInfoString,
+                            fundedPercentage = project.percentageFunded().toInt(),
+                        ) {
+                            onItemClicked(project)
+                        }
 
+                        if (itemsList.size > 1) {
                             Spacer(modifier = Modifier.height(dimensions.paddingMedium))
                         }
+                    } else {
+                        KSProjectCardSmall(
+                            modifier = Modifier
+                                .testTag(SearchScreenTestTag.NORMAL_PROJECT_VIEW.name + index),
+                            photo = project.photo(),
+                            title = project.name(),
+                            state = state,
+                            fundingInfoString = fundingInfoString,
+                            fundedPercentage = project.percentageFunded().toInt(),
+                        ) {
+                            onItemClicked(project)
+                        }
+
+                        if (index < itemsList.size - 1) {
+                            Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+                        } else {
+                            Spacer(modifier = Modifier.height(dimensions.paddingMediumLarge))
+                        }
+                    }
+                }
+
+                item(isLoading) {
+                    if (isLoading && itemsList.isNotEmpty()) {
+                        Spacer(modifier = Modifier.height(dimensions.paddingMedium))
+
+                        KSCircularProgressIndicator(
+                            modifier = Modifier
+                                .testTag(SearchScreenTestTag.IN_LIST_LOADING_VIEW.name)
+                                .size(size = dimensions.imageSizeLarge)
+                        )
+
+                        Spacer(modifier = Modifier.height(dimensions.paddingMedium))
                     }
                 }
             }

--- a/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
@@ -3,7 +3,9 @@ package com.kickstarter.features.search.viewmodel
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.features.search.data.SearchEnvelope
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.MockStatsigClient
 import com.kickstarter.libs.RefTag
+import com.kickstarter.libs.featureflag.StatsigGateKey
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.mock.factories.CategoryFactory
 import com.kickstarter.mock.factories.LocationFactory
@@ -47,7 +49,9 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
                         params = discoveryParams
                         return Result.success(SearchEnvelope(projectList))
                     }
-                }).build()
+                })
+            .statsigClient(MockStatsigClient(context = application()))
+            .build()
 
         setUpEnvironment(environment, dispatcher)
 
@@ -81,7 +85,9 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
                         params = discoveryParams
                         return Result.failure(Exception())
                     }
-                }).build()
+                })
+            .statsigClient(MockStatsigClient(context = application()))
+            .build()
 
         setUpEnvironment(environment, dispatcher)
 
@@ -117,7 +123,9 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
                         params = discoveryParams
                         return Result.success(SearchEnvelope(projectList))
                     }
-                }).build()
+                })
+            .statsigClient(MockStatsigClient(context = application()))
+            .build()
 
         setUpEnvironment(environment, dispatcher)
 
@@ -154,7 +162,9 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
                         params = discoveryParams
                         return Result.success(SearchEnvelope(projectList))
                     }
-                }).build()
+                })
+            .statsigClient(MockStatsigClient(context = application()))
+            .build()
 
         setUpEnvironment(environment, dispatcher)
 
@@ -196,7 +206,9 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
                         params = discoveryParams
                         return Result.success(SearchEnvelope(projectList))
                     }
-                }).build()
+                })
+            .statsigClient(MockStatsigClient(context = application()))
+            .build()
 
         setUpEnvironment(environment, dispatcher)
 
@@ -242,7 +254,9 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
                         params = discoveryParams
                         return Result.success(SearchEnvelope(projectList))
                     }
-                }).build()
+                })
+            .statsigClient(MockStatsigClient(context = application()))
+            .build()
 
         setUpEnvironment(environment, dispatcher)
 
@@ -287,7 +301,9 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
                         params = discoveryParams
                         return Result.success(SearchEnvelope(projectList))
                     }
-                }).build()
+                })
+            .statsigClient(MockStatsigClient(context = application()))
+            .build()
 
         setUpEnvironment(environment, dispatcher)
 
@@ -337,7 +353,9 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
                         else SearchEnvelope(projectList)
                         return Result.success(envelope)
                     }
-                }).build()
+                })
+            .statsigClient(MockStatsigClient(context = application()))
+            .build()
 
         setUpEnvironment(environment, dispatcher)
 
@@ -393,7 +411,9 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
                         else SearchEnvelope(projectList)
                         return Result.success(envelope)
                     }
-                }).build()
+                })
+            .statsigClient(MockStatsigClient(context = application()))
+            .build()
 
         setUpEnvironment(environment, dispatcher)
 
@@ -439,5 +459,43 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
 
         // - When updating search term or new params selected new events should be sent
         segmentTrack.assertValues(EventName.CTA_CLICKED.eventName, EventName.PAGE_VIEWED.eventName, EventName.CTA_CLICKED.eventName, EventName.PAGE_VIEWED.eventName)
+    }
+
+    @Test
+    fun `test isVideoFeedBannerVisible is true when gate is enabled`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val environment = environment()
+            .toBuilder()
+            .statsigClient(
+                MockStatsigClient(
+                    context = application(),
+                    gateMap = mapOf(StatsigGateKey.ANDROID_VIDEO_FEED.key to true)
+                )
+            )
+            .build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        advanceUntilIdle()
+        assertTrue(viewModel.isVideoFeedBannerVisible.value)
+    }
+
+    @Test
+    fun `test isVideoFeedBannerVisible is false when gate is disabled`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val environment = environment()
+            .toBuilder()
+            .statsigClient(
+                MockStatsigClient(
+                    context = application(),
+                    gateMap = mapOf(StatsigGateKey.ANDROID_VIDEO_FEED.key to false)
+                )
+            )
+            .build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        advanceUntilIdle()
+        assertFalse(viewModel.isVideoFeedBannerVisible.value)
     }
 }

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/search/SearchScreenTest.kt
@@ -25,6 +25,7 @@ import com.kickstarter.models.Category
 import com.kickstarter.models.Project
 import com.kickstarter.services.DiscoveryParams
 import com.kickstarter.ui.compose.designsystem.KSTheme
+import com.kickstarter.ui.compose.designsystem.KSVideoFeedBannerTestTag
 import org.junit.Test
 
 class SearchScreenTest : KSRobolectricTestCase() {
@@ -525,5 +526,78 @@ class SearchScreenTest : KSRobolectricTestCase() {
 
         composeTestRule.waitForIdle()
         assertEquals(page, FilterPages.MAIN_FILTER.ordinal)
+    }
+
+    @Test
+    fun testVideoFeedBannerVisibleWhenEnabled() {
+        var bannerClicked = false
+
+        composeTestRule.setContent {
+            val env = environment()
+            val fakeViewModel = FilterMenuViewModel(env)
+            KSTheme {
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchScreen(
+                        onBackClicked = { },
+                        isLoading = false,
+                        lazyColumnListState = rememberLazyListState(),
+                        showEmptyView = false,
+                        isDefaultList = true,
+                        itemsList = List(5) {
+                            Project.builder()
+                                .name("This is a test $it")
+                                .pledged((it * 2).toDouble())
+                                .goal(20.0)
+                                .state(Project.STATE_LIVE)
+                                .build()
+                        },
+                        categories = listOf(),
+                        onSearchTermChanged = {},
+                        onItemClicked = {},
+                        isVideoFeedBannerVisible = true,
+                        onVideoFeedBannerClicked = { bannerClicked = true }
+                    )
+                }
+            }
+        }
+
+        val banner = composeTestRule.onNodeWithTag(KSVideoFeedBannerTestTag.BANNER_CONTAINER.name)
+        banner.assertIsDisplayed()
+        banner.performClick()
+        assertTrue(bannerClicked)
+    }
+
+    @Test
+    fun testVideoFeedBannerNotVisibleWhenDisabled() {
+        composeTestRule.setContent {
+            val env = environment()
+            val fakeViewModel = FilterMenuViewModel(env)
+            KSTheme {
+                CompositionLocalProvider(LocalFilterMenuViewModel provides fakeViewModel) {
+                    SearchScreen(
+                        onBackClicked = { },
+                        isLoading = false,
+                        lazyColumnListState = rememberLazyListState(),
+                        showEmptyView = false,
+                        isDefaultList = true,
+                        itemsList = List(5) {
+                            Project.builder()
+                                .name("This is a test $it")
+                                .pledged((it * 2).toDouble())
+                                .goal(20.0)
+                                .state(Project.STATE_LIVE)
+                                .build()
+                        },
+                        categories = listOf(),
+                        onSearchTermChanged = {},
+                        onItemClicked = {},
+                        isVideoFeedBannerVisible = false
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag(KSVideoFeedBannerTestTag.BANNER_CONTAINER.name)
+            .assertDoesNotExist()
     }
 }


### PR DESCRIPTION
# 📲 What

Add a Video Feed banner to the Search screen, gated behind the `ANDROID_VIDEO_FEED` Statsig feature gate.

# 🤔 Why

We want to drive discovery of the new Video Feed experience by surfacing a promotional banner to eligible users on the Search screen.

# 🛠 How

**ViewModel**: Added StatsigClient dependency to `SearchAndFilterViewModel` and exposed an `isVideoFeedBannerVisible` StateFlow that checks the `ANDROID_VIDEO_FEED` gate on init.
**SearchScreen composable:** Added `isVideoFeedBannerVisible` and `onVideoFeedBannerClicked` parameters. When the gate is enabled, a KSVideoFeedBanner is rendered as the first item in the results LazyColumn, scrolling with the content.
**Activity:** Wired the banner click to startVideoFeed().
**Tests:** Added ViewModel tests verifying gate on/off behavior, and Compose UI tests asserting banner visibility and click handling. Updated all existing ViewModel tests to include `MockStatsigClient`.

# 👀 See

https://github.com/user-attachments/assets/99aaf420-7f93-4148-ad86-ef8c3ba3635f

|  |  |

# 📋 QA

- change your `internal_name` verision to 3.39.0 -> run the app -> open Search → verify the Video Feed banner appears at the top of results and scrolls with content.
Tap the banner → verify it navigates to the Video Feed screen.
- change back you `internal_name` to a version minor than 3.39.0 → open Search → verify the banner does not appear.

# Story 📖

[DISC-133](https://kickstarter.atlassian.net/browse/DISC-133)


[DISC-133]: https://kickstarter.atlassian.net/browse/DISC-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ