### PR TITLE
DISC-425: Discovery VideoFeed entry card edge cases

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -357,7 +357,7 @@ dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
 
     // Statsig
-    implementation 'com.statsig:android-sdk:5.1.0'
+    implementation 'com.statsig:android-sdk:5.1.3'
 }
 
 // SHA and timestamp caching courtesy of https://github.com/gdg-x/frisbee/blob/develop/app/build.gradle#L193-L218

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
@@ -12,6 +12,7 @@ import com.kickstarter.models.Category
 import com.kickstarter.models.Location
 import com.kickstarter.models.Project
 import com.kickstarter.services.DiscoveryParams
+import com.statsig.androidsdk.EvalReason
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -47,6 +48,14 @@ class SearchAndFilterViewModel(
     private val analyticEvents = requireNotNull(environment.analytics())
     private val statsigClient = requireNotNull(environment.statsigClient())
 
+    /**
+     * Whether the video feed banner should show, derived from the [StatsigGateKey.ANDROID_VIDEO_FEED]
+     * gate. It is recomputed whenever gate values settle for the current user (the client's
+     * `configReady`) rather than on the one-shot `isReady`, so the gate is never read mid user-reload
+     * (login/logout) where it returns `Loading:Unrecognized`/`false`. While values are (re)loading, or
+     * come back unrecognized, the banner keeps its current state instead of flipping to hidden and
+     * logging a phantom exposure.
+     */
     private val _isVideoFeedBannerVisible = MutableStateFlow(false)
     val isVideoFeedBannerVisible: StateFlow<Boolean> = _isVideoFeedBannerVisible.asStateFlow()
 
@@ -82,8 +91,11 @@ class SearchAndFilterViewModel(
 
     init {
         scope.launch {
-            statsigClient.isReady.collect { isReady ->
-                _isVideoFeedBannerVisible.value = isReady && statsigClient.checkGate(StatsigGateKey.ANDROID_VIDEO_FEED.key)
+            statsigClient.configReady.collect { configReady ->
+                if (!configReady) return@collect
+                val gate = statsigClient.getFeatureGate(StatsigGateKey.ANDROID_VIDEO_FEED.key)
+                if (gate.getEvalDetails().reason == EvalReason.Unrecognized) return@collect
+                _isVideoFeedBannerVisible.value = gate.getValue()
             }
         }
 

--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -90,6 +90,19 @@ interface StatsigClientType {
     /** Emits true once the SDK has been successfully initialized. */
     val isReady: StateFlow<Boolean>
 
+    /**
+     * Emits `true` once gate/config values are loaded **and settled for the current Statsig user**,
+     * and `false` while they are being (re)fetched — e.g. during the async [updateUser] triggered by
+     * a login/logout.
+     *
+     * This is deliberately distinct from [isReady], which only reflects the one-time SDK
+     * initialization and stays `true` across user changes. Reactive gate consumers should gate their
+     * reads on [configReady] rather than [isReady]: reading a gate while values are reloading returns
+     * the default (reason `Loading:Unrecognized`, i.e. `false`) which would otherwise be cached as a
+     * real result and also logs a phantom exposure.
+     */
+    val configReady: StateFlow<Boolean>
+
     val statsigUser: StateFlow<StatsigUser>
 
     suspend fun handleObservedUserData(stableId: String?, segmentAnonymousId: String?, userId: String?, isAdmin: Boolean)
@@ -136,6 +149,9 @@ open class StatsigClient @JvmOverloads constructor(
 
     protected val _isReady = MutableStateFlow(false)
     override val isReady: StateFlow<Boolean> = _isReady.asStateFlow()
+
+    protected val _configReady = MutableStateFlow(false)
+    override val configReady: StateFlow<Boolean> = _configReady.asStateFlow()
 
     private val _statsigUser = MutableStateFlow(StatsigUser())
     override val statsigUser = _statsigUser.asStateFlow()
@@ -211,6 +227,12 @@ open class StatsigClient @JvmOverloads constructor(
         }
     }
 
+    /**
+     * Applies the latest observed user identity to Statsig and refetches gate/config values for it.
+     * [configReady] is flipped to `false` for the duration of the async [updateUser] refetch and back
+     * to `true` once values have settled, so reactive consumers don't read gates mid-reload (where
+     * they return the default with reason `Loading:Unrecognized`). See [configReady].
+     */
     override suspend fun handleObservedUserData(stableId: String?, segmentAnonymousId: String?, userId: String?, isAdmin: Boolean) {
         Timber.d("handleObservedUserData(stableId: $stableId, segmentAnonymousId: $segmentAnonymousId, userId: $userId, isAdmin: $isAdmin)")
 
@@ -226,9 +248,11 @@ open class StatsigClient @JvmOverloads constructor(
         }
 
         try {
+            _configReady.value = false
             Timber.d("Statsig.updateUser($statsigUser):")
             updateUser(statsigUser)
             _statsigUser.value = statsigUser
+            _configReady.value = true
             val initializeResponseJson = Statsig.runCatching { getInitializeResponseJson() }.getOrNull()
             initializeResponseJson?.let {
                 Timber.d("- EvaluationDetails: ${it.getEvalDetails()}")

--- a/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModel.kt
@@ -37,6 +37,7 @@ import com.kickstarter.ui.viewholders.ActivitySampleFriendFollowViewHolder
 import com.kickstarter.ui.viewholders.ActivitySampleProjectViewHolder
 import com.kickstarter.ui.viewholders.DiscoveryOnboardingViewHolder
 import com.kickstarter.ui.viewholders.DiscoveryVideoFeedBannerViewHolder
+import com.statsig.androidsdk.EvalReason
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subjects.BehaviorSubject
@@ -319,7 +320,6 @@ interface DiscoveryFragmentViewModel {
             clearPage
                 .subscribe {
                     shouldShowOnboardingView.onNext(false)
-                    shouldShowVideoFeedBanner.onNext(false)
                     clearActivities.onNext(Unit)
                     projectList.onNext(emptyList())
                 }.addToDisposable(disposables)
@@ -359,18 +359,15 @@ interface DiscoveryFragmentViewModel {
                 .subscribe { shouldShowOnboardingView.onNext(it) }
                 .addToDisposable(disposables)
 
-            paramsFromActivity
-                .compose(
-                    Transformers.combineLatestPair(
-                        statsigClient.isReady.asObservable()
-                    )
-                )
-                .map {
-                    isVideoFeedBannerVisible(
-                        params = it.first,
-                        isGateOn = it.second && statsigClient.checkGate(StatsigGateKey.ANDROID_VIDEO_FEED.key)
-                    )
+            Observable.combineLatest(
+                paramsFromActivity,
+                statsigClient.configReady.asObservable()
+            ) { params, configReady -> params to configReady }
+                .concatMap { (params, configReady) ->
+                    val visible = videoFeedBannerVisibility(params, configReady)
+                    if (visible == null) Observable.empty() else Observable.just(visible)
                 }
+                .distinctUntilChanged()
                 .subscribe { shouldShowVideoFeedBanner.onNext(it) }
                 .addToDisposable(disposables)
 
@@ -582,15 +579,32 @@ interface DiscoveryFragmentViewModel {
             return params.isAllProjects.isTrue() && isSortHome && !isLoggedIn
         }
 
-        private fun isVideoFeedBannerVisible(
+        /**
+         * Single source of truth for the video feed banner's visibility for [params]. Returns `true`
+         * or `false` when the answer is known, or `null` when it is not yet decidable because the
+         * [StatsigGateKey.ANDROID_VIDEO_FEED] gate values are still (re)loading for the current user
+         * — hence gating on [configReady] rather than the one-shot `isReady`.
+         *
+         * On `null`, callers keep the banner's current state instead of hiding it. That — together
+         * with never force-hiding the banner elsewhere (e.g. on `clearPage`) — is what prevents the
+         * gate re-reading as `false` (reason `Loading:Unrecognized`) and logging a phantom exposure
+         * during the async user reload on login/logout.
+         *
+         * Surfaces that are not eligible (a category, a non-magic sort, etc.) are deterministically
+         * hidden regardless of the gate.
+         */
+        private fun videoFeedBannerVisibility(
             params: DiscoveryParams,
-            isGateOn: Boolean
-        ): Boolean {
-            if (!isGateOn) return false
+            configReady: Boolean
+        ): Boolean? {
             val isSortHome = DiscoveryParams.Sort.MAGIC == params.sort()
             val isHomeView = params.isAllProjects.isTrue() && isSortHome
             val isPwl = params.staffPicks().isTrue() && isSortHome
-            return isHomeView || isPwl
+            if (!isHomeView && !isPwl) return false
+            if (!configReady) return null
+            val gate = statsigClient.getFeatureGate(StatsigGateKey.ANDROID_VIDEO_FEED.key)
+            if (gate.getEvalDetails().reason == EvalReason.Unrecognized) return null
+            return gate.getValue()
         }
 
         private fun isSavedVisible(params: DiscoveryParams): Boolean {

--- a/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
@@ -522,11 +522,13 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         assertTrue(viewModel.isVideoFeedBannerVisible.value)
     }
 
+    /**
+     * Regression: the gate re-reads as `Loading:Unrecognized`/`false` during the async Statsig
+     * `updateUser` triggered by login/logout. While values reload the banner must keep its current
+     * (shown) state rather than flip to false, and must not log a phantom exposure.
+     */
     @Test
     fun `test isVideoFeedBannerVisible keeps shown state during user reload window`() = runTest {
-        // Regression: the gate re-reads as Loading:Unrecognized/false during the async Statsig
-        // updateUser triggered by login/logout. While values reload the banner must keep its
-        // current (shown) state rather than flip to false, and must not log a phantom exposure.
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val statsigClient = MockStatsigClient(
             context = application(),
@@ -542,12 +544,10 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         advanceUntilIdle()
         assertTrue(viewModel.isVideoFeedBannerVisible.value)
 
-        // A user change starts: values are being refetched for the new user (Loading:Unrecognized).
         statsigClient.beginUserReload()
         advanceUntilIdle()
         assertTrue(viewModel.isVideoFeedBannerVisible.value)
 
-        // Values settle for the new user; still shown.
         statsigClient.completeUserReload()
         advanceUntilIdle()
         assertTrue(viewModel.isVideoFeedBannerVisible.value)

--- a/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
@@ -521,4 +521,35 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         advanceUntilIdle()
         assertTrue(viewModel.isVideoFeedBannerVisible.value)
     }
+
+    @Test
+    fun `test isVideoFeedBannerVisible keeps shown state during user reload window`() = runTest {
+        // Regression: the gate re-reads as Loading:Unrecognized/false during the async Statsig
+        // updateUser triggered by login/logout. While values reload the banner must keep its
+        // current (shown) state rather than flip to false, and must not log a phantom exposure.
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val statsigClient = MockStatsigClient(
+            context = application(),
+            gateMap = mapOf(StatsigGateKey.ANDROID_VIDEO_FEED.key to true)
+        )
+        val environment = environment()
+            .toBuilder()
+            .statsigClient(statsigClient)
+            .build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        advanceUntilIdle()
+        assertTrue(viewModel.isVideoFeedBannerVisible.value)
+
+        // A user change starts: values are being refetched for the new user (Loading:Unrecognized).
+        statsigClient.beginUserReload()
+        advanceUntilIdle()
+        assertTrue(viewModel.isVideoFeedBannerVisible.value)
+
+        // Values settle for the new user; still shown.
+        statsigClient.completeUserReload()
+        advanceUntilIdle()
+        assertTrue(viewModel.isVideoFeedBannerVisible.value)
+    }
 }

--- a/app/src/test/java/com/kickstarter/libs/MockStatsigClient.kt
+++ b/app/src/test/java/com/kickstarter/libs/MockStatsigClient.kt
@@ -47,25 +47,66 @@ open class MockStatsigClient(
     segmentTrackingClient = segmentTrackingClient,
     sdkInitializer = { null }
 ) {
+    /**
+     * When true, simulates the async `updateUser` reload window: [configReady] is `false` and gate
+     * reads come back with reason `Loading:Unrecognized` (value `false`), exactly like the real SDK
+     * between a user change and the new values landing.
+     */
+    private var reloadingValues = false
+
     init {
-        if (startReady) _isReady.value = true
+        if (startReady) {
+            _isReady.value = true
+            _configReady.value = true
+        }
     }
 
+    /**
+     * Simulates a successful cold-start init: the SDK is ready ([isReady]) and values for the
+     * initial user have settled ([configReady]). In production both flip to `true` once the first
+     * init/updateUser completes; use [beginUserReload]/[completeUserReload] to model a later
+     * user-change reload window where only [configReady] toggles.
+     */
     fun triggerReady() {
         _isReady.value = true
+        _configReady.value = true
+    }
+
+    /**
+     * Simulates the start of a user change (login/logout): values for the new user are not loaded
+     * yet, so [configReady] flips to `false` and gate reads become `Loading:Unrecognized`. Mirrors
+     * production [StatsigClient.handleObservedUserData] before `updateUser` completes.
+     */
+    fun beginUserReload() {
+        reloadingValues = true
+        _configReady.value = false
+    }
+
+    /** Simulates the reload finishing: values have settled for the current user. */
+    fun completeUserReload() {
+        reloadingValues = false
+        _configReady.value = true
     }
 
     override fun isInitialized(): Boolean = true
 
     override fun checkGate(gateName: String): Boolean =
-        gateMap[gateName] ?: false
+        if (reloadingValues) false else gateMap[gateName] ?: false
 
     override fun getFeatureGate(gateName: String): FeatureGate =
-        FeatureGate(
-            gateName,
-            EvalDetails(EvalSource.NoValues, EvalReason.Unrecognized),
-            gateMap[gateName] ?: false
-        )
+        if (reloadingValues) {
+            FeatureGate(
+                gateName,
+                EvalDetails(EvalSource.Loading, EvalReason.Unrecognized),
+                false
+            )
+        } else {
+            FeatureGate(
+                gateName,
+                EvalDetails(EvalSource.Network, EvalReason.Recognized),
+                gateMap[gateName] ?: false
+            )
+        }
 
     override fun getExperiment(experimentName: String): DynamicConfig =
         DynamicConfig(

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.kt
@@ -840,7 +840,8 @@ class DiscoveryFragmentViewModelTest : KSRobolectricTestCase() {
         shouldShowVideoFeedBanner.assertValues(true)
 
         logUserIn(currentUser)
-        shouldShowVideoFeedBanner.assertValues(true, true)
+        // Still visible after login. The redundant re-emit is now coalesced by distinctUntilChanged.
+        shouldShowVideoFeedBanner.assertValues(true)
     }
 
     @Test
@@ -875,8 +876,67 @@ class DiscoveryFragmentViewModelTest : KSRobolectricTestCase() {
         setUpInitialHomeAllProjectsParams()
         shouldShowVideoFeedBanner.assertValues(true)
 
+        // clearPage no longer force-hides the banner; its visibility is derived reactively, so the
+        // last emitted value (true) stands until this page's params are re-pushed.
         vm.inputs.clearPage()
-        shouldShowVideoFeedBanner.assertValues(true, false)
+        shouldShowVideoFeedBanner.assertValues(true)
+    }
+
+    @Test
+    fun testShouldShowVideoFeedBanner_userReloadWindow_keepsBannerInsteadOfHiding() {
+        // Regression: the gate re-reads as Loading:Unrecognized/false during the async Statsig
+        // updateUser triggered by login/logout. While values reload the banner must keep its current
+        // (shown) state rather than flip to false.
+        val statsigClient = MockStatsigClient(
+            context = application(),
+            gateMap = mapOf(StatsigGateKey.ANDROID_VIDEO_FEED.key to true)
+        )
+        val environment = environment().toBuilder()
+            .statsigClient(statsigClient)
+            .build()
+        setUpEnvironment(environment)
+
+        setUpInitialHomeAllProjectsParams()
+        shouldShowVideoFeedBanner.assertValue(true)
+
+        // A user change starts: values are being refetched for the new user (Loading:Unrecognized).
+        statsigClient.beginUserReload()
+        // Even if params are re-pushed mid-reload (as when Discovery is recreated on logout), the
+        // banner must not flip to false.
+        vm.inputs.paramsFromActivity(
+            getDefaultParams(null).toBuilder().sort(DiscoveryParams.Sort.MAGIC).build()
+        )
+        shouldShowVideoFeedBanner.assertValue(true)
+        shouldShowVideoFeedBanner.assertValueCount(1)
+
+        // Values settle for the new user; still shown, with no redundant re-emit.
+        statsigClient.completeUserReload()
+        shouldShowVideoFeedBanner.assertValue(true)
+        shouldShowVideoFeedBanner.assertValueCount(1)
+    }
+
+    @Test
+    fun testShouldShowVideoFeedBanner_createdDuringReload_showsOnceSettled() {
+        // Simulates Discovery being recreated on logout while Statsig is still reloading values for
+        // the now-anonymous user: the banner shouldn't read the gate yet (it would be
+        // Loading:Unrecognized/false), and should appear once values settle.
+        val statsigClient = MockStatsigClient(
+            context = application(),
+            gateMap = mapOf(StatsigGateKey.ANDROID_VIDEO_FEED.key to true)
+        )
+        val environment = environment().toBuilder()
+            .statsigClient(statsigClient)
+            .build()
+        setUpEnvironment(environment)
+
+        // Reload already in flight before the fragment pushes its params.
+        statsigClient.beginUserReload()
+        setUpInitialHomeAllProjectsParams()
+        // Gate value not trustworthy yet -> banner not shown, but not decided as false either.
+        shouldShowVideoFeedBanner.assertNoValues()
+
+        statsigClient.completeUserReload()
+        shouldShowVideoFeedBanner.assertValue(true)
     }
 
     private fun logUserIn(currentUser: CurrentUserTypeV2) {

--- a/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/DiscoveryFragmentViewModelTest.kt
@@ -840,7 +840,6 @@ class DiscoveryFragmentViewModelTest : KSRobolectricTestCase() {
         shouldShowVideoFeedBanner.assertValues(true)
 
         logUserIn(currentUser)
-        // Still visible after login. The redundant re-emit is now coalesced by distinctUntilChanged.
         shouldShowVideoFeedBanner.assertValues(true)
     }
 
@@ -876,17 +875,18 @@ class DiscoveryFragmentViewModelTest : KSRobolectricTestCase() {
         setUpInitialHomeAllProjectsParams()
         shouldShowVideoFeedBanner.assertValues(true)
 
-        // clearPage no longer force-hides the banner; its visibility is derived reactively, so the
-        // last emitted value (true) stands until this page's params are re-pushed.
         vm.inputs.clearPage()
         shouldShowVideoFeedBanner.assertValues(true)
     }
 
+    /**
+     * Regression: the gate re-reads as `Loading:Unrecognized`/`false` during the async Statsig
+     * `updateUser` triggered by login/logout. While values reload — even if params are re-pushed
+     * mid-reload, as when Discovery is recreated on logout — the banner must keep its current (shown)
+     * state rather than flip to false, and must not redundantly re-emit once values settle.
+     */
     @Test
     fun testShouldShowVideoFeedBanner_userReloadWindow_keepsBannerInsteadOfHiding() {
-        // Regression: the gate re-reads as Loading:Unrecognized/false during the async Statsig
-        // updateUser triggered by login/logout. While values reload the banner must keep its current
-        // (shown) state rather than flip to false.
         val statsigClient = MockStatsigClient(
             context = application(),
             gateMap = mapOf(StatsigGateKey.ANDROID_VIDEO_FEED.key to true)
@@ -899,27 +899,25 @@ class DiscoveryFragmentViewModelTest : KSRobolectricTestCase() {
         setUpInitialHomeAllProjectsParams()
         shouldShowVideoFeedBanner.assertValue(true)
 
-        // A user change starts: values are being refetched for the new user (Loading:Unrecognized).
         statsigClient.beginUserReload()
-        // Even if params are re-pushed mid-reload (as when Discovery is recreated on logout), the
-        // banner must not flip to false.
         vm.inputs.paramsFromActivity(
             getDefaultParams(null).toBuilder().sort(DiscoveryParams.Sort.MAGIC).build()
         )
         shouldShowVideoFeedBanner.assertValue(true)
         shouldShowVideoFeedBanner.assertValueCount(1)
 
-        // Values settle for the new user; still shown, with no redundant re-emit.
         statsigClient.completeUserReload()
         shouldShowVideoFeedBanner.assertValue(true)
         shouldShowVideoFeedBanner.assertValueCount(1)
     }
 
+    /**
+     * Simulates Discovery being recreated on logout while Statsig is still reloading values for the
+     * now-anonymous user: the banner shouldn't read the gate yet (it would be
+     * `Loading:Unrecognized`/`false`), and should appear once values settle.
+     */
     @Test
     fun testShouldShowVideoFeedBanner_createdDuringReload_showsOnceSettled() {
-        // Simulates Discovery being recreated on logout while Statsig is still reloading values for
-        // the now-anonymous user: the banner shouldn't read the gate yet (it would be
-        // Loading:Unrecognized/false), and should appear once values settle.
         val statsigClient = MockStatsigClient(
             context = application(),
             gateMap = mapOf(StatsigGateKey.ANDROID_VIDEO_FEED.key to true)
@@ -929,10 +927,8 @@ class DiscoveryFragmentViewModelTest : KSRobolectricTestCase() {
             .build()
         setUpEnvironment(environment)
 
-        // Reload already in flight before the fragment pushes its params.
         statsigClient.beginUserReload()
         setUpInitialHomeAllProjectsParams()
-        // Gate value not trustworthy yet -> banner not shown, but not decided as false either.
         shouldShowVideoFeedBanner.assertNoValues()
 
         statsigClient.completeUserReload()


### PR DESCRIPTION
# 📲 What

Introduces a `configReady` gate on `StatsigClient` that reflects when gate/config values have settled for the current Statsig user, and switches the two Video Feed Banner consumers (Discovery and Search) to gate their reads on it instead of the one-shot isReady (SDK initialized). While values are (re)loading — or come back Unrecognized — the banner keeps its current state instead of flipping to hidden.

# 🤔 Why

`isReady` only reflects the one-time SDK initialization and stays true across user changes. When a user logs in/out, Statsig runs an async `updateUser` to refetch values. Reading the ANDROID_VIDEO_FEED gate mid-reload returns the default which caused the banner would flicker to hidden during the reload window

*Note: `Loading:Unrecognized` meands the SDK has no settled values yet for the current user, so it hands back the type default (false for a boolean gate) and tags it Unrecognized.

<img width="1379" height="816" alt="Screenshot 2026-07-20 at 5 17 30 PM" src="https://github.com/user-attachments/assets/1c76c55d-8464-4338-8029-12d55f5c37bf" />


# 🛠 How

- StatsigClient: Added configReady: StateFlow<Boolean>. It flips to false at the start of the handleObservedUserData → updateUser refetch and back to true once values have settled. This is deliberately distinct from isReady.

- SearchAndFilterViewModel: Now collects configReady (instead of isReady), skips while not ready, and skips when getFeatureGate(...).getEvalDetails().reason == EvalReason.Unrecognized, only updating visibility on a recognized value.

- DiscoveryFragmentViewModel: Renamed isVideoFeedBannerVisible → videoFeedBannerVisibility, now returning a nullable Boolean? — null means "not yet decidable" so callers keep the current banner state. Also removed the force-hide of the banner on clearPage (which was another source of the phantom flip/exposure).

- Test mock (MockStatsigClient): Added beginUserReload() / completeUserReload() to simulate the reload window (configReady = false, gate reads return Loading:Unrecognized/false), and triggerReady() now also settles configReady.

|  |  |

# 📋 QA
Compare with master branch or the released app: 
- - [Master branch behaviour] Start the app as logged out user, you see the banner in discovery, log in, when Discovery is presented again the banner has disappeared. 
- - [Current branch behaviour] Start the app as logged out user, you see the banner in discovery, log in, when Discovery is presented again the banner persitst. Note* the gate value will persist if it were false and no banner visible that is the expected outcome ofter logging in.

- - [Master branch behaviour] Start the app as logged in user, you see the banner in discovery, log out, when Discovery is presented again the banner has disappeared. 
- - [Current branch behaviour] Start the app as logged in user, you see the banner in discovery, log out, when Discovery is presented again the banner is still present.


# Story 📖

[Name of Trello Story](Trello link)
