### PR TITLE
CHECK-171: Fix estimated shipping range used for Rewards that ship worldwide

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -216,8 +216,7 @@ object RewardViewUtils {
         selectedShippingRule: ShippingRule,
         multipleQuantitiesAllowed: Boolean,
         useUserPreference: Boolean,
-        useAbout: Boolean,
-        forceSelectedShippingRule: Boolean = false,
+        useAbout: Boolean
     ): String {
         var min = ""
         var max = ""
@@ -225,29 +224,22 @@ object RewardViewUtils {
         var maxtotal = 0.0
 
         rewards.forEach { reward ->
-            val shippingRule = reward.shippingRules()?.firstOrNull {
+            if (RewardUtils.isDigital(reward) || RewardUtils.isLocalPickup(reward) || !RewardUtils.isShippable(reward))
+                return@forEach
+
+            var shippingRule = reward.shippingRules()?.firstOrNull {
                 it.location()?.id() == selectedShippingRule.location()?.id()
             }
 
-            val selectedShippingRuleCondition =
-                (forceSelectedShippingRule && shippingRule != null)
+            if (shippingRule == null && RewardUtils.shipsWorldwide(reward))
+                shippingRule = reward.shippingRules()?.firstOrNull()
 
-            if (!RewardUtils.isDigital(reward) && (selectedShippingRuleCondition || RewardUtils.shipsToRestrictedLocations(reward)) && !RewardUtils.isLocalPickup(reward)) {
-                reward.shippingRules()?.filter {
-                    it.location()?.id() == selectedShippingRule.location()?.id()
-                }?.map {
-                    minTotal += (it.estimatedMin() * (reward.quantity() ?: 1))
-                    maxtotal += (it.estimatedMax() * (reward.quantity() ?: 1))
-                }
-            }
-
-            if (!selectedShippingRuleCondition && RewardUtils.shipsWorldwide(reward) && !reward.shippingRules().isNullOrEmpty()) {
-                reward.shippingRules()?.first()?.let {
-                    minTotal += (it.estimatedMin() * (reward.quantity() ?: 1))
-                    maxtotal += (it.estimatedMax() * (reward.quantity() ?: 1))
-                }
+            shippingRule?.let {
+                minTotal += (it.estimatedMin() * (reward.quantity() ?: 1))
+                maxtotal += (it.estimatedMax() * (reward.quantity() ?: 1))
             }
         }
+
         if (minTotal <= 0 || maxtotal <= 0) return ""
 
         min = if (useUserPreference) {

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
@@ -370,8 +370,7 @@ fun RewardCarouselScreen(
                                             selectedShippingRule = currentShippingRule,
                                             multipleQuantitiesAllowed = false,
                                             useUserPreference = false,
-                                            useAbout = true,
-                                            forceSelectedShippingRule = true
+                                            useAbout = true
                                         )
                                     }
                                 }

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
@@ -208,6 +208,6 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
             useAbout = false,
         )
 
-        assert(estimatedShippingString.isEmpty())
+        assertTrue(estimatedShippingString.isEmpty())
     }
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
@@ -108,6 +108,10 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
             .estimatedMin(2.0)
             .estimatedMax(20.0)
             .build()
+        val caRule = ShippingRuleFactory.canadaShippingRule().toBuilder()
+            .estimatedMin(3.0)
+            .estimatedMax(30.0)
+            .build()
 
         val shippingPreference = Reward.ShippingPreference.UNRESTRICTED
         val reward = RewardFactory.reward().toBuilder()
@@ -118,7 +122,7 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
             .build()
         val rewards = listOf(reward)
 
-        val selectedShippingRule = usRule
+        val selectedShippingRule = caRule
 
         val estimatedShippingString = RewardViewUtils.getEstimatedShippingCostString(
             context, ksCurrency, ksString, project, rewards, selectedShippingRule,
@@ -131,7 +135,7 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `test estimated shipping range for reward with worldwide shipping uses first selected shipping rule when forced`() {
+    fun `test estimated shipping range for reward with restricted shipping`() {
         val context = context()
 
         val config = ConfigFactory.configForUSUser()
@@ -140,7 +144,7 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
         val ksCurrency = KSCurrency(currentConfig)
 
         val ksString = ksString()
-        val project = ProjectFactory.project() // KSCurrency.formatWithUserPreference()
+        val project = ProjectFactory.project()
 
         val usRule = ShippingRuleFactory.usShippingRule().toBuilder()
             .estimatedMin(1.0)
@@ -151,11 +155,12 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
             .estimatedMax(20.0)
             .build()
 
-        val shippingPreference = Reward.ShippingPreference.UNRESTRICTED
+        val shippingPreference = Reward.ShippingPreference.RESTRICTED
+
         val reward = RewardFactory.reward().toBuilder()
-            .shippingPreference(shippingPreference.name)
-            .shippingType(shippingPreference.name)
             .shippingPreferenceType(shippingPreference)
+            .shippingPreference(shippingPreference.name.lowercase())
+            .shippingType(shippingPreference.name.lowercase())
             .shippingRules(listOf(mxRule, usRule))
             .build()
         val rewards = listOf(reward)
@@ -167,9 +172,42 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
             multipleQuantitiesAllowed = false,
             useUserPreference = false,
             useAbout = false,
-            forceSelectedShippingRule = true
         )
 
         assertEquals("$1-$10", estimatedShippingString)
+    }
+
+    @Test
+    fun `test estimated shipping range for digital reward`() {
+        val context = context()
+
+        val config = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfigV2()
+        currentConfig.config(config)
+        val ksCurrency = KSCurrency(currentConfig)
+
+        val ksString = ksString()
+        val project = ProjectFactory.project()
+
+        val shippingPreference = Reward.ShippingPreference.NONE
+
+        val reward = RewardFactory.reward().toBuilder()
+            .shippingPreferenceType(shippingPreference)
+            .shippingPreference(shippingPreference.name.lowercase())
+            .shippingType(shippingPreference.name.lowercase())
+            .shippingRules(listOf())
+            .build()
+        val rewards = listOf(reward)
+
+        val selectedShippingRule = ShippingRuleFactory.usShippingRule()
+
+        val estimatedShippingString = RewardViewUtils.getEstimatedShippingCostString(
+            context, ksCurrency, ksString, project, rewards, selectedShippingRule,
+            multipleQuantitiesAllowed = false,
+            useUserPreference = false,
+            useAbout = false,
+        )
+
+        assert(estimatedShippingString.isEmpty())
     }
 }


### PR DESCRIPTION
# 📲 What

Fix estimated shipping range used for Rewards that ship worldwide.

# 🤔 Why

(This issue was initially reported by Support Dev)

Currently, the Estimated Shipping range displayed on the Checkout screen is incorrect when the selected base Reward ships worldwide.

Specifically, the estimated shipping range displayed for such rewards is always _technically_ incorrect. However, the range shown depends on multiple factors, such as shipping rules configured for the Reward, and the shipping location selected by the backer. So, in practice, in many cases, the range displayed is actually correct (which is likely why this didn't come up sooner).

# 🛠 How

Update the logic in `RewardViewUtils.getEstimatedShippingCostString()` -- which is used both in the Rewards Carousel and on the Checkout screen -- to always first look for a shipping rule that matches the location selected by the user. If no shipping rule is found, and the Reward ships worldwide, use a default shipping rule of the first in the `Reward.shippingRules()` list.

Effectively, this change commits to the behavior enabled by the `forceSelectedShippingRule` flag added in #2481 ([MBL-2971](https://kickstarter.atlassian.net/browse/MBL-2971)), which fixed another instance of this issue. Since we are committing to this behavior, that flag has been removed. In addition, this logic is now much more closely aligned to the counterpart function in iOS ([ios-oss/Library/SharedFunctions.swift](https://github.com/kickstarter/ios-oss/blob/7a4a50eb83f2791499e2117b79ded88456481166/Library/SharedFunctions.swift#L775))

#### Additional Notes

- Interestingly this bug also _technically_ affects Add-Ons, but when we fetch add-ons [we pass in](https://github.com/kickstarter/android-oss/blob/0a57adbf83d7299c8973559db2182b87e0471c28/app/src/main/java/com/kickstarter/viewmodels/projectpage/AddOnsViewModel.kt#L197) a non-optional location ID, and the shipping rules are filtered accordingly, returning a list with only one shipping rule to use, so in practice this bug never shows up for Add-Ons.
- We have similar logic that deals with known/fixed shipping costs in `PledgeDataExt.shippingCostIfShipping()` and `RewardViewUtils.getAddOnShippingAmountString()`, which we might look to consolidate in the future, but are also good references for the logic in this function.
- We are not showing fixed shipping costs in the Rewards Carousel and I am planning to file a separate ticket for that.
- While the [web](https://github.com/kickstarter/kickstarter/blob/6b89d4926c34d90923a49994348c28c32a3a26bc/browser/javascripts/pledge-app/pledge-reward-selection/components/SelectableRewardOrAddOn.tsx#L344) also uses GQL's `Reward.simpleShippingRulesExpanded` for these flows, it [handles](https://github.com/kickstarter/kickstarter/blob/413cca9c844f73521e7ad8ec5a3df6ffed706929/browser/javascripts/pledge-app/graph/data.ts#L162) the `Money` type a bit differently, and also supports a scenario is which there is only an `estimatedMin`. It would take some adjustments to our internal data models to match the UX of the web exactly.

# 👀 See

### Before 🐛

https://github.com/user-attachments/assets/fa3074d1-d575-4753-91b1-5664949297de

### After 🦋

https://github.com/user-attachments/assets/402f86e5-b3e6-4175-ada0-4f17edf88900

# 📋 QA

- Log in
- Find a Project with a Reward that (1) ships Worldwide, (2) has at least one shipping rule configured for a specific country, and (3) that shipping rule has non-null values for the estimated shipping min and max.
  - In the videos above and in this QA we use this Project: [Poplight Renter-Friendly Wall Light by Rose and Caroline — Kickstarter](https://www.kickstarter.com/projects/poplightforthepeople/poplight-renter-friendly-wall-light)
- Open the Rewards carousel and change the Location to a country that does not have a shipping rule configured for it specifically (for the Project used in this QA, that's any other country than the United States).
- Note the estimated shipping range shown for that Reward.
- Select that Reward and continue to Checkout.
- Confirm that the range shown for Estimated Shipping matches the range noted earlier.

# Story 📖

[\[CHECK-171\] [Android] Incorrect estimated shipping on checkout with add-ons - Jira](https://kickstarter.atlassian.net/browse/CHECK-171)


[MBL-2971]: https://kickstarter.atlassian.net/browse/MBL-2971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ