### PR TITLE
CHECK-52: Keep a StatsigUser in StatsigClient + support AA Experiments

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -77,6 +77,12 @@ open class SegmentTrackingClient(
         }
     }
 
+    override fun getAnonymousIdOrNull() = try {
+        Analytics.with(context).analyticsContext.traits().anonymousId()
+    } catch (_: Exception) {
+        null
+    }
+
     private fun privateInitializer() {
         if (build.isDebug) {
             Timber.d("${type().tag} isEnabled: ${this.isEnabled()}")

--- a/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/SegmentTrackingClient.kt
@@ -78,7 +78,9 @@ open class SegmentTrackingClient(
     }
 
     override fun getAnonymousIdOrNull() = try {
-        Analytics.with(context).analyticsContext.traits().anonymousId()
+        if (isEnabled())
+            Analytics.with(context).analyticsContext.traits().anonymousId()
+        else null
     } catch (_: Exception) {
         null
     }

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -75,6 +75,9 @@ abstract class TrackingClient(
      */
     abstract fun trackingData(eventName: String, newProperties: Map<String, Any?>)
 
+    // TODO: re-consider `abstract` here vs `open` in `SegmentTrackingClient`
+    abstract fun getAnonymousIdOrNull(): String?
+
     // Default property values
     override fun brand(): String = android.os.Build.BRAND
 

--- a/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/TrackingClient.kt
@@ -75,7 +75,7 @@ abstract class TrackingClient(
      */
     abstract fun trackingData(eventName: String, newProperties: Map<String, Any?>)
 
-    // TODO: re-consider `abstract` here vs `open` in `SegmentTrackingClient`
+    // Alternatively `open` in `SegmentTrackingClient` pending any other tracking clients
     abstract fun getAnonymousIdOrNull(): String?
 
     // Default property values

--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -41,15 +41,15 @@ object StatsigExperiments {
         val parameters: T
     }
 
-    object NoopAuthenticatedUsers : Experiment<NoopAuthenticatedUsers.Parameters> {
+    object NoOpAuthenticatedUsers : Experiment<NoOpAuthenticatedUsers.Parameters> {
         override val name = "logged_in_aa_experiment"
         override val parameters = Parameters
         object Parameters {
             const val TEST = "test_parameter"
         }
     }
-    object NoopAnonymousUsers : Experiment<NoopAnonymousUsers.Parameters> {
-        override val name = "logged_out_aa_experiment"
+    object NoOpAnonymousUsers : Experiment<NoOpAnonymousUsers.Parameters> {
+        override val name = "logged_out_aa_experiment_android"
         override val parameters = Parameters
         object Parameters {
             const val TEST = "test_parameter"

--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -226,6 +226,6 @@ open class StatsigClient @JvmOverloads constructor(
     }
 
     companion object {
-        const val KEY_SEGMENT_ANONYMOUS_ID = "segmentAnonymousId"
+        const val KEY_SEGMENT_ANONYMOUS_ID = "segmentAnonymousID"
     }
 }

--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -42,14 +42,14 @@ object StatsigExperiments {
     }
 
     object NoopAuthenticatedUsers : Experiment<NoopAuthenticatedUsers.Parameters> {
-        override val name = "2026-05-12_checkout_aa"
+        override val name = "logged_in_aa_experiment"
         override val parameters = Parameters
         object Parameters {
             const val TEST = "test_parameter"
         }
     }
     object NoopAnonymousUsers : Experiment<NoopAnonymousUsers.Parameters> {
-        override val name = "2026-05-12_checkout_aa_logged_out"
+        override val name = "logged_out_aa_experiment"
         override val parameters = Parameters
         object Parameters {
             const val TEST = "test_parameter"

--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -1,6 +1,7 @@
 package com.kickstarter.libs.featureflag
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import com.kickstarter.KSApplication
 import com.kickstarter.libs.Build
 import com.kickstarter.libs.CurrentUserTypeV2
@@ -8,7 +9,6 @@ import com.kickstarter.libs.SegmentTrackingClient
 import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.libs.utils.extensions.isFalse
 import com.kickstarter.libs.utils.extensions.isTrue
-import com.segment.analytics.Analytics
 import com.statsig.androidsdk.FeatureGate
 import com.statsig.androidsdk.InitializationDetails
 import com.statsig.androidsdk.Statsig
@@ -23,7 +23,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.rx2.asFlow
@@ -31,6 +33,28 @@ import timber.log.Timber
 
 enum class StatsigGateKey(val key: String) {
     ANDROID_VIDEO_FEED("android_video_feed")
+}
+
+object StatsigExperiments {
+    sealed interface Experiment<T> {
+        val name: String
+        val parameters: T
+    }
+
+    object NoopAuthenticatedUsers : Experiment<NoopAuthenticatedUsers.Parameters> {
+        override val name = "2026-05-12_checkout_aa"
+        override val parameters = Parameters
+        object Parameters {
+            const val TEST = "test_parameter"
+        }
+    }
+    object NoopAnonymousUsers : Experiment<NoopAnonymousUsers.Parameters> {
+        override val name = "2026-05-12_checkout_aa_logged_out"
+        override val parameters = Parameters
+        object Parameters {
+            const val TEST = "test_parameter"
+        }
+    }
 }
 
 class StatsigException(cause: Throwable) : Exception(cause)
@@ -51,10 +75,12 @@ interface StatsigClientType {
     fun getFeatureGate(gateName: String): FeatureGate = Statsig.getFeatureGate(gateName)
     fun getExperiment(experimentName: String) = Statsig.getExperiment(experimentName) // TODO: for test MOCK statsig DynamicConfig type or expose to the rest of the app just the json values, will explore in the future
     suspend fun updateUser(user: StatsigUser) = Statsig.updateUser(user)
-    fun getStableId() = Statsig.getStatsigMetadata().stableID
+    fun getStableId() = if (Statsig.isInitialized()) Statsig.getStatsigMetadata().stableID else null
 
     /** Emits true once the SDK has been successfully initialized. */
     val isReady: StateFlow<Boolean>
+
+    val statsigUser: StateFlow<StatsigUser>
 
     suspend fun handleObservedUserData(stableId: String?, segmentAnonymousId: String?, userId: String?)
 }
@@ -73,15 +99,12 @@ open class StatsigClient @JvmOverloads constructor(
     private val context: Context,
     private val currentUser: CurrentUserTypeV2,
     private val segmentTrackingClient: SegmentTrackingClient,
-    private val getAnonymousId: () -> String? = {
-        Analytics.with(context).analyticsContext.traits().anonymousId()
-    },
     private val sdkInitializer: suspend StatsigClient.() -> InitializationDetails? = {
         val isProduction = build.isRelease && Build.isExternal()
         val options = StatsigOptions().apply {
             setTier(if (isProduction) Tier.PRODUCTION else Tier.STAGING)
         }
-        val user = StatsigUser()
+        val user = statsigUser.value
         val details = Statsig.initialize(
             application = context as KSApplication,
             if (isProduction) Secrets.Statsig.PRODUCTION else Secrets.Statsig.STAGING,
@@ -103,6 +126,9 @@ open class StatsigClient @JvmOverloads constructor(
 
     protected val _isReady = MutableStateFlow(false)
     override val isReady: StateFlow<Boolean> = _isReady.asStateFlow()
+
+    private val _statsigUser = MutableStateFlow(StatsigUser())
+    override val statsigUser = _statsigUser.asStateFlow()
 
     override fun getSDKKey() =
         if (build.isRelease && Build.isExternal()) Secrets.Statsig.PRODUCTION
@@ -147,11 +173,15 @@ open class StatsigClient @JvmOverloads constructor(
             }
                 .map { (statsigIsReady, segmentIsReady, optionalUser) ->
                     val stableId = if (statsigIsReady) getStableId() else null
-                    val segmentAnonymousId = if (segmentIsReady) getAnonymousId() else null
+                    val segmentAnonymousId = if (segmentIsReady) segmentTrackingClient.getAnonymousIdOrNull() else null
                     val userId = if (optionalUser.isPresent()) optionalUser.getValue()?.id().toString() else null
                     Triple(stableId, segmentAnonymousId, userId)
                 }
-                // TODO: consider debounce
+                .onEach {
+                    val (stableId, segmentAnonymousId, userId) = it
+                    Timber.d("onEach set of user IDs: (stableId: $stableId, segmentAnonymousId: $segmentAnonymousId, userId: $userId)")
+                }
+                .distinctUntilChanged()
                 .collect {
                     val (stableId, segmentAnonymousId, userId) = it
                     handleObservedUserData(stableId, segmentAnonymousId, userId)
@@ -160,14 +190,13 @@ open class StatsigClient @JvmOverloads constructor(
     }
 
     override suspend fun handleObservedUserData(stableId: String?, segmentAnonymousId: String?, userId: String?) {
-        // `stableId` is automatically attached to `StatsigUser` internally, but included here for clarity, testing, and debugging
         Timber.d("handleObservedUserData(stableId: $stableId, segmentAnonymousId: $segmentAnonymousId, userId: $userId)")
 
-        if (stableId == null && segmentAnonymousId == null && userId == null) return
+        if (stableId == null) return
 
-        val statsigUser = StatsigUser()
+        val statsigUser = StatsigUser() // `stableId` is automatically attached to `StatsigUser` internally
         segmentAnonymousId?.let {
-            statsigUser.customIDs = mapOf("segmentAnonymousId" to it)
+            statsigUser.customIDs = mapOf(KEY_SEGMENT_ANONYMOUS_ID to it)
         }
         userId?.let {
             statsigUser.userID = userId
@@ -176,6 +205,7 @@ open class StatsigClient @JvmOverloads constructor(
         try {
             Timber.d("Statsig.updateUser($statsigUser):")
             updateUser(statsigUser)
+            _statsigUser.value = statsigUser
             val initializeResponseJson = Statsig.runCatching { getInitializeResponseJson() }.getOrNull()
             initializeResponseJson?.let {
                 Timber.d("- EvaluationDetails: ${it.getEvalDetails()}")
@@ -188,5 +218,14 @@ open class StatsigClient @JvmOverloads constructor(
 
     override suspend fun updateUser(user: StatsigUser) {
         super.updateUser(user)
+    }
+
+    @VisibleForTesting
+    fun setStatsigUser(user: StatsigUser) {
+        _statsigUser.value = user
+    }
+
+    companion object {
+        const val KEY_SEGMENT_ANONYMOUS_ID = "segmentAnonymousId"
     }
 }

--- a/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/ProjectPageActivity.kt
@@ -95,6 +95,7 @@ import com.kickstarter.ui.fragments.RewardsFragment
 import com.kickstarter.utils.WindowInsetsUtil
 import com.kickstarter.viewmodels.projectpage.AddOnsViewModel
 import com.kickstarter.viewmodels.projectpage.CheckoutFlowViewModel
+import com.kickstarter.viewmodels.projectpage.ExperimentsViewModel
 import com.kickstarter.viewmodels.projectpage.LatePledgeCheckoutViewModel
 import com.kickstarter.viewmodels.projectpage.PagerTabConfig
 import com.kickstarter.viewmodels.projectpage.ProjectPageViewModel
@@ -145,6 +146,9 @@ class ProjectPageActivity :
 
     private lateinit var similarProjectsViewModelFactory: SimilarProjectsViewModel.Factory
     private val similarProjectsViewModel: SimilarProjectsViewModel by viewModels { similarProjectsViewModelFactory }
+
+    private lateinit var experimentsViewModelFactory: ExperimentsViewModel.Factory
+    private val experimentsViewModel: ExperimentsViewModel by viewModels { experimentsViewModelFactory }
 
     private lateinit var stripe: Stripe
     private lateinit var flowController: PaymentSheet.FlowController
@@ -202,6 +206,7 @@ class ProjectPageActivity :
             addOnsViewModelFactory = AddOnsViewModel.Factory(env)
             latePledgeCheckoutViewModelFactory = LatePledgeCheckoutViewModel.Factory(env)
             similarProjectsViewModelFactory = SimilarProjectsViewModel.Factory(env)
+            experimentsViewModelFactory = ExperimentsViewModel.Factory(env)
             stripe = requireNotNull(env.stripe())
         }
 
@@ -215,6 +220,7 @@ class ProjectPageActivity :
         this.ksString = requireNotNull(environment.ksString())
 
         viewModel.configureWith(intent)
+        experimentsViewModel
 
         // Do not configure the pager at other lifecycle events apart from OnCreate
         if (savedInstanceState == null) {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ExperimentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ExperimentsViewModel.kt
@@ -34,18 +34,18 @@ class ExperimentsViewModel(
                     .onEach {
                         Timber.d(
                             """
-                        statsigUser[stableID: ${statsigClient.getStableId()}]
-                        - userID: ${it.userID}
-                        - email: ${it.email}
-                        - ip: ${it.ip}
-                        - userAgent: ${it.userAgent}
-                        - country: ${it.country}
-                        - locale: ${it.locale}
-                        - appVersion: ${it.appVersion}
-                        - custom: ${it.custom}
-                        - privateAttributes: ${it.privateAttributes}
-                        - customIDs: ${it.customIDs}
-                        """.trimIndent()
+                            statsigUser[stableID: ${statsigClient.getStableId()}]
+                            - userID: ${it.userID}
+                            - email: ${it.email}
+                            - ip: ${it.ip}
+                            - userAgent: ${it.userAgent}
+                            - country: ${it.country}
+                            - locale: ${it.locale}
+                            - appVersion: ${it.appVersion}
+                            - custom: ${it.custom}
+                            - privateAttributes: ${it.privateAttributes}
+                            - customIDs: ${it.customIDs}
+                            """.trimIndent()
                         )
                     }
                     .collect {
@@ -53,29 +53,29 @@ class ExperimentsViewModel(
                         val anonymousExperiment = statsigClient.getExperiment(StatsigExperiments.NoOpAnonymousUsers.name)
                         Timber.d(
                             """
-                        authenticatedExperiment: ${authenticatedExperiment.getName()}
-                        - getEvalDetails(): ${authenticatedExperiment.getEvalDetails()}
-                        - getIsExperimentActive(): ${authenticatedExperiment.getIsExperimentActive()}
-                        - getIsUserInExperiment(): ${authenticatedExperiment.getIsUserInExperiment()}
-                        - getValue(): ${authenticatedExperiment.getValue()}
-                        - getBooleanIfPresent(${StatsigExperiments.NoOpAuthenticatedUsers.parameters.TEST}): ${authenticatedExperiment.getBooleanIfPresent(StatsigExperiments.NoOpAuthenticatedUsers.parameters.TEST)}
-                        - getRuleID(): ${authenticatedExperiment.getRuleID()}
-                        - getRulePassed(): ${authenticatedExperiment.getRulePassed()}
-                        - getGroupName(): ${authenticatedExperiment.getGroupName()}
-                        """.trimIndent()
+                            authenticatedExperiment: ${authenticatedExperiment.getName()}
+                            - getEvalDetails(): ${authenticatedExperiment.getEvalDetails()}
+                            - getIsExperimentActive(): ${authenticatedExperiment.getIsExperimentActive()}
+                            - getIsUserInExperiment(): ${authenticatedExperiment.getIsUserInExperiment()}
+                            - getValue(): ${authenticatedExperiment.getValue()}
+                            - getBooleanIfPresent(${StatsigExperiments.NoOpAuthenticatedUsers.parameters.TEST}): ${authenticatedExperiment.getBooleanIfPresent(StatsigExperiments.NoOpAuthenticatedUsers.parameters.TEST)}
+                            - getRuleID(): ${authenticatedExperiment.getRuleID()}
+                            - getRulePassed(): ${authenticatedExperiment.getRulePassed()}
+                            - getGroupName(): ${authenticatedExperiment.getGroupName()}
+                            """.trimIndent()
                         )
                         Timber.d(
                             """
-                        anonymousExperiment: ${anonymousExperiment.getName()}
-                        - getEvalDetails(): ${anonymousExperiment.getEvalDetails()}
-                        - getIsExperimentActive(): ${anonymousExperiment.getIsExperimentActive()}
-                        - getIsUserInExperiment(): ${anonymousExperiment.getIsUserInExperiment()}
-                        - getValue(): ${anonymousExperiment.getValue()}
-                        - getBooleanIfPresent(${StatsigExperiments.NoOpAnonymousUsers.parameters.TEST}): ${anonymousExperiment.getBooleanIfPresent(StatsigExperiments.NoOpAnonymousUsers.parameters.TEST)}
-                        - getRuleID(): ${anonymousExperiment.getRuleID()}
-                        - getRulePassed(): ${anonymousExperiment.getRulePassed()}
-                        - getGroupName(): ${anonymousExperiment.getGroupName()}
-                        """.trimIndent()
+                            anonymousExperiment: ${anonymousExperiment.getName()}
+                            - getEvalDetails(): ${anonymousExperiment.getEvalDetails()}
+                            - getIsExperimentActive(): ${anonymousExperiment.getIsExperimentActive()}
+                            - getIsUserInExperiment(): ${anonymousExperiment.getIsUserInExperiment()}
+                            - getValue(): ${anonymousExperiment.getValue()}
+                            - getBooleanIfPresent(${StatsigExperiments.NoOpAnonymousUsers.parameters.TEST}): ${anonymousExperiment.getBooleanIfPresent(StatsigExperiments.NoOpAnonymousUsers.parameters.TEST)}
+                            - getRuleID(): ${anonymousExperiment.getRuleID()}
+                            - getRulePassed(): ${anonymousExperiment.getRulePassed()}
+                            - getGroupName(): ${anonymousExperiment.getGroupName()}
+                            """.trimIndent()
                         )
                     }
             } catch (exception: Exception) {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ExperimentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ExperimentsViewModel.kt
@@ -3,6 +3,7 @@ package com.kickstarter.viewmodels.projectpage
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.featureflag.StatsigExperiments
 import kotlinx.coroutines.CoroutineDispatcher
@@ -14,6 +15,8 @@ import kotlinx.coroutines.plus
 import timber.log.Timber
 import kotlin.coroutines.EmptyCoroutineContext
 
+/** For Crashlytics logging only **/
+private class ExperimentsException(cause: Exception) : Exception(cause)
 @OptIn(FlowPreview::class)
 class ExperimentsViewModel(
     environment: Environment,
@@ -21,15 +24,16 @@ class ExperimentsViewModel(
 ) : ViewModel() {
 
     private val scope = viewModelScope + (testDispatcher ?: EmptyCoroutineContext)
-    private val statsigClient = environment.statsigClient()!!
+    private val statsigClient = requireNotNull(environment.statsigClient())
 
     init {
         scope.launch {
-            statsigClient.isReady.first { it }
-            statsigClient.statsigUser
-                .onEach {
-                    Timber.d(
-                        """
+            try {
+                statsigClient.isReady.first { it }
+                statsigClient.statsigUser
+                    .onEach {
+                        Timber.d(
+                            """
                         statsigUser[stableID: ${statsigClient.getStableId()}]
                         - userID: ${it.userID}
                         - email: ${it.email}
@@ -42,13 +46,13 @@ class ExperimentsViewModel(
                         - privateAttributes: ${it.privateAttributes}
                         - customIDs: ${it.customIDs}
                         """.trimIndent()
-                    )
-                }
-                .collect {
-                    val authenticatedExperiment = statsigClient.getExperiment(StatsigExperiments.NoOpAuthenticatedUsers.name)
-                    val anonymousExperiment = statsigClient.getExperiment(StatsigExperiments.NoOpAnonymousUsers.name)
-                    Timber.d(
-                        """
+                        )
+                    }
+                    .collect {
+                        val authenticatedExperiment = statsigClient.getExperiment(StatsigExperiments.NoOpAuthenticatedUsers.name)
+                        val anonymousExperiment = statsigClient.getExperiment(StatsigExperiments.NoOpAnonymousUsers.name)
+                        Timber.d(
+                            """
                         authenticatedExperiment: ${authenticatedExperiment.getName()}
                         - getEvalDetails(): ${authenticatedExperiment.getEvalDetails()}
                         - getIsExperimentActive(): ${authenticatedExperiment.getIsExperimentActive()}
@@ -59,9 +63,9 @@ class ExperimentsViewModel(
                         - getRulePassed(): ${authenticatedExperiment.getRulePassed()}
                         - getGroupName(): ${authenticatedExperiment.getGroupName()}
                         """.trimIndent()
-                    )
-                    Timber.d(
-                        """
+                        )
+                        Timber.d(
+                            """
                         anonymousExperiment: ${anonymousExperiment.getName()}
                         - getEvalDetails(): ${anonymousExperiment.getEvalDetails()}
                         - getIsExperimentActive(): ${anonymousExperiment.getIsExperimentActive()}
@@ -72,8 +76,11 @@ class ExperimentsViewModel(
                         - getRulePassed(): ${anonymousExperiment.getRulePassed()}
                         - getGroupName(): ${anonymousExperiment.getGroupName()}
                         """.trimIndent()
-                    )
-                }
+                        )
+                    }
+            } catch (exception: Exception) {
+                FirebaseCrashlytics.getInstance().recordException(ExperimentsException(exception))
+            }
         }
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ExperimentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ExperimentsViewModel.kt
@@ -43,8 +43,8 @@ class ExperimentsViewModel(
                     )
                 }
                 .collect {
-                    val authenticatedExperiment = statsigClient.getExperiment(StatsigExperiments.NoopAuthenticatedUsers.name)
-                    val anonymousExperiment = statsigClient.getExperiment(StatsigExperiments.NoopAnonymousUsers.name)
+                    val authenticatedExperiment = statsigClient.getExperiment(StatsigExperiments.NoOpAuthenticatedUsers.name)
+                    val anonymousExperiment = statsigClient.getExperiment(StatsigExperiments.NoOpAnonymousUsers.name)
                     Timber.d(
                         """
                         authenticatedExperiment: ${authenticatedExperiment.getName()}
@@ -52,7 +52,7 @@ class ExperimentsViewModel(
                         - getIsExperimentActive(): ${authenticatedExperiment.getIsExperimentActive()}
                         - getIsUserInExperiment(): ${authenticatedExperiment.getIsUserInExperiment()}
                         - getValue(): ${authenticatedExperiment.getValue()}
-                        - getBooleanIfPresent(${StatsigExperiments.NoopAuthenticatedUsers.parameters.TEST}): ${authenticatedExperiment.getBooleanIfPresent(StatsigExperiments.NoopAuthenticatedUsers.parameters.TEST)}
+                        - getBooleanIfPresent(${StatsigExperiments.NoOpAuthenticatedUsers.parameters.TEST}): ${authenticatedExperiment.getBooleanIfPresent(StatsigExperiments.NoOpAuthenticatedUsers.parameters.TEST)}
                         - getRuleID(): ${authenticatedExperiment.getRuleID()}
                         - getRulePassed(): ${authenticatedExperiment.getRulePassed()}
                         - getGroupName(): ${authenticatedExperiment.getGroupName()}
@@ -65,7 +65,7 @@ class ExperimentsViewModel(
                         - getIsExperimentActive(): ${anonymousExperiment.getIsExperimentActive()}
                         - getIsUserInExperiment(): ${anonymousExperiment.getIsUserInExperiment()}
                         - getValue(): ${anonymousExperiment.getValue()}
-                        - getBooleanIfPresent(${StatsigExperiments.NoopAnonymousUsers.parameters.TEST}): ${anonymousExperiment.getBooleanIfPresent(StatsigExperiments.NoopAnonymousUsers.parameters.TEST)}
+                        - getBooleanIfPresent(${StatsigExperiments.NoOpAnonymousUsers.parameters.TEST}): ${anonymousExperiment.getBooleanIfPresent(StatsigExperiments.NoOpAnonymousUsers.parameters.TEST)}
                         - getRuleID(): ${anonymousExperiment.getRuleID()}
                         - getRulePassed(): ${anonymousExperiment.getRulePassed()}
                         - getGroupName(): ${anonymousExperiment.getGroupName()}

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ExperimentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ExperimentsViewModel.kt
@@ -1,0 +1,86 @@
+package com.kickstarter.viewmodels.projectpage
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.featureflag.StatsigExperiments
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import timber.log.Timber
+import kotlin.coroutines.EmptyCoroutineContext
+
+@OptIn(FlowPreview::class)
+class ExperimentsViewModel(
+    environment: Environment,
+    testDispatcher: CoroutineDispatcher? = null
+) : ViewModel() {
+
+    private val scope = viewModelScope + (testDispatcher ?: EmptyCoroutineContext)
+    private val statsigClient = environment.statsigClient()!!
+
+    init {
+        scope.launch {
+            statsigClient.statsigUser
+                .onEach {
+                    Timber.d(
+                        """
+                        statsigUser[stableID: ${statsigClient.getStableId()}]
+                        - userID: ${it.userID}
+                        - email: ${it.email}
+                        - ip: ${it.ip}
+                        - userAgent: ${it.userAgent}
+                        - country: ${it.country}
+                        - locale: ${it.locale}
+                        - appVersion: ${it.appVersion}
+                        - custom: ${it.custom}
+                        - privateAttributes: ${it.privateAttributes}
+                        - customIDs: ${it.customIDs}
+                        """.trimIndent()
+                    )
+                }
+                .collect {
+                    val authenticatedExperiment = statsigClient.getExperiment(StatsigExperiments.NoopAuthenticatedUsers.name)
+                    val anonymousExperiment = statsigClient.getExperiment(StatsigExperiments.NoopAnonymousUsers.name)
+                    Timber.d(
+                        """
+                        authenticatedExperiment: ${authenticatedExperiment.getName()}
+                        - getEvalDetails(): ${authenticatedExperiment.getEvalDetails()}
+                        - getIsExperimentActive(): ${authenticatedExperiment.getIsExperimentActive()}
+                        - getIsUserInExperiment(): ${authenticatedExperiment.getIsUserInExperiment()}
+                        - getValue(): ${authenticatedExperiment.getValue()}
+                        - getBooleanIfPresent(${StatsigExperiments.NoopAuthenticatedUsers.parameters.TEST}): ${authenticatedExperiment.getBooleanIfPresent(StatsigExperiments.NoopAuthenticatedUsers.parameters.TEST)}
+                        - getRuleID(): ${authenticatedExperiment.getRuleID()}
+                        - getRulePassed(): ${authenticatedExperiment.getRulePassed()}
+                        - getGroupName(): ${authenticatedExperiment.getGroupName()}
+                        """.trimIndent()
+                    )
+                    Timber.d(
+                        """
+                        anonymousExperiment: ${anonymousExperiment.getName()}
+                        - getEvalDetails(): ${anonymousExperiment.getEvalDetails()}
+                        - getIsExperimentActive(): ${anonymousExperiment.getIsExperimentActive()}
+                        - getIsUserInExperiment(): ${anonymousExperiment.getIsUserInExperiment()}
+                        - getValue(): ${anonymousExperiment.getValue()}
+                        - getBooleanIfPresent(${StatsigExperiments.NoopAnonymousUsers.parameters.TEST}): ${anonymousExperiment.getBooleanIfPresent(StatsigExperiments.NoopAnonymousUsers.parameters.TEST)}
+                        - getRuleID(): ${anonymousExperiment.getRuleID()}
+                        - getRulePassed(): ${anonymousExperiment.getRulePassed()}
+                        - getGroupName(): ${anonymousExperiment.getGroupName()}
+                        """.trimIndent()
+                    )
+                }
+        }
+    }
+
+    class Factory(
+        private val environment: Environment,
+        private val testDispatcher: CoroutineDispatcher? = null
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return ExperimentsViewModel(environment, testDispatcher) as T
+        }
+    }
+}

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ExperimentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ExperimentsViewModel.kt
@@ -7,6 +7,7 @@ import com.kickstarter.libs.Environment
 import com.kickstarter.libs.featureflag.StatsigExperiments
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
@@ -24,6 +25,7 @@ class ExperimentsViewModel(
 
     init {
         scope.launch {
+            statsigClient.isReady.first { it }
             statsigClient.statsigUser
                 .onEach {
                     Timber.d(

--- a/app/src/test/java/com/kickstarter/libs/MockStatsigClient.kt
+++ b/app/src/test/java/com/kickstarter/libs/MockStatsigClient.kt
@@ -2,6 +2,7 @@ package com.kickstarter.libs
 
 import android.content.Context
 import com.kickstarter.libs.featureflag.StatsigClient
+import com.statsig.androidsdk.DynamicConfig
 import com.statsig.androidsdk.EvalDetails
 import com.statsig.androidsdk.EvalReason
 import com.statsig.androidsdk.EvalSource
@@ -36,15 +37,14 @@ open class MockStatsigClient(
     context: Context,
     currentUser: CurrentUserTypeV2 = MockCurrentUserV2(),
     segmentTrackingClient: SegmentTrackingClient = mockk<SegmentTrackingClient>(),
-    getAnonymousId: () -> String? = { null },
     private val gateMap: Map<String, Boolean> = emptyMap(),
+    private val experimentMap: Map<String, Map<String, Any>> = emptyMap(),
     startReady: Boolean = true
 ) : StatsigClient(
     build = mockk<Build> { every { isRelease } returns false },
     context = context,
     currentUser = currentUser,
     segmentTrackingClient = segmentTrackingClient,
-    getAnonymousId = getAnonymousId,
     sdkInitializer = { null }
 ) {
     init {
@@ -65,6 +65,13 @@ open class MockStatsigClient(
             gateName,
             EvalDetails(EvalSource.NoValues, EvalReason.Unrecognized),
             gateMap[gateName] ?: false
+        )
+
+    override fun getExperiment(experimentName: String): DynamicConfig =
+        DynamicConfig(
+            name = experimentName,
+            EvalDetails(EvalSource.NoValues, EvalReason.Unrecognized),
+            experimentMap[experimentName] ?: emptyMap()
         )
 
     override fun getSDKKey(): String = "test-sdk-key"

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -112,7 +112,8 @@ class SegmentTest : KSRobolectricTestCase() {
         }
         override fun isEnabled() = this.isInitialized
 
-        override fun getAnonymousIdOrNull(): String? = "00000000-0000-0000-0000-000000000000"
+        override fun getAnonymousIdOrNull(): String? =
+            if (isEnabled()) "00000000-0000-0000-0000-000000000000" else null
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -107,6 +107,8 @@ class SegmentTest : KSRobolectricTestCase() {
             this._initialized.value = true
         }
         override fun isEnabled() = this.isInitialized
+
+        override fun getAnonymousIdOrNull(): String? = "00000000-0000-0000-0000-000000000000"
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
@@ -416,6 +416,30 @@ class StatsigClientTest : KSRobolectricTestCase() {
         assertEquals(StatsigUser(), statsigClient.statsigUser.value)
     }
 
+    @Test
+    fun `updateUser - method is not called when StatsigClient is not ready`() = runTest {
+        val testScope = TestScope(UnconfinedTestDispatcher(testScheduler))
+
+        var count = 0
+
+        val currentUser = MockCurrentUserV2()
+        val segmentTrackingClient = mockSegmentTrackingClient()
+        val statsigClient = object : MockStatsigClient(
+            context = application(),
+            currentUser = currentUser,
+            segmentTrackingClient = segmentTrackingClient,
+            startReady = false
+        ) {
+            override suspend fun updateUser(user: StatsigUser) { count++ }
+        }
+
+        statsigClient.observeUserAndFetchConfigs(testScope)
+        segmentTrackingClient.initialize()
+        currentUser.login(UserFactory.user())
+
+        assertEquals(0, count)
+    }
+
     companion object {
         var initializationDetails: InitializationDetails? = null
     }

--- a/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
@@ -10,6 +10,7 @@ import com.statsig.androidsdk.InitializeFailReason
 import com.statsig.androidsdk.InitializeResponse
 import com.statsig.androidsdk.Statsig
 import com.statsig.androidsdk.StatsigOptions
+import com.statsig.androidsdk.StatsigUser
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -28,7 +29,6 @@ class StatsigClientTest : KSRobolectricTestCase() {
     private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
 
     private lateinit var segmentTrackingClient: SegmentTest.MockSegmentTrackingClient
-    private val segmentAnonymousId = "00000000-0000-0000-0000-000000000000"
 
     /**
      * Builds a [StatsigClient] subclass that simulates SDK initialization behavior.
@@ -47,7 +47,6 @@ class StatsigClientTest : KSRobolectricTestCase() {
             context = application(),
             currentUser = requireNotNull(environment().currentUserV2()),
             segmentTrackingClient = segmentTrackingClient,
-            getAnonymousId = { segmentAnonymousId },
             sdkInitializer = {
                 initException?.let { throw it }
                 initResult
@@ -62,7 +61,6 @@ class StatsigClientTest : KSRobolectricTestCase() {
             context = application(),
             currentUser = requireNotNull(environment().currentUserV2()),
             segmentTrackingClient = segmentTrackingClient,
-            getAnonymousId = { segmentAnonymousId },
             sdkInitializer = {
                 if (initializationDetails == null) {
                     initializationDetails = Statsig.initialize(
@@ -329,7 +327,6 @@ class StatsigClientTest : KSRobolectricTestCase() {
             context = application(),
             currentUser = currentUser,
             segmentTrackingClient = segmentTrackingClient,
-            getAnonymousId = { segmentAnonymousId },
             startReady = false
         ) {
             override suspend fun handleObservedUserData(
@@ -351,12 +348,72 @@ class StatsigClientTest : KSRobolectricTestCase() {
 
         segmentTrackingClient.initialize()
 
-        assertEquals(data.last(), Triple(statsigClient.getStableId(), segmentAnonymousId, null))
+        assertEquals(data.last(), Triple(statsigClient.getStableId(), segmentTrackingClient.getAnonymousIdOrNull(), null))
 
         val user = UserFactory.user()
         currentUser.login(user)
 
-        assertEquals(data.last(), Triple(statsigClient.getStableId(), segmentAnonymousId, user.id().toString()))
+        assertEquals(data.last(), Triple(statsigClient.getStableId(), segmentTrackingClient.getAnonymousIdOrNull()!!, user.id().toString()))
+    }
+
+    @Test
+    fun `updateUser - StatsigUser is mutated when successful`() = runTest {
+        val testScope = TestScope(UnconfinedTestDispatcher(testScheduler))
+
+        val currentUser = MockCurrentUserV2()
+        val segmentTrackingClient = mockSegmentTrackingClient()
+        val statsigClient = object : MockStatsigClient(
+            context = application(),
+            currentUser = currentUser,
+            segmentTrackingClient = segmentTrackingClient,
+            startReady = false
+        ) {
+            override suspend fun updateUser(user: StatsigUser) {}
+        }
+
+        var expectedStatsigUser = StatsigUser()
+        assertEquals(expectedStatsigUser, statsigClient.statsigUser.value)
+
+        statsigClient.observeUserAndFetchConfigs(testScope)
+        statsigClient.triggerReady()
+        segmentTrackingClient.initialize()
+
+        expectedStatsigUser = StatsigUser().apply {
+            customIDs = mapOf(StatsigClient.KEY_SEGMENT_ANONYMOUS_ID to segmentTrackingClient.getAnonymousIdOrNull()!!)
+        }
+        assertEquals(expectedStatsigUser, statsigClient.statsigUser.value)
+
+        val user = UserFactory.user()
+        currentUser.login(user)
+
+        expectedStatsigUser = StatsigUser().apply {
+            userID = user.id().toString()
+            customIDs = mapOf(StatsigClient.KEY_SEGMENT_ANONYMOUS_ID to segmentTrackingClient.getAnonymousIdOrNull()!!)
+        }
+        assertEquals(expectedStatsigUser, statsigClient.statsigUser.value)
+    }
+
+    @Test
+    fun `updateUser - StatsigUser is unchanged when failed`() = runTest {
+        val testScope = TestScope(UnconfinedTestDispatcher(testScheduler))
+
+        val currentUser = MockCurrentUserV2()
+        val segmentTrackingClient = mockSegmentTrackingClient()
+        val statsigClient = object : MockStatsigClient(
+            context = application(),
+            currentUser = currentUser,
+            segmentTrackingClient = segmentTrackingClient,
+            startReady = false
+        ) {
+            override suspend fun updateUser(user: StatsigUser) { throw Exception() }
+        }
+
+        statsigClient.observeUserAndFetchConfigs(testScope)
+        statsigClient.triggerReady()
+        segmentTrackingClient.initialize()
+        currentUser.login(UserFactory.user())
+
+        assertEquals(StatsigUser(), statsigClient.statsigUser.value)
     }
 
     companion object {

--- a/app/src/test/java/com/kickstarter/viewmodels/ExperimentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ExperimentsViewModelTest.kt
@@ -1,0 +1,58 @@
+package com.kickstarter.viewmodels
+
+import com.kickstarter.KSRobolectricTestCase
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.MockStatsigClient
+import com.kickstarter.libs.featureflag.StatsigExperiments
+import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.viewmodels.projectpage.ExperimentsViewModel
+import com.statsig.androidsdk.DynamicConfig
+import com.statsig.androidsdk.StatsigUser
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalStdlibApi::class)
+class ExperimentsViewModelTest : KSRobolectricTestCase() {
+
+    private lateinit var viewModel: ExperimentsViewModel
+
+    private fun mockStatsigClient(
+        getExperiment: (String) -> Unit
+    ) = object : MockStatsigClient(context = application()) {
+        override fun getExperiment(experimentName: String): DynamicConfig {
+            getExperiment(experimentName)
+            return super.getExperiment(experimentName)
+        }
+    }
+
+    private fun setUpEnvironment(environment: Environment, dispatcher: CoroutineDispatcher) {
+        viewModel = ExperimentsViewModel.Factory(environment, dispatcher)
+            .create(ExperimentsViewModel::class.java)
+    }
+
+    @Test
+    fun `test getExperiment is called when StatsigUser is emitted`() = runTest {
+        val countMap = mutableMapOf<String, Int>()
+        val statsigClient = mockStatsigClient { experimentName ->
+            countMap[experimentName] = (countMap[experimentName] ?: 0) + 1
+        }
+
+        val environment = environment().toBuilder()
+            .statsigClient(statsigClient)
+            .build()
+
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        setUpEnvironment(environment, unconfinedDispatcher)
+
+        assertEquals(1, countMap[StatsigExperiments.NoopAuthenticatedUsers.name])
+        assertEquals(1, countMap[StatsigExperiments.NoopAnonymousUsers.name])
+
+        statsigClient.setStatsigUser(StatsigUser(UserFactory.user().id().toString()))
+
+        assertEquals(2, countMap[StatsigExperiments.NoopAuthenticatedUsers.name])
+        assertEquals(2, countMap[StatsigExperiments.NoopAnonymousUsers.name])
+    }
+}

--- a/app/src/test/java/com/kickstarter/viewmodels/ExperimentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ExperimentsViewModelTest.kt
@@ -47,12 +47,12 @@ class ExperimentsViewModelTest : KSRobolectricTestCase() {
         val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
         setUpEnvironment(environment, unconfinedDispatcher)
 
-        assertEquals(1, countMap[StatsigExperiments.NoopAuthenticatedUsers.name])
-        assertEquals(1, countMap[StatsigExperiments.NoopAnonymousUsers.name])
+        assertEquals(1, countMap[StatsigExperiments.NoOpAuthenticatedUsers.name])
+        assertEquals(1, countMap[StatsigExperiments.NoOpAnonymousUsers.name])
 
         statsigClient.setStatsigUser(StatsigUser(UserFactory.user().id().toString()))
 
-        assertEquals(2, countMap[StatsigExperiments.NoopAuthenticatedUsers.name])
-        assertEquals(2, countMap[StatsigExperiments.NoopAnonymousUsers.name])
+        assertEquals(2, countMap[StatsigExperiments.NoOpAuthenticatedUsers.name])
+        assertEquals(2, countMap[StatsigExperiments.NoOpAnonymousUsers.name])
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/ExperimentsViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/ExperimentsViewModelTest.kt
@@ -21,7 +21,7 @@ class ExperimentsViewModelTest : KSRobolectricTestCase() {
 
     private fun mockStatsigClient(
         getExperiment: (String) -> Unit
-    ) = object : MockStatsigClient(context = application()) {
+    ) = object : MockStatsigClient(context = application(), startReady = false) {
         override fun getExperiment(experimentName: String): DynamicConfig {
             getExperiment(experimentName)
             return super.getExperiment(experimentName)
@@ -31,6 +31,27 @@ class ExperimentsViewModelTest : KSRobolectricTestCase() {
     private fun setUpEnvironment(environment: Environment, dispatcher: CoroutineDispatcher) {
         viewModel = ExperimentsViewModel.Factory(environment, dispatcher)
             .create(ExperimentsViewModel::class.java)
+    }
+
+    @Test
+    fun `test getExperiment is only called when StatsigClient is ready`() = runTest {
+        var count = 0
+        val statsigClient = mockStatsigClient { experimentName ->
+            count++
+        }
+
+        val environment = environment().toBuilder()
+            .statsigClient(statsigClient)
+            .build()
+
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        setUpEnvironment(environment, unconfinedDispatcher)
+
+        assertEquals(0, count)
+
+        statsigClient.triggerReady()
+
+        assertEquals(2, count)
     }
 
     @Test
@@ -46,6 +67,8 @@ class ExperimentsViewModelTest : KSRobolectricTestCase() {
 
         val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
         setUpEnvironment(environment, unconfinedDispatcher)
+
+        statsigClient.triggerReady()
 
         assertEquals(1, countMap[StatsigExperiments.NoOpAuthenticatedUsers.name])
         assertEquals(1, countMap[StatsigExperiments.NoOpAnonymousUsers.name])


### PR DESCRIPTION
# 📲 What

- Add a stateful and reactive `StatsigUser` property to `StatsigClient`. 
- Create a new `ExperimentsViewModel` that logs exposure events for two A/A experiments for a given `StatisigUser`, and include this VM in Project Page.

# 🤔 Why

Checkout team is running an A/A test with Statsig - a null hypothesis test to validate that our configurations work correctly. There are two experiments as a part of this test -- one for anonymous users, and the other for authenticated users. (See [Mobile A/B Testing for Conversion with Statsig - Checkout - Confluence](https://kickstarter.atlassian.net/wiki/spaces/Checkout/pages/4438818822/Mobile+A+B+Testing+for+Conversion+with+Statsig))

Statsig's analysis of Metric impact depends on the app logging "exposure" events through the SDK ([Raw Events - Statsig Documentation](https://docs.statsig.com/metrics/raw-events). For experiments, an exposure event is logged for every non-redundant call to `Statsig.getExperiment()` for a given User. A given user is distinguished by the properties included in the [StatsigUser](https://docs.statsig.com/sdks/user) object passed to Statsig via `initialize()` and `updateUser()`.

To ensure that an experiment is retrieved for an up-to-date StatsigUser object, we can keep track of the latest one sent to Statsig, and make a call to `getExperiment()` whenever the object is updated.

# 🛠 How

- Add a `MutableStateFlow<StatsigUser>` to `StatsigClient` and set a new `value` upon a successful call to `Statsig.updateUser()`, particularly in reaction to newly observed user data (i.e. anonymous and user IDs) via `handleObservedUserData()`.
- Create a new `ExperimentsViewModel` that collects `StatsigClient`'s `MutableStateFlow<StatsigUser>`, and calls `getExperiment()` for both A/A experiments in order to properly log exposure events.
- Add an instance of `ExperimentsViewModel` to Project Page to only trigger such exposures for users who view the Project Page, and to validate this orchestration in preparation for further A/B tests on the Project Page.
- Re: https://github.com/kickstarter/android-oss/pull/2509:
  - Add a method `getAnonymousIdOrNull()` to `SegmentTrackingClient` that returns the Segment anonymous ID if possible; remove the `getAnonymousId` lambda from `StatsigClient`; and refactor tests in `StatsigClientTest` accordingly.

# 👀 See

**Note:** As this is just an A/A experiment with no change to the user experience, the app does not and should not behave any differently.

<img width="1024" src="https://github.com/user-attachments/assets/7af2ba35-c891-4300-a3bc-d5e26ed0be05" />

# 📋 QA

> [!IMPORTANT]
> Before starting these QA steps, in `StatsigClient`:
> - Set `NoOpAuthenticatedUsers.name` to `"2026-05-12_checkout_aa"`
> - Set `NoOpAnonymousUsers.name` to `"2026-05-12_checkout_aa_logged_out"`

- Precondition: Fresh install of the app (Internal build)
- Launch the app from the Home Screen, App Drawer, Android Studio)
- Result:
  - The system navigates to Discover and immediately displays Onboarding
- Step through Onboarding to **DECLINE Personalization**, then click through to **Explore the App**
- Open any Project Page for a Project that you are not backing
- Results Logged for `tag:ExperimentsViewModel`:
  - Under `statsigUser[stableID: ...]`
    - `userID` : `null`
  - Under `authenticatedExperiment: 2026-05-12_checkout_aa`
    - `getIsUserInExperiment()` : `false`
  - Under `anonymousExperiment: 2026-05-12_checkout_aa_logged_out`
    - `getIsUserInExperiment()` : `true`
- Click Back this Project to trigger the authentication flow, and sign into the app (you do not need to actually pledge).
- Results Logged for `tag:ExperimentsViewModel`:
  - Under `statsigUser[stableID: ...]`
    - `userID` : `<Your KSR User ID`
  - Under `authenticatedExperiment: 2026-05-12_checkout_aa`
    - `getIsUserInExperiment()` : `true`
  - Under `anonymousExperiment: 2026-05-12_checkout_aa_logged_out`
    - `getIsUserInExperiment()` : `true`

**Optional:** Exposure events can take a few minutes to show up in the Console, but you should also see at least entry for each distinct User object in the Exposure Stream under Diagnostics for each experiment.

<img width="1144" src="https://github.com/user-attachments/assets/39ca3e74-268d-4b45-b49f-d9a07114001f" />


# Story 📖

- [\[CHECK-52\] Android: Add checks for A/A experiments to Project page - Jira](https://kickstarter.atlassian.net/browse/CHECK-52)
- [\[CHECK-158\] [Android] Create A/A experiment for logged-out users with Segment Anonymous ID - Jira](https://kickstarter.atlassian.net/browse/CHECK-158)