### PR TITLE
CHECK-71: Update Reward Card CTA selectability logic

### DIFF
--- a/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
+++ b/app/src/main/java/com/kickstarter/ui/activities/compose/projectpage/RewardCarouselScreen.kt
@@ -209,15 +209,6 @@ fun RewardCarouselScreen(
                     val ctaButtonEnabled = when {
                         RewardUtils.isNoReward(reward) -> true
 
-                        !reward.isAvailable() -> false
-
-                        !RewardUtils.isShippableToLocation(reward, selectedLocationId) -> false
-
-                        !reward.hasAddons() && backing?.isBacked(reward) != true -> true
-
-                        backing?.rewardId() != reward.id() &&
-                            RewardUtils.isAvailableForProject(project, reward) -> true
-
                         reward.hasAddons() &&
                             backing?.rewardId() == reward.id() &&
                             (
@@ -227,6 +218,15 @@ fun RewardCarouselScreen(
                                     )
 
                                 ) -> true
+
+                        !reward.isAvailable() -> false
+
+                        !RewardUtils.isShippableToLocation(reward, selectedLocationId) -> false
+
+                        !reward.hasAddons() && backing?.isBacked(reward) != true -> true
+
+                        backing?.rewardId() != reward.id() &&
+                            RewardUtils.isAvailableForProject(project, reward) -> true
 
                         else -> false
                     }

--- a/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/RewardsFragment.kt
@@ -76,7 +76,7 @@ class RewardsFragment : Fragment() {
                         preloadImages(LocalContext.current, rewards)
 
                         val project = projectData.project()
-                        val backing = projectData.backing()
+                        val backing = projectData.backing() ?: project.backing()
 
                         val rewardLoading = shippingUIState.loading
                         val currentUserShippingRule = shippingUIState.selectedShippingRule

--- a/app/src/test/java/com/kickstarter/ui/activities/compose/RewardCarouselScreenTest.kt
+++ b/app/src/test/java/com/kickstarter/ui/activities/compose/RewardCarouselScreenTest.kt
@@ -1,6 +1,8 @@
 package com.kickstarter.ui.activities.compose.projectpage
 
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
@@ -15,6 +17,7 @@ import androidx.compose.ui.test.performScrollToIndex
 import com.kickstarter.KSRobolectricTestCase
 import com.kickstarter.R
 import com.kickstarter.libs.utils.RewardUtils
+import com.kickstarter.mock.factories.BackingFactory
 import com.kickstarter.mock.factories.RewardFactory
 import com.kickstarter.mock.factories.RewardsItemFactory
 import com.kickstarter.mock.factories.ShippingRuleFactory
@@ -119,9 +122,9 @@ class RewardCarouselScreenTest : KSRobolectricTestCase() {
     fun `test expired rewards are not selectable`() {
         val context = context()
 
-        val reward = RewardFactory.reward().toBuilder().id(0L).build()
-        val rewardEndingSoon = RewardFactory.endingSoon().toBuilder().id(1L).build()
-        val rewardExpired = RewardFactory.ended().toBuilder().id(2L).build()
+        val reward = RewardFactory.reward().toBuilder().id(1L).isAvailable(true).build()
+        val rewardEndingSoon = RewardFactory.endingSoon().toBuilder().id(2L).isAvailable(true).build()
+        val rewardExpired = RewardFactory.ended().toBuilder().id(4L).isAvailable(false).build()
 
         val rewards = listOf(
             reward, rewardEndingSoon, rewardExpired
@@ -162,9 +165,200 @@ class RewardCarouselScreenTest : KSRobolectricTestCase() {
             ).assert(
                 hasAnyDescendant(
                     SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
-                        and hasText(context().getString(R.string.No_longer_available))
+                        and hasText(context.getString(R.string.No_longer_available))
                         and isNotEnabled()
                 )
+            )
+        }
+    }
+
+    @Test
+    fun `test reward selectability given an existing backing`() {
+        val context = context()
+
+        val noReward = RewardFactory.noReward()
+        val reward = RewardFactory.reward().toBuilder().id(1L).hasAddons(true).isAvailable(true).build()
+        val rewardEndingSoon = RewardFactory.endingSoon().toBuilder().id(2L).hasAddons(true).isAvailable(true).build()
+        val rewardExpiredExplicit = RewardFactory.ended().toBuilder().id(3L).hasAddons(true).isAvailable(false).build()
+        val rewardLimitReached = RewardFactory.limitReached().toBuilder().id(4L).hasAddons(true).isAvailable(false).build()
+
+        val rewards = listOf(
+            noReward, reward, rewardEndingSoon, rewardExpiredExplicit, rewardLimitReached
+        )
+
+        val backingState = mutableStateOf(BackingFactory.backing(reward))
+
+        composeTestRule.setContent {
+            val project = remember(backingState.value) {
+                Project.builder().state(Project.STATE_LIVE).backing(backingState.value).build()
+            }
+
+            KSTheme {
+                RewardCarouselScreen(
+                    lazyRowState = rememberLazyListState(),
+                    environment = environment(),
+                    rewards = rewards,
+                    project = project,
+                    backing = project.backing(),
+                    onRewardSelected = {},
+                    currentShippingRule = ShippingRuleFactory.usShippingRule(),
+                    countryList = listOf(ShippingRuleFactory.usShippingRule()),
+                    onShippingRuleSelected = {}
+                )
+            }
+        }
+
+        with(rewardCarousel) {
+            var targetReward = noReward
+            performScrollToIndex(rewards.indexOf(targetReward))
+            composeTestRule.onNodeWithTag(
+                RewardCarouselTestTag.REWARD_CARD.name + targetReward.id()
+            ).assert(
+                hasAnyDescendant(
+                    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+                        and hasText(context.getString(R.string.Select))
+                        and isEnabled()
+                )
+            )
+
+            targetReward = reward
+            performScrollToIndex(rewards.indexOf(targetReward))
+            composeTestRule.onNodeWithTag(
+                RewardCarouselTestTag.REWARD_CARD.name + targetReward.id()
+            ).assert(
+                hasAnyDescendant(
+                    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+                        and hasText(context.getString(R.string.Select))
+                        and isEnabled()
+                ) and hasAnyDescendant(hasText(context.getString(R.string.Your_selection)))
+            )
+
+            targetReward = rewardExpiredExplicit
+            performScrollToIndex(rewards.indexOf(targetReward))
+            composeTestRule.onNodeWithTag(
+                RewardCarouselTestTag.REWARD_CARD.name + targetReward.id()
+            ).assert(
+                hasAnyDescendant(
+                    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+                        and hasText(context.getString(R.string.No_longer_available))
+                        and isNotEnabled()
+                )
+            )
+
+            targetReward = rewardLimitReached
+            performScrollToIndex(rewards.indexOf(targetReward))
+            composeTestRule.onNodeWithTag(
+                RewardCarouselTestTag.REWARD_CARD.name + targetReward.id()
+            ).assert(
+                hasAnyDescendant(
+                    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+                        and hasText(context.getString(R.string.No_longer_available))
+                        and isNotEnabled()
+                )
+            )
+        }
+
+        backingState.value = BackingFactory.backing(rewardExpiredExplicit)
+
+        with(rewardCarousel) {
+            var targetReward = noReward
+            performScrollToIndex(rewards.indexOf(targetReward))
+            composeTestRule.onNodeWithTag(
+                RewardCarouselTestTag.REWARD_CARD.name + targetReward.id()
+            ).assert(
+                hasAnyDescendant(
+                    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+                        and hasText(context.getString(R.string.Select))
+                        and isEnabled()
+                )
+            )
+
+            targetReward = reward
+            performScrollToIndex(rewards.indexOf(targetReward))
+            composeTestRule.onNodeWithTag(
+                RewardCarouselTestTag.REWARD_CARD.name + targetReward.id()
+            ).assert(
+                hasAnyDescendant(
+                    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+                        and hasText(context.getString(R.string.Select))
+                        and isEnabled()
+                )
+            )
+
+            targetReward = rewardExpiredExplicit
+            performScrollToIndex(rewards.indexOf(targetReward))
+            composeTestRule.onNodeWithTag(
+                RewardCarouselTestTag.REWARD_CARD.name + targetReward.id()
+            ).assert(
+                hasAnyDescendant(
+                    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+                        and hasText(context.getString(R.string.Select))
+                        and isEnabled()
+                ) and hasAnyDescendant(hasText(context.getString(R.string.Your_selection)))
+            )
+
+            targetReward = rewardLimitReached
+            performScrollToIndex(rewards.indexOf(targetReward))
+            composeTestRule.onNodeWithTag(
+                RewardCarouselTestTag.REWARD_CARD.name + targetReward.id()
+            ).assert(
+                hasAnyDescendant(
+                    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+                        and hasText(context.getString(R.string.No_longer_available))
+                        and isNotEnabled()
+                )
+            )
+        }
+
+        backingState.value = BackingFactory.backing(rewardLimitReached)
+
+        with(rewardCarousel) {
+            var targetReward = noReward
+            performScrollToIndex(rewards.indexOf(targetReward))
+            composeTestRule.onNodeWithTag(
+                RewardCarouselTestTag.REWARD_CARD.name + targetReward.id()
+            ).assert(
+                hasAnyDescendant(
+                    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+                        and hasText(context.getString(R.string.Select))
+                        and isEnabled()
+                )
+            )
+
+            targetReward = reward
+            performScrollToIndex(rewards.indexOf(targetReward))
+            composeTestRule.onNodeWithTag(
+                RewardCarouselTestTag.REWARD_CARD.name + targetReward.id()
+            ).assert(
+                hasAnyDescendant(
+                    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+                        and hasText(context.getString(R.string.Select))
+                        and isEnabled()
+                )
+            )
+
+            targetReward = rewardExpiredExplicit
+            performScrollToIndex(rewards.indexOf(targetReward))
+            composeTestRule.onNodeWithTag(
+                RewardCarouselTestTag.REWARD_CARD.name + targetReward.id()
+            ).assert(
+                hasAnyDescendant(
+                    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+                        and hasText(context.getString(R.string.No_longer_available))
+                        and isNotEnabled()
+                )
+            )
+
+            targetReward = rewardLimitReached
+            performScrollToIndex(rewards.indexOf(targetReward))
+            composeTestRule.onNodeWithTag(
+                RewardCarouselTestTag.REWARD_CARD.name + targetReward.id()
+            ).assert(
+                hasAnyDescendant(
+                    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+                        and hasText(context.getString(R.string.Select))
+                        and isEnabled()
+                ) and hasAnyDescendant(hasText(context.getString(R.string.Your_selection)))
             )
         }
     }


### PR DESCRIPTION
# 📲 What

Allow backers to edit add-ons of an existing pledge regardless of if the reward has expired or sold out.

# 🤔 Why

Currently, to update add-ons for a pledge, backers must re-enter the pledge flow and select the same reward that they previous pledged to. However, if that reward has expired or sold out, existing backers cannot re-select it to update their add-ons.

# 🛠 How

- Ensure that a Backing is passed to `RewardCarouselScreen` by falling back to `Project.backing()` if the one from `ProjectData` is `null`, following the pattern used by `RewardsSelectionViewModel` and elsewhere within `RewardsCarouselScreen`.
- Update the logic controlling whether or not the Reward Card CTA is enabled to prioritize the scenario of an existing backing to a reward with add-ons over the reward's availability.

# 👀 See

### Before 🐛

https://github.com/user-attachments/assets/47f6a115-f307-40c1-a1eb-f1dab8599525

### After 🦋

https://github.com/user-attachments/assets/ff74d5d7-712b-49ea-9f45-d2f2cfaa94d2

# 📋 QA

- Visit the Staging project [Solar Fort Community Space by Grace Calloway — Kickstarter (staging)](https://staging.kickstarter.com/projects/1768690592/solar-fort-community-space-0)
- Open the rewards carousel and scroll to the Reward titled "Limited edition!"
- Result:
  - The Reward Card should have a badge that displays "1 left of 2"
  - The Reward should be selectable
- Select the "Limited edition!" Reward
- Select any combination of Add-Ons
- Complete checkout
- Open the 'Manage your pledge' view, and confirm your Add-Ons selections
- Open the context menu and choose 'Edit pledge'
- Scroll to the Reward titled "Limited edition!"
- Result:
  - The Reward Card should no longer have a remaining quantity badge
  - The Reward should be selectable
- Select the "Limited edition!" Reward
- Result:
  - The system should navigate to the Add-Ons + Bonus Support screen
  - Your previous Add-Ons selections should be pre-selected
- Select a different combination of Add-Ons
- Complete checkout
- Open the 'Manage your pledge' view, and confirm your Add-Ons selections

# Story 📖

[\[CHECK-71\] [Android] backers cannot edit pledge to include add-ons - Jira](https://kickstarter.atlassian.net/browse/CHECK-71)
