### PR TITLE
PF-48: Upgrade Stripe & map `PaymentSheetResult` to an internal data model

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -249,7 +249,7 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
     implementation 'com.jakewharton:process-phoenix:3.0.0'
     implementation "com.jakewharton.timber:timber:5.0.1"
-    implementation 'com.stripe:stripe-android:20.47.3'
+    implementation 'com.stripe:stripe-android:23.17.1'
 
     final okhttp_version = '5.1.0'
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp_version"

--- a/app/src/main/java/com/kickstarter/models/StripePaymentSheetResult.kt
+++ b/app/src/main/java/com/kickstarter/models/StripePaymentSheetResult.kt
@@ -1,0 +1,16 @@
+package com.kickstarter.models
+
+import com.stripe.android.paymentsheet.PaymentSheetResult
+
+sealed class StripePaymentSheetResult {
+    object Completed : StripePaymentSheetResult()
+    object Canceled : StripePaymentSheetResult()
+    data class Failed(val error: Throwable) : StripePaymentSheetResult()
+}
+
+fun PaymentSheetResult.toStripePaymentSheetResult() =
+    when (this) {
+        is PaymentSheetResult.Canceled -> StripePaymentSheetResult.Canceled
+        is PaymentSheetResult.Failed -> StripePaymentSheetResult.Failed(error)
+        is PaymentSheetResult.Completed -> StripePaymentSheetResult.Completed
+    }

--- a/app/src/main/java/com/kickstarter/ui/fragments/CrowdfundCheckoutFragment.kt
+++ b/app/src/main/java/com/kickstarter/ui/fragments/CrowdfundCheckoutFragment.kt
@@ -22,6 +22,7 @@ import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.StoredCard
 import com.kickstarter.models.chrome.ChromeTabsHelperActivity
+import com.kickstarter.models.toStripePaymentSheetResult
 import com.kickstarter.ui.activities.DisclaimerItems
 import com.kickstarter.ui.activities.PledgeDelegate
 import com.kickstarter.ui.activities.compose.projectpage.CheckoutScreen
@@ -295,7 +296,7 @@ class CrowdfundCheckoutFragment : Fragment() {
         }
 
         val onPaymentSheetResult = PaymentSheetResultCallback { paymentSheetResult ->
-            this.viewModel.paymentSheetResult(paymentSheetResult)
+            this.viewModel.paymentSheetResult(paymentSheetResult.toStripePaymentSheetResult())
             when (paymentSheetResult) {
                 is PaymentSheetResult.Canceled -> {
                     binding?.composeView?.let { view ->

--- a/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
+++ b/app/src/main/java/com/kickstarter/viewmodels/projectpage/CrowdfundCheckoutViewModel.kt
@@ -25,6 +25,7 @@ import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.ShippingRule
 import com.kickstarter.models.StoredCard
+import com.kickstarter.models.StripePaymentSheetResult
 import com.kickstarter.models.User
 import com.kickstarter.models.extensions.getBackingData
 import com.kickstarter.models.extensions.isFromPaymentSheet
@@ -36,7 +37,6 @@ import com.kickstarter.ui.data.PledgeData
 import com.kickstarter.ui.data.PledgeFlowContext
 import com.kickstarter.ui.data.PledgeReason
 import com.kickstarter.viewmodels.usecases.SendThirdPartyEventUseCaseV2
-import com.stripe.android.paymentsheet.PaymentSheetResult
 import io.reactivex.Observable
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -70,6 +70,7 @@ data class CheckoutUIState(
 )
 
 data class PaymentSheetPresenterState(val setupClientId: String = "")
+
 class CrowdfundCheckoutViewModel(val environment: Environment, bundle: Bundle? = null) : ViewModel() {
     val analytics = requireNotNull(environment.analytics())
     val apolloClient = requireNotNull(environment.apolloClientV2())
@@ -609,24 +610,25 @@ class CrowdfundCheckoutViewModel(val environment: Environment, bundle: Bundle? =
     }
 
     /**
-     * If @param = PaymentSheetResult.Failed or PaymentSheetResult.Canceled
+     * If Stripe's `PaymentSheetResult` is PaymentSheetResult.Failed or PaymentSheetResult.Canceled
      * reload remove the payment methods added via payment sheet and keep only those
      * obtained via `apolloClient.getStoredCards()`. PaymentSheetResult.Canceled will be produce
      * by a failed/abandoned 3DS challenge
      *
      * If @PaymentSheetResult.Completed stop loading state
      */
-    fun paymentSheetResult(paymentSheetResult: PaymentSheetResult) {
+
+    fun paymentSheetResult(paymentSheetResult: StripePaymentSheetResult) {
         when (paymentSheetResult) {
-            PaymentSheetResult.Canceled,
-            is PaymentSheetResult.Failed -> {
+            is StripePaymentSheetResult.Canceled,
+            is StripePaymentSheetResult.Failed -> {
                 scope.launch {
                     val updatedList = storedCards.filter { !it.isFromPaymentSheet() }
                     storedCards = updatedList
                     emitCurrentState(isLoading = false)
                 }
             }
-            PaymentSheetResult.Completed -> {
+            is StripePaymentSheetResult.Completed -> {
                 scope.launch {
                     emitCurrentState(isLoading = false)
                 }

--- a/app/src/test/java/com/kickstarter/viewmodels/CrowdfundCheckoutViewModelTest.kt
+++ b/app/src/test/java/com/kickstarter/viewmodels/CrowdfundCheckoutViewModelTest.kt
@@ -31,6 +31,7 @@ import com.kickstarter.models.PaymentPlan
 import com.kickstarter.models.Project
 import com.kickstarter.models.Reward
 import com.kickstarter.models.StoredCard
+import com.kickstarter.models.StripePaymentSheetResult
 import com.kickstarter.models.UserPrivacy
 import com.kickstarter.services.mutations.CreateBackingData
 import com.kickstarter.services.mutations.UpdateBackingData
@@ -45,7 +46,6 @@ import com.kickstarter.viewmodels.projectpage.CheckoutUIState
 import com.kickstarter.viewmodels.projectpage.CrowdfundCheckoutViewModel
 import com.kickstarter.viewmodels.projectpage.PaymentSheetPresenterState
 import com.kickstarter.viewmodels.usecases.TPEventInputData
-import com.stripe.android.paymentsheet.PaymentSheetResult
 import io.reactivex.Observable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
@@ -1371,7 +1371,7 @@ class CrowdfundCheckoutViewModelTest : KSRobolectricTestCase() {
         backgroundScope.launch(dispatcher) {
             viewModel.paymentSheetPresented(true)
             viewModel.newlyAddedPaymentMethod(StoredCardFactory.fromPaymentSheetCard())
-            viewModel.paymentSheetResult(PaymentSheetResult.Completed)
+            viewModel.paymentSheetResult(StripePaymentSheetResult.Completed)
             viewModel.crowdfundCheckoutUIState.toList(uiState)
         }
 
@@ -1450,7 +1450,7 @@ class CrowdfundCheckoutViewModelTest : KSRobolectricTestCase() {
         advanceUntilIdle()
 
         backgroundScope.launch(dispatcher) {
-            viewModel.paymentSheetResult(PaymentSheetResult.Failed(Throwable()))
+            viewModel.paymentSheetResult(StripePaymentSheetResult.Failed(Throwable()))
         }
 
         assertEquals(uiState.last().storeCards, cards)


### PR DESCRIPTION
# 📲 What

Upgrade the Stripe dependency and map its `PaymentSheetResult` to a new `StripePaymentSheetResult` type.

# 🤔 Why

App maintenance and to provide a stable foundation for integrating Google Pay in the future.

# 🛠 How

Bump the Stripe library to the [latest version](https://github.com/stripe/stripe-android/releases/tag/v23.17.1) as of yesterday. Note that, as recommended in [Compatibility with Jetpack Compose](https://github.com/stripe/stripe-android#compatibility-with-jetpack-compose), this version is compatible with the app's current version of Compose UI based on the [BOM version mapping](https://developer.android.com/develop/ui/compose/bom/bom-mapping) for `androidx.compose:compose-bom:2026.03.01`.

The latest version of the library marks `PaymentSheetResult`'s subclass constructors as `internal`, so we create a new `StripePaymentSheetResult` type and map from those classes where needed.

# 👀 See

N/A - There are no notable UI changes w/ this upgrade given the current configuration for the PaymentSheet

# 📋 QA

Regression test the following flows:

* Add a new payment method from Profile Settings
* Crowdfunding checkout with a new payment method
* Late pledge checkout with a new payment method
* Change payment method

# Story 📖

[\[PF-48\] Upgrade Stripe (requires kotlin 2.1+) - Jira](https://kickstarter.atlassian.net/browse/PF-48)
