### PR TITLE
PF-188: Move PreLaunchProjectPageScreen's content into a `LazyColumn`

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreen.kt
@@ -9,9 +9,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Share
@@ -33,6 +32,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
 import com.kickstarter.R
 import com.kickstarter.libs.utils.extensions.toHtml
 import com.kickstarter.mock.factories.ProjectFactory
@@ -46,6 +46,7 @@ import com.kickstarter.ui.activities.compose.PreLaunchProjectPageScreenTestTag.P
 import com.kickstarter.ui.activities.compose.PreLaunchProjectPageScreenTestTag.PROJECT_LOCATION_NAME
 import com.kickstarter.ui.activities.compose.PreLaunchProjectPageScreenTestTag.PROJECT_NAME
 import com.kickstarter.ui.activities.compose.PreLaunchProjectPageScreenTestTag.PROJECT_SAVE_BUTTON
+import com.kickstarter.ui.activities.compose.PreLaunchProjectPageScreenTestTag.SIMILAR_PROJECTS_CONTAINER
 import com.kickstarter.ui.compose.ProjectImageFromURl
 import com.kickstarter.ui.compose.TextBody2Style
 import com.kickstarter.ui.compose.TextCaptionStyle
@@ -83,7 +84,8 @@ enum class PreLaunchProjectPageScreenTestTag() {
     PROJECT_CATEGORY_NAME,
     PROJECT_LOCATION_NAME,
     PROJECT_SAVE_BUTTON,
-    PROJECT_FOLLOWERS
+    PROJECT_FOLLOWERS,
+    SIMILAR_PROJECTS_CONTAINER
 }
 
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
@@ -128,147 +130,145 @@ fun PreLaunchProjectPageScreen(
                 .fillMaxSize()
                 .background(colors.kds_support_100)
         ) {
-            val (constraintLayout, buttonCardLayout) = createRefs()
+            val (lazyColumn, buttonCardLayout) = createRefs()
             val screenPadding = dimensionResource(id = R.dimen.activity_horizontal_margin)
 
-            ConstraintLayout(
+            LazyColumn(
                 modifier = Modifier
-                    .constrainAs(constraintLayout) {
-                        linkTo(parent.top, buttonCardLayout.bottom, bias = 0.0f)
+                    .constrainAs(lazyColumn) {
+                        linkTo(parent.top, buttonCardLayout.bottom)
                         absoluteLeft.linkTo(parent.absoluteLeft)
                         absoluteRight.linkTo(parent.absoluteRight)
+                        width = Dimension.fillToConstraints
+                        height = Dimension.fillToConstraints
                     }
-                    .verticalScroll(rememberScrollState())
             ) {
-                val (
-                    projectImage, comingSoonBadge, projectName, creatorLayout,
-                    projectDescription, category, location, similarProjects
-                ) = createRefs()
+                item {
+                    ConstraintLayout(
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        val (
+                            projectImage, comingSoonBadge, projectName, creatorLayout,
+                            projectDescription, category, location, similarProjects
+                        ) = createRefs()
 
-                ProjectImageFromURl(
-                    imageUrl = (project?.photo()?.full()),
-                    modifier = Modifier
-                        .testTag(PROJECT_IMAGE.name)
-                        .constrainAs(projectImage) {
-                            top.linkTo(parent.top)
-                        }
-                        .aspectRatio(1.77f)
-                )
+                        ProjectImageFromURl(
+                            imageUrl = (project?.photo()?.full()),
+                            modifier = Modifier
+                                .testTag(PROJECT_IMAGE.name)
+                                .constrainAs(projectImage) {
+                                    top.linkTo(parent.top)
+                                }
+                                .aspectRatio(1.77f)
+                        )
 
-                TextWithKdsSupport700Bg(
-                    stringResource(id = R.string.Coming_soon),
-                    Modifier
-                        .constrainAs(comingSoonBadge) {
-                            top.linkTo(projectImage.bottom)
-                            bottom.linkTo(projectImage.bottom)
-                            start.linkTo(parent.start, screenPadding)
-                        }
-                        .testTag(COMING_SOON_BADGE.name)
-                )
+                        TextWithKdsSupport700Bg(
+                            stringResource(id = R.string.Coming_soon),
+                            Modifier
+                                .constrainAs(comingSoonBadge) {
+                                    top.linkTo(projectImage.bottom)
+                                    bottom.linkTo(projectImage.bottom)
+                                    start.linkTo(parent.start, screenPadding)
+                                }
+                                .testTag(COMING_SOON_BADGE.name)
+                        )
 
-                val projectNameAlpha = if (project?.name().isNullOrBlank()) 0f else 1f
-                TextH6ExtraBoldTitle(
-                    text = project?.name().orEmpty(),
-                    modifier = Modifier
-                        .alpha(projectNameAlpha)
-                        .constrainAs(projectName) {
-                            top.linkTo(comingSoonBadge.bottom)
-                            start.linkTo(parent.start, screenPadding)
-                        }
-                        .padding(end = screenPadding)
-                        .testTag(PROJECT_NAME.name)
-                )
+                        val projectNameAlpha = if (project?.name().isNullOrBlank()) 0f else 1f
+                        TextH6ExtraBoldTitle(
+                            text = project?.name().orEmpty(),
+                            modifier = Modifier
+                                .alpha(projectNameAlpha)
+                                .constrainAs(projectName) {
+                                    top.linkTo(comingSoonBadge.bottom)
+                                    start.linkTo(parent.start, screenPadding)
+                                }
+                                .padding(end = screenPadding)
+                                .testTag(PROJECT_NAME.name)
+                        )
 
-                KsCreatorLayout(
-                    creatorName = project?.creator()?.name() ?: "",
-                    imageUrl = project?.creator()?.avatar()?.medium() ?: "",
-                    modifier = Modifier
-                        .testTag(CREATOR_LAYOUT.name)
-                        .fillMaxWidth()
-                        .constrainAs(creatorLayout) {
-                            top.linkTo(projectName.bottom)
-                            start.linkTo(parent.start, screenPadding)
-                        }
-                        .padding(end = screenPadding)
-                        .padding(
-                            vertical = dimensionResource(id = R.dimen.grid_1)
-                        ),
-                    onClickAction = {
-                        onCreatorLayoutClicked.invoke()
-                    }
-                )
-
-                project?.blurb()?.let {
-                    TextBody2Style(
-                        text = it.toHtml().toString(),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .testTag(PROJECT_DESCRIPTION.name)
-                            .constrainAs(projectDescription) {
-                                top.linkTo(creatorLayout.bottom)
-                                start.linkTo(parent.start, screenPadding)
+                        KsCreatorLayout(
+                            creatorName = project?.creator()?.name() ?: "",
+                            imageUrl = project?.creator()?.avatar()?.medium() ?: "",
+                            modifier = Modifier
+                                .testTag(CREATOR_LAYOUT.name)
+                                .fillMaxWidth()
+                                .constrainAs(creatorLayout) {
+                                    top.linkTo(projectName.bottom)
+                                    start.linkTo(parent.start, screenPadding)
+                                }
+                                .padding(end = screenPadding)
+                                .padding(
+                                    vertical = dimensionResource(id = R.dimen.grid_1)
+                                ),
+                            onClickAction = {
+                                onCreatorLayoutClicked.invoke()
                             }
-                            .padding(end = screenPadding)
-                            .padding(
-                                vertical = dimensionResource(id = R.dimen.grid_1)
+                        )
+
+                        project?.blurb()?.let {
+                            TextBody2Style(
+                                text = it.toHtml().toString(),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .testTag(PROJECT_DESCRIPTION.name)
+                                    .constrainAs(projectDescription) {
+                                        top.linkTo(creatorLayout.bottom)
+                                        start.linkTo(parent.start, screenPadding)
+                                    }
+                                    .padding(end = screenPadding)
+                                    .padding(
+                                        vertical = dimensionResource(id = R.dimen.grid_1)
+                                    )
                             )
-                    )
-                }
-
-                project?.category()?.name()?.let {
-                    TextCaptionStyleWithStartIcon(
-                        it,
-                        painterResource(R.drawable.icon__compass),
-                        modifier = Modifier
-                            .testTag(PROJECT_CATEGORY_NAME.name)
-                            .constrainAs(category) {
-                                top.linkTo(projectDescription.bottom)
-                                start.linkTo(parent.start, screenPadding)
-                            }
-                            .padding(end = screenPadding)
-                            .padding(vertical = dimensionResource(id = R.dimen.grid_2))
-                    )
-                }
-
-                project?.location()?.name()?.let {
-                    val locationPadding = dimensionResource(id = R.dimen.grid_5)
-                    TextCaptionStyleWithStartIcon(
-                        it,
-                        Icons.Filled.LocationOn,
-                        modifier = Modifier
-                            .testTag(PROJECT_LOCATION_NAME.name)
-                            .constrainAs(location) {
-                                start.linkTo(category.end, locationPadding)
-                                top.linkTo(category.top)
-                                bottom.linkTo(category.bottom)
-                            }
-                            .padding(end = screenPadding)
-                    )
-                }
-
-                val spcAnchor = when {
-                    project?.location()?.name() != null -> location
-                    project?.category()?.name() != null -> category
-                    project?.blurb() != null -> projectDescription
-                    else -> creatorLayout
-                }
-
-                val spcMarginTop = dimensionResource(id = R.dimen.grid_3)
-                val spcMarginBottom = dimensionResource(id = R.dimen.grid_27)
-
-                Box(
-                    modifier = Modifier
-                        .constrainAs(similarProjects) {
-                            start.linkTo(parent.start)
-                            end.linkTo(parent.end)
-                            top.linkTo(spcAnchor.bottom, spcMarginTop)
                         }
-                        .padding(bottom = spcMarginBottom)
-                ) {
-                    SimilarProjectsComponent(
-                        uiState = similarProjectsState,
-                        onClick = onSimilarProjectClick
-                    )
+
+                        project?.category()?.name()?.let {
+                            TextCaptionStyleWithStartIcon(
+                                it,
+                                painterResource(R.drawable.icon__compass),
+                                modifier = Modifier
+                                    .testTag(PROJECT_CATEGORY_NAME.name)
+                                    .constrainAs(category) {
+                                        top.linkTo(projectDescription.bottom)
+                                        start.linkTo(parent.start, screenPadding)
+                                    }
+                                    .padding(end = screenPadding)
+                                    .padding(vertical = dimensionResource(id = R.dimen.grid_2))
+                            )
+                        }
+
+                        project?.location()?.name()?.let {
+                            val locationPadding = dimensionResource(id = R.dimen.grid_5)
+                            TextCaptionStyleWithStartIcon(
+                                it,
+                                Icons.Filled.LocationOn,
+                                modifier = Modifier
+                                    .testTag(PROJECT_LOCATION_NAME.name)
+                                    .constrainAs(location) {
+                                        start.linkTo(category.end, locationPadding)
+                                        top.linkTo(category.top)
+                                        bottom.linkTo(category.bottom)
+                                    }
+                                    .padding(end = screenPadding)
+                            )
+                        }
+                    }
+                }
+
+                item {
+                    val spcMarginTop = dimensionResource(id = R.dimen.grid_3)
+                    val spcMarginBottom = dimensionResource(id = R.dimen.grid_27)
+
+                    Box(
+                        modifier = Modifier
+                            .padding(top = spcMarginTop, bottom = spcMarginBottom)
+                            .testTag(SIMILAR_PROJECTS_CONTAINER.name)
+                    ) {
+                        SimilarProjectsComponent(
+                            uiState = similarProjectsState,
+                            onClick = onSimilarProjectClick
+                        )
+                    }
                 }
             }
 

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreenTest.kt
@@ -19,6 +19,7 @@ import com.kickstarter.ui.activities.compose.PreLaunchProjectPageScreenTestTag.P
 import com.kickstarter.ui.activities.compose.PreLaunchProjectPageScreenTestTag.PROJECT_LOCATION_NAME
 import com.kickstarter.ui.activities.compose.PreLaunchProjectPageScreenTestTag.PROJECT_NAME
 import com.kickstarter.ui.activities.compose.PreLaunchProjectPageScreenTestTag.PROJECT_SAVE_BUTTON
+import com.kickstarter.ui.activities.compose.PreLaunchProjectPageScreenTestTag.SIMILAR_PROJECTS_CONTAINER
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.viewmodels.projectpage.SimilarProjectsUiState
 import org.joda.time.DateTime
@@ -34,6 +35,7 @@ class PreLaunchProjectPageScreenTest : KSRobolectricTestCase() {
     private val projectLocation = composeTestRule.onNodeWithTag(PROJECT_LOCATION_NAME.name)
     private val projectSaveButton = composeTestRule.onNodeWithTag(PROJECT_SAVE_BUTTON.name)
     private val projectFollowers = composeTestRule.onNodeWithTag(PROJECT_FOLLOWERS.name)
+    private val similarProjectsContainer = composeTestRule.onNodeWithTag(SIMILAR_PROJECTS_CONTAINER.name)
 
     @Test
     fun verifyInitState() {
@@ -55,6 +57,7 @@ class PreLaunchProjectPageScreenTest : KSRobolectricTestCase() {
         projectSaveButton.assertExists()
         projectSaveButton.assertTextEquals(context().getString(R.string.Notify_me_on_launch))
         projectFollowers.assertDoesNotExist()
+        similarProjectsContainer.assertExists()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Move the main content of `PrelaunchProjectPageScreen` into a `LazyColumn`.

# 🤔 Why

This is a preliminary step to dynamically emitting SDUI-powered Project Story components into the screen, while also preserving the existing components. (Following the strategy from the PoC branch in #2474.)

# 🛠 How

Virtually all of the page content is contained in a secondary `ConstraintLayout`. Wrap this content in a `LazyColumn` by emitting the `ConstraintLayout` and its content via `LazyListScope.item()`. The Similar Projects Carousel is separately emitted so that Project Story components can be emitted above it.

# 👀 See

There should be no detectable visual changes.

# 📋 QA

Visit any Prelaunch Project to confirm that the behavior is the same. Existing tests pass.

# Story 📖

[\[PF-188\] Update layout in PrelaunchProjectPageScreen to support new Project Story component - Jira](https://kickstarter.atlassian.net/browse/PF-188)
