### PR TITLE
DISC-142: Small fixes

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -11,6 +11,7 @@ fragment videoFeedProject on Project {
     watchesCount
     sharesCount
     isWatched
+    imageUrl(blur: false, width: 1024)
     pledged {
         ...amount
     }

--- a/app/src/main/java/com/kickstarter/features/videofeed/data/VideoFeedModels.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/data/VideoFeedModels.kt
@@ -20,7 +20,8 @@ sealed class KSVideoBadgeType {
 data class VideoFeedItem(
     val badges: List<KSVideoBadgeType>,
     val project: Project,
-    val hlsUrl: String?
+    val hlsUrl: String?,
+    val videoId: Long = 0
 )
 
 data class VideoFeedEnvelope(

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
@@ -91,18 +91,18 @@ class VideoFeedActivity : ComponentActivity() {
                             previousScreen = ThirdPartyEventValues.ScreenName.DISCOVERY.value
                         )
                     },
-                    onVideoImpression = { project, position ->
-                        viewModel.onVideoImpression(project, position)
+                    onVideoImpression = { videoFeedItem, position ->
+                        viewModel.onVideoImpression(videoFeedItem, position)
                     },
-                    onVideoPageSettled = { toProject, toPosition, fromProject, watchTimeMs, videoDurationMs ->
-                        viewModel.onVideoPageSettled(toProject, toPosition, fromProject, watchTimeMs, videoDurationMs)
+                    onVideoPageSettled = { videoFeedItem, toPosition, fromProject, watchTimeMs, videoDurationMs ->
+                        viewModel.onVideoPageSettled(videoFeedItem, toPosition, fromProject, watchTimeMs, videoDurationMs)
                     },
                     onPlayPauseTap = { project, isPlaying ->
                         val cta = if (isPlaying) CtaContextName.VIDEO_PLAY else CtaContextName.VIDEO_PAUSE
                         viewModel.onCTAClicked(project, cta)
                     },
-                    onProgressBarTap = { project, progress ->
-                        viewModel.onProgressBarTapped(project, progress)
+                    onProgressBarTap = { videoFeedItem, progress ->
+                        viewModel.onProgressBarTapped(videoFeedItem, progress)
                     },
                     onShareCTAClick = { project ->
                         viewModel.onCTAClicked(project, CtaContextName.VIDEO_SHARE)

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
@@ -82,10 +82,10 @@ fun VideoFeedScreen(
     onShareIntentReady: (Intent) -> Unit = {},
     preLaunchedCallback: (project: Project, refTag: RefTag) -> Unit = { _, _ -> },
     projectCallback: (project: Project, refTag: RefTag) -> Unit = { _, _ -> },
-    onVideoImpression: (project: Project, position: Int) -> Unit = { _, _ -> },
-    onVideoPageSettled: (toProject: Project, toPosition: Int, fromProject: Project, watchTimeMs: Long?, videoDurationMs: Long?) -> Unit = { _, _, _, _, _ -> },
+    onVideoImpression: (item: VideoFeedItem, position: Int) -> Unit = { _, _ -> },
+    onVideoPageSettled: (videoFeedItem: VideoFeedItem, toPosition: Int, fromProject: Project, watchTimeMs: Long?, videoDurationMs: Long?) -> Unit = { _, _, _, _, _ -> },
     onPlayPauseTap: (project: Project, isPlaying: Boolean) -> Unit = { _, _ -> },
-    onProgressBarTap: (project: Project, progress: Float) -> Unit = { _, _ -> },
+    onProgressBarTap: (item: VideoFeedItem, progress: Float) -> Unit = { _, _ -> },
     onShareCTAClick: (project: Project) -> Unit = { _ -> }
 ) {
     val pagerState = rememberPagerState(pageCount = { items.size })
@@ -113,12 +113,12 @@ fun VideoFeedScreen(
         val currentPage = pagerState.settledPage
         if (items.isEmpty() || currentPage >= items.size) return@LaunchedEffect
 
-        onVideoImpression(items[currentPage].project, currentPage)
+        onVideoImpression(items[currentPage], currentPage)
 
         if (previousSettledPage in items.indices && previousSettledPage != currentPage) {
             val watchData = watchTimeByPage.remove(previousSettledPage)
             onVideoPageSettled(
-                items[currentPage].project,
+                items[currentPage],
                 currentPage,
                 items[previousSettledPage].project,
                 watchData?.first,
@@ -162,7 +162,7 @@ fun VideoFeedScreen(
                     videoUrl = videoUrl,
                     isActive = pagerState.currentPage == page,
                     onPlayPauseToggle = { isPlaying -> onPlayPauseTap(project, isPlaying) },
-                    onProgressBarInteraction = { currentProgress -> onProgressBarTap(project, currentProgress) },
+                    onProgressBarInteraction = { currentProgress -> onProgressBarTap(item, currentProgress) },
                     onBecameInactive = { watchTimeMs, videoDurationMs ->
                         watchTimeByPage[page] = Pair(watchTimeMs, videoDurationMs)
                     },

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
@@ -153,7 +153,7 @@ fun VideoFeedScreen(
             }
             val percentageFounded by remember(page) {
                 derivedStateOf {
-                    if (pagerState.settledPage == page) project.percentageFunded() else 0f
+                    if (pagerState.settledPage == page) project.percentFunded()?.toFloat() ?: 0f else 0f
                 }
             }
 

--- a/app/src/main/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModel.kt
@@ -120,22 +120,22 @@ class VideoFeedViewModel(
         }
     }
 
-    fun onVideoImpression(project: Project, position: Int) {
-        analyticEvents.trackVideoFeedImpression(project, position, entrySurface)
+    fun onVideoImpression(item: VideoFeedItem, position: Int) {
+        analyticEvents.trackVideoFeedImpression(item, position, entrySurface)
     }
 
     fun onVideoPageSettled(
-        toProject: Project,
+        videoFeedItem: VideoFeedItem,
         toPosition: Int,
         fromProject: Project,
         watchTimeMs: Long?,
         videoDurationMs: Long?
     ) {
-        analyticEvents.trackVideoFeedPageViewed(toProject, toPosition, fromProject, watchTimeMs, videoDurationMs, entrySurface)
+        analyticEvents.trackVideoFeedPageViewed(videoFeedItem, toPosition, fromProject, watchTimeMs, videoDurationMs, entrySurface)
     }
 
-    fun onProgressBarTapped(project: Project, percentageWatched: Float, watchTimeAtClick: Long? = null) {
-        analyticEvents.trackVideoFeedProgressBarTap(project, percentageWatched, watchTimeAtClick)
+    fun onProgressBarTapped(item: VideoFeedItem, percentageWatched: Float, watchTimeAtClick: Long? = null) {
+        analyticEvents.trackVideoFeedProgressBarTap(item, percentageWatched, watchTimeAtClick)
     }
 
     fun onCTAClicked(project: Project, ctaType: CtaContextName, watchTimeAtClick: Long? = null) {

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -2,6 +2,7 @@ package com.kickstarter.libs
 
 import OnboardingPage
 import com.kickstarter.features.pledgedprojectsoverview.data.PPOCard
+import com.kickstarter.features.videofeed.data.VideoFeedItem
 import com.kickstarter.libs.utils.AnalyticEventsUtils
 import com.kickstarter.libs.utils.ContextPropertyKeyName.COMMENT_BODY
 import com.kickstarter.libs.utils.ContextPropertyKeyName.COMMENT_CHARACTER_COUNT
@@ -928,14 +929,14 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      * Fires every time a video settles as the primary visible item, including the first load.
      * Covers impression measurement independently of navigation.
      *
-     * @param project: The project now in the primary position.
+     * @param videoFeedItem: The item now in the primary position, containing project and video
      * @param position: 0-based index of the video in this session.
      */
-    fun trackVideoFeedImpression(project: Project, position: Int, entrySurface: String) {
+    fun trackVideoFeedImpression(item: VideoFeedItem, position: Int, entrySurface: String) {
         val props = HashMap<String, Any>()
         props[CONTEXT_PAGE.contextName] = VIDEO_FEED.contextName
         props[CONTEXT_LOCATION.contextName] = VIDEO_FEED_LOCATION.contextName
-        props.putAll(AnalyticEventsUtils.videoFeedItemProperties(project, position))
+        props.putAll(AnalyticEventsUtils.videoFeedItemProperties(item, position))
         props["video_feed_entry_surface"] = entrySurface
         client.track(PAGE_VIEWED.eventName, props)
     }
@@ -945,14 +946,14 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      * navigation and watch-progress data into a single PAGE_VIEWED event. Never fires on
      * the initial feed load — only on explicit user navigation.
      *
-     * @param toProject: The project now in the primary position.
+     * @param videoFeedItem: The item now in the primary position.
      * @param toPosition: 0-based index of the destination video in this session.
      * @param fromProject: The project the user swiped away from.
      * @param watchTimeMs: Milliseconds the previous video was in the primary position.
      * @param videoDurationMs: Total duration of the previous video in milliseconds.
      */
     fun trackVideoFeedPageViewed(
-        toProject: Project,
+        videoFeedItem: VideoFeedItem,
         toPosition: Int,
         fromProject: Project,
         watchTimeMs: Long?,
@@ -964,7 +965,7 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         props[CONTEXT_LOCATION.contextName] = VIDEO_FEED_LOCATION.contextName
         props.putAll(
             AnalyticEventsUtils.videoFeedPageViewedProperties(
-                toProject, toPosition, fromProject, watchTimeMs, videoDurationMs, entrySurface
+                videoFeedItem, toPosition, fromProject, watchTimeMs, videoDurationMs, entrySurface
             )
         )
         client.track(PAGE_VIEWED.eventName, props)
@@ -973,15 +974,15 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
     /**
      * Fires when the user taps the video progress bar while watching.
      *
-     * @param project: The project whose progress bar was tapped.
+     * @param item: The videoItem whose progress bar was tapped.
      * @param percentageWatched: Value from 0.0 to 1.0 representing watch completion at tap time.
      * @param watchTimeAtClick: Optional milliseconds watched at the moment of the tap.
      */
-    fun trackVideoFeedProgressBarTap(project: Project, percentageWatched: Float, watchTimeAtClick: Long? = null) {
+    fun trackVideoFeedProgressBarTap(item: VideoFeedItem, percentageWatched: Float, watchTimeAtClick: Long? = null) {
         val props = HashMap<String, Any>()
         props[CONTEXT_PAGE.contextName] = VIDEO_FEED.contextName
         props[CONTEXT_CTA.contextName] = VIDEO_PROGRESS_BAR.contextName
-        props.putAll(AnalyticEventsUtils.videoFeedItemProperties(project, 0))
+        props.putAll(AnalyticEventsUtils.videoFeedItemProperties(item, 0))
         props["video_feed_percentage_watched"] = percentageWatched
         watchTimeAtClick?.let { props["video_feed_watch_time_at_click"] = it }
         client.track(CTA_CLICKED.eventName, props)

--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -2,6 +2,7 @@ package com.kickstarter.libs.utils
 
 import com.kickstarter.features.pledgedprojectsoverview.data.PPOCard
 import com.kickstarter.features.pledgedprojectsoverview.ui.PPOCardViewType
+import com.kickstarter.features.videofeed.data.VideoFeedItem
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.utils.EventContextValues.VideoContextName.LENGTH
 import com.kickstarter.libs.utils.EventContextValues.VideoContextName.POSITION
@@ -351,16 +352,16 @@ object AnalyticEventsUtils {
         return properties
     }
 
-    fun videoFeedItemProperties(project: Project, position: Int): Map<String, Any> {
+    fun videoFeedItemProperties(item: VideoFeedItem, position: Int): Map<String, Any> {
         return hashMapOf(
-            "video_feed_video_id" to project.id().toString(),
-            "video_feed_project_id" to project.id().toString(),
+            "video_feed_video_id" to item.videoId.toString(),
+            "video_feed_project_id" to item.project.id().toString(),
             "video_feed_position_in_session" to position
         )
     }
 
     fun videoFeedPageViewedProperties(
-        toProject: Project,
+        item: VideoFeedItem,
         toPosition: Int,
         fromProject: Project? = null,
         watchTimeMs: Long? = null,
@@ -368,7 +369,7 @@ object AnalyticEventsUtils {
         entrySurface: String = ""
     ): Map<String, Any> {
         val props = HashMap<String, Any>()
-        props.putAll(videoFeedItemProperties(toProject, toPosition))
+        props.putAll(videoFeedItemProperties(item, toPosition))
         fromProject?.let { props["video_feed_from_video_id"] = it.id().toString() }
         watchTimeMs?.let { props["video_feed_total_watch_time"] = it }
         videoDurationMs?.let { props["video_feed_total_video_duration"] = it }

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ContextExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ContextExt.kt
@@ -13,9 +13,11 @@ import androidx.core.content.ContextCompat
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import com.kickstarter.KSApplication
 import com.kickstarter.R
 import com.kickstarter.libs.Environment
@@ -91,8 +93,24 @@ fun Context.initializeExoplayer(): ExoPlayer {
         renderersFactory.forceDisableMediaCodecAsynchronousQueueing()
     }
 
+    // Cap buffer to prevent OOM when multiple players are alive simultaneously (e.g. pager with
+    // beyondViewportPageCount=1 keeps up to 3 instances). ExoPlayer's defaults (50s / unlimited
+    // bytes) let each instance consume 30-50 MB, exhausting the heap on constrained devices.
+    val loadControl = DefaultLoadControl.Builder()
+        .setBufferDurationsMs(
+            /* minBufferMs */ 10_000,
+            /* maxBufferMs */ 20_000,
+            /* bufferForPlaybackMs */ 1_000,
+            /* bufferForPlaybackAfterRebufferMs */ 1_500
+        )
+        .setTargetBufferBytes(12 * 1024 * 1024)
+        .setPrioritizeTimeOverSizeThresholds(true)
+        .build()
+
     val player = ExoPlayer.Builder(this, renderersFactory)
         .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
+        .setLoadControl(loadControl)
+        .setBandwidthMeter(DefaultBandwidthMeter.getSingletonInstance(this))
         .build()
 
     return player

--- a/app/src/main/java/com/kickstarter/services/transformers/extensions/VideoFeedTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/extensions/VideoFeedTransformers.kt
@@ -60,7 +60,8 @@ fun VideoFeedQuery.VideoFeed?.toVideoFeedEnvelope(): VideoFeedEnvelope {
         VideoFeedItem(
             badges = badges,
             project = project,
-            hlsUrl = frag.verticalVideo?.videoSources?.hls?.src
+            hlsUrl = frag.verticalVideo?.videoSources?.hls?.src,
+            videoId = decodeRelayId(frag.verticalVideo?.id) ?: -1
         )
     } ?: emptyList()
 

--- a/app/src/main/java/com/kickstarter/services/transformers/extensions/VideoFeedTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/extensions/VideoFeedTransformers.kt
@@ -6,6 +6,7 @@ import com.kickstarter.features.videofeed.data.VideoFeedEnvelope
 import com.kickstarter.features.videofeed.data.VideoFeedItem
 import com.kickstarter.models.Avatar
 import com.kickstarter.models.Category
+import com.kickstarter.models.Photo
 import com.kickstarter.models.Project
 import com.kickstarter.models.User
 import com.kickstarter.services.apiresponses.commentresponse.PageInfoEnvelope
@@ -36,6 +37,9 @@ fun VideoFeedQuery.VideoFeed?.toVideoFeedEnvelope(): VideoFeedEnvelope {
         val category = Category.builder()
             .name(frag.category?.name)
             .build()
+        val photo = Photo.builder()
+            .full(frag.imageUrl)
+            .build()
         val project = Project.builder()
             .id(decodeRelayId(frag.id) ?: -1)
             .name(frag.name)
@@ -49,6 +53,7 @@ fun VideoFeedQuery.VideoFeed?.toVideoFeedEnvelope(): VideoFeedEnvelope {
             .isStarred(frag.isWatched)
             .pledged(frag.pledged?.amount?.amount?.toDouble() ?: 0.0)
             .currencySymbol(frag.pledged?.amount?.symbol ?: "")
+            .photo(photo)
             .creator(creator)
             .category(category)
             .build()

--- a/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
@@ -22,6 +22,7 @@ import com.kickstarter.features.videofeed.ui.components.KSVideoActionsColumnTest
 import com.kickstarter.features.videofeed.ui.components.KSVideoCampaignCardTestTag
 import com.kickstarter.libs.RefTag
 import com.kickstarter.mock.factories.ProjectFactory
+import com.kickstarter.models.Photo
 import com.kickstarter.models.Project
 import com.kickstarter.ui.compose.designsystem.KSSnackbarTypes
 import com.kickstarter.ui.compose.designsystem.KSTheme
@@ -533,5 +534,54 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
 
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag(VideoFeedScreenTestTag.VIDEO_FEED_PAGER.name).assertExists()
+    }
+
+    @Test
+    fun `share button triggers onShareCTAClick with the current project`() {
+        var capturedProject: Project? = null
+
+        val project = ProjectFactory.project().toBuilder().id(5001L).build()
+        val items = listOf(VideoFeedItem(badges = emptyList(), project = project, hlsUrl = hlsUrl))
+
+        composeTestRule.setContent {
+            KSTheme {
+                VideoFeedScreen(
+                    items = items,
+                    onShareCTAClick = { capturedProject = it }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(KSVideoActionsColumnTestTag.SHARE_BUTTON.name, useUnmergedTree = true)
+            .performClick()
+
+        assertEquals(project, capturedProject)
+    }
+
+    @Test
+    fun `share button passes project photo url as share image`() {
+        val photoUrl = "https://example.com/cover.jpg"
+        val photo = Photo.builder().full(photoUrl).build()
+        val project = ProjectFactory.project()
+            .toBuilder()
+            .id(5002L)
+            .photo(photo)
+            .build()
+        val items = listOf(VideoFeedItem(badges = emptyList(), project = project, hlsUrl = hlsUrl))
+
+        var shareImageUrl: String? = null
+        composeTestRule.setContent {
+            KSTheme {
+                VideoFeedScreen(
+                    items = items,
+                    onShareCTAClick = { shareImageUrl = it.photo()?.full() }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(KSVideoActionsColumnTestTag.SHARE_BUTTON.name, useUnmergedTree = true)
+            .performClick()
+
+        assertEquals(photoUrl, shareImageUrl)
     }
 }

--- a/app/src/test/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModelTest.kt
@@ -299,10 +299,10 @@ class VideoFeedViewModelTest : KSRobolectricTestCase() {
     @Test
     fun `onVideoImpression sends PAGE_VIEWED`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
-        val project = ProjectFactory.project()
+        val item = VideoFeedItem(badges = emptyList(), project = ProjectFactory.project(), hlsUrl = null)
         setUpEnvironment(environment(), dispatcher)
 
-        viewModel.onVideoImpression(project, position = 0)
+        viewModel.onVideoImpression(item, position = 0)
 
         segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
     }
@@ -310,11 +310,11 @@ class VideoFeedViewModelTest : KSRobolectricTestCase() {
     @Test
     fun `onVideoPageSettled sends PAGE_VIEWED`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
-        val toProject = ProjectFactory.project()
+        val toItem = VideoFeedItem(badges = emptyList(), project = ProjectFactory.project(), hlsUrl = null)
         val fromProject = ProjectFactory.caProject()
         setUpEnvironment(environment(), dispatcher)
 
-        viewModel.onVideoPageSettled(toProject, 1, fromProject, 4000L, 30000L)
+        viewModel.onVideoPageSettled(toItem, 1, fromProject, 4000L, 30000L)
 
         segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
     }
@@ -333,10 +333,10 @@ class VideoFeedViewModelTest : KSRobolectricTestCase() {
     @Test
     fun `onProgressBarTapped sends CTA_CLICKED`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
-        val project = ProjectFactory.project()
+        val item = VideoFeedItem(badges = emptyList(), project = ProjectFactory.project(), hlsUrl = null)
         setUpEnvironment(environment(), dispatcher)
 
-        viewModel.onProgressBarTapped(project, percentageWatched = 0.5f)
+        viewModel.onProgressBarTapped(item, percentageWatched = 0.5f)
 
         segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
     }

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -1877,7 +1877,8 @@ class SegmentTest : KSRobolectricTestCase() {
     @Test
     fun testVideoFeedImpression_Properties() {
         val project = ProjectFactory.project()
-        val item = VideoFeedItem(badges = emptyList(), project = project, hlsUrl = null)
+        val videoId = 9876L
+        val item = VideoFeedItem(badges = emptyList(), project = project, hlsUrl = null, videoId = videoId)
         val client = client(null)
         client.eventNames.subscribe { this.segmentTrack.onNext(it) }.addToDisposable(disposables)
         client.eventProperties.subscribe { this.propertiesTest.onNext(it) }.addToDisposable(disposables)
@@ -1889,7 +1890,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val props = this.propertiesTest.value ?: mapOf()
         assertEquals(VIDEO_FEED.contextName, props[CONTEXT_PAGE.contextName])
         assertEquals(VIDEO_FEED_LOCATION.contextName, props[CONTEXT_LOCATION.contextName])
-        assertEquals(project.id().toString(), props["video_feed_video_id"])
+        assertEquals(videoId.toString(), props["video_feed_video_id"])
         assertEquals(project.id().toString(), props["video_feed_project_id"])
         assertEquals(2, props["video_feed_position_in_session"])
         assertEquals("discovery", props["video_feed_entry_surface"])
@@ -1898,7 +1899,8 @@ class SegmentTest : KSRobolectricTestCase() {
     @Test
     fun testVideoFeedPageViewed_Properties() {
         val toProject = ProjectFactory.project()
-        val toItem = VideoFeedItem(badges = emptyList(), project = toProject, hlsUrl = null)
+        val toVideoId = 9876L
+        val toItem = VideoFeedItem(badges = emptyList(), project = toProject, hlsUrl = null, videoId = toVideoId)
         val fromProject = ProjectFactory.caProject()
         val client = client(null)
         client.eventNames.subscribe { this.segmentTrack.onNext(it) }.addToDisposable(disposables)
@@ -1918,7 +1920,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val props = this.propertiesTest.value ?: mapOf()
         assertEquals(VIDEO_FEED.contextName, props[CONTEXT_PAGE.contextName])
         assertEquals(VIDEO_FEED_LOCATION.contextName, props[CONTEXT_LOCATION.contextName])
-        assertEquals(toProject.id().toString(), props["video_feed_video_id"])
+        assertEquals(toVideoId.toString(), props["video_feed_video_id"])
         assertEquals(toProject.id().toString(), props["video_feed_project_id"])
         assertEquals(1, props["video_feed_position_in_session"])
         assertEquals(fromProject.id().toString(), props["video_feed_from_video_id"])
@@ -1949,7 +1951,8 @@ class SegmentTest : KSRobolectricTestCase() {
     @Test
     fun testVideoFeedProgressBarTap_Properties() {
         val project = ProjectFactory.project()
-        val item = VideoFeedItem(badges = emptyList(), project = project, hlsUrl = null)
+        val videoId = 9876L
+        val item = VideoFeedItem(badges = emptyList(), project = project, hlsUrl = null, videoId = videoId)
         val client = client(null)
         client.eventNames.subscribe { this.segmentTrack.onNext(it) }.addToDisposable(disposables)
         client.eventProperties.subscribe { this.propertiesTest.onNext(it) }.addToDisposable(disposables)
@@ -1961,7 +1964,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val props = this.propertiesTest.value ?: mapOf()
         assertEquals(VIDEO_FEED.contextName, props[CONTEXT_PAGE.contextName])
         assertEquals(VIDEO_PROGRESS_BAR.contextName, props[CONTEXT_CTA.contextName])
-        assertEquals(project.id().toString(), props["video_feed_video_id"])
+        assertEquals(videoId.toString(), props["video_feed_video_id"])
         assertEquals(project.id().toString(), props["video_feed_project_id"])
         assertEquals(0.75f, props["video_feed_percentage_watched"])
         assertEquals(8000L, props["video_feed_watch_time_at_click"])

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.features.pledgedprojectsoverview.data.PPOCardFactory
+import com.kickstarter.features.videofeed.data.VideoFeedItem
 import com.kickstarter.libs.utils.ContextPropertyKeyName
 import com.kickstarter.libs.utils.ContextPropertyKeyName.COMMENT_BODY
 import com.kickstarter.libs.utils.ContextPropertyKeyName.COMMENT_CHARACTER_COUNT
@@ -1876,12 +1877,13 @@ class SegmentTest : KSRobolectricTestCase() {
     @Test
     fun testVideoFeedImpression_Properties() {
         val project = ProjectFactory.project()
+        val item = VideoFeedItem(badges = emptyList(), project = project, hlsUrl = null)
         val client = client(null)
         client.eventNames.subscribe { this.segmentTrack.onNext(it) }.addToDisposable(disposables)
         client.eventProperties.subscribe { this.propertiesTest.onNext(it) }.addToDisposable(disposables)
         val segment = AnalyticEvents(listOf(client))
 
-        segment.trackVideoFeedImpression(project, position = 2, entrySurface = "discovery")
+        segment.trackVideoFeedImpression(item, position = 2, entrySurface = "discovery")
 
         this.segmentTrack.assertValue(PAGE_VIEWED.eventName)
         val props = this.propertiesTest.value ?: mapOf()
@@ -1896,6 +1898,7 @@ class SegmentTest : KSRobolectricTestCase() {
     @Test
     fun testVideoFeedPageViewed_Properties() {
         val toProject = ProjectFactory.project()
+        val toItem = VideoFeedItem(badges = emptyList(), project = toProject, hlsUrl = null)
         val fromProject = ProjectFactory.caProject()
         val client = client(null)
         client.eventNames.subscribe { this.segmentTrack.onNext(it) }.addToDisposable(disposables)
@@ -1903,7 +1906,7 @@ class SegmentTest : KSRobolectricTestCase() {
         val segment = AnalyticEvents(listOf(client))
 
         segment.trackVideoFeedPageViewed(
-            toProject = toProject,
+            videoFeedItem = toItem,
             toPosition = 1,
             fromProject = fromProject,
             watchTimeMs = 5000L,
@@ -1946,12 +1949,13 @@ class SegmentTest : KSRobolectricTestCase() {
     @Test
     fun testVideoFeedProgressBarTap_Properties() {
         val project = ProjectFactory.project()
+        val item = VideoFeedItem(badges = emptyList(), project = project, hlsUrl = null)
         val client = client(null)
         client.eventNames.subscribe { this.segmentTrack.onNext(it) }.addToDisposable(disposables)
         client.eventProperties.subscribe { this.propertiesTest.onNext(it) }.addToDisposable(disposables)
         val segment = AnalyticEvents(listOf(client))
 
-        segment.trackVideoFeedProgressBarTap(project, percentageWatched = 0.75f, watchTimeAtClick = 8000L)
+        segment.trackVideoFeedProgressBarTap(item, percentageWatched = 0.75f, watchTimeAtClick = 8000L)
 
         this.segmentTrack.assertValue(CTA_CLICKED.eventName)
         val props = this.propertiesTest.value ?: mapOf()

--- a/app/src/test/java/com/kickstarter/services/transformers/extensions/VideoFeedTransformersTest.kt
+++ b/app/src/test/java/com/kickstarter/services/transformers/extensions/VideoFeedTransformersTest.kt
@@ -114,7 +114,7 @@ class VideoFeedTransformersTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `toVideoFeedEnvelope maps hlsUrl from lastUploadedVerticalVideo`() {
+    fun `toVideoFeedEnvelope maps hlsUrl from verticalVideo`() {
         val expectedUrl = "https://example.com/video.m3u8"
         val node = fixtureNode(
             project = fixtureProject(
@@ -206,8 +206,8 @@ class VideoFeedTransformersTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `toVideoFeedEnvelope maps null imageUrl to empty photo full`() {
-        val node = fixtureNode(project = fixtureProject(imageUrl = null))
+    fun `toVideoFeedEnvelope maps empty imageUrl to empty photo full`() {
+        val node = fixtureNode(project = fixtureProject(imageUrl = ""))
         val project = fixtureVideoFeed(nodes = listOf(node)).toVideoFeedEnvelope().items.first().project
 
         assertEquals("", project.photo()?.full())
@@ -263,7 +263,7 @@ private fun fixtureProject(
     watchesCount: Int? = 10,
     sharesCount: Int = 5,
     isWatched: Boolean = false,
-    imageUrl: String? = "https://example.com/project.jpg",
+    imageUrl: String = "https://example.com/project.jpg",
     pledged: VideoFeedProject.Pledged = VideoFeedProject.Pledged(
         __typename = "Money",
         amount = Amount(amount = "5000.00", currency = CurrencyCode.USD, symbol = "$")

--- a/app/src/test/java/com/kickstarter/services/transformers/extensions/VideoFeedTransformersTest.kt
+++ b/app/src/test/java/com/kickstarter/services/transformers/extensions/VideoFeedTransformersTest.kt
@@ -197,6 +197,23 @@ class VideoFeedTransformersTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun `toVideoFeedEnvelope maps imageUrl to project photo full`() {
+        val url = "https://example.com/project-cover.jpg"
+        val node = fixtureNode(project = fixtureProject(imageUrl = url))
+        val project = fixtureVideoFeed(nodes = listOf(node)).toVideoFeedEnvelope().items.first().project
+
+        assertEquals(url, project.photo()?.full())
+    }
+
+    @Test
+    fun `toVideoFeedEnvelope maps null imageUrl to empty photo full`() {
+        val node = fixtureNode(project = fixtureProject(imageUrl = null))
+        val project = fixtureVideoFeed(nodes = listOf(node)).toVideoFeedEnvelope().items.first().project
+
+        assertEquals("", project.photo()?.full())
+    }
+
+    @Test
     fun `toVideoFeedEnvelope falls back to 0 and empty string when pledged amount is null`() {
         val node = fixtureNode(
             project = fixtureProject(
@@ -246,6 +263,7 @@ private fun fixtureProject(
     watchesCount: Int? = 10,
     sharesCount: Int = 5,
     isWatched: Boolean = false,
+    imageUrl: String? = "https://example.com/project.jpg",
     pledged: VideoFeedProject.Pledged = VideoFeedProject.Pledged(
         __typename = "Money",
         amount = Amount(amount = "5000.00", currency = CurrencyCode.USD, symbol = "$")
@@ -273,6 +291,7 @@ private fun fixtureProject(
         watchesCount = watchesCount,
         sharesCount = sharesCount,
         isWatched = isWatched,
+        imageUrl = imageUrl,
         pledged = pledged,
         creator = creator,
         category = category,


### PR DESCRIPTION
# 📲 What

Fix analytics events sending the wrong video ID (projectId was used as videoId), add the project cover image to the video feed data model for the share experience, and fix the percentage funded calculation in the video feed screen.

# 🤔 Why

Three bugs were found in the Video Feed analytics and UI:

1- `video_feed_video_id` was incorrectly populated with project.id() instead of the actual vertical video's ID — the two IDs are different entities. (thanks for catching this one up tony). 
2- The project cover image (imageUrl) was missing from the GraphQL fragment and transformer, so the share experience had no image to display.
3- percentageFounded() rendering animation
4 - Fixed OOM crash 

# 🛠 How

1 - Added videoId: Long to VideoFeedItem and populated it by decoding the relay ID of frag.verticalVideo?.id in VideoFeedTransformers. Updated all analytics callbacks — onVideoImpression, onVideoPageSettled, onProgressBarTap — throughout VideoFeedScreen, VideoFeedActivity, VideoFeedViewModel, AnalyticEvents, and AnalyticEventsUtils to accept VideoFeedItem instead of Project, so the correct videoId is forwarded.

2 - Added imageUrl(blur: false, width: 1024) to the videoFeedProject GraphQL fragment and mapped it to a Photo object on the Project model in the transformer.

3 -  Fixed percentageFounded() → percentFunded()?.toFloat() ?: 0f in VideoFeedScreen.

4 -  With beyondViewportPageCount = 1, Compose keeps 3 pages composed simultaneously. Each page creates and prepares its own ExoPlayer via remember(player ?: videoUrl). With the previous default buffer controls, three players each buffering 50s of HLS at even 2 Mbps = ~37 MB per player = ~111 MB just for video buffers, on a device with a 256 MB heap limit already under pressure from the rest of the app. ExoPlayer's internal buffer allocation is where the Fatal Exception: java.lang.OutOfMemoryError took place

# 👀 See

- No user facing changes

| --- | --- |
|  |  |

# 📋 QA

- Open social share experience, the image now loads.
- Percentage founded animation running.
- Take a look to logcat, Segment events now have the VideoId
- Load VideoFeed scroll to the end and back up several times, you should not have any OOM crash 

# Story 📖

[DISC-142](https://kickstarter.atlassian.net/browse/DISC-142)


[DISC-142]: https://kickstarter.atlassian.net/browse/DISC-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ