### PR TITLE
DISC-236: Pagination loading state UI for the Video Feed

### DIFF
--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -55,7 +56,11 @@ class VideoFeedActivity : ComponentActivity() {
                 val errorAction = setUpVideoFeedErrorActions(snackbarHostState)
                 viewModel.provideErrorAction { message -> errorAction.invoke(message) }
 
-                viewModel.loadVideoFeed()
+                // Initial load must live within LaunchedEffect, calling it directly in the
+                // composable body re-runs it on every recomposition (e.g. when items emit)
+                LaunchedEffect(Unit) {
+                    viewModel.loadVideoFeed()
+                }
 
                 val uiState by viewModel.videoFeedUIState.collectAsStateWithLifecycle()
                 VideoFeedScreen(
@@ -63,7 +68,9 @@ class VideoFeedActivity : ComponentActivity() {
                     environment = env,
                     errorSnackBarHostState = snackbarHostState,
                     hasMore = uiState.hasMore,
-                    onLoadMore = { viewModel.loadVideoFeed() },
+                    onLoadMore = {
+                        viewModel.loadVideoFeed()
+                    },
                     onReachedLastVideo = {
                         showRatingDialogWidget()
                     },

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
@@ -68,6 +68,7 @@ class VideoFeedActivity : ComponentActivity() {
                     environment = env,
                     errorSnackBarHostState = snackbarHostState,
                     hasMore = uiState.hasMore,
+                    isLoading = uiState.isLoading,
                     onLoadMore = {
                         viewModel.loadVideoFeed()
                     },

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
@@ -2,6 +2,7 @@ package com.kickstarter.features.videofeed.ui
 
 import android.content.Intent
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -58,6 +59,7 @@ import com.kickstarter.libs.utils.extensions.isTrue
 import com.kickstarter.libs.utils.extensions.toCompactFormat
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.models.Project
+import com.kickstarter.ui.compose.designsystem.KSCircularProgressIndicator
 import com.kickstarter.ui.compose.designsystem.KSSnackbarTypes
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
@@ -71,8 +73,13 @@ import kotlinx.coroutines.launch
 enum class VideoFeedScreenTestTag {
     VIDEO_FEED_PAGER,
     VIDEO_FEED_OVERLAY_CONTAINER,
-    VIDEO_FEED_CLOSE_BUTTON
+    VIDEO_FEED_CLOSE_BUTTON,
+    VIDEO_FEED_LOADING_PAGE
 }
+
+// Stable pager key for the trailing pagination loading page. Project ids are positive,
+// so this sentinel never collides with a real item key.
+private const val LOADING_PAGE_KEY = Long.MIN_VALUE
 
 @Composable
 fun VideoFeedScreen(
@@ -80,6 +87,7 @@ fun VideoFeedScreen(
     environment: Environment,
     errorSnackBarHostState: SnackbarHostState = SnackbarHostState(),
     hasMore: Boolean = true,
+    isLoading: Boolean = false,
     onLoadMore: () -> Unit = {},
     onReachedLastVideo: () -> Unit = {},
     onClose: () -> Unit = {},
@@ -94,7 +102,11 @@ fun VideoFeedScreen(
     onProgressBarTap: (item: VideoFeedItem, progress: Float) -> Unit = { _, _ -> },
     onShareCTAClick: (project: Project) -> Unit = { _ -> }
 ) {
-    val pagerState = rememberPagerState(pageCount = { items.size })
+    // Append a trailing loading page while the next page is being fetched. The prefetch in the
+    // pagination LaunchedEffect usually completes before the user reaches the end, so this is only
+    // seen when the user out-swipes the request (or during the very first load).
+    val showLoadingPage = isLoading && hasMore
+    val pagerState = rememberPagerState(pageCount = { items.size + if (showLoadingPage) 1 else 0 })
 
     var previousSettledPage by remember { mutableStateOf(-1) }
     var hasTriggeredReview by remember { mutableStateOf(false) }
@@ -155,8 +167,13 @@ fun VideoFeedScreen(
                 .testTag(VideoFeedScreenTestTag.VIDEO_FEED_PAGER.name),
             state = pagerState,
             beyondViewportPageCount = 1,
-            key = { index -> items[index].project.id() }
+            key = { index -> if (index < items.size) items[index].project.id() else LOADING_PAGE_KEY }
         ) { page ->
+
+            if (page >= items.size) {
+                VideoFeedLoadingPage()
+                return@VerticalPager
+            }
 
             val item = items[page]
             val project = item.project
@@ -302,6 +319,32 @@ fun VideoFeedScreen(
                 KSVideoFeedSnackbar(text = data.visuals.message, hazeState = screenHazeState)
             }
         )
+    }
+}
+
+/**
+ * Full-screen loading page rendered as the trailing page of the feed while the next page is
+ * being fetched. A centered spinner over the video background keeps the look consistent with the
+ * player while the user waits for more videos to load.
+ */
+@Composable
+fun VideoFeedLoadingPage(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(KSTheme.colors.videoPlayer.background)
+            .testTag(VideoFeedScreenTestTag.VIDEO_FEED_LOADING_PAGE.name),
+        contentAlignment = Alignment.Center
+    ) {
+        KSCircularProgressIndicator(color = KSTheme.colors.videoPlayer.content)
+    }
+}
+
+@Preview
+@Composable
+fun VideoFeedLoadingPagePreview() {
+    KSTheme {
+        VideoFeedLoadingPage()
     }
 }
 

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
@@ -122,16 +122,17 @@ fun KSLinearProgressIndicator(
 @Composable
 fun KSCircularProgressIndicator(
     modifier: Modifier = Modifier,
-    progress: Float? = null
+    progress: Float? = null,
+    color: Color = colors.kds_create_700
 ) {
     if (progress != null) {
         CircularProgressIndicator(
             progress = { progress },
             modifier = modifier,
-            color = colors.kds_create_700
+            color = color
         )
     } else {
-        CircularProgressIndicator(modifier = modifier, color = colors.kds_create_700)
+        CircularProgressIndicator(modifier = modifier, color = color)
     }
 }
 

--- a/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/features/videofeed/ui/VideoFeedScreenTest.kt
@@ -519,6 +519,79 @@ class VideoFeedScreenTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun `pagination loading page is shown at the end when isLoading and hasMore are true`() {
+        val project = ProjectFactory.project().toBuilder().id(8001L).build()
+        val items = listOf(VideoFeedItem(badges = emptyList(), project = project, hlsUrl = hlsUrl))
+
+        composeTestRule.setContent {
+            KSTheme {
+                VideoFeedScreen(
+                    environment = environment(),
+                    items = items,
+                    hasMore = true,
+                    isLoading = true
+                )
+            }
+        }
+
+        // The loading page is the trailing page; it exists in composition (beyondViewportPageCount = 1)
+        // but is not displayed until the user swipes past the last video.
+        composeTestRule.onNodeWithTag(VideoFeedScreenTestTag.VIDEO_FEED_LOADING_PAGE.name, useUnmergedTree = true)
+            .assertExists()
+            .assertIsNotDisplayed()
+
+        composeTestRule.onNodeWithTag(VideoFeedScreenTestTag.VIDEO_FEED_PAGER.name)
+            .performTouchInput { swipeUp() }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(VideoFeedScreenTestTag.VIDEO_FEED_LOADING_PAGE.name, useUnmergedTree = true)
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `pagination loading page is not shown when isLoading is false`() {
+        val project = ProjectFactory.project().toBuilder().id(8002L).build()
+        val items = listOf(VideoFeedItem(badges = emptyList(), project = project, hlsUrl = hlsUrl))
+
+        composeTestRule.setContent {
+            KSTheme {
+                VideoFeedScreen(
+                    environment = environment(),
+                    items = items,
+                    hasMore = true,
+                    isLoading = false
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(VideoFeedScreenTestTag.VIDEO_FEED_LOADING_PAGE.name, useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `pagination loading page is not shown when there are no more pages`() {
+        val project = ProjectFactory.project().toBuilder().id(8003L).build()
+        val items = listOf(VideoFeedItem(badges = emptyList(), project = project, hlsUrl = hlsUrl))
+
+        composeTestRule.setContent {
+            KSTheme {
+                VideoFeedScreen(
+                    environment = environment(),
+                    items = items,
+                    hasMore = false,
+                    isLoading = true
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(VideoFeedScreenTestTag.VIDEO_FEED_LOADING_PAGE.name, useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    @Test
     fun `error snackbar is displayed when errorSnackBarHostState receives a message`() {
         val snackbarHostState = SnackbarHostState()
         val errorMessage = "Something went wrong, please try again"

--- a/app/src/test/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModelTest.kt
@@ -96,6 +96,65 @@ class VideoFeedViewModelTest : KSRobolectricTestCase() {
     }
 
     @Test
+    fun `loadVideoFeed sets isLoading true while fetching and false once items arrive`() = runTest {
+        val item = VideoFeedItem(badges = emptyList(), project = ProjectFactory.project(), hlsUrl = null)
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val feedSignal = CompletableDeferred<Result<VideoFeedEnvelope>>()
+
+        val environment = environment().toBuilder()
+            .apolloClientV2(object : MockApolloClientV2() {
+                override suspend fun getVideoFeed(first: Int, cursor: String?, categoryId: String?): Result<VideoFeedEnvelope> =
+                    feedSignal.await()
+            })
+            .build()
+
+        setUpEnvironment(environment, dispatcher)
+        viewModel.loadVideoFeed()
+        // Run the coroutine up to the suspended network call, not beyond
+        testScheduler.runCurrent()
+
+        // While the request is in flight, isLoading is true and no items are present yet
+        assertTrue(viewModel.videoFeedUIState.value.isLoading)
+        assertTrue(viewModel.videoFeedUIState.value.items.isEmpty())
+
+        feedSignal.complete(Result.success(VideoFeedEnvelope(items = listOf(item))))
+        advanceUntilIdle()
+
+        assertFalse(viewModel.videoFeedUIState.value.isLoading)
+        assertEquals(listOf(item), viewModel.videoFeedUIState.value.items)
+    }
+
+    @Test
+    fun `loadVideoFeed does not start a second request while one is already in flight`() = runTest {
+        val item = VideoFeedItem(badges = emptyList(), project = ProjectFactory.project(), hlsUrl = null)
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val feedSignal = CompletableDeferred<Result<VideoFeedEnvelope>>()
+        var fetchCount = 0
+
+        val environment = environment().toBuilder()
+            .apolloClientV2(object : MockApolloClientV2() {
+                override suspend fun getVideoFeed(first: Int, cursor: String?, categoryId: String?): Result<VideoFeedEnvelope> {
+                    fetchCount++
+                    return feedSignal.await()
+                }
+            })
+            .build()
+
+        setUpEnvironment(environment, dispatcher)
+        viewModel.loadVideoFeed()
+        testScheduler.runCurrent()
+
+        // A second call while loading is a no-op
+        viewModel.loadVideoFeed()
+        testScheduler.runCurrent()
+
+        feedSignal.complete(Result.success(VideoFeedEnvelope(items = listOf(item))))
+        advanceUntilIdle()
+
+        assertEquals(1, fetchCount)
+    }
+
+    @Test
     fun `bookmarkProject on unstarred project calls watchProjectSuspend and sets isStarred true`() = runTest {
         val project = ProjectFactory.project().toBuilder().id(1L).isStarred(false).build()
         val item = VideoFeedItem(badges = emptyList(), project = project, hlsUrl = null)


### PR DESCRIPTION
# 📲 What

Surfaces the pagination loading state in the Video Feed, and prevents redundant feed loads.

- Adds a full-screen loading page (a centered spinner over the video background) that appears as a trailing page in the feed while the next page of videos is being fetched.
- Moves the initial `loadVideoFeed()` call into a `LaunchedEffect` so it no longer re-runs on every recomposition.
- `KSCircularProgressIndicator` now accepts an optional `color` parameter so the spinner can match the video player content color.

# 🤔 Why

The `isLoading` flag already existed in `VideoFeedUIState`, but it was never wired to any UI — so pagination gave the user no visual feedback while waiting for more videos to load.

Separately, `loadVideoFeed()` was being invoked directly in the composable body, which caused it to re-run on every recomposition (e.g. whenever items emit), triggering more network calls than necessary.

# 🛠 How

- **`VideoFeedScreen`**: Appends an extra trailing page to the pager when `isLoading && hasMore`. A sentinel key (`Long.MIN_VALUE`) keeps the pager key stable for the loading page without colliding with real (always positive) project ids. The new `VideoFeedLoadingPage` composable renders a centered `KSCircularProgressIndicator` over the player background. Thanks to prefetch + `beyondViewportPageCount = 1`, the next page usually loads before the user reaches the end, so the loading page is typically only seen when the user out-swipes the request, or on the very first load.
- **`VideoFeedActivity`**: Wraps the initial `loadVideoFeed()` in `LaunchedEffect(Unit)` and passes `uiState.isLoading` into `VideoFeedScreen`.
- **`KSCircularProgressIndicator`**: New optional `color` param defaulting to `kds_create_700`, so existing call sites are unaffected.
- **Tests**: Screen tests cover the loading-page visibility rules (shown when `isLoading && hasMore`, hidden when `isLoading` is false or there are no more pages). View-model tests assert `isLoading` toggles around the fetch and that a second `loadVideoFeed()` call while one is already in flight is a no-op.


# 📋 QA

1. Open the Video Feed.
2. Swipe through the videos to the end of the currently loaded page.
4. Confirm no spinner page appears once there are no more videos to load (`hasMore = false`).
5. Confirm the feed still loads correctly on first open, and that scrolling / recomposition does not trigger duplicate network loads.

Worth noticing the pagination loading state as of now is hard to trigger as the pre-fecth happens on item 7, preparing and rendering 3 items in advance, will be visible on very first load and on new page reached only on very poor quality networks

# Story 📖


[DISC-236]: (https://kickstarter.atlassian.net/browse/DISC-236)