### PR TITLE
CHECK-176: Stop logging CancellationExceptions to Firebase

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/ExperimentsViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/ExperimentsViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import timber.log.Timber
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.cancellation.CancellationException
 
 /** For Crashlytics logging only **/
 private class ExperimentsException(cause: Exception) : Exception(cause)
@@ -78,6 +79,8 @@ class ExperimentsViewModel(
                             """.trimIndent()
                         )
                     }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
             } catch (exception: Exception) {
                 FirebaseCrashlytics.getInstance().recordException(ExperimentsException(exception))
             }


### PR DESCRIPTION
# 📲 What

Stop logging CancellationExceptions to Firebase

# 🤔 Why

The `ExperimentsViewModel` in Project Page is inadvertently logging [CancellationExceptions](https://console.firebase.google.com/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/6063f5036db8ce3f6ad63285b19a7767?time=7d&sessionEventKey=6A0D4F18011B0001707398A92F3D157C_2220301588815668064) to Firebase, which can potentially mask other important Exceptions that we want to monitor (and is also noisy).

# 🛠 How

Catch and re-throw `CancellationException` specifically

# 👀 See

N/A

# 📋 QA

N/A

# Story 📖

[\[CHECK-176\] Stop logging `CancellationException`s to Firebase - Jira](https://kickstarter.atlassian.net/browse/CHECK-176)
