### PR TITLE
PF-214: Upgrade GlideWebpDecoder to 2.7 for 16 KB page support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -272,7 +272,7 @@ dependencies {
     // GLIDE
     final glide_version = "4.16.0"
     // webpdecoder
-    implementation "com.github.zjupure:webpdecoder:2.6.$glide_version"
+    implementation "com.github.zjupure:webpdecoder:2.7.$glide_version"
     implementation "com.github.bumptech.glide:glide:$glide_version"
     annotationProcessor "com.github.bumptech.glide:compiler:$glide_version"
     kapt "com.github.bumptech.glide:compiler:$glide_version"


### PR DESCRIPTION
# 📲 What

Upgrade GlideWebpDecoder to 2.7

# 🤔 Why

Google Play requires all apps targeting Android 15+ to support 16 KB memory page sizes:

<img width="512" src="https://github.com/user-attachments/assets/55dd6274-eb21-49c7-8e3d-35bc38c42362" />

GlideWebpDecoder 2.6 has the native binary that is not aligned:

<img width="512" src="https://github.com/user-attachments/assets/7615a5c9-12da-40d6-a6df-b750dacd6adb" />

The `zipalign` check [by itself](https://developer.android.com/guide/practices/page-sizes#alignment-use-tools) was not sufficient to check the binary requirements.

# 🛠 How

Upgrade the library to `2.7.*` where it adds support for the `x86_64` target, which is all that's required:

- [Release Release 2.7 version · zjupure/GlideWebpDecoder · GitHub](https://github.com/zjupure/GlideWebpDecoder/releases/tag/2.7)
- [Comparing 2.6...2.7 · zjupure/GlideWebpDecoder · GitHub](https://github.com/zjupure/GlideWebpDecoder/compare/2.6...2.7#diff-e32b2a3b257c85c9e38f98678d7995909c98788e8330195dcd4fc25611a38e0a)

# 👀 See

<img width="1024" src="https://github.com/user-attachments/assets/6a11e0cd-2b29-463e-95e3-f1f46ef2e0a8" />

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="512" src="https://github.com/user-attachments/assets/3c4f40cf-283f-4a93-9513-a5509c92d606" /> | <img width="512" src="https://github.com/user-attachments/assets/3ddb1cc0-f945-47db-b190-bbd49517e9cb" /> |

# 📋 QA

CircleCI compilation covers it. However, you can also create an `externalRelease` build and:

- Run the [APK Analyzer](https://developer.android.com/guide/practices/page-sizes#identify-native-code) in Android Studio
- Run the `check_elf_alignment.sh` [script](https://developer.android.com/guide/practices/page-sizes#alignment-use-script)

Which is where the above screenshots come from.

# Story 📖

[\[PF-214\] Update Glide WebP library to 2.7+ - Jira](https://kickstarter.atlassian.net/browse/PF-214)
