### PR TITLE
DISC-264: Android native app sending "-1" project ID in some watchProject requests

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/ProjectExt.kt
@@ -55,6 +55,14 @@ fun Project.updateProjectWith(config: Config, user: User?): Project {
         .build()
 }
 
+/**
+ * The watch/unwatch mutations build their Relay id from [Project.id] via `encodeRelayId`. An
+ * invalid id (e.g. `-1`) yields a malformed id like Base64("Project--1") and a backend 500,
+ * so callers should skip the request for such a project.
+ * see https://kickstarter.atlassian.net/browse/DISC-264
+ */
+fun Project.hasValidRelayId(): Boolean = this.id() > 0L
+
 fun Project.showLatePledgeFlow() = this.isInPostCampaignPledgingPhase() ?: false && this.postCampaignPledgingEnabled() ?: false && !this.isBacking()
 
 fun Project.isLatePledgesActive() = this.isInPostCampaignPledgingPhase() ?: false && this.postCampaignPledgingEnabled() ?: false

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -67,6 +67,7 @@ import com.kickstarter.features.projectstory.data.StoriedProject
 import com.kickstarter.features.search.data.SearchEnvelope
 import com.kickstarter.features.videofeed.data.VideoFeedEnvelope
 import com.kickstarter.libs.utils.extensions.addToDisposable
+import com.kickstarter.libs.utils.extensions.hasValidRelayId
 import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.libs.utils.extensions.isPresent
 import com.kickstarter.libs.utils.extensions.isTrue
@@ -543,6 +544,9 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
     }
 
     override fun watchProject(project: Project): Observable<Project> {
+        if (!project.hasValidRelayId()) {
+            return Observable.error(invalidProjectException(project))
+        }
         return Observable.defer {
             val ps = PublishSubject.create<Project>()
             val mutation = WatchProjectMutation(
@@ -575,6 +579,9 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
     }
 
     override fun unWatchProject(project: Project): Observable<Project> {
+        if (!project.hasValidRelayId()) {
+            return Observable.error(invalidProjectException(project))
+        }
         return Observable.defer {
             val ps = PublishSubject.create<Project>()
             val mutation = UnwatchProjectMutation(
@@ -2002,27 +2009,33 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
         response.data?.videoFeed.toVideoFeedEnvelope()
     }
 
-    override suspend fun watchProjectSuspend(project: Project): Result<Project> = executeForResult {
-        val mutation = WatchProjectMutation(id = encodeRelayId(project))
-        val response = this.service.mutation(mutation).execute()
+    override suspend fun watchProjectSuspend(project: Project): Result<Project> {
+        if (!project.hasValidRelayId()) {
+            return Result.failure(invalidProjectException(project))
+        }
+        return executeForResult {
+            val mutation = WatchProjectMutation(id = encodeRelayId(project))
+            val response = this.service.mutation(mutation).execute()
 
-        if (response.hasErrors())
-            throw buildClientException(response.errors)
-
-        // TODO: review, might not require this part, "update" the project on the UI side,
-        // risking here overriding VideoFeed information
-        projectTransformer(response.data?.watchProject?.project?.fullProject)
+            if (response.hasErrors())
+                throw buildClientException(response.errors)
+            projectTransformer(response.data?.watchProject?.project?.fullProject)
+        }
     }
 
-    // TODO: review if we can join watchProjectSuspend with unWatchProjectSuspend and namming
-    override suspend fun unWatchProjectSuspend(project: Project): Result<Project> = executeForResult {
-        val mutation = UnwatchProjectMutation(id = encodeRelayId(project))
-        val response = this.service.mutation(mutation).execute()
+    override suspend fun unWatchProjectSuspend(project: Project): Result<Project> {
+        if (!project.hasValidRelayId()) {
+            return Result.failure(invalidProjectException(project))
+        }
+        return executeForResult {
+            val mutation = UnwatchProjectMutation(id = encodeRelayId(project))
+            val response = this.service.mutation(mutation).execute()
 
-        if (response.hasErrors())
-            throw buildClientException(response.errors)
+            if (response.hasErrors())
+                throw buildClientException(response.errors)
 
-        projectTransformer(response.data?.watchProject?.project?.fullProject)
+            projectTransformer(response.data?.watchProject?.project?.fullProject)
+        }
     }
 
     override suspend fun getLocations(useDefault: Boolean, term: String?, lat: Float?, long: Float?, radius: Float?, filterByCoordinates: Boolean?): Result<List<Location>> = executeForResult {
@@ -2071,10 +2084,22 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
             message: String? = null,
             cause: Throwable? = null
         ) : KSApolloClientV2Exception(message, cause)
+        class InvalidProject(
+            message: String? = null,
+            cause: Throwable? = null
+        ) : KSApolloClientV2Exception(message, cause)
     }
 
     private fun buildClientException(errors: List<Error>?): KSApolloClientV2Exception {
         return KSApolloClientV2Exception.ApiError(errors?.first()?.message)
+    }
+
+    private fun invalidProjectException(project: Project): KSApolloClientV2Exception {
+        val exception = KSApolloClientV2Exception.InvalidProject(
+            "Attempted watch/unwatch mutation with invalid project id: ${project.id()}"
+        )
+        FirebaseCrashlytics.getInstance().recordException(exception)
+        return exception
     }
 
     private fun ApolloException.toClientException(): Exception =

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -143,6 +143,7 @@ import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.PublishSubject
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.rx2.asObservable
+import timber.log.Timber
 import java.net.SocketTimeoutException
 import java.nio.charset.Charset
 import kotlin.coroutines.cancellation.CancellationException
@@ -298,14 +299,14 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
                 }
                 .subscribe { response ->
                     if (response.hasErrors()) {
-                        if (response.hasErrors()) ps.onError(java.lang.Exception(response.errors?.first()?.message))
+                        ps.onError(java.lang.Exception(response.errors?.first()?.message))
                     } else {
-                        response.data?.let { responseData ->
-                            ps.onNext(
-                                projectTransformer(
-                                    responseData.project?.fullProject
-                                )
-                            )
+                        // Evidence of A null/partial project node transforms to a project with an invalid id see DISC-264.
+                        val project = projectTransformer(response.data?.project?.fullProject)
+                        if (project.hasValidRelayId()) {
+                            ps.onNext(project)
+                        } else {
+                            ps.onError(invalidProjectException(project, "getProject($slug)"))
                         }
                     }
                     ps.onComplete()
@@ -544,10 +545,10 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
     }
 
     override fun watchProject(project: Project): Observable<Project> {
-        if (!project.hasValidRelayId()) {
-            return Observable.error(invalidProjectException(project))
-        }
         return Observable.defer {
+            if (!project.hasValidRelayId()) {
+                return@defer Observable.error<Project>(invalidProjectException(project))
+            }
             val ps = PublishSubject.create<Project>()
             val mutation = WatchProjectMutation(
                 id = encodeRelayId(project)
@@ -579,10 +580,10 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
     }
 
     override fun unWatchProject(project: Project): Observable<Project> {
-        if (!project.hasValidRelayId()) {
-            return Observable.error(invalidProjectException(project))
-        }
         return Observable.defer {
+            if (!project.hasValidRelayId()) {
+                return@defer Observable.error<Project>(invalidProjectException(project))
+            }
             val ps = PublishSubject.create<Project>()
             val mutation = UnwatchProjectMutation(
                 id = encodeRelayId(project)
@@ -2094,11 +2095,18 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
         return KSApolloClientV2Exception.ApiError(errors?.first()?.message)
     }
 
-    private fun invalidProjectException(project: Project): KSApolloClientV2Exception {
+    private fun invalidProjectException(
+        project: Project,
+        context: String = "Attempted watch/unwatch mutation"
+    ): KSApolloClientV2Exception {
         val exception = KSApolloClientV2Exception.InvalidProject(
-            "Attempted watch/unwatch mutation with invalid project id: ${project.id()}"
+            "$context: Invalid project id: ${project.id()}"
         )
-        FirebaseCrashlytics.getInstance().recordException(exception)
+        runCatching {
+            FirebaseCrashlytics.getInstance().recordException(exception)
+        }.onFailure { e ->
+            Timber.e(e, "Error recording exception in Firebase")
+        }
         return exception
     }
 

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -547,7 +547,7 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
     override fun watchProject(project: Project): Observable<Project> {
         return Observable.defer {
             if (!project.hasValidRelayId()) {
-                return@defer Observable.error<Project>(invalidProjectException(project))
+                return@defer Observable.error<Project>(invalidProjectException(project, "watchProject"))
             }
             val ps = PublishSubject.create<Project>()
             val mutation = WatchProjectMutation(
@@ -576,13 +576,13 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
                     ps.onComplete()
                 }.addToDisposable(disposables)
             return@defer ps
-        }
+        }.subscribeOn(Schedulers.io())
     }
 
     override fun unWatchProject(project: Project): Observable<Project> {
         return Observable.defer {
             if (!project.hasValidRelayId()) {
-                return@defer Observable.error<Project>(invalidProjectException(project))
+                return@defer Observable.error<Project>(invalidProjectException(project, "unWatchProject"))
             }
             val ps = PublishSubject.create<Project>()
             val mutation = UnwatchProjectMutation(
@@ -610,7 +610,7 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
                     ps.onComplete()
                 }.addToDisposable(disposables)
             return@defer ps
-        }
+        }.subscribeOn(Schedulers.io())
     }
 
     override fun updateUserPassword(
@@ -2012,7 +2012,7 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
 
     override suspend fun watchProjectSuspend(project: Project): Result<Project> {
         if (!project.hasValidRelayId()) {
-            return Result.failure(invalidProjectException(project))
+            return Result.failure(invalidProjectException(project, "watchProjectSuspend"))
         }
         return executeForResult {
             val mutation = WatchProjectMutation(id = encodeRelayId(project))
@@ -2026,7 +2026,7 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
 
     override suspend fun unWatchProjectSuspend(project: Project): Result<Project> {
         if (!project.hasValidRelayId()) {
-            return Result.failure(invalidProjectException(project))
+            return Result.failure(invalidProjectException(project, "unWatchProjectSuspend"))
         }
         return executeForResult {
             val mutation = UnwatchProjectMutation(id = encodeRelayId(project))

--- a/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/utils/extensions/ProjectExtTest.kt
@@ -560,4 +560,22 @@ class ProjectExtTest : KSRobolectricTestCase() {
 
         assertFalse(project.pledgeManagementAvailable())
     }
+
+    @Test
+    fun `test hasValidRelayId when id is positive should return true`() {
+        val project = ProjectFactory.project().toBuilder().id(123L).build()
+        assertTrue(project.hasValidRelayId())
+    }
+
+    @Test
+    fun `test hasValidRelayId when id is the -1 decode-failure sentinel should return false`() {
+        val project = ProjectFactory.project().toBuilder().id(-1L).build()
+        assertFalse(project.hasValidRelayId())
+    }
+
+    @Test
+    fun `test hasValidRelayId when id is zero default should return false`() {
+        val project = ProjectFactory.project().toBuilder().id(0L).build()
+        assertFalse(project.hasValidRelayId())
+    }
 }

--- a/app/src/test/java/com/kickstarter/services/transformers/GraphQLTransformersTest.kt
+++ b/app/src/test/java/com/kickstarter/services/transformers/GraphQLTransformersTest.kt
@@ -7,6 +7,7 @@ import com.kickstarter.fragment.AiDisclosure
 import com.kickstarter.fragment.Amount
 import com.kickstarter.fragment.EnvironmentalCommitment
 import com.kickstarter.fragment.Faq
+import com.kickstarter.fragment.FullProject
 import com.kickstarter.fragment.Reward
 import com.kickstarter.fragment.Reward.AllowedAddons
 import com.kickstarter.fragment.User
@@ -344,5 +345,12 @@ class GraphQLTransformersTest : KSRobolectricTestCase() {
         )
 
         assertFalse(nonFeaturedReward.isFeatured())
+    }
+
+    @Test
+    fun `test projectTransformer with a null fragment produces an invalid project id`() {
+        val project = projectTransformer(null as FullProject?)
+
+        assertEquals(-1L, project.id())
     }
 }


### PR DESCRIPTION
# 📲 What

Prevents the Android app from sending watch/unwatch GraphQL mutations with an invalid Project.id() (notably the -1 sentinel), which produce a malformed Relay id and a backend 500.

# 🤔 Why

Backend telemetry shows Android sending watchProject requests with id: "UHJvamVjdC0tMQ==", which decodes to Project--1 — i.e. Project.id() == -1.

Project transformers use `decodeRelayId(fragment.id) ?: -1`, so any GraphQL project whose Relay id fails to decode (e.g. a null/partial project node from a degraded response or an unavailable project) becomes a Project with id = -1. When that project is later watched/unwatched, encodeRelayId turns the -1 back into Base64("Project--1"), which the backend can't resolve → 500. The error predates and is independent of any recent feature.

🛠 How
- `ProjectExt.hasValidRelayId() `: single source of truth: a project is watchable only if id() > 0L (rejects both the 0 builder default and the -1 decode-failure sentinel).
Guards in KSApolloClientV2:
- watchProject / unWatchProject: the check lives inside Observable.defer, returning Observable.error(InvalidProject) on subscription (keeps the Observable cold; no eager side effects).
- watchProjectSuspend / unWatchProjectSuspend: return Result.failure(InvalidProject) before executeForResult, so the mutation is never issued.
- invalidProjectException(project, context): builds the InvalidProject exception and records it to Crashlytics inside runCatching (a telemetry failure never breaks the caller flow).


# 👀 See
- No user facing feedback
| --- | --- |
|  |  |

# 📋 QA

On Discovery, as logged in user Project page, and the Thanks page, tap the save/star toggle on several live projects — watching and unwatching should work exactly as before, and the starred state should persist on refresh.
Confirm normal project loading via getProject still works (open projects from deep links, discovery, notifications).

On Discovery, as logged in user Project page, and the Thanks page, tap the save/star toggle as a logged out user, make sure no network call is made to watching and unwatching mutations, but the login flow is triggered.

# Story 📖

[DISC-264](https://kickstarter.atlassian.net/browse/DISC-264)


[DISC-264]: https://kickstarter.atlassian.net/browse/DISC-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ