### PR TITLE
CHECK-47: Re-fetch Statsig configs when Segment and User IDs become available

### DIFF
--- a/app/src/main/java/com/kickstarter/ApplicationModule.java
+++ b/app/src/main/java/com/kickstarter/ApplicationModule.java
@@ -416,9 +416,10 @@ public class ApplicationModule {
   StatsigClient provideStatsigClient(
           final @ApplicationContext @NonNull Context context,
           final @NonNull CurrentUserTypeV2 currentUser,
+          final @NonNull SegmentTrackingClient segmentTrackingClient,
           final @NonNull Build build
   ) {
-    return new StatsigClient(build, context, currentUser);
+    return new StatsigClient(build, context, currentUser, segmentTrackingClient);
   }
 
   @Provides

--- a/app/src/main/java/com/kickstarter/KSApplication.kt
+++ b/app/src/main/java/com/kickstarter/KSApplication.kt
@@ -140,6 +140,7 @@ open class KSApplication : MultiDexApplication(), IKSApplicationComponent, Image
                 FirebaseCrashlytics.getInstance().recordException(StatsigException(exception))
             }
         )
+        statsigClient.observeUserAndFetchConfigs(applicationScope)
 
         return true
     }

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -19,6 +19,9 @@ import com.segment.analytics.integrations.BasePayload
 import com.segment.analytics.integrations.IdentifyPayload
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import timber.log.Timber
 
 open class SegmentTrackingClient(
@@ -32,6 +35,9 @@ open class SegmentTrackingClient(
     override var isInitialized = false
     override var loggedInUser: User? = null
     override var config: Config? = null
+
+    protected val _initialized = MutableStateFlow(false)
+    val initialized: StateFlow<Boolean> = _initialized.asStateFlow()
 
     private var calledFromOnCreate = false
     private var prefStorage = preference
@@ -123,6 +129,7 @@ open class SegmentTrackingClient(
             )
 
             this.isInitialized = true
+            this._initialized.value = true
 
             if (build.isDebug) {
                 Timber.d("${type().tag} client:$segmentClient isInitialized:$isInitialized")

--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -4,12 +4,15 @@ import android.content.Context
 import com.kickstarter.KSApplication
 import com.kickstarter.libs.Build
 import com.kickstarter.libs.CurrentUserTypeV2
+import com.kickstarter.libs.SegmentTrackingClient
 import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.libs.utils.extensions.isFalse
 import com.kickstarter.libs.utils.extensions.isTrue
+import com.segment.analytics.Analytics
 import com.statsig.androidsdk.FeatureGate
 import com.statsig.androidsdk.InitializationDetails
 import com.statsig.androidsdk.Statsig
+import com.statsig.androidsdk.Statsig.getInitializeResponseJson
 import com.statsig.androidsdk.StatsigOptions
 import com.statsig.androidsdk.StatsigUser
 import com.statsig.androidsdk.Tier
@@ -19,7 +22,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.rx2.asFlow
+import timber.log.Timber
 
 enum class StatsigGateKey(val key: String) {
     ANDROID_VIDEO_FEED("android_video_feed")
@@ -33,7 +41,7 @@ interface StatsigClientType {
 
     /**
      * Returns the full [FeatureGate] object for [gateName], including the evaluated boolean value,
-     * the matched [com.statsig.androidsdk.FeatureGate.getRuleID] (which rule in the Statsig
+     * the matched [FeatureGate.getRuleID] (which rule in the Statsig
      * console was responsible for the result), and [com.statsig.androidsdk.EvaluationDetails]
      * describing how the value was resolved (network, cache, etc.).
      *
@@ -42,11 +50,13 @@ interface StatsigClientType {
      */
     fun getFeatureGate(gateName: String): FeatureGate = Statsig.getFeatureGate(gateName)
     fun getExperiment(experimentName: String) = Statsig.getExperiment(experimentName) // TODO: for test MOCK statsig DynamicConfig type or expose to the rest of the app just the json values, will explore in the future
-    suspend fun updateUser(id: String) = Statsig.updateUser(StatsigUser(id))
-    fun getStableId() = Statsig.getStableID()
+    suspend fun updateUser(user: StatsigUser) = Statsig.updateUser(user)
+    fun getStableId() = Statsig.getStatsigMetadata().stableID
 
     /** Emits true once the SDK has been successfully initialized. */
     val isReady: StateFlow<Boolean>
+
+    suspend fun handleObservedUserData(stableId: String?, segmentAnonymousId: String?, userId: String?)
 }
 
 /**
@@ -62,17 +72,30 @@ open class StatsigClient @JvmOverloads constructor(
     internal val build: Build,
     private val context: Context,
     private val currentUser: CurrentUserTypeV2,
+    private val segmentTrackingClient: SegmentTrackingClient,
+    private val getAnonymousId: () -> String? = {
+        Analytics.with(context).analyticsContext.traits().anonymousId()
+    },
     private val sdkInitializer: suspend StatsigClient.() -> InitializationDetails? = {
         val isProduction = build.isRelease && Build.isExternal()
         val options = StatsigOptions().apply {
             setTier(if (isProduction) Tier.PRODUCTION else Tier.STAGING)
         }
-        Statsig.initialize(
+        val user = StatsigUser()
+        val details = Statsig.initialize(
             application = context as KSApplication,
             if (isProduction) Secrets.Statsig.PRODUCTION else Secrets.Statsig.STAGING,
-            StatsigUser(),
+            user,
             options = options
         )
+        Timber.d("Statsig.initialize():")
+        Timber.d("- Stable ID: ${getStableId()}")
+        val initializeResponseJson = Statsig.runCatching { getInitializeResponseJson() }.getOrNull()
+        initializeResponseJson?.let {
+            Timber.d("- EvaluationDetails: ${it.getEvalDetails()}")
+            Timber.d("- JSON: ${it.getInitializeResponseJSON()}")
+        }
+        details
     }
 ) : StatsigClientType {
 
@@ -98,8 +121,8 @@ open class StatsigClient @JvmOverloads constructor(
      * @param errorCallback invoked with the error when initialization fails or throws
      */
     fun initialize(scope: CoroutineScope, dispatcher: CoroutineDispatcher = Dispatchers.IO, errorCallback: (Throwable) -> Unit) {
-        this.scope = scope
-        scope.launch(context = dispatcher) {
+        this.scope = (scope + dispatcher)
+        scope.launch {
             try {
                 val details = sdkInitializer()
 
@@ -112,5 +135,58 @@ open class StatsigClient @JvmOverloads constructor(
                 errorCallback.invoke(e)
             }
         }
+    }
+
+    fun observeUserAndFetchConfigs(scope: CoroutineScope) {
+        scope.launch {
+            val statsigInitialization = isReady
+            val segmentInitializationFlow = segmentTrackingClient.initialized
+            val currentUserFlow = currentUser.observable().asFlow()
+            combine(statsigInitialization, segmentInitializationFlow, currentUserFlow) { statsigIsReady, segmentIsReady, optionalUser ->
+                Triple(statsigIsReady, segmentIsReady, optionalUser)
+            }
+                .map { (statsigIsReady, segmentIsReady, optionalUser) ->
+                    val stableId = if (statsigIsReady) getStableId() else null
+                    val segmentAnonymousId = if (segmentIsReady) getAnonymousId() else null
+                    val userId = if (optionalUser.isPresent()) optionalUser.getValue()?.id().toString() else null
+                    Triple(stableId, segmentAnonymousId, userId)
+                }
+                // TODO: consider debounce
+                .collect {
+                    val (stableId, segmentAnonymousId, userId) = it
+                    handleObservedUserData(stableId, segmentAnonymousId, userId)
+                }
+        }
+    }
+
+    override suspend fun handleObservedUserData(stableId: String?, segmentAnonymousId: String?, userId: String?) {
+        // `stableId` is automatically attached to `StatsigUser` internally, but included here for clarity, testing, and debugging
+        Timber.d("handleObservedUserData(stableId: $stableId, segmentAnonymousId: $segmentAnonymousId, userId: $userId)")
+
+        if (stableId == null && segmentAnonymousId == null && userId == null) return
+
+        val statsigUser = StatsigUser()
+        segmentAnonymousId?.let {
+            statsigUser.customIDs = mapOf("segmentAnonymousId" to it)
+        }
+        userId?.let {
+            statsigUser.userID = userId
+        }
+
+        try {
+            Timber.d("Statsig.updateUser($statsigUser):")
+            updateUser(statsigUser)
+            val initializeResponseJson = Statsig.runCatching { getInitializeResponseJson() }.getOrNull()
+            initializeResponseJson?.let {
+                Timber.d("- EvaluationDetails: ${it.getEvalDetails()}")
+                Timber.d("- JSON: ${it.getInitializeResponseJSON()}")
+            }
+        } catch (e: Exception) {
+            Timber.d(e)
+        }
+    }
+
+    override suspend fun updateUser(user: StatsigUser) {
+        super.updateUser(user)
     }
 }

--- a/app/src/test/java/com/kickstarter/libs/MockStatsigClient.kt
+++ b/app/src/test/java/com/kickstarter/libs/MockStatsigClient.kt
@@ -32,15 +32,19 @@ import io.mockk.mockk
  *   the boolean directly) and [getFeatureGate] (wraps the value in a [FeatureGate] with
  *   [EvaluationReason.Unrecognized]). Gates absent from the map default to `false`.
  */
-class MockStatsigClient(
+open class MockStatsigClient(
     context: Context,
     currentUser: CurrentUserTypeV2 = MockCurrentUserV2(),
+    segmentTrackingClient: SegmentTrackingClient = mockk<SegmentTrackingClient>(),
+    getAnonymousId: () -> String? = { null },
     private val gateMap: Map<String, Boolean> = emptyMap(),
     startReady: Boolean = true
 ) : StatsigClient(
     build = mockk<Build> { every { isRelease } returns false },
     context = context,
     currentUser = currentUser,
+    segmentTrackingClient = segmentTrackingClient,
+    getAnonymousId = getAnonymousId,
     sdkInitializer = { null }
 ) {
     init {
@@ -64,4 +68,6 @@ class MockStatsigClient(
         )
 
     override fun getSDKKey(): String = "test-sdk-key"
+
+    override fun getStableId(): String? = "11111111-1111-1111-1111-111111111111"
 }

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -104,6 +104,7 @@ class SegmentTest : KSRobolectricTestCase() {
 
         override fun initialize() {
             this.isInitialized = true
+            this._initialized.value = true
         }
         override fun isEnabled() = this.isInitialized
     }

--- a/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
@@ -2,6 +2,7 @@ package com.kickstarter.libs
 
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.featureflag.StatsigClient
+import com.kickstarter.mock.factories.UserFactory
 import com.statsig.androidsdk.EvalReason
 import com.statsig.androidsdk.EvalSource
 import com.statsig.androidsdk.InitializationDetails
@@ -14,6 +15,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -24,6 +26,9 @@ import org.junit.Test
 class StatsigClientTest : KSRobolectricTestCase() {
 
     private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var segmentTrackingClient: SegmentTest.MockSegmentTrackingClient
+    private val segmentAnonymousId = "00000000-0000-0000-0000-000000000000"
 
     /**
      * Builds a [StatsigClient] subclass that simulates SDK initialization behavior.
@@ -36,22 +41,28 @@ class StatsigClientTest : KSRobolectricTestCase() {
         initResult: InitializationDetails? = null,
         initException: Exception? = null
     ): StatsigClient {
+        segmentTrackingClient = mockSegmentTrackingClient()
         return StatsigClient(
             build = mockk<Build> { every { isRelease } returns false },
             context = application(),
             currentUser = requireNotNull(environment().currentUserV2()),
+            segmentTrackingClient = segmentTrackingClient,
+            getAnonymousId = { segmentAnonymousId },
             sdkInitializer = {
                 initException?.let { throw it }
                 initResult
-            }
+            },
         )
     }
 
     private fun buildOfflineClientForOverrides(): StatsigClient {
+        segmentTrackingClient = mockSegmentTrackingClient()
         return StatsigClient(
             build = mockk<Build> { every { isRelease } returns false },
             context = application(),
             currentUser = requireNotNull(environment().currentUserV2()),
+            segmentTrackingClient = segmentTrackingClient,
+            getAnonymousId = { segmentAnonymousId },
             sdkInitializer = {
                 if (initializationDetails == null) {
                     initializationDetails = Statsig.initialize(
@@ -65,7 +76,18 @@ class StatsigClientTest : KSRobolectricTestCase() {
                     )
                 }
                 initializationDetails
-            }
+            },
+        )
+    }
+
+    private fun mockSegmentTrackingClient(): SegmentTest.MockSegmentTrackingClient {
+        val build = environment().build()!!
+        val context = application()
+        val currentConfigV2 = environment().currentConfigV2()!!
+        val currentUserV2 = environment().currentUserV2()!!
+        val sharedPreferences = MockSharedPreferences()
+        return SegmentTest.MockSegmentTrackingClient(
+            build, context, currentConfigV2, currentUserV2, sharedPreferences
         )
     }
 
@@ -75,21 +97,6 @@ class StatsigClientTest : KSRobolectricTestCase() {
     }
 
     // - Initialize tests
-    @Test
-    fun `initialize - Sets scope and completes without error on success`() = runTest(testDispatcher) {
-        val initDetails = InitializationDetails(200L, true, source = EvalSource.Network)
-        val client = buildInitializableClient(initResult = initDetails)
-
-        var errorCount = 0
-        client.initialize(this, testDispatcher) { errorCount++ }
-
-        advanceUntilIdle()
-
-        assertEquals(0, errorCount)
-        assertEquals(this, client.scope)
-        assertTrue(client.isReady.value)
-    }
-
     @Test
     fun `initialize - Invokes error callback with failure details on SDK failure`() = runTest(testDispatcher) {
         val failureDetails = InitializeResponse.FailedInitializeResponse(
@@ -294,6 +301,48 @@ class StatsigClientTest : KSRobolectricTestCase() {
         assertEquals(0, errorCount)
         assertEquals(EvalReason.LocalOverride, evalDetails.reason)
         assertNull(stringValue)
+    }
+
+    @Test
+    fun `test user data observation`() = runTest {
+        val testScope = TestScope(UnconfinedTestDispatcher(testScheduler))
+
+        val data = mutableListOf<Triple<String?, String?, String?>>()
+
+        val currentUser = MockCurrentUserV2()
+        val segmentTrackingClient = mockSegmentTrackingClient()
+        val statsigClient = object : MockStatsigClient(
+            context = application(),
+            currentUser = currentUser,
+            segmentTrackingClient = segmentTrackingClient,
+            getAnonymousId = { segmentAnonymousId },
+            startReady = false
+        ) {
+            override suspend fun handleObservedUserData(
+                stableId: String?,
+                segmentAnonymousId: String?,
+                userId: String?
+            ) {
+                data += Triple(stableId, segmentAnonymousId, userId)
+            }
+        }
+
+        statsigClient.observeUserAndFetchConfigs(testScope)
+
+        assertEquals(Triple(null, null, null), data.last())
+
+        statsigClient.triggerReady()
+
+        assertEquals(data.last(), Triple(statsigClient.getStableId(), null, null))
+
+        segmentTrackingClient.initialize()
+
+        assertEquals(data.last(), Triple(statsigClient.getStableId(), segmentAnonymousId, null))
+
+        val user = UserFactory.user()
+        currentUser.login(user)
+
+        assertEquals(data.last(), Triple(statsigClient.getStableId(), segmentAnonymousId, user.id().toString()))
     }
 
     companion object {

--- a/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
@@ -98,6 +98,20 @@ class StatsigClientTest : KSRobolectricTestCase() {
 
     // - Initialize tests
     @Test
+    fun `initialize - Sets scope and completes without error on success`() = runTest(testDispatcher) {
+        val initDetails = InitializationDetails(200L, true, source = EvalSource.Network)
+        val client = buildInitializableClient(initResult = initDetails)
+
+        var errorCount = 0
+        client.initialize(this, testDispatcher) { errorCount++ }
+
+        advanceUntilIdle()
+
+        assertEquals(0, errorCount)
+        assertTrue(client.isReady.value)
+    }
+
+    @Test
     fun `initialize - Invokes error callback with failure details on SDK failure`() = runTest(testDispatcher) {
         val failureDetails = InitializeResponse.FailedInitializeResponse(
             reason = InitializeFailReason.NetworkError,


### PR DESCRIPTION
# 📲 What

Launch a `Job` that re-fetches feature configurations from Statsig when the Segment Anonymous and KSR User IDs become available.

# 🤔 Why

As described in the docs: "Statsig evaluates gates and experiment buckets based only on the information you provide when you check something." ([User (StatsigUser) Object - Statsig Documentation](https://docs.statsig.com/sdks/user#i-passed-that-attribute-before-why-do-i-need-to-pass-it-again))

In order to target and bucket both anonymous and authenticated users, as well as to ensure a consistent user experience, the app needs to pass all available IDs (and in the future, other User properties) to Statsig when fetching configurations. ([Build your first Device-level Experiment - Statsig Documentation](https://docs.statsig.com/guides/first-device-level-experiment#step-3-optional--update-user-info-for-logged-in-users), [Client SDKs - Statsig Documentation](https://docs.statsig.com/client/introduction#updating-experiment-configuration))

# 🛠 How

Add a method `observeUserAndFetchConfigs()` to our `StatsigClient` that launches a long-lived `Job` for observing the Segment client state and current User. When the Segment client is ready and an Anonymous ID is available, and/or when a user signs in, a call is made to `Statsig.updateUser()` with an updated `StatsigUser` data object.

# 👀 See

<img width="1024" src="https://github.com/user-attachments/assets/b3b4bf84-8055-4a66-a59c-980e34a1181e" />

# 📋 QA

**Anonymous User without tracking -> Authenticated User**
- Precondition: Fresh install of the app
- Launch the app from the Home Screen or App Drawer (or Android Studio)
- Result:
  - The system navigates to Discover and immediately displays Onboarding
  - The key `"1839732653"` in the JSON map logged under `Statsig.initialize(): - JSON: {...}` includes:
    - `is_user_in_experiment` : `false`
    - `secondary_exposures[0].gateValue` : `false`
- Step through Onboarding to **DECLINE Personalization**, then click through and **log into the app**
- Result:
  - After authentication, the system navigates back to Discover
  - The key `"1839732653"` in the JSON map logged under `Statsig.updateUser: - JSON: {...}` includes:
    - `is_user_in_experiment` : `true`
    - `secondary_exposures[0].gateValue` : `true`
- Terminate the app
- Re-install the app, or Clear storage from the app's system Settings.

**Anonymous User with tracking**
- Precondition: Fresh install of the app
- Launch the app from the Home Screen or App Drawer (or Android Studio)
- Result:
  - The system navigates to Discover and immediately displays Onboarding
  - The key `"1839732653"` in the JSON map logged under `Statsig.initialize(): - JSON: {...}` includes:
    - `is_user_in_experiment` : `false`
    - `secondary_exposures[0].gateValue` : `false`
- Step through Onboarding to **ALLOW Personalization**, then click through to Explore the app
- Navigate away from the app, then return
- Result:
  - The key `"1839732653"` in the JSON map logged under `Statsig.updateUser: - JSON: {...}` includes:
    - `is_user_in_experiment` : `true`
    - `secondary_exposures[0].gateValue` : `true`

# Story 📖

[\[CHECK-47\] [Android] Verify logged-in and logged-out users are correctly attributed in Statsig - Jira](https://kickstarter.atlassian.net/browse/CHECK-47)
