### PR TITLE
PF-37: Pin RichTextItemPhotoComponent when its image loads successfully

### DIFF
--- a/app/src/main/java/com/kickstarter/features/projectstory/ProjectStoryViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/projectstory/ProjectStoryViewModel.kt
@@ -38,8 +38,8 @@ class ProjectStoryViewModel(
 
     private var project: Project? = null
 
-//    val txt = mutableStateOf("https://www.kickstarter.com/projects/peak-design/roller-pro-carry-on-luggage-by-peak-design")
-    val txt = mutableStateOf("https://www.kickstarter.com/projects/glennf/flong-time-no-see")
+    val txt = mutableStateOf("https://www.kickstarter.com/projects/peak-design/roller-pro-carry-on-luggage-by-peak-design")
+//    val txt = mutableStateOf("https://www.kickstarter.com/projects/glennf/flong-time-no-see")
 
     private var job: Job? = null
 

--- a/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryComponents.kt
+++ b/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryComponents.kt
@@ -8,6 +8,7 @@ import android.webkit.WebView
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.LocalPinnableContainer
 import androidx.compose.ui.text.AnnotatedString
@@ -25,6 +26,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
+import coil.compose.AsyncImagePainter
 import com.kickstarter.features.projectstory.data.RichTextItem
 import com.kickstarter.libs.utils.Secrets
 import com.kickstarter.libs.utils.extensions.getEnvironment
@@ -180,10 +182,20 @@ fun RichTextItemPhotoComponent(item: RichTextItem.Photo, link: String? = null) {
     val imageUrl = item.asset?.url ?: item.url
     // `item.caption` can be empty
     val caption = item.caption.ifBlank { null }
+    val pinnableContainer = LocalPinnableContainer.current
+    val onSuccess: (AsyncImagePainter.State.Success) -> Unit = remember(pinnableContainer) {
+        {
+            // TODO: We should be able to use the dimensions of the `Drawable` contained in the `Success`
+            //  state to further optimize for only pinning tall images as determined by aspect ratio or
+            //  compared to the screen size/resolution.
+            pinnableContainer?.pin()
+        }
+    }
     ProjectStoryCaptionedImage(
         image = imageUrl,
         caption = caption,
-        link = link
+        link = link,
+        onSuccess = onSuccess
     )
 }
 

--- a/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryCaptionedImageTest.kt
+++ b/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryCaptionedImageTest.kt
@@ -143,12 +143,19 @@ class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
     fun `test image error with caption`() {
         val caption = "Aye aye, Caption"
 
+        var onSuccessCount = 0
+
         composeTestRule.setContent {
             ProjectStoryCaptionedImage(
                 image = "https://www.example.com/red.jpg",
                 caption = caption,
+                onSuccess = {
+                    onSuccessCount++
+                }
             )
         }
+
+        assertEquals(0, onSuccessCount)
 
         composeTestRule.onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.IMAGE.name))
             .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Image))


### PR DESCRIPTION
# 📲 What

Update `RichTextItemPhotoComponent` to call `pin()` on a `LocalPinnableContainer` (e.g. LazyList) when the photo url is loaded successfully by the underlying `AsyncImagePainter`.

# 🤔 Why

Within a lazy list, images associated with `RichTextItemPhotoComponent`s load progressively for performance, but are also disposed of when scrolled out of view. 

As a result of being disposed (combined with `AsyncImagePainter` always starting in a `Loading` state), images are reloaded from either memory or the on-disk cache when the component is scrolled back into view. This can lead to the surrounding content being shifted up/down not just the first time an image loads, but every time it is reloaded.

By pinning the component when the image first loads successfully, we can prevent the component from being disposed, and thus prevent the surrounding content from shifting as the user scrolls the view. (We only pin on success so that the `AsycImagePainter` attempts to reload the image if the request previous failed.)

# 🛠 How

Leverage the `onSuccess` callback of the underlying `ProjectStoryCaptionedImage` to call `PinnableContainer.pin()` for a `LocalPinnableContainer`.

# 👀 See

https://github.com/user-attachments/assets/d82b8225-b332-4954-a606-160ba013bdc5

# 📋 QA

Visit Internal Tools > Project Story Activity and load the default project (Roller Pro)

# Story 📖

[\[PF-37\] Image optimizations for loading & scrolling - Jira](https://kickstarter.atlassian.net/browse/PF-37)
