### PR TITLE
PF-410: Fix Report Project submission button color

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/FormularyScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/FormularyScreen.kt
@@ -41,6 +41,8 @@ import com.kickstarter.ui.compose.designsystem.KSTheme
 import com.kickstarter.ui.compose.designsystem.KSTheme.colors
 import com.kickstarter.ui.compose.designsystem.KSTheme.dimensions
 import com.kickstarter.ui.compose.designsystem.KSTheme.typographyV2
+import com.kickstarter.ui.compose.designsystem.kds_create_700
+import com.kickstarter.ui.compose.designsystem.kds_white
 import com.kickstarter.viewmodels.ReportProjectViewModel
 import io.reactivex.Observable
 
@@ -217,7 +219,7 @@ fun FormularyScreen(
         KSButton(
             modifier = Modifier
                 .padding(horizontal = dimensionResource(id = R.dimen.grid_3)),
-            textColor = colors.kds_white,
+            textColor = kds_white,
             isEnabled = details.isNotEmpty(),
             onClickAction = {
                 inputs.createFlagging()
@@ -225,7 +227,7 @@ fun FormularyScreen(
             shape = RoundedCornerShape(size = dimensions.radiusExtraSmall),
             textStyle = typographyV2.buttonLabel,
             text = stringResource(id = R.string.Send),
-            backgroundColor = colors.backgroundSurfaceSecondary,
+            backgroundColor = kds_create_700,
             shouldWrapContentWidth = true
         )
     }


### PR DESCRIPTION
# 📲 What

Fix the background color of the 'Send' button on the Report Project screen.

# 🤔 Why

The button color is currently misconfigured such that it looks disabled in light mode and hidden in dark mode, so backers believe they are unable to report projects.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="256" src="https://github.com/user-attachments/assets/2fd990ca-60e6-488a-92de-411516faf5af" /> | <img width="256" src="https://github.com/user-attachments/assets/9b708a0a-39b0-49ee-9575-679a8ef13ed5" /> |
| <img width="256" src="https://github.com/user-attachments/assets/8da4351b-0cce-4fa7-9cdf-bef5a1cc5a0a" /> | <img width="256" src="https://github.com/user-attachments/assets/7dc94d2f-94d9-4fd8-b5c4-7f0b0532ae0d" /> |
| <img width="256" src="https://github.com/user-attachments/assets/5beefd1b-037c-4f51-9fd6-c3ab0e477cea" /> | <img width="256" src="https://github.com/user-attachments/assets/258b8da4-6894-44ed-80e5-679dfd71e92c" /> |


# 📋 QA

Step through the Report Project flow on staging and confirm that the button is enabled when the report details are not empty and visible in both light and dark mode.

# Story 📖

[\[PF-410\] [Placeholder] Report Project submission button is hidden/disabled - Jira](https://kickstarter.atlassian.net/browse/PF-410)
