### PR TITLE
DISC-142: Small fixes 2

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -228,8 +228,9 @@
             android:theme="@style/VideoPlayerActivity" />
         <activity
             android:name=".features.videofeed.ui.VideoFeedActivity"
-            android:configChanges="keyboardHidden|screenSize"
+            android:configChanges="keyboardHidden|screenSize|orientation"
             android:exported="false"
+            android:screenOrientation="portrait"
             android:theme="@style/KSTheme" />
         <activity
             android:name=".ui.activities.BackingActivity"

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
@@ -94,8 +94,8 @@ class VideoFeedActivity : ComponentActivity() {
                     onVideoImpression = { videoFeedItem, position ->
                         viewModel.onVideoImpression(videoFeedItem, position)
                     },
-                    onVideoPageSettled = { videoFeedItem, toPosition, fromProject, watchTimeMs, videoDurationMs ->
-                        viewModel.onVideoPageSettled(videoFeedItem, toPosition, fromProject, watchTimeMs, videoDurationMs)
+                    onVideoPageSettled = { videoFeedItem, toPosition, fromVideoFeedItem, watchTimeMs, videoDurationMs ->
+                        viewModel.onVideoPageSettled(videoFeedItem, toPosition, fromVideoFeedItem, watchTimeMs, videoDurationMs)
                     },
                     onPlayPauseTap = { project, isPlaying ->
                         val cta = if (isPlaying) CtaContextName.VIDEO_PLAY else CtaContextName.VIDEO_PAUSE

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
@@ -83,7 +83,7 @@ fun VideoFeedScreen(
     preLaunchedCallback: (project: Project, refTag: RefTag) -> Unit = { _, _ -> },
     projectCallback: (project: Project, refTag: RefTag) -> Unit = { _, _ -> },
     onVideoImpression: (item: VideoFeedItem, position: Int) -> Unit = { _, _ -> },
-    onVideoPageSettled: (videoFeedItem: VideoFeedItem, toPosition: Int, fromProject: Project, watchTimeMs: Long?, videoDurationMs: Long?) -> Unit = { _, _, _, _, _ -> },
+    onVideoPageSettled: (videoFeedItem: VideoFeedItem, toPosition: Int, fromVideoFeedItem: VideoFeedItem, watchTimeMs: Long?, videoDurationMs: Long?) -> Unit = { _, _, _, _, _ -> },
     onPlayPauseTap: (project: Project, isPlaying: Boolean) -> Unit = { _, _ -> },
     onProgressBarTap: (item: VideoFeedItem, progress: Float) -> Unit = { _, _ -> },
     onShareCTAClick: (project: Project) -> Unit = { _ -> }
@@ -120,7 +120,7 @@ fun VideoFeedScreen(
             onVideoPageSettled(
                 items[currentPage],
                 currentPage,
-                items[previousSettledPage].project,
+                items[previousSettledPage],
                 watchData?.first,
                 watchData?.second
             )

--- a/app/src/main/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModel.kt
@@ -127,11 +127,11 @@ class VideoFeedViewModel(
     fun onVideoPageSettled(
         videoFeedItem: VideoFeedItem,
         toPosition: Int,
-        fromProject: Project,
+        fromVideoFeedItem: VideoFeedItem,
         watchTimeMs: Long?,
         videoDurationMs: Long?
     ) {
-        analyticEvents.trackVideoFeedPageViewed(videoFeedItem, toPosition, fromProject, watchTimeMs, videoDurationMs, entrySurface)
+        analyticEvents.trackVideoFeedPageViewed(videoFeedItem, toPosition, fromVideoFeedItem, watchTimeMs, videoDurationMs, entrySurface)
     }
 
     fun onProgressBarTapped(item: VideoFeedItem, percentageWatched: Float, watchTimeAtClick: Long? = null) {

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -948,14 +948,14 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      *
      * @param videoFeedItem: The item now in the primary position.
      * @param toPosition: 0-based index of the destination video in this session.
-     * @param fromProject: The project the user swiped away from.
+     * @param fromVideoFeedItem: The item the user swiped away from.
      * @param watchTimeMs: Milliseconds the previous video was in the primary position.
      * @param videoDurationMs: Total duration of the previous video in milliseconds.
      */
     fun trackVideoFeedPageViewed(
         videoFeedItem: VideoFeedItem,
         toPosition: Int,
-        fromProject: Project,
+        fromVideoFeedItem: VideoFeedItem,
         watchTimeMs: Long?,
         videoDurationMs: Long?,
         entrySurface: String
@@ -965,7 +965,7 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
         props[CONTEXT_LOCATION.contextName] = VIDEO_FEED_LOCATION.contextName
         props.putAll(
             AnalyticEventsUtils.videoFeedPageViewedProperties(
-                videoFeedItem, toPosition, fromProject, watchTimeMs, videoDurationMs, entrySurface
+                videoFeedItem, toPosition, fromVideoFeedItem, watchTimeMs, videoDurationMs, entrySurface
             )
         )
         client.track(PAGE_VIEWED.eventName, props)

--- a/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/AnalyticEventsUtils.kt
@@ -363,14 +363,14 @@ object AnalyticEventsUtils {
     fun videoFeedPageViewedProperties(
         item: VideoFeedItem,
         toPosition: Int,
-        fromProject: Project? = null,
+        fromVideoFeedItem: VideoFeedItem? = null,
         watchTimeMs: Long? = null,
         videoDurationMs: Long? = null,
         entrySurface: String = ""
     ): Map<String, Any> {
         val props = HashMap<String, Any>()
         props.putAll(videoFeedItemProperties(item, toPosition))
-        fromProject?.let { props["video_feed_from_video_id"] = it.id().toString() }
+        fromVideoFeedItem?.let { props["video_feed_from_video_id"] = it.videoId.toString() }
         watchTimeMs?.let { props["video_feed_total_watch_time"] = it }
         videoDurationMs?.let { props["video_feed_total_video_duration"] = it }
         if (entrySurface.isNotEmpty()) props["video_feed_entry_surface"] = entrySurface

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
@@ -156,6 +156,7 @@ fun KSVideoPlayer(
     var showControls by remember { mutableStateOf(false) }
     val hazeState = rememberHazeState()
     val lifecycleOwner = LocalLifecycleOwner.current
+    var isAppInForeground by remember { mutableStateOf(true) }
 
     // Keep references to the latest callback lambdas so lambdas inside remember(exoPlayer)
     // blocks always invoke the current version even if the parent recomposes.
@@ -163,17 +164,11 @@ fun KSVideoPlayer(
     val onProgressBarInteractionState = rememberUpdatedState(onProgressBarInteraction)
     val onBecameInactiveState = rememberUpdatedState(onBecameInactive)
 
-    DisposableEffect(lifecycleOwner, isActive) {
+    DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
-                Lifecycle.Event.ON_RESUME -> {
-                    if (isActive) {
-                        exoPlayer.play()
-                    }
-                }
-                Lifecycle.Event.ON_PAUSE -> {
-                    exoPlayer.pause()
-                }
+                Lifecycle.Event.ON_RESUME -> isAppInForeground = true
+                Lifecycle.Event.ON_PAUSE -> isAppInForeground = false
                 else -> {}
             }
         }
@@ -184,9 +179,10 @@ fun KSVideoPlayer(
     }
 
     // - Updated progress bar only when active and not scrubbing
-    LaunchedEffect(isActive) {
-        exoPlayer.playWhenReady = isActive
-        if (isActive) {
+    LaunchedEffect(isActive, isAppInForeground) {
+        val shouldPlay = isActive && isAppInForeground
+        exoPlayer.playWhenReady = shouldPlay
+        if (shouldPlay) {
             while (true) {
                 if (!isScrubbing) {
                     val duration = exoPlayer.duration

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
@@ -40,6 +40,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
@@ -152,12 +155,33 @@ fun KSVideoPlayer(
 
     var showControls by remember { mutableStateOf(false) }
     val hazeState = rememberHazeState()
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     // Keep references to the latest callback lambdas so lambdas inside remember(exoPlayer)
     // blocks always invoke the current version even if the parent recomposes.
     val onPlayPauseToggleState = rememberUpdatedState(onPlayPauseToggle)
     val onProgressBarInteractionState = rememberUpdatedState(onProgressBarInteraction)
     val onBecameInactiveState = rememberUpdatedState(onBecameInactive)
+
+    DisposableEffect(lifecycleOwner, isActive) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> {
+                    if (isActive) {
+                        exoPlayer.play()
+                    }
+                }
+                Lifecycle.Event.ON_PAUSE -> {
+                    exoPlayer.pause()
+                }
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
 
     // - Updated progress bar only when active and not scrubbing
     LaunchedEffect(isActive) {

--- a/app/src/test/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModelTest.kt
@@ -311,10 +311,10 @@ class VideoFeedViewModelTest : KSRobolectricTestCase() {
     fun `onVideoPageSettled sends PAGE_VIEWED`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val toItem = VideoFeedItem(badges = emptyList(), project = ProjectFactory.project(), hlsUrl = null)
-        val fromProject = ProjectFactory.caProject()
+        val fromItem = VideoFeedItem(badges = emptyList(), project = ProjectFactory.caProject(), hlsUrl = null)
         setUpEnvironment(environment(), dispatcher)
 
-        viewModel.onVideoPageSettled(toItem, 1, fromProject, 4000L, 30000L)
+        viewModel.onVideoPageSettled(toItem, 1, fromItem, 4000L, 30000L)
 
         segmentTrack.assertValue(EventName.PAGE_VIEWED.eventName)
     }

--- a/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/SegmentTest.kt
@@ -1903,8 +1903,9 @@ class SegmentTest : KSRobolectricTestCase() {
     fun testVideoFeedPageViewed_Properties() {
         val toProject = ProjectFactory.project()
         val toVideoId = 9876L
+        val fromVideoId = 1234L
         val toItem = VideoFeedItem(badges = emptyList(), project = toProject, hlsUrl = null, videoId = toVideoId)
-        val fromProject = ProjectFactory.caProject()
+        val fromItem = VideoFeedItem(badges = emptyList(), project = ProjectFactory.caProject(), hlsUrl = null, videoId = fromVideoId)
         val client = client(null)
         client.eventNames.subscribe { this.segmentTrack.onNext(it) }.addToDisposable(disposables)
         client.eventProperties.subscribe { this.propertiesTest.onNext(it) }.addToDisposable(disposables)
@@ -1913,7 +1914,7 @@ class SegmentTest : KSRobolectricTestCase() {
         segment.trackVideoFeedPageViewed(
             videoFeedItem = toItem,
             toPosition = 1,
-            fromProject = fromProject,
+            fromVideoFeedItem = fromItem,
             watchTimeMs = 5000L,
             videoDurationMs = 20000L,
             entrySurface = "search"
@@ -1926,7 +1927,7 @@ class SegmentTest : KSRobolectricTestCase() {
         assertEquals(toVideoId.toString(), props["video_feed_video_id"])
         assertEquals(toProject.id().toString(), props["video_feed_project_id"])
         assertEquals(1, props["video_feed_position_in_session"])
-        assertEquals(fromProject.id().toString(), props["video_feed_from_video_id"])
+        assertEquals(fromVideoId.toString(), props["video_feed_from_video_id"])
         assertEquals(5000L, props["video_feed_total_watch_time"])
         assertEquals(20000L, props["video_feed_total_video_duration"])
         assertEquals("search", props["video_feed_entry_surface"])

--- a/app/src/test/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayerTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayerTest.kt
@@ -3,6 +3,7 @@ package com.kickstarter.ui.compose.designsystem.videoplayer
 import android.graphics.Matrix
 import android.view.TextureView
 import androidx.compose.material3.Text
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -16,12 +17,17 @@ import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.media3.exoplayer.ExoPlayer
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.atLeastOnce
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
@@ -494,6 +500,85 @@ class KSVideoPlayerTest() : KSRobolectricTestCase() {
         composeTestRule.waitForIdle()
 
         assertEquals(0L, capturedDuration)
+    }
+
+    @Test
+    fun `test player pauses on lifecycle ON_PAUSE and resumes on ON_RESUME when active`() {
+        val mockPlayer = mock(ExoPlayer::class.java)
+        val lifecycleOwner = object : LifecycleOwner {
+            private val registry = LifecycleRegistry(this)
+            override val lifecycle: Lifecycle = registry
+            fun handleEvent(event: Lifecycle.Event) = registry.handleLifecycleEvent(event)
+        }
+        lifecycleOwner.handleEvent(Lifecycle.Event.ON_RESUME)
+
+        composeTestRule.setContent {
+            KSTheme {
+                CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                    KSVideoPlayer(
+                        videoUrl = "https://example.com/video.mp4",
+                        isActive = true,
+                        player = mockPlayer
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+
+        // - Move to ON_PAUSE (simulates backgrounding)
+        lifecycleOwner.handleEvent(Lifecycle.Event.ON_PAUSE)
+        composeTestRule.waitForIdle()
+
+        // - Player should be paused (playWhenReady = false)
+        verify(mockPlayer).playWhenReady = false
+
+        // - Move back to ON_RESUME
+        lifecycleOwner.handleEvent(Lifecycle.Event.ON_RESUME)
+        composeTestRule.waitForIdle()
+
+        // - Player should resume (playWhenReady = true)
+        verify(mockPlayer, atLeastOnce()).playWhenReady = true
+    }
+
+    @Test
+    fun `test player does not resume on lifecycle ON_RESUME when inactive`() {
+        val mockPlayer = mock(ExoPlayer::class.java)
+        val lifecycleOwner = object : LifecycleOwner {
+            private val registry = LifecycleRegistry(this)
+            override val lifecycle: Lifecycle = registry
+            fun handleEvent(event: Lifecycle.Event) = registry.handleLifecycleEvent(event)
+        }
+        lifecycleOwner.handleEvent(Lifecycle.Event.ON_RESUME)
+
+        composeTestRule.setContent {
+            KSTheme {
+                CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                    KSVideoPlayer(
+                        videoUrl = "https://example.com/video.mp4",
+                        isActive = false,
+                        player = mockPlayer
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+
+        // - Move to ON_PAUSE
+        lifecycleOwner.handleEvent(Lifecycle.Event.ON_PAUSE)
+        composeTestRule.waitForIdle()
+
+        verify(mockPlayer, atLeastOnce()).playWhenReady = false
+
+        // - Move back to ON_RESUME
+        lifecycleOwner.handleEvent(Lifecycle.Event.ON_RESUME)
+        composeTestRule.waitForIdle()
+
+        // - Player should NOT resume (playWhenReady should stay false or be set to false again)
+        // Since isActive is false, it should have been set to false initially and stay false.
+        verify(mockPlayer, atLeastOnce()).playWhenReady = false
+        verify(mockPlayer, never()).play()
     }
 
     private fun <T> any(): T = org.mockito.ArgumentMatchers.any()


### PR DESCRIPTION
# 📲 What

- Fix an analytics bug where the `video_feed_from_video_id` property was incorrectly sending the project ID of the video the user swiped away from, instead of the video ID. 
- Improved lifecycle awareness in the video player so playback automatically stops when the app is backgrounded or the user navigates to a creator profile/project page
- Locks VideoFeedActivity to portrait orientation.

# 🤔 Why

- The `video_feed_from_video_id` analytic property was being populated using fromProject.id() — the Kickstarter project ID — instead of the VideoFeedItem.videoId. 

- Video playback was not pausing fast enough when navigating away (project page or creator bio), because it waited for Compose to signal inactivity rather than reacting immediately to lifecycle events, resulting on audio still playing for a few seconds when in other activities.

# 🛠 How

**Analytics fix:**
Changed the `fromProject: Project` parameter across the entire call chain (VideoFeedScreen → VideoFeedActivity → VideoFeedViewModel → AnalyticEvents → AnalyticEventsUtils) to `fromVideoFeedItem: VideoFeedItem` .

**Lifecycle awareness:**
Added a `LifecycleEventObserver` inside `KSVideoPlayer` via `DisposableEffect` that tracks ON_RESUME/ON_PAUSE events using `LocalLifecycleOwner`.The LaunchedEffect controlling exoPlayer.playWhenReady now depends on both isActive and isAppInForeground, so playback stops immediately when the lifecycle pauses.

**Portrait lock:**
Added `android:screenOrientation="portrait"` and `android:configChanges="orientation"` to VideoFeedActivity in AndroidManifest.xml.

# 👀 See
- No user facing channges

|  |  |

# 📋 QA

Open the Video Feed.
- Swipe through a few videos and verify in analytics/Segment that video_feed_from_video_id matches the video ID (not the project ID) of the video you swiped away from.
- While a video is playing -ideally a video with sound-, navigate to the project page — confirm the video stops immediately (no delay).
- Background the app while a video is playing — confirm it pauses. Return to the app — confirm it resumes.
- Rotate the device while in the Video Feed — confirm the screen stays locked in portrait.

# Story 📖

[DISC-142](https://kickstarter.atlassian.net/browse/DISC-142)


[DISC-142]: https://kickstarter.atlassian.net/browse/DISC-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ