### PR TITLE
CHECK-27: Turn the No-Reward position into an A/B Experiment

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -55,6 +55,14 @@ object StatsigExperiments {
             const val TEST = "test_parameter"
         }
     }
+
+    object MoveNoRewardOption : Experiment<MoveNoRewardOption.Parameters> {
+        override val name = "move_no-reward_option_android"
+        override val parameters = Parameters
+        object Parameters {
+            const val PLACE_AT_END = "place_at_end"
+        }
+    }
 }
 
 class StatsigException(cause: Throwable) : Exception(cause)

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
@@ -4,7 +4,10 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.libs.Environment
+import com.kickstarter.libs.featureflag.StatsigException
+import com.kickstarter.libs.featureflag.StatsigExperiments
 import com.kickstarter.libs.utils.extensions.isBacked
 import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.mock.factories.ShippingRuleFactory
@@ -17,6 +20,7 @@ import com.kickstarter.ui.data.PledgeFlowContext
 import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.usecases.GetShippingRulesUseCase
+import com.kickstarter.viewmodels.usecases.NoRewardPlacement
 import com.kickstarter.viewmodels.usecases.ShippingRulesState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -30,9 +34,12 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.cancellation.CancellationException
 
 data class RewardSelectionUIState(
     val selectedReward: Reward = Reward.builder().build(),
@@ -45,6 +52,11 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
     private val analytics = requireNotNull(environment.analytics())
     private val apolloClient = requireNotNull(environment.apolloClientV2())
     private val currentConfig = requireNotNull(environment.currentConfigV2()?.observable())
+
+    private val currentUserV2 = requireNotNull(environment.currentUserV2())
+    private val statsigClient = requireNotNull(environment.statsigClient())
+
+    private var statsigTimeout = 500L
 
     private lateinit var currentProjectData: ProjectData
     private var pReason: PledgeReason? = null
@@ -96,6 +108,30 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
         val project = projectData.project()
         viewModelScope.launch {
             emitCurrentState()
+
+            var noRewardPlacement = NoRewardPlacement.START
+            val currentUserIsLoggedIn = currentUserV2.isLoggedIn.asFlow().first()
+            if (currentUserIsLoggedIn) {
+                try {
+                    /* The timeout reflects how long we are willing to wait for `Statsig.initialize()`
+                     * and `Statsig.updateUser()` when an authenticated user is deep-linked to Project Page; or
+                     * just `Statsig.updateUser()` after the user completes the auth flow upon clicking 'Back this project'.
+                     * We could also _not_ wait, and access the StateFlow values directly, but this will result in an
+                     * even less consistent and deterministic experience for users. */
+                    noRewardPlacement = withTimeoutOrNull(statsigTimeout) {
+                        statsigClient.isReady.first { it }
+                        statsigClient.statsigUser.first { it.userID != null }
+                        val experiment = statsigClient.getExperiment(StatsigExperiments.MoveNoRewardOption.name)
+                        val placeAtEnd = experiment.getBooleanIfPresent(StatsigExperiments.MoveNoRewardOption.parameters.PLACE_AT_END)
+                        if (placeAtEnd == true) NoRewardPlacement.END else NoRewardPlacement.START
+                    } ?: noRewardPlacement
+                } catch (cancellationException: CancellationException) {
+                    throw cancellationException
+                } catch (exception: Exception) {
+                    FirebaseCrashlytics.getInstance().recordException(StatsigException(exception))
+                }
+            }
+
             apolloClient.getRewardsFromProject(project.slug() ?: "")
                 .asFlow()
                 .combine(currentConfig.asFlow()) { rewardsList, config ->
@@ -105,7 +141,8 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
                             config = config,
                             projectRewards = rewardsList,
                             viewModelScope,
-                            Dispatchers.IO
+                            Dispatchers.IO,
+                            noRewardPlacement,
                         )
                     }
                     shippingRulesUseCase?.invoke()
@@ -238,6 +275,11 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
         viewModelScope.launch {
             emitShippingUIState()
         }
+    }
+
+    @VisibleForTesting
+    fun setStatsigTimeout(timeMillis: Long) {
+        statsigTimeout = timeMillis
     }
 
     class Factory(private val environment: Environment, private var shippingRulesUseCase: GetShippingRulesUseCase? = null) :

--- a/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
@@ -24,6 +24,10 @@ data class ShippingRulesState(
     val filteredRw: List<Reward> = emptyList()
 )
 
+enum class NoRewardPlacement {
+    START, END
+}
+
 /**
  * Will provide ShippingRulesState where:
  * `shippingRules` is the list of available shipping rules for a given project
@@ -41,7 +45,8 @@ class GetShippingRulesUseCase(
     private val config: Config?,
     private val projectRewards: List<Reward> = emptyList(),
     private val scope: CoroutineScope,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val noRewardPlacement: NoRewardPlacement = NoRewardPlacement.START
 ) {
 
     private val filteredRewards = mutableListOf<Reward>()
@@ -109,7 +114,7 @@ class GetShippingRulesUseCase(
                     project
                 )
 
-                setRewardsList(RewardUtils.filterHasStarted(projectRewards))
+                setRewardsList(RewardUtils.filterHasStarted(projectRewards), noRewardPlacement)
             }
             // - all rewards digital
             if (rewardsByShippingType.isEmpty() && project.isAllowedToPledge()) {
@@ -153,7 +158,7 @@ class GetShippingRulesUseCase(
      * Sets [filteredRewards] to the full list in backend order (no reward first when present).
      * No location-based filtering: reward cards show "unavailable" UI when shipping is not available.
      */
-    private fun setRewardsList(rewards: List<Reward>) {
+    private fun setRewardsList(rewards: List<Reward>, noRewardPlacement: NoRewardPlacement) {
         filteredRewards.clear()
         var noReward: Reward? = null
         rewards.forEach { rw ->
@@ -163,7 +168,12 @@ class GetShippingRulesUseCase(
                 filteredRewards.add(rw)
             }
         }
-        noReward?.let { filteredRewards.add(0, it) }
+        noReward?.let {
+            when (noRewardPlacement) {
+                NoRewardPlacement.END -> filteredRewards.add(it)
+                else -> filteredRewards.add(0, it)
+            }
+        }
     }
 
     /**

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
@@ -454,6 +454,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         val shippingUiState = mutableListOf<ShippingRulesState>()
         backgroundScope.launch(dispatcher) {
             createViewModel(env)
+            viewModel.setStatsigTimeout(0L)
             viewModel.provideProjectData(projectData)
 
             val useCase = GetShippingRulesUseCase(project, config, rwList, this, dispatcher)
@@ -498,6 +499,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         val shippingUiState = mutableListOf<ShippingRulesState>()
         backgroundScope.launch(dispatcher) {
             createViewModel(env)
+            viewModel.setStatsigTimeout(0L)
             viewModel.provideProjectData(projectData)
             val useCase = GetShippingRulesUseCase(project, config, rwList, this, dispatcher)
             viewModel.overrideShippingRulesUseCase(useCase)


### PR DESCRIPTION
> [!NOTE]
> We are aware that this branch is missing relevant tests, which will be added in the next PR. As an aside, the branch prefix `tony/check-24` is a typo - this PR is specifically associated with CHECK-27.

# 📲 What

Turn the placement of the no-reward option in the rewards carousel into an A/B Experiment, where it can either be in the first position or last position.

# 🤔 Why

Currently within the rewards carousel, the No-Reward card occupies most of the screen when first opened, requiring backers to scroll before they can see any other rewards.

This change enables an A/B test for moving the position of the No-Reward card to the end of the carousel, allowing backers quickly discover compelling rewards while still preserving a clear path to pledge without a reward.

References:
- [\[CHECK-27\] [Tech Plan] A/B test move bonus support card on mobile from first to last - Jira](https://kickstarter.atlassian.net/browse/CHECK-27)
- [\[CHECK-27\] A/B Test Moving the ‘No-Reward’ Card From First to Last Place - Tony Teate - Confluence](https://kickstarter.atlassian.net/wiki/spaces/~71202080e31ddbc13843688236276f984b2f22/pages/4565434369/CHECK-27+A+B+Test+Moving+the+No-Reward+Card+From+First+to+Last+Place)

# 🛠 How

- Add a new entry to `StatsigExperiments`
- Add a sort option (`NoRewardPlacement` enum) to `GetShippingRuleseUseCase`
- Update `RewardsSelectionViewModel` to conditionally check the Experiment, and pass the appropriate sort option into `GetShippingRuleseUseCase` based on the experimental Parameter value.
  - Only authenticated users are eligible for A/B Experiment, so for an optimized and deterministic experience, the Experiment is only checked if the user is logged in.

# 👀 See

The video first demonstrates the default experience, which is the same for users in the Control group. Then the app is closed, the user is overridden into the Test group and re-opened.

https://github.com/user-attachments/assets/df2ace8b-61c9-4582-915c-cdff642257aa


# 📋 QA

Override your User ID into the Test group for the [move_no-reward_option_android](https://console.statsig.com/63RYuAXh4n2yKAubACXeg1/experiments/move_no-reward_option_android/setup) Experiment, and visit the rewards carousel for any Live/Late Pledge Project.

# Story 📖

[\[CHECK-27\] [Tech Plan] A/B test move bonus support card on mobile from first to last - Jira](https://kickstarter.atlassian.net/browse/CHECK-27)
[\[CHECK-160\] Add a sort option that places the Bonus Support card at the end of the Rewards list - Jira](https://kickstarter.atlassian.net/browse/CHECK-160)
[\[CHECK-161\] Check the Experiment client-side and connect the Parameter to the sort option - Jira](https://kickstarter.atlassian.net/browse/CHECK-161)
