### PR TITLE
PF-408: Improve `RichTextItemPhotoComponent` image loading and handling

### DIFF
--- a/app/src/main/java/com/kickstarter/features/projectstory/data/RichText.kt
+++ b/app/src/main/java/com/kickstarter/features/projectstory/data/RichText.kt
@@ -80,3 +80,8 @@ sealed interface RichTextItem {
 
 val RichTextItem.Oembed.aspectRatio: Float?
     get() = if (height > 0) width.toFloat() / height.toFloat() else null
+
+fun RichTextItem.Text.Paragraph.childPhoto(): RichTextItem.Photo? =
+    children?.firstOrNull { it is RichTextItem.Photo } as? RichTextItem.Photo
+
+fun RichTextItem.Text.Paragraph.hasChildPhoto(): Boolean = childPhoto() != null

--- a/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryCaptionedImage.kt
+++ b/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryCaptionedImage.kt
@@ -167,6 +167,8 @@ fun ProjectStoryCaptionedImage(
     val isLoading = asyncPainter.state is AsyncImagePainter.State.Empty ||
         asyncPainter.state is AsyncImagePainter.State.Loading
 
+    val placeholderAspectRatio = placeholderAspectRatio?.takeIf { it > 0f }
+
     Column(
         modifier = Modifier
             .then(modifier)

--- a/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryCaptionedImage.kt
+++ b/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryCaptionedImage.kt
@@ -1,11 +1,14 @@
 package com.kickstarter.features.projectstory.ui
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.systemBarsPadding
@@ -34,6 +37,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
+import coil.drawable.CrossfadeDrawable
 import coil.imageLoader
 import coil.request.ImageRequest
 import coil.size.SizeResolver
@@ -94,7 +98,8 @@ fun ProjectStoryCaptionedImage(
     image: String?,
     caption: String?,
     link: String? = null,
-    onSuccess: ((AsyncImagePainter.State.Success) -> Unit)? = null
+    onSuccess: ((AsyncImagePainter.State.Success) -> Unit)? = null,
+    placeholderAspectRatio: Float? = null
 ) {
     val context = LocalContext.current
     val defaults = context.imageLoader.defaults
@@ -135,6 +140,7 @@ fun ProjectStoryCaptionedImage(
         sizeResolver,
         caption,
         link,
+        placeholderAspectRatio
     )
 }
 
@@ -146,6 +152,7 @@ fun ProjectStoryCaptionedImage(
     sizeResolver: SizeResolver,
     caption: String?,
     link: String? = null,
+    placeholderAspectRatio: Float? = null
 ) {
     val uriHandler = LocalUriHandler.current
 
@@ -157,14 +164,29 @@ fun ProjectStoryCaptionedImage(
                 uriHandler.openUri(link)
             }
 
+    val isLoading = asyncPainter.state is AsyncImagePainter.State.Empty ||
+        asyncPainter.state is AsyncImagePainter.State.Loading
+
     Column(
         modifier = Modifier
             .then(modifier)
             .then(clickableModifier),
         verticalArrangement = Arrangement.spacedBy(dimensions.paddingXSmall)
     ) {
+
+        val placeholderAlpha = animateFloatAsState(
+            targetValue = if (placeholderAspectRatio != null && isLoading) 1f else 0f,
+            animationSpec = tween(durationMillis = CrossfadeDrawable.DEFAULT_DURATION)
+        )
+
+        val aspectRatioModifier = if (placeholderAspectRatio != null) {
+            Modifier.aspectRatio(placeholderAspectRatio).background(grey_04.copy(alpha = placeholderAlpha.value))
+        } else {
+            Modifier
+        }
+
         Box(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth().then(aspectRatioModifier)
         ) {
             ConstrainedImage(
                 modifier = Modifier
@@ -176,9 +198,7 @@ fun ProjectStoryCaptionedImage(
                 sizeResolver = sizeResolver,
                 wrapContentHeightUnbounded = true
             )
-            if (asyncPainter.state is AsyncImagePainter.State.Empty ||
-                asyncPainter.state is AsyncImagePainter.State.Loading
-            ) {
+            if (placeholderAspectRatio == null && isLoading) {
                 LinearProgressIndicator(
                     modifier = Modifier
                         .align(Alignment.Center)

--- a/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryComponents.kt
+++ b/app/src/main/java/com/kickstarter/features/projectstory/ui/ProjectStoryComponents.kt
@@ -8,7 +8,9 @@ import android.webkit.WebView
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.LocalPinnableContainer
 import androidx.compose.ui.layout.PinnableContainer
@@ -176,26 +178,40 @@ private fun parseRichTextChildrenOfRichText(children: List<RichTextItem.Text.Chi
 }
 
 @Composable
-fun RichTextItemPhotoComponent(item: RichTextItem.Photo, link: String? = null) {
+fun RichTextItemPhotoComponent(
+    item: RichTextItem.Photo,
+    link: String? = null,
+    placeholderAspectRatio: Float? = null,
+    onPhotoAspectRatioResolved: ((Float) -> Unit)? = null
+) {
     // Consider special handling of empty image url
     val imageUrl = item.asset?.url ?: item.url
     // `item.caption` can be empty
     val caption = item.caption.ifBlank { null }
-    val pinnableContainer = LocalPinnableContainer.current
-    val onSuccess: (AsyncImagePainter.State.Success) -> Unit = remember(pinnableContainer) {
+    val currentOnPhotoAspectRatioResolved by rememberUpdatedState(onPhotoAspectRatioResolved)
+    val onSuccess: (AsyncImagePainter.State.Success) -> Unit = remember {
         {
-            // TODO: We should be able to use the dimensions of the `Drawable` contained in the `Success`
-            //  state to further optimize for only pinning tall images as determined by aspect ratio or
-            //  compared to the screen size/resolution.
-            pinnableContainer?.pin()
+            val drawable = it.result.drawable
+            val width = drawable.intrinsicWidth
+            val height = drawable.intrinsicHeight
+            val aspectRatio = if (width > 0 && height > 0) {
+                width.toFloat() / height.toFloat()
+            } else {
+                null
+            }
+            aspectRatio?.let { aspectRatio ->
+                currentOnPhotoAspectRatioResolved?.invoke(aspectRatio)
+            }
         }
     }
+
     ProjectStoryCaptionedImage(
         modifier = Modifier.testTag(ProjectStoryComponentTestTag.PHOTO.name),
         image = imageUrl,
         caption = caption,
         link = link,
-        onSuccess = onSuccess
+        onSuccess = onSuccess,
+        placeholderAspectRatio = placeholderAspectRatio
     )
 }
 

--- a/app/src/main/java/com/kickstarter/libs/utils/extensions/StringExt.kt
+++ b/app/src/main/java/com/kickstarter/libs/utils/extensions/StringExt.kt
@@ -227,11 +227,11 @@ fun String.toHtml(): Spanned {
     return Html.fromHtml(TextUtils.htmlEncode(this), Html.FROM_HTML_MODE_LEGACY)
 }
 
-fun String.toHashedSHAEmail(): String {
+fun String.toSha256(): String {
     return MessageDigest
         .getInstance("SHA-256")
         .digest(this.toByteArray())
-        .fold("") { str, it -> str + "%02x".format(it) }
+        .joinToString("") { "%02x".format(it) }
 }
 
 fun String?.toInteger(): Int? {

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreen.kt
@@ -47,6 +47,7 @@ import com.kickstarter.features.projectstory.ui.RichTextItemPhotoComponent
 import com.kickstarter.features.projectstory.ui.RichTextItemTextComponent
 import com.kickstarter.features.projectstory.ui.WebViewComponent
 import com.kickstarter.libs.utils.extensions.toHtml
+import com.kickstarter.libs.utils.extensions.toSha256
 import com.kickstarter.mock.factories.ProjectFactory
 import com.kickstarter.models.Project
 import com.kickstarter.ui.activities.compose.PreLaunchProjectPageScreenTestTag.COMING_SOON_BADGE
@@ -283,7 +284,7 @@ fun PreLaunchProjectPageScreen(
                     }
                 }
 
-                itemsIndexed(story?.items ?: emptyList(), key = { index, item -> "$item$index" }, contentType = { index, item -> item.lazyListContentType() }) { index, item ->
+                itemsIndexed(story?.items ?: emptyList(), key = { index, item -> item.lazyListKey(index) }, contentType = { index, item -> item.lazyListContentType() }) { index, item ->
                     Box(
                         modifier = Modifier
                             .padding(horizontal = screenPadding, vertical = dimensionResource(id = R.dimen.grid_1))
@@ -439,3 +440,6 @@ private fun RichTextItem.lazyListContentType(): String =
     } else {
         this::class.simpleName.orEmpty()
     }
+
+private fun RichTextItem.lazyListKey(index: Int): String =
+    "${this.toString().toSha256()}_$index"

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
@@ -22,6 +23,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -40,6 +42,8 @@ import com.kickstarter.R
 import com.kickstarter.features.projectstory.ProjectStoryUiState
 import com.kickstarter.features.projectstory.data.RichTextItem
 import com.kickstarter.features.projectstory.data.aspectRatio
+import com.kickstarter.features.projectstory.data.childPhoto
+import com.kickstarter.features.projectstory.data.hasChildPhoto
 import com.kickstarter.features.projectstory.ui.RichTextItemPhotoComponent
 import com.kickstarter.features.projectstory.ui.RichTextItemTextComponent
 import com.kickstarter.features.projectstory.ui.WebViewComponent
@@ -117,6 +121,7 @@ fun PreLaunchProjectPageScreen(
 ) {
     val project = projectState.value
     val story = projectStoryState.value.storiedProject?.story
+    val photoAspectRatiosByUrl = remember { mutableStateMapOf<String, Float>() }
 
     Scaffold(
         modifier = Modifier.systemBarsPadding(),
@@ -279,7 +284,7 @@ fun PreLaunchProjectPageScreen(
                     }
                 }
 
-                items(story?.items ?: emptyList(), contentType = { it::class.simpleName }) { item ->
+                itemsIndexed(story?.items ?: emptyList(), key = { index, item -> "$item$index" }, contentType = { index, item -> item.lazyListContentType() }) { index, item ->
                     Box(
                         modifier = Modifier
                             .padding(horizontal = screenPadding, vertical = dimensionResource(id = R.dimen.grid_1))
@@ -289,11 +294,19 @@ fun PreLaunchProjectPageScreen(
                             is RichTextItem.Text -> {
                                 when (item) {
                                     is RichTextItem.Text.Paragraph -> {
-                                        val childPhoto = item.children?.firstOrNull { it is RichTextItem.Photo } as? RichTextItem.Photo
+                                        val childPhoto = item.childPhoto()
                                         when {
                                             childPhoto != null -> {
                                                 val link = item.link
-                                                RichTextItemPhotoComponent(childPhoto, link)
+                                                val photoUrl = childPhoto.asset?.url ?: childPhoto.url
+                                                RichTextItemPhotoComponent(
+                                                    childPhoto,
+                                                    link,
+                                                    placeholderAspectRatio = photoAspectRatiosByUrl[photoUrl],
+                                                    onPhotoAspectRatioResolved = { aspectRatio ->
+                                                        photoAspectRatiosByUrl[photoUrl] = aspectRatio
+                                                    }
+                                                )
                                             }
                                             else -> RichTextItemTextComponent(item)
                                         }
@@ -307,7 +320,14 @@ fun PreLaunchProjectPageScreen(
                                 Box(
                                     modifier = Modifier.fillMaxWidth().padding(vertical = dimensionResource(id = R.dimen.grid_1))
                                 ) {
-                                    RichTextItemPhotoComponent(item)
+                                    val photoUrl = item.asset?.url ?: item.url
+                                    RichTextItemPhotoComponent(
+                                        item,
+                                        placeholderAspectRatio = photoAspectRatiosByUrl[photoUrl],
+                                        onPhotoAspectRatioResolved = { aspectRatio ->
+                                            photoAspectRatiosByUrl[photoUrl] = aspectRatio
+                                        }
+                                    )
                                 }
                             }
                             is RichTextItem.Oembed -> {
@@ -413,3 +433,10 @@ fun PreLaunchProjectPageScreen(
         }
     }
 }
+
+private fun RichTextItem.lazyListContentType(): String =
+    if (this is RichTextItem.Text.Paragraph && hasChildPhoto()) {
+        RichTextItem.Photo::class.simpleName.orEmpty()
+    } else {
+        this::class.simpleName.orEmpty()
+    }

--- a/app/src/main/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/PreLaunchProjectPageScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons

--- a/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryCaptionedImageTest.kt
+++ b/app/src/test/java/com/kickstarter/features/projecstory/ui/ProjectStoryCaptionedImageTest.kt
@@ -6,6 +6,7 @@ import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ExperimentalTestApi
@@ -301,6 +302,46 @@ class ProjectStoryCaptionedImageTest : KSRobolectricTestCase() {
         onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.CAPTION.name))
             .assertTextEquals(caption)
             .assertIsDisplayed()
+    }
+
+    @Test
+    @OptIn(ExperimentalTestApi::class)
+    fun `test image loading with aspect ratio placeholder`() = runComposeUiTest {
+        val standardDispatcher = StandardTestDispatcher(mainClock.scheduler)
+
+        setUpImageLoader(
+            ImageLoader.Builder(context)
+                .components { add(fakeImageLoaderEngine()) }
+                .dispatcher(standardDispatcher)
+                .interceptorDispatcher(standardDispatcher)
+                .build()
+        )
+
+        val placeholderAspectRatio = mutableStateOf<Float?>(null)
+
+        setContent {
+            ProjectStoryCaptionedImage(
+                image = "https://www.example.com/blue.jpg",
+                caption = null,
+                placeholderAspectRatio = placeholderAspectRatio.value
+            )
+        }
+
+        onNode(hasTestTag(ProjectStoryCaptionedImageTestTag.LOADING_INDICATOR.name))
+            .assert(SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo))
+            .assertIsDisplayed()
+
+        placeholderAspectRatio.value = 1.78f
+
+        onNode(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
+        ).assertDoesNotExist()
+
+        mainClock.advanceTimeBy(REQUEST_DELAY)
+
+        onNode(
+            SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
+        ).assertDoesNotExist()
     }
 
     @Test


### PR DESCRIPTION
# 📲 What

Fast-follow optimizations to fix Compose rendering bugs in Pre-launch Project story as reported in Firebase. Specifically,

- Stop `pin`-ing the `RichTextItemPhotoComponent`
- When the image for `ProjectStoryCaptionedImage`'s loads successfully, capture the aspect ratio and use it to render a placeholder for subsequent loads.

# 🤔 Why

For many Projects, the campaign story is composed heavily of images. In the current implementation, we keep all successfully loaded images in the composition to prevent surrounding content from shifting around when scrolling. However, given the memory limits Android imposes on each app, the Project Story experience sometimes suffers from performance related issues, reflected in two notable exceptions logged in Firebase ([1](https://console.firebase.google.com/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/788308c5f327bbb6afbab570cd424ba8?time=7d&types=crash&sessionEventKey=6A60AC2503A700011C664AC37F0DD272_2243794871889421666), [2](https://console.firebase.google.com/project/android-external-release/crashlytics/app/android:com.kickstarter.kickstarter/issues/159e25351be7042db517f3af684684db?time=7d&types=crash&sessionEventKey=6A6114DE00160001420883751327BE5C_2243885395847163487)) (lesser reported OOM exceptions have been logged as well in internal testing).

# 🛠 How

Within `RichTextItemPhotoComponent`, we no longer call `PinnableContainer.pin()` on a successful image load, allowing images to be disposed. Instead we determine the aspect ratio of the loaded image, cache it in a state map, and pass it back down to `ProjectStoryCaptionedImage` for subsequent loads.

When provided, `ProjectStoryCaptionedImage` uses the aspect ratio to render a placeholder Box (the image's containing box itself was an sensible choice here) that simulates a crossfade on subsequent image loads, preserving the space required by the image as the user scrolls around.

# 👀 See

> [!NOTE]
> Recorded with a hardcoded `delay(1000L)` in the global `ImageLoader` interceptor chain

https://github.com/user-attachments/assets/a12084cf-3554-4652-9e6a-dd24ab00dfa9

# 📋 QA

Open any Pre-launch Project Page and scroll around. Once images have loaded, confirm that the surrounding content doesn't shift on subsequent loads.

# Story 📖

[\[PF-408\] Compose UI IllegalStateException in Pre-launch Activity - Jira](https://kickstarter.atlassian.net/browse/PF-408)
