### PR TITLE
CHECK-225: Update carousel Reward cards to show quantity remaining

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -23,6 +23,8 @@ import com.kickstarter.models.ShippingRule
 import java.math.RoundingMode
 import kotlin.math.floor
 
+private const val EMPTY_STRING = ""
+
 object RewardViewUtils {
 
     /**
@@ -218,9 +220,6 @@ object RewardViewUtils {
         reward: Reward,
         locationId: Long,
     ): String? {
-        // TO-DO: move to class-level constant and replace all instances of ""
-        val EMPTY_STRING = ""
-
         if (RewardUtils.isDigital(reward) || RewardUtils.isLocalPickup(reward) || !RewardUtils.isShippable(reward))
             return null
 
@@ -365,5 +364,26 @@ object RewardViewUtils {
             shippingAmount
         )
         return ammountAndShippingString ?: ""
+    }
+
+    fun getQuantityRemainingString(context: Context, ksString: KSString, reward: Reward): String {
+        val limit = reward.limit()
+        if (limit != null && limit > 0) { // matches web + we don't know if `limit` of `0` is possible or what it implies.
+            val remaining = reward.remaining()
+            if (remaining != null && remaining > 0) {
+                val remainingCountLeftOfLimitCountString = context.getString(R.string.remaining_count_left_of_limit_count)
+                return ksString.format(
+                    remainingCountLeftOfLimitCountString,
+                    "remaining_count",
+                    NumberUtils.format(remaining),
+                    "limit_count",
+                    NumberUtils.format(limit),
+                )
+            } else { // matches existing behavior for the ui. hide the badge if the remaining quantity is <= 0. implementation detail, but would be unclear without this comment.
+                return EMPTY_STRING
+            }
+        } else {
+            return EMPTY_STRING
+        }
     }
 }

--- a/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/RewardViewUtils.kt
@@ -368,7 +368,7 @@ object RewardViewUtils {
 
     fun getQuantityRemainingString(context: Context, ksString: KSString, reward: Reward): String {
         val limit = reward.limit()
-        if (limit != null && limit > 0) { // matches web + we don't know if `limit` of `0` is possible or what it implies.
+        if (limit != null && limit > 0) { // Matches the web, and we don't know what a `limit` of `0` implies.
             val remaining = reward.remaining()
             if (remaining != null && remaining > 0) {
                 val remainingCountLeftOfLimitCountString = context.getString(R.string.remaining_count_left_of_limit_count)
@@ -379,7 +379,7 @@ object RewardViewUtils {
                     "limit_count",
                     NumberUtils.format(limit),
                 )
-            } else { // matches existing behavior for the ui. hide the badge if the remaining quantity is <= 0. implementation detail, but would be unclear without this comment.
+            } else { // To match pre-existing UI behavior: hide the badge if the remaining quantity is <= 0.
                 return EMPTY_STRING
             }
         } else {

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
@@ -348,15 +348,7 @@ fun RewardCarouselScreen(
                             },
                             remainingText =
                             environment.ksString()?.let { ksString ->
-                                if (!reward.isLimited()) {
-                                    if (remaining > 0) {
-                                        ksString.format(
-                                            stringResource(id = R.string.Left_count_left_few),
-                                            "left_count",
-                                            NumberUtils.format(remaining)
-                                        )
-                                    } else ""
-                                } else ""
+                                RewardViewUtils.getQuantityRemainingString(context, ksString, reward)
                             },
                             estimatedShippingCost =
                             if (!RewardUtils.isDigital(reward) && RewardUtils.isShippable(reward) && !RewardUtils.isLocalPickup(reward)) {

--- a/app/src/main/java/com/kickstarter/ui/compose/KSRewardCard.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/KSRewardCard.kt
@@ -36,6 +36,7 @@ import com.kickstarter.ui.compose.designsystem.KSFeaturedRewardBadge
 import com.kickstarter.ui.compose.designsystem.KSGreenBadge
 import com.kickstarter.ui.compose.designsystem.KSPrimaryGreenButton
 import com.kickstarter.ui.compose.designsystem.KSSecretRewardBadge
+import com.kickstarter.ui.compose.designsystem.KSSubtleWarningBadge
 import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
@@ -623,7 +624,7 @@ fun KSRewardCard(
                             KSGreenBadge(text = expirationDateText)
                         }
                         if (!remainingText.isNullOrEmpty()) {
-                            KSGreenBadge(text = remainingText)
+                            KSSubtleWarningBadge(text = remainingText)
                         }
                         if (!shippingSummaryText.isNullOrEmpty()) {
                             KSGreenBadge(text = shippingSummaryText)

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSBadges.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSBadges.kt
@@ -90,6 +90,10 @@ fun KSBadgesPreview() {
             Spacer(modifier = Modifier.height(dimensions.listItemSpacingSmall))
 
             KSVideoBadge(text = "Just launched")
+
+            Spacer(modifier = Modifier.height(dimensions.listItemSpacingSmall))
+
+            KSSubtleWarningBadge(text = "19 left of 1,000")
         }
     }
 }
@@ -261,6 +265,37 @@ fun KSWarningBadge(
                 style = typographyV2.footNoteMedium
             )
         }
+    }
+}
+
+@Composable
+fun KSSubtleWarningBadge(
+    modifier: Modifier = Modifier,
+    text: String,
+    leadingIcon: (@Composable (iconTint: Color) -> Unit)? = null,
+    iconTint: Color = colors.textAccentYellowBold,
+    textColor: Color = colors.textAccentYellowBold,
+    textStyle: TextStyle = typographyV2.footNoteMedium
+) {
+    Row(
+        modifier
+            .background(
+                color = colors.backgroundWarningSubtle,
+                shape = shapes.small
+            )
+            .padding(
+                start = dimensions.paddingMediumSmall,
+                top = dimensions.paddingSmall,
+                bottom = dimensions.paddingSmall,
+                end = dimensions.paddingMediumSmall
+            )
+    ) {
+        leadingIcon?.invoke(iconTint)
+        Text(
+            text = text,
+            color = textColor,
+            style = textStyle
+        )
     }
 }
 

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
@@ -486,4 +486,73 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
 
         assertEquals("", estimatedShippingString)
     }
+
+    @Test
+    fun `getQuantityRemainingString - returns empty string for unknown limit`() {
+        val context = context()
+        val ksString = ksString()
+
+        listOf(-1, 0, null).forEach { limit ->
+            val reward = RewardFactory.reward().toBuilder()
+                .limit(limit)
+                .remaining(10)
+                .build()
+            val quantityRemainingString = RewardViewUtils.getQuantityRemainingString(context, ksString, reward)
+            assertEquals("", quantityRemainingString)
+        }
+    }
+
+    @Test
+    fun `getQuantityRemainingString - returns empty string for unknown remaining quantity`() {
+        val context = context()
+        val ksString = ksString()
+
+        listOf(-1, null).forEach { remaining ->
+            val reward = RewardFactory.reward().toBuilder()
+                .limit(10)
+                .remaining(remaining)
+                .build()
+            val quantityRemainingString = RewardViewUtils.getQuantityRemainingString(context, ksString, reward)
+            assertEquals("", quantityRemainingString)
+        }
+    }
+
+    @Test
+    fun `getQuantityRemainingString - returns empty string for when remaining quantity is 0`() {
+        // Separate test case for this scenario because it is an intentional design choice.
+        val context = context()
+        val ksString = ksString()
+
+        val reward = RewardFactory.reward().toBuilder()
+            .limit(10)
+            .remaining(0)
+            .build()
+        val quantityRemainingString = RewardViewUtils.getQuantityRemainingString(context, ksString, reward)
+        assertEquals("", quantityRemainingString)
+    }
+
+    @Test
+    fun `getQuantityRemainingString - returns formatted string limit and remaining quantity are positive`() {
+        val context = context()
+        val ksString = ksString()
+
+        var reward = RewardFactory.reward().toBuilder()
+            .limit(10)
+            .remaining(5)
+            .build()
+        assertEquals("5 left of 10", RewardViewUtils.getQuantityRemainingString(context, ksString, reward))
+
+        reward = RewardFactory.reward().toBuilder()
+            .limit(10_000)
+            .remaining(5_000)
+            .build()
+        assertEquals("5,000 left of 10,000", RewardViewUtils.getQuantityRemainingString(context, ksString, reward))
+
+        reward = RewardFactory.reward().toBuilder()
+            .limit(20)
+            .remaining(100)
+            .build()
+        // Should not happen in practice but we the validate the same expected behavior regardless.
+        assertEquals("100 left of 20", RewardViewUtils.getQuantityRemainingString(context, ksString, reward))
+    }
 }

--- a/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/RewardViewUtilsTest.kt
@@ -532,7 +532,7 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
     }
 
     @Test
-    fun `getQuantityRemainingString - returns formatted string limit and remaining quantity are positive`() {
+    fun `getQuantityRemainingString - returns formatted string when limit and remaining quantity are positive`() {
         val context = context()
         val ksString = ksString()
 
@@ -542,17 +542,27 @@ class RewardViewUtilsTest : KSRobolectricTestCase() {
             .build()
         assertEquals("5 left of 10", RewardViewUtils.getQuantityRemainingString(context, ksString, reward))
 
+        // Test with larger numbers to ensure formatting is correct.
         reward = RewardFactory.reward().toBuilder()
             .limit(10_000)
             .remaining(5_000)
             .build()
         assertEquals("5,000 left of 10,000", RewardViewUtils.getQuantityRemainingString(context, ksString, reward))
+    }
 
-        reward = RewardFactory.reward().toBuilder()
+    @Test
+    fun `getQuantityRemainingString - returns formatted string when remaining quantity is larger than limit`() {
+        /* Separate test case for this scenario so that it's consideration is intentional.
+         * Should not happen in practice, but we validate the same expected behavior regardless. */
+
+        val context = context()
+        val ksString = ksString()
+
+        val reward = RewardFactory.reward().toBuilder()
             .limit(20)
             .remaining(100)
             .build()
-        // Should not happen in practice but we the validate the same expected behavior regardless.
+
         assertEquals("100 left of 20", RewardViewUtils.getQuantityRemainingString(context, ksString, reward))
     }
 }


### PR DESCRIPTION
# 📲 What

Update carousel Reward cards to show quantity remaining when applicable.

# 🤔 Why

Surfacing to backers that a reward is limited in quantity, and how many are left, can help them decide when to pledge and which reward tier to choose. It may also improve conversion.

# 🛠 How

- Fix and update the logic for deciding when to show the badge associated with `KSRewardCard`'s  `remainingText` + move this logic into `RewardViewUtils.getQuantityRemainingString()` to simplify testability.
  - This function returns a localized string in the form `<remaining> left of <limit>` when `remaining` and `limit` are positive; and an empty string otherwise.
- Add a new badge `KSSubtleWarningBadge` to use on the Reward card for this text.

([Web](https://github.com/kickstarter/kickstarter/blob/a6f27b2e014e818bc4434c53fa33f2e066a45955/browser/javascripts/pledge-app/pledge-reward-selection/components/SelectableRewardOrAddOn.tsx#L191) and [iOS](https://github.com/kickstarter/ios-oss/blob/37b9cc62444747213f10a6661bcccef840d073a7/Library/Sources/Library/Library/ViewModels/RewardCardViewModel.swift#L340) implementations for reference.)

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="256" src="https://github.com/user-attachments/assets/f78f009a-f719-400a-ad27-18d624b510ab" /> | <img width="256" src="https://github.com/user-attachments/assets/1c240c7e-fede-46ce-a84c-f412e1656903" /> |
| <img width="256" src="https://github.com/user-attachments/assets/359c1522-5c87-448e-84ca-69056c65cfc2" /> | <img width="256" src="https://github.com/user-attachments/assets/faef9fe7-01e4-45e3-a0f9-9e45929963e9" /> |

# 📋 QA

Visit the Rewards Carousel for Projects configured in the following states, and compare the results to the web, with exceptions noted:

- Live/Completed Project with Rewards that are not limited do not show a quantity remaining badge, ex.:
  - [Blast Air - Redefining Portable Air Power by tommylee — Kickstarter](https://www.kickstarter.com/projects/flextail/blast-air/pledge/new?clicked_reward=false) > 'Super Early Bird | Blast Air *1'
  - [Astro Burn 😸 Cute-em-up Indie Game: Physical Edition by Beyond The Pixels — Kickstarter](https://www.kickstarter.com/projects/beyondthepixels/astro-burn-limited-edition-physical-indie-game) > 'Core Edition'

- Live/Completed Project with limited Rewards do _not_ show a quantity remaining badge when the quantity is 0 (**note:** the web still shows a badge in this case, but the apps do not), ex.:
  - [GL.iNet Comet Q: Wake, Unlock & Control Remotely by GL.iNet — Kickstarter](https://www.kickstarter.com/projects/glinet/comet-q/pledge/new?clicked_reward=false) > 'Comet Q (GL-RMQ1) - Super Early Bird'
  - [Astro Burn 😸 Cute-em-up Indie Game: Physical Edition by Beyond The Pixels — Kickstarter](https://www.kickstarter.com/projects/beyondthepixels/astro-burn-limited-edition-physical-indie-game) > 'Legacy Founders Edition'

- Live/Completed Project with limited Rewards show a quantity remaining badge when the quantity is > 0, ex.:
  - [GL.iNet Comet Q: Wake, Unlock & Control Remotely by GL.iNet — Kickstarter](https://www.kickstarter.com/projects/glinet/comet-q/pledge/new?clicked_reward=false) > 'Comet Q (GL-RMQ1), KS Special'
  - [Astro Burn 😸 Cute-em-up Indie Game: Physical Edition by Beyond The Pixels — Kickstarter](https://www.kickstarter.com/projects/beyondthepixels/astro-burn-limited-edition-physical-indie-game) > 'Collectors Edition'

- Late Pledge Project with limited Rewards show a quantity remaining badge when the quantity is > 0, ex.:
  - [Birdie® Pro: the iconic air monitor - now smarter! » Back this project — Kickstarter](https://www.kickstarter.com/projects/birdie-scandinavia/birdie-pro-your-fresh-air-pet/pledge/new?clicked_reward=false) > 'Early Bird (20% off) - Wood'

# Story 📖

[\[CHECK-225\] Limited reward quantity label is missing - Jira](https://kickstarter.atlassian.net/browse/CHECK-225)
