### PR TITLE
PF-411: Add `watchesCount` to the `projectCard` fragment

### DIFF
--- a/app/src/main/graphql/fragments.graphql
+++ b/app/src/main/graphql/fragments.graphql
@@ -83,6 +83,7 @@ fragment projectCard on Project {
     state
     stateChangedAt
     url
+    watchesCount
     isInPostCampaignPledgingPhase
     postCampaignPledgingEnabled
     pledgeOverTimeCollectionPlanChargeExplanation

--- a/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
+++ b/app/src/main/java/com/kickstarter/services/transformers/GraphQLTransformers.kt
@@ -624,6 +624,7 @@ fun projectTransformer(projectFragment: ProjectCard?): Project {
         .build()
     val urls = Urls.builder().web(urlsWeb).build()
     val video = videoTransformer(projectFragment?.video?.video)
+    val watchesCount = projectFragment?.watchesCount ?: 0
     val displayPrelaunch = (projectFragment?.isLaunched ?: false).negate()
     val isInPostCampaignPledgingPhase = projectFragment?.isInPostCampaignPledgingPhase ?: false
     val postCampaignPledgingEnabled = projectFragment?.postCampaignPledgingEnabled ?: false
@@ -662,6 +663,7 @@ fun projectTransformer(projectFragment: ProjectCard?): Project {
         .isInPostCampaignPledgingPhase(isInPostCampaignPledgingPhase)
         .video(video)
         .postCampaignPledgingEnabled(postCampaignPledgingEnabled)
+        .watchesCount(watchesCount)
         .build()
 }
 


### PR DESCRIPTION
# 📲 What

Add `watchesCount` to the `projectCard` fragment

# 🤔 Why

This fixes a bug where Pre-launch Project pages opened from search always display a follower count of 0.

# 🛠 How

Search uses `FetchProjectsQuery`, and when opening a Pre-launch Project from the results, passes a parcelized version to `PreLaunchProjectPageActivity` via `Activity.startPreLaunchProjectActivity()`, which is an optimization the Activity uses to load some of the page content immediately.

# 👀 See

#### Before 🐛

https://github.com/user-attachments/assets/f046c30e-8d5f-481c-88a7-dad85b43ca57

#### After 🦋 |

https://github.com/user-attachments/assets/910db355-cfb6-45af-8893-45a7c2f0ebdb

# 📋 QA

Visit any Pre-launch Project page from Search and compare the follower count on this branch to `master.

# Story 📖

[\[PF-411\] Follower count on pre-launch project page is sometimes incorrectly 0 - Jira](https://kickstarter.atlassian.net/browse/PF-411)
