### PR TITLE
DISC-258: Inconsistencies on play button

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/KSProgressIndicators.kt
@@ -398,6 +398,7 @@ fun KSVideoScrubBar(
                 awaitEachGesture {
                     // - detect touch down for scale animation
                     val down = awaitFirstDown()
+                    down.consume()
                     isDragging = true
                     onScrubStart()
                     dragProgress = (down.position.x / size.width).coerceIn(0f, 1f)

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
@@ -195,6 +195,11 @@ fun KSVideoPlayer(
         val shouldPlay = isActive && isAppInForeground
         exoPlayer.playWhenReady = shouldPlay
         if (shouldPlay) {
+            // The player auto-resumes when the page becomes active or the app returns to the
+            // foreground, overriding any earlier manual pause. Reset the controls overlay so the
+            // play button doesn't linger on screen while the video is actually playing
+            // (e.g. pause → swipe away → swipe back, or pause → leave the screen → return).
+            showControls = false
             while (true) {
                 if (!isScrubbing) {
                     val duration = exoPlayer.duration

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
@@ -195,10 +195,6 @@ fun KSVideoPlayer(
         val shouldPlay = isActive && isAppInForeground
         exoPlayer.playWhenReady = shouldPlay
         if (shouldPlay) {
-            // The player auto-resumes when the page becomes active or the app returns to the
-            // foreground, overriding any earlier manual pause. Reset the controls overlay so the
-            // play button doesn't linger on screen while the video is actually playing
-            // (e.g. pause → swipe away → swipe back, or pause → leave the screen → return).
             showControls = false
             while (true) {
                 if (!isScrubbing) {

--- a/app/src/test/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayerTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayerTest.kt
@@ -582,6 +582,84 @@ class KSVideoPlayerTest() : KSRobolectricTestCase() {
         verify(mockPlayer, never()).play()
     }
 
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun `test controls are hidden when paused video becomes active again after swiping away and back`() {
+        val mockPlayer = mock(ExoPlayer::class.java)
+
+        var isActive by mutableStateOf(true)
+
+        composeTestRule.setContent {
+            KSTheme {
+                KSVideoPlayer(
+                    videoUrl = "https://example.com/video.mp4",
+                    isActive = isActive,
+                    player = mockPlayer
+                )
+            }
+        }
+
+        // - Tap surface to pause and show controls
+        composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_SURFACE.name).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_CONTROLS.name, useUnmergedTree = true)
+            .assertIsDisplayed()
+
+        // - Swipe away to the next video (page deactivates)
+        isActive = false
+        composeTestRule.waitForIdle()
+
+        // - Swipe back (page reactivates and the video auto-resumes)
+        isActive = true
+        composeTestRule.waitForIdle()
+
+        // - Controls overlay should be hidden to reflect the playing state
+        composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_CONTROLS.name, useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun `test controls are hidden when paused video resumes after app returns to foreground`() {
+        val mockPlayer = mock(ExoPlayer::class.java)
+        val lifecycleOwner = object : LifecycleOwner {
+            private val registry = LifecycleRegistry(this)
+            override val lifecycle: Lifecycle = registry
+            fun handleEvent(event: Lifecycle.Event) = registry.handleLifecycleEvent(event)
+        }
+        lifecycleOwner.handleEvent(Lifecycle.Event.ON_RESUME)
+
+        composeTestRule.setContent {
+            KSTheme {
+                CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                    KSVideoPlayer(
+                        videoUrl = "https://example.com/video.mp4",
+                        isActive = true,
+                        player = mockPlayer
+                    )
+                }
+            }
+        }
+
+        // - Tap surface to pause and show controls
+        composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_SURFACE.name).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_CONTROLS.name, useUnmergedTree = true)
+            .assertIsDisplayed()
+
+        // - Navigate away (app backgrounds)
+        lifecycleOwner.handleEvent(Lifecycle.Event.ON_PAUSE)
+        composeTestRule.waitForIdle()
+
+        // - Return to the video feed (app foregrounds and the video auto-resumes)
+        lifecycleOwner.handleEvent(Lifecycle.Event.ON_RESUME)
+        composeTestRule.waitForIdle()
+
+        // - Controls overlay should be hidden to reflect the playing state
+        composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_CONTROLS.name, useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
     @Test
     fun `poster is displayed while the first frame has not rendered`() {
         val mockPlayer = mock(ExoPlayer::class.java)

--- a/app/src/test/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayerTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayerTest.kt
@@ -290,6 +290,60 @@ class KSVideoPlayerTest() : KSRobolectricTestCase() {
     }
 
     @Test
+    fun `test tapping progress bar does not show controls`() {
+        val mockPlayer = mock(ExoPlayer::class.java)
+        `when`(mockPlayer.duration).thenReturn(100000L)
+        composeTestRule.setContent {
+            KSTheme {
+                KSVideoPlayer(
+                    videoUrl = "https://example.com/video.mp4",
+                    isActive = true,
+                    player = mockPlayer
+                )
+            }
+        }
+
+        // - Tap the progress bar (a pure tap, no drag)
+        composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_PROGRESS_BAR.name, useUnmergedTree = true)
+            .performTouchInput {
+                click(position = Offset(x = width * 0.25f, y = height / 2f))
+            }
+        composeTestRule.waitForIdle()
+
+        // - The tap should seek but must not fall through to the surface click and show controls
+        verify(mockPlayer).seekTo(25000L)
+        composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_CONTROLS.name, useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `test dragging progress bar does not show controls`() {
+        val mockPlayer = mock(ExoPlayer::class.java)
+        `when`(mockPlayer.duration).thenReturn(100000L)
+        composeTestRule.setContent {
+            KSTheme {
+                KSVideoPlayer(
+                    videoUrl = "https://example.com/video.mp4",
+                    isActive = true,
+                    player = mockPlayer
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_PROGRESS_BAR.name, useUnmergedTree = true)
+            .performTouchInput {
+                down(Offset(x = width * 0.2f, y = height / 2f))
+                moveBy(Offset(x = width * 0.5f, y = 0f))
+                up()
+            }
+        composeTestRule.waitForIdle()
+
+        // - The drag must not fall through to the surface click and show controls
+        composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_CONTROLS.name, useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    @Test
     fun `test scrubbing while controls visible does not resume playback on release`() {
         val mockPlayer = mock(ExoPlayer::class.java)
         `when`(mockPlayer.duration).thenReturn(100000L)


### PR DESCRIPTION
# 📲 What

Fixes the related glitches with the VideoFeed play/pause controls overlay, where the play-button icon got out of sync with the video's actual playback state:

- The play button lingering on screen over a video that is actually playing (specially when navigating away either snapping to another page or navigating to another activity).
- The play button appearing intermittently when the user only meant to tap or drag the progress bar.


# 🛠 How

- `KSVideoPlayer.kt`: In the LaunchedEffect(isActive, isAppInForeground) that resumes playback, reset showControls = false when the player auto-resumes. This covers both the swipe-away/back and the leave-screen/return cases, keeping the overlay in sync with the forced playback.
- KSProgressIndicators.kt (KSVideoScrubBar) — Consume the down event immediately on awaitFirstDown(). Since Compose's clickable uses awaitFirstDown(requireUnconsumed = true), claiming the gesture up front stops a tap or short drag on the scrub bar from propagating to the surface click handler and toggling the controls.
- Added tests for previous use cases

# 📋 QA

Open the VideoFeed.
- Swipe scenario: Pause a video (play button shows) → swipe up to the next video → swipe back. Play button should not appear
- Navigation scenario: Pause a video → tap into Creator Bio or the project page → return to the feed. Play button should not appear
- Progress bar scenario: While a video is playing, tap and also drag (fast-forward/rewind) on the progress bar several times. The play button never appears.

# Story 📖

[DISC-258](https://kickstarter.atlassian.net/browse/DISC-258)


[DISC-258]: https://kickstarter.atlassian.net/browse/DISC-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ