### PR TITLE
[No-jira]: playback error telemetry + retry

### DIFF
--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedActivity.kt
@@ -113,6 +113,9 @@ class VideoFeedActivity : ComponentActivity() {
                     },
                     onShareCTAClick = { project ->
                         viewModel.onCTAClicked(project, CtaContextName.VIDEO_SHARE)
+                    },
+                    onVideoPlaybackError = { videoFeedItem, position, error, isActive ->
+                        viewModel.onVideoPlaybackError(videoFeedItem, position, error, isActive)
                     }
                 )
             }

--- a/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/ui/VideoFeedScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
+import androidx.media3.common.PlaybackException
 import com.kickstarter.R
 import com.kickstarter.features.socialshare.AndroidSocialShareService
 import com.kickstarter.features.socialshare.data.SocialShareData
@@ -100,7 +101,8 @@ fun VideoFeedScreen(
     onVideoPageSettled: (videoFeedItem: VideoFeedItem, toPosition: Int, fromVideoFeedItem: VideoFeedItem, watchTimeMs: Long?, videoDurationMs: Long?) -> Unit = { _, _, _, _, _ -> },
     onPlayPauseTap: (project: Project, isPlaying: Boolean) -> Unit = { _, _ -> },
     onProgressBarTap: (item: VideoFeedItem, progress: Float) -> Unit = { _, _ -> },
-    onShareCTAClick: (project: Project) -> Unit = { _ -> }
+    onShareCTAClick: (project: Project) -> Unit = { _ -> },
+    onVideoPlaybackError: (item: VideoFeedItem, position: Int, error: PlaybackException, isActive: Boolean) -> Unit = { _, _, _, _ -> }
 ) {
     // Append a trailing loading page while the next page is being fetched. The prefetch in the
     // pagination LaunchedEffect usually completes before the user reaches the end, so this is only
@@ -203,6 +205,7 @@ fun VideoFeedScreen(
                     onBecameInactive = { watchTimeMs, videoDurationMs ->
                         watchTimeByPage[page] = Pair(watchTimeMs, videoDurationMs)
                     },
+                    onPlaybackError = { error, active -> onVideoPlaybackError(item, page, error, active) },
                     overlayContent = { hazeState ->
                         Column(
                             modifier = Modifier

--- a/app/src/main/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/videofeed/viewmodel/VideoFeedViewModel.kt
@@ -3,6 +3,8 @@ package com.kickstarter.features.videofeed.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import androidx.media3.common.PlaybackException
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.kickstarter.features.videofeed.data.VideoFeedItem
 import com.kickstarter.libs.Environment
 import com.kickstarter.libs.utils.EventContextValues.CtaContextName
@@ -144,6 +146,26 @@ class VideoFeedViewModel(
 
     fun onCTAClicked(project: Project, ctaType: CtaContextName, watchTimeAtClick: Long? = null) {
         analyticEvents.trackVideoFeedCTAClicked(project, ctaType, watchTimeAtClick)
+    }
+
+    /**
+     * Observe-only telemetry for a video playback failure. Records a Crashlytics non-fatal so we can
+     * see, segmented by device/OS, how often feed videos fail and whether it was the on-screen video
+     * ([isActive]) — e.g. [PlaybackException.ERROR_CODE_DECODING_RESOURCES_RECLAIMED] flags a device
+     * running out of hardware-decoder budget. Wrapped so telemetry can never affect playback.
+     */
+    fun onVideoPlaybackError(item: VideoFeedItem, position: Int, error: PlaybackException, isActive: Boolean) {
+        try {
+            FirebaseCrashlytics.getInstance().apply {
+                setCustomKey("video_feed_video_id", item.videoId)
+                setCustomKey("video_feed_error_code", error.errorCodeName)
+                setCustomKey("video_feed_is_active", isActive)
+                setCustomKey("video_feed_position", position)
+                recordException(error)
+            }
+        } catch (t: Throwable) {
+            Timber.w(t, "Failed to record video feed playback error telemetry")
+        }
     }
 
     class Factory(

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
@@ -45,6 +45,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
 import androidx.media3.exoplayer.ExoPlayer
@@ -70,6 +71,19 @@ enum class KSVideoPlayerTestTag {
     VIDEO_PLAYER_REWIND_BUTTON,
     VIDEO_PLAYER_PROGRESS_BAR,
     VIDEO_PLAYER_POSTER
+}
+
+/** How many times the on-screen player will re-prepare after a *recoverable* error before giving up.
+* Bounded so a device that is genuinely over its decoder budget. */
+private const val MAX_PLAYBACK_RECOVERY_ATTEMPTS = 3
+
+/** A reclaimed decoder or a transient network failure can succeed on a re-prepare;
+* format/source/DRM errors cannot, so we never retry (or loop on) those.*/
+private fun PlaybackException.isRecoverable(): Boolean = when (errorCode) {
+    PlaybackException.ERROR_CODE_DECODING_RESOURCES_RECLAIMED,
+    PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
+    PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> true
+    else -> false
 }
 
 /**
@@ -145,7 +159,8 @@ fun KSVideoPlayer(
     overlayContent: @Composable BoxScope.(HazeState) -> Unit = {},
     onPlayPauseToggle: (isPlaying: Boolean) -> Unit = {},
     onProgressBarInteraction: (currentProgress: Float) -> Unit = {},
-    onBecameInactive: (watchTimeMs: Long, videoDurationMs: Long) -> Unit = { _, _ -> }
+    onBecameInactive: (watchTimeMs: Long, videoDurationMs: Long) -> Unit = { _, _ -> },
+    onPlaybackError: (error: PlaybackException, isActive: Boolean) -> Unit = { _, _ -> }
 ) {
     if (videoUrl.isEmpty()) return // TODO: Check video format of the url on the VM
     val context = LocalContext.current
@@ -175,6 +190,8 @@ fun KSVideoPlayer(
     val onPlayPauseToggleState = rememberUpdatedState(onPlayPauseToggle)
     val onProgressBarInteractionState = rememberUpdatedState(onProgressBarInteraction)
     val onBecameInactiveState = rememberUpdatedState(onBecameInactive)
+    val onPlaybackErrorState = rememberUpdatedState(onPlaybackError)
+    val isActiveState = rememberUpdatedState(isActive)
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -357,6 +374,33 @@ fun KSVideoPlayer(
     // External (pool) players are never released here — the pool owns their lifecycle.
     DisposableEffect(exoPlayer) {
         onDispose { if (player == null) exoPlayer.release() }
+    }
+
+    // Playback-error telemetry + bounded self-recovery for the on-screen video. We always report the error (telemetry) and, additionally, re-prepare to recover —
+    // but ONLY with the guardrails the freeze-loop on the pooled version taught us:
+    //  - only the on-screen video recovers ([isActive]); an off-screen player must not re-grab a
+    //    decoder it doesn't need and feed the very pressure that caused the reclaim;
+    //  - only recoverable errors are retried (reclaim / transient network), never broken media;
+    //  - retries are bounded, and the budget refills only once the video genuinely plays again
+    //    (onIsPlayingChanged), never on a momentary STATE_READY between reclaims — so a device that is
+    //    truly over budget tries a few times then gives up (still reported) instead of looping forever.
+    DisposableEffect(exoPlayer) {
+        var recoveryAttempts = 0
+        val errorListener = object : Player.Listener {
+            override fun onPlayerError(error: PlaybackException) {
+                onPlaybackErrorState.value(error, isActiveState.value)
+                if (isActiveState.value && error.isRecoverable() && recoveryAttempts < MAX_PLAYBACK_RECOVERY_ATTEMPTS) {
+                    recoveryAttempts++
+                    exoPlayer.prepare()
+                }
+            }
+
+            override fun onIsPlayingChanged(isPlaying: Boolean) {
+                if (isPlaying) recoveryAttempts = 0
+            }
+        }
+        exoPlayer.addListener(errorListener)
+        onDispose { exoPlayer.removeListener(errorListener) }
     }
 
     DisposableEffect(isActive) {

--- a/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
+++ b/app/src/main/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayer.kt
@@ -377,13 +377,9 @@ fun KSVideoPlayer(
     }
 
     // Playback-error telemetry + bounded self-recovery for the on-screen video. We always report the error (telemetry) and, additionally, re-prepare to recover —
-    // but ONLY with the guardrails the freeze-loop on the pooled version taught us:
-    //  - only the on-screen video recovers ([isActive]); an off-screen player must not re-grab a
-    //    decoder it doesn't need and feed the very pressure that caused the reclaim;
-    //  - only recoverable errors are retried (reclaim / transient network), never broken media;
+    //  - only the on-screen video recovers ([isActive]);
+    //  - only recoverable errors are retried, never broken media
     //  - retries are bounded, and the budget refills only once the video genuinely plays again
-    //    (onIsPlayingChanged), never on a momentary STATE_READY between reclaims — so a device that is
-    //    truly over budget tries a few times then gives up (still reported) instead of looping forever.
     DisposableEffect(exoPlayer) {
         var recoveryAttempts = 0
         val errorListener = object : Player.Listener {

--- a/app/src/test/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayerTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayerTest.kt
@@ -21,16 +21,19 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.ui.compose.designsystem.KSTheme
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.atLeastOnce
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 
@@ -780,6 +783,98 @@ class KSVideoPlayerTest() : KSRobolectricTestCase() {
         // - Poster fades out and is removed once the video is rendering
         composeTestRule.onNodeWithTag(KSVideoPlayerTestTag.VIDEO_PLAYER_POSTER.name, useUnmergedTree = true)
             .assertDoesNotExist()
+    }
+
+    @Test
+    fun `onPlaybackError surfaces the player error with the active flag`() {
+        val mockPlayer = mock(ExoPlayer::class.java)
+        var reportedError: PlaybackException? = null
+        var reportedIsActive: Boolean? = null
+        composeTestRule.setContent {
+            KSTheme {
+                KSVideoPlayer(
+                    videoUrl = "https://example.com/video.mp4",
+                    isActive = true,
+                    player = mockPlayer,
+                    onPlaybackError = { error, isActive ->
+                        reportedError = error
+                        reportedIsActive = isActive
+                    }
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        // Capture the listeners KSVideoPlayer registered and simulate a player error.
+        val error = mock(PlaybackException::class.java)
+        val listenerCaptor = ArgumentCaptor.forClass(Player.Listener::class.java)
+        verify(mockPlayer, atLeastOnce()).addListener(listenerCaptor.capture())
+        composeTestRule.runOnUiThread {
+            listenerCaptor.allValues.forEach { it.onPlayerError(error) }
+        }
+        composeTestRule.waitForIdle()
+
+        // A non-recoverable error (mock errorCode defaults to 0) is surfaced (isActive=true) but the
+        // player is NOT retried.
+        assertEquals(error, reportedError)
+        assertEquals(true, reportedIsActive)
+        verify(mockPlayer, never()).prepare()
+    }
+
+    @Test
+    fun `a recoverable error on the active video is re-prepared`() {
+        val mockPlayer = mock(ExoPlayer::class.java)
+        composeTestRule.setContent {
+            KSTheme {
+                KSVideoPlayer(
+                    videoUrl = "https://example.com/video.mp4",
+                    isActive = true,
+                    player = mockPlayer
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        val error = mock(PlaybackException::class.java)
+        `when`(error.errorCode).thenReturn(PlaybackException.ERROR_CODE_DECODING_RESOURCES_RECLAIMED)
+        val listenerCaptor = ArgumentCaptor.forClass(Player.Listener::class.java)
+        verify(mockPlayer, atLeastOnce()).addListener(listenerCaptor.capture())
+        composeTestRule.runOnUiThread {
+            listenerCaptor.allValues.forEach { it.onPlayerError(error) }
+        }
+        composeTestRule.waitForIdle()
+
+        verify(mockPlayer, times(1)).prepare()
+    }
+
+    @Test
+    fun `a recoverable error on an inactive video is reported but not re-prepared`() {
+        val mockPlayer = mock(ExoPlayer::class.java)
+        var reported = false
+        composeTestRule.setContent {
+            KSTheme {
+                KSVideoPlayer(
+                    videoUrl = "https://example.com/video.mp4",
+                    isActive = false,
+                    player = mockPlayer,
+                    onPlaybackError = { _, _ -> reported = true }
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        val error = mock(PlaybackException::class.java)
+        `when`(error.errorCode).thenReturn(PlaybackException.ERROR_CODE_DECODING_RESOURCES_RECLAIMED)
+        val listenerCaptor = ArgumentCaptor.forClass(Player.Listener::class.java)
+        verify(mockPlayer, atLeastOnce()).addListener(listenerCaptor.capture())
+        composeTestRule.runOnUiThread {
+            listenerCaptor.allValues.forEach { it.onPlayerError(error) }
+        }
+        composeTestRule.waitForIdle()
+
+        // Off-screen: reported for telemetry, but never re-prepared (must not re-grab a decoder).
+        assertEquals(true, reported)
+        verify(mockPlayer, never()).prepare()
     }
 
     private fun <T> any(): T = org.mockito.ArgumentMatchers.any()

--- a/app/src/test/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayerTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/compose/designsystem/videoplayer/KSVideoPlayerTest.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlaybackException
 import androidx.media3.exoplayer.ExoPlayer
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.ui.compose.designsystem.KSTheme
@@ -36,6 +37,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import java.io.IOException
 
 class KSVideoPlayerTest() : KSRobolectricTestCase() {
 
@@ -835,8 +837,10 @@ class KSVideoPlayerTest() : KSRobolectricTestCase() {
         }
         composeTestRule.waitForIdle()
 
-        val error = mock(PlaybackException::class.java)
-        `when`(error.errorCode).thenReturn(PlaybackException.ERROR_CODE_DECODING_RESOURCES_RECLAIMED)
+        val error = ExoPlaybackException.createForSource(
+            IOException("decoder reclaimed"),
+            PlaybackException.ERROR_CODE_DECODING_RESOURCES_RECLAIMED
+        )
         val listenerCaptor = ArgumentCaptor.forClass(Player.Listener::class.java)
         verify(mockPlayer, atLeastOnce()).addListener(listenerCaptor.capture())
         composeTestRule.runOnUiThread {
@@ -863,8 +867,10 @@ class KSVideoPlayerTest() : KSRobolectricTestCase() {
         }
         composeTestRule.waitForIdle()
 
-        val error = mock(PlaybackException::class.java)
-        `when`(error.errorCode).thenReturn(PlaybackException.ERROR_CODE_DECODING_RESOURCES_RECLAIMED)
+        val error = ExoPlaybackException.createForSource(
+            IOException("decoder reclaimed"),
+            PlaybackException.ERROR_CODE_DECODING_RESOURCES_RECLAIMED
+        )
         val listenerCaptor = ArgumentCaptor.forClass(Player.Listener::class.java)
         verify(mockPlayer, atLeastOnce()).addListener(listenerCaptor.capture())
         composeTestRule.runOnUiThread {


### PR DESCRIPTION
# 📲 What

Adds observability for **playback failures**, plus **bounded self-recovery** for the on-screen video.

# 🤔 Why

We have no visibility into how reliably feed videos actually play, on which devices, or whether the hardware-decoder budget is a real problem on lower-end hardware.

This telemetry gives us sata so future playback-performance decisions can be data-driven instead of speculative. 

The recovery piece turns the most common failures (the OS reclaiming our decoder under pressure) from a permanently frozen frame into an automatic resume for the user.

# 🛠 How

- `KSVideoPlayer` now reports `ExoPlayer` `onPlayerError`s via a new optional `onPlaybackError(error, isActive)` callback, threaded through `VideoFeedScreen` → `VideoFeedActivity` → `VideoFeedViewModel`.
- `VideoFeedViewModel` records a **Crashlytics non-fatal** for each failure, tagged with `video_feed_video_id`, `video_feed_error_code`, `video_feed_is_active`, and `video_feed_position`.
- When the error is **recoverable** (a reclaimed hardware decoder or a transient network failure) **and** it's the video currently on screen, the player re-prepares to resume — bounded so it can never loop.

# 👀 See

No UI change; the observable surface is Crashlytics (non-fatals filterable by the new custom keys).

|  |  |

# 📋 QA
1. - Everything should be working as usual in terms of user experience.
2. **Telemetry:** in a debug build, force an error (e.g. point a feed item's HLS URL at an invalid/expired source) and confirm a Crashlytics non-fatal is recorded with keys `video_feed_error_code`, `video_feed_is_active`, `video_feed_video_id`, `video_feed_position` (or the Timber fallback warning in logcat).

