### PR TITLE
DISC-1: Prelaunch pages being cut off in the Android app

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreen.kt
@@ -121,9 +121,12 @@ fun PreLaunchProjectPageScreen(
                 leftOnClickAction = { leftOnClickAction() }
             )
         }
-    ) {
+    ) { contentPadding ->
         ConstraintLayout(
-            modifier = Modifier.fillMaxSize().background(colors.kds_support_100)
+            modifier = Modifier
+                .padding(contentPadding)
+                .fillMaxSize()
+                .background(colors.kds_support_100)
         ) {
             val (constraintLayout, buttonCardLayout) = createRefs()
             val screenPadding = dimensionResource(id = R.dimen.activity_horizontal_margin)


### PR DESCRIPTION
# 📲 What

Applied the contentPadding provided by the `Scaffold` to the main `ConstraintLayout` in the `PreLaunchProjectPageScreen`.

# 🤔 Why

The prelaunch project page content was being partially obscured or "cut off" (specifically the top portion) because the Scaffold's contentPadding, which accounts for the top toolbar height, was not being applied to the internal layout.

# 🛠 How

Updated the PreLaunchProjectPageScreen composable to:
• Capture the contentPadding from the Scaffold content lambda.
• Apply .padding(contentPadding) to the root ConstraintLayout modifier.
• Kept Modifier.systemBarsPadding() on the Scaffold itself to ensure proper handling of status and navigation bars.

# 👀 See

| Before 🐛 | 
<img width="421" height="860" alt="Before" src="https://github.com/user-attachments/assets/240a79b9-d413-4e7f-b949-28ce9e3c11df" />
|After 🦋 |
<img width="422" height="867" alt="After" src="https://github.com/user-attachments/assets/e928995f-7754-4e15-b33d-282df53b2bdd" />
 |
|  |  |

# 📋 QA

- Open a prelaunch project page, the project image is fully visible now.
- To search for projects on pre-launch state go to search, and filter by project status upcoming. 


https://github.com/user-attachments/assets/b299ca5e-444c-4a71-b627-f6493f88142f



# Story 📖

[DISC-1](https://kickstarter.atlassian.net/browse/DISC-1)


[DISC-1]: https://kickstarter.atlassian.net/browse/DISC-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ