### PR TITLE
DISC-199: Android 3.39.0 regression testing crashes

### DIFF
--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
@@ -81,7 +81,11 @@ class SearchAndFilterViewModel(
     private var isLoadingMore = false
 
     init {
-        _isVideoFeedBannerVisible.value = statsigClient.checkGate(StatsigGateKey.ANDROID_VIDEO_FEED.key)
+        scope.launch {
+            statsigClient.isReady.collect { isReady ->
+                _isVideoFeedBannerVisible.value = isReady && statsigClient.checkGate(StatsigGateKey.ANDROID_VIDEO_FEED.key)
+            }
+        }
 
         scope.launch {
             val debounced = _searchTerm

--- a/app/src/main/java/com/kickstarter/viewmodels/ReportProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/ReportProjectViewModel.kt
@@ -59,7 +59,7 @@ interface ReportProjectViewModel {
         private val flaggingKind = PublishSubject.create<String>()
         private val urlTag = PublishSubject.create<String>()
 
-        private fun arguments() = Observable.just(this.arguments).filter { it.isNotNull() }.map { requireNotNull(it) }
+        private fun arguments() = this.arguments?.let { Observable.just(it) } ?: Observable.empty()
         private val disposables = CompositeDisposable()
 
         init {

--- a/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
@@ -498,4 +498,27 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         advanceUntilIdle()
         assertFalse(viewModel.isVideoFeedBannerVisible.value)
     }
+
+    @Test
+    fun `test isVideoFeedBannerVisible stays false until statsig is ready then reflects gate value`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val statsigClient = MockStatsigClient(
+            context = application(),
+            gateMap = mapOf(StatsigGateKey.ANDROID_VIDEO_FEED.key to true),
+            startReady = false
+        )
+        val environment = environment()
+            .toBuilder()
+            .statsigClient(statsigClient)
+            .build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        advanceUntilIdle()
+        assertFalse(viewModel.isVideoFeedBannerVisible.value)
+
+        statsigClient.triggerReady()
+        advanceUntilIdle()
+        assertTrue(viewModel.isVideoFeedBannerVisible.value)
+    }
 }

--- a/app/src/test/java/com/kickstarter/libs/MockStatsigClient.kt
+++ b/app/src/test/java/com/kickstarter/libs/MockStatsigClient.kt
@@ -34,7 +34,8 @@ import io.mockk.mockk
 class MockStatsigClient(
     context: Context,
     currentUser: CurrentUserTypeV2 = MockCurrentUserV2(),
-    private val gateMap: Map<String, Boolean> = emptyMap()
+    private val gateMap: Map<String, Boolean> = emptyMap(),
+    startReady: Boolean = true
 ) : StatsigClient(
     build = mockk<Build> { every { isRelease } returns false },
     context = context,
@@ -42,6 +43,10 @@ class MockStatsigClient(
     sdkInitializer = { null }
 ) {
     init {
+        if (startReady) _isReady.value = true
+    }
+
+    fun triggerReady() {
         _isReady.value = true
     }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/ReportProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ReportProjectViewModelTest.kt
@@ -57,7 +57,7 @@ class ReportProjectViewModelTest : KSRobolectricTestCase() {
         return bundle
     }
 
-    private fun setUpEnvironment(environment: Environment, bundle: Bundle) {
+    private fun setUpEnvironment(environment: Environment, bundle: Bundle?) {
 
         this.vm = ReportProjectViewModel.ReportProjectViewModel(environment, bundle)
 
@@ -126,6 +126,16 @@ class ReportProjectViewModelTest : KSRobolectricTestCase() {
 
         vm.inputs.openExternalBrowser("")
         openExternal.assertValueCount(0)
+        openExternal.assertNoValues()
+    }
+
+    @Test
+    fun testNullBundle_doesNotCrash() {
+        setUpEnvironment(getEnvironment(), null)
+
+        projectUrl.assertNoValues()
+        email.assertValue("some@email.com")
+        finish.assertNoValues()
         openExternal.assertNoValues()
     }
 


### PR DESCRIPTION
# 📲 What

Fix two fatal crashes affecting `SearchAndFilterActivity` and `ReportProjectActivity`.

# 🤔 Why

Both crashes were triggered by unsafe assumptions at ViewModel initialization time:

`SearchAndFilterViewModel` called `statsigClient.checkGate()` synchronously in init before the Statsig SDK had finished its async initialization, causing an IllegalStateException.
`ReportProjectViewModel` passed intent.extras (which can be null) directly into Observable.just(), which rejects null items immediately with a NullPointerException — before any null-filtering operators had a chance to run.

# 🛠 How

**Crash 1 — Statsig not initialized**:

* Moved the checkGate call out of the synchronous init and into a coroutine that collects `statsigClient.isReady: StateFlow<Boolean>`. The banner value now stays false until Statsig signals readiness, then evaluates the gate. Two separate `scope.launch` blocks are used so the Statsig collector and the search params collector run concurrently — a single coroutine would have blocked on collect forever and prevented search from working.
* Updated `MockStatsigClient` with a `startReady: Boolean = true` parameter and a `triggerReady()` method to support deferred-initialization test scenarios.

* Added a test covering the new behavior: banner is false while not ready, flips to the gate value once triggerReady() is called.


**Crash 2 — Null intent extras**:

`Observable.just(null)` throws before any operators run in RxJava 2. Replaced arguments() with a null-safe Kotlin expression: `this.arguments?.let { Observable.just(it) } ?: Observable.empty()`, which emits the bundle when present and completes silently when not.
Updated `setUpEnvironment` in the test to accept `Bundle?` and added `testNullBundle_doesNotCrash` which instantiates the VM with null and asserts no crash, no project-dependent emissions, and that email still loads independently.

# 👀 See
- No user facing changes

# 📋 QA

- Verify normal Search & Filter functionality (search, filters, pagination) still works end to end.
- Verify the Report Project flow works normally when reached through the standard in-app path (project page → report project).
- Crashes were likely generated by opening both activities using CLI: `adb shell am start -n com.kickstarter.dev/com.kickstarter.ui.activities.ReportProjectActivity`, found no way of reproducing with user navigation nor deeplinks associated.


# Story 📖

[DISC-199](https://kickstarter.atlassian.net/browse/DISC-199)


[DISC-199]: https://kickstarter.atlassian.net/browse/DISC-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ