### PR TITLE
CHECK-288: Show fixed shipping costs in the rewards carousel

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -203,11 +203,69 @@ object RewardViewUtils {
     }
 
     /**
-     * Return the string for the estimated shipping costs for a given shipping rule
+     * Return a string for the estimated shipping cost of a single Reward for a given Location:
+     * either a range or a fixed cost, depending on the shipping rule for that location.
      *
-     * Ex. "About $10-$15" or "About $10-%15 each"
+     * Ex. "About $10-$15" or "$10"
+     *
+     * Used specifically for each Reward Card in the Rewards Carousel.
      */
-    fun getEstimatedShippingCostString(
+    fun getEstimatedShippingCost(
+        context: Context,
+        ksCurrency: KSCurrency,
+        ksString: KSString,
+        project: Project,
+        reward: Reward,
+        locationId: Long,
+    ): String? {
+        // TO-DO: move to class-level constant and replace all instances of ""
+        val EMPTY_STRING = ""
+
+        if (RewardUtils.isDigital(reward) || RewardUtils.isLocalPickup(reward) || !RewardUtils.isShippable(reward))
+            return null
+
+        val shippingRule = reward.shippingRules()?.firstOrNull { it.location()?.id() == locationId }
+            ?: if (RewardUtils.shipsWorldwide(reward)) reward.shippingRules()?.firstOrNull() else null
+
+        if (shippingRule == null)
+            return null
+
+        val estimatedMin = shippingRule.estimatedMin()
+        val estimatedMax = shippingRule.estimatedMax()
+        val cost = shippingRule.cost()
+
+        // consistent w/ iOS but no longer w/ the other getEstimatedShippingCostString()
+        if (estimatedMin > 0.0 || estimatedMax > 0.0) {
+            val estimatedMinFormatted = ksCurrency.format(estimatedMin, project, RoundingMode.HALF_UP)
+            val estimatedMaxFormatted = ksCurrency.format(estimatedMax, project, RoundingMode.HALF_UP)
+            return if (estimatedMinFormatted.isEmpty() || estimatedMaxFormatted.isEmpty()) {
+                EMPTY_STRING
+            } else {
+                ksString.format(
+                    context.getString(R.string.About_reward_amount),
+                    "reward_amount",
+                    "$estimatedMinFormatted-$estimatedMaxFormatted"
+                )
+            }
+        } else if (cost > 0) {
+            val costFormatted = ksCurrency.format(cost, project, RoundingMode.HALF_UP)
+            return costFormatted.ifEmpty {
+                EMPTY_STRING
+            }
+        } else {
+            return EMPTY_STRING
+        }
+    }
+
+    /**
+     * Return a string for the estimated shipping costs for a collection Rewards (i.e. a base Reward + Add-Ons)
+     * for a given shipping rule.
+     *
+     * Ex. "About $10-$15" or "About $10-$15 each"
+     *
+     * Used for Add-On Cards (for now) and on the Checkout Screen.
+     */
+    fun getEstimatedShippingRange(
         context: Context,
         ksCurrency: KSCurrency,
         ksString: KSString,
@@ -240,7 +298,7 @@ object RewardViewUtils {
             }
         }
 
-        if (minTotal <= 0 || maxtotal <= 0) return ""
+        if (minTotal <= 0 && maxtotal <= 0) return ""
 
         min = if (useUserPreference) {
             ksCurrency.formatWithUserPreference(minTotal, project, RoundingMode.HALF_UP, precision = 2)

--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -234,7 +234,6 @@ object RewardViewUtils {
         val estimatedMax = shippingRule.estimatedMax()
         val cost = shippingRule.cost()
 
-        // consistent w/ iOS but no longer w/ the other getEstimatedShippingCostString()
         if (estimatedMin > 0.0 || estimatedMax > 0.0) {
             val estimatedMinFormatted = ksCurrency.format(estimatedMin, project, RoundingMode.HALF_UP)
             val estimatedMaxFormatted = ksCurrency.format(estimatedMax, project, RoundingMode.HALF_UP)
@@ -258,8 +257,8 @@ object RewardViewUtils {
     }
 
     /**
-     * Return a string for the estimated shipping costs for a collection Rewards (i.e. a base Reward + Add-Ons)
-     * for a given shipping rule.
+     * Return a string for the estimated shipping costs for a collection of
+     * Rewards (i.e. a base Reward + Add-Ons) for a given shipping rule.
      *
      * Ex. "About $10-$15" or "About $10-$15 each"
      *

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/AddOnsScreen.kt
@@ -288,7 +288,7 @@ fun AddOnsScreen(
                         if (!RewardUtils.isDigital(reward) && RewardUtils.isShippable(reward) && !RewardUtils.isLocalPickup(reward)) {
                             environment.ksCurrency()?.let { ksCurrency ->
                                 environment.ksString()?.let { ksString ->
-                                    RewardViewUtils.getEstimatedShippingCostString(
+                                    RewardViewUtils.getEstimatedShippingRange(
                                         context = context,
                                         ksCurrency = ksCurrency,
                                         ksString = ksString,

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/CheckoutScreen.kt
@@ -638,7 +638,7 @@ fun CheckoutScreen(
                     .isNotNull() && currentShippingRule.isNotNull()
                 ) {
                     val estimatedShippingRangeString =
-                        RewardViewUtils.getEstimatedShippingCostString(
+                        RewardViewUtils.getEstimatedShippingRange(
                             context = LocalContext.current,
                             ksCurrency = environment.ksCurrency()!!,
                             ksString = environment.ksString()!!,
@@ -653,7 +653,7 @@ fun CheckoutScreen(
                     val estimatedShippingRangeConversionString =
                         if (project.currentCurrency() == project.currency()) null
                         else {
-                            RewardViewUtils.getEstimatedShippingCostString(
+                            RewardViewUtils.getEstimatedShippingRange(
                                 context = LocalContext.current,
                                 ksCurrency = environment.ksCurrency()!!,
                                 ksString = environment.ksString()!!,

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
@@ -43,6 +43,7 @@ import com.kickstarter.libs.utils.extensions.isNullOrZero
 import com.kickstarter.mock.factories.RewardsItemFactory
 import com.kickstarter.mock.factories.ShippingRuleFactory
 import com.kickstarter.models.Backing
+import com.kickstarter.models.Location
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.ShippingRule
@@ -361,16 +362,13 @@ fun RewardCarouselScreen(
                             if (!RewardUtils.isDigital(reward) && RewardUtils.isShippable(reward) && !RewardUtils.isLocalPickup(reward)) {
                                 environment.ksCurrency()?.let { ksCurrency ->
                                     environment.ksString()?.let { ksString ->
-                                        RewardViewUtils.getEstimatedShippingCostString(
+                                        RewardViewUtils.getEstimatedShippingCost(
                                             context = context,
                                             ksCurrency = ksCurrency,
                                             ksString = ksString,
                                             project = project,
-                                            rewards = listOf(reward),
-                                            selectedShippingRule = currentShippingRule,
-                                            multipleQuantitiesAllowed = false,
-                                            useUserPreference = false,
-                                            useAbout = true
+                                            reward = reward,
+                                            locationId = currentShippingRule.location()?.id() ?: Location.builder().build().id(),
                                         )
                                     }
                                 }

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
@@ -6,6 +6,7 @@ import com.kickstarter.R
 import com.kickstarter.libs.KSCurrency
 import com.kickstarter.mock.MockCurrentConfigV2
 import com.kickstarter.mock.factories.ConfigFactory
+import com.kickstarter.mock.factories.LocationFactory
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.mock.factories.ShippingRuleFactory
@@ -124,7 +125,7 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
 
         val selectedShippingRule = caRule
 
-        val estimatedShippingString = RewardViewUtils.getEstimatedShippingCostString(
+        val estimatedShippingString = RewardViewUtils.getEstimatedShippingRange(
             context, ksCurrency, ksString, project, rewards, selectedShippingRule,
             multipleQuantitiesAllowed = false,
             useUserPreference = false,
@@ -167,7 +168,7 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
 
         val selectedShippingRule = usRule
 
-        val estimatedShippingString = RewardViewUtils.getEstimatedShippingCostString(
+        val estimatedShippingString = RewardViewUtils.getEstimatedShippingRange(
             context, ksCurrency, ksString, project, rewards, selectedShippingRule,
             multipleQuantitiesAllowed = false,
             useUserPreference = false,
@@ -201,7 +202,7 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
 
         val selectedShippingRule = ShippingRuleFactory.usShippingRule()
 
-        val estimatedShippingString = RewardViewUtils.getEstimatedShippingCostString(
+        val estimatedShippingString = RewardViewUtils.getEstimatedShippingRange(
             context, ksCurrency, ksString, project, rewards, selectedShippingRule,
             multipleQuantitiesAllowed = false,
             useUserPreference = false,
@@ -209,5 +210,280 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
         )
 
         assertTrue(estimatedShippingString.isEmpty())
+    }
+
+    @Test
+    fun `test estimated shipping range when min or max is 0, when min and max are 0`() {
+        val context = context()
+
+        val configForUSUser = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfigV2()
+        currentConfig.config(configForUSUser)
+        val ksCurrency = KSCurrency(currentConfig)
+
+        val ksString = ksString()
+        val caProject = ProjectFactory.caProject()
+
+        val usRule = ShippingRuleFactory.usShippingRule().toBuilder()
+            .estimatedMin(0.0)
+            .estimatedMax(0.0)
+            .build()
+        val mxRule = ShippingRuleFactory.mexicoShippingRule().toBuilder()
+            .estimatedMin(0.0)
+            .estimatedMax(20.0)
+            .build()
+
+        val shippingPreference = Reward.ShippingPreference.RESTRICTED
+        val reward = RewardFactory.reward().toBuilder()
+            .shippingPreference(shippingPreference.name)
+            .shippingType(shippingPreference.name)
+            .shippingPreferenceType(shippingPreference)
+            .shippingRules(listOf(mxRule, usRule))
+            .build()
+        val rewards = listOf(reward)
+
+        val estimatedShippingStringForUS = RewardViewUtils.getEstimatedShippingRange(
+            context, ksCurrency, ksString, caProject, rewards, usRule,
+            multipleQuantitiesAllowed = false,
+            useUserPreference = false,
+            useAbout = false,
+        )
+        val estimatedShippingStringForMX = RewardViewUtils.getEstimatedShippingRange(
+            context, ksCurrency, ksString, caProject, rewards, mxRule,
+            multipleQuantitiesAllowed = false,
+            useUserPreference = false,
+            useAbout = false,
+        )
+
+        assertEquals("", estimatedShippingStringForUS)
+        assertEquals("CA$ 0-CA$ 20", estimatedShippingStringForMX)
+    }
+
+    @Test
+    fun `getEstimatedShippingCost - returns null when reward is not shippable`() {
+        val context = context()
+
+        val configForUSUser = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfigV2()
+        currentConfig.config(configForUSUser)
+        val ksCurrency = KSCurrency(currentConfig)
+
+        val ksString = ksString()
+        val caProject = ProjectFactory.caProject()
+
+        val shippingPreference = Reward.ShippingPreference.NONE
+        val digitalReward = RewardFactory.reward().toBuilder()
+            .shippingPreferenceType(shippingPreference)
+            .shippingPreference(shippingPreference.name.lowercase())
+            .shippingType(shippingPreference.name.lowercase())
+            // For testing. In practice, the shipping rules list for digital rewards is typically empty.
+            .shippingRules(listOf(ShippingRuleFactory.usShippingRule()))
+            .build()
+
+        val selectedLocation = LocationFactory.unitedStates()
+
+        val estimatedShippingString = RewardViewUtils.getEstimatedShippingCost(
+            context, ksCurrency, ksString, caProject, digitalReward, selectedLocation.id(),
+        )
+
+        assertNull(estimatedShippingString)
+    }
+
+    @Test
+    fun `getEstimatedShippingCost - returns null when no shipping rule matches and reward shipping is restricted `() {
+        val context = context()
+
+        val configForUSUser = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfigV2()
+        currentConfig.config(configForUSUser)
+        val ksCurrency = KSCurrency(currentConfig)
+
+        val ksString = ksString()
+        val caProject = ProjectFactory.caProject()
+
+        val usRule = ShippingRuleFactory.usShippingRule().toBuilder()
+            .estimatedMin(1.0)
+            .estimatedMax(10.0)
+            .build()
+        val mxRule = ShippingRuleFactory.mexicoShippingRule().toBuilder()
+            .estimatedMin(2.0)
+            .estimatedMax(20.0)
+            .build()
+
+        val shippingPreference = Reward.ShippingPreference.RESTRICTED
+        val reward = RewardFactory.reward().toBuilder()
+            .shippingPreferenceType(shippingPreference)
+            .shippingPreference(shippingPreference.name.lowercase())
+            .shippingType(shippingPreference.name.lowercase())
+            .shippingRules(listOf(mxRule, usRule))
+            .build()
+
+        val selectedLocation = LocationFactory.canada()
+
+        val estimatedShippingString = RewardViewUtils.getEstimatedShippingCost(
+            context, ksCurrency, ksString, caProject, reward, selectedLocation.id(),
+        )
+
+        assertNull(estimatedShippingString)
+    }
+
+    @Test
+    fun `getEstimatedShippingCost - uses first shipping rule by default when none match but reward ships worldwide `() {
+        val context = context()
+
+        val configForUSUser = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfigV2()
+        currentConfig.config(configForUSUser)
+        val ksCurrency = KSCurrency(currentConfig)
+
+        val ksString = ksString()
+        val caProject = ProjectFactory.caProject()
+
+        val usRule = ShippingRuleFactory.usShippingRule().toBuilder()
+            .estimatedMin(1.0)
+            .estimatedMax(10.0)
+            .build()
+
+        val mxLocation = LocationFactory.mexico()
+        val mxRule = ShippingRuleFactory.mexicoShippingRule().toBuilder()
+            .location(mxLocation)
+            .estimatedMin(2.0)
+            .estimatedMax(20.0)
+            .build()
+
+        val shippingPreference = Reward.ShippingPreference.UNRESTRICTED
+        val reward = RewardFactory.reward().toBuilder()
+            .shippingPreference(shippingPreference.name)
+            .shippingType(shippingPreference.name)
+            .shippingPreferenceType(shippingPreference)
+            .shippingRules(listOf(mxRule, usRule))
+            .build()
+
+        val caLocation = LocationFactory.canada()
+
+        val selectedLocation = caLocation
+
+        val expectedEstimatedShippingString = RewardViewUtils.getEstimatedShippingCost(
+            context, ksCurrency, ksString, caProject, reward, mxLocation.id()
+        )
+        val estimatedShippingString = RewardViewUtils.getEstimatedShippingCost(
+            context, ksCurrency, ksString, caProject, reward, selectedLocation.id(),
+        )
+
+        assertEquals(expectedEstimatedShippingString, estimatedShippingString)
+    }
+
+    @Test
+    fun `getEstimatedShippingCost - returns formatted range when min or max is non-zero`() {
+        val context = context()
+
+        val configForUSUser = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfigV2()
+        currentConfig.config(configForUSUser)
+        val ksCurrency = KSCurrency(currentConfig)
+
+        val ksString = ksString()
+        val caProject = ProjectFactory.caProject()
+
+        val usLocation = LocationFactory.unitedStates()
+        val usRule = ShippingRuleFactory.usShippingRule().toBuilder()
+            .location(usLocation)
+            .estimatedMin(0.0)
+            .estimatedMax(10.0)
+            .build()
+        val mxLocation = LocationFactory.mexico()
+        val mxRule = ShippingRuleFactory.mexicoShippingRule().toBuilder()
+            .location(mxLocation)
+            .estimatedMin(2.0)
+            .estimatedMax(20.0)
+            .build()
+
+        val shippingPreference = Reward.ShippingPreference.RESTRICTED
+        val reward = RewardFactory.reward().toBuilder()
+            .shippingPreference(shippingPreference.name)
+            .shippingType(shippingPreference.name)
+            .shippingPreferenceType(shippingPreference)
+            .shippingRules(listOf(mxRule, usRule))
+            .build()
+
+        val estimatedShippingStringForUS = RewardViewUtils.getEstimatedShippingCost(
+            context, ksCurrency, ksString, caProject, reward, usLocation.id(),
+        )
+        val estimatedShippingStringForMX = RewardViewUtils.getEstimatedShippingCost(
+            context, ksCurrency, ksString, caProject, reward, mxLocation.id(),
+        )
+
+        assertEquals("About CA$ 0-CA$ 10", estimatedShippingStringForUS)
+        assertEquals("About CA$ 2-CA$ 20", estimatedShippingStringForMX)
+    }
+
+    @Test
+    fun `getEstimatedShippingCost - returns formatted cost when min and max are 0, cost is positive`() {
+        val context = context()
+
+        val configForUSUser = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfigV2()
+        currentConfig.config(configForUSUser)
+        val ksCurrency = KSCurrency(currentConfig)
+
+        val ksString = ksString()
+        val caProject = ProjectFactory.caProject()
+
+        val usLocation = LocationFactory.unitedStates()
+        val usRule = ShippingRuleFactory.usShippingRule().toBuilder()
+            .location(usLocation)
+            .estimatedMin(0.0)
+            .estimatedMax(0.0)
+            .cost(10.0)
+            .build()
+
+        val shippingPreference = Reward.ShippingPreference.RESTRICTED
+        val reward = RewardFactory.reward().toBuilder()
+            .shippingPreference(shippingPreference.name)
+            .shippingType(shippingPreference.name)
+            .shippingPreferenceType(shippingPreference)
+            .shippingRules(listOf(usRule))
+            .build()
+
+        val estimatedShippingString = RewardViewUtils.getEstimatedShippingCost(
+            context, ksCurrency, ksString, caProject, reward, usLocation.id(),
+        )
+
+        assertEquals("CA$ 10", estimatedShippingString)
+    }
+
+    @Test
+    fun `getEstimatedShippingCost - returns empty string when min, max, and cost are 0`() {
+        val context = context()
+
+        val configForUSUser = ConfigFactory.configForUSUser()
+        val currentConfig = MockCurrentConfigV2()
+        currentConfig.config(configForUSUser)
+        val ksCurrency = KSCurrency(currentConfig)
+
+        val ksString = ksString()
+        val caProject = ProjectFactory.caProject()
+
+        val usLocation = LocationFactory.unitedStates()
+        val usRule = ShippingRuleFactory.usShippingRule().toBuilder()
+            .location(usLocation)
+            .estimatedMin(0.0)
+            .estimatedMax(0.0)
+            .cost(0.0)
+            .build()
+
+        val shippingPreference = Reward.ShippingPreference.RESTRICTED
+        val reward = RewardFactory.reward().toBuilder()
+            .shippingPreference(shippingPreference.name)
+            .shippingType(shippingPreference.name)
+            .shippingPreferenceType(shippingPreference)
+            .shippingRules(listOf(usRule))
+            .build()
+
+        val estimatedShippingString = RewardViewUtils.getEstimatedShippingCost(
+            context, ksCurrency, ksString, caProject, reward, usLocation.id(),
+        )
+
+        assertEquals("", estimatedShippingString)
     }
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
@@ -290,7 +290,7 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `getEstimatedShippingCost - returns null when no shipping rule matches and reward shipping is restricted `() {
+    fun `getEstimatedShippingCost - returns null when no shipping rule matches and reward shipping is restricted`() {
         val context = context()
 
         val configForUSUser = ConfigFactory.configForUSUser()
@@ -328,7 +328,7 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `getEstimatedShippingCost - uses first shipping rule by default when none match but reward ships worldwide `() {
+    fun `getEstimatedShippingCost - uses first shipping rule by default when none match but reward ships worldwide`() {
         val context = context()
 
         val configForUSUser = ConfigFactory.configForUSUser()


### PR DESCRIPTION
# 📲 What

Show the fixed shipping cost of a Reward in the rewards carousel.

Also, fix a bug where shipping ranges with min or max of 0 are not accounted for.

# 🤔 Why

Currently, the only shipping information surfaced to backers before they reach checkout is an estimated shipping range if a Reward's shipping rules are configured with one. If a Reward's shipping rules are configured with a fixed cost, that cost is not visible to backers until they reach checkout, which may not align with backers' expectations.

Separately, there is another small bug in the existing function for generating a shipping range string for a set of Rewards, where the output is an empty string if either one of the min or max values is 0.

# 🛠 How

Previously, there was a single utility function for generating a shipping range string for a set of Rewards and a given 'location': `getEstimatedShippingCostString()`.

For clarity, we rename that function to `getEstimatedShippingRange()`, and update the conditional within such that the function outputs an empty string only if both the min and max values are 0. (Outputting an empty string in this case is intentional for a sort of 'backwards compatibility' with hiding certain UI components on the Add-Ons and Checkout screens).

We add a new utility function, `getEstimatedShippingCost()`, that generates an estimated shipping cost string -- either a range or a fixed cost -- for a single Reward and a given Location. Specifically it returns:
- A shipping range if either the min or max value is > 0
- The fixed shipping cost if the cost is > 0
- An empty string if the min, max, and cost are all 0
- `null` if a shipping rule cannot be found for the given Location
  - This is also generally the case for non-shippable rewards (digital, local), but we explicitly check for those as well.

This new function is used specifically for Reward cards in the rewards carousel, replacing the usage of the function now named `getEstimatedShippingRange()`.

Note: Due to slight differences in the data models and UX, the implementation here does not match the web _exactly_, but it's still used as a reference: [`deriveFormattedShippingEstimateOrCost()`](https://github.com/kickstarter/kickstarter/blob/6b89d4926c34d90923a49994348c28c32a3a26bc/browser/javascripts/pledge-app/pledge-reward-selection/components/SelectableRewardOrAddOn.tsx#L344)

# 👀 See

### Fixed shipping cost shown in the Rewards Carousel

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="256" src="https://github.com/user-attachments/assets/5321cbd0-de5f-45f1-b150-2fcaec6f91ba" />| <img width="256" src="https://github.com/user-attachments/assets/b5c4d8a2-6534-4dd5-aed9-1b1c7019198b" /> |

### Shipping range shown for Add-Ons

#### Before 🐛

https://github.com/user-attachments/assets/62dadbea-5aba-4dc4-bf63-780b4cfe77d5

#### After 🦋

https://github.com/user-attachments/assets/1834b7a5-b38c-4795-a03f-e2d120901f96

# 📋 QA

(Note: for sanity, compare all values with the web)

- Visit any Project with Rewards that have a fixed shipping cost > 0 to some location and confirm that they are displayed in the rewards carousel. E.g. [SHELBY Tool Mechanical Watch:Carbon Fiber Racing Chronograph by Iustus — Kickstarter](https://www.kickstarter.com/projects/1068134248/shelby-tool-mechanical-watch-carbon-fiber-racing-chronograph)
- Visit any Project with Rewards and Add-Ons that have an estimated shipping cost range where either the min or max are > 0. Confirm that the range is displayed in the Add-Ons screen, and that when selected, the aggregate shipping range shown on Checkout is correct. E.g. [Camtells: The First AI Camera That Understands Your Space by Camtells — Kickstarter](https://www.kickstarter.com/projects/948304531/camtells-the-first-ai-camera-that-understands-your-space?ref=checkout_rewards_page)

# Story 📖

[\[CHECK-288\] [Placeholder] Show all shipping costs in the rewards carousel and add-ons screen - Jira](https://kickstarter.atlassian.net/browse/CHECK-288)
