### PR TITLE
DISC-215: New Social Share Experience on Pre-launch Project Page

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -32,7 +32,8 @@ import kotlinx.coroutines.rx2.asFlow
 import timber.log.Timber
 
 enum class StatsigGateKey(val key: String) {
-    ANDROID_VIDEO_FEED("android_video_feed")
+    ANDROID_VIDEO_FEED("android_video_feed"),
+    ANDROID_PRELAUNCH_SOCIAL_SHARE("android_social_share")
 }
 
 object StatsigExperiments {

--- a/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/EventContextValues.kt
@@ -109,6 +109,7 @@ class EventContextValues {
         TWO_FACTOR_AUTH("two_factor_auth"),
         ONBOARDING("onboarding"),
         VIDEO_FEED("video_feed"),
+        PRE_LAUNCH_PROJECT("pre_launch_project"),
     }
 
     /**

--- a/app/src/main/java/com/kickstarter/ui/activities/PreLaunchProjectPageActivity.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/PreLaunchProjectPageActivity.kt
@@ -8,15 +8,26 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rxjava2.subscribeAsState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import com.kickstarter.R
+import com.kickstarter.features.socialshare.AndroidSocialShareService
+import com.kickstarter.features.socialshare.data.SocialShareData
+import com.kickstarter.features.socialshare.ui.LocalSocialShareViewModel
+import com.kickstarter.features.socialshare.ui.SocialShareSheet
+import com.kickstarter.features.socialshare.viewmodel.SocialShareViewModel
 import com.kickstarter.libs.ActivityRequestCodes
 import com.kickstarter.libs.KSString
 import com.kickstarter.libs.RefTag
 import com.kickstarter.libs.featureflag.FlagKey
+import com.kickstarter.libs.utils.EventContextValues.ContextPageName
 import com.kickstarter.libs.utils.ViewUtils
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.getEnvironment
@@ -82,6 +93,7 @@ class PreLaunchProjectPageActivity : ComponentActivity() {
                 val context = LocalContext.current
                 val projectState = viewModel.project().subscribeAsState(initial = null)
                 val similarProjectsState = similarProjectsViewModel.similarProjectsUiState.collectAsState()
+                var shareData: SocialShareData? by remember { mutableStateOf(null) }
 
                 LaunchedEffect(projectState.value) {
                     projectState.value?.let {
@@ -96,7 +108,20 @@ class PreLaunchProjectPageActivity : ComponentActivity() {
                     rightOnClickAction = {
                         projectState.value?.let { this.viewModel.inputs.bookmarkButtonClicked() }
                     },
-                    middleRightClickAction = { this.viewModel.inputs.shareButtonClicked() },
+                    middleRightClickAction = {
+                        if (viewModel.outputs.isNewSocialShareEnabled()) {
+                            projectState.value?.let { project ->
+                                shareData = SocialShareData(
+                                    projectName = project.name() ?: "",
+                                    projectUrl = project.urls()?.web()?.project() ?: "",
+                                    imageUrl = project.photo()?.full() ?: "",
+                                    creatorName = project.creator()?.name() ?: ""
+                                )
+                            }
+                        } else {
+                            this.viewModel.inputs.shareButtonClicked()
+                        }
+                    },
                     onCreatorLayoutClicked = { this.viewModel.inputs.creatorInfoClicked() },
                     onButtonClicked = {
                         projectState.value?.let { this.viewModel.inputs.bookmarkButtonClicked() }
@@ -118,6 +143,25 @@ class PreLaunchProjectPageActivity : ComponentActivity() {
                         startActivity(intent)
                     }
                 )
+
+                shareData?.let { data ->
+                    val shareViewModel = remember(data) {
+                        SocialShareViewModel(
+                            environment = requireNotNull(getEnvironment()),
+                            shareService = AndroidSocialShareService(context.applicationContext),
+                            shareData = data,
+                            contextPage = ContextPageName.PRE_LAUNCH_PROJECT
+                        )
+                    }
+                    CompositionLocalProvider(LocalSocialShareViewModel provides shareViewModel) {
+                        SocialShareSheet(
+                            shareData = data,
+                            isVisible = true,
+                            onDismiss = { shareData = null },
+                            onIntentReady = { startActivity(it) }
+                        )
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreen.kt
@@ -117,6 +117,7 @@ fun PreLaunchProjectPageScreen(
                 middle = {
                     ToolbarIconButton(
                         icon = Icons.Filled.Share,
+                        contentDescription = stringResource(R.string.project_accessibility_button_share_label),
                         clickAction = { middleRightClickAction.invoke() }
                     )
                 },

--- a/app/src/main/java/com/kickstarter/ui/toolbars/compose/ToolBar.kt
+++ b/app/src/main/java/com/kickstarter/ui/toolbars/compose/ToolBar.kt
@@ -194,11 +194,11 @@ fun TopToolBarBetaIcon(
 }
 
 @Composable
-fun ToolbarIconButton(icon: ImageVector, clickAction: () -> Unit = {}) =
+fun ToolbarIconButton(icon: ImageVector, contentDescription: String? = null, clickAction: () -> Unit = {}) =
     IconButton(onClick = { clickAction.invoke() }) {
         Icon(
             imageVector = icon,
-            contentDescription = null
+            contentDescription = contentDescription
         )
     }
 

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/PrelaunchProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/PrelaunchProjectViewModel.kt
@@ -81,7 +81,7 @@ interface PrelaunchProjectViewModel {
         private val sharedPreferences = requireNotNull(environment.sharedPreferences())
         private val ffClient = requireNotNull(environment.featureFlagClient())
         private val attributionEvents = requireNotNull(environment.attributionEvents())
-        private val statsigClient = environment.statsigClient()
+        private val statsigClient = requireNotNull(environment.statsigClient())
 
         private val intent = BehaviorSubject.create<Intent>()
         private val creatorInfoClicked = PublishSubject.create<Unit>()
@@ -373,7 +373,8 @@ interface PrelaunchProjectViewModel {
         override fun showSavedPrompt(): Observable<Unit> = this.showSavedPrompt
         override fun startCreatorView(): Observable<Project> = this.startCreatorView
         override fun isNewSocialShareEnabled(): Boolean =
-            statsigClient?.checkGate(StatsigGateKey.ANDROID_PRELAUNCH_SOCIAL_SHARE.key) ?: false
+            statsigClient.isReady.value &&
+                statsigClient.checkGate(StatsigGateKey.ANDROID_PRELAUNCH_SOCIAL_SHARE.key)
     }
 
     class Factory(private val environment: Environment) : ViewModelProvider.Factory {

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/PrelaunchProjectViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/PrelaunchProjectViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.RefTag
+import com.kickstarter.libs.featureflag.StatsigGateKey
 import com.kickstarter.libs.rx.transformers.TakeWhenTransformerV2
 import com.kickstarter.libs.rx.transformers.Transformers
 import com.kickstarter.libs.utils.KsOptional
@@ -62,6 +63,9 @@ interface PrelaunchProjectViewModel {
         fun showSavedPrompt(): Observable<Unit>
 
         fun startCreatorView(): Observable<Project>
+
+        /** Returns true when the new social sharing experience should be shown. */
+        fun isNewSocialShareEnabled(): Boolean
     }
 
     class PrelaunchProjectViewModel(val environment: Environment) : ViewModel(), Inputs, Outputs {
@@ -77,6 +81,7 @@ interface PrelaunchProjectViewModel {
         private val sharedPreferences = requireNotNull(environment.sharedPreferences())
         private val ffClient = requireNotNull(environment.featureFlagClient())
         private val attributionEvents = requireNotNull(environment.attributionEvents())
+        private val statsigClient = environment.statsigClient()
 
         private val intent = BehaviorSubject.create<Intent>()
         private val creatorInfoClicked = PublishSubject.create<Unit>()
@@ -367,6 +372,8 @@ interface PrelaunchProjectViewModel {
         override fun startLoginToutActivity(): Observable<Unit> = this.startLoginToutActivity
         override fun showSavedPrompt(): Observable<Unit> = this.showSavedPrompt
         override fun startCreatorView(): Observable<Project> = this.startCreatorView
+        override fun isNewSocialShareEnabled(): Boolean =
+            statsigClient?.checkGate(StatsigGateKey.ANDROID_PRELAUNCH_SOCIAL_SHARE.key) ?: false
     }
 
     class Factory(private val environment: Environment) : ViewModelProvider.Factory {

--- a/app/src/test/java/com/kickstarter/viewmodels/PrelaunchProjectViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/PrelaunchProjectViewModelTest.kt
@@ -6,7 +6,9 @@ import android.util.Pair
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.MockCurrentUserV2
+import com.kickstarter.libs.MockStatsigClient
 import com.kickstarter.libs.featureflag.FlagKey
+import com.kickstarter.libs.featureflag.StatsigGateKey
 import com.kickstarter.libs.utils.ThirdPartyEventValues
 import com.kickstarter.libs.utils.extensions.addToDisposable
 import com.kickstarter.libs.utils.extensions.reduceProjectPayload
@@ -325,6 +327,28 @@ class PrelaunchProjectViewModelTest : KSRobolectricTestCase() {
         vm.inputs.configureWith(intent = intent)
 
         assertEquals(true, this.vm.onThirdPartyEventSent.value)
+    }
+
+    @Test
+    fun testIsNewSocialShareEnabled_whenFlagIsOn() {
+        val statsigClient = MockStatsigClient(
+            context = application(),
+            gateMap = mapOf(StatsigGateKey.ANDROID_PRELAUNCH_SOCIAL_SHARE.key to true)
+        )
+        setUpEnvironment(testEnvironment.toBuilder().statsigClient(statsigClient).build())
+
+        assertTrue(vm.outputs.isNewSocialShareEnabled())
+    }
+
+    @Test
+    fun testIsNewSocialShareEnabled_whenFlagIsOff() {
+        val statsigClient = MockStatsigClient(
+            context = application(),
+            gateMap = mapOf(StatsigGateKey.ANDROID_PRELAUNCH_SOCIAL_SHARE.key to false)
+        )
+        setUpEnvironment(testEnvironment.toBuilder().statsigClient(statsigClient).build())
+
+        assertFalse(vm.outputs.isNewSocialShareEnabled())
     }
 
     @After


### PR DESCRIPTION
# 📲 What

Adds a Statsig feature flag (android_social_share) to the Pre-Launch Project Page that gates the new social sharing experience behind StatsigGateKey.ANDROID_PRELAUNCH_SOCIAL_SHARE. When the flag is on, tapping the share button opens the new SocialShareSheet bottom sheet. When off, the existing native Android share sheet continues to be shown.

# 🤔 Why

The new social sharing experience is already in place for the Video Feed. This change brings it to the Pre-Launch Project Page while allowing a safe, controlled rollout via separated Statsig gate.

# 🛠 How

- `StatsigGateKey` — added `ANDROID_PRELAUNCH_SOCIAL_SHARE("android_social_share")` to the enum.
- `EventContextValues.ContextPageName` — added `PRE_LAUNCH_PROJECT("pre_launch_project")` so the SocialShareViewModel can tag analytics events with the correct page context.
-`PrelaunchProjectViewModel` — owns the gate check. 
-`PreLaunchProjectPageActivity `— the middleRightClickAction lambda now calls viewModel.outputs.isNewSocialShareEnabled() to branch:
Flag ON → builds a SocialShareData from the current project state and renders SocialShareSheet via CompositionLocalProvider, mirroring the same composition pattern used in VideoFeedScreen.
Flag OFF → calls viewModel.inputs.shareButtonClicked() as before, letting the existing showShareSheet → startShareIntent flow handle it.
- `ToolbarIconButton` — added an optional contentDescription parameter (backwards-compatible, defaults to null) and wired it up on the share button for accessibility.
- `PrelaunchProjectViewModelTest` — two new unit tests verify `isNewSocialShareEnabled()` returns true/false by injecting a MockStatsigClient with the gate set accordingly.


# 👀 See


https://github.com/user-attachments/assets/2cfdbf8d-d5fd-4d08-b874-99135d3f3b99



| --- | --- |
|  |  |

# 📋 QA

Open any Pre-Launch project page.
- Flag OFF (default): tap the share icon in the toolbar → the native Android share chooser should appear as before.
- Flag ON (change your `internal_version_name` to 3.41.0): tap the share icon → the new social share bottom sheet should slide up, showing the project card and platform grid (X, WhatsApp, Instagram, etc.).

# Story 📖

[DISC-215](https://kickstarter.atlassian.net/browse/DISC-215)


[DISC-215]: https://kickstarter.atlassian.net/browse/DISC-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ