### PR TITLE
DISC-403: Statsig Feature Gates able to be enabled for Admin users

### DIFF
--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -92,7 +92,7 @@ interface StatsigClientType {
 
     val statsigUser: StateFlow<StatsigUser>
 
-    suspend fun handleObservedUserData(stableId: String?, segmentAnonymousId: String?, userId: String?)
+    suspend fun handleObservedUserData(stableId: String?, segmentAnonymousId: String?, userId: String?, isAdmin: Boolean)
 }
 
 /**
@@ -173,6 +173,18 @@ open class StatsigClient @JvmOverloads constructor(
         }
     }
 
+    /**
+     * Snapshot of the identity attributes forwarded to Statsig on each observed change.
+     * Carried through the [observeUserAndFetchConfigs] pipeline so that [distinctUntilChanged]
+     * re-fires whenever any of them change — including [isAdmin].
+     */
+    private data class ObservedUserData(
+        val stableId: String?,
+        val segmentAnonymousId: String?,
+        val userId: String?,
+        val isAdmin: Boolean
+    )
+
     fun observeUserAndFetchConfigs(scope: CoroutineScope) {
         scope.launch {
             val statsigInitialization = isReady
@@ -182,25 +194,25 @@ open class StatsigClient @JvmOverloads constructor(
                 Triple(statsigIsReady, segmentIsReady, optionalUser)
             }
                 .map { (statsigIsReady, segmentIsReady, optionalUser) ->
+                    val user = if (optionalUser.isPresent()) optionalUser.getValue() else null
                     val stableId = if (statsigIsReady) getStableId() else null
                     val segmentAnonymousId = if (segmentIsReady) segmentTrackingClient.getAnonymousIdOrNull() else null
-                    val userId = if (optionalUser.isPresent()) optionalUser.getValue()?.id().toString() else null
-                    Triple(stableId, segmentAnonymousId, userId)
+                    val userId = user?.id()?.toString()
+                    val isAdmin = user?.isAdmin() ?: false
+                    ObservedUserData(stableId, segmentAnonymousId, userId, isAdmin)
                 }
                 .onEach {
-                    val (stableId, segmentAnonymousId, userId) = it
-                    Timber.d("onEach set of user IDs: (stableId: $stableId, segmentAnonymousId: $segmentAnonymousId, userId: $userId)")
+                    Timber.d("onEach observed user data: (stableId: ${it.stableId}, segmentAnonymousId: ${it.segmentAnonymousId}, userId: ${it.userId}, isAdmin: ${it.isAdmin})")
                 }
                 .distinctUntilChanged()
                 .collect {
-                    val (stableId, segmentAnonymousId, userId) = it
-                    handleObservedUserData(stableId, segmentAnonymousId, userId)
+                    handleObservedUserData(it.stableId, it.segmentAnonymousId, it.userId, it.isAdmin)
                 }
         }
     }
 
-    override suspend fun handleObservedUserData(stableId: String?, segmentAnonymousId: String?, userId: String?) {
-        Timber.d("handleObservedUserData(stableId: $stableId, segmentAnonymousId: $segmentAnonymousId, userId: $userId)")
+    override suspend fun handleObservedUserData(stableId: String?, segmentAnonymousId: String?, userId: String?, isAdmin: Boolean) {
+        Timber.d("handleObservedUserData(stableId: $stableId, segmentAnonymousId: $segmentAnonymousId, userId: $userId, isAdmin: $isAdmin)")
 
         if (stableId == null) return
 
@@ -210,6 +222,7 @@ open class StatsigClient @JvmOverloads constructor(
         }
         userId?.let {
             statsigUser.userID = userId
+            statsigUser.custom = mapOf(KEY_IS_ADMIN to isAdmin)
         }
 
         try {
@@ -237,5 +250,6 @@ open class StatsigClient @JvmOverloads constructor(
 
     companion object {
         const val KEY_SEGMENT_ANONYMOUS_ID = "segmentAnonymousID"
+        const val KEY_IS_ADMIN = "is_admin"
     }
 }

--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -222,7 +222,7 @@ open class StatsigClient @JvmOverloads constructor(
         }
         userId?.let {
             statsigUser.userID = userId
-            statsigUser.custom = mapOf(KEY_IS_ADMIN to isAdmin)
+            statsigUser.privateAttributes = mapOf(KEY_IS_KSR_ADMIN to isAdmin)
         }
 
         try {
@@ -250,6 +250,6 @@ open class StatsigClient @JvmOverloads constructor(
 
     companion object {
         const val KEY_SEGMENT_ANONYMOUS_ID = "segmentAnonymousID"
-        const val KEY_IS_ADMIN = "is_admin"
+        const val KEY_IS_KSR_ADMIN = "is_ksr_admin"
     }
 }

--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -221,7 +221,7 @@ open class StatsigClient @JvmOverloads constructor(
             statsigUser.customIDs = mapOf(KEY_SEGMENT_ANONYMOUS_ID to it)
         }
         userId?.let {
-            statsigUser.userID = userId
+            statsigUser.userID = it
             statsigUser.privateAttributes = mapOf(KEY_IS_KSR_ADMIN to isAdmin)
         }
 

--- a/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
+++ b/app/src/test/java/com/kickstarter/libs/StatsigClientTest.kt
@@ -319,7 +319,7 @@ class StatsigClientTest : KSRobolectricTestCase() {
     fun `test user data observation`() = runTest {
         val testScope = TestScope(UnconfinedTestDispatcher(testScheduler))
 
-        val data = mutableListOf<Triple<String?, String?, String?>>()
+        val data = mutableListOf<ObservedData>()
 
         val currentUser = MockCurrentUserV2()
         val segmentTrackingClient = mockSegmentTrackingClient()
@@ -332,28 +332,74 @@ class StatsigClientTest : KSRobolectricTestCase() {
             override suspend fun handleObservedUserData(
                 stableId: String?,
                 segmentAnonymousId: String?,
-                userId: String?
+                userId: String?,
+                isAdmin: Boolean
             ) {
-                data += Triple(stableId, segmentAnonymousId, userId)
+                data += ObservedData(stableId, segmentAnonymousId, userId, isAdmin)
             }
         }
 
         statsigClient.observeUserAndFetchConfigs(testScope)
 
-        assertEquals(Triple(null, null, null), data.last())
+        assertEquals(ObservedData(null, null, null, false), data.last())
 
         statsigClient.triggerReady()
 
-        assertEquals(data.last(), Triple(statsigClient.getStableId(), null, null))
+        assertEquals(ObservedData(statsigClient.getStableId(), null, null, false), data.last())
 
         segmentTrackingClient.initialize()
 
-        assertEquals(data.last(), Triple(statsigClient.getStableId(), segmentTrackingClient.getAnonymousIdOrNull(), null))
+        assertEquals(ObservedData(statsigClient.getStableId(), segmentTrackingClient.getAnonymousIdOrNull(), null, false), data.last())
 
         val user = UserFactory.user()
         currentUser.login(user)
 
-        assertEquals(data.last(), Triple(statsigClient.getStableId(), segmentTrackingClient.getAnonymousIdOrNull()!!, user.id().toString()))
+        assertEquals(ObservedData(statsigClient.getStableId(), segmentTrackingClient.getAnonymousIdOrNull()!!, user.id().toString(), false), data.last())
+
+        val adminUser = user.toBuilder().isAdmin(true).build()
+        currentUser.login(adminUser)
+
+        assertEquals(ObservedData(statsigClient.getStableId(), segmentTrackingClient.getAnonymousIdOrNull()!!, adminUser.id().toString(), true), data.last())
+    }
+
+    @Test
+    fun `handleObservedUserData - forwards is_ksr_admin as a private attribute for logged-in users`() = runTest {
+        val testScope = TestScope(UnconfinedTestDispatcher(testScheduler))
+
+        val currentUser = MockCurrentUserV2()
+        val segmentTrackingClient = mockSegmentTrackingClient()
+
+        val updatedUsers = mutableListOf<StatsigUser>()
+        val statsigClient = object : MockStatsigClient(
+            context = application(),
+            currentUser = currentUser,
+            segmentTrackingClient = segmentTrackingClient,
+            startReady = false
+        ) {
+            override suspend fun updateUser(user: StatsigUser) { updatedUsers += user }
+        }
+
+        statsigClient.observeUserAndFetchConfigs(testScope)
+        statsigClient.triggerReady()
+        segmentTrackingClient.initialize()
+        advanceUntilIdle()
+
+        // Anonymous users carry no admin concept, so no admin attribute is attached.
+        assertNull(updatedUsers.last().privateAttributes)
+
+        // Logged-in non-admin: is_ksr_admin = false.
+        val user = UserFactory.user()
+        currentUser.login(user)
+        advanceUntilIdle()
+        assertEquals(user.id().toString(), updatedUsers.last().userID)
+        assertEquals(mapOf(StatsigClient.KEY_IS_KSR_ADMIN to false), updatedUsers.last().privateAttributes)
+
+        // Admin (same id, only isAdmin flips): is_ksr_admin = true is forwarded to Statsig. Also
+        // guards against distinctUntilChanged swallowing an admin-status change on an unchanged id.
+        val adminUser = user.toBuilder().isAdmin(true).build()
+        currentUser.login(adminUser)
+        advanceUntilIdle()
+        assertEquals(mapOf(StatsigClient.KEY_IS_KSR_ADMIN to true), updatedUsers.last().privateAttributes)
     }
 
     @Test
@@ -439,6 +485,14 @@ class StatsigClientTest : KSRobolectricTestCase() {
 
         assertEquals(0, count)
     }
+
+    /** Test-only mirror of the params passed to [StatsigClient.handleObservedUserData]. */
+    private data class ObservedData(
+        val stableId: String?,
+        val segmentAnonymousId: String?,
+        val userId: String?,
+        val isAdmin: Boolean
+    )
 
     companion object {
         var initializationDetails: InitializationDetails? = null


### PR DESCRIPTION
# 📲 What

Extends Statsig identity propagation so feature gates can target Kickstarter admins. When a logged-in user is observed. The android_video_feed gate is extended with a rule requiring admin status.

# 🤔 Why

Lets us gate features to admin users straight from the Statsig console (staged rollout / internal validation) with no app release. Starting with the Video Feed entry points.

# 🛠 How

- `observeUserAndFetchConfigs` now carries User.isAdmin() through a private ObservedUserData, so distinctUntilChanged re-fires when admin status changes.
- `handleObservedUserData` sets `StatsigUser.privateAttributes = {"is_ksr_admin": <bool>}` for logged-in users. 
- privateAttributes (vs custom) keeps the value usable for gate evaluation but excludes it from Statsig exposure logs

# 👀 See


https://github.com/user-attachments/assets/b88c2885-fa89-4384-a00d-2ddc91a553e9




| --- | --- |
|  |  |

# 📋 QA

- As logged out user, the entry cards to VideoFeed are not visible now, the gate has been extended with a new rule, where the user needs to be an admin user.
- Once you log-in with an admin user, either navigate to Search or kill the app and open discovery, you will see the entry card available again.

# Story 📖

[DISC-403](https://kickstarter.atlassian.net/browse/DISC-403)


[DISC-403]: https://kickstarter.atlassian.net/browse/DISC-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ