### PR TITLE
DISC-224: Allow `ImageViewElement` to display `"src"` if `"data-src"` is blank

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/htmlparser/ElementExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/htmlparser/ElementExt.kt
@@ -76,7 +76,10 @@ fun Element.parseImageElement(): ImageViewElement {
 
     // - it's a gif collect attribute data-src instead
     if (src.contains(".gif")) {
-        src = this.children().getOrNull(0)?.children()?.getOrNull(0)?.attr("data-src").toString()
+        val dataSrc = this.children().getOrNull(0)?.children()?.getOrNull(0)?.attr("data-src").toString()
+        if (dataSrc.isNotBlank()) {
+            src = dataSrc
+        }
     }
 
     return ImageViewElement(src = src, href = href, caption = caption)

--- a/app/src/test/java/com/kickstarter/libs/htmlparser/HTMLParserTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/htmlparser/HTMLParserTest.kt
@@ -122,6 +122,24 @@ class HTMLParserTest {
     }
 
     @Test
+    fun parseGifWithMissingDataSrc() {
+        val src = "https://i.kickstarter.com/assets/035/272/962/ad1848184f8254f017730e6978565521_original.gif?anim=false&fit=contain&origin=ugc-qa&q=92&width=700&sig=rvKKMk41FS3KoXYlBctOWRpnysKR58LIBwkmNXHmL5I%3D"
+        val onlyImageHtml = "<div class=\"template asset\" contenteditable=\"false\" data-alt-text=\"\" data-caption=\"\" data-id=\"35272962\">\n" +
+            "<figure>" +
+            "\n<img alt=\"\" class=\"fit js-lazy-image\" data-src=\"\" src=\"$src\">\n" +
+            "<figcaption class=\"px2\">This is Ted having the time of his life with a caption and a link</figcaption>" +
+            "</figure>" +
+            "\n\n</div>\n"
+
+        println("onlyImageHtml: $onlyImageHtml")
+
+        val listOfElements = HTMLParser().parse(onlyImageHtml)
+        val imageView: ImageViewElement = listOfElements.first() as ImageViewElement
+        assert(listOfElements.size == 1)
+        assert(imageView.src == src)
+    }
+
+    @Test
     fun parseTextElementListWithNestedLinks() {
 
         val url = "https://www.meneame.net/"

--- a/app/src/test/java/com/kickstarter/libs/htmlparser/HTMLParserTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/htmlparser/HTMLParserTest.kt
@@ -131,8 +131,6 @@ class HTMLParserTest {
             "</figure>" +
             "\n\n</div>\n"
 
-        println("onlyImageHtml: $onlyImageHtml")
-
         val listOfElements = HTMLParser().parse(onlyImageHtml)
         val imageView: ImageViewElement = listOfElements.first() as ImageViewElement
         assert(listOfElements.size == 1)


### PR DESCRIPTION
# 📲 What

Allow `ImageViewElement` to display `"src"` if `"data-src"` is blank.

# 🤔 Why

GIF `<image>` elements in the `Project.story` HTML have historically included both `"src"` and `"data-src"` attributes, the former referencing a still image, and the latter referencing an animated image. (This duo of attributes was previously used in concert on the web to show a placeholder while lazily loading the animated image.)

Currently, the `ImageViewElement` overwrites the parsed `"src"` with the value of `"data-src"`, even if it's blank. In the future, the `"data-src"` attribute may always be empty or missing (and thus parsed as an empty string), a change that was temporarily applied on the backend, leading to GIFs not loading within the project story tab (initially reported as a mobile [SD ticket](https://kickstarter.atlassian.net/browse/DISC-223)).

# 🛠 How

Check that the value parsed from `"data-src"` is not blank before replacing the value parsed from `"src"`.

Same fix on [iOS](https://github.com/kickstarter/ios-oss/pull/2870).

# 👀 See

### Before 🐛

https://github.com/user-attachments/assets/3c186820-04af-49e7-961c-bf2af94fd293

### After 🦋

https://github.com/user-attachments/assets/5658f369-f222-463b-b97d-63e44598b03b

# 📋 QA

Visit any Project that includes GIFs in the campaign story, e.g. (on prod):

- [Amethysts & Alchemy Deluxe Special Edition by Rachel Rener — Kickstarter](https://www.kickstarter.com/projects/author-rachel-rener/amethysts-and-alchemy-deluxe-special-edition)
- [Feed the Scorchpot: A Digital Tabletop Roguelike by Indieformer — Kickstarter](https://www.kickstarter.com/projects/indieformer/feed-the-scorchpot-a-digital-tabletop-roguelike)

# Story 📖

[\[DISC-224\] [Android] GIFs do not populate on mobile for HRC4s live project. - Jira](https://kickstarter.atlassian.net/browse/DISC-224)
