### PR TITLE
DISC-209: Reftags added for social sharing

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -12,6 +12,7 @@ fragment videoFeedProject on Project {
     sharesCount
     isWatched
     imageUrl(blur: false, width: 1024)
+    url
     pledged {
         ...amount
     }

--- a/app/src/main/java/com/kickstarter/features/socialshare/SocialShareIntentBuilder.kt
+++ b/app/src/main/java/com/kickstarter/features/socialshare/SocialShareIntentBuilder.kt
@@ -170,8 +170,9 @@ object SocialShareIntentBuilder {
 
     /**
      * Email — text always included; image attached as an inline attachment when available.
-     * ACTION_SEND with image/jpeg opens email clients in compose mode with the image
-     * attached and the body/subject pre-filled. Falls back to ACTION_SENDTO + mailto:
+     * ACTION_SEND with message/rfc822 restricts the chooser to email clients only (prevents
+     * social apps like Instagram from appearing) and opens them in compose mode with the
+     * image attached and the body/subject pre-filled. Falls back to ACTION_SENDTO + mailto:
      * (no attachment support) when no image is cached yet.
      */
     private fun emailIntent(shareData: SocialShareData, imageUri: Uri?): Intent {

--- a/app/src/main/java/com/kickstarter/features/socialshare/SocialShareIntentBuilder.kt
+++ b/app/src/main/java/com/kickstarter/features/socialshare/SocialShareIntentBuilder.kt
@@ -179,7 +179,7 @@ object SocialShareIntentBuilder {
         val body = "I thought you'd love this — ${shareData.projectName} by ${shareData.creatorName}:\n\n${shareData.projectUrl}"
         return if (imageUri != null) {
             Intent(Intent.ACTION_SEND).apply {
-                type = "image/jpeg"
+                type = "message/rfc822"
                 putExtra(Intent.EXTRA_SUBJECT, subject)
                 putExtra(Intent.EXTRA_TEXT, body)
                 putExtra(Intent.EXTRA_STREAM, imageUri)

--- a/app/src/main/java/com/kickstarter/features/socialshare/data/SocialShareModels.kt
+++ b/app/src/main/java/com/kickstarter/features/socialshare/data/SocialShareModels.kt
@@ -1,6 +1,8 @@
 package com.kickstarter.features.socialshare.data
 
 import android.net.Uri
+import com.kickstarter.libs.RefTag
+import com.kickstarter.libs.utils.EventContextValues.SharePlatformContextType
 
 data class SocialShareData(
     val projectName: String,
@@ -28,6 +30,32 @@ enum class SocialSharePlatform(val targetPackage: String?) {
         FACEBOOK_STORIES -> true
         else -> false
     }
+}
+
+fun SocialSharePlatform.refTag(): RefTag = when (this) {
+    SocialSharePlatform.COPY_LINK -> RefTag.projectShareCopyLink()
+    SocialSharePlatform.INSTAGRAM_FEED -> RefTag.projectShareInstagramFeed()
+    SocialSharePlatform.INSTAGRAM_STORIES -> RefTag.projectShareInstagramStories()
+    SocialSharePlatform.X -> RefTag.projectShareX()
+    SocialSharePlatform.FACEBOOK_FEED -> RefTag.projectShareFacebookFeed()
+    SocialSharePlatform.FACEBOOK_STORIES -> RefTag.projectShareFacebookStories()
+    SocialSharePlatform.WHATSAPP -> RefTag.projectShareWhatsApp()
+    SocialSharePlatform.MESSAGES -> RefTag.projectShareMessages()
+    SocialSharePlatform.EMAIL -> RefTag.projectShareEmail()
+    SocialSharePlatform.MORE -> RefTag.projectShareMore()
+}
+
+fun SocialSharePlatform.analyticsContextType(): String = when (this) {
+    SocialSharePlatform.COPY_LINK -> SharePlatformContextType.COPY_LINK.contextName
+    SocialSharePlatform.INSTAGRAM_FEED -> SharePlatformContextType.INSTAGRAM_FEED.contextName
+    SocialSharePlatform.INSTAGRAM_STORIES -> SharePlatformContextType.INSTAGRAM_STORIES.contextName
+    SocialSharePlatform.X -> SharePlatformContextType.X.contextName
+    SocialSharePlatform.FACEBOOK_FEED -> SharePlatformContextType.FACEBOOK_FEED.contextName
+    SocialSharePlatform.FACEBOOK_STORIES -> SharePlatformContextType.FACEBOOK_STORIES.contextName
+    SocialSharePlatform.WHATSAPP -> SharePlatformContextType.WHATSAPP.contextName
+    SocialSharePlatform.MESSAGES -> SharePlatformContextType.MESSAGES.contextName
+    SocialSharePlatform.EMAIL -> SharePlatformContextType.EMAIL.contextName
+    SocialSharePlatform.MORE -> SharePlatformContextType.MORE.contextName
 }
 
 data class SocialShareUIState(

--- a/app/src/main/java/com/kickstarter/features/socialshare/ui/components/SocialSharePlatformGrid.kt
+++ b/app/src/main/java/com/kickstarter/features/socialshare/ui/components/SocialSharePlatformGrid.kt
@@ -107,11 +107,11 @@ private fun PlatformButton(
         Icon(
             imageVector = platform.icon(),
             contentDescription = null,
-            tint = Color.Unspecified,
+            tint = if (platform.isBrandIcon()) Color.Unspecified else colors.socialShare.monochromeIconTint,
             modifier = Modifier
                 .size(dimensions.socialSharePlatformIconSize)
                 .clip(CircleShape)
-                .background(colors.backgroundSurfaceRaised)
+                .background(colors.socialShare.iconBackground)
                 .padding(dimensions.socialSharePlatformIconPadding)
         )
         Text(
@@ -122,6 +122,15 @@ private fun PlatformButton(
             modifier = Modifier.padding(top = dimensions.paddingXSmall)
         )
     }
+}
+
+private fun SocialSharePlatform.isBrandIcon(): Boolean = when (this) {
+    SocialSharePlatform.INSTAGRAM_FEED,
+    SocialSharePlatform.INSTAGRAM_STORIES,
+    SocialSharePlatform.FACEBOOK_FEED,
+    SocialSharePlatform.FACEBOOK_STORIES,
+    SocialSharePlatform.WHATSAPP -> true
+    else -> false
 }
 
 private fun SocialSharePlatform.icon(): ImageVector = when (this) {

--- a/app/src/main/java/com/kickstarter/features/socialshare/viewmodel/SocialShareViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/socialshare/viewmodel/SocialShareViewModel.kt
@@ -28,7 +28,15 @@ import kotlin.coroutines.EmptyCoroutineContext
  *   detection, image caching, intent construction). In production this is
  *   [com.kickstarter.features.socialshare.AndroidSocialShareService]; in tests a fake
  *   implementation is injected directly.
- * @param shareData Snapshot of the project information used across every sharing action.
+ * @param shareData Snapshot of the project information used across every sharing action:
+ *   - [SocialShareData.projectName] — included as text in platform captions and SMS/email subjects.
+ *   - [SocialShareData.projectUrl]  — the canonical link appended to every share payload.
+ *   - [SocialShareData.imageUrl]    — remote URL of the project hero image; downloaded and
+ *     cached as a `content://` URI during [init] so it can be attached to image-bearing
+ *     intents (Instagram, Facebook, WhatsApp, etc.). An empty value skips caching.
+ *   - [SocialShareData.creatorName] — displayed in email body copy.
+ *   This object is immutable for the lifetime of the ViewModel; one ViewModel instance
+ *   corresponds to one sharing session for a specific project.
  * @param contextPage The screen from which the share sheet was opened, used as the
  *   analytics context_page property.
  */

--- a/app/src/main/java/com/kickstarter/features/socialshare/viewmodel/SocialShareViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/socialshare/viewmodel/SocialShareViewModel.kt
@@ -8,6 +8,10 @@ import com.kickstarter.features.socialshare.SocialShareService
 import com.kickstarter.features.socialshare.data.SocialShareData
 import com.kickstarter.features.socialshare.data.SocialSharePlatform
 import com.kickstarter.features.socialshare.data.SocialShareUIState
+import com.kickstarter.features.socialshare.data.refTag
+import com.kickstarter.libs.Environment
+import com.kickstarter.libs.utils.EventContextValues.ContextPageName
+import com.kickstarter.libs.utils.UrlUtils
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -19,28 +23,25 @@ import kotlin.coroutines.EmptyCoroutineContext
 /**
  * ViewModel for the Social Share bottom sheet.
  *
+ * @param environment Provides analytics and other app-level dependencies.
  * @param shareService Abstraction over Android framework operations (clipboard, package
  *   detection, image caching, intent construction). In production this is
  *   [com.kickstarter.features.socialshare.AndroidSocialShareService]; in tests a fake
  *   implementation is injected directly.
- *
- * @param shareData Snapshot of the project information used across every sharing action:
- *   - [SocialShareData.projectName] — included as text in platform captions and SMS/email subjects.
- *   - [SocialShareData.projectUrl]  — the canonical link appended to every share payload.
- *   - [SocialShareData.imageUrl]    — remote URL of the project hero image; downloaded and
- *     cached as a `content://` URI during [init] so it can be attached to image-bearing
- *     intents (Instagram, Facebook, WhatsApp, etc.). An empty value skips caching.
- *   - [SocialShareData.creatorName] — displayed in email body copy.
- *   This object is immutable for the lifetime of the ViewModel; one ViewModel instance
- *   corresponds to one sharing session for a specific project.
+ * @param shareData Snapshot of the project information used across every sharing action.
+ * @param contextPage The screen from which the share sheet was opened, used as the
+ *   analytics context_page property.
  */
 class SocialShareViewModel(
+    private val environment: Environment,
     private val shareService: SocialShareService,
     private val shareData: SocialShareData,
+    private val contextPage: ContextPageName,
     private val testDispatcher: CoroutineDispatcher? = null
 ) : ViewModel() {
 
     private val scope = viewModelScope + (testDispatcher ?: EmptyCoroutineContext)
+    private val analyticEvents = requireNotNull(environment.analytics())
 
     private val _uiState = MutableStateFlow(SocialShareUIState())
     val uiState: StateFlow<SocialShareUIState> = _uiState.asStateFlow()
@@ -69,9 +70,10 @@ class SocialShareViewModel(
             return
         }
 
+        val urlWithRefTag = UrlUtils.appendRefTag(shareData.projectUrl, platform.refTag().tag())
         val intent = shareService.buildIntent(
             platform = platform,
-            shareData = shareData,
+            shareData = shareData.copy(projectUrl = urlWithRefTag),
             imageUri = _uiState.value.shareImageUri
         )
 
@@ -80,11 +82,14 @@ class SocialShareViewModel(
             return
         }
 
+        analyticEvents.trackSharePlatformCTAClicked(platform, contextPage)
         intentLaunchAction.invoke(intent)
     }
 
     fun onCopyLinkClicked() {
-        shareService.copyToClipboard("Kickstarter project link", shareData.projectUrl)
+        val urlWithRefTag = UrlUtils.appendRefTag(shareData.projectUrl, SocialSharePlatform.COPY_LINK.refTag().tag())
+        shareService.copyToClipboard("Kickstarter project link", urlWithRefTag)
+        analyticEvents.trackSharePlatformCTAClicked(SocialSharePlatform.COPY_LINK, contextPage)
         scope.launch {
             _uiState.emit(_uiState.value.copy(copiedToClipboard = true))
         }
@@ -117,12 +122,14 @@ class SocialShareViewModel(
     }
 
     class Factory(
+        private val environment: Environment,
         private val service: SocialShareService,
         private val shareData: SocialShareData,
+        private val contextPage: ContextPageName,
         private val testDispatcher: CoroutineDispatcher? = null
     ) : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return SocialShareViewModel(service, shareData, testDispatcher) as T
+            return SocialShareViewModel(environment, service, shareData, contextPage, testDispatcher) as T
         }
     }
 }

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
@@ -59,6 +59,7 @@ class VideoFeedActivity : ComponentActivity() {
                 val uiState by viewModel.videoFeedUIState.collectAsStateWithLifecycle()
                 VideoFeedScreen(
                     items = uiState.items,
+                    environment = env,
                     errorSnackBarHostState = snackbarHostState,
                     onLoadMore = { viewModel.loadVideoFeed() },
                     onClose = { onBackPressedDispatcher.onBackPressed() },

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
@@ -50,7 +50,9 @@ import com.kickstarter.features.videofeed.data.VideoFeedItem
 import com.kickstarter.features.videofeed.ui.components.KSVideoActionsColumn
 import com.kickstarter.features.videofeed.ui.components.KSVideoBadgesRow
 import com.kickstarter.features.videofeed.ui.components.KSVideoCampaignCard
+import com.kickstarter.libs.Environment
 import com.kickstarter.libs.RefTag
+import com.kickstarter.libs.utils.EventContextValues.ContextPageName
 import com.kickstarter.libs.utils.NumberUtils
 import com.kickstarter.libs.utils.extensions.isTrue
 import com.kickstarter.libs.utils.extensions.toCompactFormat
@@ -74,6 +76,7 @@ enum class VideoFeedScreenTestTag {
 @Composable
 fun VideoFeedScreen(
     items: List<VideoFeedItem>,
+    environment: Environment,
     errorSnackBarHostState: SnackbarHostState = SnackbarHostState(),
     onLoadMore: () -> Unit = {},
     onClose: () -> Unit = {},
@@ -253,8 +256,10 @@ fun VideoFeedScreen(
             val context = LocalContext.current
             val shareViewModel = remember(data) {
                 SocialShareViewModel(
+                    environment = environment,
                     shareService = AndroidSocialShareService(context.applicationContext),
-                    shareData = data
+                    shareData = data,
+                    contextPage = ContextPageName.VIDEO_FEED
                 )
             }
             CompositionLocalProvider(LocalSocialShareViewModel provides shareViewModel) {
@@ -300,8 +305,10 @@ fun setUpVideoFeedErrorActions(snackbarHostState: SnackbarHostState): (String?) 
 @Preview
 @Composable
 fun VideoFeedScreenPreview() {
+    val previewEnv = Environment.builder().build()
     KSTheme {
         VideoFeedScreen(
+            environment = previewEnv,
             items = listOf(
                 VideoFeedItem(
                     badges = listOf(KSVideoBadgeType.ProjectWeLove, KSVideoBadgeType.DaysLeft("3 days left")),

--- a/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
+++ b/app/src/main/java/com/kickstarter/libs/AnalyticEvents.kt
@@ -2,6 +2,8 @@ package com.kickstarter.libs
 
 import OnboardingPage
 import com.kickstarter.features.pledgedprojectsoverview.data.PPOCard
+import com.kickstarter.features.socialshare.data.SocialSharePlatform
+import com.kickstarter.features.socialshare.data.analyticsContextType
 import com.kickstarter.features.videofeed.data.VideoFeedItem
 import com.kickstarter.libs.utils.AnalyticEventsUtils
 import com.kickstarter.libs.utils.ContextPropertyKeyName.COMMENT_BODY
@@ -64,6 +66,7 @@ import com.kickstarter.libs.utils.EventContextValues.CtaContextName.PLEDGE_INITI
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.PLEDGE_SUBMIT
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.REWARD_CONTINUE
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.SEARCH
+import com.kickstarter.libs.utils.EventContextValues.CtaContextName.SHARE_PLATFORM_CLICKED
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.SIGNUP_LOGIN
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.SIGN_UP_INITIATE
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName.SIGN_UP_SUBMIT
@@ -996,6 +999,17 @@ class AnalyticEvents(trackingClients: List<TrackingClientType?>) {
      * @param ctaType: The specific action that was tapped.
      * @param watchTimeAtClick: Optional milliseconds watched at the moment of the tap.
      */
+    fun trackSharePlatformCTAClicked(
+        platform: SocialSharePlatform,
+        contextPage: EventContextValues.ContextPageName
+    ) {
+        val props = HashMap<String, Any>()
+        props[CONTEXT_CTA.contextName] = SHARE_PLATFORM_CLICKED.contextName
+        props[CONTEXT_PAGE.contextName] = contextPage.contextName
+        props[CONTEXT_TYPE.contextName] = platform.analyticsContextType()
+        client.track(CTA_CLICKED.eventName, props)
+    }
+
     fun trackVideoFeedCTAClicked(
         project: Project,
         ctaType: EventContextValues.CtaContextName,

--- a/app/src/main/java/com/kickstarter/libs/RefTag.kt
+++ b/app/src/main/java/com/kickstarter/libs/RefTag.kt
@@ -91,6 +91,17 @@ class RefTag private constructor(
             return builder().tag("android_project_share").build()
         }
 
+        fun projectShareCopyLink(): RefTag = builder().tag("android_project_share_copy_link").build()
+        fun projectShareInstagramFeed(): RefTag = builder().tag("android_project_share_instagram_feed").build()
+        fun projectShareInstagramStories(): RefTag = builder().tag("android_project_share_instagram_stories").build()
+        fun projectShareX(): RefTag = builder().tag("android_project_share_x").build()
+        fun projectShareFacebookFeed(): RefTag = builder().tag("android_project_share_facebook_feed").build()
+        fun projectShareFacebookStories(): RefTag = builder().tag("android_project_share_facebook_stories").build()
+        fun projectShareWhatsApp(): RefTag = builder().tag("android_project_share_whatsapp").build()
+        fun projectShareMessages(): RefTag = builder().tag("android_project_share_messages").build()
+        fun projectShareEmail(): RefTag = builder().tag("android_project_share_email").build()
+        fun projectShareMore(): RefTag = builder().tag("android_project_share_more").build()
+
         @JvmStatic
         fun push(): RefTag {
             return builder().tag("push").build()

--- a/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
@@ -66,6 +66,7 @@ class EventContextValues {
         VIDEO_SAVE("video_save"),
         VIDEO_CREATOR("video_creator"),
         VIDEO_SHARE("video_share"),
+        SHARE_PLATFORM_CLICKED("share_platform_clicked"),
     }
 
     /**
@@ -212,5 +213,18 @@ class EventContextValues {
     enum class VideoContextName(val contextName: String) {
         LENGTH("length"),
         POSITION("position")
+    }
+
+    enum class SharePlatformContextType(val contextName: String) {
+        COPY_LINK("copy_link"),
+        INSTAGRAM_FEED("instagram_feed"),
+        INSTAGRAM_STORIES("instagram_stories"),
+        X("x"),
+        FACEBOOK_FEED("facebook_feed"),
+        FACEBOOK_STORIES("facebook_stories"),
+        WHATSAPP("whatsapp"),
+        MESSAGES("messages"),
+        EMAIL("email"),
+        MORE("more"),
     }
 }

--- a/app/src/main/java/com/kickstarter/services/transformers/extensions/VideoFeedTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/extensions/VideoFeedTransformers.kt
@@ -8,7 +8,9 @@ import com.kickstarter.models.Avatar
 import com.kickstarter.models.Category
 import com.kickstarter.models.Photo
 import com.kickstarter.models.Project
+import com.kickstarter.models.Urls
 import com.kickstarter.models.User
+import com.kickstarter.models.Web
 import com.kickstarter.services.apiresponses.commentresponse.PageInfoEnvelope
 import com.kickstarter.services.transformers.decodeRelayId
 import com.kickstarter.type.BadgeTypeEnum
@@ -40,6 +42,9 @@ fun VideoFeedQuery.VideoFeed?.toVideoFeedEnvelope(): VideoFeedEnvelope {
         val photo = Photo.builder()
             .full(frag.imageUrl)
             .build()
+        val urls = Urls.builder()
+            .web(Web.builder().project(frag.url).build())
+            .build()
         val project = Project.builder()
             .id(decodeRelayId(frag.id) ?: -1)
             .name(frag.name)
@@ -56,6 +61,7 @@ fun VideoFeedQuery.VideoFeed?.toVideoFeedEnvelope(): VideoFeedEnvelope {
             .photo(photo)
             .creator(creator)
             .category(category)
+            .urls(urls)
             .build()
         VideoFeedItem(
             badges = badges,

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSColors.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSColors.kt
@@ -160,7 +160,8 @@ data class KSSocialShareColors(
     // Text sits on the green background — always black regardless of theme.
     val text: Color = Color.Unspecified,
     val platformLabel: Color = Color.Unspecified,
-    val iconBackground: Color = Color.Unspecified
+    val iconBackground: Color = Color.Unspecified,
+    val monochromeIconTint: Color = Color.Unspecified
 )
 
 // Extracted into its own data class to work around a JVM limitation:
@@ -443,7 +444,8 @@ val KSLightCustomColors = KSCustomColors(
         dragHandle = black.copy(alpha = 0.3f),
         text = black,
         platformLabel = black,
-        iconBackground = kds_white
+        iconBackground = kds_white,
+        monochromeIconTint = black
     ),
 
     // OLD COLORS
@@ -611,7 +613,8 @@ val KSDarkCustomColors = KSCustomColors(
         dragHandle = black.copy(alpha = 0.3f),
         text = black,
         platformLabel = black,
-        iconBackground = kds_white
+        iconBackground = kds_support_700,
+        monochromeIconTint = white
     ),
 
     // OLD COLORS

--- a/app/src/test/java/com/kickstarter/features/socialshare/SocialShareIntentBuilderTest.kt
+++ b/app/src/test/java/com/kickstarter/features/socialshare/SocialShareIntentBuilderTest.kt
@@ -162,7 +162,7 @@ class SocialShareIntentBuilderTest : KSRobolectricTestCase() {
         val intent = SocialShareIntentBuilder.buildIntent(context(), SocialSharePlatform.EMAIL, shareData, imageUri)!!
 
         assertEquals(Intent.ACTION_SEND, intent.action)
-        assertEquals("image/jpeg", intent.type)
+        assertEquals("message/rfc822", intent.type)
         assertTrue(intent.getStringExtra(Intent.EXTRA_SUBJECT)!!.contains(shareData.projectName))
         val body = intent.getStringExtra(Intent.EXTRA_TEXT)!!
         assertTrue(body.contains(shareData.projectUrl))

--- a/app/src/test/java/com/kickstarter/features/socialshare/ui/SocialShareSheetTest.kt
+++ b/app/src/test/java/com/kickstarter/features/socialshare/ui/SocialShareSheetTest.kt
@@ -18,6 +18,7 @@ import com.kickstarter.features.socialshare.SocialShareService
 import com.kickstarter.features.socialshare.data.SocialShareData
 import com.kickstarter.features.socialshare.data.SocialSharePlatform
 import com.kickstarter.features.socialshare.viewmodel.SocialShareViewModel
+import com.kickstarter.libs.utils.EventContextValues.ContextPageName
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -38,7 +39,7 @@ class SocialShareSheetTest : KSRobolectricTestCase() {
 
     @Test
     fun `sheet content is displayed when isVisible is true`() {
-        val viewModel = SocialShareViewModel(FakeSocialShareService(), shareData, UnconfinedTestDispatcher())
+        val viewModel = SocialShareViewModel(environment(), FakeSocialShareService(), shareData, ContextPageName.VIDEO_FEED, UnconfinedTestDispatcher())
 
         composeTestRule.setContent {
             KSTheme {
@@ -60,7 +61,7 @@ class SocialShareSheetTest : KSRobolectricTestCase() {
 
     @Test
     fun `sheet content is not shown when isVisible is false`() {
-        val viewModel = SocialShareViewModel(FakeSocialShareService(), shareData, UnconfinedTestDispatcher())
+        val viewModel = SocialShareViewModel(environment(), FakeSocialShareService(), shareData, ContextPageName.VIDEO_FEED, UnconfinedTestDispatcher())
 
         composeTestRule.setContent {
             KSTheme {
@@ -84,10 +85,12 @@ class SocialShareSheetTest : KSRobolectricTestCase() {
     fun `sheet shows only platforms returned by the service`() {
         val platforms = listOf(SocialSharePlatform.X, SocialSharePlatform.EMAIL, SocialSharePlatform.MORE)
         val viewModel = SocialShareViewModel(
+            environment(),
             object : FakeSocialShareService() {
                 override fun getInstalledPlatforms() = platforms
             },
             shareData,
+            ContextPageName.VIDEO_FEED,
             UnconfinedTestDispatcher()
         )
 
@@ -122,11 +125,13 @@ class SocialShareSheetTest : KSRobolectricTestCase() {
         var capturedIntent: Intent? = null
 
         val viewModel = SocialShareViewModel(
+            environment(),
             object : FakeSocialShareService() {
                 override fun getInstalledPlatforms() = listOf(SocialSharePlatform.X)
                 override fun buildIntent(platform: SocialSharePlatform, shareData: SocialShareData, imageUri: Uri?) = fakeIntent
             },
             shareData,
+            ContextPageName.VIDEO_FEED,
             UnconfinedTestDispatcher()
         )
 
@@ -154,11 +159,13 @@ class SocialShareSheetTest : KSRobolectricTestCase() {
     fun `clicking a platform when buildIntent returns null shows error snackbar`() {
         val snackbarHostState = SnackbarHostState()
         val viewModel = SocialShareViewModel(
+            environment(),
             object : FakeSocialShareService() {
                 override fun getInstalledPlatforms() = listOf(SocialSharePlatform.X)
                 override fun buildIntent(platform: SocialSharePlatform, shareData: SocialShareData, imageUri: Uri?): Intent? = null
             },
             shareData,
+            ContextPageName.VIDEO_FEED,
             UnconfinedTestDispatcher()
         )
 
@@ -189,10 +196,12 @@ class SocialShareSheetTest : KSRobolectricTestCase() {
     fun `clicking Copy Link shows Link copied snackbar`() {
         val snackbarHostState = SnackbarHostState()
         val viewModel = SocialShareViewModel(
+            environment(),
             object : FakeSocialShareService() {
                 override fun getInstalledPlatforms() = listOf(SocialSharePlatform.COPY_LINK)
             },
             shareData,
+            ContextPageName.VIDEO_FEED,
             UnconfinedTestDispatcher()
         )
 
@@ -221,7 +230,7 @@ class SocialShareSheetTest : KSRobolectricTestCase() {
 
     @Test
     fun `Share project header has heading semantics`() {
-        val viewModel = SocialShareViewModel(FakeSocialShareService(), shareData, UnconfinedTestDispatcher())
+        val viewModel = SocialShareViewModel(environment(), FakeSocialShareService(), shareData, ContextPageName.VIDEO_FEED, UnconfinedTestDispatcher())
 
         composeTestRule.setContent {
             KSTheme {
@@ -245,7 +254,7 @@ class SocialShareSheetTest : KSRobolectricTestCase() {
 
     @Test
     fun `project card container is accessible via sheet-level test tag`() {
-        val viewModel = SocialShareViewModel(FakeSocialShareService(), shareData, UnconfinedTestDispatcher())
+        val viewModel = SocialShareViewModel(environment(), FakeSocialShareService(), shareData, ContextPageName.VIDEO_FEED, UnconfinedTestDispatcher())
 
         composeTestRule.setContent {
             KSTheme {
@@ -267,7 +276,7 @@ class SocialShareSheetTest : KSRobolectricTestCase() {
 
     @Test
     fun `platform grid container is accessible via sheet-level test tag`() {
-        val viewModel = SocialShareViewModel(FakeSocialShareService(), shareData, UnconfinedTestDispatcher())
+        val viewModel = SocialShareViewModel(environment(), FakeSocialShareService(), shareData, ContextPageName.VIDEO_FEED, UnconfinedTestDispatcher())
 
         composeTestRule.setContent {
             KSTheme {

--- a/app/src/test/java/com/kickstarter/features/socialshare/viewmodel/SocialShareViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/socialshare/viewmodel/SocialShareViewModelTest.kt
@@ -6,6 +6,10 @@ import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.features.socialshare.SocialShareService
 import com.kickstarter.features.socialshare.data.SocialShareData
 import com.kickstarter.features.socialshare.data.SocialSharePlatform
+import com.kickstarter.libs.RefTag
+import com.kickstarter.libs.utils.EventContextValues.ContextPageName
+import com.kickstarter.libs.utils.EventName
+import com.kickstarter.libs.utils.UrlUtils
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -36,8 +40,9 @@ class SocialShareViewModelTest : KSRobolectricTestCase() {
     private fun buildViewModel(
         service: SocialShareService,
         data: SocialShareData = shareData,
+        contextPage: ContextPageName = ContextPageName.VIDEO_FEED,
         dispatcher: kotlinx.coroutines.CoroutineDispatcher
-    ) = SocialShareViewModel(service, data, dispatcher)
+    ) = SocialShareViewModel(environment(), service, data, contextPage, dispatcher)
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // init: detectInstalledPlatforms
@@ -239,12 +244,75 @@ class SocialShareViewModelTest : KSRobolectricTestCase() {
         assertEquals(fakeIntent, capturedIntent)
     }
 
+    @Test
+    fun `onPlatformSelected appends platform reftag to URL before building intent`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        var capturedShareData: SocialShareData? = null
+
+        val service = object : FakeSocialShareService() {
+            override suspend fun cacheImage(imageUrl: String): Uri = fakeImageUri
+            override fun buildIntent(
+                platform: SocialSharePlatform,
+                shareData: SocialShareData,
+                imageUri: Uri?
+            ): Intent {
+                capturedShareData = shareData
+                return Intent(Intent.ACTION_SEND)
+            }
+        }
+
+        val viewModel = buildViewModel(service, dispatcher = dispatcher)
+        advanceUntilIdle()
+
+        viewModel.onPlatformSelected(SocialSharePlatform.X)
+
+        val expectedUrl = UrlUtils.appendRefTag(shareData.projectUrl, RefTag.projectShareX().tag())
+        assertEquals(expectedUrl, capturedShareData?.projectUrl)
+    }
+
+    @Test
+    fun `onPlatformSelected fires CTA_CLICKED analytics event`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+
+        val service = object : FakeSocialShareService() {
+            override suspend fun cacheImage(imageUrl: String): Uri = fakeImageUri
+        }
+
+        val viewModel = buildViewModel(service, dispatcher = dispatcher)
+        advanceUntilIdle()
+
+        viewModel.onPlatformSelected(SocialSharePlatform.WHATSAPP)
+
+        segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
+    }
+
+    @Test
+    fun `onPlatformSelected does not fire analytics when intent is null`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+
+        val service = object : FakeSocialShareService() {
+            override suspend fun cacheImage(imageUrl: String): Uri = fakeImageUri
+            override fun buildIntent(
+                platform: SocialSharePlatform,
+                shareData: SocialShareData,
+                imageUri: Uri?
+            ): Intent? = null
+        }
+
+        val viewModel = buildViewModel(service, dispatcher = dispatcher)
+        advanceUntilIdle()
+
+        viewModel.onPlatformSelected(SocialSharePlatform.WHATSAPP)
+
+        segmentTrack.assertNoValues()
+    }
+
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // onCopyLinkClicked / onCopiedToastShown
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     @Test
-    fun `onCopyLinkClicked delegates to service and sets copiedToClipboard true`() = runTest {
+    fun `onCopyLinkClicked copies URL with copy link reftag appended`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         var copiedLabel: String? = null
         var copiedUrl: String? = null
@@ -262,9 +330,23 @@ class SocialShareViewModelTest : KSRobolectricTestCase() {
         viewModel.onCopyLinkClicked()
         advanceUntilIdle()
 
+        val expectedUrl = UrlUtils.appendRefTag(shareData.projectUrl, RefTag.projectShareCopyLink().tag())
         assertNotNull(copiedLabel)
-        assertEquals(shareData.projectUrl, copiedUrl)
+        assertEquals(expectedUrl, copiedUrl)
         assertTrue(viewModel.uiState.value.copiedToClipboard)
+    }
+
+    @Test
+    fun `onCopyLinkClicked fires CTA_CLICKED analytics event`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+
+        val viewModel = buildViewModel(FakeSocialShareService(), dispatcher = dispatcher)
+        advanceUntilIdle()
+
+        viewModel.onCopyLinkClicked()
+        advanceUntilIdle()
+
+        segmentTrack.assertValue(EventName.CTA_CLICKED.eventName)
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
@@ -58,7 +58,9 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
 
         composeTestRule.setContent {
             KSTheme {
-                VideoFeedScreen(items = items)
+                VideoFeedScreen(
+                    environment = environment(), items = items
+                )
             }
         }
 
@@ -108,7 +110,9 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
 
         composeTestRule.setContent {
             KSTheme {
-                VideoFeedScreen(items = items)
+                VideoFeedScreen(
+                    environment = environment(), items = items
+                )
             }
         }
 
@@ -130,6 +134,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     onClose = { closeCalled = true }
                 )
@@ -162,7 +167,9 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
 
         composeTestRule.setContent {
             KSTheme {
-                VideoFeedScreen(items = items)
+                VideoFeedScreen(
+                    environment = environment(), items = items
+                )
             }
         }
 
@@ -197,6 +204,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     onProfileClick = { capturedProject = it }
                 )
@@ -223,6 +231,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     onProfileClick = { capturedProject = it }
                 )
@@ -256,6 +265,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     projectCallback = { p, ref ->
                         capturedProject = p
@@ -283,6 +293,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     preLaunchedCallback = { p, ref ->
                         capturedProject = p
@@ -309,6 +320,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     preLaunchedCallback = { _, _ -> preLaunchedCalled = true }
                 )
@@ -331,6 +343,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     projectCallback = { _, _ -> projectCallbackCalled = true }
                 )
@@ -353,6 +366,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     onBookmarkClick = { p, _ -> capturedProject = p }
                 )
@@ -382,6 +396,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     onBookmarkClick = { _, index -> capturedIndex = index }
                 )
@@ -421,6 +436,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     onBookmarkClick = { p, _ -> capturedProject = p }
                 )
@@ -456,6 +472,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     onLoadMore = { loadMoreCallCount++ }
                 )
@@ -488,6 +505,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     onLoadMore = { loadMoreCalled = true }
                 )
@@ -508,6 +526,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     errorSnackBarHostState = snackbarHostState
                 )
@@ -528,7 +547,9 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
     fun `VideoFeedScreen renders without crash when items list is empty`() {
         composeTestRule.setContent {
             KSTheme {
-                VideoFeedScreen(items = emptyList())
+                VideoFeedScreen(
+                    environment = environment(), items = emptyList()
+                )
             }
         }
 
@@ -546,6 +567,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     onShareCTAClick = { capturedProject = it }
                 )
@@ -573,6 +595,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     onShareCTAClick = { shareImageUrl = it.photo()?.full() }
                 )

--- a/app/src/test/java/com/kickstarter/models/RefTagTest.kt
+++ b/app/src/test/java/com/kickstarter/models/RefTagTest.kt
@@ -259,4 +259,54 @@ class RefTagTest : TestCase() {
         assertTrue(updateShareRefTag is RefTag)
         assertEquals(updateShareRefTag.tag(), "android_update_share")
     }
+
+    @Test
+    fun testProjectShareCopyLink_returnsCorrectTag() {
+        assertEquals("android_project_share_copy_link", RefTag.projectShareCopyLink().tag())
+    }
+
+    @Test
+    fun testProjectShareInstagramFeed_returnsCorrectTag() {
+        assertEquals("android_project_share_instagram_feed", RefTag.projectShareInstagramFeed().tag())
+    }
+
+    @Test
+    fun testProjectShareInstagramStories_returnsCorrectTag() {
+        assertEquals("android_project_share_instagram_stories", RefTag.projectShareInstagramStories().tag())
+    }
+
+    @Test
+    fun testProjectShareX_returnsCorrectTag() {
+        assertEquals("android_project_share_x", RefTag.projectShareX().tag())
+    }
+
+    @Test
+    fun testProjectShareFacebookFeed_returnsCorrectTag() {
+        assertEquals("android_project_share_facebook_feed", RefTag.projectShareFacebookFeed().tag())
+    }
+
+    @Test
+    fun testProjectShareFacebookStories_returnsCorrectTag() {
+        assertEquals("android_project_share_facebook_stories", RefTag.projectShareFacebookStories().tag())
+    }
+
+    @Test
+    fun testProjectShareWhatsApp_returnsCorrectTag() {
+        assertEquals("android_project_share_whatsapp", RefTag.projectShareWhatsApp().tag())
+    }
+
+    @Test
+    fun testProjectShareMessages_returnsCorrectTag() {
+        assertEquals("android_project_share_messages", RefTag.projectShareMessages().tag())
+    }
+
+    @Test
+    fun testProjectShareEmail_returnsCorrectTag() {
+        assertEquals("android_project_share_email", RefTag.projectShareEmail().tag())
+    }
+
+    @Test
+    fun testProjectShareMore_returnsCorrectTag() {
+        assertEquals("android_project_share_more", RefTag.projectShareMore().tag())
+    }
 }

--- a/app/src/test/java/com/kickstarter/services/transformers/extensions/VideoFeedTransformersTest.kt
+++ b/app/src/test/java/com/kickstarter/services/transformers/extensions/VideoFeedTransformersTest.kt
@@ -263,6 +263,7 @@ private fun fixtureProject(
     watchesCount: Int? = 10,
     sharesCount: Int = 5,
     isWatched: Boolean = false,
+    url: String = "https://www.kickstarter.com/projects/creator/test-project",
     imageUrl: String = "https://example.com/project.jpg",
     pledged: VideoFeedProject.Pledged = VideoFeedProject.Pledged(
         __typename = "Money",
@@ -291,6 +292,7 @@ private fun fixtureProject(
         watchesCount = watchesCount,
         sharesCount = sharesCount,
         isWatched = isWatched,
+        url = url,
         imageUrl = imageUrl,
         pledged = pledged,
         creator = creator,


### PR DESCRIPTION
# 📲 What

- Adds platform-specific reftags and a `CTA Clicked` analytics event to the Social Share bottom sheet. 
- Also ships three bug fixes uncovered during implementation: 
- - empty project URL in share payloads for VideoFeed
- - the email intent incorrectly surfacing Instagram as a candidate
- - invisible monochrome icons in dark mode

# 🤔 Why

Share projects from the Video Feed were not attribution-tracked, making it impossible to measure how users discover projects via social sharing. Each platform needed its own reftag appended to the shared URL so downstream analytics can attribute traffic back to the specific channel (X, WhatsApp, email, etc.).

# 🛠 How

**Analytics & reftags**
- Added 10 platform-specific RefTag factory methods (android_project_share_copy_link, android_project_share_x, android_project_share_whatsapp, etc.).
- Added SHARE_PLATFORM_CLICKED to CtaContextName and a new SharePlatformContextType enum covering all 10 platforms.
- Added trackSharePlatformCTAClicked(platform, contextPage) to AnalyticEvents, firing CTA_CLICKED with context_cta, context_page, and context_type properties.
- `SocialShareViewModel` now receives Environment (contains analytics client) and ContextPageName (for the page property). Before building the share intent or copying to clipboard, it appends the platform's reftag to the URL via `UrlUtils.appendRefTag` and fires the analytics event.

**Bug: empty project URL in VideoFeed payloads**
The videoFeedProject GraphQL fragment was missing the url field, so project.urls()?.web()?.project() always returned "". Added url to the fragment and mapped it through VideoFeedTransformers into Urls → Web.project(). Originally Social Share feature was developed under PreLaunch page scope.

**Bug: email intent surfacing Instagram**
emailIntent with an image was using ACTION_SEND + type = "image/jpeg" with no package restriction. Android's intent resolver presented Instagram as a top candidate. Changed to type = "message/rfc822" (the standard email MIME type), which limits the chooser to email clients only while still allowing the image attachment.

**Bug: monochrome icons invisible in dark mode**
Platform icons (Copy Link, X, Email, Messages, More) use hardcoded dark-grey SVG paths (#3C3C3C / black). The icon container was using backgroundSurfaceRaised (dark in dark mode) and tint = Color.Unspecified (no override). Added monochromeIconTint to KSSocialShareColors (black in light, white in dark), switched the container background to socialShare.iconBackground (white in light, #222222 in dark), and applied the tint selectively — brand icons (Instagram, Facebook, WhatsApp) keep Color.Unspecified to preserve their gradients/colors.

# 👀 See


https://github.com/user-attachments/assets/151901ed-4b1f-4fc0-ac6e-b5f55d774086



|  |  |

# 📋 QA

1 - Open the Video Feed and tap the share icon on any project.
Reftags — tap each platform and verify the shared URL contains the expected ?ref= parameter:
- Copy Link → ?ref=android_project_share_copy_link
- Instagram Feed/Stories → android_project_share_instagram_feed / _stories
- X → android_project_share_x
- Facebook Feed/Stories → android_project_share_facebook_feed / _stories
- WhatsApp → android_project_share_whatsapp
- Messages → android_project_share_messages
- Email → android_project_share_email
- More → android_project_share_more

2 - Analytics — confirm a CTA Clicked event fires with `context_cta: share_platform_clicked`, the correct `context_page`, and `context_type` matching the tapped platform.

3 - Dark mode — switch device to dark mode, open the share sheet, and confirm all icons are visible (Copy Link, X, Email, Messages, More should appear white on dark circles).

4 - Email — tap the Email icon and confirm only email apps appear in the chooser (no Instagram, WhatsApp, etc.).
Copy Link — tap Copy Link and paste; confirm the pasted URL is a full Kickstarter URL with reftag, not just ?ref=....

# Story 📖

[DISC-209](https://kickstarter.atlassian.net/browse/DISC-209)


[DISC-209]: https://kickstarter.atlassian.net/browse/DISC-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ