### PR TITLE
CHECK-187: Tests + Apply the no-reward A/B experiment to projects in different states

### DIFF
--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
@@ -22,6 +22,7 @@ import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.usecases.GetShippingRulesUseCase
 import com.kickstarter.viewmodels.usecases.NoRewardPlacement
 import com.kickstarter.viewmodels.usecases.ShippingRulesState
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -56,8 +57,6 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
     private val currentUserV2 = requireNotNull(environment.currentUserV2())
     private val statsigClient = requireNotNull(environment.statsigClient())
 
-    private var statsigTimeout = 500L
-
     private lateinit var currentProjectData: ProjectData
     private var pReason: PledgeReason? = null
     private var previousUserBacking: Backing? = null
@@ -65,6 +64,8 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
     private var indexOfBackedReward = 0
     private var newUserReward: Reward = Reward.builder().build()
     private var selectedShippingRule: ShippingRule = ShippingRuleFactory.emptyShippingRule()
+
+    private var shippingRuleUseCaseDispatcher = Dispatchers.IO
 
     private val mutableRewardSelectionUIState = MutableStateFlow(RewardSelectionUIState())
     val rewardSelectionUIState: StateFlow<RewardSelectionUIState>
@@ -118,7 +119,7 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
                      * just `Statsig.updateUser()` after the user completes the auth flow upon clicking 'Back this project'.
                      * We could also _not_ wait, and access the StateFlow values directly, but this will result in an
                      * even less consistent and deterministic experience for users. */
-                    noRewardPlacement = withTimeoutOrNull(statsigTimeout) {
+                    noRewardPlacement = withTimeoutOrNull(STATSIG_TIMEOUT) {
                         statsigClient.isReady.first { it }
                         statsigClient.statsigUser.first { it.userID != null }
                         val experiment = statsigClient.getExperiment(StatsigExperiments.MoveNoRewardOption.name)
@@ -141,7 +142,7 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
                             config = config,
                             projectRewards = rewardsList,
                             viewModelScope,
-                            Dispatchers.IO,
+                            shippingRuleUseCaseDispatcher,
                             noRewardPlacement,
                         )
                     }
@@ -278,8 +279,8 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
     }
 
     @VisibleForTesting
-    fun setStatsigTimeout(timeMillis: Long) {
-        statsigTimeout = timeMillis
+    fun setShippingRuleUseCaseDispatcher(dispatcher: CoroutineDispatcher) {
+        shippingRuleUseCaseDispatcher = dispatcher
     }
 
     class Factory(private val environment: Environment, private var shippingRulesUseCase: GetShippingRulesUseCase? = null) :
@@ -287,5 +288,9 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             return RewardsSelectionViewModel(environment = environment, shippingRulesUseCase) as T
         }
+    }
+
+    companion object {
+        const val STATSIG_TIMEOUT = 500L
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/RewardsSelectionViewModel.kt
@@ -291,6 +291,6 @@ class RewardsSelectionViewModel(private val environment: Environment, private va
     }
 
     companion object {
-        const val STATSIG_TIMEOUT = 500L
+        private const val STATSIG_TIMEOUT = 500L
     }
 }

--- a/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCase.kt
@@ -118,14 +118,12 @@ class GetShippingRulesUseCase(
             }
             // - all rewards digital
             if (rewardsByShippingType.isEmpty() && project.isAllowedToPledge()) {
-                filteredRewards.clear()
-                filteredRewards.addAll(RewardUtils.filterHasStarted(projectRewards))
+                setRewardsList(RewardUtils.filterHasStarted(projectRewards), noRewardPlacement)
             }
 
             // - Just displaying all rewards available or not, project no collecting any longer
             if (!project.isAllowedToPledge()) {
-                filteredRewards.clear()
-                filteredRewards.addAll(RewardUtils.filterHasStarted(projectRewards))
+                setRewardsList(RewardUtils.filterHasStarted(projectRewards), noRewardPlacement)
             }
 
             emitCurrentState(isLoading = false)

--- a/app/src/test/java/com/kickstarter/KSRobolectricTestCase.kt
+++ b/app/src/test/java/com/kickstarter/KSRobolectricTestCase.kt
@@ -10,6 +10,7 @@ import com.kickstarter.libs.Environment
 import com.kickstarter.libs.KSCurrency
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.MockCurrentUserV2
+import com.kickstarter.libs.MockStatsigClient
 import com.kickstarter.libs.MockTrackingClient
 import com.kickstarter.libs.TrackingClientType
 import com.kickstarter.libs.featureflag.FeatureFlagClientType
@@ -61,6 +62,7 @@ abstract class KSRobolectricTestCase : TestCase() {
         val mockCurrentConfigV2 = MockCurrentConfigV2()
         val mockFeatureFlagClient = MockFeatureFlagClient()
         val segmentTestClient = segmentTrackingClient(mockCurrentConfigV2, mockFeatureFlagClient)
+        val mockStatsigClient = MockStatsigClient(application())
 
         val component = DaggerApplicationComponent.builder()
             .applicationModule(TestApplicationModule(application()))
@@ -78,6 +80,7 @@ abstract class KSRobolectricTestCase : TestCase() {
             .analytics(AnalyticEvents(listOf(segmentTestClient)))
             .attributionEvents(AttributionEvents(mockApolloClientV2))
             .featureFlagClient(mockFeatureFlagClient)
+            .statsigClient(mockStatsigClient)
             .build()
     }
 

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
@@ -873,7 +873,7 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `A-B Experiment - experiment is fetched for authenticated user + no-reward option is first given Test parameters`() = runTest(mainDispatcher) {
+    fun `A-B Experiment - experiment is fetched for authenticated user + no-reward option is last given Test parameters`() = runTest(mainDispatcher) {
         Dispatchers.setMain(mainDispatcher)
 
         val noReward = RewardFactory.noReward()

--- a/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/RewardsSelectionViewModelTest.kt
@@ -3,6 +3,8 @@ package com.kickstarter.viewmodels
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUserV2
+import com.kickstarter.libs.MockStatsigClient
+import com.kickstarter.libs.featureflag.StatsigExperiments
 import com.kickstarter.libs.utils.EventName
 import com.kickstarter.mock.MockCurrentConfigV2
 import com.kickstarter.mock.factories.BackingFactory
@@ -13,9 +15,11 @@ import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.mock.factories.ShippingRuleFactory
 import com.kickstarter.mock.factories.ShippingRulesEnvelopeFactory
 import com.kickstarter.mock.factories.UserFactory
+import com.kickstarter.mock.services.MockApolloClientV2
 import com.kickstarter.models.Backing
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
+import com.kickstarter.type.ProjectRewardsSort
 import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.ui.data.ProjectData
 import com.kickstarter.viewmodels.projectpage.FlowUIState
@@ -23,12 +27,20 @@ import com.kickstarter.viewmodels.projectpage.RewardSelectionUIState
 import com.kickstarter.viewmodels.projectpage.RewardsSelectionViewModel
 import com.kickstarter.viewmodels.usecases.GetShippingRulesUseCase
 import com.kickstarter.viewmodels.usecases.ShippingRulesState
+import com.statsig.androidsdk.DynamicConfig
+import com.statsig.androidsdk.StatsigUser
+import io.reactivex.Observable
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -36,9 +48,26 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
 
     private lateinit var viewModel: RewardsSelectionViewModel
 
+    private val mainDispatcher = StandardTestDispatcher()
+
+    private fun mockStatsigClient(
+        experimentMap: Map<String, Map<String, Any>> = emptyMap(),
+        getExperiment: (String) -> Unit,
+    ) = object : MockStatsigClient(context = application(), experimentMap = experimentMap, startReady = true) {
+        override fun getExperiment(experimentName: String): DynamicConfig {
+            getExperiment(experimentName)
+            return super.getExperiment(experimentName)
+        }
+    }
+
     private fun createViewModel(environment: Environment = environment(), useCase: GetShippingRulesUseCase? = null) {
         viewModel =
             RewardsSelectionViewModel.Factory(environment, useCase).create(RewardsSelectionViewModel::class.java)
+    }
+
+    @After
+    fun after() {
+        Dispatchers.resetMain()
     }
 
     @Test
@@ -394,7 +423,9 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `Default Location when Backing Project is backed location, and list of shipping rules for restricted is all places available for all restricted rewards without duplicated`() = runTest {
+    fun `Default Location when Backing Project is backed location, and list of shipping rules for restricted is all places available for all restricted rewards without duplicated`() = runTest(mainDispatcher) {
+        Dispatchers.setMain(mainDispatcher)
+
         val testShippingRulesList = ShippingRulesEnvelopeFactory.shippingRules().shippingRules()
 
         val rw1 = RewardFactory
@@ -454,7 +485,6 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         val shippingUiState = mutableListOf<ShippingRulesState>()
         backgroundScope.launch(dispatcher) {
             createViewModel(env)
-            viewModel.setStatsigTimeout(0L)
             viewModel.provideProjectData(projectData)
 
             val useCase = GetShippingRulesUseCase(project, config, rwList, this, dispatcher)
@@ -471,7 +501,9 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `config is from Canada and available rules are global so Default Shipping is Canada, and list of shipping Rules provided matches all available reward global shipping`() = runTest {
+    fun `config is from Canada and available rules are global so Default Shipping is Canada, and list of shipping Rules provided matches all available reward global shipping`() = runTest(mainDispatcher) {
+        Dispatchers.setMain(mainDispatcher)
+
         val testShippingRulesList = ShippingRulesEnvelopeFactory.shippingRules()
         val rw = RewardFactory
             .reward()
@@ -499,7 +531,6 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         val shippingUiState = mutableListOf<ShippingRulesState>()
         backgroundScope.launch(dispatcher) {
             createViewModel(env)
-            viewModel.setStatsigTimeout(0L)
             viewModel.provideProjectData(projectData)
             val useCase = GetShippingRulesUseCase(project, config, rwList, this, dispatcher)
             viewModel.overrideShippingRulesUseCase(useCase)
@@ -595,5 +626,314 @@ class RewardsSelectionViewModelTest : KSRobolectricTestCase() {
         advanceUntilIdle() // wait until all state emissions completed
         assertEquals(viewModel.shouldShowAlert(), false)
         assertEquals(viewModel.getPledgeData()?.second, PledgeReason.LATE_PLEDGE)
+    }
+
+    @Test
+    fun `A-B Experiment - for a logged out user, no experiment is fetched and the no-reward option is first `() = runTest(mainDispatcher) {
+        Dispatchers.setMain(mainDispatcher)
+
+        val noReward = RewardFactory.noReward()
+        val testRewards: List<Reward> = (0..8).map {
+            when (it) {
+                0 -> noReward
+                else -> Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(false).build()
+            }
+        }
+        val testProject = Project.builder().rewards(testRewards).build()
+        val testProjectData = ProjectData.builder().project(testProject).build()
+
+        val apolloClient = object : MockApolloClientV2() {
+            override fun getRewardsFromProject(slug: String, sort: ProjectRewardsSort): Observable<List<Reward>> {
+                return Observable.just(testRewards)
+            }
+        }
+
+        val config = ConfigFactory.configForUSUser()
+        val currentConfigV2 = MockCurrentConfigV2()
+        currentConfigV2.config(config)
+
+        var getExperimentCount = 0
+        val statsigClient = mockStatsigClient { experimentName ->
+            getExperimentCount++
+        }
+        statsigClient.setStatsigUser(StatsigUser())
+
+        val environment = environment().toBuilder()
+            .apolloClientV2(apolloClient)
+            .currentConfig2(currentConfigV2)
+            .statsigClient(statsigClient)
+            .build()
+        createViewModel(environment)
+
+        val standardDispatcher = StandardTestDispatcher(testScheduler)
+        viewModel.setShippingRuleUseCaseDispatcher(standardDispatcher)
+
+        val shippingUiState = mutableListOf<ShippingRulesState>()
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        backgroundScope.launch(unconfinedDispatcher) {
+            viewModel.shippingUIState.toList(shippingUiState)
+        }
+
+        viewModel.provideProjectData(testProjectData)
+
+        advanceUntilIdle()
+
+        val outputRewards = shippingUiState.last().filteredRw
+
+        assertEquals(0, getExperimentCount)
+        assertEquals(noReward, outputRewards.first())
+    }
+
+    @Test
+    fun `A-B Experiment - if Statsig hasn't been updated with an authenticated user, no experiment is fetched and the no-reward option is first `() = runTest(mainDispatcher) {
+        Dispatchers.setMain(mainDispatcher)
+
+        val noReward = RewardFactory.noReward()
+        val testRewards: List<Reward> = (0..8).map {
+            when (it) {
+                0 -> noReward
+                else -> Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(false).build()
+            }
+        }
+        val testProject = Project.builder().rewards(testRewards).build()
+        val testProjectData = ProjectData.builder().project(testProject).build()
+
+        val apolloClient = object : MockApolloClientV2() {
+            override fun getRewardsFromProject(slug: String, sort: ProjectRewardsSort): Observable<List<Reward>> {
+                return Observable.just(testRewards)
+            }
+        }
+
+        val config = ConfigFactory.configForUSUser()
+        val currentConfigV2 = MockCurrentConfigV2()
+        currentConfigV2.config(config)
+
+        val user = UserFactory.user()
+        val currentUserV2 = MockCurrentUserV2(user)
+
+        var getExperimentCount = 0
+        val statsigClient = mockStatsigClient { experimentName ->
+            getExperimentCount++
+        }
+        statsigClient.setStatsigUser(StatsigUser())
+
+        val environment = environment().toBuilder()
+            .apolloClientV2(apolloClient)
+            .currentConfig2(currentConfigV2)
+            .currentUserV2(currentUserV2)
+            .statsigClient(statsigClient)
+            .build()
+        createViewModel(environment)
+
+        val standardDispatcher = StandardTestDispatcher(testScheduler)
+        viewModel.setShippingRuleUseCaseDispatcher(standardDispatcher)
+
+        val shippingUiState = mutableListOf<ShippingRulesState>()
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        backgroundScope.launch(unconfinedDispatcher) {
+            viewModel.shippingUIState.toList(shippingUiState)
+        }
+
+        viewModel.provideProjectData(testProjectData)
+
+        advanceUntilIdle()
+
+        val outputRewards = shippingUiState.last().filteredRw
+
+        assertEquals(0, getExperimentCount)
+        assertEquals(noReward, outputRewards.first())
+    }
+
+    @Test
+    fun `A-B Experiment - experiment is fetched for authenticated user but missing so the no-reward option is first `() = runTest(mainDispatcher) {
+        /* This is the scenario when Statsig fails to properly initialize via network call, and
+         * no configuration has been cached. */
+
+        Dispatchers.setMain(mainDispatcher)
+
+        val noReward = RewardFactory.noReward()
+        val testRewards: List<Reward> = (0..8).map {
+            when (it) {
+                0 -> noReward
+                else -> Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(false).build()
+            }
+        }
+        val testProject = Project.builder().rewards(testRewards).build()
+        val testProjectData = ProjectData.builder().project(testProject).build()
+
+        val apolloClient = object : MockApolloClientV2() {
+            override fun getRewardsFromProject(slug: String, sort: ProjectRewardsSort): Observable<List<Reward>> {
+                return Observable.just(testRewards)
+            }
+        }
+
+        val config = ConfigFactory.configForUSUser()
+        val currentConfigV2 = MockCurrentConfigV2()
+        currentConfigV2.config(config)
+
+        val user = UserFactory.user()
+        val currentUserV2 = MockCurrentUserV2(user)
+
+        var getExperimentCount = 0
+        val statsigClient = mockStatsigClient(mapOf()) { experimentName ->
+            getExperimentCount++
+        }
+        statsigClient.setStatsigUser(StatsigUser(userID = user.id().toString()))
+
+        val environment = environment().toBuilder()
+            .apolloClientV2(apolloClient)
+            .currentConfig2(currentConfigV2)
+            .currentUserV2(currentUserV2)
+            .statsigClient(statsigClient)
+            .build()
+        createViewModel(environment)
+
+        val standardDispatcher = StandardTestDispatcher(testScheduler)
+        viewModel.setShippingRuleUseCaseDispatcher(standardDispatcher)
+
+        val shippingUiState = mutableListOf<ShippingRulesState>()
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        backgroundScope.launch(unconfinedDispatcher) {
+            viewModel.shippingUIState.toList(shippingUiState)
+        }
+
+        viewModel.provideProjectData(testProjectData)
+
+        advanceUntilIdle()
+
+        val outputRewards = shippingUiState.last().filteredRw
+
+        assertEquals(1, getExperimentCount)
+        assertEquals(noReward, outputRewards.first())
+    }
+
+    @Test
+    fun `A-B Experiment - experiment is fetched for authenticated user + no-reward option is first given Control parameters`() = runTest(mainDispatcher) {
+        Dispatchers.setMain(mainDispatcher)
+
+        val noReward = RewardFactory.noReward()
+        val testRewards: List<Reward> = (0..8).map {
+            when (it) {
+                0 -> noReward
+                else -> Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(false).build()
+            }
+        }
+        val testProject = Project.builder().rewards(testRewards).build()
+        val testProjectData = ProjectData.builder().project(testProject).build()
+
+        val apolloClient = object : MockApolloClientV2() {
+            override fun getRewardsFromProject(slug: String, sort: ProjectRewardsSort): Observable<List<Reward>> {
+                return Observable.just(testRewards)
+            }
+        }
+
+        val config = ConfigFactory.configForUSUser()
+        val currentConfigV2 = MockCurrentConfigV2()
+        currentConfigV2.config(config)
+
+        val user = UserFactory.user()
+        val currentUserV2 = MockCurrentUserV2(user)
+
+        var getExperimentCount = 0
+        val experimentMap = mapOf(
+            StatsigExperiments.MoveNoRewardOption.name to mapOf(
+                StatsigExperiments.MoveNoRewardOption.parameters.PLACE_AT_END to false
+            )
+        )
+        val statsigClient = mockStatsigClient(experimentMap) { experimentName ->
+            getExperimentCount++
+        }
+        statsigClient.setStatsigUser(StatsigUser(userID = user.id().toString()))
+
+        val environment = environment().toBuilder()
+            .apolloClientV2(apolloClient)
+            .currentConfig2(currentConfigV2)
+            .currentUserV2(currentUserV2)
+            .statsigClient(statsigClient)
+            .build()
+        createViewModel(environment)
+
+        val standardDispatcher = StandardTestDispatcher(testScheduler)
+        viewModel.setShippingRuleUseCaseDispatcher(standardDispatcher)
+
+        val shippingUiState = mutableListOf<ShippingRulesState>()
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        backgroundScope.launch(unconfinedDispatcher) {
+            viewModel.shippingUIState.toList(shippingUiState)
+        }
+
+        viewModel.provideProjectData(testProjectData)
+
+        advanceUntilIdle()
+
+        val outputRewards = shippingUiState.last().filteredRw
+
+        assertEquals(1, getExperimentCount)
+        assertEquals(noReward, outputRewards.first())
+    }
+
+    @Test
+    fun `A-B Experiment - experiment is fetched for authenticated user + no-reward option is first given Test parameters`() = runTest(mainDispatcher) {
+        Dispatchers.setMain(mainDispatcher)
+
+        val noReward = RewardFactory.noReward()
+        val testRewards: List<Reward> = (0..8).map {
+            when (it) {
+                0 -> noReward
+                else -> Reward.builder().title("$it").id(it.toLong()).isAvailable(true).hasAddons(false).build()
+            }
+        }
+        val testProject = Project.builder().rewards(testRewards).build()
+        val testProjectData = ProjectData.builder().project(testProject).build()
+
+        val apolloClient = object : MockApolloClientV2() {
+            override fun getRewardsFromProject(slug: String, sort: ProjectRewardsSort): Observable<List<Reward>> {
+                return Observable.just(testRewards)
+            }
+        }
+
+        val config = ConfigFactory.configForUSUser()
+        val currentConfigV2 = MockCurrentConfigV2()
+        currentConfigV2.config(config)
+
+        val user = UserFactory.user()
+        val currentUserV2 = MockCurrentUserV2(user)
+
+        var getExperimentCount = 0
+        val experimentMap = mapOf(
+            StatsigExperiments.MoveNoRewardOption.name to mapOf(
+                StatsigExperiments.MoveNoRewardOption.parameters.PLACE_AT_END to true
+            )
+        )
+        val statsigClient = mockStatsigClient(experimentMap) { experimentName ->
+            getExperimentCount++
+        }
+        statsigClient.setStatsigUser(StatsigUser(userID = user.id().toString()))
+
+        val environment = environment().toBuilder()
+            .apolloClientV2(apolloClient)
+            .currentConfig2(currentConfigV2)
+            .currentUserV2(currentUserV2)
+            .statsigClient(statsigClient)
+            .build()
+        createViewModel(environment)
+
+        val standardDispatcher = StandardTestDispatcher(testScheduler)
+        viewModel.setShippingRuleUseCaseDispatcher(standardDispatcher)
+
+        val shippingUiState = mutableListOf<ShippingRulesState>()
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        backgroundScope.launch(unconfinedDispatcher) {
+            viewModel.shippingUIState.toList(shippingUiState)
+        }
+
+        viewModel.provideProjectData(testProjectData)
+
+        advanceUntilIdle()
+
+        val outputRewards = shippingUiState.last().filteredRw
+
+        assertEquals(1, getExperimentCount)
+        assertEquals(noReward, outputRewards.last())
     }
 }

--- a/app/src/test/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCaseTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/usecases/GetShippingRulesUseCaseTest.kt
@@ -11,12 +11,14 @@ import com.kickstarter.models.Reward
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.joda.time.DateTime
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class GetShippingRulesUseCaseTest : KSRobolectricTestCase() {
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -329,5 +331,81 @@ class GetShippingRulesUseCaseTest : KSRobolectricTestCase() {
         val filtered = state.last().filteredRw
         assertEquals(2, filtered.size)
         assertEquals(listOf(validReward, expiredReward), filtered)
+    }
+
+    @Test
+    fun `test no-reward option is placed first for NoRewardPlacement_START`() = runTest {
+        val noReward = RewardFactory.noReward()
+        val rewards: List<Reward> = (0..2).map {
+            when (it) {
+                0 -> noReward
+                else -> Reward.builder().title("$it").id(it.toLong()).isAvailable(true).build()
+            }
+        }
+
+        val project = ProjectFactory.project()
+            .toBuilder()
+            .rewards(rewards)
+            .build()
+
+        val config = ConfigFactory.configForUSUser()
+
+        val standardDispatcher = StandardTestDispatcher(testScheduler)
+        val useCase = GetShippingRulesUseCase(
+            project, config, project.rewards()!!, this, standardDispatcher, NoRewardPlacement.START
+        )
+
+        val states = mutableListOf<ShippingRulesState>()
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        backgroundScope.launch(unconfinedDispatcher) {
+            useCase.shippingRulesState.toList(states)
+        }
+
+        useCase.invoke()
+
+        advanceUntilIdle()
+
+        val filteredRw = states.last().filteredRw
+
+        assertEquals(rewards.size, filteredRw.size)
+        assertEquals(noReward, filteredRw.first())
+    }
+
+    @Test
+    fun `test no-reward option is placed last for NoRewardPlacement_END`() = runTest {
+        val noReward = RewardFactory.noReward()
+        val rewards: List<Reward> = (0..2).map {
+            when (it) {
+                0 -> noReward
+                else -> Reward.builder().title("$it").id(it.toLong()).isAvailable(true).build()
+            }
+        }
+
+        val project = ProjectFactory.project()
+            .toBuilder()
+            .rewards(rewards)
+            .build()
+
+        val config = ConfigFactory.configForUSUser()
+
+        val standardDispatcher = StandardTestDispatcher(testScheduler)
+        val useCase = GetShippingRulesUseCase(
+            project, config, project.rewards()!!, this, standardDispatcher, NoRewardPlacement.END
+        )
+
+        val states = mutableListOf<ShippingRulesState>()
+        val unconfinedDispatcher = UnconfinedTestDispatcher(testScheduler)
+        backgroundScope.launch(unconfinedDispatcher) {
+            useCase.shippingRulesState.toList(states)
+        }
+
+        useCase.invoke()
+
+        advanceUntilIdle()
+
+        val filteredRw = states.last().filteredRw
+
+        assertEquals(rewards.size, filteredRw.size)
+        assertEquals(noReward, filteredRw.last())
     }
 }


### PR DESCRIPTION
# 📲 What

As an immediate follow up to #2517, update `GetShippingRulesUseCase` such that the A/B experiment applies for all-digital rewards lists, and for rewards that belong to ended Projects.

In addition, add inclusive tests for changes across both PRs.

# 🤔 Why

- For users that are a part of the experiment, this helps to ensure a more consistent experience when viewing the rewards carousel for all Projects.
- As a critical part of the user journey, we aim to include thorough automated tests for all parts of the pledge flow.

# 🛠 How

The adjustments to `GetShippingRulesUseCase` are small and straightforward.

With regard to testing:

- To enable deterministic control of the shipping rules UseCase created within `RewardsSelectionViewModel`, we move the hardcoded `IO` Dispatcher to a variable that can be (and is) overridden in tests as necessary.
- To enable more deterministic control of `RewardsSelectionViewModel`'s coroutines, and proper test support, we update certain instances of `runTest` to execute on a `StandardTestDispatcher`, and leverage `Dispatchers.setMain()` to replace the dispatcher used by `viewModelScope` with a test dispatcher that shares the same scheduler.
  - By using a test scheduler, time-based operations such as `withTimeoutOrNull` can be skipped normally or managed manually, removing the need for `setStatsigTimeout()`.
- For integrity, add a `MockStatsigClient` to the base `environment` created in `KSRobolectricTestCase`.

# 👀 See

https://github.com/user-attachments/assets/b6506b67-c355-4c1a-a699-f3170716c327

# 📋 QA

Override your User ID into the Test group for the [move_no-reward_option_android](https://console.statsig.com/63RYuAXh4n2yKAubACXeg1/experiments/move_no-reward_option_android/setup) Experiment, and visit the rewards carousel for any Ended Project.

# Story 📖

- [\[CHECK-27\] [Tech Plan] A/B test move bonus support card on mobile from first to last - Jira](https://kickstarter.atlassian.net/browse/CHECK-27)
- [\[CHECK-187\] Apply the no-reward A/B experiment to projects in different states - Jira](https://kickstarter.atlassian.net/browse/CHECK-187)