### PR TITLE
DISC-386 && Disc-388 && Disc-392: Open Calls filter Network layer

### DIFF
--- a/app/src/main/graphql/project.graphql
+++ b/app/src/main/graphql/project.graphql
@@ -14,6 +14,7 @@ query FetchProjects(
   $amountRaisedBucket: PledgedBuckets,
   $goalBucket: GoalBuckets
   $following: Boolean
+  $tagId: Int
 ) {
     projects(
       first: $first,
@@ -30,7 +31,8 @@ query FetchProjects(
       locationId: $location,
       pledged: $amountRaisedBucket,
       goal: $goalBucket,
-      following: $following
+      following: $following,
+      tagId: $tagId
       ) {
         edges {
           cursor

--- a/app/src/main/graphql/tags.graphql
+++ b/app/src/main/graphql/tags.graphql
@@ -1,0 +1,13 @@
+query GetCreativePromptTags {
+  tags(first: 21, scope: CREATIVE_PROMPT) {
+    pageInfo {
+      hasNextPage
+    }
+    nodes {
+      id
+      name
+      url
+      slug
+    }
+  }
+}

--- a/app/src/main/graphql/tags.graphql
+++ b/app/src/main/graphql/tags.graphql
@@ -1,8 +1,5 @@
 query GetCreativePromptTags {
-  tags(first: 21, scope: CREATIVE_PROMPT) {
-    pageInfo {
-      hasNextPage
-    }
+  tags(scope: CREATIVE_PROMPT) {
     nodes {
       id
       name

--- a/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
+++ b/app/src/main/java/com/kickstarter/features/search/ui/SearchAndFilterActivity.kt
@@ -36,6 +36,7 @@ class SearchAndFilterActivity : ComponentActivity() {
             viewModelFactory = SearchAndFilterViewModel.Factory(env)
             filterMenuViewModelFactory = FilterMenuViewModel.Factory(env)
             filterMenuViewModel.getRootCategories()
+            filterMenuViewModel.getTags()
 
             setContent {
                 KickstarterApp {

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModel.kt
@@ -7,6 +7,7 @@ import com.kickstarter.libs.Environment
 import com.kickstarter.libs.utils.extensions.isNotNull
 import com.kickstarter.models.Category
 import com.kickstarter.models.Location
+import com.kickstarter.models.Tag
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -25,7 +26,8 @@ import kotlin.coroutines.EmptyCoroutineContext
 
 data class FilterMenuUIState(
     val isLoading: Boolean = false,
-    val categoriesList: List<Category> = emptyList()
+    val categoriesList: List<Category> = emptyList(),
+    val tagsList: List<Tag> = emptyList()
 )
 
 data class LocationsUIState(
@@ -73,6 +75,7 @@ open class FilterMenuViewModel(
         )
 
     private var categoriesList = emptyList<Category>()
+    private var tagsList = emptyList<Tag>()
 
     private val _searchQuery = MutableStateFlow("")
     private var nearbyLocations = emptyList<Location>()
@@ -134,6 +137,21 @@ open class FilterMenuViewModel(
         }
     }
 
+    fun getTags() {
+        scope.launch {
+            emitCurrentState(isLoading = true)
+            val response = apolloClient.getTags()
+
+            if (response.isSuccess)
+                tagsList = response.getOrDefault(emptyList())
+            else
+                errorAction.invoke(response.exceptionOrNull()?.message)
+
+            Timber.d("${this.javaClass} tags: ${tagsList.map { "${it.name()} id: ${it.id()}"}}")
+            emitCurrentState(isLoading = false)
+        }
+    }
+
     suspend fun getLocations(default: Boolean, term: String? = null) {
         emitCurrentState(isLoading = true)
 
@@ -156,7 +174,8 @@ open class FilterMenuViewModel(
         _filterMenu.emit(
             FilterMenuUIState(
                 isLoading = isLoading,
-                categoriesList = categoriesList
+                categoriesList = categoriesList,
+                tagsList = tagsList
             )
         )
     }

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
@@ -59,6 +59,16 @@ class SearchAndFilterViewModel(
     private val _isVideoFeedBannerVisible = MutableStateFlow(false)
     val isVideoFeedBannerVisible: StateFlow<Boolean> = _isVideoFeedBannerVisible.asStateFlow()
 
+    /**
+     * Whether the Open Calls filter (pill, filter-menu row, and tag fetching) should be exposed,
+     * derived from the [StatsigGateKey.ANDROID_OPEN_CALLS] gate. Recomputed on the client's
+     * `configReady` — not the one-shot `isReady` — so the gate is never read mid user-reload
+     * (login/logout) where it returns `Loading:Unrecognized`/`false`, mirroring
+     * [isVideoFeedBannerVisible].
+     */
+    private val _isOpenCallsEnabled = MutableStateFlow(false)
+    val isOpenCallsEnabled: StateFlow<Boolean> = _isOpenCallsEnabled.asStateFlow()
+
     private val _searchUIState = MutableStateFlow(SearchUIState())
     val searchUIState: StateFlow<SearchUIState>
         get() = _searchUIState
@@ -96,6 +106,15 @@ class SearchAndFilterViewModel(
                 val gate = statsigClient.getFeatureGate(StatsigGateKey.ANDROID_VIDEO_FEED.key)
                 if (gate.getEvalDetails().reason == EvalReason.Unrecognized) return@collect
                 _isVideoFeedBannerVisible.value = gate.getValue()
+            }
+        }
+
+        scope.launch {
+            statsigClient.configReady.collect { configReady ->
+                if (!configReady) return@collect
+                val gate = statsigClient.getFeatureGate(StatsigGateKey.ANDROID_OPEN_CALLS.key)
+                if (gate.getEvalDetails().reason == EvalReason.Unrecognized) return@collect
+                _isOpenCallsEnabled.value = gate.getValue()
             }
         }
 
@@ -138,7 +157,8 @@ class SearchAndFilterViewModel(
         recommended: Boolean = false,
         projectsLoved: Boolean = false,
         savedProjects: Boolean = false,
-        social: Boolean = false
+        social: Boolean = false,
+        tagId: Int? = null
     ) {
         val update = params.value.toBuilder()
             .apply {
@@ -153,6 +173,7 @@ class SearchAndFilterViewModel(
                 this.staffPicks(if (projectsLoved) true else null)
                 this.starred(if (savedProjects) 1 else null)
                 this.social(if (social) 1 else null)
+                this.tagId(tagId)
             }
             .build()
 

--- a/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
+++ b/app/src/main/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModel.kt
@@ -60,11 +60,8 @@ class SearchAndFilterViewModel(
     val isVideoFeedBannerVisible: StateFlow<Boolean> = _isVideoFeedBannerVisible.asStateFlow()
 
     /**
-     * Whether the Open Calls filter (pill, filter-menu row, and tag fetching) should be exposed,
-     * derived from the [StatsigGateKey.ANDROID_OPEN_CALLS] gate. Recomputed on the client's
-     * `configReady` — not the one-shot `isReady` — so the gate is never read mid user-reload
-     * (login/logout) where it returns `Loading:Unrecognized`/`false`, mirroring
-     * [isVideoFeedBannerVisible].
+     * Whether the Open Calls filter should be exposed,
+     * derived from the [StatsigGateKey.ANDROID_OPEN_CALLS] gate.
      */
     private val _isOpenCallsEnabled = MutableStateFlow(false)
     val isOpenCallsEnabled: StateFlow<Boolean> = _isOpenCallsEnabled.asStateFlow()

--- a/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
+++ b/app/src/main/java/com/kickstarter/libs/featureflag/StatsigClient.kt
@@ -35,6 +35,7 @@ enum class StatsigGateKey(val key: String) {
     ANDROID_VIDEO_FEED("android_video_feed"),
     ANDROID_PRELAUNCH_SOCIAL_SHARE("android_social_share"),
     ANDROID_PRELAUNCH_PROJECT_STORY("android_pre-launch_project_story"),
+    ANDROID_OPEN_CALLS("android_open_calls"),
 }
 
 object StatsigExperiments {

--- a/app/src/main/java/com/kickstarter/mock/factories/TagFactory.kt
+++ b/app/src/main/java/com/kickstarter/mock/factories/TagFactory.kt
@@ -1,0 +1,45 @@
+package com.kickstarter.mock.factories
+
+import com.kickstarter.models.Tag
+
+object TagFactory {
+    @JvmStatic
+    fun tag(): Tag {
+        return make100()
+    }
+
+    @JvmStatic
+    fun make100(): Tag {
+        return Tag.builder()
+            .id(1L)
+            .name("Make 100")
+            .slug("make-100")
+            .url("https://www.kickstarter.com/discover/advanced?tag_id=1")
+            .build()
+    }
+
+    @JvmStatic
+    fun zineQuest(): Tag {
+        return Tag.builder()
+            .id(2L)
+            .name("Zine Quest")
+            .slug("zine-quest")
+            .url("https://www.kickstarter.com/discover/advanced?tag_id=2")
+            .build()
+    }
+
+    @JvmStatic
+    fun witchstarter(): Tag {
+        return Tag.builder()
+            .id(3L)
+            .name("Witchstarter")
+            .slug("witchstarter")
+            .url("https://www.kickstarter.com/discover/advanced?tag_id=3")
+            .build()
+    }
+
+    @JvmStatic
+    fun tags(): List<Tag> {
+        return listOf(make100(), zineQuest(), witchstarter())
+    }
+}

--- a/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/mock/services/MockApolloClientV2.kt
@@ -39,6 +39,7 @@ import com.kickstarter.models.PaymentValidationResponse
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.StoredCard
+import com.kickstarter.models.Tag
 import com.kickstarter.models.User
 import com.kickstarter.models.UserPrivacy
 import com.kickstarter.services.ApolloClientTypeV2
@@ -374,6 +375,10 @@ open class MockApolloClientV2 : ApolloClientTypeV2 {
     }
 
     override suspend fun getCategories(): Result<List<Category>> {
+        return Result.success(emptyList())
+    }
+
+    override suspend fun getTags(): Result<List<Tag>> {
         return Result.success(emptyList())
     }
 

--- a/app/src/main/java/com/kickstarter/models/Tag.kt
+++ b/app/src/main/java/com/kickstarter/models/Tag.kt
@@ -1,0 +1,56 @@
+package com.kickstarter.models
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Represents a single Open Call / Creative Prompt tag (e.g. Make 100, Zine Quest, Witchstarter).
+ *
+ * [id] is the numeric tag id, decoded from the GraphQL Relay `ID!` via `decodeRelayId`. It is
+ * applied to a search through [com.kickstarter.services.DiscoveryParams.tagId] (an `Int`), so
+ * callers convert with `id.toInt()` at that boundary.
+ */
+@Parcelize
+data class Tag(
+    val id: Long,
+    val name: String,
+    val url: String,
+    val slug: String,
+) : Parcelable {
+    fun id() = this.id
+    fun name() = this.name
+    fun url() = this.url
+    fun slug() = this.slug
+
+    @Parcelize
+    data class Builder(
+        var id: Long = 0L,
+        var name: String = "",
+        var url: String = "",
+        var slug: String = "",
+    ) : Parcelable {
+        fun id(id: Long) = apply { this.id = id }
+        fun name(name: String) = apply { this.name = name }
+        fun url(url: String) = apply { this.url = url }
+        fun slug(slug: String) = apply { this.slug = slug }
+
+        fun build() = Tag(
+            id = id,
+            name = name,
+            url = url,
+            slug = slug,
+        )
+    }
+
+    fun toBuilder() = Builder(
+        id = id,
+        name = name,
+        url = url,
+        slug = slug,
+    )
+
+    companion object {
+        @JvmStatic
+        fun builder() = Builder()
+    }
+}

--- a/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
+++ b/app/src/main/java/com/kickstarter/services/KSApolloClientV2.kt
@@ -36,6 +36,7 @@ import com.kickstarter.FetchProjectsQuery
 import com.kickstarter.FetchSimilarProjectsQuery
 import com.kickstarter.GetBackingQuery
 import com.kickstarter.GetCommentQuery
+import com.kickstarter.GetCreativePromptTagsQuery
 import com.kickstarter.GetLocationsQuery
 import com.kickstarter.GetProjectAddOnsQuery
 import com.kickstarter.GetProjectBackingQuery
@@ -95,6 +96,7 @@ import com.kickstarter.models.PaymentValidationResponse
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.StoredCard
+import com.kickstarter.models.Tag
 import com.kickstarter.models.User
 import com.kickstarter.models.UserPrivacy
 import com.kickstarter.services.apiresponses.DiscoverEnvelope
@@ -259,6 +261,7 @@ interface ApolloClientTypeV2 {
     suspend fun getSearchProjects(discoveryParams: DiscoveryParams, cursor: String? = null): Result<SearchEnvelope>
     suspend fun fetchSimilarProjects(pid: Long): Result<List<Project>>
     suspend fun getCategories(): Result<List<Category>>
+    suspend fun getTags(): Result<List<Tag>>
     suspend fun getLocations(useDefault: Boolean, term: String?, lat: Float? = null, long: Float? = null, radius: Float? = null, filterByCoordinates: Boolean? = null): Result<List<Location>>
 
     suspend fun fetchProjectStory(slug: String): Result<StoriedProject>
@@ -368,9 +371,17 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
             amountRaisedBucket = if (discoveryParams.amountBucket() == null) Optional.absent() else Optional.present(discoveryParams.amountBucket()?.toPledgedBucket()),
             goalBucket = if (discoveryParams.goalBucket() == null) Optional.absent() else Optional.present(discoveryParams.goalBucket()?.toGoalBucket()),
             following = if (discoveryParams.social() == null) Optional.absent() else Optional.present(discoveryParams.social().toBoolean()),
-            staffPicks = if (discoveryParams.staffPicks() == null) Optional.absent() else Optional.present(discoveryParams.staffPicks())
+            staffPicks = if (discoveryParams.staffPicks() == null) Optional.absent() else Optional.present(discoveryParams.staffPicks()),
+            tagId = discoveryParams.tagId().toOptional()
         )
     }
+
+    /**
+     * Collapses the repeated `if (x == null) Optional.absent() else Optional.present(x)` pattern
+     * used when building Apollo query variables.
+     */
+    private fun <T : Any> T?.toOptional(): Optional<T> =
+        if (this == null) Optional.absent() else Optional.present(this)
 
     override fun createSetupIntent(project: Project?): Observable<String> {
         return Observable.defer {
@@ -1937,6 +1948,24 @@ class KSApolloClientV2(val service: ApolloClient, val gson: Gson) : ApolloClient
             }
 
             categories
+        } ?: emptyList()
+    }
+
+    override suspend fun getTags(): Result<List<Tag>> = executeForResult {
+        val response = this.service.query(GetCreativePromptTagsQuery()).execute()
+
+        if (response.hasErrors())
+            throw buildClientException(response.errors)
+
+        response.data?.tags?.nodes?.mapNotNull { node ->
+            node?.let {
+                Tag(
+                    id = decodeRelayId(it.id) ?: return@mapNotNull null,
+                    name = it.name,
+                    url = it.url,
+                    slug = it.slug,
+                )
+            }
         } ?: emptyList()
     }
 

--- a/app/src/test/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/search/viewmodel/FilterMenuViewModelTest.kt
@@ -7,10 +7,12 @@ import com.kickstarter.libs.utils.extensions.isFalse
 import com.kickstarter.libs.utils.extensions.isTrue
 import com.kickstarter.mock.factories.CategoryFactory
 import com.kickstarter.mock.factories.LocationFactory
+import com.kickstarter.mock.factories.TagFactory
 import com.kickstarter.mock.factories.UserFactory
 import com.kickstarter.mock.services.MockApolloClientV2
 import com.kickstarter.models.Category
 import com.kickstarter.models.Location
+import com.kickstarter.models.Tag
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
@@ -136,6 +138,63 @@ class FilterMenuViewModelTest : KSRobolectricTestCase() {
         assertEquals(errorCounter, 1)
         assertEquals(state.size, 1)
         assertEquals(state.first().categoriesList, emptyList<Category>())
+    }
+
+    @Test
+    fun `test obtain tags succeed`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val environment = environment()
+            .toBuilder()
+            .apolloClientV2(
+                object : MockApolloClientV2() {
+                    override suspend fun getTags(): Result<List<Tag>> {
+                        return Result.success(TagFactory.tags())
+                    }
+                }).build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        var errorCounter = 0
+        val state = mutableListOf<FilterMenuUIState>()
+        backgroundScope.launch(dispatcher) {
+            viewModel.provideErrorAction { errorCounter++ }
+            viewModel.getTags()
+            viewModel.filterMenuUIState.toList(state)
+        }
+
+        advanceUntilIdle()
+        assertEquals(errorCounter, 0)
+        assertEquals(state.size, 2)
+        assertEquals(state.first().tagsList, emptyList<Tag>())
+        assertEquals(state.last().tagsList, TagFactory.tags())
+    }
+
+    @Test
+    fun `test obtain tags errored`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val environment = environment()
+            .toBuilder()
+            .apolloClientV2(
+                object : MockApolloClientV2() {
+                    override suspend fun getTags(): Result<List<Tag>> {
+                        return Result.failure(Exception())
+                    }
+                }).build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        var errorCounter = 0
+        val state = mutableListOf<FilterMenuUIState>()
+        backgroundScope.launch(dispatcher) {
+            viewModel.provideErrorAction { errorCounter++ }
+            viewModel.getTags()
+            viewModel.filterMenuUIState.toList(state)
+        }
+
+        advanceUntilIdle()
+        assertEquals(errorCounter, 1)
+        assertEquals(state.size, 1)
+        assertEquals(state.first().tagsList, emptyList<Tag>())
     }
 
     @Test

--- a/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/features/search/viewmodel/SearchAndFilterViewModelTest.kt
@@ -552,4 +552,78 @@ class SearchAndFilterViewModelTest : KSRobolectricTestCase() {
         advanceUntilIdle()
         assertTrue(viewModel.isVideoFeedBannerVisible.value)
     }
+
+    @Test
+    fun `test updateParamsToSearchWith tagId sets DiscoveryParams tagId and triggers search`() = runTest {
+        var params: DiscoveryParams? = null
+        val projectList = listOf(ProjectFactory.project())
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val environment = environment()
+            .toBuilder()
+            .apolloClientV2(
+                object : MockApolloClientV2() {
+                    override suspend fun getSearchProjects(
+                        discoveryParams: DiscoveryParams,
+                        cursor: String?
+                    ): Result<SearchEnvelope> {
+                        params = discoveryParams
+                        return Result.success(SearchEnvelope(projectList))
+                    }
+                })
+            .statsigClient(MockStatsigClient(context = application()))
+            .build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        val searchState = mutableListOf<SearchUIState>()
+        backgroundScope.launch(dispatcher) {
+            viewModel.updateParamsToSearchWith(
+                projectSort = DiscoveryParams.Sort.MAGIC,
+                tagId = 123
+            )
+            viewModel.searchUIState.toList(searchState)
+        }
+
+        advanceUntilIdle()
+        assertEquals(params?.tagId(), 123)
+        assertEquals(searchState.last().popularProjectsList, projectList)
+    }
+
+    @Test
+    fun `test isOpenCallsEnabled is true when gate is enabled`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val environment = environment()
+            .toBuilder()
+            .statsigClient(
+                MockStatsigClient(
+                    context = application(),
+                    gateMap = mapOf(StatsigGateKey.ANDROID_OPEN_CALLS.key to true)
+                )
+            )
+            .build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        advanceUntilIdle()
+        assertTrue(viewModel.isOpenCallsEnabled.value)
+    }
+
+    @Test
+    fun `test isOpenCallsEnabled is false when gate is disabled`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val environment = environment()
+            .toBuilder()
+            .statsigClient(
+                MockStatsigClient(
+                    context = application(),
+                    gateMap = mapOf(StatsigGateKey.ANDROID_OPEN_CALLS.key to false)
+                )
+            )
+            .build()
+
+        setUpEnvironment(environment, dispatcher)
+
+        advanceUntilIdle()
+        assertFalse(viewModel.isOpenCallsEnabled.value)
+    }
 }


### PR DESCRIPTION
📲 What
Adds the network + ViewModel + feature-gate foundation for the Open Calls (Creative Prompt) search filter:

- New `GetCreativePromptTags` GraphQL query and a `Tag` model (id/name/url/slug).
- `KSApolloClientV2.getTags()` to fetch Creative Prompt tags.
- `tagId` threaded into the `FetchProjects` query and `DiscoveryParams`, so a selected tag scopes search results.
- `FilterMenuViewModel.getTags()` exposes the tag list via FilterMenuUIState.tagsList, loaded on screen entry.
- `SearchAndFilterViewModel.isOpenCallsEnabled`, gated on the new `android_open_calls` Statsig gate.

🤔 Why
Open Calls lets backers filter search to projects participating in a Creative Prompt (Make 100, Zine Quest, etc.). This is the first of the chained PRs — it lands the data/gate layer so the UI PR can build on top without a giant single diff.

🛠 How
- `tags.graphql`: new query scoped to CREATIVE_PROMPT. Tag.id is a Long decoded from the Relay ID!; converted with id.toInt() at the DiscoveryParams.tagId (Int) boundary.
- `project.graphql`: added $tagId: Int variable, passed to projects(tagId:).
- ViewModel: getTags() fetches on SearchAndFilterActivity entry and emits into FilterMenuUIState. applyParams(...) gained a tagId argument. 
- Gate read follows the established configReady + EvalReason.Unrecognized guard pattern. This `SearchAndFilterViewModel.isOpenCallsEnabled` will be consumed to hide/show the UI piece in follow up PR's.

👀 See
<img width="1112" height="413" alt="Screenshot 2026-07-28 at 12 01 46 PM" src="https://github.com/user-attachments/assets/7c7f1488-6fec-4694-9b49-1c9c1296ab9a" />


📋 QA
No user-facing UI yet, but use Network Profiler to check the newly added query response. Unit test coverage added in FilterMenuViewModelTest and SearchAndFilterViewModelTest.

Story 📖
[DISC-386](https://kickstarter.atlassian.net/browse/DISC-386)
[DISC-388](https://kickstarter.atlassian.net/browse/DISC-388)
[DISC-392](https://kickstarter.atlassian.net/browse/DISC-392)


[DISC-386]: https://kickstarter.atlassian.net/browse/DISC-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ