### PR TITLE
DISC-212: New error UI

### DIFF
--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
@@ -56,13 +56,14 @@ import com.kickstarter.libs.utils.extensions.isTrue
 import com.kickstarter.libs.utils.extensions.toCompactFormat
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.models.Project
-import com.kickstarter.ui.compose.designsystem.KSErrorSnackbar
-import com.kickstarter.ui.compose.designsystem.KSHeadsupSnackbar
 import com.kickstarter.ui.compose.designsystem.KSSnackbarTypes
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
+import com.kickstarter.ui.compose.designsystem.KSVideoFeedSnackbar
 import com.kickstarter.ui.compose.designsystem.videoplayer.KSVideoPlayer
 import com.kickstarter.ui.compose.designsystem.videoplayer.icons.Close
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.rememberHazeState
 import kotlinx.coroutines.launch
 
 enum class VideoFeedScreenTestTag {
@@ -129,10 +130,13 @@ fun VideoFeedScreen(
         previousSettledPage = currentPage
     }
 
+    val screenHazeState = rememberHazeState()
+
     Box(modifier = Modifier.fillMaxSize()) {
         VerticalPager(
             modifier = Modifier
                 .fillMaxSize()
+                .hazeSource(state = screenHazeState)
                 .testTag(VideoFeedScreenTestTag.VIDEO_FEED_PAGER.name),
             state = pagerState,
             beyondViewportPageCount = 1,
@@ -269,14 +273,16 @@ fun VideoFeedScreen(
         }
 
         SnackbarHost(
-            modifier = Modifier.align(Alignment.BottomCenter),
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(
+                    top = dimensions.videoFeedCloseButtonTopPadding,
+                    start = dimensions.paddingMediumSmall,
+                    end = dimensions.paddingMediumSmall
+                ),
             hostState = errorSnackBarHostState,
             snackbar = { data ->
-                if (data.visuals.actionLabel == KSSnackbarTypes.KS_ERROR.name) {
-                    KSErrorSnackbar(text = data.visuals.message)
-                } else {
-                    KSHeadsupSnackbar(text = data.visuals.message)
-                }
+                KSVideoFeedSnackbar(text = data.visuals.message, hazeState = screenHazeState)
             }
         )
     }
@@ -288,6 +294,7 @@ fun setUpVideoFeedErrorActions(snackbarHostState: SnackbarHostState): (String?) 
     val defaultErrorMessage = stringResource(R.string.Something_went_wrong_please_try_again)
     return { message: String? ->
         scope.launch {
+            snackbarHostState.currentSnackbarData?.dismiss()
             snackbarHostState.showSnackbar(
                 message = message ?: defaultErrorMessage,
                 actionLabel = KSSnackbarTypes.KS_ERROR.name,

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
@@ -281,9 +281,9 @@ fun VideoFeedScreen(
             modifier = Modifier
                 .align(Alignment.TopCenter)
                 .padding(
-                    top = dimensions.videoFeedCloseButtonTopPadding,
-                    start = dimensions.paddingMediumSmall,
-                    end = dimensions.paddingMediumSmall
+                    top = dimensions.videoFeedSnackbarTopPadding,
+                    start = dimensions.videoFeedSnackbarHorizontalMargin,
+                    end = dimensions.videoFeedSnackbarHorizontalMargin
                 ),
             hostState = errorSnackBarHostState,
             snackbar = { data ->

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSAlerts.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSAlerts.kt
@@ -3,6 +3,7 @@ package com.kickstarter.ui.compose.designsystem
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Snackbar
@@ -20,16 +22,22 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.Popup
 import com.kickstarter.libs.utils.safeLet
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
 import com.kickstarter.ui.compose.designsystem.KSTheme.typographyV2
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.HazeTint
+import dev.chrisbanes.haze.hazeEffect
 
 // Snackbars
 @Composable
@@ -90,6 +98,53 @@ fun KSSuccessSnackbar(
             KSSuccessRoundedText(text = text, padding = padding)
         }
     )
+}
+
+@Composable
+@Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+fun KSVideoFeedSnackbarPreview() {
+    KSTheme {
+        KSVideoFeedSnackbar(text = "Couldn't load video")
+    }
+}
+
+@Composable
+fun KSVideoFeedSnackbar(
+    text: String,
+    modifier: Modifier = Modifier,
+    hazeState: HazeState? = null
+) {
+    val baseColor = Color(0xFF2B2B2D).copy(alpha = 0.45f)
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(dimensions.radiusMedium))
+            .then(
+                if (hazeState != null) {
+                    Modifier.hazeEffect(state = hazeState) {
+                        blurRadius = 28.dp
+                        noiseFactor = 0.05f
+                        backgroundColor = baseColor
+                        tints = listOf(HazeTint(baseColor))
+                    }
+                } else {
+                    Modifier.background(baseColor)
+                }
+            )
+            .padding(
+                horizontal = dimensions.paddingMedium,
+                vertical = dimensions.paddingMediumSmall
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            color = Color.White,
+            style = typographyV2.bodyMD,
+            textAlign = TextAlign.Center
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSAlerts.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSAlerts.kt
@@ -2,6 +2,7 @@ package com.kickstarter.ui.compose.designsystem
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -132,10 +133,12 @@ fun KSVideoFeedSnackbar(
                     Modifier.background(baseColor)
                 }
             )
-            .padding(
-                horizontal = dimensions.paddingMedium,
-                vertical = dimensions.paddingMediumSmall
-            ),
+            .border(
+                width = 1.dp,
+                color = Color.White.copy(alpha = 0.14f),
+                shape = RoundedCornerShape(dimensions.radiusMedium)
+            )
+            .padding(all = dimensions.paddingMedium),
         contentAlignment = Alignment.Center
     ) {
         Text(

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSDimensions.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSDimensions.kt
@@ -103,6 +103,8 @@ data class KSDimensions(
     val videoFeedCampaignTitleSubtitleSpacing: Dp = Dp.Unspecified,
     val videoFeedScrubBarTrackHeight: Dp = Dp.Unspecified,
     val videoFeedScrubBarThumbSize: Dp = Dp.Unspecified,
+    val videoFeedSnackbarTopPadding: Dp = Dp.Unspecified,
+    val videoFeedSnackbarHorizontalMargin: Dp = Dp.Unspecified,
 
     // Discovery Banner dimensions
     val discoveryBannerImageWidth: Dp = Dp.Unspecified,
@@ -222,6 +224,8 @@ val KSStandardDimensions = KSDimensions(
     videoFeedCampaignTitleSubtitleSpacing = 5.dp,
     videoFeedScrubBarTrackHeight = 4.dp,
     videoFeedScrubBarThumbSize = 16.dp,
+    videoFeedSnackbarTopPadding = 122.dp,
+    videoFeedSnackbarHorizontalMargin = 10.dp,
 
     // Discovery Banner dimensions
     discoveryBannerImageWidth = 86.dp,

--- a/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
@@ -549,6 +549,7 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
         composeTestRule.setContent {
             KSTheme {
                 VideoFeedScreen(
+                    environment = environment(),
                     items = items,
                     errorSnackBarHostState = snackbarHostState
                 )

--- a/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
@@ -24,7 +24,6 @@ import com.kickstarter.libs.RefTag
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.models.Photo
 import com.kickstarter.models.Project
-import com.kickstarter.ui.compose.designsystem.KSSnackbarTypes
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import org.junit.Test
 
@@ -512,16 +511,44 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
                     errorSnackBarHostState = snackbarHostState
                 )
                 LaunchedEffect(Unit) {
-                    snackbarHostState.showSnackbar(
-                        message = errorMessage,
-                        actionLabel = KSSnackbarTypes.KS_ERROR.name
-                    )
+                    snackbarHostState.showSnackbar(message = errorMessage)
                 }
             }
         }
 
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText(errorMessage).assertIsDisplayed()
+    }
+
+    @Test
+    fun `snackbar is positioned in the top half of the screen`() {
+        val snackbarHostState = SnackbarHostState()
+        val errorMessage = "Couldn't load video"
+        val project = ProjectFactory.project().toBuilder().id(4002L).build()
+        val items = listOf(VideoFeedItem(badges = emptyList(), project = project, hlsUrl = hlsUrl))
+
+        composeTestRule.setContent {
+            KSTheme {
+                VideoFeedScreen(
+                    items = items,
+                    errorSnackBarHostState = snackbarHostState
+                )
+                LaunchedEffect(Unit) {
+                    snackbarHostState.showSnackbar(message = errorMessage)
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+
+        val snackbarNode = composeTestRule.onNodeWithText(errorMessage)
+        snackbarNode.assertIsDisplayed()
+
+        val snackbarBounds = snackbarNode.fetchSemanticsNode().boundsInRoot
+        val screenHeight = composeTestRule.onNodeWithTag(VideoFeedScreenTestTag.VIDEO_FEED_PAGER.name)
+            .fetchSemanticsNode().boundsInRoot.height
+
+        assertTrue("Snackbar should be in the top half of the screen", snackbarBounds.top < screenHeight / 2)
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Introduces a new glassmorphism-style snackbar (KSVideoFeedSnackbar) for the Video Feed screen, replacing the generic error/headsup snackbars previously used there.

# 🤔 Why

The video feed is a full-screen, immersive experience. The standard bottom-anchored snackbars didn't visually integrate well with the video content, and multiple errors could stack on top of each other causing a poor UX. A frosted-glass snackbar that blends with the underlying video content is more appropriate for this context.

# 🛠 How

- Added KSVideoFeedSnackbar to KSAlerts.kt, a composable that uses the haze library (hazeSource / hazeEffect) to render a blurred, semi-transparent overlay on top of the video feed content. 

- Repositioned the SnackbarHost from Alignment.BottomCenter to Alignment.TopCenter (below the close button).

- Calls snackbarHostState.currentSnackbarData?.dismiss() before showing a new snackbar to prevent stacking.

# 👀 See
<img width="357" height="791" alt="Screenshot 2026-06-01 at 10 53 57 AM" src="https://github.com/user-attachments/assets/af23535c-bbf6-40f8-946e-4feb9283e14a" />



| --- | --- |
|  |  |

# 📋 QA

Open the Video Feed
- Trigger an error (airplane mode or lost connectivity)
- Verify the snackbar appears at the top of the screen with a frosted glass appearance.
- Trigger multiple errors in quick succession, confirm only one snackbar is shown at a time (no stacking), to test this try loading the first videofeed page and set airplane mode, try to save project on any of the first 3 pages.
- Verify the snackbar dismisses automatically and doesn't obscure the close (X) button.

# Story 📖

[DISC-212](https://kickstarter.atlassian.net/browse/DISC-212)


[DISC-212]: https://kickstarter.atlassian.net/browse/DISC-212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ